### PR TITLE
Add provisoining of external bootstrap cluster to provisioning logic.

### DIFF
--- a/clusterctl/README.md
+++ b/clusterctl/README.md
@@ -8,7 +8,8 @@ Read the [experience doc here](https://docs.google.com/document/d/1-sYb3EdkRga49
 
 ### Prerequisites
 
-1. Build the `clusterctl` tool
+1. Install [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) 
+2. Build the `clusterctl` tool
 
 ```bash
 $ cd $GOPATH/src/sigs.k8s.io/

--- a/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/clusterctl/clusterdeployer/clusterdeployer.go
@@ -1,13 +1,38 @@
 package clusterdeployer
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/cluster-api/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-type ClusterDeployer struct {
+// Can provision a kubernetes cluster
+type ClusterProvisioner interface {
+	Create() error
+	Delete() error
+	GetKubeconfig() (string, error)
 }
 
-func (*ClusterDeployer) Create(_ *clusterv1.Cluster, _ []*clusterv1.Machine) error {
-	return errors.NotImplementedError
+type ClusterDeployer struct {
+	externalProvisioner    ClusterProvisioner
+	cleanupExternalCluster bool
+}
+
+func New(externalProvisioner ClusterProvisioner, cleanupExternalCluster bool) *ClusterDeployer {
+	return &ClusterDeployer{
+		externalProvisioner:    externalProvisioner,
+		cleanupExternalCluster: cleanupExternalCluster,
+	}
+}
+
+// Creates the a cluster from the provided cluster definition and machine list.
+func (d *ClusterDeployer) Create(_ *clusterv1.Cluster, _ []*clusterv1.Machine) error {
+	if err := d.externalProvisioner.Create(); err != nil {
+		return fmt.Errorf("could not create external control plane: %v", err)
+	}
+	if d.cleanupExternalCluster {
+		defer d.externalProvisioner.Delete()
+	}
+	return errors.NotImplementedError // Not fully functional yet.
 }

--- a/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -1,0 +1,81 @@
+package clusterdeployer_test
+
+import (
+	"fmt"
+	"sigs.k8s.io/cluster-api/clusterctl/clusterdeployer"
+	"testing"
+)
+
+type testClusterProvisioner struct {
+	err            error
+	clusterCreated bool
+	clusterExists  bool
+}
+
+func (p *testClusterProvisioner) Create() error {
+	if p.err != nil {
+		return p.err
+	}
+	p.clusterCreated = true
+	p.clusterExists = true
+	return nil
+}
+
+func (p *testClusterProvisioner) Delete() error {
+	if p.err != nil {
+		return p.err
+	}
+	p.clusterExists = false
+	return nil
+}
+
+func (p *testClusterProvisioner) GetKubeconfig() (string, error) {
+	return "", p.err
+}
+
+func TestCreate(t *testing.T) {
+	var testcases = []struct {
+		name                  string
+		provisionExternalErr  error
+		cleanupExternal       bool
+		expectErr             bool
+		expectExternalExists  bool
+		expectExternalCreated bool
+	}{
+		{
+			name:                  "success",
+			cleanupExternal:       true,
+			expectExternalExists:  false,
+			expectExternalCreated: true,
+			expectErr:            true,
+		},
+		{
+			name:                  "success no cleaning external",
+			cleanupExternal:       false,
+			expectExternalExists:  true,
+			expectExternalCreated: true,
+			expectErr:            true,
+		},
+		{
+			name:                 "fail provision external cluster",
+			provisionExternalErr: fmt.Errorf("Test failure"),
+			expectErr:            true,
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			p := &testClusterProvisioner{err: testcase.provisionExternalErr}
+			d := clusterdeployer.New(p, testcase.cleanupExternal)
+			err := d.Create(nil, nil)
+			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
+				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
+			}
+			if testcase.expectExternalExists != p.clusterExists {
+				t.Errorf("Unexpected external cluster existance. Got: %v, Want: %v", p.clusterExists, testcase.expectExternalExists)
+			}
+			if testcase.expectExternalCreated != p.clusterCreated {
+				t.Errorf("Unexpected external cluster provisioning. Got: %v, Want: %v", p.clusterCreated, testcase.expectExternalCreated)
+			}
+		})
+	}
+}

--- a/clusterctl/clusterdeployer/minikube/minikube.go
+++ b/clusterctl/clusterdeployer/minikube/minikube.go
@@ -1,0 +1,68 @@
+package minikube
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"os"
+	"os/exec"
+	"io/ioutil"
+)
+
+type Minikube struct {
+	kubeconfigpath string
+	vmDriver       string
+	// minikubeExec implemented as function variable for testing hooks
+	minikubeExec   func(env []string, args ...string) (string, error)
+}
+
+func New(vmDriver string) *Minikube {
+	return &Minikube{
+		minikubeExec: minikubeExec,
+		vmDriver: vmDriver,
+		// Arbitrary file name. Can potentially be randomly generated.
+		kubeconfigpath: "minikube.config",
+	}
+}
+
+var minikubeExec = func(env []string, args ...string) (string, error) {
+	const executable = "minikube"
+	glog.V(5).Infof("Running: %v %v", executable, args)
+	cmd := exec.Command(executable, args...)
+	cmd.Env = env
+	cmdOut, err := cmd.CombinedOutput()
+	glog.V(4).Infof("Ran: %v %v Output: %v", executable, args, string(cmdOut))
+	return string(cmdOut), err
+}
+
+func (m *Minikube) Create() error {
+	args := []string {"start", "--bootstrapper=kubeadm"}
+	if m.vmDriver != ""{
+		args = append(args, fmt.Sprintf("--vm-driver=%v", m.vmDriver))
+	}
+	_, err := m.exec(args...)
+	return err
+}
+
+func (m *Minikube) Delete() error {
+	_, err := m.exec("delete")
+	os.Remove(m.kubeconfigpath)
+	return err
+}
+
+func (m *Minikube) GetKubeconfig() (string, error) {
+	b, err := ioutil.ReadFile(m.kubeconfigpath)
+	if err!= nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func (m *Minikube) exec(args ...string) (string, error) {
+	// Override kubeconfig environment variable in call
+	// so that minikube will generate and reference
+	// the kubeconfig in the desired location.
+	// Note that the last value set for a key is the final value.
+	const kubeconfigEnvVar = "KUBECONFIG"
+	env := append(os.Environ(), fmt.Sprintf("%v=%v", kubeconfigEnvVar, m.kubeconfigpath))
+	return m.minikubeExec(env, args...)
+}

--- a/clusterctl/clusterdeployer/minikube/minikube_test.go
+++ b/clusterctl/clusterdeployer/minikube/minikube_test.go
@@ -1,0 +1,106 @@
+package minikube
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestCreate(t *testing.T) {
+	var testcases = []struct {
+		name      string
+		execError error
+		expectErr bool
+	}{
+		{
+			name: "success",
+		},
+		{
+			name:      "exec fail",
+			execError: fmt.Errorf("test error"),
+			expectErr: true,
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			m := New("")
+			m.minikubeExec = func(env []string, args ...string) (string, error) {
+				return "", testcase.execError
+			}
+			err := m.Create()
+			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
+				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	var testcases = []struct {
+		name      string
+		execError error
+		expectErr bool
+	}{
+		{
+			name: "success",
+		},
+		{
+			name:      "exec fail",
+			execError: fmt.Errorf("test error"),
+			expectErr: true,
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			m := New("")
+			m.minikubeExec = func(env []string, args ...string) (string, error) {
+				return "", testcase.execError
+			}
+			err := m.Delete()
+			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
+				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
+			}
+		})
+	}
+}
+
+func TestGetKubeconfig(t *testing.T) {
+	const contents = "dfserfafaew"
+	m := New("")
+	f, err := createTempFile(contents)
+	if err != nil {
+		t.Fatal("Unable to create test file.")
+	}
+	defer os.Remove(f)
+	t.Run("file does not exist", func(t *testing.T) {
+		c, err := m.GetKubeconfig()
+		if err == nil {
+			t.Fatal("Able to read a file that does not exist")
+		}
+		if c != "" {
+			t.Fatal("Able to return contents for file that does not exist.")
+		}
+	})
+	t.Run("file exists", func(t *testing.T) {
+		m.kubeconfigpath = f
+		c, err := m.GetKubeconfig()
+		if err != nil {
+			t.Fatal("Unexpected err. Got: %v", err)
+			return
+		}
+		if c != contents {
+			t.Fatal("Unexpected contents. Got: %v, Want: %v", c, contents)
+		}
+	})
+}
+
+func createTempFile(contents string) (string, error) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	f.WriteString(contents)
+	return f.Name(), nil
+}

--- a/clusterctl/cmd/create_cluster_test.go
+++ b/clusterctl/cmd/create_cluster_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+const validCluster = `
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Cluster
+metadata:
+  name: cluster1 
+spec:`
+
+const validMachines = `
+items:
+- apiVersion: "cluster.k8s.io/v1alpha1"
+  kind: Machine
+  metadata:
+    name: machine1
+  spec:`
+
+func TestParseClusterYaml(t *testing.T) {
+	t.Run("File does not exist", func(t *testing.T) {
+		_, err := parseClusterYaml("fileDoesNotExist")
+		if err == nil {
+			t.Fatal("Was able to parse a file that does not exist")
+		}
+	})
+	var testcases = []struct {
+		name        string
+		contents    string
+		expectedName string
+		expectErr   bool
+	}{
+		{
+			name: "valid file",
+			contents: validCluster,
+			expectedName: "cluster1",
+		},
+		{
+			name: "gibberish in file",
+			contents:    `blah ` + validCluster + ` blah`,
+			expectErr: true,
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			file, err := createTempFile(testcase.contents)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(file)
+
+			c, err := parseClusterYaml(file)
+			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
+				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
+			}
+			if err != nil {
+				return
+			}
+			if c == nil {
+				t.Fatalf("No cluster returned in success case.")
+			}
+			if c.Name != testcase.expectedName {
+				t.Fatalf("Unexpected name. Got: %v, Want:%v", c.Name, testcase.expectedName)
+			}
+		})
+	}
+}
+
+func TestParseMachineYaml(t *testing.T) {
+	t.Run("File does not exist", func(t *testing.T) {
+		_, err := parseMachinesYaml("fileDoesNotExist")
+		if err == nil {
+			t.Fatal("Was able to parse a file that does not exist")
+		}
+	})
+	var testcases = []struct {
+		name        string
+		contents    string
+		expectErr bool
+		expectedMachineCount int
+	}{
+		{
+			name: "valid file",
+			contents: validMachines,
+			expectedMachineCount: 1,
+		},
+		{
+			name: "gibberish in file",
+			contents:    `blah ` + validMachines + ` blah`,
+			expectErr: true,
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			file, err := createTempFile(testcase.contents)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(file)
+
+			m, err := parseMachinesYaml(file)
+			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
+				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
+			}
+			if err != nil {
+				return
+			}
+			if m == nil {
+				t.Fatalf("No machines returned in success case.")
+			}
+			if len(m) != testcase.expectedMachineCount {
+				t.Fatalf("Unexpected machine count. Got: %v, Want: %v", len(m), testcase.expectedMachineCount)
+			}
+		})
+	}
+}
+
+func createTempFile(contents string) (string, error) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	f.WriteString(contents)
+	return f.Name(), nil
+}

--- a/clusterctl/cmd/root.go
+++ b/clusterctl/cmd/root.go
@@ -19,9 +19,9 @@ package cmd
 import (
 	"flag"
 	"os"
-
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/apiserver/pkg/util/logs"
 )
 
@@ -49,6 +49,10 @@ func exitWithHelp(cmd *cobra.Command, err string) {
 
 func init() {
 	flag.CommandLine.Parse([]string{})
+
+	// Honor glog flags for verbosity control
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
 	logs.InitLogs()
 	RootCmd.AddCommand(createCmd)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Add logic to create external cluster. External provisioning logic is behind an interface to allow changing of what we use for the external cluster. Part of #157 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
