### PR TITLE
Bump for #133

### DIFF
--- a/cloud/google/cmd/gce-machine-controller/Makefile
+++ b/cloud/google/cmd/gce-machine-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = gce-machine-controller
-TAG = 0.0.6
+TAG = 0.0.7
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/google/pods.go
+++ b/cloud/google/pods.go
@@ -32,9 +32,9 @@ import (
 	"sigs.k8s.io/cluster-api/cloud/google/config"
 )
 
-var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.2"
+var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.3"
 var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.2"
-var machineControllerImage = "gcr.io/k8s-cluster-api/gce-machine-controller:0.0.6"
+var machineControllerImage = "gcr.io/k8s-cluster-api/gce-machine-controller:0.0.7"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/cmd/apiserver/Makefile
+++ b/cmd/apiserver/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = cluster-apiserver
-TAG = 0.0.2
+TAG = 0.0.3
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../..


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Bump GCE images to include up to and including https://github.com/kubernetes-sigs/cluster-api/pull/133

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
