### PR TITLE
Ensure getProjects(...) does not return duplicate project names.

### DIFF
--- a/cloud/google/serviceaccount.go
+++ b/cloud/google/serviceaccount.go
@@ -222,14 +222,18 @@ func (gce *GCEClient) deleteServiceAccount(serviceAccountPrefix string, roles []
 
 func (gce *GCEClient) getProjects(machines []*clusterv1.Machine) ([]string, error) {
 	// Figure out what projects the service account needs permission to.
+	uniqueProjects := make(map[string]struct{})
+	exists := struct{}{}
 	var projects []string
 	for _, machine := range machines {
 		config, err := gce.providerconfig(machine.Spec.ProviderConfig)
 		if err != nil {
 			return nil, err
 		}
-
-		projects = append(projects, config.Project)
+		if _, ok := uniqueProjects[config.Project]; !ok {
+			uniqueProjects[config.Project] = exists
+			projects = append(projects, config.Project)
+		}
 	}
 	return projects, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the behavior of getProjects(...) to remove duplicates from the results. This ensures that clients do not do duplicate work. For example, the method, createServiceAccount(...) was doing duplicate work in this for loop:

```
	for _, project := range projects {
		for _, role := range roles {
			err = run("gcloud", "projects", "add-iam-policy-binding", project, "--member=serviceAccount:"+email, "--role=roles/"+role)
			if err != nil {
				return "", "", fmt.Errorf("couldn't grant permissions to service account: %v", err)
			}
		}
	}
```

Before adding this code, instructing gcp deployer to create a cluster with 1 Master and 3 Nodes took 5m27s , after the change the time was reduced to 4m39s.

I would like to punt on unit tests because this piece of code should probably stay private and it is best to unit test the public methods. Unit testing the public methods would greatly increase the scope of this work. 

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
