### PR TITLE
Add .gitignore for gcp-deployer files.

### DIFF
--- a/gcp-deployer/.gitignore
+++ b/gcp-deployer/.gitignore
@@ -1,0 +1,2 @@
+gcp-deployer
+machines.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the developer generated machines.yaml and gcp-deployer binary to .gitignore. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
