### PR TITLE
Bump version for controller-manager to pick up #108

### DIFF
--- a/cloud/google/pods.go
+++ b/cloud/google/pods.go
@@ -33,7 +33,7 @@ import (
 )
 
 var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.2"
-var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.1"
+var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.2"
 var machineControllerImage = "gcr.io/k8s-cluster-api/gce-machine-controller:0.0.6"
 
 func init() {

--- a/cloud/terraform/pods.go
+++ b/cloud/terraform/pods.go
@@ -33,7 +33,7 @@ import (
 )
 
 var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.2"
-var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.1"
+var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.2"
 var machineControllerImage = "gcr.io/karangoel-gke-1/terraform-machine-controller:0.0.1-dev"
 
 func init() {

--- a/cmd/controller-manager/Makefile
+++ b/cmd/controller-manager/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = controller-manager
-TAG = 0.0.1
+TAG = 0.0.2
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../..


### PR DESCRIPTION
**What this PR does / why we need it**:
The pull is for machine/machineset owner refs


<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
