### PR TITLE
Add the ability to configure disk size and type for GCP clusters (Kube Deploy 638)

### DIFF
--- a/cloud/google/cmd/gce-machine-controller/app/controller.go
+++ b/cloud/google/cmd/gce-machine-controller/app/controller.go
@@ -60,8 +60,12 @@ func StartMachineController(server *options.MachineControllerServer, shutdown <-
 	if err != nil {
 		glog.Fatalf("Could not create config watch: %v", err)
 	}
-
-	actuator, err := google.NewMachineActuator(server.KubeadmToken, client.ClusterV1alpha1().Machines(corev1.NamespaceDefault), configWatch)
+	params := google.MachineActuatorParams{
+		KubeadmToken:             server.KubeadmToken,
+		MachineClient:            client.ClusterV1alpha1().Machines(corev1.NamespaceDefault),
+		MachineSetupConfigGetter: configWatch,
+	}
+	actuator, err := google.NewMachineActuator(params)
 	if err != nil {
 		glog.Fatalf("Could not create Google machine actuator: %v", err)
 	}

--- a/cloud/google/gceproviderconfig/types.go
+++ b/cloud/google/gceproviderconfig/types.go
@@ -29,5 +29,15 @@ type GCEProviderConfig struct {
 	MachineType string `json:"machineType"`
 
 	// The name of the OS to be installed on the machine.
-	OS string `json:"os"`
+	OS    string `json:"os"`
+	Disks []Disk `json:"disks"`
+}
+
+type Disk struct {
+	InitializeParams DiskInitializeParams `json:"initializeParams"`
+}
+
+type DiskInitializeParams struct {
+	DiskSizeGb int64  `json:"diskSizeGb"`
+	DiskType   string `json:"diskType"`
 }

--- a/cloud/google/gceproviderconfig/v1alpha1/types.go
+++ b/cloud/google/gceproviderconfig/v1alpha1/types.go
@@ -29,5 +29,15 @@ type GCEProviderConfig struct {
 	MachineType string `json:"machineType"`
 
 	// The name of the OS to be installed on the machine.
-	OS string `json:"os"`
+	OS    string `json:"os"`
+	Disks []Disk `json:"disks"`
+}
+
+type Disk struct {
+	InitializeParams DiskInitializeParams `json:"initializeParams"`
+}
+
+type DiskInitializeParams struct {
+	DiskSizeGb int64  `json:"diskSizeGb"`
+	DiskType   string `json:"diskType"`
 }

--- a/cloud/google/machineactuator.go
+++ b/cloud/google/machineactuator.go
@@ -34,11 +34,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	"regexp"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/cluster-api/cloud/google/clients"
 	gceconfigv1 "sigs.k8s.io/cluster-api/cloud/google/gceproviderconfig/v1alpha1"
@@ -81,6 +81,7 @@ type GCEClientComputeService interface {
 
 type GCEClient struct {
 	computeService           GCEClientComputeService
+	gceProviderConfigCodec   *gceconfigv1.GCEProviderConfigCodec
 	scheme                   *runtime.Scheme
 	codecFactory             *serializer.CodecFactory
 	kubeadmToken             string
@@ -89,25 +90,29 @@ type GCEClient struct {
 	machineSetupConfigGetter GCEClientMachineSetupConfigGetter
 }
 
+type MachineActuatorParams struct {
+	ComputeService           GCEClientComputeService
+	KubeadmToken             string
+	MachineClient            client.MachineInterface
+	MachineSetupConfigGetter GCEClientMachineSetupConfigGetter
+}
+
 const (
 	gceTimeout   = time.Minute * 10
 	gceWaitSleep = time.Second * 5
 )
 
-func NewMachineActuator(kubeadmToken string, machineClient client.MachineInterface, machineSetupConfigGetter GCEClientMachineSetupConfigGetter) (*GCEClient, error) {
-	// The default GCP client expects the environment variable
-	// GOOGLE_APPLICATION_CREDENTIALS to point to a file with service credentials.
-	client, err := google.DefaultClient(context.TODO(), compute.ComputeScope)
+func NewMachineActuator(params MachineActuatorParams) (*GCEClient, error) {
+	computeService, err := getOrNewComputeService(params)
 	if err != nil {
 		return nil, err
 	}
 
-	computeService, err := clients.NewComputeService(client)
+	scheme, err := gceconfigv1.NewScheme()
 	if err != nil {
 		return nil, err
 	}
-
-	scheme, codecFactory, err := gceconfigv1.NewSchemeAndCodecs()
+	codec, err := gceconfigv1.NewCodec()
 	if err != nil {
 		return nil, err
 	}
@@ -126,16 +131,16 @@ func NewMachineActuator(kubeadmToken string, machineClient client.MachineInterfa
 	}
 
 	return &GCEClient{
-		computeService: computeService,
-		scheme:         scheme,
-		codecFactory:   codecFactory,
-		kubeadmToken:   kubeadmToken,
+		computeService:         computeService,
+		scheme:                 scheme,
+		gceProviderConfigCodec: codec,
+		kubeadmToken:           params.KubeadmToken,
 		sshCreds: SshCreds{
 			privateKeyPath: privateKeyPath,
 			user:           user,
 		},
-		machineClient:            machineClient,
-		machineSetupConfigGetter: machineSetupConfigGetter,
+		machineClient:            params.MachineClient,
+		machineSetupConfigGetter: params.MachineSetupConfigGetter,
 	}, nil
 }
 
@@ -257,7 +262,6 @@ func (gce *GCEClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 	name := machine.ObjectMeta.Name
 	project := config.Project
 	zone := config.Zone
-	diskSize := int64(30)
 
 	if instance == nil {
 		labels := map[string]string{}
@@ -292,16 +296,7 @@ func (gce *GCEClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 					},
 				},
 			},
-			Disks: []*compute.AttachedDisk{
-				{
-					AutoDelete: true,
-					Boot:       true,
-					InitializeParams: &compute.AttachedDiskInitializeParams{
-						SourceImage: imagePath,
-						DiskSizeGb:  diskSize,
-					},
-				},
-			},
+			Disks: newDisks(config, zone, imagePath, int64(30)),
 			Metadata: &compute.Metadata{
 				Items: metadataItems,
 			},
@@ -565,16 +560,7 @@ func (gce *GCEClient) instanceIfExists(machine *clusterv1.Machine) (*compute.Ins
 }
 
 func (gce *GCEClient) providerconfig(providerConfig clusterv1.ProviderConfig) (*gceconfigv1.GCEProviderConfig, error) {
-	obj, gvk, err := gce.codecFactory.UniversalDecoder(gceconfigv1.SchemeGroupVersion).Decode(providerConfig.Value.Raw, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("decoding failure: %v", err)
-	}
-	config, ok := obj.(*gceconfigv1.GCEProviderConfig)
-	if !ok {
-		return nil, fmt.Errorf("failure to cast to gce; type: %v", gvk)
-	}
-
-	return config, nil
+	return gce.gceProviderConfigCodec.DecodeFromProviderConfig(providerConfig)
 }
 
 func (gce *GCEClient) waitForOperation(c *gceconfigv1.GCEProviderConfig, op *compute.Operation) error {
@@ -715,12 +701,53 @@ func (gce *GCEClient) getImagePath(img string) (imagePath string) {
 	return defaultImg
 }
 
+func newDisks(config *gceconfigv1.GCEProviderConfig, zone string, imagePath string, minDiskSizeGb int64) []*compute.AttachedDisk {
+	var disks []*compute.AttachedDisk
+	for idx, disk := range config.Disks {
+		diskSizeGb := disk.InitializeParams.DiskSizeGb
+		d := compute.AttachedDisk{
+			AutoDelete: true,
+			InitializeParams: &compute.AttachedDiskInitializeParams{
+				DiskSizeGb:  diskSizeGb,
+				DiskType:    fmt.Sprintf("zones/%s/diskTypes/%s", zone, disk.InitializeParams.DiskType),
+			},
+		}
+		if idx == 0 {
+			d.InitializeParams.SourceImage = imagePath
+			d.Boot = true
+			if diskSizeGb < minDiskSizeGb {
+				glog.Info("increasing disk size to %v gb, the supplied disk size of %v gb is below the minimum", minDiskSizeGb, diskSizeGb)
+				d.InitializeParams.DiskSizeGb = minDiskSizeGb
+			}
+		}
+		disks = append(disks, &d)
+	}
+	return disks
+}
+
 // Just a temporary hack to grab a single range from the config.
 func getSubnet(netRange clusterv1.NetworkRanges) string {
 	if len(netRange.CIDRBlocks) == 0 {
 		return ""
 	}
 	return netRange.CIDRBlocks[0]
+}
+
+func getOrNewComputeService(params MachineActuatorParams) (GCEClientComputeService, error) {
+	if params.ComputeService != nil {
+		return params.ComputeService, nil
+	}
+	// The default GCP client expects the environment variable
+	// GOOGLE_APPLICATION_CREDENTIALS to point to a file with service credentials.
+	client, err := google.DefaultClient(context.TODO(), compute.ComputeScope)
+	if err != nil {
+		return nil, err
+	}
+	computeService, err := clients.NewComputeService(client)
+	if err != nil {
+		return nil, err
+	}
+	return computeService, nil
 }
 
 // TODO: We need to change this when we create dedicated service account for apiserver/controller

--- a/cloud/google/machineactuator_test.go
+++ b/cloud/google/machineactuator_test.go
@@ -1,0 +1,305 @@
+package google_test
+
+import (
+	compute "google.golang.org/api/compute/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/cloud/google"
+	gceconfigv1 "sigs.k8s.io/cluster-api/cloud/google/gceproviderconfig/v1alpha1"
+	"sigs.k8s.io/cluster-api/cloud/google/machinesetup"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"strings"
+	"testing"
+)
+
+type GCEClientComputeServiceMock struct {
+	mockImagesGet           func(project string, image string) (*compute.Image, error)
+	mockImagesGetFromFamily func(project string, family string) (*compute.Image, error)
+	mockInstancesDelete     func(project string, zone string, targetInstance string) (*compute.Operation, error)
+	mockInstancesGet        func(project string, zone string, instance string) (*compute.Instance, error)
+	mockInstancesInsert     func(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
+	mockZoneOperationsGet   func(project string, zone string, operation string) (*compute.Operation, error)
+}
+
+func (c *GCEClientComputeServiceMock) ImagesGet(project string, image string) (*compute.Image, error) {
+	if c.mockImagesGet == nil {
+		return nil, nil
+	}
+	return c.mockImagesGet(project, image)
+}
+
+func (c *GCEClientComputeServiceMock) ImagesGetFromFamily(project string, family string) (*compute.Image, error) {
+	if c.mockImagesGetFromFamily == nil {
+		return nil, nil
+	}
+	return c.mockImagesGetFromFamily(project, family)
+}
+
+func (c *GCEClientComputeServiceMock) InstancesDelete(project string, zone string, targetInstance string) (*compute.Operation, error) {
+	if c.mockInstancesDelete == nil {
+		return nil, nil
+	}
+	return c.mockInstancesDelete(project, zone, targetInstance)
+}
+
+func (c *GCEClientComputeServiceMock) InstancesGet(project string, zone string, instance string) (*compute.Instance, error) {
+	if c.mockInstancesGet == nil {
+		return nil, nil
+	}
+	return c.mockInstancesGet(project, zone, instance)
+}
+
+func (c *GCEClientComputeServiceMock) InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+	if c.mockInstancesInsert == nil {
+		return nil, nil
+	}
+	return c.mockInstancesInsert(project, zone, instance)
+}
+
+func (c *GCEClientComputeServiceMock) ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error) {
+	if c.mockZoneOperationsGet == nil {
+		return nil, nil
+	}
+	return c.mockZoneOperationsGet(project, zone, operation)
+}
+
+type GCEClientMachineSetupConfigMock struct {
+	mockGetYaml     func() (string, error)
+	mockGetImage    func(params *machinesetup.ConfigParams) (string, error)
+	mockGetMetadata func(params *machinesetup.ConfigParams) (machinesetup.Metadata, error)
+}
+
+func (m *GCEClientMachineSetupConfigMock) GetYaml() (string, error) {
+	if m.mockGetYaml == nil {
+		return "", nil
+	}
+	return m.mockGetYaml()
+}
+
+func (m *GCEClientMachineSetupConfigMock) GetImage(params *machinesetup.ConfigParams) (string, error) {
+	if m.mockGetYaml == nil {
+		return "", nil
+	}
+	return m.mockGetImage(params)
+}
+
+func (m *GCEClientMachineSetupConfigMock) GetMetadata(params *machinesetup.ConfigParams) (machinesetup.Metadata, error) {
+	if m.mockGetYaml == nil {
+		return machinesetup.Metadata{}, nil
+	}
+	return m.mockGetMetadata(params)
+}
+
+func TestNoDisks(t *testing.T) {
+	config := newGCEProviderConfigFixture()
+	config.Disks = make([]gceconfigv1.Disk, 0)
+	receivedInstance, computeServiceMock := newInsertInstanceCapturingMock()
+	createCluster(t, config, computeServiceMock)
+	checkInstanceValues(t, receivedInstance, 0)
+}
+
+func TestMinimumSizeShouldBeEnforced(t *testing.T) {
+	config := newGCEProviderConfigFixture()
+	config.Disks = []gceconfigv1.Disk{
+		{
+			InitializeParams: gceconfigv1.DiskInitializeParams{
+				DiskType:   "pd-ssd",
+				DiskSizeGb: int64(6),
+			},
+		},
+	}
+	receivedInstance, computeServiceMock := newInsertInstanceCapturingMock()
+	createCluster(t, config, computeServiceMock)
+	checkInstanceValues(t, receivedInstance, 1)
+	checkDiskValues(t, receivedInstance.Disks[0], true, 30, "pd-ssd", "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710")
+}
+
+func TestOneDisk(t *testing.T) {
+	config := newGCEProviderConfigFixture()
+	config.Disks = []gceconfigv1.Disk{
+		{
+			InitializeParams: gceconfigv1.DiskInitializeParams{
+				DiskType:   "pd-ssd",
+				DiskSizeGb: 37,
+			},
+		},
+	}
+	receivedInstance, computeServiceMock := newInsertInstanceCapturingMock()
+	createCluster(t, config, computeServiceMock)
+	checkInstanceValues(t, receivedInstance, 1)
+	checkDiskValues(t, receivedInstance.Disks[0], true, 37, "pd-ssd", "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710")
+}
+
+func TestTwoDisks(t *testing.T) {
+	config := newGCEProviderConfigFixture()
+	config.Disks = []gceconfigv1.Disk{
+		{
+			InitializeParams: gceconfigv1.DiskInitializeParams{
+				DiskType:   "pd-ssd",
+				DiskSizeGb: 32,
+			},
+		},
+		{
+			InitializeParams: gceconfigv1.DiskInitializeParams{
+				DiskType:   "pd-standard",
+				DiskSizeGb: 45,
+			},
+		},
+	}
+	receivedInstance, computeServiceMock := newInsertInstanceCapturingMock()
+	createCluster(t, config, computeServiceMock)
+	checkInstanceValues(t, receivedInstance, 2)
+	checkDiskValues(t, receivedInstance.Disks[0], true, 32, "pd-ssd", "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710")
+	checkDiskValues(t, receivedInstance.Disks[1], false, 45, "pd-standard", "")
+}
+
+func checkInstanceValues(t *testing.T, instance *compute.Instance, diskCount int) {
+	t.Helper()
+	if instance == nil {
+		t.Error("expected a valid instance")
+	}
+	if len(instance.Disks) != diskCount {
+		t.Errorf("invalid disk count: expected '%v' got '%v'", diskCount, len(instance.Disks))
+	}
+}
+
+func checkDiskValues(t *testing.T, disk *compute.AttachedDisk, boot bool, sizeGb int64, diskType string, image string) {
+	t.Helper()
+	if disk.Boot != boot {
+		t.Errorf("invalid disk.Boot value: expected '%v' got '%v'", boot, disk.Boot)
+	}
+	if disk.InitializeParams.DiskSizeGb != sizeGb {
+		t.Errorf("invalid disk size: expected '%v' got '%v'", sizeGb, disk.InitializeParams.DiskSizeGb)
+	}
+	if !strings.Contains(disk.InitializeParams.DiskType, diskType) {
+		t.Errorf("invalid disk type '%v': expected it to contain '%v'", disk.InitializeParams.DiskType, diskType)
+	}
+	if disk.InitializeParams.SourceImage != image {
+		t.Errorf("invalid image: expected '%v' got '%v'", image, disk.InitializeParams.SourceImage)
+	}
+}
+
+func createCluster(t *testing.T, config gceconfigv1.GCEProviderConfig, computeServiceMock *GCEClientComputeServiceMock) {
+	cluster := newDefaultClusterFixture()
+	machine := newMachine(t, config)
+	configWatch := newMachineSetupConfigWatcher()
+	params := google.MachineActuatorParams{
+		ComputeService:           computeServiceMock,
+		MachineSetupConfigGetter: configWatch,
+	}
+	gce, err := google.NewMachineActuator(params)
+	if err != nil {
+		t.Fatalf("unable to create machine actuator: %v", err)
+	}
+	err = gce.Create(cluster, machine)
+	if err != nil {
+		t.Fatalf("unable to create cluster: %v", err)
+	}
+}
+
+func newInsertInstanceCapturingMock() (*compute.Instance, *GCEClientComputeServiceMock) {
+	var receivedInstance compute.Instance
+	computeServiceMock := GCEClientComputeServiceMock{
+		mockInstancesInsert: func(project string, zone string, instance *compute.Instance) (*compute.Operation, error) {
+			receivedInstance = *instance
+			return &compute.Operation{
+				Status: "DONE",
+			}, nil
+		},
+	}
+	return &receivedInstance, &computeServiceMock
+}
+
+func newMachineSetupConfigMock() *GCEClientMachineSetupConfigMock {
+	return &GCEClientMachineSetupConfigMock{
+		mockGetYaml: func() (string, error) {
+			return "", nil
+		},
+		mockGetMetadata: func(params *machinesetup.ConfigParams) (machinesetup.Metadata, error) {
+			metadata := machinesetup.Metadata{}
+			return metadata, nil
+		},
+		mockGetImage: func(params *machinesetup.ConfigParams) (string, error) {
+			return "image-name", nil
+		},
+	}
+}
+
+type TestMachineSetupConfigWatcher struct {
+	machineSetupConfigMock *GCEClientMachineSetupConfigMock
+}
+
+func newMachineSetupConfigWatcher() *TestMachineSetupConfigWatcher {
+	return &TestMachineSetupConfigWatcher{
+		machineSetupConfigMock: newMachineSetupConfigMock(),
+	}
+}
+
+func (cw *TestMachineSetupConfigWatcher) GetMachineSetupConfig() (machinesetup.MachineSetupConfig, error) {
+	return cw.machineSetupConfigMock, nil
+}
+
+func newMachine(t *testing.T, gceProviderConfig gceconfigv1.GCEProviderConfig) *v1alpha1.Machine {
+	gceProviderConfigCodec, err := gceconfigv1.NewCodec()
+	if err != nil {
+		t.Fatalf("unable to create GCE provider config codec: %v", err)
+	}
+	providerConfig, err := gceProviderConfigCodec.EncodeToProviderConfig(&gceProviderConfig)
+	if err != nil {
+		t.Fatalf("unable to encode provider config: %v", err)
+	}
+	return &v1alpha1.Machine{
+		Spec: v1alpha1.MachineSpec{
+			ProviderConfig: *providerConfig,
+			Versions: v1alpha1.MachineVersionInfo{
+				Kubelet:      "1.9.4",
+				ControlPlane: "1.9.4",
+				ContainerRuntime: v1alpha1.ContainerRuntimeInfo{
+					Name:    "docker",
+					Version: "1.12.0",
+				},
+			},
+			Roles: []common.MachineRole{
+				common.MasterRole,
+			},
+		},
+	}
+}
+
+func newGCEProviderConfigFixture() gceconfigv1.GCEProviderConfig {
+	return gceconfigv1.GCEProviderConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "gceproviderconfig/v1alpha1",
+			Kind:       "GCEProviderConfig",
+		},
+		Project: "project-name-2000",
+		Zone:    "us-west5-f",
+		OS:      "os-name",
+		Disks:   make([]gceconfigv1.Disk, 0),
+	}
+}
+
+func newDefaultClusterFixture() *v1alpha1.Cluster {
+	return &v1alpha1.Cluster{
+		TypeMeta: v1.TypeMeta{
+			Kind: "Cluster",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "cluster-test",
+		},
+		Spec: v1alpha1.ClusterSpec{
+			ClusterNetwork: v1alpha1.ClusterNetworkingConfig{
+				Services: v1alpha1.NetworkRanges{
+					CIDRBlocks: []string{
+						"10.96.0.0/12",
+					},
+				},
+				Pods: v1alpha1.NetworkRanges{
+					CIDRBlocks: []string{
+						"192.168.0.0/16",
+					},
+				},
+			},
+		},
+	}
+}

--- a/cloud/google/machinesetup/config_types_test.go
+++ b/cloud/google/machinesetup/config_types_test.go
@@ -90,7 +90,7 @@ func TestParseMachineSetupYaml(t *testing.T) {
 				t.Errorf("An error was not received as expected.")
 			}
 			if validConfigs != nil {
-				t.Errorf("ValidConfigs should be nil, got %v", validConfigs)
+				t.Errorf("GetMachineSetupConfigs should be nil, got %v", validConfigs)
 			}
 		}
 		if !table.expectedErr {
@@ -98,7 +98,7 @@ func TestParseMachineSetupYaml(t *testing.T) {
 				t.Errorf("Got unexpected error: %s", err)
 			}
 			if validConfigs == nil {
-				t.Errorf("ValidConfigs should have been parsed, but was nil")
+				t.Errorf("GetMachineSetupConfigs should have been parsed, but was nil")
 			}
 		}
 	}

--- a/gcp-deployer/deploy/deploy.go
+++ b/gcp-deployer/deploy/deploy.go
@@ -61,7 +61,11 @@ func NewDeployer(provider string, kubeConfigPath string, machineSetupConfigPath 
 	if err != nil {
 		glog.Exit(fmt.Sprintf("Could not create config watch: %v\n", err))
 	}
-	ma, err := google.NewMachineActuator(token, nil, configWatch)
+	params := google.MachineActuatorParams{
+		MachineSetupConfigGetter: configWatch,
+		KubeadmToken:             token,
+	}
+	ma, err := google.NewMachineActuator(params)
 	if err != nil {
 		glog.Exit(err)
 	}

--- a/gcp-deployer/machines.yaml.template
+++ b/gcp-deployer/machines.yaml.template
@@ -14,6 +14,10 @@ items:
         zone: "$ZONE"
         machineType: "n1-standard-2"
         os: "ubuntu-1604-lts"
+        disks:
+        - initializeParams:
+            diskSizeGb: 30
+            diskType: "pd-standard"
     versions:
       kubelet: 1.9.4
       controlPlane: 1.9.4
@@ -37,6 +41,10 @@ items:
         zone: "$ZONE"
         machineType: "n1-standard-1"
         os: "ubuntu-1604-lts"
+        disks:
+        - initializeParams:
+            diskSizeGb: 30
+            diskType: "pd-standard"
     versions:
       kubelet: 1.9.4
       containerRuntime:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables administrators using gcp-deployer to customize the size and types of the disks in their clusters.

**Special notes for your reviewer**:
Please ignore the first commit, a5bcde4c7236788249e27f9a535c9b073efa2abc (Refactor GCEClient: wrap compute.Service in an interface for mocking GCP compute), it is a prerequisite commit and has its own PR open here: https://github.com/kubernetes-sigs/cluster-api/pull/73.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the ability to customize the size and type of disks of GCP compute nodes.
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
