### PR TITLE
Correct the network configuration to allow the master to come up successfully

### DIFF
--- a/gcp-deployer/machines.yaml.template
+++ b/gcp-deployer/machines.yaml.template
@@ -13,7 +13,7 @@ items:
         project: "$GCLOUD_PROJECT"
         zone: "$ZONE"
         machineType: "n1-standard-2"
-        os: "ubuntu-1604-lts"
+        os: "ubuntu-1710-weave"
     versions:
       kubelet: 1.9.4
       controlPlane: 1.9.4
@@ -36,7 +36,7 @@ items:
         project: "$GCLOUD_PROJECT"
         zone: "$ZONE"
         machineType: "n1-standard-1"
-        os: "ubuntu-1604-lts"
+        os: "ubuntu-1710-weave"
     versions:
       kubelet: 1.9.4
       containerRuntime:


### PR DESCRIPTION
**What this PR does / why we need it**:
The current OS version does not allow the master to successfully come up due to network issues. Switching it to ubuntu-1710-weave corrects this.
This stems from PR #104 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

@kubernetes/kube-deploy-reviewers
