### PR TITLE
Fix a typo in GCP Deployer

### DIFF
--- a/cloud/google/metadata.go
+++ b/cloud/google/metadata.go
@@ -123,5 +123,5 @@ MASTER={{ .MasterEndpoint }}
 MACHINE={{ .Machine.ObjectMeta.Name }}
 CLUSTER_DNS_DOMAIN={{ .Cluster.Spec.ClusterNetwork.ServiceDomain }}
 POD_CIDR={{ .PodCIDR }}
-SERVICE_CIDER={{ .ServiceCIDR }}
+SERVICE_CIDR={{ .ServiceCIDR }}
 `


### PR DESCRIPTION
**What this PR does / why we need it**:
Cluster DNS didn't work on nodes because of this bug.

**Release note**:
```release-note
NONE
```

@kubernetes/kube-deploy-reviewers
