### PR TITLE
Gce cloud provider

### DIFF
--- a/cloud/google/metadata.go
+++ b/cloud/google/metadata.go
@@ -39,11 +39,12 @@ type metadataParams struct {
 	MasterEndpoint string
 }
 
-func nodeMetadata(token string, cluster *clusterv1.Cluster, machine *clusterv1.Machine, metadata *machinesetup.Metadata) (map[string]string, error) {
+func nodeMetadata(token string, cluster *clusterv1.Cluster, machine *clusterv1.Machine, project string, metadata *machinesetup.Metadata) (map[string]string, error) {
 	params := metadataParams{
 		Token:          token,
 		Cluster:        cluster,
 		Machine:        machine,
+		Project:        project,
 		Metadata:       metadata,
 		PodCIDR:        getSubnet(cluster.Spec.ClusterNetwork.Pods),
 		ServiceCIDR:    getSubnet(cluster.Spec.ClusterNetwork.Services),
@@ -124,4 +125,10 @@ MACHINE={{ .Machine.ObjectMeta.Name }}
 CLUSTER_DNS_DOMAIN={{ .Cluster.Spec.ClusterNetwork.ServiceDomain }}
 POD_CIDR={{ .PodCIDR }}
 SERVICE_CIDER={{ .ServiceCIDR }}
+# Environment variables for GCE cloud config
+PROJECT={{ .Project }}
+NETWORK=default
+SUBNETWORK=kubernetes
+CLUSTER_NAME={{ .Cluster.Name }}
+NODE_TAG="$CLUSTER_NAME-worker"
 `

--- a/cloud/google/serviceaccount.go
+++ b/cloud/google/serviceaccount.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,47 +23,71 @@ import (
 )
 
 const (
-	ServiceAccountPrefix    = "k8s-machine-controller-"
-	ServiceAccount          = "service-account"
-	MachineControllerSecret = "machine-controller-credential"
+	MasterNodeServiceAccountPrefix        = "k8s-master"
+	WorkerNodeServiceAccountPrefix        = "k8s-worker"
+	MachineControllerServiceAccountPrefix = "k8s-machine-controller"
+	MachineControllerSecret               = "machine-controller-credential"
+	ClusterAnnotationPrefix               = "service-account-"
 )
+
+var (
+	MasterNodeRoles = []string{
+		"compute.instanceAdmin",
+		"compute.networkAdmin",
+		"compute.securityAdmin",
+		"compute.viewer",
+		"iam.serviceAccountUser",
+		"storage.admin",
+		"storage.objectViewer",
+	}
+	WorkerNodeRoles = []string{
+		"compute.instanceAdmin",
+		"compute.networkAdmin",
+		"compute.securityAdmin",
+	}
+	MachineControllerRoles = []string{
+		"compute.instanceAdmin.v1",
+		"iam.serviceAccountActor",
+	}
+)
+
+// Returns the email address of the service account that should be used
+// as the default service account for this machine
+func (gce *GCEClient) GetDefaultServiceAccountForMachine(cluster *clusterv1.Cluster, machine *clusterv1.Machine) string {
+	if util.IsMaster(machine) {
+		return cluster.ObjectMeta.Annotations[ClusterAnnotationPrefix+MasterNodeServiceAccountPrefix]
+	} else {
+		return cluster.ObjectMeta.Annotations[ClusterAnnotationPrefix+WorkerNodeServiceAccountPrefix]
+	}
+}
+
+// Creates a GCP service account for the master node, granted permissions
+// that allow the control plane to provision disks and networking resources
+func (gce *GCEClient) CreateMasterNodeServiceAccount(cluster *clusterv1.Cluster, initialMachines []*clusterv1.Machine) error {
+	_, _, err := gce.createServiceAccount(MasterNodeServiceAccountPrefix, MasterNodeRoles, cluster, initialMachines)
+
+	return err
+}
+
+// Creates a GCP service account for the worker node
+func (gce *GCEClient) CreateWorkerNodeServiceAccount(cluster *clusterv1.Cluster, initialMachines []*clusterv1.Machine) error {
+	_, _, err := gce.createServiceAccount(WorkerNodeServiceAccountPrefix, WorkerNodeRoles, cluster, initialMachines)
+
+	return err
+}
 
 // Creates a GCP service account for the machine controller, granted the
 // permissions to manage compute instances, and stores its credentials as a
 // Kubernetes secret.
 func (gce *GCEClient) CreateMachineControllerServiceAccount(cluster *clusterv1.Cluster, initialMachines []*clusterv1.Machine) error {
-
-	if len(initialMachines) == 0 {
-		return fmt.Errorf("machine count is zero, cannot create service a/c")
-	}
-
-	// TODO: use real go bindings
-	// Figure out what projects the service account needs permission to.
-	projects, err := gce.getProjects(initialMachines)
+	accountId, project, err := gce.createServiceAccount(MachineControllerServiceAccountPrefix, MachineControllerRoles, cluster, initialMachines)
 	if err != nil {
 		return err
 	}
 
-	// The service account needs to be created in a single project, so just
-	// use the first one, but grant permission to all projects in the list.
-	project := projects[0]
-	accountId := ServiceAccountPrefix + util.RandomString(5)
-
-	err = run("gcloud", "--project", project, "iam", "service-accounts", "create", "--display-name=k8s machines controller", accountId)
-	if err != nil {
-		return fmt.Errorf("couldn't create service account: %v", err)
-	}
-
 	email := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", accountId, project)
+
 	localFile := accountId + "-key.json"
-
-	for _, project := range projects {
-		err = run("gcloud", "projects", "add-iam-policy-binding", project, "--member=serviceAccount:"+email, "--role=roles/compute.instanceAdmin.v1")
-		if err != nil {
-			return fmt.Errorf("couldn't grant permissions to service account: %v", err)
-		}
-	}
-
 	err = run("gcloud", "--project", project, "iam", "service-accounts", "keys", "create", localFile, "--iam-account", email)
 	if err != nil {
 		return fmt.Errorf("couldn't create service account key: %v", err)
@@ -76,18 +97,68 @@ func (gce *GCEClient) CreateMachineControllerServiceAccount(cluster *clusterv1.C
 	if err != nil {
 		return fmt.Errorf("couldn't import service account key as credential: %v", err)
 	}
+
 	if err := run("rm", localFile); err != nil {
 		glog.Error(err)
+	}
+
+	return nil
+}
+
+func (gce *GCEClient) createServiceAccount(serviceAccountPrefix string, roles []string, cluster *clusterv1.Cluster, initialMachines []*clusterv1.Machine) (string, string, error) {
+	if len(initialMachines) == 0 {
+		return "", "", fmt.Errorf("machine count is zero, cannot create service a/c")
+	}
+
+	// TODO: use real go bindings
+	// Figure out what projects the service account needs permission to.
+	projects, err := gce.getProjects(initialMachines)
+	if err != nil {
+		return "", "", err
+	}
+
+	// The service account needs to be created in a single project, so just
+	// use the first one, but grant permission to all projects in the list.
+	project := projects[0]
+	accountId := serviceAccountPrefix + "-" + util.RandomString(5)
+
+	err = run("gcloud", "--project", project, "iam", "service-accounts", "create", "--display-name="+serviceAccountPrefix+" service account", accountId)
+	if err != nil {
+		return "", "", fmt.Errorf("couldn't create service account: %v", err)
+	}
+
+	email := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", accountId, project)
+
+	for _, project := range projects {
+		for _, role := range roles {
+			err = run("gcloud", "projects", "add-iam-policy-binding", project, "--member=serviceAccount:"+email, "--role=roles/"+role)
+			if err != nil {
+				return "", "", fmt.Errorf("couldn't grant permissions to service account: %v", err)
+			}
+		}
 	}
 
 	if cluster.ObjectMeta.Annotations == nil {
 		cluster.ObjectMeta.Annotations = make(map[string]string)
 	}
-	cluster.ObjectMeta.Annotations[ServiceAccount] = email
-	return nil
+	cluster.ObjectMeta.Annotations[ClusterAnnotationPrefix+serviceAccountPrefix] = email
+
+	return accountId, project, nil
+}
+
+func (gce *GCEClient) DeleteMasterNodeServiceAccount(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) error {
+	return gce.deleteServiceAccount(MasterNodeServiceAccountPrefix, MasterNodeRoles, cluster, machines)
+}
+
+func (gce *GCEClient) DeleteWorkerNodeServiceAccount(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) error {
+	return gce.deleteServiceAccount(WorkerNodeServiceAccountPrefix, WorkerNodeRoles, cluster, machines)
 }
 
 func (gce *GCEClient) DeleteMachineControllerServiceAccount(cluster *clusterv1.Cluster, machines []*clusterv1.Machine) error {
+	return gce.deleteServiceAccount(MachineControllerServiceAccountPrefix, MachineControllerRoles, cluster, machines)
+}
+
+func (gce *GCEClient) deleteServiceAccount(serviceAccountPrefix string, roles []string, cluster *clusterv1.Cluster, machines []*clusterv1.Machine) error {
 	if len(machines) == 0 {
 		glog.Info("machine count is zero, cannot determine project for service a/c deletion")
 		return nil
@@ -100,7 +171,7 @@ func (gce *GCEClient) DeleteMachineControllerServiceAccount(cluster *clusterv1.C
 	project := projects[0]
 	var email string
 	if cluster.ObjectMeta.Annotations != nil {
-		email = cluster.ObjectMeta.Annotations[ServiceAccount]
+		email = cluster.ObjectMeta.Annotations[ClusterAnnotationPrefix+serviceAccountPrefix]
 	}
 
 	if email == "" {
@@ -108,7 +179,9 @@ func (gce *GCEClient) DeleteMachineControllerServiceAccount(cluster *clusterv1.C
 		return nil
 	}
 
-	err = run("gcloud", "projects", "remove-iam-policy-binding", project, "--member=serviceAccount:"+email, "--role=roles/compute.instanceAdmin.v1")
+	for _, role := range roles {
+		err = run("gcloud", "projects", "remove-iam-policy-binding", project, "--member=serviceAccount:"+email, "--role=roles/"+role)
+	}
 
 	if err != nil {
 		return fmt.Errorf("couldn't remove permissions to service account: %v", err)

--- a/docs/examples/gce-ingress-controller/README.md
+++ b/docs/examples/gce-ingress-controller/README.md
@@ -1,0 +1,12 @@
+# Deploy GCE Ingress Controller
+
+Instructions for how to deploy an ingress controller in a cluster
+that was deployed by gcp-deployer
+
+1. Replace `<YOUR PROJECT ID>` and `<YOUR CLUSTER NAME>` in
+`ingress-controller.yml`.
+1. Run `kubectl create -f ingress-controller.yml`. This will create
+Kubernetes service account with the correct permissions in the cluster,
+a default backend for the ingress controller, and the glbc app
+
+Now you will be able to create ingress objects.

--- a/docs/examples/gce-ingress-controller/ingress-controller.yaml
+++ b/docs/examples/gce-ingress-controller/ingress-controller.yaml
@@ -1,0 +1,165 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: glbc
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/
+kind: ClusterRole
+metadata:
+  name: system:controller:glbc
+rules:
+- apiGroups: [""]
+  resources: ["secrets", "endpoints", "services", "pods", "nodes", "namespaces", "configmaps", "events"]
+  verbs: ["describe", "get", "list", "watch", "update", "create", "patch"]
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["extensions"]
+  resources: ["ingresses/status"]
+  verbs: ["update"]
+---
+apiVersion: rbac.authorization.k8s.io/
+kind: ClusterRoleBinding
+metadata:
+  name: system:controller:glbc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:controller:glbc
+subjects:
+- kind: ServiceAccount
+  name: glbc
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: l7-default-backend
+  namespace: kube-system
+  labels:
+    k8s-app: glbc
+    kubernetes.io/name: "GLBC"
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: glbc
+  template:
+    metadata:
+      labels:
+        k8s-app: glbc
+        name: glbc
+    spec:
+      containers:
+      - name: default-http-backend
+        # Any image is permissible as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.4
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingress-controller-config
+  namespace: kube-system
+data:
+  gce.conf: |
+    [global]
+    project-id = <YOUR PROJECT ID>
+    node-tags = <YOUR CLUSTER NAME>
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # This must match the --default-backend-service argument of the l7 lb
+  # controller and is required because GCE mandates a default backend.
+  name: default-http-backend
+  namespace: kube-system
+  labels:
+    k8s-app: glbc
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "GLBCDefaultBackend"
+spec:
+  # The default backend must be of type NodePort.
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    k8s-app: glbc
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  namespace: kube-system
+  name: l7-lb-controller
+  labels:
+    k8s-app: glbc
+    version: v1.1.1
+spec:
+  # There should never be more than 1 controller alive simultaneously.
+  replicas: 1
+  selector:
+    k8s-app: glbc
+    version: v1.1.1
+  template:
+    metadata:
+      labels:
+        k8s-app: glbc
+        version: v1.1.1
+        name: glbc
+    spec:
+      serviceAccountName: glbc
+      terminationGracePeriodSeconds: 600
+      containers:
+      - image: k8s.gcr.io/ingress-gce-glbc-amd64:v1.1.1
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        name: l7-lb-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        args:
+        - --default-backend-service=kube-system/default-http-backend
+        - --sync-period=300s
+        - --config-file-path=/etc/ingress-config/gce.conf
+        volumeMounts:
+        - mountPath: /etc/ingress-config
+          name: cloudconfig
+          readOnly: true
+      volumes:
+      - configMap:
+          name: ingress-controller-config
+        name: cloudconfig

--- a/gcp-deployer/README.md
+++ b/gcp-deployer/README.md
@@ -74,6 +74,10 @@ to find the broken node (using the dry run flag) and fix it.
 
 ### Deleting a cluster
 
+***NOTE***: Before deleting your cluster, it is recommended that you delete any Kubernetes
+objects which have created resources external to the cluster, like services with type LoadBalancer,
+some types of persistent volume claims, and ingress resources.
+
 To delete your cluster run `./gcp-deployer delete`
 
 

--- a/gcp-deployer/deploy/deploy_helper.go
+++ b/gcp-deployer/deploy/deploy_helper.go
@@ -55,6 +55,12 @@ func (d *deployer) createCluster(c *clusterv1.Cluster, machines []*clusterv1.Mac
 		master.Name = master.GetGenerateName() + c.GetName()
 	}
 
+	glog.Infof("Starting cluster dependency creation %s", c.GetName())
+
+	if err := d.machineDeployer.ProvisionClusterDependencies(c, machines); err != nil {
+		return err
+	}
+
 	glog.Infof("Starting cluster creation %s", c.GetName())
 
 	glog.Infof("Starting master creation %s", master.GetName())

--- a/gcp-deployer/machine_setup_configs.yaml
+++ b/gcp-deployer/machine_setup_configs.yaml
@@ -70,6 +70,7 @@ items:
       Environment="KUBELET_NETWORK_ARGS=--network-plugin=kubenet"
       Environment="KUBELET_DNS_ARGS=--cluster-dns=${CLUSTER_DNS_SERVER} --cluster-domain=${CLUSTER_DNS_DOMAIN}"
       EOF
+      sed -i "2iEnvironment=\"KUBELET_EXTRA_ARGS=--cloud-provider=gce --cloud-config=/etc/kubernetes/cloud-config\"" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
       systemctl daemon-reload
       systemctl restart kubelet.service
       PRIVATEIP=`curl --retry 5 -sfH "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/network-interfaces/0/ip"`
@@ -112,6 +113,21 @@ items:
       modprobe br_netfilter
 
       kubeadm init --config /etc/kubernetes/kubeadm_config.yaml
+
+      # add default storage class
+      cat > /etc/kubernetes/default-storage-class.yaml <<EOF
+      kind: StorageClass
+      apiVersion: storage.k8s.io/v1
+      metadata:
+        name: standard
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "true"
+      provisioner: kubernetes.io/gce-pd
+      parameters:
+        type: pd-standard
+      EOF
+      kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f /etc/kubernetes/default-storage-class.yaml
+
       for tries in $(seq 1 60); do
           kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate --overwrite node $(hostname) machine=${MACHINE} && break
           sleep 1
@@ -159,6 +175,15 @@ items:
       deb http://apt.kubernetes.io/ kubernetes-xenial main
       EOF
       apt-get update
+
+      mkdir -p /etc/kubernetes/
+      cat > /etc/kubernetes/cloud-config <<EOF
+      [global]
+      project-id = ${PROJECT}
+      network-name = ${NETWORK}
+      subnetwork-name = ${SUBNETWORK}
+      node-tags = ${NODE_TAG}
+      EOF
       # Our Debian packages have versions like "1.8.0-00" or "1.8.0-01". Do a prefix
       # search based on our SemVer to find the right (newest) package version.
       function getversion() {
@@ -183,6 +208,7 @@ items:
       Environment="KUBELET_NETWORK_ARGS=--network-plugin=kubenet"
       Environment="KUBELET_DNS_ARGS=--cluster-dns=${CLUSTER_DNS_SERVER} --cluster-domain=${CLUSTER_DNS_DOMAIN}"
       EOF
+      sed -i "2iEnvironment=\"KUBELET_EXTRA_ARGS=--cloud-provider=gce --cloud-config=/etc/kubernetes/cloud-config\"" /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
       systemctl daemon-reload
       systemctl restart kubelet.service
       kubeadm join --token "${TOKEN}" "${MASTER}" --ignore-preflight-errors=all --discovery-token-unsafe-skip-ca-verification

--- a/pkg/controller/machine/actuator.go
+++ b/pkg/controller/machine/actuator.go
@@ -23,6 +23,10 @@ import (
 // Actuator controls machines on a specific infrastructure. All
 // methods should be idempotent unless otherwise specified.
 type Actuator interface {
+	// TODO mkjelland move ProvisionClusterDependencies to a cluster actuator
+	// Provision infrastructure that the cluster needs before it
+	// can be created
+	ProvisionClusterDependencies(*clusterv1.Cluster, []*clusterv1.Machine) error
 	// Create the machine.
 	Create(*clusterv1.Cluster, *clusterv1.Machine) error
 	// Delete the machine.


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables GCE cloud provider support:
- Creates GCE service accounts that have the specific permissions needed by the master and worker machines for cloud provider functionality
- Starts the kubelet with cloud provider configuration, this is necessary for the kubelet to attach and detach gce persistent disks
- Adds a default storage class in the master node's startup script
- Instructs users how to deploy a gce ingress controller to their cluster

**Which issue(s) this PR fixes**:
Fixes #81 

**Special notes for your reviewer**:
Once we have a way to deploy addons, the ingress controller and storage class can be deployed in that way.
