### PR TITLE
Implement parallel worker in machine controller.

### DIFF
--- a/cloud/google/cmd/gce-machine-controller/main.go
+++ b/cloud/google/cmd/gce-machine-controller/main.go
@@ -64,6 +64,6 @@ func main() {
 	// If this doesn't compile, the code generator probably
 	// overwrote the customized NewMachineController function.
 	c := machine.NewMachineController(config, si, actuator)
-	c.Run(shutdown)
+	c.RunAsync(shutdown)
 	select {}
 }

--- a/pkg/controller/config/configuration.go
+++ b/pkg/controller/config/configuration.go
@@ -21,15 +21,18 @@ import (
 )
 
 type Configuration struct {
-	Kubeconfig string
-	InCluster  bool
+	Kubeconfig  string
+	InCluster   bool
+	WorkerCount int
 }
 
 var ControllerConfig = Configuration{
-	InCluster: true,
+	InCluster:   true,
+	WorkerCount: 5, // Default 5 worker.
 }
 
 func (c *Configuration) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Kubeconfig, "kubeconfig", c.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	fs.BoolVar(&c.InCluster, "incluster", c.InCluster, "Controller will be running inside the cluster.")
+	fs.IntVar(&c.WorkerCount, "workers", c.WorkerCount, "The number of workers for controller.")
 }

--- a/pkg/controller/machine/queue.go
+++ b/pkg/controller/machine/queue.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/controller"
+	"sigs.k8s.io/cluster-api/pkg/controller/config"
+)
+
+func (c *MachineController) RunAsync(stopCh <-chan struct{}) {
+	for _, q := range c.Informers.WorkerQueues {
+		go c.StartWorkerQueue(q, stopCh)
+	}
+}
+
+// StartWorkerQueue schedules a routine to continuously process Queue messages
+// until shutdown is closed
+func (c *MachineController) StartWorkerQueue(q *controller.QueueWorker, shutdown <-chan struct{}) {
+	glog.Infof("Start %s Queue", q.Name)
+	defer q.Queue.ShutDown()
+
+	for i := 0; i < config.ControllerConfig.WorkerCount; i++ {
+		// Every second, process all messages in the Queue until it is time to shutdown
+		go wait.Until(q.ProcessAllMessages, time.Second, shutdown)
+	}
+
+	<-shutdown
+
+	// Stop accepting messages into the Queue
+	glog.V(1).Infof("Shutting down %s Queue\n", q.Name)
+}

--- a/pkg/controller/machine/reconcile_test.go
+++ b/pkg/controller/machine/reconcile_test.go
@@ -30,46 +30,20 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-type CountActuator struct{
-	CreateCallCount int64
-	DeleteCallCount int64
-	UpdateCallCount int64
-	ExistsCallCount int64
-	ExistsValue     bool
-}
-
-func (a *CountActuator) Create(*v1alpha1.Cluster, *v1alpha1.Machine) error {
-	a.CreateCallCount++
-	return nil
-}
-func (a *CountActuator) Delete(*v1alpha1.Machine) error {
-	a.DeleteCallCount++
-	return nil
-}
-func (a *CountActuator) Update(c *v1alpha1.Cluster, machine *v1alpha1.Machine) error {
-	a.UpdateCallCount++
-	return nil
-}
-func (a *CountActuator) Exists(*v1alpha1.Machine) (bool, error) {
-	a.ExistsCallCount++
-	return a.ExistsValue, nil
-}
-
-
 func TestMachineSetControllerReconcileHandler(t *testing.T) {
 	tests := []struct {
-		name                      string
-		objExists                 bool
-		instanceExists            bool
-		isDeleting                bool
-		withFinalizer             bool
-		isMaster                  bool
-		ignoreDeleteCallCount     bool
-		expectFinalizerRemoved    bool
-		numExpectedCreateCalls    int64
-		numExpectedDeleteCalls    int64
-		numExpectedUpdateCalls    int64
-		numExpectedExistsCalls    int64
+		name                   string
+		objExists              bool
+		instanceExists         bool
+		isDeleting             bool
+		withFinalizer          bool
+		isMaster               bool
+		ignoreDeleteCallCount  bool
+		expectFinalizerRemoved bool
+		numExpectedCreateCalls int64
+		numExpectedDeleteCalls int64
+		numExpectedUpdateCalls int64
+		numExpectedExistsCalls int64
 	}{
 		{
 			name:                   "Create machine",
@@ -96,11 +70,11 @@ func TestMachineSetControllerReconcileHandler(t *testing.T) {
 		},
 		{
 			// This should not be possible. Here for completeness.
-			name:                   "Delete machine, instance exists without finalizer",
-			objExists:              true,
-			instanceExists:         true,
-			isDeleting:             true,
-			withFinalizer:          false,
+			name:           "Delete machine, instance exists without finalizer",
+			objExists:      true,
+			instanceExists: true,
+			isDeleting:     true,
+			withFinalizer:  false,
 		},
 		{
 			name:                   "Delete machine, instance does not exist, with finalizer",
@@ -112,19 +86,19 @@ func TestMachineSetControllerReconcileHandler(t *testing.T) {
 			expectFinalizerRemoved: true,
 		},
 		{
-			name:                   "Delete machine, instance does not exist, without finalizer",
-			objExists:              true,
-			instanceExists:         false,
-			isDeleting:             true,
-			withFinalizer:          false,
+			name:           "Delete machine, instance does not exist, without finalizer",
+			objExists:      true,
+			instanceExists: false,
+			isDeleting:     true,
+			withFinalizer:  false,
 		},
 		{
-			name:                   "Delete machine, skip master",
-			objExists:              true,
-			instanceExists:         true,
-			isDeleting:             true,
-			withFinalizer:          true,
-			isMaster:               true,
+			name:           "Delete machine, skip master",
+			objExists:      true,
+			instanceExists: true,
+			isDeleting:     true,
+			withFinalizer:  true,
+			isMaster:       true,
 		},
 	}
 
@@ -151,7 +125,8 @@ func TestMachineSetControllerReconcileHandler(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			actuator := &CountActuator{ExistsValue: test.instanceExists}
+			actuator := NewTestActuator()
+			actuator.ExistsValue = test.instanceExists
 
 			target := &MachineControllerImpl{}
 			target.actuator = actuator
@@ -193,7 +168,7 @@ func getMachine(name string, isDeleting, hasFinalizer, isMaster bool) *v1alpha1.
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
 			Namespace: metav1.NamespaceDefault,
 		},
 	}

--- a/pkg/controller/machine/testactuator.go
+++ b/pkg/controller/machine/testactuator.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"sync"
+
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+type TestActuator struct {
+	unblock         chan string
+	BlockOnCreate   bool
+	BlockOnDelete   bool
+	BlockOnUpdate   bool
+	BlockOnExists   bool
+	CreateCallCount int64
+	DeleteCallCount int64
+	UpdateCallCount int64
+	ExistsCallCount int64
+	ExistsValue     bool
+	Lock            sync.Mutex
+}
+
+func (a *TestActuator) Create(*v1alpha1.Cluster, *v1alpha1.Machine) error {
+	defer func() {
+		if a.BlockOnCreate {
+			<-a.unblock
+		}
+	}()
+
+	a.Lock.Lock()
+	defer a.Lock.Unlock()
+	a.CreateCallCount++
+	return nil
+}
+
+func (a *TestActuator) Delete(*v1alpha1.Machine) error {
+	defer func() {
+		if a.BlockOnDelete {
+			<-a.unblock
+		}
+	}()
+
+	a.Lock.Lock()
+	defer a.Lock.Unlock()
+	a.DeleteCallCount++
+	return nil
+}
+
+func (a *TestActuator) Update(c *v1alpha1.Cluster, machine *v1alpha1.Machine) error {
+	defer func() {
+		if a.BlockOnUpdate {
+			<-a.unblock
+		}
+	}()
+
+	a.Lock.Lock()
+	defer a.Lock.Unlock()
+	a.UpdateCallCount++
+	return nil
+}
+
+func (a *TestActuator) Exists(*v1alpha1.Machine) (bool, error) {
+	defer func() {
+		if a.BlockOnExists {
+			<-a.unblock
+		}
+	}()
+
+	a.Lock.Lock()
+	defer a.Lock.Unlock()
+	a.ExistsCallCount++
+	return a.ExistsValue, nil
+}
+
+func NewTestActuator() *TestActuator {
+	ta := new(TestActuator)
+	ta.unblock = make(chan string)
+	return ta
+}
+
+func (a *TestActuator) Unblock() {
+	close(a.unblock)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR add multiple workers for machine controller loop which make machine reconciliation loops in parallel for different machine resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #101 

**Special notes for your reviewer**:
This is a migration for PR: https://github.com/kubernetes/kube-deploy/pull/681. Thanks for Martin's explanation for how client-go queue works, it makes the solution much simpler! The ultimate goal is still to incorpate it into apiserver-builder so that other controller can benefit from it too.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
