### PR TITLE
Implement machine set status

### DIFF
--- a/pkg/controller/machineset/controller.go
+++ b/pkg/controller/machineset/controller.go
@@ -18,14 +18,28 @@ package machineset
 
 import (
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-	machineclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+	clusterapiclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+	machinesetclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
 	listers "sigs.k8s.io/cluster-api/pkg/client/listers_generated/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/controller/sharedinformers"
+)
+
+const (
+	// The number of times we retry updating a ReplicaSet's status.
+	statusUpdateRetries = 1
 )
 
 // controllerKind contains the schema.GroupVersionKind for this controller type.
@@ -35,8 +49,11 @@ var controllerKind = v1alpha1.SchemeGroupVersion.WithKind("MachineSet")
 type MachineSetControllerImpl struct {
 	builders.DefaultControllerFns
 
-	// machineClient a client that knows how to consume Machine resources
-	machineClient machineclientset.Interface
+	// kubernetesClient a client that knows how to consume Node resources
+	kubernetesClient kubernetes.Interface
+
+	// clusterAPIClient a client that knows how to consume Cluster API resources
+	clusterAPIClient clusterapiclientset.Interface
 
 	// machineSetsLister indexes properties about MachineSet
 	machineSetsLister listers.MachineSetLister
@@ -48,13 +65,15 @@ type MachineSetControllerImpl struct {
 // Init initializes the controller and is called by the generated code
 // Register watches for additional resource types here.
 func (c *MachineSetControllerImpl) Init(arguments sharedinformers.ControllerInitArguments) {
+	c.kubernetesClient = arguments.GetSharedInformers().KubernetesClientSet
+
 	c.machineSetsLister = arguments.GetSharedInformers().Factory.Cluster().V1alpha1().MachineSets().Lister()
 	c.machineLister = arguments.GetSharedInformers().Factory.Cluster().V1alpha1().Machines().Lister()
 
 	var err error
-	c.machineClient, err = machineclientset.NewForConfig(arguments.GetRestConfig())
+	c.clusterAPIClient, err = clusterapiclientset.NewForConfig(arguments.GetRestConfig())
 	if err != nil {
-		glog.Fatalf("error building clientset for machineClient: %v", err)
+		glog.Fatalf("error building clientset for clusterAPIClient: %v", err)
 	}
 }
 
@@ -68,61 +87,49 @@ func (c *MachineSetControllerImpl) Reconcile(machineSet *v1alpha1.MachineSet) er
 		return err
 	}
 
-	return c.syncReplicas(machineSet, filteredMachines)
+	// Take ownership of machines if not already owned.
+	for _, machine := range filteredMachines {
+		if shouldAdopt(machineSet, machine) {
+			c.adoptOrphan(machineSet, machine)
+		}
+	}
+
+	var manageReplicasErr error
+	if machineSet.DeletionTimestamp == nil {
+		manageReplicasErr = c.manageReplicas(filteredMachines, machineSet)
+	}
+	ms := machineSet.DeepCopy()
+	newStatus := c.calculateStatus(ms, filteredMachines)
+
+	// Always updates status as machines come up or die.
+	updatedMS, err := updateMachineSetStatus(c.clusterAPIClient.ClusterV1alpha1().MachineSets(machineSet.Namespace), machineSet, newStatus)
+	if err != nil {
+		// Multiple things could lead to this update failing. Requeuing the replica set ensures
+		// Returning an error causes a requeue without forcing a hotloop
+		return fmt.Errorf("failed to update machine set status, %v", err)
+	}
+	// Resync the MachineSet after MinReadySeconds as a last line of defense to guard against clock-skew.
+	// Clock-skew is an issue as it may impact whether an available replica is counted as a ready replica.
+	// A replica is available if the amount of time since last transition exceeds MinReadySeconds.
+	// If there was a clock skew, checking whether the amount of time since last transition to ready state
+	// exceeds MinReadySeconds could be incorrect.
+	// To avoid an available replica stuck in the ready state, we force a reconcile after MinReadySeconds,
+	// at which point it should confirm any available replica to be available.
+	if manageReplicasErr == nil && updatedMS.Spec.MinReadySeconds > 0 &&
+		updatedMS.Status.ReadyReplicas == *(updatedMS.Spec.Replicas) &&
+		updatedMS.Status.AvailableReplicas != *(updatedMS.Spec.Replicas) {
+		c.reconcileAfter(updatedMS, time.Duration(updatedMS.Spec.MinReadySeconds)*time.Second)
+	}
+	return manageReplicasErr
 }
 
 func (c *MachineSetControllerImpl) Get(namespace, name string) (*v1alpha1.MachineSet, error) {
 	return c.machineSetsLister.MachineSets(namespace).Get(name)
 }
 
-// syncReplicas essentially scales machine resources up and down.
-func (c *MachineSetControllerImpl) syncReplicas(machineSet *v1alpha1.MachineSet, machines []*v1alpha1.Machine) error {
-	// Take ownership of machines if not already owned.
-	for _, machine := range machines {
-		if shouldAdopt(machineSet, machine) {
-			c.adoptOrphan(machineSet, machine)
-		}
-	}
-
-	var result error
-	currentMachineCount := int32(len(machines))
-	desiredReplicas := *machineSet.Spec.Replicas
-	diff := int(currentMachineCount - desiredReplicas)
-
-	if diff < 0 {
-		diff *= -1
-		for i := 0; i < diff; i++ {
-			glog.V(2).Infof("creating a machine ( spec.replicas(%d) > currentMachineCount(%d) )", desiredReplicas, currentMachineCount)
-			machine, err := c.createMachine(machineSet)
-			if err != nil {
-				return err
-			}
-			_, err = c.machineClient.ClusterV1alpha1().Machines(machineSet.Namespace).Create(machine)
-			if err != nil {
-				glog.Errorf("unable to create a machine = %s, due to %v", machine.Name, err)
-				result = err
-			}
-		}
-	} else if diff > 0 {
-		for i := 0; i < diff; i++ {
-			glog.V(2).Infof("deleting a machine ( spec.replicas(%d) < currentMachineCount(%d) )", desiredReplicas, currentMachineCount)
-			// TODO: Define machines deletion policies.
-			// see: https://github.com/kubernetes/kube-deploy/issues/625
-			machineToDelete := machines[i]
-			err := c.machineClient.ClusterV1alpha1().Machines(machineSet.Namespace).Delete(machineToDelete.Name, &metav1.DeleteOptions{})
-			if err != nil {
-				glog.Errorf("unable to delete a machine = %s, due to %v", machineToDelete.Name, err)
-				result = err
-			}
-		}
-	}
-
-	return result
-}
-
 // createMachine creates a machine resource.
 // the name of the newly created resource is going to be created by the API server, we set the generateName field
-func (c *MachineSetControllerImpl) createMachine(machineSet *v1alpha1.MachineSet) (*v1alpha1.Machine, error) {
+func (c *MachineSetControllerImpl) createMachine(machineSet *v1alpha1.MachineSet) *v1alpha1.Machine {
 	gv := v1alpha1.SchemeGroupVersion
 	machine := &v1alpha1.Machine{
 		TypeMeta: metav1.TypeMeta{
@@ -133,20 +140,41 @@ func (c *MachineSetControllerImpl) createMachine(machineSet *v1alpha1.MachineSet
 		Spec:       machineSet.Spec.Template.Spec,
 	}
 	machine.ObjectMeta.GenerateName = fmt.Sprintf("%s-", machineSet.Name)
-	machine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(machineSet, controllerKind),}
+	machine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(machineSet, controllerKind)}
 
-	return machine, nil
+	return machine
 }
 
 // getMachines returns a list of machines that match on machineSet.Spec.Selector
 func (c *MachineSetControllerImpl) getMachines(machineSet *v1alpha1.MachineSet) ([]*v1alpha1.Machine, error) {
-	selector, err := metav1.LabelSelectorAsSelector(&machineSet.Spec.Selector)
+	// list all machines to include the machines that don't match the machineSet`s selector
+	// anymore but has the stale controller ref.
+	// TODO: Do the List and Filter in a single pass, or use an index.
+	allMachines, err := c.machineLister.Machines(machineSet.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
-	filteredMachines, err := c.machineLister.List(selector)
-	if err != nil {
-		return nil, err
+	var filteredMachines []*v1alpha1.Machine
+	for _, machine := range allMachines {
+		// Ignore inactive machines.
+		if machine.DeletionTimestamp != nil {
+			continue
+		}
+
+		if metav1.GetControllerOf(machine) != nil && !metav1.IsControlledBy(machine, machineSet) {
+			glog.V(4).Infof("%s not controlled by %v", machine.Name, machineSet.Name)
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(&machineSet.Spec.Selector)
+		if err != nil {
+			glog.Warningf("unable to convert selector: %v", err)
+			continue
+		}
+		// If a deployment with a nil or empty selector creeps in, it should match nothing, not everything.
+		if selector.Empty() || !selector.Matches(labels.Set(machine.Labels)) {
+			continue
+		}
+		filteredMachines = append(filteredMachines, machine)
 	}
 	return filteredMachines, err
 }
@@ -182,7 +210,218 @@ func (c *MachineSetControllerImpl) adoptOrphan(machineSet *v1alpha1.MachineSet, 
 	newRef := *metav1.NewControllerRef(machineSet, controllerKind)
 	ownerRefs = append(ownerRefs, newRef)
 	machine.ObjectMeta.SetOwnerReferences(ownerRefs)
-	if _, err := c.machineClient.ClusterV1alpha1().Machines(machineSet.Namespace).Update(machine); err != nil {
+
+	if _, err := c.clusterAPIClient.ClusterV1alpha1().Machines(machineSet.Namespace).Update(machine); err != nil {
 		glog.Warningf("Failed to update machine owner reference. %v", err)
 	}
+}
+
+// manageReplicas checks and updates replicas for the given MachineSet.
+// Does NOT modify <filteredMachines>.
+// It will requeue the replica set in case of an error while creating/deleting machines.
+func (c *MachineSetControllerImpl) manageReplicas(filteredMachines []*v1alpha1.Machine, ms *v1alpha1.MachineSet) error {
+	diff := len(filteredMachines) - int(*(ms.Spec.Replicas))
+	if diff < 0 {
+		diff *= -1
+		glog.V(4).Infof("Too few replicas for %v %s/%s, need %d, creating %d", controllerKind, ms.Namespace, ms.Name, *(ms.Spec.Replicas), diff)
+
+		var errstrings []string
+		for i := 0; i < diff; i++ {
+			glog.V(4).Infof("creating a machine ( spec.replicas(%d) > currentMachineCount(%d) )", *(ms.Spec.Replicas), len(filteredMachines))
+			machine := c.createMachine(ms)
+			_, err := c.clusterAPIClient.ClusterV1alpha1().Machines(ms.Namespace).Create(machine)
+			if err != nil {
+				glog.Errorf("unable to create a machine = %s, due to %v", machine.Name, err)
+				errstrings = append(errstrings, err.Error())
+			}
+		}
+
+		if errstrings != nil {
+			return fmt.Errorf(strings.Join(errstrings, "; "))
+		}
+
+		return nil
+	} else if diff > 0 {
+		glog.V(4).Infof("Too many replicas for %v %s/%s, need %d, deleting %d", controllerKind, ms.Namespace, ms.Name, *(ms.Spec.Replicas), diff)
+
+		// Choose which Machines to delete.
+		machinesToDelete := getMachinesToDelete(filteredMachines, diff)
+
+		errCh := make(chan error, diff)
+		var wg sync.WaitGroup
+		wg.Add(diff)
+		for _, machine := range machinesToDelete {
+			go func(targetMachine *v1alpha1.Machine) {
+				defer wg.Done()
+				err := c.clusterAPIClient.ClusterV1alpha1().Machines(ms.Namespace).Delete(targetMachine.Name, &metav1.DeleteOptions{})
+				if err != nil {
+					glog.Errorf("unable to delete a machine = %s, due to %v", machine.Name, err)
+					errCh <- err
+				}
+			}(machine)
+		}
+		wg.Wait()
+
+		select {
+		case err := <-errCh:
+			// all errors have been reported before and they're likely to be the same, so we'll only return the first one we hit.
+			if err != nil {
+				return err
+			}
+		default:
+		}
+	}
+
+	return nil
+}
+
+func (c *MachineSetControllerImpl) reconcileAfter(machineSet *v1alpha1.MachineSet, after time.Duration) {
+	timer := time.NewTimer(after)
+	go func(newMS v1alpha1.MachineSet) {
+		<-timer.C
+		c.Reconcile(&newMS)
+	}(*machineSet)
+}
+
+// updateMachineSetStatus attempts to update the Status.Replicas of the given MachineSet, with a single GET/PUT retry.
+func updateMachineSetStatus(c machinesetclientset.MachineSetInterface, ms *v1alpha1.MachineSet, newStatus v1alpha1.MachineSetStatus) (*v1alpha1.MachineSet, error) {
+	// This is the steady state. It happens when the MachineSet doesn't have any expectations, since
+	// we do a periodic relist every 30s. If the generations differ but the replicas are
+	// the same, a caller might've resized to the same replica count.
+	if ms.Status.Replicas == newStatus.Replicas &&
+		ms.Status.FullyLabeledReplicas == newStatus.FullyLabeledReplicas &&
+		ms.Status.ReadyReplicas == newStatus.ReadyReplicas &&
+		ms.Status.AvailableReplicas == newStatus.AvailableReplicas &&
+		ms.Generation == ms.Status.ObservedGeneration {
+		return ms, nil
+	}
+
+	// Save the generation number we acted on, otherwise we might wrongfully indicate
+	// that we've seen a spec update when we retry.
+	// TODO: This can clobber an update if we allow multiple agents to write to the
+	// same status.
+	newStatus.ObservedGeneration = ms.Generation
+
+	var getErr, updateErr error
+	var updatedMS *v1alpha1.MachineSet
+	for i := 0; ; i++ {
+		glog.V(4).Infof(fmt.Sprintf("Updating status for %v: %s/%s, ", ms.Kind, ms.Namespace, ms.Name) +
+			fmt.Sprintf("replicas %d->%d (need %d), ", ms.Status.Replicas, newStatus.Replicas, *(ms.Spec.Replicas)) +
+			fmt.Sprintf("fullyLabeledReplicas %d->%d, ", ms.Status.FullyLabeledReplicas, newStatus.FullyLabeledReplicas) +
+			fmt.Sprintf("readyReplicas %d->%d, ", ms.Status.ReadyReplicas, newStatus.ReadyReplicas) +
+			fmt.Sprintf("availableReplicas %d->%d, ", ms.Status.AvailableReplicas, newStatus.AvailableReplicas) +
+			fmt.Sprintf("sequence No: %v->%v", ms.Status.ObservedGeneration, newStatus.ObservedGeneration))
+
+		ms.Status = newStatus
+		updatedMS, updateErr = c.UpdateStatus(ms)
+		if updateErr == nil {
+			return updatedMS, nil
+		}
+		// Stop retrying if we exceed statusUpdateRetries - the machineSet will be requeued with a rate limit.
+		if i >= statusUpdateRetries {
+			break
+		}
+		// Update the MachineSet with the latest resource version for the next poll
+		if ms, getErr = c.Get(ms.Name, metav1.GetOptions{}); getErr != nil {
+			// If the GET fails we can't trust status.Replicas anymore. This error
+			// is bound to be more interesting than the update failure.
+			return nil, getErr
+		}
+	}
+
+	return nil, updateErr
+}
+
+func (c *MachineSetControllerImpl) calculateStatus(ms *v1alpha1.MachineSet, filteredMachines []*v1alpha1.Machine) v1alpha1.MachineSetStatus {
+	newStatus := ms.Status
+	// Count the number of machines that have labels matching the labels of the machine
+	// template of the replica set, the matching machines may have more
+	// labels than are in the template. Because the label of machineTemplateSpec is
+	// a superset of the selector of the replica set, so the possible
+	// matching machines must be part of the filteredMachines.
+	fullyLabeledReplicasCount := 0
+	readyReplicasCount := 0
+	availableReplicasCount := 0
+	templateLabel := labels.Set(ms.Spec.Template.Labels).AsSelectorPreValidated()
+	for _, machine := range filteredMachines {
+		if templateLabel.Matches(labels.Set(machine.Labels)) {
+			fullyLabeledReplicasCount++
+		}
+		node, err := c.getMachineNode(machine)
+		if err != nil {
+			glog.Warningf("Unable to get node for machine %v, %v", machine.Name, err)
+			continue
+		}
+		if isNodeReady(node) {
+			readyReplicasCount++
+			if isNodeAvailable(node, ms.Spec.MinReadySeconds, metav1.Now()) {
+				availableReplicasCount++
+			}
+		}
+	}
+
+	newStatus.Replicas = int32(len(filteredMachines))
+	newStatus.FullyLabeledReplicas = int32(fullyLabeledReplicasCount)
+	newStatus.ReadyReplicas = int32(readyReplicasCount)
+	newStatus.AvailableReplicas = int32(availableReplicasCount)
+	return newStatus
+}
+
+func isNodeAvailable(node *corev1.Node, minReadySeconds int32, now metav1.Time) bool {
+	if !isNodeReady(node) {
+		return false
+	}
+
+	if minReadySeconds == 0 {
+		return true
+	}
+
+	minReadySecondsDuration := time.Duration(minReadySeconds) * time.Second
+	_, readyCondition := getNodeCondition(&node.Status, corev1.NodeReady)
+
+	if !readyCondition.LastTransitionTime.IsZero() &&
+		readyCondition.LastTransitionTime.Add(minReadySecondsDuration).Before(now.Time) {
+		return true
+	}
+
+	return false
+}
+
+func (c *MachineSetControllerImpl) getMachineNode(machine *v1alpha1.Machine) (*corev1.Node, error) {
+	nodeRef := machine.Status.NodeRef
+	if nodeRef == nil {
+		return nil, fmt.Errorf("machine has no node ref")
+	}
+
+	return c.kubernetesClient.CoreV1().Nodes().Get(nodeRef.Name, metav1.GetOptions{})
+}
+
+// getNodeCondition extracts the provided condition from the given status and returns that.
+// Returns nil and -1 if the condition is not present, and the index of the located condition.
+func getNodeCondition(status *corev1.NodeStatus, conditionType corev1.NodeConditionType) (int, *corev1.NodeCondition) {
+	if status == nil {
+		return -1, nil
+	}
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == conditionType {
+			return i, &status.Conditions[i]
+		}
+	}
+	return -1, nil
+}
+
+// isNodeReady returns true if a node is ready; false otherwise.
+func isNodeReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func getMachinesToDelete(filteredMachines []*v1alpha1.Machine, diff int) []*v1alpha1.Machine {
+	// TODO: Define machines deletion policies.
+	// see: https://github.com/kubernetes/kube-deploy/issues/625
+	return filteredMachines[:diff]
 }

--- a/pkg/controller/machineset/status_test.go
+++ b/pkg/controller/machineset/status_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+func TestMachineSetController_calculateStatus(t *testing.T) {
+	readyNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "rNode"},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.Time{Time: time.Now()},
+				},
+			},
+		},
+	}
+	notReadyNode := readyNode.DeepCopy()
+	notReadyNode.Name = "nrNode"
+	notReadyNode.Status.Conditions[0].Status = corev1.ConditionFalse
+	unknownStatusNode := readyNode.DeepCopy()
+	unknownStatusNode.Name = "usNode"
+	unknownStatusNode.Status.Conditions[0].Status = corev1.ConditionUnknown
+	noConditionNode := readyNode.DeepCopy()
+	noConditionNode.Name = "ncNode"
+	noConditionNode.Status.Conditions = []corev1.NodeCondition{}
+	availableNode := readyNode.DeepCopy()
+	availableNode.Name = "aNode"
+	availableNode.Status.Conditions[0].LastTransitionTime.Time = time.Now().Add(time.Duration(-6) * time.Minute)
+
+	tests := []struct {
+		name                      string
+		machines                  []*v1alpha1.Machine
+		setMinReadySeconds        bool
+		minReadySeconds           int32
+		expectedReplicas          int32
+		expectedLabeledReplicas   int32
+		expectedReadyReplicas     int32
+		expectedAvailableReplicas int32
+	}{
+		{
+			name: "scenario 1: empty machinset.",
+		},
+		{
+			name: "scenario 2: 1 replica, 1 labeled machine",
+			machines: []*v1alpha1.Machine{
+				machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"),
+			},
+			expectedReplicas:        1,
+			expectedLabeledReplicas: 1,
+		},
+		{
+			name: "scenario 3: 1 replica, 0 labeled machine",
+			machines: []*v1alpha1.Machine{
+				setDifferentLabels(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1")),
+			},
+			expectedReplicas: 1,
+		},
+		{
+			name: "scenario 4: 1 replica, 1 ready machine",
+			machines: []*v1alpha1.Machine{
+				setNode(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"), readyNode),
+			},
+			expectedReplicas:        1,
+			expectedLabeledReplicas: 1,
+			expectedReadyReplicas:   1,
+		},
+		{
+			name: "scenario 5: 1 replica, 0 ready machine, not ready node",
+			machines: []*v1alpha1.Machine{
+				setNode(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"), notReadyNode),
+			},
+			expectedReplicas:        1,
+			expectedLabeledReplicas: 1,
+		},
+		{
+			name: "scenario 5: 1 replica, 0 ready machine, unknown node",
+			machines: []*v1alpha1.Machine{
+				setNode(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"), unknownStatusNode),
+			},
+			expectedReplicas:        1,
+			expectedLabeledReplicas: 1,
+		},
+		{
+			name: "scenario 5: 1 replica, 0 ready machine, missing condition node",
+			machines: []*v1alpha1.Machine{
+				setNode(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"), noConditionNode),
+			},
+			expectedReplicas:        1,
+			expectedLabeledReplicas: 1,
+		},
+		{
+			name: "scenario 6: 1 replica, 1 available machine, minReadySeconds = 0",
+			machines: []*v1alpha1.Machine{
+				setNode(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"), readyNode),
+			},
+			setMinReadySeconds:        true,
+			minReadySeconds:           0,
+			expectedReplicas:          1,
+			expectedLabeledReplicas:   1,
+			expectedReadyReplicas:     1,
+			expectedAvailableReplicas: 1,
+		},
+		{
+			name: "scenario 7: 1 replica, 1 available machine, 360s elapsed, need 300s",
+			machines: []*v1alpha1.Machine{
+				setNode(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"), availableNode),
+			},
+			setMinReadySeconds:        true,
+			minReadySeconds:           300,
+			expectedReplicas:          1,
+			expectedLabeledReplicas:   1,
+			expectedReadyReplicas:     1,
+			expectedAvailableReplicas: 1,
+		},
+		{
+			name: "scenario 8: 4 replicas, 3 labeled, 2 ready, 1 available machine",
+			machines: []*v1alpha1.Machine{
+				setDifferentLabels(setNode(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"), noConditionNode)),
+				setNode(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"), notReadyNode),
+				setNode(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"), readyNode),
+				setNode(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"), availableNode),
+			},
+			setMinReadySeconds:        true,
+			minReadySeconds:           300,
+			expectedReplicas:          4,
+			expectedLabeledReplicas:   3,
+			expectedReadyReplicas:     2,
+			expectedAvailableReplicas: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rObjects := []runtime.Object{readyNode, notReadyNode, unknownStatusNode, noConditionNode, availableNode}
+			k8sClient := fake.NewSimpleClientset(rObjects...)
+
+			c := &MachineSetControllerImpl{}
+			c.kubernetesClient = k8sClient
+
+			ms := createMachineSet(len(test.machines), "foo", "bar1", "acme")
+			if test.setMinReadySeconds {
+				ms.Spec.MinReadySeconds = test.minReadySeconds
+			}
+
+			status := c.calculateStatus(ms, test.machines)
+
+			if status.Replicas != test.expectedReplicas {
+				t.Errorf("got %v replicas, expected %v replicas", status.Replicas, test.expectedReplicas)
+			}
+
+			if status.FullyLabeledReplicas != test.expectedLabeledReplicas {
+				t.Errorf("got %v fully labeled replicas, expected %v fully labeled replicas", status.FullyLabeledReplicas, test.expectedLabeledReplicas)
+			}
+
+			if status.ReadyReplicas != test.expectedReadyReplicas {
+				t.Errorf("got %v ready replicas, expected %v ready replicas", status.ReadyReplicas, test.expectedReadyReplicas)
+			}
+
+			if status.AvailableReplicas != test.expectedAvailableReplicas {
+				t.Errorf("got %v available replicas, expected %v available replicas", status.AvailableReplicas, test.expectedAvailableReplicas)
+			}
+
+		})
+	}
+}
+
+func setNode(machine *v1alpha1.Machine, node *corev1.Node) *v1alpha1.Machine {
+	machine.Status.NodeRef = getNodeRef(node)
+	return machine
+}
+
+func getNodeRef(node *corev1.Node) *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind: "Node",
+		Name: node.ObjectMeta.Name,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements the machineset status. Sets the replicas, fullylabeledreplicas, readyreplicas, availablereplicas fields.

Slight change to orphan adoptions, list all available machines, will not count machines with different owner refs, or non-matching labels.

@kubernetes/kube-deploy-reviewers
