### PR TITLE
Add boilerplate for clusterctl

### DIFF
--- a/clusterctl/.gitignore
+++ b/clusterctl/.gitignore
@@ -1,0 +1,1 @@
+clusterctl

--- a/clusterctl/CONTRIBUTING.md
+++ b/clusterctl/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+# Contributing Guidelines

--- a/clusterctl/README.md
+++ b/clusterctl/README.md
@@ -1,0 +1,61 @@
+# clusterctl
+
+`clusterctl` is the SIG-cluster-lifecycle sponsored tool that implements the Cluster API.
+
+Read the [experience doc here](https://docs.google.com/document/d/1-sYb3EdkRga49nULH1kSwuQFf1o6GvAw_POrsNo5d8c/edit#).
+
+## Getting Started
+
+### Prerequisites
+
+Follow the steps listed at [CONTRIBUTING.md](https://github.com/kubernetes/kube-deploy/blob/master/cluster-api/clusterctl/CONTRIBUTING.md) to:
+
+1. Build the `clusterctl` tool 
+3. Create a `machines.yaml` file configured for your cluster. See the provided template for an example.
+
+### Limitation
+
+
+### Creating a cluster
+
+**NOT YET SUPPORTED!**
+
+In order to create a cluster with the Cluster API, the user will supply these:
+
+* Cluster which defines the spec common across the entire cluster.
+* Machine which defines the spec of a machine. Further abstractions of
+MachineSets and MachineClass and MachineDeployments are supported as well.
+* Extras (optional) spec extras.yaml file with specs of all controllers
+(ConfigMaps) that the cluster needs. This would include the Machine controller,
+MachineSet controller, Machine Setup ConfigMap etc. Note that this is not a new API
+object. There will be defaults running. This will make the tool easily pluggage
+(change the controller spec) instead of changing the tool or mucking with flags.
+
+1. Create a cluster: `./clusterctl create cluster -c cluster.yaml -m machines.yaml -e extras.yaml`
+
+### Interacting with your cluster
+
+Once you have created a cluster, you can interact with the cluster and machine
+resources using kubectl:
+
+```
+$ kubectl get clusters
+$ kubectl get machines
+$ kubectl get machines -o yaml
+```
+
+#### Scaling your cluster
+
+**NOT YET SUPPORTED!**
+
+#### Upgrading your cluster
+
+**NOT YET SUPPORTED!**
+
+#### Node repair
+
+**NOT YET SUPPORTED!**
+
+### Deleting a cluster
+
+**NOT YET SUPPORTED!**

--- a/clusterctl/README.md
+++ b/clusterctl/README.md
@@ -8,30 +8,22 @@ Read the [experience doc here](https://docs.google.com/document/d/1-sYb3EdkRga49
 
 ### Prerequisites
 
-Follow the steps listed at [CONTRIBUTING.md](https://github.com/kubernetes/kube-deploy/blob/master/cluster-api/clusterctl/CONTRIBUTING.md) to:
+Follow the steps listed at [CONTRIBUTING.md](https://github.com/kubernetes-sigs/cluster-api/blob/master/cluster-api/clusterctl/CONTRIBUTING.md) to:
 
-1. Build the `clusterctl` tool 
-3. Create a `machines.yaml` file configured for your cluster. See the provided template for an example.
+1. Build the `clusterctl` tool
 
-### Limitation
+```
+go build
+```
+ 
+2. Create a `machines.yaml` file configured for your cluster. See the provided template for an example.
+
+### Limitations
 
 
 ### Creating a cluster
 
 **NOT YET SUPPORTED!**
-
-In order to create a cluster with the Cluster API, the user will supply these:
-
-* Cluster which defines the spec common across the entire cluster.
-* Machine which defines the spec of a machine. Further abstractions of
-MachineSets and MachineClass and MachineDeployments are supported as well.
-* Extras (optional) spec extras.yaml file with specs of all controllers
-(ConfigMaps) that the cluster needs. This would include the Machine controller,
-MachineSet controller, Machine Setup ConfigMap etc. Note that this is not a new API
-object. There will be defaults running. This will make the tool easily pluggage
-(change the controller spec) instead of changing the tool or mucking with flags.
-
-1. Create a cluster: `./clusterctl create cluster -c cluster.yaml -m machines.yaml -e extras.yaml`
 
 ### Interacting with your cluster
 

--- a/clusterctl/cmd/create.go
+++ b/clusterctl/cmd/create.go
@@ -17,55 +17,16 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
-
-	//"fmt"
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/cluster-api/errors"
 )
-
-type CreateOptions struct {
-	Cluster string
-	Machine string
-	Extras  string
-}
-
-var co = &CreateOptions{}
 
 var createCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create kubernetes cluster",
-	Long:  `Create a kubernetes cluster with one command`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if co.Cluster == "" {
-			glog.Error("Please provide yaml file for cluster definition.")
-			cmd.Help()
-			os.Exit(1)
-		}
-		if co.Machine == "" {
-			glog.Error("Please provide yaml file for machine definition.")
-			cmd.Help()
-			os.Exit(1)
-		}
-		if co.Extras == "" {
-			glog.Error("Please provide a yaml file for extra definitions (controllers, Addons etc).")
-			cmd.Help()
-			os.Exit(1)
-		}
-		if err := RunCreate(co); err != nil {
-			glog.Exit(err)
-		}
-	},
+	Short: "Create a cluster API resource",
+	Long:  `Create a cluster API resource with one command`,
 }
 
-func RunCreate(co *CreateOptions) error {
-	return errors.NotImplementedError
-}
 func init() {
-	createCmd.Flags().StringVarP(&co.Cluster, "cluster", "c", "", "cluster yaml file")
-	createCmd.Flags().StringVarP(&co.Machine, "machines", "m", "", "machine yaml file")
-	createCmd.Flags().StringVarP(&co.Extras, "extras", "e", "", "extras yaml file")
-
+	createCmd.AddCommand(NewCmdCreateCluster())
 	RootCmd.AddCommand(createCmd)
 }

--- a/clusterctl/cmd/create.go
+++ b/clusterctl/cmd/create.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+
+	//"fmt"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/errors"
+)
+
+type CreateOptions struct {
+	Cluster string
+	Machine string
+	Extras  string
+}
+
+var co = &CreateOptions{}
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create kubernetes cluster",
+	Long:  `Create a kubernetes cluster with one command`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if co.Cluster == "" {
+			glog.Error("Please provide yaml file for cluster definition.")
+			cmd.Help()
+			os.Exit(1)
+		}
+		if co.Machine == "" {
+			glog.Error("Please provide yaml file for machine definition.")
+			cmd.Help()
+			os.Exit(1)
+		}
+		if co.Extras == "" {
+			glog.Error("Please provide a yaml file for extra definitions (controllers, Addons etc).")
+			cmd.Help()
+			os.Exit(1)
+		}
+		if err := RunCreate(co); err != nil {
+			glog.Exit(err)
+		}
+	},
+}
+
+func RunCreate(co *CreateOptions) error {
+	return errors.NotImplementedError
+}
+func init() {
+	createCmd.Flags().StringVarP(&co.Cluster, "cluster", "c", "", "cluster yaml file")
+	createCmd.Flags().StringVarP(&co.Machine, "machines", "m", "", "machine yaml file")
+	createCmd.Flags().StringVarP(&co.Extras, "extras", "e", "", "extras yaml file")
+
+	RootCmd.AddCommand(createCmd)
+}

--- a/clusterctl/cmd/create_cluster.go
+++ b/clusterctl/cmd/create_cluster.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/errors"
+)
+
+type CreateOptions struct {
+	Cluster string
+	Machine string
+	ProviderComponents  string
+}
+
+var co = &CreateOptions{}
+
+func NewCmdCreateCluster() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cluster",
+		Short: "Create kubernetes cluster",
+		Long:  `Create a kubernetes cluster with one command`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if co.Cluster == "" {
+				exitWithHelp(cmd, "Please provide yaml file for cluster definition.")
+			}
+			if co.Machine == "" {
+				exitWithHelp(cmd, "Please provide yaml file for machine definition.")
+			}
+			if co.ProviderComponents == "" {
+				exitWithHelp(cmd, "Please provide a yaml file for provider component definitions.")
+			}
+			if err := RunCreate(co); err != nil {
+				glog.Exit(err)
+			}
+		},
+	}
+
+	return cmd
+}
+
+func RunCreate(co *CreateOptions) error {
+	return errors.NotImplementedError
+}

--- a/clusterctl/cmd/delete.go
+++ b/clusterctl/cmd/delete.go
@@ -17,40 +17,16 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"os"
-	"sigs.k8s.io/cluster-api/errors"
 )
-
-type DeleteOptions struct {
-	ClusterName string
-}
-
-var do = &DeleteOptions{}
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "Delete kubernetes cluster",
-	Long:  `Delete a kubernetes cluster with one command`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if do.ClusterName == "" {
-			glog.Error("Please provide cluster name.")
-			cmd.Help()
-			os.Exit(1)
-		}
-		if err := RunDelete(); err != nil {
-			glog.Exit(err)
-		}
-	},
-}
-
-func RunDelete() error {
-	return errors.NotImplementedError
+	Short: "Delete a cluster API resource",
+	Long:  `Delete a cluster API resource with one command`,
 }
 
 func init() {
-	deleteCmd.Flags().StringVarP(&do.ClusterName, "cluster-name", "n", "", "cluster name")
-
+	deleteCmd.AddCommand(NewCmdDeleteCluster())
 	RootCmd.AddCommand(deleteCmd)
 }

--- a/clusterctl/cmd/delete.go
+++ b/clusterctl/cmd/delete.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"os"
+	"sigs.k8s.io/cluster-api/errors"
+)
+
+type DeleteOptions struct {
+	ClusterName string
+}
+
+var do = &DeleteOptions{}
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete kubernetes cluster",
+	Long:  `Delete a kubernetes cluster with one command`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if do.ClusterName == "" {
+			glog.Error("Please provide cluster name.")
+			cmd.Help()
+			os.Exit(1)
+		}
+		if err := RunDelete(); err != nil {
+			glog.Exit(err)
+		}
+	},
+}
+
+func RunDelete() error {
+	return errors.NotImplementedError
+}
+
+func init() {
+	deleteCmd.Flags().StringVarP(&do.ClusterName, "cluster-name", "n", "", "cluster name")
+
+	RootCmd.AddCommand(deleteCmd)
+}

--- a/clusterctl/cmd/delete_cluster.go
+++ b/clusterctl/cmd/delete_cluster.go
@@ -17,41 +17,35 @@ limitations under the License.
 package cmd
 
 import (
-	"os"
-
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/cluster-api/errors"
 )
 
-type RegisterOptions struct {
-	RegistryEndpoint string
+type DeleteOptions struct {
+	ClusterName string
 }
 
-var ro = &RegisterOptions{}
+var do = &DeleteOptions{}
 
-var registerCmd = &cobra.Command{
-	Use:   "register",
-	Short: "Register a kubernetes cluster with a Cluster Registry",
-	Long:  `Register a kubernetes cluster with a Cluster Registry`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if ro.RegistryEndpoint == "" {
-			glog.Error("Please provide yaml file for cluster definition.")
-			cmd.Help()
-			os.Exit(1)
-		}
-		if err := RunRegister(ro); err != nil {
-			glog.Exit(err)
-		}
-	},
+func NewCmdDeleteCluster() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete kubernetes cluster",
+		Long:  `Delete a kubernetes cluster with one command`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if do.ClusterName == "" {
+				exitWithHelp(cmd, "Please provide cluster name.")
+			}
+			if err := RunDelete(); err != nil {
+				glog.Exit(err)
+			}
+		},
+	}
+
+	return cmd
 }
 
-func RunRegister(co *RegisterOptions) error {
+func RunDelete() error {
 	return errors.NotImplementedError
-}
-
-func init() {
-	registerCmd.Flags().StringVarP(&ro.RegistryEndpoint, "registry-endpoint", "r", "", "registry endpoint")
-
-	RootCmd.AddCommand(registerCmd)
 }

--- a/clusterctl/cmd/register.go
+++ b/clusterctl/cmd/register.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/errors"
+)
+
+type RegisterOptions struct {
+	RegistryEndpoint string
+}
+
+var ro = &RegisterOptions{}
+
+var registerCmd = &cobra.Command{
+	Use:   "register",
+	Short: "Register a kubernetes cluster with a Cluster Registry",
+	Long:  `Register a kubernetes cluster with a Cluster Registry`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if ro.RegistryEndpoint == "" {
+			glog.Error("Please provide yaml file for cluster definition.")
+			cmd.Help()
+			os.Exit(1)
+		}
+		if err := RunRegister(ro); err != nil {
+			glog.Exit(err)
+		}
+	},
+}
+
+func RunRegister(co *RegisterOptions) error {
+	return errors.NotImplementedError
+}
+
+func init() {
+	registerCmd.Flags().StringVarP(&ro.RegistryEndpoint, "registry-endpoint", "r", "", "registry endpoint")
+
+	RootCmd.AddCommand(registerCmd)
+}

--- a/clusterctl/cmd/root.go
+++ b/clusterctl/cmd/root.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"flag"
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"k8s.io/apiserver/pkg/util/logs"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+var RootCmd = &cobra.Command{
+	Use:   "clusterctl",
+	Short: "cluster management",
+	Long:  `Simple kubernetes cluster management`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Do Stuff Here
+		cmd.Help()
+	},
+}
+
+var (
+	kubeConfig string
+)
+
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		glog.Exit(err)
+	}
+}
+
+func parseClusterYaml(file string) (*clusterv1.Cluster, error) {
+	bytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster := &clusterv1.Cluster{}
+	err = yaml.Unmarshal(bytes, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
+}
+
+func parseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
+	bytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	machines := &clusterv1.MachineList{}
+	err = yaml.Unmarshal(bytes, &machines)
+	if err != nil {
+		return nil, err
+	}
+
+	return util.MachineP(machines.Items), nil
+}
+
+func init() {
+	RootCmd.PersistentFlags().StringVarP(&kubeConfig, "kubeconfig", "k", "", "location for the kubernetes config file. If not provided, $HOME/.kube/config is used")
+	flag.CommandLine.Parse([]string{})
+	logs.InitLogs()
+}

--- a/clusterctl/cmd/root.go
+++ b/clusterctl/cmd/root.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"flag"
 	"io/ioutil"
+	"os"
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
@@ -37,10 +38,6 @@ var RootCmd = &cobra.Command{
 		cmd.Help()
 	},
 }
-
-var (
-	kubeConfig string
-)
 
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
@@ -78,8 +75,13 @@ func parseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
 	return util.MachineP(machines.Items), nil
 }
 
+func exitWithHelp(cmd *cobra.Command, err string) {
+	glog.Error(err)
+	cmd.Help()
+	os.Exit(1)
+}
+
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&kubeConfig, "kubeconfig", "k", "", "location for the kubernetes config file. If not provided, $HOME/.kube/config is used")
 	flag.CommandLine.Parse([]string{})
 	logs.InitLogs()
 }

--- a/clusterctl/main.go
+++ b/clusterctl/main.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "sigs.k8s.io/cluster-api/clusterctl/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/errors/deployer.go
+++ b/errors/deployer.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+)
+
+var NotImplementedError = fmt.Errorf("not implemented")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Adds boilerplate for clusterctl tool.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #112

**Special notes for your reviewer**: This is only a boilerplate to unblock anyone who wants to start working on adding features.

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
