### PR TITLE
Use generic ssh instead of provider specific ssh.

### DIFF
--- a/cloud/google/cmd/gce-machine-controller/Dockerfile
+++ b/cloud/google/cmd/gce-machine-controller/Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs
 
 # Final container
 FROM alpine:3.7
-RUN apk --no-cache add ca-certificates bash openssh 
+RUN apk --no-cache add ca-certificates bash openssh
 
 COPY --from=builder /go/bin/gce-machine-controller .
 

--- a/cloud/google/cmd/gce-machine-controller/app/controller.go
+++ b/cloud/google/cmd/gce-machine-controller/app/controller.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/controller"
+	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,10 +61,24 @@ func StartMachineController(server *options.MachineControllerServer, shutdown <-
 	if err != nil {
 		glog.Fatalf("Could not create config watch: %v", err)
 	}
+
+	sshUser, err := ioutil.ReadFile(server.SSHUserPath)
+	if err != nil {
+		glog.Fatalf("Could not read user file: %v", err)
+	}
+
+	sshPublicKey, err := ioutil.ReadFile(server.SSHPublicKeyPath)
+	if err != nil {
+		glog.Fatalf("Could not read ssh public key file: %v", err)
+	}
+
 	params := google.MachineActuatorParams{
 		KubeadmToken:             server.KubeadmToken,
 		MachineClient:            client.ClusterV1alpha1().Machines(corev1.NamespaceDefault),
 		MachineSetupConfigGetter: configWatch,
+		SSHPrivateKeyPath:        server.SSHPrivateKeyPath,
+		SSHPublicKey:             string(sshPublicKey),
+		SSHUser:                  string(sshUser),
 	}
 	actuator, err := google.NewMachineActuator(params)
 	if err != nil {

--- a/cloud/google/cmd/gce-machine-controller/app/options/options.go
+++ b/cloud/google/cmd/gce-machine-controller/app/options/options.go
@@ -25,6 +25,9 @@ type MachineControllerServer struct {
 	CommonConfig            *config.Configuration
 	KubeadmToken            string
 	MachineSetupConfigsPath string
+	SSHPrivateKeyPath       string
+	SSHPublicKeyPath        string
+	SSHUserPath             string
 }
 
 func NewMachineControllerServer() *MachineControllerServer {
@@ -37,6 +40,9 @@ func NewMachineControllerServer() *MachineControllerServer {
 func (s *MachineControllerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeadmToken, "token", s.KubeadmToken, "Kubeadm token to use to join new machines")
 	fs.StringVar(&s.MachineSetupConfigsPath, "machinesetup", s.MachineSetupConfigsPath, "path to machine setup configs file")
+	fs.StringVar(&s.SSHPrivateKeyPath, "sshprivatekeypath", s.SSHPrivateKeyPath, "path to the private ssh key file")
+	fs.StringVar(&s.SSHPublicKeyPath, "sshpublickeypath", s.SSHPrivateKeyPath, "path to the public ssh key file")
+	fs.StringVar(&s.SSHUserPath, "sshuserpath", s.SSHUserPath, "path to the ssh user file")
 
 	config.ControllerConfig.AddFlags(pflag.CommandLine)
 }

--- a/cloud/google/config/configtemplate.go
+++ b/cloud/google/config/configtemplate.go
@@ -150,6 +150,9 @@ spec:
         - --kubeconfig=/etc/kubernetes/admin.conf
         - --token={{ .Token }}
         - --machinesetup=/etc/machinesetup/machine_setup_configs.yaml
+        - --sshprivatekeypath=/etc/sshkeys/private
+        - --sshpublickeypath=/etc/sshkeys/public
+        - --sshuserpath=/etc/sshkeys/user
         resources:
           requests:
             cpu: 100m

--- a/cloud/google/run.go
+++ b/cloud/google/run.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package google
+
+import (
+	"os/exec"
+	"fmt"
+)
+
+func run(cmd string, args ...string) error {
+	_, err := runOutput(cmd, args...)
+	return err
+}
+
+// runOutput is declared as function variable to allow for testing hooks.
+var runOutput = func(cmd string, args ...string) (string, error) {
+	c := exec.Command(cmd, args...)
+	if out, err := c.CombinedOutput(); err != nil {
+		return string(out), fmt.Errorf("error: %v, output: %s", err, string(out))
+	}
+	return "", nil
+}

--- a/cloud/google/run_test.go
+++ b/cloud/google/run_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// White box testing for functionality in run.go
+package google
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	oldRunOutput := runOutput
+	defer func() { runOutput = oldRunOutput }()
+
+	tests := []struct {
+		name        string
+		cmd         string
+		args        []string
+		runErr      error
+		expectErr   bool
+	}{
+		{
+			name: "success",
+		},
+		{
+			name:      "error",
+			runErr:    fmt.Errorf("404"),
+			expectErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runOutput = func(cmd string, args ...string) (string, error) {
+				if cmd != test.cmd {
+					t.Errorf("Unexpected command. Got: %v, Want: %v", cmd, test.cmd)
+				}
+				if len(args) != len(test.args) {
+					t.Fatalf("Unexpected number of arguments. Got: %v, Want: %v", len(args), len(test.args))
+				}
+				for idx := range test.args {
+					if args[idx] != test.args[idx] {
+						t.Errorf("Unexpected argument at index %v. Got: %v, Want: %v", idx, args[idx], test.args[idx])
+					}
+				}
+				return "", test.runErr
+			}
+
+			err := run(test.cmd, test.args...)
+			if (test.expectErr && err == nil) || (!test.expectErr && err != nil) {
+				t.Fatalf("Error not as expected. Got: %v, Want Err: %v", err, test.expectErr)
+			}
+		})
+	}
+}

--- a/cloud/google/serviceaccount.go
+++ b/cloud/google/serviceaccount.go
@@ -15,7 +15,6 @@ package google
 
 import (
 	"fmt"
-	"os/exec"
 
 	"github.com/golang/glog"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -232,12 +231,4 @@ func (gce *GCEClient) getProjects(machines []*clusterv1.Machine) ([]string, erro
 		projects = append(projects, config.Project)
 	}
 	return projects, nil
-}
-
-func run(cmd string, args ...string) error {
-	c := exec.Command(cmd, args...)
-	if out, err := c.CombinedOutput(); err != nil {
-		return fmt.Errorf("error: %v, output: %s", err, string(out))
-	}
-	return nil
 }

--- a/cloud/google/ssh.go
+++ b/cloud/google/ssh.go
@@ -18,93 +18,34 @@ package google
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/golang/glog"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-const (
-	MachineControllerSshKeySecret = "machine-controller-sshkeys"
-	// Arbitrary name used for SSH.
-	SshUser                = "clusterapi"
-	SshKeyFile             = "clusterapi-key"
-	SshKeyFilePublic       = SshKeyFile + ".pub"
-	SshKeyFilePublicGcloud = SshKeyFilePublic + ".gcloud"
-)
-
-func createSshKeyPairs() error {
-	err := run("ssh-keygen", "-t", "rsa", "-f", SshKeyFile, "-C", SshUser, "-N", "")
-	if err != nil {
-		return fmt.Errorf("couldn't generate RSA keys: %v", err)
-	}
-
-	// Prepare a gce format public key file
-	outfile, err := os.Create(SshKeyFilePublicGcloud)
-	if err != nil {
-		return err
-	}
-	defer outfile.Close()
-
-	b, err := ioutil.ReadFile(SshKeyFilePublic)
-	if err == nil {
-		outfile.WriteString(SshUser + ":" + string(b))
-	}
-
-	return err
+func (gce *GCEClient) sshMetadata(metadata map[string]string) (map[string]string, error) {
+	sshMetadata(metadata, gce.sshCreds.user, gce.sshCreds.publicKey)
+	return metadata, nil
 }
 
-func cleanupSshKeyPairs() {
-	os.Remove(SshKeyFile)
-	os.Remove(SshKeyFilePublic)
-	os.Remove(SshKeyFilePublicGcloud)
-}
-
-// It creates secret to store private key.
-func (gce *GCEClient) setupSSHAccess(m *clusterv1.Machine) error {
-	// Create public/private key pairs
-	err := createSshKeyPairs()
-	if err != nil {
-		return err
-	}
-
-	config, err := gce.providerconfig(m.Spec.ProviderConfig)
-	if err != nil {
-		return err
-	}
-
-	err = run("gcloud", "compute", "instances", "add-metadata", m.Name,
-		"--metadata-from-file", "ssh-keys="+SshKeyFile+".pub.gcloud",
-		"--project", config.Project, "--zone", config.Zone)
-	if err != nil {
-		return err
-	}
-
-	// Create secrets so that machine controller container can load them.
-	err = run("kubectl", "create", "secret", "generic", MachineControllerSshKeySecret, "--from-file=private="+SshKeyFile, "--from-literal=user="+SshUser)
-	if err != nil {
-		return fmt.Errorf("couldn't create service account key as credential: %v", err)
-	}
-
-	cleanupSshKeyPairs()
-
-	return err
+func sshMetadata(metadata map[string]string, user, publicKey string) (map[string]string) {
+	metadata["ssh-keys"] = fmt.Sprintf("%s:%s", user, publicKey)
+	return metadata
 }
 
 func (gce *GCEClient) remoteSshCommand(m *clusterv1.Machine, cmd string) (string, error) {
-	glog.Infof("Remote SSH execution '%s' on %s", cmd, m.ObjectMeta.Name)
-
 	publicIP, err := gce.GetIP(m)
 	if err != nil {
 		return "", err
 	}
 
-	command := fmt.Sprintf("%s", cmd)
-	c := exec.Command("ssh", "-i", gce.sshCreds.privateKeyPath, "-q", gce.sshCreds.user+"@"+publicIP, command)
-	out, err := c.CombinedOutput()
+	glog.Infof("Remote SSH execution '%s' on %s %s", cmd, m.ObjectMeta.Name, publicIP)
+  return remoteSshCommand(publicIP, cmd, gce.sshCreds.user, gce.sshCreds.privateKeyPath)
+}
+
+func remoteSshCommand(ip, cmd, user, privateKeyPath string) (string, error) {
+	out, err := runOutput("ssh", "-i", privateKeyPath, "-q", user+"@"+ip, "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", cmd)
 	if err != nil {
 		return "", fmt.Errorf("error: %v, output: %s", err, string(out))
 	}

--- a/cloud/google/ssh_test.go
+++ b/cloud/google/ssh_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// White box testing for functionality in ssh.go
+package google
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSSHMetadata(t *testing.T) {
+	tests := []struct {
+		name             string
+		metadata         map[string]string
+		user             string
+		publicKey        string
+		expectedMetadata map[string]string
+	}{
+		{
+			name:             "Empty metadata",
+			metadata:         map[string]string{},
+			user:             "user1",
+			publicKey:        "key1",
+			expectedMetadata: map[string]string{"ssh-keys": "user1:key1"},
+		},
+		{
+			name:             "Some metadata",
+			metadata:         map[string]string{"foo": "bar"},
+			user:             "user2",
+			publicKey:        "key2",
+			expectedMetadata: map[string]string{"foo": "bar", "ssh-keys": "user2:key2"},
+		},
+		{
+			name:             "Overwrite metadata",
+			metadata:         map[string]string{"foo": "bar", "ssh-keys": "user1:key1"},
+			user:             "user3",
+			publicKey:        "key3",
+			expectedMetadata: map[string]string{"foo": "bar", "ssh-keys": "user3:key3"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := sshMetadata(test.metadata, test.user, test.publicKey)
+			if len(m) != len(test.expectedMetadata) {
+				t.Fatalf("Unexepected metadata count. Got:%v, Want:%v", len(m), len(test.expectedMetadata))
+			}
+			for eKey, eValue := range test.expectedMetadata {
+				value, ok := m[eKey]
+				if !ok {
+					t.Fatalf("Missing metadata value for key:%v", eKey)
+				}
+				if value != eValue {
+					t.Fatalf("Unexpected value for key %v. Got:%v, Want:%v", eKey, value, eValue)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteSSHCommand(t *testing.T) {
+	oldRunOutput := runOutput
+	defer func() { runOutput = oldRunOutput }()
+
+	tests := []struct {
+		name        string
+		runErr      error
+		runOut      string
+		expectErr   bool
+		expectedOut string
+	}{
+		{
+			name: "success with no output",
+		},
+		{
+			name:        "success with output",
+			runOut:      "legen...",
+			expectedOut: "legen...",
+		},
+		{
+			name:        "success with cleaned output",
+			runOut:      "  ...wait for it... ...dary",
+			expectedOut: "...wait for it... ...dary",
+		},
+		{
+			name:      "error",
+			runErr:    fmt.Errorf("404"),
+			expectErr: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runOutput = func(cmd string, args ...string) (string, error) {
+				if cmd != "ssh" {
+					t.Errorf("Unexpected call to %v", cmd)
+				}
+				return test.runOut, test.runErr
+			}
+
+			out, err := remoteSshCommand("", "", "", "")
+			if (test.expectErr && err == nil) || (!test.expectErr && err != nil) {
+				t.Fatalf("Error not as expected. Got: %v, Want Err: %v", err, test.expectErr)
+			}
+			if test.expectedOut != out {
+				t.Fatalf("Unexpected output. Got:%v, Want:%v", out, test.expectedOut)
+			}
+		})
+	}
+}

--- a/gcp-deployer/deploy/machinedeployer.go
+++ b/gcp-deployer/deploy/machinedeployer.go
@@ -10,7 +10,6 @@ import (
 type machineDeployer interface {
 	machine.Actuator
 	GetIP(machine *clusterv1.Machine) (string, error)
-	GetKubeConfig(master *clusterv1.Machine) (string, error)
 
 	// Provision infrastructure that the cluster needs before it
 	// can be created

--- a/gcp-deployer/deploy/ssh.go
+++ b/gcp-deployer/deploy/ssh.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/golang/glog"
+)
+
+const (
+	MachineControllerSshKeySecret = "machine-controller-sshkeys"
+
+	// Arbitrary name used for SSH.
+	SshUser                = "clusterapi"
+	SshUserFile            = "clusterapi-user"
+	SshKeyFilePrivate      = "clusterapi-key"
+	SshKeyFilePublic       = SshKeyFilePrivate + ".pub"
+)
+
+func createSshKeyPairs() error {
+	if fileExists(SshUserFile) || fileExists(SshKeyFilePrivate) || fileExists (SshKeyFilePublic) {
+		if !fileExists(SshUserFile) || !fileExists(SshKeyFilePrivate) || !fileExists (SshKeyFilePublic) {
+			return fmt.Errorf(
+				"an incomplete set of ssh files exist and cannot be reused. Please remove all files to regenerate ssh keys: %v, %v, %v",
+				SshUserFile,
+				SshKeyFilePrivate,
+				SshKeyFilePublic)
+		} else {
+			glog.Info("Re-using existing ssh files.\n")
+			return nil
+		}
+	}
+
+	_, err := exec.Command("ssh-keygen", "-t", "rsa", "-f", SshKeyFilePrivate, "-C", SshUser, "-N", "").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("couldn't generate RSA keys: %v", err)
+	}
+
+	f, err := os.Create(SshUserFile)
+	defer f.Close()
+	if err != nil {
+		return fmt.Errorf("couldn't create ssh user file: %v", err)
+	}
+
+	_, err = f.WriteString(SshUser)
+	if err != nil {
+		return fmt.Errorf("couldn't write ssh user file: %v", err)
+	}
+
+	glog.Info("Created ssh files.\n")
+
+	return nil
+}
+
+func cleanupSshKeyPairs() {
+	os.Remove(SshKeyFilePrivate)
+	os.Remove(SshKeyFilePublic)
+	os.Remove(SshUserFile)
+}
+
+// It creates secret to store private key.
+func setupSSHSecret() error {
+	// Create secrets so that machine controller container can load them
+	c := exec.Command("kubectl",
+		"create",
+			"secret",
+			"generic",
+			MachineControllerSshKeySecret,
+			"--from-file=private="+SshKeyFilePrivate,
+		  "--from-file=public="+SshKeyFilePublic,
+			"--from-literal=user="+SshUser)
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("couldn't create ssh secret. error: %v output: %v", err, string(out))
+	}
+
+	return err
+}
+
+func remoteSshCommand(ip, cmd, sshKeyPath, sshUser string) (string, error) {
+	glog.Infof("Remote SSH execution '%s' on %s", cmd, ip)
+
+	c := exec.Command("ssh", "-i", sshKeyPath, "-q", sshUser+"@"+ip, "-o", "StrictHostKeyChecking=no","-o", "UserKnownHostsFile=/dev/null", cmd)
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed command '%v'. error: %v, output: %s", cmd, err, string(out))
+	}
+	return string(out), err
+}
+
+func sshCommand(ip, cmd string) (string, error) {
+	b, err := ioutil.ReadFile(SshUserFile)
+	if err != nil {
+		return "", fmt.Errorf("Could not read user file %v:%v", SshUserFile, err)
+	}
+	user := string(b)
+	return remoteSshCommand(ip, cmd, SshKeyFilePrivate, user)
+}
+
+func fileExists(file string) bool {
+	_, err := os.Stat(file)
+	return err == nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Getting kubeconfig should be be required to be provider specific. Use a generic ssh.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #160

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
