### PR TITLE
Change references from the 'kubernetes/kube-deploy' to 'kubernetes-si…

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To learn more, see the [Cluster API KEP][cluster-api-kep].
 * `kubectl` is required, see [here](http://kubernetes.io/docs/user-guide/prereqs/).
 
 ### Prototype implementations
-* [gcp](https://github.com/kubernetes/kube-deploy/blob/master/cluster-api/gcp-deployer/README.md)
+* [gcp](gcp-deployer/README.md)
 
 ## How to use the API
 

--- a/gcp-deployer/CONTRIBUTING.md
+++ b/gcp-deployer/CONTRIBUTING.md
@@ -70,7 +70,7 @@ If you need to rebuild container image for the extension APIServer and Controlle
 
 ## Fetch Source Code
 
-1. Fork [kube-deploy repo](https://github.com/kubernetes/kube-deploy). If it's your first time forking, please take a look at [GitHub Repo instructions](https://help.github.com/articles/fork-a-repo/). The general [Kubernetes GitHub workflow](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md) is helpful here too if you're getting started.
+1. Fork [cluster-api repo](https://github.com/kubernetes-sigs/cluster-api/). If it's your first time forking, please take a look at [GitHub Repo instructions](https://help.github.com/articles/fork-a-repo/). The general [Kubernetes GitHub workflow](https://github.com/kubernetes/community/blob/master/contributors/guide/github-workflow.md) is helpful here too if you're getting started.
 
 2. Clone Repo Locally
 ```bash

--- a/gcp-deployer/README.md
+++ b/gcp-deployer/README.md
@@ -1,12 +1,12 @@
 # Cluster API GCP Prototype
 
-The Cluster API GCP prototype implements the [Cluster API](https://github.com/kubernetes/kube-deploy/blob/master/cluster-api/README.md) for GCP.
+The Cluster API GCP prototype implements the [Cluster API](../README.md) for GCP.
 
 ## Getting Started
 
 ### Prerequisites
 
-Follow the steps listed at [CONTRIBUTING.md](https://github.com/kubernetes/kube-deploy/blob/master/cluster-api/gcp-deployer/CONTRIBUTING.md) to:
+Follow the steps listed at [CONTRIBUTING.md](CONTRIBUTING.md) to:
 1. Build the `gcp-deployer` tool
 2. Generate base `machines.yaml` file configured for your GCP project
 3. Login with gcloud `gcloud auth application-default login`
@@ -52,7 +52,7 @@ You can add machines to your cluster using `kubectl apply` or `kubectl create`.
 
 By default, your cluster will initially be running Kubernetes version 1.7.4. You
 can upgrade the control plane or nodes using `kubectl edit` or you can run the
-[upgrader tool](https://github.com/kubernetes/kube-deploy/tree/master/cluster-api/tools/upgrader)
+[upgrader tool](../tools/upgrader)
 to upgrade your entire cluster with a single command.
 
 #### Node repair
@@ -67,7 +67,7 @@ $ gcloud compute ssh $node --zone us-central1-f
 ```
 
 Then run the [node repair
-tool]( https://github.com/kubernetes/kube-deploy/tree/master/cluster-api/tools/repair)
+tool]( ../tools/repair)
 to find the broken node (using the dry run flag) and fix it.
 
 


### PR DESCRIPTION
…gs/cluster-api/'
**What this PR does / why we need it**:
This fixes a few more broken links from with in the new repository.

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
