### PR TITLE
Add instructions for iterating on a developer version of gce-machine-…

### DIFF
--- a/cloud/google/cmd/gce-machine-controller/README.md
+++ b/cloud/google/cmd/gce-machine-controller/README.md
@@ -1,0 +1,28 @@
+# GCE Machine Controller
+
+The GCE Machine Controller is a machine controller implementation for clusters running on Google Compute Engine.
+
+## Development
+The instructions below will enable you to get started with running your own version of the gce-machine-controller on a GCE Kubernetes cluster.
+
+### Prerequisites
+
+1. Follow the "Before you begin" section from the google cloud container registry [pushing and pulling images documentation](https://cloud.google.com/container-registry/docs/pushing-and-pulling).
+1. From this directory, run `make dev_push`.
+1. Note from the ouput of the above step the name of the image. It should be in this format, `gcr.io/MY-GCP-PROJECT-NAME/gce-machine-controller:VERSION-dev`.
+1. From the same terminal in which you will create your cluster using gcp-deployer, run `export MACHINE_CONTROLLER_IMAGE=gcr.io/MY-GCP-PROJECT-NAME/gce-machine-controller:VERSION-dev`. Note that the value should be equal to the name of the image you noted in the output from the previous step.
+1. Follow the steps listed at [gcp-deployer](../../../../gcp-deployer/) and create a new cluster.
+1. Run the following command to ensure that new images are fetched for every new gce-machine-controller container, `kubectl patch deployment clusterapi -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"gce-machine-controller\",\"imagePullPolicy\":\"Always\"}]}}}}"`.
+
+### Running a Custom GCE Machine Controller
+
+1. Make a change to gce-machine-controller. For example, edit main.go and insert the following print statement `glog.Error("Hello World!")` below `logs.InitLogs()`.
+1. From this folder, run `make dev_push`.
+1. Run `kubectl patch deployment clusterapi -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"gce-machine-controller\",\"env\":[{\"name\":\"DATE\",\"value\":\"$(date +'%s')\"}]}]}}}}"`. This command inserts or updates an environment variable named `DATE` which triggers a new deployment.
+
+### Verifying Your Environment
+
+1. Install `jq`. Instructions can be found [here](https://stedolan.github.io/jq/download/). 
+1. Run the following, `kubectl get pods -o json | jq '.items[].status.containerStatuses[] | select(.name=="gce-machine-controller")'`. Validate the the hash in the `imageID` field matches the image you built above. 
+1. Run the following, it will store, in `${POD_NAME}`, the name of your main clusterapi pod, `POD_NAME=$(kubectl get pods -o json | jq '.items[] | select(.status.containerStatuses[].name=="gce-machine-controller") | .metadata.name' --raw-output)`.
+1. Run `kubectl logs --namespace=default ${POD_NAME} -c gce-machine-controller`. Look for the output or change that you added to gce-machine-controller.


### PR DESCRIPTION
…controller.

**What this PR does / why we need it**:
This PR adds instructions for how to build and run a custom version of gce-machine-controller on a GCE Kubernetes cluster. It is an incremental bit of progress on issue https://github.com/kubernetes-sigs/cluster-api/issues/63 which asks for a better local developer experience on gce-machine-controller. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
