### PR TITLE
Adding the '-q' flag to all ssh commands and remove the 'echo STARTFI…

### DIFF
--- a/cloud/google/machineactuator.go
+++ b/cloud/google/machineactuator.go
@@ -489,15 +489,11 @@ func (gce *GCEClient) GetKubeConfig(master *clusterv1.Machine) (string, error) {
 		return "", err
 	}
 
-	command := "echo STARTFILE; sudo cat /etc/kubernetes/admin.conf"
+	command := "sudo cat /etc/kubernetes/admin.conf"
 	result := strings.TrimSpace(util.ExecCommand(
 		"gcloud", "compute", "ssh", "--project", config.Project,
-		"--zone", config.Zone, master.ObjectMeta.Name, "--command", command))
-	parts := strings.Split(result, "STARTFILE")
-	if len(parts) != 2 {
-		return "", nil
-	}
-	return strings.TrimSpace(parts[1]), nil
+		"--zone", config.Zone, master.ObjectMeta.Name, "--command", command, "--", "-q"))
+	return result, nil
 }
 
 func (gce *GCEClient) updateAnnotations(machine *clusterv1.Machine) error {

--- a/cloud/google/ssh.go
+++ b/cloud/google/ssh.go
@@ -102,17 +102,12 @@ func (gce *GCEClient) remoteSshCommand(m *clusterv1.Machine, cmd string) (string
 		return "", err
 	}
 
-	command := fmt.Sprintf("echo STARTFILE; %s", cmd)
-	c := exec.Command("ssh", "-i", gce.sshCreds.privateKeyPath, gce.sshCreds.user+"@"+publicIP, command)
+	command := fmt.Sprintf("%s", cmd)
+	c := exec.Command("ssh", "-i", gce.sshCreds.privateKeyPath, "-q", gce.sshCreds.user+"@"+publicIP, command)
 	out, err := c.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("error: %v, output: %s", err, string(out))
 	}
 	result := strings.TrimSpace(string(out))
-	parts := strings.Split(result, "STARTFILE")
-	if len(parts) != 2 {
-		return "", nil
-	}
-	// TODO: Check error.
-	return strings.TrimSpace(parts[1]), nil
+	return result, nil
 }

--- a/cloud/terraform/machineactuator.go
+++ b/cloud/terraform/machineactuator.go
@@ -394,19 +394,16 @@ func (tf *TerraformClient) GetKubeConfig(master *clusterv1.Machine) (string, err
 	cmd := exec.Command(
 		// TODO: this is taking my private key and username for now.
 		"ssh", "-i", "~/.ssh/vsphere_tmp",
+		"-q",
 		"-o", "StrictHostKeyChecking no",
 		"-o", "UserKnownHostsFile /dev/null",
 		fmt.Sprintf("ubuntu@%s", ip),
-		"echo STARTFILE; sudo cat /etc/kubernetes/admin.conf")
+		"sudo cat /etc/kubernetes/admin.conf")
 	cmd.Stdout = &out
 	cmd.Stderr = os.Stderr
 	cmd.Run()
 	result := strings.TrimSpace(out.String())
-	parts := strings.Split(result, "STARTFILE")
-	if len(parts) != 2 {
-		return "", nil
-	}
-	return strings.TrimSpace(parts[1]), nil
+	return result, nil
 }
 
 // After master created, move the plugins folder from local to


### PR DESCRIPTION
…LE' hack from all ssh usage.

**What this PR does / why we need it**:
This PR simplifies the usage of ssh. Previously, all locations of ssh needed to put in a bit of a hack in that they would echo some text and then capture all the output after that text. This was done to remove undesired output such as the warning ssh adds when adding a new host to the known_hosts list. Enabling the '-q' flag to ssh removes the need for this hack. 

**Special notes for your reviewer**:
This change was tested with gcp-deployer create. 

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
