### PR TITLE
Clean up adoption code, parallelize deletion and handle edge case updating machine status

### DIFF
--- a/pkg/controller/machineset/controller.go
+++ b/pkg/controller/machineset/controller.go
@@ -18,12 +18,18 @@ package machineset
 
 import (
 	"fmt"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/builders"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	clusterapiclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
@@ -49,6 +55,8 @@ type MachineSetControllerImpl struct {
 
 	// machineLister holds a lister that knows how to list Machines from a cache
 	machineLister listers.MachineLister
+
+	queue workqueue.RateLimitingInterface
 }
 
 // Init initializes the controller and is called by the generated code
@@ -64,6 +72,8 @@ func (c *MachineSetControllerImpl) Init(arguments sharedinformers.ControllerInit
 	if err != nil {
 		glog.Fatalf("error building clientset for clusterAPIClient: %v", err)
 	}
+
+	c.queue = arguments.GetSharedInformers().WorkerQueues["MachineSet"].Queue
 }
 
 // Reconcile holds the controller's business logic.
@@ -71,9 +81,25 @@ func (c *MachineSetControllerImpl) Init(arguments sharedinformers.ControllerInit
 // note that the current state of the cluster is calculated based on the number of machines
 // that are owned by the given machineSet (key).
 func (c *MachineSetControllerImpl) Reconcile(machineSet *v1alpha1.MachineSet) error {
-	filteredMachines, err := c.getMachines(machineSet)
+	allMachines, err := c.machineLister.Machines(machineSet.Namespace).List(labels.Everything())
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list machines, %v", err)
+	}
+
+	// Filter out irrelevant machines (deleting/mismatch labels) and claim orphaned machines.
+	var filteredMachines []*v1alpha1.Machine
+	for _, machine := range allMachines {
+		if c.shouldExcludeMachine(machineSet, machine) {
+			continue
+		}
+		// Attempt to adopt machine if it meets previous conditions and it has no controller ref.
+		if metav1.GetControllerOf(machine) == nil {
+			if err := c.adoptOrphan(machineSet, machine); err != nil {
+				glog.V(4).Infof("failed to adopt machine %v into machineset %v. %v", machine.Name, machineSet.Name, err)
+				continue
+			}
+		}
+		filteredMachines = append(filteredMachines, machine)
 	}
 
 	syncErr := c.syncReplicas(machineSet, filteredMachines)
@@ -82,15 +108,32 @@ func (c *MachineSetControllerImpl) Reconcile(machineSet *v1alpha1.MachineSet) er
 	newStatus := c.calculateStatus(ms, filteredMachines)
 
 	// Always updates status as machines come up or die.
-	_, err = updateMachineSetStatus(c.clusterAPIClient.ClusterV1alpha1().MachineSets(machineSet.Namespace), machineSet, newStatus)
+	updatedMS, err := updateMachineSetStatus(c.clusterAPIClient.ClusterV1alpha1().MachineSets(machineSet.Namespace), machineSet, newStatus)
 	if err != nil {
 		if syncErr != nil {
 			return fmt.Errorf("failed to sync machines. %v. failed to update machine set status. %v", syncErr, err)
-		} else {
-			return fmt.Errorf("failed to update machine set status. %v", err)
 		}
+		return fmt.Errorf("failed to update machine set status. %v", err)
+	}
+	if updatedMS.Spec.Replicas == nil {
+		return fmt.Errorf("the Replicas field in Spec for machineset %v is nil, this should not be allowed.", ms.Name)
 	}
 
+	// Resync the MachineSet after MinReadySeconds as a last line of defense to guard against clock-skew.
+	// Clock-skew is an issue as it may impact whether an available replica is counted as a ready replica.
+	// A replica is available if the amount of time since last transition exceeds MinReadySeconds.
+	// If there was a clock skew, checking whether the amount of time since last transition to ready state
+	// exceeds MinReadySeconds could be incorrect.
+	// To avoid an available replica stuck in the ready state, we force a reconcile after MinReadySeconds,
+	// at which point it should confirm any available replica to be available.
+	if syncErr == nil && updatedMS.Spec.MinReadySeconds > 0 &&
+		updatedMS.Status.ReadyReplicas == *(updatedMS.Spec.Replicas) &&
+		updatedMS.Status.AvailableReplicas != *(updatedMS.Spec.Replicas) {
+
+		if err := c.enqueueAfter(updatedMS, time.Duration(updatedMS.Spec.MinReadySeconds)*time.Second); err != nil {
+			return fmt.Errorf("failed to enqueue %v machineset for later. %v", updatedMS.Name, err)
+		}
+	}
 	return syncErr
 }
 
@@ -99,45 +142,64 @@ func (c *MachineSetControllerImpl) Get(namespace, name string) (*v1alpha1.Machin
 }
 
 // syncReplicas essentially scales machine resources up and down.
-func (c *MachineSetControllerImpl) syncReplicas(machineSet *v1alpha1.MachineSet, machines []*v1alpha1.Machine) error {
-	// Take ownership of machines if not already owned.
-	for _, machine := range machines {
-		if shouldAdopt(machineSet, machine) {
-			c.adoptOrphan(machineSet, machine)
-		}
+func (c *MachineSetControllerImpl) syncReplicas(ms *v1alpha1.MachineSet, machines []*v1alpha1.Machine) error {
+	if ms.Spec.Replicas == nil {
+		return fmt.Errorf("the Replicas field in Spec for machineset %v is nil, this should not be allowed.", ms.Name)
 	}
-
-	var result error
-	currentMachineCount := int32(len(machines))
-	desiredReplicas := *machineSet.Spec.Replicas
-	diff := int(currentMachineCount - desiredReplicas)
-
+	diff := len(machines) - int(*(ms.Spec.Replicas))
 	if diff < 0 {
 		diff *= -1
+		glog.V(4).Infof("Too few replicas for %v %s/%s, need %d, creating %d", controllerKind, ms.Namespace, ms.Name, *(ms.Spec.Replicas), diff)
+
+		var errstrings []string
 		for i := 0; i < diff; i++ {
-			glog.V(2).Infof("creating a machine ( spec.replicas(%d) > currentMachineCount(%d) )", desiredReplicas, currentMachineCount)
-			machine := c.createMachine(machineSet)
-			_, err := c.clusterAPIClient.ClusterV1alpha1().Machines(machineSet.Namespace).Create(machine)
+			glog.V(2).Infof("creating a machine ( spec.replicas(%d) > currentMachineCount(%d) )", *(ms.Spec.Replicas), len(machines))
+			machine := c.createMachine(ms)
+			_, err := c.clusterAPIClient.ClusterV1alpha1().Machines(ms.Namespace).Create(machine)
 			if err != nil {
 				glog.Errorf("unable to create a machine = %s, due to %v", machine.Name, err)
-				result = err
+				errstrings = append(errstrings, err.Error())
 			}
 		}
+
+		if len(errstrings) > 0 {
+			return fmt.Errorf(strings.Join(errstrings, "; "))
+		}
+
+		return nil
 	} else if diff > 0 {
-		for i := 0; i < diff; i++ {
-			glog.V(2).Infof("deleting a machine ( spec.replicas(%d) < currentMachineCount(%d) )", desiredReplicas, currentMachineCount)
-			// TODO: Define machines deletion policies.
-			// see: https://github.com/kubernetes/kube-deploy/issues/625
-			machineToDelete := machines[i]
-			err := c.clusterAPIClient.ClusterV1alpha1().Machines(machineSet.Namespace).Delete(machineToDelete.Name, &metav1.DeleteOptions{})
+		glog.V(4).Infof("Too many replicas for %v %s/%s, need %d, deleting %d", controllerKind, ms.Namespace, ms.Name, *(ms.Spec.Replicas), diff)
+
+		// Choose which Machines to delete.
+		machinesToDelete := getMachinesToDelete(machines, diff)
+
+		// TODO: Add cap to limit concurrent delete calls.
+		errCh := make(chan error, diff)
+		var wg sync.WaitGroup
+		wg.Add(diff)
+		for _, machine := range machinesToDelete {
+			go func(targetMachine *v1alpha1.Machine) {
+				defer wg.Done()
+				err := c.clusterAPIClient.ClusterV1alpha1().Machines(ms.Namespace).Delete(targetMachine.Name, &metav1.DeleteOptions{})
+				if err != nil {
+					glog.Errorf("unable to delete a machine = %s, due to %v", machine.Name, err)
+					errCh <- err
+				}
+			}(machine)
+		}
+		wg.Wait()
+
+		select {
+		case err := <-errCh:
+			// all errors have been reported before and they're likely to be the same, so we'll only return the first one we hit.
 			if err != nil {
-				glog.Errorf("unable to delete a machine = %s, due to %v", machineToDelete.Name, err)
-				result = err
+				return err
 			}
+		default:
 		}
 	}
 
-	return result
+	return nil
 }
 
 // createMachine creates a machine resource.
@@ -158,41 +220,36 @@ func (c *MachineSetControllerImpl) createMachine(machineSet *v1alpha1.MachineSet
 	return machine
 }
 
-// getMachines returns a list of machines that match on machineSet.Spec.Selector
-func (c *MachineSetControllerImpl) getMachines(machineSet *v1alpha1.MachineSet) ([]*v1alpha1.Machine, error) {
+// shoudExcludeMachine returns true if the machine should be filtered out, false otherwise.
+func (c *MachineSetControllerImpl) shouldExcludeMachine(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machine) bool {
+	// Ignore inactive machines.
+	if machine.DeletionTimestamp != nil || !machine.DeletionTimestamp.IsZero() {
+		glog.V(2).Infof("Skipping machine (%v), as it is being deleted.", machine.Name)
+		return true
+	}
+
+	if metav1.GetControllerOf(machine) != nil && !metav1.IsControlledBy(machine, machineSet) {
+		glog.V(4).Infof("%s not controlled by %v", machine.Name, machineSet.Name)
+		return true
+	}
 	selector, err := metav1.LabelSelectorAsSelector(&machineSet.Spec.Selector)
 	if err != nil {
-		return nil, err
+		glog.Warningf("unable to convert selector: %v", err)
+		return true
 	}
-	filteredMachines, err := c.machineLister.List(selector)
-	if err != nil {
-		return nil, err
+	// If a deployment with a nil or empty selector creeps in, it should match nothing, not everything.
+	if selector.Empty() {
+		glog.V(4).Infof("%v machineset has empty selector", machineSet.Name)
+		return true
 	}
-	return filteredMachines, err
+	if !selector.Matches(labels.Set(machine.Labels)) {
+		glog.V(4).Infof("%v machine has mismatch labels", machine.Name)
+		return true
+	}
+	return false
 }
 
-func shouldAdopt(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machine) bool {
-	// Do nothing if the machine is being deleted.
-	if !machine.ObjectMeta.DeletionTimestamp.IsZero() {
-		glog.V(2).Infof("Skipping machine (%v), as it is being deleted.", machine.Name)
-		return false
-	}
-
-	// Machine owned by another controller.
-	if metav1.GetControllerOf(machine) != nil && !metav1.IsControlledBy(machine, machineSet) {
-		glog.Warningf("Skipping machine (%v), as it is owned by someone else.", machine.Name)
-		return false
-	}
-
-	// Machine we control.
-	if metav1.IsControlledBy(machine, machineSet) {
-		return false
-	}
-
-	return true
-}
-
-func (c *MachineSetControllerImpl) adoptOrphan(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machine) {
+func (c *MachineSetControllerImpl) adoptOrphan(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machine) error {
 	// Add controller reference.
 	ownerRefs := machine.ObjectMeta.GetOwnerReferences()
 	if ownerRefs == nil {
@@ -204,5 +261,23 @@ func (c *MachineSetControllerImpl) adoptOrphan(machineSet *v1alpha1.MachineSet, 
 	machine.ObjectMeta.SetOwnerReferences(ownerRefs)
 	if _, err := c.clusterAPIClient.ClusterV1alpha1().Machines(machineSet.Namespace).Update(machine); err != nil {
 		glog.Warningf("Failed to update machine owner reference. %v", err)
+		return err
 	}
+	return nil
+}
+
+func (c *MachineSetControllerImpl) enqueueAfter(machineSet *v1alpha1.MachineSet, after time.Duration) error {
+	key, err := cache.MetaNamespaceKeyFunc(machineSet)
+	if err != nil {
+		glog.Errorf("Couldn't get key for object %+v: %v", machineSet, after)
+		return err
+	}
+	c.queue.AddAfter(key, after)
+	return nil
+}
+
+func getMachinesToDelete(filteredMachines []*v1alpha1.Machine, diff int) []*v1alpha1.Machine {
+	// TODO: Define machines deletion policies.
+	// see: https://github.com/kubernetes/kube-deploy/issues/625
+	return filteredMachines[:diff]
 }

--- a/pkg/controller/machineset/reconcile_test.go
+++ b/pkg/controller/machineset/reconcile_test.go
@@ -106,20 +106,20 @@ func TestMachineSetControllerReconcileHandler(t *testing.T) {
 			expectedMachine:     machineFromMachineSet(createMachineSet(1, "foo", "bar2", "acme"), "bar1"),
 		},
 		{
-			name:                "scenario 8: the current machine has different controller ref, do nothing.",
+			name:                "scenario 8: the current machine has different controller ref, create new machine.",
 			startingMachineSets: []*v1alpha1.MachineSet{createMachineSet(1, "foo", "bar2", "acme")},
 			startingMachines:    []*v1alpha1.Machine{setDifferentOwnerUID(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"))},
 			machineSetToSync:    "foo",
 			namespaceToSync:     "acme",
-			expectedActions:     []string{},
+			expectedActions:     []string{"create"},
 		},
 		{
-			name:                "scenario 9: the current machine is being deleted, do nothing.",
+			name:                "scenario 9: the current machine is being deleted, create new machine.",
 			startingMachineSets: []*v1alpha1.MachineSet{createMachineSet(1, "foo", "bar2", "acme")},
 			startingMachines:    []*v1alpha1.Machine{setMachineDeleting(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"))},
 			machineSetToSync:    "foo",
 			namespaceToSync:     "acme",
-			expectedActions:     []string{},
+			expectedActions:     []string{"create"},
 		},
 		{
 			name:                "scenario 10: the current machine has no controller refs, owner refs preserved, machine should be adopted.",
@@ -174,7 +174,7 @@ func TestMachineSetControllerReconcileHandler(t *testing.T) {
 			actions := fakeClient.Actions()
 			actions = getFilteredActions(actions, "machines")
 			if len(actions) != len(test.expectedActions) {
-				t.Fatalf("unexpected actions: %v, expected %d actions got %d", actions, len(test.expectedActions), len(actions))
+				t.Fatalf("got %d actions, expected %d actions; got %v actions, expected %v actions", len(actions), len(test.expectedActions), actions, test.expectedActions)
 			}
 			for i, verb := range test.expectedActions {
 				if actions[i].GetVerb() != verb {

--- a/pkg/controller/machineset/zz_generated.api.register.go
+++ b/pkg/controller/machineset/zz_generated.api.register.go
@@ -54,14 +54,6 @@ func NewMachineSetController(config *rest.Config, si *sharedinformers.SharedInfo
 	uc := &MachineSetControllerImpl{}
 	var ci sharedinformers.Controller = uc
 
-	// Call the Init method that is implemented.
-	// Support multiple Init methods for backwards compatibility
-	if i, ok := ci.(sharedinformers.LegacyControllerInit); ok {
-		i.Init(config, si, c.LookupAndReconcile)
-	} else if i, ok := ci.(sharedinformers.ControllerInit); ok {
-		i.Init(&sharedinformers.ControllerInitArgumentsImpl{si, config, c.LookupAndReconcile})
-	}
-
 	c.controller = uc
 
 	queue.Reconcile = c.reconcile
@@ -71,6 +63,15 @@ func NewMachineSetController(config *rest.Config, si *sharedinformers.SharedInfo
 	c.Informers.WorkerQueues["MachineSet"] = queue
 	si.Factory.Cluster().V1alpha1().MachineSets().Informer().
 		AddEventHandler(&controller.QueueingEventHandler{q, nil, false})
+
+	// Call the Init method that is implemented.
+	// Support multiple Init methods for backwards compatibility
+	if i, ok := ci.(sharedinformers.LegacyControllerInit); ok {
+		i.Init(config, si, c.LookupAndReconcile)
+	} else if i, ok := ci.(sharedinformers.ControllerInit); ok {
+		i.Init(&sharedinformers.ControllerInitArgumentsImpl{si, config, c.LookupAndReconcile})
+	}
+
 	return c
 }
 


### PR DESCRIPTION
This PR was split off from PR #165 to make it a smaller PR.

We list all available machines and explicitly filter out irrelevant machines. What remains that aren't controlled by the controller will be selected for adoption.


@kubernetes/kube-deploy-reviewers
