### PR TITLE
Prototype of named machines for vsphere

### DIFF
--- a/cloud/terraform/cmd/terraform-machine-controller/Dockerfile
+++ b/cloud/terraform/cmd/terraform-machine-controller/Dockerfile
@@ -23,7 +23,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api/cloud/terraform/cmd/terraform-machine-controller
 
 # Final container
-FROM golang:alpine3.7
+FROM alpine:3.7
 RUN apk --no-cache add --update ca-certificates bash openssh
 RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 RUN echo "UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config

--- a/cloud/terraform/cmd/terraform-machine-controller/Dockerfile
+++ b/cloud/terraform/cmd/terraform-machine-controller/Dockerfile
@@ -23,7 +23,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api/cloud/terraform/cmd/terraform-machine-controller
 
 # Final container
-FROM alpine3.7
+FROM golang:alpine3.7
 RUN apk --no-cache add --update ca-certificates bash openssh
 RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 RUN echo "UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config

--- a/cloud/terraform/cmd/terraform-machine-controller/main.go
+++ b/cloud/terraform/cmd/terraform-machine-controller/main.go
@@ -31,7 +31,8 @@ import (
 )
 
 var (
-	kubeadmToken = pflag.String("token", "", "Kubeadm token to use to join new machines")
+	kubeadmToken      = pflag.String("token", "", "Kubeadm token to use to join new machines")
+	namedMachinesPath = pflag.String("namedmachines", "", "path to named machines yaml file")
 )
 
 func init() {
@@ -54,7 +55,7 @@ func main() {
 		glog.Fatalf("Could not create client for talking to the apiserver: %v", err)
 	}
 
-	actuator, err := terraform.NewMachineActuator(*kubeadmToken, client.ClusterV1alpha1().Machines(corev1.NamespaceDefault))
+	actuator, err := terraform.NewMachineActuator(*kubeadmToken, client.ClusterV1alpha1().Machines(corev1.NamespaceDefault), *namedMachinesPath)
 	if err != nil {
 		glog.Fatalf("Could not create Terraform machine actuator: %v", err)
 	}

--- a/cloud/terraform/config/configtemplate.go
+++ b/cloud/terraform/config/configtemplate.go
@@ -139,11 +139,14 @@ spec:
             mountPath: /root/.terraform.d
           - name: sshkeys
             mountPath: /root/.ssh
+          - name: named-machines
+            mountPath: /etc/named-machines
         command:
         - "./terraform-machine-controller"
         args:
         - --kubeconfig=/etc/kubernetes/admin.conf
         - --token={{ .Token }}
+        - --namedmachines=/etc/named-machines/vsphere_named_machines.yaml
         resources:
           requests:
             cpu: 200m
@@ -167,6 +170,9 @@ spec:
       - name: sshkeys
         hostPath:
           path: /home/ubuntu/.ssh
+      - name: named-machines
+        configMap:
+          name: named-machines
 ---
 apiVersion: apps/v1beta1
 kind: StatefulSet

--- a/cloud/terraform/namedmachines/namedmachines.go
+++ b/cloud/terraform/namedmachines/namedmachines.go
@@ -23,7 +23,6 @@ import (
 )
 
 // Config Watch holds the path to the named machines yaml file.
-// This is used during bootstrap when the apiserver does not yet exist.
 type ConfigWatch struct {
 	path string
 }

--- a/cloud/terraform/namedmachines/namedmachines.go
+++ b/cloud/terraform/namedmachines/namedmachines.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namedmachines
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/ghodss/yaml"
+)
+
+// Config Watch holds the path to the named machines yaml file.
+// This is used during bootstrap when the apiserver does not yet exist.
+type ConfigWatch struct {
+	path string
+}
+
+// A single named machine.
+type NamedMachine struct {
+	MachineName string
+	MachineHcl  string
+}
+
+// A list of named machines.
+type NamedMachinesItems struct {
+	Items []NamedMachine `json:"items"`
+}
+
+// All named machines defined in yaml.
+type NamedMachines struct {
+	namedMachinesItems *NamedMachinesItems
+}
+
+func NewConfigWatch(path string) (*ConfigWatch, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, err
+	}
+	return &ConfigWatch{path: path}, nil
+}
+
+// Returns all named machines for ConfigWatch.
+func (cw *ConfigWatch) NamedMachines() (*NamedMachines, error) {
+	file, err := os.Open(cw.path)
+	if err != nil {
+		return nil, err
+	}
+	return parseNamedMachinesYaml(file)
+}
+
+func parseNamedMachinesYaml(reader io.Reader) (*NamedMachines, error) {
+	bytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	items := &NamedMachinesItems{}
+	err = yaml.Unmarshal(bytes, items)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NamedMachines{items}, nil
+}
+
+func (nm *NamedMachines) GetYaml() (string, error) {
+	bytes, err := yaml.Marshal(nm.namedMachinesItems)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+// Returns a NamedMachine that matches the passed name.
+func (nm *NamedMachines) MatchMachine(machineName string) (*NamedMachine, error) {
+	for _, namedMachine := range nm.namedMachinesItems.Items {
+		if namedMachine.MachineName == machineName {
+			return &namedMachine, nil
+		}
+	}
+	return nil, fmt.Errorf("could not find a machine with name %s", machineName)
+}

--- a/cloud/terraform/pods.go
+++ b/cloud/terraform/pods.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/cluster-api/cloud/terraform/config"
 )
 
-var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.1"
+var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.2"
 var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.1"
 var machineControllerImage = "gcr.io/karangoel-gke-1/terraform-machine-controller:0.0.1-dev"
 

--- a/cloud/terraform/terraformproviderconfig/types.go
+++ b/cloud/terraform/terraformproviderconfig/types.go
@@ -24,9 +24,8 @@ import (
 type TerraformProviderConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// Contents of a terrafrom config file.
-	// This is the HCL config encoded as a string.
-	TerraformConfig string `json:"terraformConfig"`
+	// Name of the machine that's registered in the NamedMachines ConfigMap.
+	TerraformMachine string `json:"terraformMachine"`
 	// List of contents of terraform variables used.
 	// HCL variables encoded as string.
 	TerraformVariables []string `json:"terraformVariables"`

--- a/cloud/terraform/terraformproviderconfig/v1alpha1/types.go
+++ b/cloud/terraform/terraformproviderconfig/v1alpha1/types.go
@@ -24,8 +24,8 @@ import (
 type TerraformProviderConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// Contents of a terrafrom config file.
-	TerraformConfig string `json:"terraformConfig"`
+	// Name of the machine that's registered in the NamedMachines ConfigMap.
+	TerraformMachine string `json:"terraformMachine"`
 	// List of contents of terraform variable files used.
 	TerraformVariables []string `json:"terraformVariables"`
 }

--- a/tf-deployer/cluster.yaml
+++ b/tf-deployer/cluster.yaml
@@ -11,5 +11,5 @@ spec:
         serviceDomain: "cluster.local"
     providerConfig:
       value:
-        apiVersion: "terraformproviderconfig/v1alpha1",
+        apiVersion: "terraformproviderconfig/v1alpha1"
         kind: "TerraformProviderConfig"

--- a/tf-deployer/cmd/add.go
+++ b/tf-deployer/cmd/add.go
@@ -52,7 +52,7 @@ func RunAdd(ao *AddOptions) error {
 		return err
 	}
 
-	d := deploy.NewDeployer(kubeConfig)
+	d := deploy.NewDeployer(kubeConfig, "")
 
 	return d.AddNodes(machines)
 }

--- a/tf-deployer/cmd/delete.go
+++ b/tf-deployer/cmd/delete.go
@@ -34,7 +34,7 @@ var deleteCmd = &cobra.Command{
 }
 
 func RunDelete() error {
-	d := deploy.NewDeployer(kubeConfig)
+	d := deploy.NewDeployer(kubeConfig, "")
 	return d.DeleteCluster()
 }
 

--- a/tf-deployer/deploy/deploy.go
+++ b/tf-deployer/deploy/deploy.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/golang/glog"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/cluster-api/cloud/terraform"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
@@ -30,16 +31,17 @@ import (
 )
 
 type deployer struct {
-	token           string
-	configPath      string
-	machineDeployer machineDeployer
-	client          v1alpha1.ClusterV1alpha1Interface
-	clientSet       clientset.Interface
+	token               string
+	configPath          string
+	machineDeployer     machineDeployer
+	client              v1alpha1.ClusterV1alpha1Interface
+	clientSet           clientset.Interface
+	kubernetesClientSet kubernetes.Clientset
 }
 
 // NewDeployer returns a cloud provider specific deployer and
 // sets kubeconfig path for the cluster to be deployed
-func NewDeployer(configPath string) *deployer {
+func NewDeployer(configPath, namedMachinesPath string) *deployer {
 	token := util.RandomToken()
 	if configPath == "" {
 		configPath = os.Getenv("KUBECONFIG")
@@ -53,7 +55,7 @@ func NewDeployer(configPath string) *deployer {
 			glog.Exit(fmt.Sprintf("Failed to set Kubeconfig path err %v\n", err))
 		}
 	}
-	ma, err := terraform.NewMachineActuator(token, nil)
+	ma, err := terraform.NewMachineActuator(token, nil, namedMachinesPath)
 	if err != nil {
 		glog.Exit(err)
 	}

--- a/tf-deployer/deploy/machinedeployer.go
+++ b/tf-deployer/deploy/machinedeployer.go
@@ -1,15 +1,16 @@
 package deploy
 
 import (
-clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-"sigs.k8s.io/cluster-api/pkg/controller/machine"
+	"k8s.io/client-go/kubernetes"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/pkg/controller/machine"
 )
 
 // Provider-specific machine logic the deployer needs.
 type machineDeployer interface {
 	machine.Actuator
 	GetIP(machine *clusterv1.Machine) (string, error)
-	SetupRemoteMaster(machine *clusterv1.Machine) (error)
+	SetupRemoteMaster(machine *clusterv1.Machine) error
 	GetKubeConfig(master *clusterv1.Machine) (string, error)
 
 	// Create and start the machine controller. The list of initial
@@ -17,6 +18,6 @@ type machineDeployer interface {
 	// are provided in case the function wants to refer to them (and their
 	// ProviderConfigs) to know how to configure the machine controller.
 	// Not idempotent.
-	CreateMachineController(cluster *clusterv1.Cluster, initialMachines []*clusterv1.Machine) error
+	CreateMachineController(cluster *clusterv1.Cluster, initialMachines []*clusterv1.Machine, clientSet kubernetes.Clientset) error
 	PostDelete(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) error
 }

--- a/tf-deployer/machines.yaml.template
+++ b/tf-deployer/machines.yaml.template
@@ -6,17 +6,16 @@ items:
     labels:
       set: master
   spec:
-    providerConfig: >
-      {
-        "apiVersion": "terraformproviderconfig/v1alpha1",
-        "kind": "TerraformProviderConfig",
-        "terraformConfig": "",
-        "terraformVariables": [
+    providerConfig:
+      value:
+        apiVersion: "terraformproviderconfig/v1alpha1"
+        kind: "TerraformProviderConfig"
+        terraformMachine: "standard-master"
+        terraformVariables: [
           "user = \"foo\"",
           "password = \"bar\"",
           "vsphere_server = \"192.169.1.1\"",
         ]
-      }
     versions:
       kubelet: 1.8.3
       controlPlane: 1.8.3
@@ -32,17 +31,16 @@ items:
     labels:
       set: master
   spec:
-    providerConfig: >
-      {
-        "apiVersion": "terraformproviderconfig/v1alpha1",
-        "kind": "TerraformProviderConfig",
-        "terraformConfig": "",
-        "terraformVariables": [
+    providerConfig:
+      value:
+        apiVersion: "terraformproviderconfig/v1alpha1"
+        kind: "TerraformProviderConfig"
+        terraformMachine: "standard-node"
+        terraformVariables: [
           "user = \"foo\"",
           "password = \"bar\"",
           "vsphere_server = \"192.169.1.1\"",
         ]
-      }
     versions:
       kubelet: 1.8.3
       controlPlane: 1.8.3

--- a/tf-deployer/vsphere_named_machines.yaml
+++ b/tf-deployer/vsphere_named_machines.yaml
@@ -1,0 +1,279 @@
+items:
+- machineName: standard-master
+  machineHcl: |
+    variable "user" {}
+    variable "password" {}
+    variable "vsphere_server" {}
+
+    variable "datacenter" {}
+    variable "datastore" {}
+    variable "resource_pool" {}
+    variable "network" {}
+    variable "num_cpus" {}
+    variable "memory" {}
+    variable "vm_template" {}
+    variable "disk_label" {}
+    variable "disk_size" {}
+
+    // The domain name to set up each virtual machine as.
+    variable "virtual_machine_domain" {}
+
+    // The network address for the virtual machines, in the form of 10.0.0.0/24.
+    variable "virtual_machine_network_address" {}
+
+    // The last octect that serves as the start of the IP addresses for the virtual
+    // machines. Given the default value here of 100, if the network address is
+    // 10.0.0.0/24, the 3 virtual machines will be assigned addresses 10.0.0.100,
+    // 10.0.0.101, and 10.0.0.102.
+    variable "virtual_machine_ip_address_start" {}
+
+    // The default gateway for the network the virtual machines reside in.
+    variable "virtual_machine_gateway" {}
+
+    // The DNS servers for the network the virtual machines reside in.
+    variable "virtual_machine_dns_servers" {
+      type = "list"
+    }
+
+    variable "vm_name" {
+      type = "string"
+    }
+
+    provider "vsphere" {
+      user           = "${var.user}"
+      password       = "${var.password}"
+      vsphere_server = "${var.vsphere_server}"
+
+      # if you have a self-signed cert
+      allow_unverified_ssl = true
+    }
+
+    data "vsphere_datacenter" "dc" {
+      name = "${var.datacenter}"
+    }
+
+    data "vsphere_datastore" "datastore" {
+      name          = "${var.datastore}"
+      datacenter_id = "${data.vsphere_datacenter.dc.id}"
+    }
+
+    data "vsphere_resource_pool" "pool" {
+      name          = "${var.resource_pool}"
+      datacenter_id = "${data.vsphere_datacenter.dc.id}"
+    }
+
+    data "vsphere_network" "network" {
+      name          = "${var.network}"
+      datacenter_id = "${data.vsphere_datacenter.dc.id}"
+    }
+
+    data "vsphere_virtual_machine" "template" {
+      name          = "${var.vm_template}"
+      datacenter_id = "${data.vsphere_datacenter.dc.id}"
+    }
+
+    resource "vsphere_virtual_machine" "master" {
+      name             = "${var.vm_name}"
+      resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+      datastore_id     = "${data.vsphere_datastore.datastore.id}"
+
+      num_cpus         = "${var.num_cpus}"
+      memory           = "${var.memory}"
+      guest_id         = "${data.vsphere_virtual_machine.template.guest_id}"
+      enable_disk_uuid = "true"
+
+      scsi_type = "${data.vsphere_virtual_machine.template.scsi_type}"
+
+      network_interface {
+        network_id   = "${data.vsphere_network.network.id}"
+        adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+      }
+
+      disk {
+        label            = "${var.disk_label}"
+        size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+        eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
+        thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+      }
+
+      clone {
+        template_uuid = "${data.vsphere_virtual_machine.template.id}"
+
+        customize {
+          linux_options {
+            host_name = "${var.vm_name}"
+            domain    = "${var.virtual_machine_domain}"
+          }
+
+          network_interface {
+            ipv4_address = "${cidrhost(var.virtual_machine_network_address, var.virtual_machine_ip_address_start + count.index)}"
+            ipv4_netmask = "${element(split("/", var.virtual_machine_network_address), 1)}"
+          }
+
+          ipv4_gateway    = "${var.virtual_machine_gateway}"
+          dns_suffix_list = ["${var.virtual_machine_domain}"]
+          dns_server_list = ["${var.virtual_machine_dns_servers}"]
+        }
+      }
+
+      provisioner "file" {
+        source      = "/tmp/machine-startup.sh"
+        destination = "/tmp/master.sh"
+
+        connection {
+          type        = "ssh"
+          private_key = "${file("~/.ssh/vsphere_tmp")}"
+          user        = "ubuntu"
+          agent       = true
+        }
+      }
+
+      // Copy the private key over so the controller is able to ssh into the nodes.
+      provisioner "file" {
+        source      = "~/.ssh/vsphere_tmp"
+        destination = "~/.ssh/id_rsa"
+
+        connection {
+          type        = "ssh"
+          private_key = "${file("~/.ssh/vsphere_tmp")}"
+          user        = "ubuntu"
+          agent       = true
+        }
+      }
+
+      // NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE
+      // Use username/password here because the machine controller will be running
+      // on a different machine and the image does not have that machines private key.
+      // So either I use user/pw or I inject my SSH private key in the controller.
+      provisioner "remote-exec" {
+        inline = [
+          "echo Making startup script executable...",
+          "chmod +x /tmp/master.sh",
+          "echo Running startup script...",
+          "echo '${var.password}' | sudo -S /tmp/master.sh",
+
+          // This is required for the controller to be able to read the conf file.
+          "echo '${var.password}' | sudo -S chown ubuntu:ubuntu /etc/kubernetes/admin.conf",
+        ]
+
+        connection {
+          type        = "ssh"
+          private_key = "${file("~/.ssh/vsphere_tmp")}"
+          user        = "ubuntu"
+          agent       = true
+        }
+      }
+    }
+- machineName: standard-node
+  machineHcl: |
+    variable "user" {}
+    variable "password" {}
+    variable "vsphere_server" {}
+    variable "datacenter" {}
+    variable "datastore" {}
+    variable "resource_pool" {}
+    variable "network" {}
+    variable "num_cpus" {}
+    variable "memory" {}
+    variable "vm_template" {}
+    variable "disk_label" {}
+    variable "disk_size" {}
+    variable "virtual_machine_domain" {}
+    variable "virtual_machine_network_address" {}
+    variable "virtual_machine_ip_address_start" {}
+    variable "virtual_machine_gateway" {}
+    variable "virtual_machine_dns_servers" {
+      type = "list"
+      }
+    variable "vm_name" {}
+    provider "vsphere" {
+      user           = "${var.user}"
+      password       = "${var.password}"
+      vsphere_server = "${var.vsphere_server}"
+      # if you have a self-signed cert
+      allow_unverified_ssl = true
+      }
+    data "vsphere_datacenter" "dc" {
+      name = "${var.datacenter}"
+      }
+    data "vsphere_datastore" "datastore" {
+      name          = "${var.datastore}"
+      datacenter_id = "${data.vsphere_datacenter.dc.id}"
+      }
+    data "vsphere_resource_pool" "pool" {
+      name          = "${var.resource_pool}"
+      datacenter_id = "${data.vsphere_datacenter.dc.id}"
+      }
+    data "vsphere_network" "network" {
+      name          = "${var.network}"
+      datacenter_id = "${data.vsphere_datacenter.dc.id}"
+      }
+    data "vsphere_virtual_machine" "template" {
+      name          = "${var.vm_template}"
+      datacenter_id = "${data.vsphere_datacenter.dc.id}"
+      }
+    resource "vsphere_virtual_machine" "nodes" {
+      name             = "${var.vm_name}"
+      resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
+      datastore_id     = "${data.vsphere_datastore.datastore.id}"
+      num_cpus         = "${var.num_cpus}"
+      memory           = "${var.memory}"
+      guest_id         = "${data.vsphere_virtual_machine.template.guest_id}"
+      enable_disk_uuid = "true"
+      scsi_type = "${data.vsphere_virtual_machine.template.scsi_type}"
+      network_interface {
+        network_id   = "${data.vsphere_network.network.id}"
+        adapter_type = "${data.vsphere_virtual_machine.template.network_interface_types[0]}"
+      }
+      disk {
+        label            = "${var.disk_label}"
+        size             = "${data.vsphere_virtual_machine.template.disks.0.size}"
+        eagerly_scrub    = "${data.vsphere_virtual_machine.template.disks.0.eagerly_scrub}"
+        thin_provisioned = "${data.vsphere_virtual_machine.template.disks.0.thin_provisioned}"
+      }
+      clone {
+        template_uuid = "${data.vsphere_virtual_machine.template.id}"
+        customize {
+          linux_options {
+            host_name = "${var.vm_name}"
+            domain    = "${var.virtual_machine_domain}"
+          }
+          network_interface {
+            ipv4_address = "${cidrhost(var.virtual_machine_network_address, var.virtual_machine_ip_address_start + count.index + 1)}"
+            ipv4_netmask = "${element(split("/", var.virtual_machine_network_address), 1)}"
+          }
+          ipv4_gateway    = "${var.virtual_machine_gateway}"
+          dns_suffix_list = ["${var.virtual_machine_domain}"]
+          dns_server_list = ["${var.virtual_machine_dns_servers}"]
+        }
+      }
+
+      // Need to make sure that the private key exists at ~/.ssh/id_rsa
+      provisioner "file" {
+        source      = "/tmp/machine-startup.sh"
+        destination = "/tmp/node.sh"
+        connection {
+          type        = "ssh"
+          private_key = "${file("~/.ssh/id_rsa")}"
+          user        = "ubuntu"
+        }
+      }
+      // NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE
+      // Use username/password here because the machine controller will be running
+      // on a different machine and the image does not have that machines private key.
+      // So either I use user/pw or I inject my SSH private key in the controller.
+      provisioner "remote-exec" {
+        inline = [
+          "echo Making startup script executable...",
+          "ls -al /tmp/",
+          "chmod +x /tmp/node.sh",
+          "echo Running startup script...",
+          "echo '${var.password}' | sudo -S /tmp/node.sh",
+        ]
+        connection {
+          type        = "ssh"
+          private_key = "${file("~/.ssh/id_rsa")}"
+          user        = "ubuntu"
+        }
+      }
+    }


### PR DESCRIPTION
Current implementation for vSphere is to let the customer specify the raw Terraform config (in Hashicorp Config Language) in the Machine spec yaml, in the providerConfig section. While this works, it does not make the spec maintainable (the user needs to encoded back and forth between the HCL and the string).

Effectively, we create some “standard”, templated VMs that represent the configuration of machines in HCL. The customer then only needs to reference one of those and provide variables to complete the VM config. The definition of the machines is configured using a ConfigMap.

## General design

A file named `vsphere_named_machines.yaml` contains a map of machine name and the HCL config for that machine. This file is mounted in the master as a ConfigMap (similar to #104). The controller reads from this map and tries to find a machine by name referenced in `machines.yaml`.

I have tested this change in a vSphere lab.

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
