### PR TITLE
update machine status when node ready state has changed

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -44,10 +44,11 @@ type MachineControllerImpl struct {
 
 	actuator Actuator
 
-	kubernetesClientSet *kubernetes.Clientset
+	kubernetesClientSet kubernetes.Interface
 	clientSet           clientset.Interface
 	machineClient       v1alpha1.MachineInterface
 	linkedNodes         map[string]bool
+	cachedReadiness     map[string]bool
 }
 
 // Init initializes the controller and is called by the generated code
@@ -64,6 +65,7 @@ func (c *MachineControllerImpl) Init(arguments sharedinformers.ControllerInitArg
 	c.kubernetesClientSet = arguments.GetSharedInformers().KubernetesClientSet
 
 	c.linkedNodes = make(map[string]bool)
+	c.cachedReadiness = make(map[string]bool)
 
 	// Create machine actuator.
 	// TODO: Assume default namespace for now. Maybe a separate a controller per namespace?

--- a/pkg/controller/machine/node_test.go
+++ b/pkg/controller/machine/node_test.go
@@ -1,0 +1,253 @@
+package machine
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
+	v1alpha1listers "sigs.k8s.io/cluster-api/pkg/client/listers_generated/cluster/v1alpha1"
+)
+
+func TestReconcileNode(t *testing.T) {
+	tests := []struct {
+		name                     string
+		nodeHasMachineAnnotation bool
+		nodeIsDeleting           bool
+		nodeLinked               bool
+		nodeCached               bool
+		nodeCachedReady          bool
+		nodeReady                bool
+		nodeNotPresent           bool
+		machineNotPresent        bool
+		nodeRefName              string
+		expectedErr              bool
+		expectLinked             bool
+		expectedActions          []string
+	}{
+		{
+			name: "node doesn't exist, noop",
+			nodeHasMachineAnnotation: true,
+			nodeNotPresent:           true,
+		},
+		{
+			name: "node with machine annotations, link",
+			nodeHasMachineAnnotation: true,
+			expectLinked:             true,
+			expectedActions:          []string{"get", "update"},
+		},
+		{
+			name: "node with no machine annotations, noop",
+		},
+		{
+			name: "node with machine annotations, missing machine, err",
+			nodeHasMachineAnnotation: true,
+			machineNotPresent:        true,
+			expectedErr:              true,
+			expectedActions:          []string{"get"},
+		},
+		{
+			name: "node being deleted, unlink",
+			nodeHasMachineAnnotation: true,
+			nodeIsDeleting:           true,
+			nodeRefName:              "bar",
+			nodeCached:               true,
+			expectedActions:          []string{"get", "update"},
+		},
+		{
+			name:           "node being deleted, no machine annotations, noop",
+			nodeIsDeleting: true,
+		},
+		{
+			name: "node being deleted, missing machine, err",
+			nodeHasMachineAnnotation: true,
+			nodeIsDeleting:           true,
+			machineNotPresent:        true,
+			expectedActions:          []string{"get"},
+			expectedErr:              true,
+		},
+		{
+			name: "node being deleted, no node ref, noop",
+			nodeHasMachineAnnotation: true,
+			nodeIsDeleting:           true,
+			expectedActions:          []string{"get"},
+		},
+		{
+			name: "node being deleted, node ref mismatch, noop",
+			nodeHasMachineAnnotation: true,
+			nodeIsDeleting:           true,
+			nodeRefName:              "random",
+			expectedActions:          []string{"get"},
+		},
+		{
+			name:       "node cached and no change to ready state, noop",
+			nodeCached: true,
+			nodeReady:  true,
+		},
+		{
+			name:                     "node cached ready and change to not ready state, update",
+			nodeCached:               true,
+			nodeCachedReady:          true,
+			nodeReady:                false,
+			nodeHasMachineAnnotation: true,
+			expectLinked:             true,
+			expectedActions:          []string{"get", "update"},
+		},
+		{
+			name:                     "node cached not ready and change to ready state, update",
+			nodeCached:               true,
+			nodeCachedReady:          false,
+			nodeReady:                true,
+			nodeHasMachineAnnotation: true,
+			expectLinked:             true,
+			expectedActions:          []string{"get", "update"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := getMachine("foo", false, false, false)
+			if test.nodeRefName != "" {
+				m.Status.NodeRef = &corev1.ObjectReference{
+					Kind: "Node",
+					Name: test.nodeRefName,
+				}
+			}
+			mrObjects := []runtime.Object{}
+			if !test.machineNotPresent {
+				mrObjects = append(mrObjects, m)
+			}
+
+			machinesIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			err := machinesIndexer.Add(m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			machineLister := v1alpha1listers.NewMachineLister(machinesIndexer)
+
+			fakeClient := fake.NewSimpleClientset(mrObjects...)
+			fakeMachineClient := fakeClient.Cluster().Machines(metav1.NamespaceDefault)
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "bar",
+					Annotations: make(map[string]string),
+				},
+			}
+			if test.nodeReady {
+				node.Status = corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						corev1.NodeCondition{
+							Type:               corev1.NodeReady,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.Now(),
+						},
+					},
+				}
+			}
+			if test.nodeHasMachineAnnotation {
+				node.ObjectMeta.Annotations[machineAnnotationKey] = "foo"
+			}
+			if test.nodeIsDeleting {
+				node.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			}
+
+			krObjects := []runtime.Object{}
+			if !test.nodeNotPresent {
+				krObjects = append(krObjects, node)
+			}
+			fakeK8sClient := k8sfake.NewSimpleClientset(krObjects...)
+
+			target := &MachineControllerImpl{}
+			target.clientSet = fakeClient
+			target.machineClient = fakeMachineClient
+			target.kubernetesClientSet = fakeK8sClient
+			target.lister = machineLister
+			target.linkedNodes = make(map[string]bool)
+			target.cachedReadiness = make(map[string]bool)
+			if test.nodeCached {
+				target.linkedNodes["bar"] = true
+				target.cachedReadiness["bar"] = test.nodeCachedReady
+			}
+
+			nodeKey, err := cache.MetaNamespaceKeyFunc(node)
+			if err != nil {
+				t.Fatalf("unable to get key for test node, %v", err)
+			}
+			err = target.reconcileNode(nodeKey)
+
+			if (err != nil) != test.expectedErr {
+				t.Fatalf("got %v error, expected %v error", err, test.expectedErr)
+			}
+
+			cached := target.linkedNodes["bar"]
+			if cached != test.expectLinked && !test.nodeCached {
+				t.Errorf("got %v node cache result, expected %v node cache result", cached, test.expectLinked)
+			}
+			// Successful unlink should clear cache.
+			if test.nodeIsDeleting && len(test.expectedActions) == 2 {
+				if cached {
+					t.Errorf("got %v node cache result, expected no node cache result", cached)
+				}
+			}
+			if cached {
+				isReady := target.cachedReadiness["bar"]
+				// If successful, isRead
+				if len(test.expectedActions) == 2 {
+					if isReady != test.nodeReady {
+						t.Errorf("got %v cached node ready, expected %v cached node ready", isReady, test.nodeReady)
+					}
+				} else {
+					if isReady != test.nodeCachedReady {
+						t.Errorf("got %v cached node ready, expected %v cached node ready", isReady, test.nodeCachedReady)
+					}
+				}
+			}
+
+			var actualMachine *v1alpha1.Machine
+			actions := fakeClient.Actions()
+			if len(actions) != len(test.expectedActions) {
+				t.Fatalf("got %v actions, expected %v actions; got actions %v, expected actions %v", len(actions), len(test.expectedActions), actions, test.expectedActions)
+			}
+
+			for i, action := range test.expectedActions {
+				if actions[i].GetVerb() != action {
+					t.Errorf("got %v action verb, expected %v action verb", actions[i].GetVerb(), action)
+				}
+				if actions[i].GetVerb() == "update" {
+					updateAction, ok := actions[i].(clienttesting.UpdateAction)
+					if !ok {
+						t.Fatalf("unexpected action %#v", action)
+					}
+					actualMachine, ok = updateAction.GetObject().(*v1alpha1.Machine)
+					if !ok {
+						t.Fatalf("unexpected object %#v", actualMachine)
+					}
+				}
+			}
+			if actualMachine != nil && actualMachine.Status.LastUpdated.IsZero() {
+				t.Errorf("got %v last updated time, expected non-zero last updated time.", actualMachine.Status.LastUpdated)
+			}
+			if test.expectLinked {
+				if actualMachine.Status.NodeRef == nil {
+					t.Fatalf("got nil node ref, expected non-nil node ref")
+				}
+				if actualMachine.Status.NodeRef.Name != "bar" {
+					t.Errorf("got %v node ref name, expected bar node ref name.", actualMachine.Status.NodeRef.Name)
+				}
+			}
+			if !test.expectLinked {
+				if actualMachine != nil && actualMachine.Status.NodeRef != nil {
+					t.Fatalf("got non-nil node ref, expected nil node ref")
+				}
+			}
+		})
+	}
+}

--- a/pkg/node/util/util.go
+++ b/pkg/node/util/util.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IsNodeAvailable returns true if the node is ready and minReadySeconds have elapsed or is 0. False otherwise.
+func IsNodeAvailable(node *corev1.Node, minReadySeconds int32, now metav1.Time) bool {
+	if !IsNodeReady(node) {
+		return false
+	}
+
+	if minReadySeconds == 0 {
+		return true
+	}
+
+	minReadySecondsDuration := time.Duration(minReadySeconds) * time.Second
+	readyCondition := GetReadyCondition(&node.Status)
+
+	if !readyCondition.LastTransitionTime.IsZero() &&
+		readyCondition.LastTransitionTime.Add(minReadySecondsDuration).Before(now.Time) {
+		return true
+	}
+
+	return false
+}
+
+// GetReadyCondition extracts the ready condition from the given status and returns that.
+// Returns nil and -1 if the condition is not present, and the index of the located condition.
+func GetReadyCondition(status *corev1.NodeStatus) *corev1.NodeCondition {
+	if status == nil {
+		return nil
+	}
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == corev1.NodeReady {
+			return &status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// IsNodeReady returns true if a node is ready; false otherwise.
+func IsNodeReady(node *corev1.Node) bool {
+	if node == nil || &node.Status == nil {
+		return false
+	}
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/pkg/node/util/util_test.go
+++ b/pkg/node/util/util_test.go
@@ -1,0 +1,294 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsNodeAvaialble(t *testing.T) {
+	tests := []struct {
+		name              string
+		node              *corev1.Node
+		minReadySeconds   int32
+		expectedAvailable bool
+	}{
+		{
+			name:              "no node",
+			expectedAvailable: false,
+		},
+		{
+			name:              "no status",
+			node:              &corev1.Node{},
+			expectedAvailable: false,
+		},
+		{
+			name:              "no condition",
+			node:              &corev1.Node{Status: corev1.NodeStatus{}},
+			expectedAvailable: false,
+		},
+		{
+			name: "no ready condition",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeOutOfDisk,
+						Status: corev1.ConditionTrue,
+					},
+				}},
+			},
+			expectedAvailable: false,
+		},
+		{
+			name: "ready condition true, minReadySeconds = 0, lastTransitionTime now",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: metav1.Now(),
+					},
+				}},
+			},
+			expectedAvailable: true,
+		},
+		{
+			name: "ready condition true, minReadySeconds = 0, lastTransitionTime past",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: metav1.Time{Time: time.Now().Add(time.Duration(-700) * time.Second)},
+					},
+				}},
+			},
+			expectedAvailable: true,
+		},
+		{
+			name: "ready condition true, minReadySeconds = 300, lastTransitionTime now",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: metav1.Now(),
+					},
+				}},
+			},
+			minReadySeconds:   300,
+			expectedAvailable: false,
+		},
+		{
+			name: "ready condition true, minReadySeconds = 300, lastTransitionTime past",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: metav1.Time{Time: time.Now().Add(time.Duration(-700) * time.Second)},
+					},
+				}},
+			},
+			minReadySeconds:   300,
+			expectedAvailable: true,
+		},
+		{
+			name: "ready condition false",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionFalse,
+					},
+				}},
+			},
+			expectedAvailable: false,
+		},
+		{
+			name: "ready condition unknown",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionUnknown,
+					},
+				}},
+			},
+			expectedAvailable: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isAvailable := IsNodeAvailable(test.node, test.minReadySeconds, metav1.Now())
+			if isAvailable != test.expectedAvailable {
+				t.Fatalf("got %v available, expected %v available", isAvailable, test.expectedAvailable)
+			}
+		})
+	}
+}
+
+func TestGetReadyCondition(t *testing.T) {
+	tests := []struct {
+		name              string
+		nodeStatus        *corev1.NodeStatus
+		expectedCondition *corev1.NodeCondition
+	}{
+		{
+			name: "no status",
+		},
+		{
+			name:       "no condition",
+			nodeStatus: &corev1.NodeStatus{},
+		},
+		{
+			name: "no ready condition",
+			nodeStatus: &corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeOutOfDisk,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			name: "ready condition true",
+			nodeStatus: &corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+			expectedCondition: &corev1.NodeCondition{
+				Type:   corev1.NodeReady,
+				Status: corev1.ConditionTrue,
+			},
+		},
+		{
+			name: "ready condition false",
+			nodeStatus: &corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionFalse,
+					},
+				},
+			},
+			expectedCondition: &corev1.NodeCondition{
+				Type:   corev1.NodeReady,
+				Status: corev1.ConditionFalse,
+			},
+		},
+		{
+			name: "ready condition unknown",
+			nodeStatus: &corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionUnknown,
+					},
+				},
+			},
+			expectedCondition: &corev1.NodeCondition{
+				Type:   corev1.NodeReady,
+				Status: corev1.ConditionUnknown,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := GetReadyCondition(test.nodeStatus)
+			if !reflect.DeepEqual(c, test.expectedCondition) {
+				t.Fatalf("got %v condition, expected %v condition", c, test.expectedCondition)
+			}
+		})
+	}
+}
+
+func TestIsNodeReady(t *testing.T) {
+	tests := []struct {
+		name          string
+		node          *corev1.Node
+		expectedReady bool
+	}{
+		{
+			name:          "no node",
+			expectedReady: false,
+		},
+		{
+			name:          "no status",
+			node:          &corev1.Node{},
+			expectedReady: false,
+		},
+		{
+			name:          "no condition",
+			node:          &corev1.Node{Status: corev1.NodeStatus{}},
+			expectedReady: false,
+		},
+		{
+			name: "no ready condition",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeOutOfDisk,
+						Status: corev1.ConditionTrue,
+					},
+				}},
+			},
+			expectedReady: false,
+		},
+		{
+			name: "ready condition true",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				}},
+			},
+			expectedReady: true,
+		},
+		{
+			name: "ready condition false",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionFalse,
+					},
+				}},
+			},
+			expectedReady: false,
+		},
+		{
+			name: "ready condition unknown",
+			node: &corev1.Node{Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					corev1.NodeCondition{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionUnknown,
+					},
+				}},
+			},
+			expectedReady: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isReady := IsNodeReady(test.node)
+			if isReady != test.expectedReady {
+				t.Fatalf("got %v ready, expected %v ready", isReady, test.expectedReady)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR changes such that the machine controller will update the machine status if there is a change in readiness of the node.
It changes caching the readiness of the node upon linking instead of strictly that it is linked.
This is to allow the propagation of events up to the machineset controller such that it is aware that another machine is ready (by proxy of the node readiness), which is used to update the machinset status that is used for rolling updates.
The machineset controller will need to be listening to machine events for this to work, which will be in an upcoming PR.

@kubernetes/kube-deploy-reviewers
