### PR TITLE
Remove docker version check

### DIFF
--- a/cloud/google/machineactuator.go
+++ b/cloud/google/machineactuator.go
@@ -675,9 +675,6 @@ func (gce *GCEClient) validateMachine(machine *clusterv1.Machine, config *gcecon
 	if machine.Spec.Versions.ContainerRuntime.Name != "docker" {
 		return apierrors.InvalidMachineConfiguration("Only docker is supported")
 	}
-	if machine.Spec.Versions.ContainerRuntime.Version != "1.12.0" {
-		return apierrors.InvalidMachineConfiguration("Only docker 1.12.0 is supported")
-	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes checks that asserts docker version 1.12.0 for gcp deployer

**Release note**:
```release-note
NONE
```

@jessicaochen 
