### PR TITLE
Cluster controller implementation

### DIFF
--- a/pkg/apis/cluster/v1alpha1/cluster_types_test.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types_test.go
@@ -75,6 +75,10 @@ func crudAccessToClusterClient(t *testing.T, cs *clientset.Clientset) {
 	}
 
 	// Test deleting the item for delete requests.
+	actual.Finalizers = nil
+	if _, updateErr := client.Update(actual); updateErr != nil {
+		t.Fatal(updateErr)
+	}
 	if deleteErr := client.Delete(instance.Name, &metav1.DeleteOptions{}); deleteErr != nil {
 		t.Fatal(deleteErr)
 	}

--- a/pkg/controller/cluster/actuator.go
+++ b/pkg/controller/cluster/actuator.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+// Actuator controls clusters on a specific infrastructure. All
+// methods should be idempotent unless otherwise specified.
+type Actuator interface {
+	// Create or update the cluster
+	Reconcile(*clusterv1.Cluster) error
+	// Delete the cluster.
+	Delete(*clusterv1.Cluster) error
+}

--- a/pkg/controller/cluster/queue.go
+++ b/pkg/controller/cluster/queue.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/controller"
+	"sigs.k8s.io/cluster-api/pkg/controller/config"
+)
+
+func (c *ClusterController) RunAsync(stopCh <-chan struct{}) {
+	for _, q := range c.Informers.WorkerQueues {
+		go c.StartWorkerQueue(q, stopCh)
+	}
+}
+
+// StartWorkerQueue schedules a routine to continuously process Queue messages
+// until shutdown is closed
+func (c *ClusterController) StartWorkerQueue(q *controller.QueueWorker, shutdown <-chan struct{}) {
+	glog.Infof("Start %s Queue", q.Name)
+	defer q.Queue.ShutDown()
+
+	for i := 0; i < config.ControllerConfig.WorkerCount; i++ {
+		// Every second, process all messages in the Queue until it is time to shutdown
+		go wait.Until(q.ProcessAllMessages, time.Second, shutdown)
+	}
+
+	<-shutdown
+
+	// Stop accepting messages into the Queue
+	glog.V(1).Infof("Shutting down %s Queue\n", q.Name)
+}

--- a/pkg/controller/cluster/reconcile_test.go
+++ b/pkg/controller/cluster/reconcile_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/fake"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+func TestClusterSetControllerReconcileHandler(t *testing.T) {
+	tests := []struct {
+		name                      string
+		objExists                 bool
+		isDeleting                bool
+		withFinalizer             bool
+		isMaster                  bool
+		ignoreDeleteCallCount     bool
+		expectFinalizerRemoved    bool
+		numExpectedReconcileCalls int64
+		numExpectedDeleteCalls    int64
+	}{
+		{
+			name:                      "Create cluster",
+			objExists:                 false,
+			numExpectedReconcileCalls: 1,
+		},
+		{
+			name:                      "Update cluster",
+			objExists:                 true,
+			numExpectedReconcileCalls: 1,
+		},
+		{
+			name:                   "Delete cluster, instance exists, with finalizer",
+			objExists:              true,
+			isDeleting:             true,
+			withFinalizer:          true,
+			expectFinalizerRemoved: true,
+			numExpectedDeleteCalls: 1,
+		},
+		{
+			// This should not be possible. Here for completeness.
+			name:          "Delete cluster, instance exists without finalizer",
+			objExists:     true,
+			isDeleting:    true,
+			withFinalizer: false,
+		},
+		{
+			name:                   "Delete cluster, instance does not exist, with finalizer",
+			objExists:              true,
+			isDeleting:             true,
+			withFinalizer:          true,
+			ignoreDeleteCallCount:  true,
+			expectFinalizerRemoved: true,
+		},
+		{
+			name:          "Delete cluster, instance does not exist, without finalizer",
+			objExists:     true,
+			isDeleting:    true,
+			withFinalizer: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clusterToTest := getCluster("bar", test.isDeleting, test.withFinalizer)
+			knownObjects := []runtime.Object{}
+			if test.objExists {
+				knownObjects = append(knownObjects, clusterToTest)
+			}
+
+			clusterUpdated := false
+			fakeClient := fake.NewSimpleClientset(knownObjects...)
+			fakeClusterClient := fakeClient.Cluster().Clusters(metav1.NamespaceDefault)
+			fakeClient.PrependReactor("update", "clusters", func(action core.Action) (bool, runtime.Object, error) {
+				clusterUpdated = true
+				return false, nil, nil
+			})
+
+			actuator := NewTestActuator()
+
+			target := &ClusterControllerImpl{}
+			target.actuator = actuator
+			target.clientSet = fakeClient
+			target.clusterClient = fakeClusterClient
+
+			var err error
+			err = target.Reconcile(clusterToTest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			finalizerRemoved := clusterUpdated && !util.Contains(clusterToTest.ObjectMeta.Finalizers, v1alpha1.ClusterFinalizer)
+
+			if finalizerRemoved != test.expectFinalizerRemoved {
+				t.Errorf("Got finalizer removed %v, expected finalizer removed %v", finalizerRemoved, test.expectFinalizerRemoved)
+			}
+			if actuator.ReconcileCallCount != test.numExpectedReconcileCalls {
+				t.Errorf("Got %v create calls, expected %v", actuator.ReconcileCallCount, test.numExpectedReconcileCalls)
+			}
+			if actuator.DeleteCallCount != test.numExpectedDeleteCalls && !test.ignoreDeleteCallCount {
+				t.Errorf("Got %v delete calls, expected %v", actuator.DeleteCallCount, test.numExpectedDeleteCalls)
+			}
+
+		})
+	}
+}
+
+func getCluster(name string, isDeleting bool, hasFinalizer bool) *v1alpha1.Cluster {
+	m := &v1alpha1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+	if isDeleting {
+		now := metav1.NewTime(time.Now())
+		m.ObjectMeta.SetDeletionTimestamp(&now)
+	}
+	if hasFinalizer {
+		m.ObjectMeta.SetFinalizers([]string{v1alpha1.ClusterFinalizer})
+	}
+
+	return m
+}

--- a/pkg/controller/cluster/testactuator.go
+++ b/pkg/controller/cluster/testactuator.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"sync"
+
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+type TestActuator struct {
+	unblock            chan string
+	BlockOnReconcile   bool
+	BlockOnDelete      bool
+	ReconcileCallCount int64
+	DeleteCallCount    int64
+	Lock               sync.Mutex
+}
+
+func (a *TestActuator) Reconcile(*v1alpha1.Cluster) error {
+	defer func() {
+		if a.BlockOnReconcile {
+			<-a.unblock
+		}
+	}()
+
+	a.Lock.Lock()
+	defer a.Lock.Unlock()
+	a.ReconcileCallCount++
+	return nil
+}
+
+func (a *TestActuator) Delete(*v1alpha1.Cluster) error {
+	defer func() {
+		if a.BlockOnDelete {
+			<-a.unblock
+		}
+	}()
+
+	a.Lock.Lock()
+	defer a.Lock.Unlock()
+	a.DeleteCallCount++
+	return nil
+}
+
+func NewTestActuator() *TestActuator {
+	ta := new(TestActuator)
+	ta.unblock = make(chan string)
+	return ta
+}
+
+func (a *TestActuator) Unblock() {
+	close(a.unblock)
+}

--- a/pkg/controller/cluster/zz_generated.api.register.go
+++ b/pkg/controller/cluster/zz_generated.api.register.go
@@ -44,25 +44,15 @@ type ClusterController struct {
 }
 
 // NewController returns a new ClusterController for responding to Cluster events
-func NewClusterController(config *rest.Config, si *sharedinformers.SharedInformers) *ClusterController {
+func NewClusterController(config *rest.Config, si *sharedinformers.SharedInformers, actuator Actuator) *ClusterController {
 	q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Cluster")
 
 	queue := &controller.QueueWorker{q, 10, "Cluster", nil}
 	c := &ClusterController{queue, nil, "Cluster", nil, nil, si}
 
 	// For non-generated code to add events
-	uc := &ClusterControllerImpl{}
-	var ci sharedinformers.Controller = uc
-
-	// Call the Init method that is implemented.
-	// Support multiple Init methods for backwards compatibility
-	if i, ok := ci.(sharedinformers.LegacyControllerInit); ok {
-		i.Init(config, si, c.LookupAndReconcile)
-	} else if i, ok := ci.(sharedinformers.ControllerInit); ok {
-		i.Init(&sharedinformers.ControllerInitArgumentsImpl{si, config, c.LookupAndReconcile})
-	}
-
-	c.controller = uc
+	c.controller = &ClusterControllerImpl{}
+	c.controller.Init(&sharedinformers.ControllerInitArgumentsImpl{si, config, c.LookupAndReconcile}, actuator)
 
 	queue.Reconcile = c.reconcile
 	if c.Informers.WorkerQueues == nil {

--- a/pkg/controller/zz_generated.api.register.go
+++ b/pkg/controller/zz_generated.api.register.go
@@ -21,7 +21,6 @@ package controller
 import (
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/controller"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/cluster-api/pkg/controller/cluster"
 	"sigs.k8s.io/cluster-api/pkg/controller/machinedeployment"
 	"sigs.k8s.io/cluster-api/pkg/controller/machineset"
 	"sigs.k8s.io/cluster-api/pkg/controller/sharedinformers"
@@ -31,7 +30,6 @@ func GetAllControllers(config *rest.Config) ([]controller.Controller, chan struc
 	shutdown := make(chan struct{})
 	si := sharedinformers.NewSharedInformers(config, shutdown)
 	return []controller.Controller{
-		cluster.NewClusterController(config, si),
 		machinedeployment.NewMachineDeploymentController(config, si),
 		machineset.NewMachineSetController(config, si),
 	}, shutdown


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements the cluster controller loop, and provides a definition for the cluster actuator. The cluster actuator will need to be implemented by each cloud provider.

**Special notes for your reviewer**:
Much of this code was based on the machine controller.

The cluster actuator functions only take a cluster object, but will eventually be responsible for creating the master machine. The machine object definition will need to be generated from fields on the cluster itself, my thinking is that this would be handled by the cloud providers, but this is up for discussion.