### PR TITLE
Fix service name and namespace in cert generation

### DIFF
--- a/cloud/google/pods.go
+++ b/cloud/google/pods.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"text/template"
@@ -55,22 +54,6 @@ type caCertParams struct {
 	caBundle string
 	tlsCrt   string
 	tlsKey   string
-}
-
-func getBase64(file string) string {
-	buff := bytes.Buffer{}
-	enc := base64.NewEncoder(base64.StdEncoding, &buff)
-	data, err := ioutil.ReadFile(file)
-	if err != nil {
-		glog.Fatalf("Could not read file %s: %v", file, err)
-	}
-
-	_, err = enc.Write(data)
-	if err != nil {
-		glog.Fatalf("Could not write bytes: %v", err)
-	}
-	enc.Close()
-	return buff.String()
 }
 
 func getApiServerCerts() (*caCertParams, error) {

--- a/cloud/google/pods.go
+++ b/cloud/google/pods.go
@@ -85,8 +85,8 @@ func getApiServerCerts() (*caCertParams, error) {
 	apiServerKeyPair, err := triple.NewServerKeyPair(
 		caKeyPair,
 		fmt.Sprintf("%s.%s.svc", name, namespace),
-		"kubernetes",
-		"default",
+		name,
+		namespace,
 		"cluster.local",
 		[]string{},
 		[]string{})


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix GCP deployment by correcting the name and namespace when using triple to generate certs.

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
