### PR TITLE
Add owner reference for machines created via machineset controller

### DIFF
--- a/pkg/controller/machineset/controller.go
+++ b/pkg/controller/machineset/controller.go
@@ -28,6 +28,9 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/controller/sharedinformers"
 )
 
+// controllerKind contains the schema.GroupVersionKind for this controller type.
+var controllerKind = v1alpha1.SchemeGroupVersion.WithKind("MachineSet")
+
 // +controller:group=cluster,version=v1alpha1,kind=MachineSet,resource=machinesets
 type MachineSetControllerImpl struct {
 	builders.DefaultControllerFns
@@ -74,6 +77,13 @@ func (c *MachineSetControllerImpl) Get(namespace, name string) (*v1alpha1.Machin
 
 // syncReplicas essentially scales machine resources up and down.
 func (c *MachineSetControllerImpl) syncReplicas(machineSet *v1alpha1.MachineSet, machines []*v1alpha1.Machine) error {
+	// Take ownership of machines if not already owned.
+	for _, machine := range machines {
+		if shouldAdopt(machineSet, machine) {
+			c.adoptOrphan(machineSet, machine)
+		}
+	}
+
 	var result error
 	currentMachineCount := int32(len(machines))
 	desiredReplicas := *machineSet.Spec.Replicas
@@ -123,6 +133,7 @@ func (c *MachineSetControllerImpl) createMachine(machineSet *v1alpha1.MachineSet
 		Spec:       machineSet.Spec.Template.Spec,
 	}
 	machine.ObjectMeta.GenerateName = fmt.Sprintf("%s-", machineSet.Name)
+	machine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(machineSet, controllerKind),}
 
 	return machine, nil
 }
@@ -138,4 +149,40 @@ func (c *MachineSetControllerImpl) getMachines(machineSet *v1alpha1.MachineSet) 
 		return nil, err
 	}
 	return filteredMachines, err
+}
+
+func shouldAdopt(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machine) bool {
+	// Do nothing if the machine is being deleted.
+	if !machine.ObjectMeta.DeletionTimestamp.IsZero() {
+		glog.V(2).Infof("Skipping machine (%v), as it is being deleted.", machine.Name)
+		return false
+	}
+
+	// Machine owned by another controller.
+	if metav1.GetControllerOf(machine) != nil && !metav1.IsControlledBy(machine, machineSet) {
+		glog.V(2).Infof("Skipping machine (%v), as it is owned by someone else.", machine.Name)
+		return false
+	}
+
+	// Machine we control.
+	if metav1.IsControlledBy(machine, machineSet) {
+		return false
+	}
+
+	return true
+}
+
+func (c *MachineSetControllerImpl) adoptOrphan(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machine) {
+	// Add controller reference.
+	ownerRefs := machine.ObjectMeta.GetOwnerReferences()
+	if ownerRefs == nil {
+		ownerRefs = []metav1.OwnerReference{}
+	}
+
+	newRef := *metav1.NewControllerRef(machineSet, controllerKind)
+	ownerRefs = append(ownerRefs, newRef)
+	machine.ObjectMeta.SetOwnerReferences(ownerRefs)
+	if _, err := c.machineClient.ClusterV1alpha1().Machines(machineSet.Namespace).Update(machine); err != nil {
+		glog.Warningf("Failed to update machine owner reference. %v", err)
+	}
 }

--- a/pkg/controller/machineset/controller.go
+++ b/pkg/controller/machineset/controller.go
@@ -160,7 +160,7 @@ func shouldAdopt(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machine) boo
 
 	// Machine owned by another controller.
 	if metav1.GetControllerOf(machine) != nil && !metav1.IsControlledBy(machine, machineSet) {
-		glog.V(2).Infof("Skipping machine (%v), as it is owned by someone else.", machine.Name)
+		glog.Warningf.Infof("Skipping machine (%v), as it is owned by someone else.", machine.Name)
 		return false
 	}
 

--- a/pkg/controller/machineset/controller.go
+++ b/pkg/controller/machineset/controller.go
@@ -160,7 +160,7 @@ func shouldAdopt(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machine) boo
 
 	// Machine owned by another controller.
 	if metav1.GetControllerOf(machine) != nil && !metav1.IsControlledBy(machine, machineSet) {
-		glog.Warningf.Infof("Skipping machine (%v), as it is owned by someone else.", machine.Name)
+		glog.Warningf("Skipping machine (%v), as it is owned by someone else.", machine.Name)
 		return false
 	}
 


### PR DESCRIPTION

**What this PR does / why we need it**:
This adds owner reference to machine objects created through the machineset controller. This allows garbage collection and cascading deletion to work.
Deleting the machineset will trigger the corresponding machines to be deleted.

Continuation from https://github.com/kubernetes/kube-deploy/pull/667


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #41 

**Special notes for your reviewer**:

**Release note**:

@kubernetes/kube-deploy-reviewers
