### PR TITLE
CLUSTER-API-159: Enhance gce-machine-controller to fetch kubeadm join token

### DIFF
--- a/cloud/google/cmd/gce-machine-controller/Makefile
+++ b/cloud/google/cmd/gce-machine-controller/Makefile
@@ -31,7 +31,7 @@ fix_gcs_permissions:
 	gsutil acl ch -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
 	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
 
-dev_image: 
+dev_image:
 	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../../../..
 
 dev_push: dev_image

--- a/cloud/google/cmd/gce-machine-controller/app/controller.go
+++ b/cloud/google/cmd/gce-machine-controller/app/controller.go
@@ -61,7 +61,6 @@ func StartMachineController(server *options.MachineControllerServer, shutdown <-
 		glog.Fatalf("Could not create config watch: %v", err)
 	}
 	params := google.MachineActuatorParams{
-		KubeadmToken:             server.KubeadmToken,
 		MachineClient:            client.ClusterV1alpha1().Machines(corev1.NamespaceDefault),
 		MachineSetupConfigGetter: configWatch,
 	}

--- a/cloud/google/cmd/gce-machine-controller/app/options/options.go
+++ b/cloud/google/cmd/gce-machine-controller/app/options/options.go
@@ -23,7 +23,6 @@ import (
 
 type MachineControllerServer struct {
 	CommonConfig            *config.Configuration
-	KubeadmToken            string
 	MachineSetupConfigsPath string
 }
 
@@ -35,7 +34,6 @@ func NewMachineControllerServer() *MachineControllerServer {
 }
 
 func (s *MachineControllerServer) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&s.KubeadmToken, "token", s.KubeadmToken, "Kubeadm token to use to join new machines")
 	fs.StringVar(&s.MachineSetupConfigsPath, "machinesetup", s.MachineSetupConfigsPath, "path to machine setup configs file")
 
 	config.ControllerConfig.AddFlags(pflag.CommandLine)

--- a/cloud/google/config/configtemplate.go
+++ b/cloud/google/config/configtemplate.go
@@ -141,6 +141,8 @@ spec:
             mountPath: /etc/sshkeys
           - name: machine-setup
             mountPath: /etc/machinesetup
+          - name: kubeadm
+            mountPath: /usr/bin/kubeadm
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/credentials/service-account.json
@@ -148,7 +150,6 @@ spec:
         - "./gce-machine-controller"
         args:
         - --kubeconfig=/etc/kubernetes/admin.conf
-        - --token={{ .Token }}
         - --machinesetup=/etc/machinesetup/machine_setup_configs.yaml
         resources:
           requests:
@@ -177,6 +178,9 @@ spec:
       - name: machine-setup
         configMap: 
           name: machine-setup
+      - name: kubeadm
+        hostPath:
+          path: /usr/bin/kubeadm
 ---
 apiVersion: apps/v1beta1
 kind: StatefulSet

--- a/cloud/google/metadata.go
+++ b/cloud/google/metadata.go
@@ -18,9 +18,9 @@ package google
 
 import (
 	"bytes"
-	"fmt"
 	"text/template"
 
+	"fmt"
 	"sigs.k8s.io/cluster-api/cloud/google/machinesetup"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
@@ -61,9 +61,8 @@ func nodeMetadata(token string, cluster *clusterv1.Cluster, machine *clusterv1.M
 	return nodeMetadata, nil
 }
 
-func masterMetadata(token string, cluster *clusterv1.Cluster, machine *clusterv1.Machine, project string, metadata *machinesetup.Metadata) (map[string]string, error) {
+func masterMetadata(cluster *clusterv1.Cluster, machine *clusterv1.Machine, project string, metadata *machinesetup.Metadata) (map[string]string, error) {
 	params := metadataParams{
-		Token:       token,
 		Cluster:     cluster,
 		Machine:     machine,
 		Project:     project,
@@ -101,7 +100,6 @@ const masterEnvironmentVars = `
 #!/bin/bash
 KUBELET_VERSION={{ .Machine.Spec.Versions.Kubelet }}
 VERSION=v${KUBELET_VERSION}
-TOKEN={{ .Token }}
 PORT=443
 MACHINE={{ .Machine.ObjectMeta.Name }}
 CONTROL_PLANE_VERSION={{ .Machine.Spec.Versions.ControlPlane }}

--- a/cloud/google/pods.go
+++ b/cloud/google/pods.go
@@ -86,7 +86,7 @@ func getApiServerCerts() (*caCertParams, error) {
 	return certParams, nil
 }
 
-func CreateApiServerAndController(token string) error {
+func CreateApiServerAndController() error {
 	tmpl, err := template.New("config").Parse(config.ClusterAPIDeployConfigTemplate)
 	if err != nil {
 		return err
@@ -99,7 +99,6 @@ func CreateApiServerAndController(token string) error {
 	}
 
 	type params struct {
-		Token                  string
 		APIServerImage         string
 		ControllerManagerImage string
 		MachineControllerImage string
@@ -110,7 +109,6 @@ func CreateApiServerAndController(token string) error {
 
 	var tmplBuf bytes.Buffer
 	err = tmpl.Execute(&tmplBuf, params{
-		Token:                  token,
 		APIServerImage:         apiServerImage,
 		ControllerManagerImage: controllerManagerImage,
 		MachineControllerImage: machineControllerImage,
@@ -129,7 +127,7 @@ func CreateApiServerAndController(token string) error {
 			return nil
 		} else {
 			if tries < maxTries-1 {
-				glog.Info("Error scheduling machine controller. Will retry...\n")
+				glog.Infof("Retrying scheduling machine controller after encountering error: %v\n", err)
 				time.Sleep(3 * time.Second)
 			}
 		}

--- a/gcp-deployer/deploy/deploy.go
+++ b/gcp-deployer/deploy/deploy.go
@@ -65,7 +65,6 @@ func NewDeployer(provider string, kubeConfigPath string, machineSetupConfigPath 
 	params := google.MachineActuatorParams{
 		CertificateAuthority:     ca,
 		MachineSetupConfigGetter: configWatch,
-		KubeadmToken:             token,
 	}
 	ma, err := google.NewMachineActuator(params)
 	if err != nil {

--- a/kubeadm/kubeadm.go
+++ b/kubeadm/kubeadm.go
@@ -1,0 +1,74 @@
+package kubeadm
+
+import (
+	"sigs.k8s.io/cluster-api/pkg/cmd-runner"
+	"strings"
+	"time"
+)
+
+type Kubeadm struct {
+	runner cmd_runner.CmdRunner
+}
+
+// see https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-token/ for an explanation of the parameters
+type TokenCreateParams struct {
+	Config           string
+	Description      string
+	Groups           []string
+	Help             bool
+	PrintJoinCommand bool
+	Ttl              time.Duration
+	Usages           []string
+}
+
+func NewWithCmdRunner(runner cmd_runner.CmdRunner) *Kubeadm {
+	return &Kubeadm{
+		runner: runner,
+	}
+}
+
+func New() *Kubeadm {
+	return NewWithCmdRunner(cmd_runner.New())
+}
+
+func (k *Kubeadm) TokenCreate(params TokenCreateParams) (string, error) {
+	args := []string{"token", "create"}
+	args = appendStringParamIfPresent(args, "--config", params.Config)
+	args = appendStringParamIfPresent(args, "--description", params.Description)
+	args = appendStringSliceIfValid(args, "--groups", params.Groups)
+	args = appendFlagIfTrue(args, "--help", params.Help)
+	args = appendFlagIfTrue(args, "--print-join-command", params.PrintJoinCommand)
+	if params.Ttl != time.Duration(0) {
+		args = append(args, "--ttl")
+		args = append(args, params.Ttl.String())
+	}
+	args = appendStringSliceIfValid(args, "--usages", params.Usages)
+	return k.runner.CombinedOutput("kubeadm", args...)
+}
+
+func appendFlagIfTrue(args []string, paramName string, value bool) []string {
+	if value {
+		return append(args, paramName)
+	}
+	return args
+}
+
+func appendStringParamIfPresent(args []string, paramName string, value string) []string {
+	if value == "" {
+		return args
+	}
+	args = append(args, paramName)
+	return append(args, value)
+}
+
+func appendStringSliceIfValid(args []string, paramName string, values []string) []string {
+	if len(values) == 0 {
+		return args
+	}
+	args = append(args, paramName)
+	return append(args, toStringSlice(values))
+}
+
+func toStringSlice(args []string) string {
+	return strings.Join(args, ":")
+}

--- a/kubeadm/kubeadm_test.go
+++ b/kubeadm/kubeadm_test.go
@@ -1,0 +1,103 @@
+package kubeadm_test
+
+import (
+	"fmt"
+	"os"
+	"sigs.k8s.io/cluster-api/pkg/cmd-runner"
+	"sigs.k8s.io/cluster-api/kubeadm"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	joinCommand   = "kubeadm join --token a53d73.21029eb48b9002d0 35.199.169.93:443 --discovery-token-ca-cert-hash sha256:3bb9ee3aa3cee9898b85523e8dd6921752e07e3053453084c8d26d40d929a132"
+	errorExitCode = -1
+	errorMessage  = "error message"
+)
+
+func init() {
+	cmd_runner.RegisterCallback(echoCallback)
+	cmd_runner.RegisterCallback(errorCallback)
+	cmd_runner.RegisterCallback(tokenCallback)
+}
+
+func TestTokenCreateParameters(t *testing.T) {
+	var tests = []struct {
+		name   string
+		err    error
+		output string
+		params kubeadm.TokenCreateParams
+	}{
+		{"empty params", nil, "kubeadm token create", kubeadm.TokenCreateParams{}},
+		{"config", nil, "kubeadm token create --config /my/path/to/kubeadm-config", kubeadm.TokenCreateParams{Config: "/my/path/to/kubeadm-config"}},
+		{"description", nil, "kubeadm token create --description my custom description", kubeadm.TokenCreateParams{Description: "my custom description"}},
+		{"groups", nil, "kubeadm token create --groups system:bootstrappers:kubeadm:default-node-token", kubeadm.TokenCreateParams{Groups: []string{"system", "bootstrappers", "kubeadm", "default-node-token"}}},
+		{"help", nil, "kubeadm token create --help", kubeadm.TokenCreateParams{Help: true}},
+		{"print join command", nil, "kubeadm token create --print-join-command", kubeadm.TokenCreateParams{PrintJoinCommand: true}},
+		{"ttl 24 hours", nil, "kubeadm token create --ttl 24h0m0s", kubeadm.TokenCreateParams{Ttl: toDuration(24, 0, 0)}},
+		{"ttl 55 minutes", nil, "kubeadm token create --ttl 55m0s", kubeadm.TokenCreateParams{Ttl: toDuration(0, 55, 0)}},
+		{"ttl 9 seconds", nil, "kubeadm token create --ttl 9s", kubeadm.TokenCreateParams{Ttl: toDuration(0, 0, 9)}},
+		{"ttl 1 second", nil, "kubeadm token create --ttl 1s", kubeadm.TokenCreateParams{Ttl: toDuration(0, 0, 1)}},
+		{"ttl 16 hours, 38 minutes, 2 seconds", nil, "kubeadm token create --ttl 16h38m2s", kubeadm.TokenCreateParams{Ttl: toDuration(16, 38, 2)}},
+		{"usages", nil, "kubeadm token create --usages signing:authentication", kubeadm.TokenCreateParams{Usages: []string{"signing", "authentication"}}},
+		{"all", nil, "kubeadm token create --config /my/config --description my description --groups bootstrappers --help --print-join-command --ttl 1h1m1s --usages authentication",
+			kubeadm.TokenCreateParams{Config: "/my/config", Description: "my description", Groups: []string{"bootstrappers"}, Help: true, PrintJoinCommand: true, Ttl: toDuration(1, 1, 1), Usages: []string{"authentication"}}},
+	}
+	kadm := kubeadm.NewWithCmdRunner(cmd_runner.NewTestRunnerFailOnErr(t, echoCallback))
+	for _, tst := range tests {
+		output, err := kadm.TokenCreate(tst.params)
+		if err != tst.err {
+			t.Errorf("test case '%v', unexpected error: got '%v', want '%v'", tst.name, err, tst.err)
+		}
+		if output != tst.output {
+			t.Errorf("test case '%v', unexpected output: got '%v', want '%v'", tst.name, output, tst.output)
+		}
+	}
+}
+
+func TestTokenCreateReturnsUnmodifiedOutput(t *testing.T) {
+	kadm := kubeadm.NewWithCmdRunner(cmd_runner.NewTestRunnerFailOnErr(t, tokenCallback))
+	output, err := kadm.TokenCreate(kubeadm.TokenCreateParams{})
+	if err != nil {
+		t.Errorf("unexpected error: wanted nil")
+	}
+	if output != joinCommand {
+		t.Errorf("unexpected output: got '%v', want '%v'", output, joinCommand)
+	}
+}
+
+func TestNonZeroExitCodeResultsInError(t *testing.T) {
+	kadm := kubeadm.NewWithCmdRunner(cmd_runner.NewTestRunnerFailOnErr(t, errorCallback))
+	output, err := kadm.TokenCreate(kubeadm.TokenCreateParams{})
+	if err == nil {
+		t.Errorf("expected error: got nil")
+	}
+	if output != errorMessage {
+		t.Errorf("unexpected output: got '%v', want '%v'", output, errorMessage)
+	}
+}
+
+func echoCallback(cmd string, args ...string) int {
+	fullCmd := append([]string{cmd}, args...)
+	fmt.Print(strings.Join(fullCmd, " "))
+	return 0
+}
+
+func tokenCallback(cmd string, args ...string) int {
+	fmt.Print(joinCommand)
+	return 0
+}
+
+func errorCallback(cmd string, args ...string) int {
+	fmt.Fprintf(os.Stderr, errorMessage)
+	return errorExitCode
+}
+
+func TestMain(m *testing.M) {
+	cmd_runner.TestMain(m)
+}
+
+func toDuration(hour int, minute int, second int) time.Duration {
+	return time.Duration(hour)*time.Hour + time.Duration(minute)*time.Minute + time.Duration(second)*time.Second
+}

--- a/pkg/cmd-runner/cmd_runner.go
+++ b/pkg/cmd-runner/cmd_runner.go
@@ -1,0 +1,21 @@
+package cmd_runner
+
+import (
+	"os/exec"
+)
+
+type CmdRunner interface {
+	CombinedOutput(cmd string, args ...string) (output string, err error)
+}
+
+type realCmdRunner struct {
+}
+
+func New() *realCmdRunner {
+	return &realCmdRunner{}
+}
+
+func (runner *realCmdRunner) CombinedOutput(cmd string, args ...string) (string, error) {
+	output, err := exec.Command(cmd, args...).CombinedOutput()
+	return string(output), err
+}

--- a/pkg/cmd-runner/cmd_runner_test.go
+++ b/pkg/cmd-runner/cmd_runner_test.go
@@ -1,0 +1,68 @@
+package cmd_runner_test
+
+import (
+	"io/ioutil"
+	"os"
+	"sigs.k8s.io/cluster-api/pkg/cmd-runner"
+	"testing"
+)
+
+func TestInvalidCommand(t *testing.T) {
+	runner := cmd_runner.New()
+	output, err := runner.CombinedOutput("asdf")
+	if err == nil {
+		t.Errorf("invalid error: expected 'nil', got '%v'", err)
+	}
+	if output != "" {
+		t.Errorf("unexpected output: expected empty string '', got '%v'", output)
+	}
+}
+
+func TestValidCommandErrors(t *testing.T) {
+	skipIfCommandNotPresent(t, "ls")
+	runner := cmd_runner.New()
+	_, err := runner.CombinedOutput("ls /invalid/path")
+	if err == nil {
+		t.Errorf("invalid error: expected 'nil', got '%v'", err)
+	}
+}
+
+func TestValidCommandSucceeds(t *testing.T) {
+	skipIfCommandNotPresent(t, "ls")
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Errorf("unable to create temp dir: %v", err)
+		t.FailNow()
+	}
+	defer os.RemoveAll(dir)
+	runner := cmd_runner.New()
+	output, err := runner.CombinedOutput("ls", "-al", dir)
+	if err != nil {
+		t.Errorf("invalid error: expected 'nil', got '%v'", err)
+	}
+	if output == "" {
+		t.Errorf("expected valid output got empty string")
+	}
+}
+
+func TestCombinedOutputShouldIncludeStdOutAndErr(t *testing.T) {
+	skipIfCommandNotPresent(t, "echo")
+	skipIfCommandNotPresent(t, "sh")
+	runner := cmd_runner.New()
+	output, err := runner.CombinedOutput("sh", "-c", "echo \"stdout\" && (>&2 echo \"stderr\")")
+	if err != nil {
+		t.Errorf("invalid error: expected 'nil', got '%v'", err)
+	}
+	expectedOutput := "stdout\nstderr\n"
+	if output != expectedOutput {
+		t.Errorf("invalid output: expected '%v', got '%v'", expectedOutput, output)
+	}
+}
+
+func skipIfCommandNotPresent(t *testing.T, cmd string) {
+	runner := cmd_runner.New()
+	_, err := runner.CombinedOutput("ls")
+	if err != nil {
+		t.Skipf("unable to run test, 'ls' reults in error: %v", err)
+	}
+}

--- a/pkg/cmd-runner/test_cmd_runner.go
+++ b/pkg/cmd-runner/test_cmd_runner.go
@@ -1,0 +1,103 @@
+package cmd_runner
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type TestRunner struct {
+	callback func(string, ...string) int
+}
+
+var (
+	TestModeEnvVar       = "GO_TEST_MODE"
+	CallbackTestMode     = "CALLBACK"
+	CallbackFunctionName = "GO_CALLBACK_FUNCTION_NAME"
+	reggedFunctions      = make(map[string]func(string, ...string) int)
+)
+
+// TestRunner makes it easy to mock out shell commands. It will start a new program that calls into the callback function
+// supplied when creating TestRunner.
+//
+// To use TestRunner from your test, you must do the following:
+// 1. In your test file's init() method call RegisterCallback with the same callback function you passed into TestRunner
+// 2. Copy the TestMain below and insert it into your test file:
+//		func TestMain(m *testing.M) {
+//			cmd_runner.TestMain(m)
+//		}
+func NewTestRunner(callback func(cmd string, args ...string) (exitCode int)) (*TestRunner, error) {
+	name := getFullyQualifiedFunctionName(callback)
+	if _, ok := reggedFunctions[name]; !ok {
+		shortName := getUnqualifiedFunctionName(name)
+		registerCallbackShortName := getUnqualifiedFunctionName(getFullyQualifiedFunctionName(RegisterCallback))
+		return nil, fmt.Errorf("unregistered function: '%v', you must add the following to your package's init() method, %v(%v)", name, registerCallbackShortName, shortName)
+	}
+	return &TestRunner{
+		callback: callback,
+	}, nil
+}
+
+func NewTestRunnerFailOnErr(t *testing.T, callback func(cmd string, args ...string) int) *TestRunner {
+	runner, err := NewTestRunner(callback)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runner
+}
+
+// Call this method to register your callback function from your init() method. This is required before creating a TestRunner that uses your function.
+func RegisterCallback(fn func(cmd string, args ...string) int) {
+	name := getFullyQualifiedFunctionName(fn)
+	reggedFunctions[name] = fn
+}
+
+func (runner *TestRunner) CombinedOutput(cmd string, args ...string) (string, error) {
+	args = append([]string{cmd}, args...)
+	command := exec.Command(os.Args[0], args...)
+	command.Env = []string{
+		fmt.Sprintf("%v=%v", TestModeEnvVar, CallbackTestMode),
+		fmt.Sprintf("%v=%v", CallbackFunctionName, getFullyQualifiedFunctionName(runner.callback)),
+	}
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(run(m))
+}
+
+func run(m *testing.M) int {
+	switch os.Getenv(TestModeEnvVar) {
+	case CallbackTestMode:
+		return runTestExec()
+	default:
+		return m.Run()
+	}
+}
+
+func runTestExec() int {
+	functionName := os.Getenv(CallbackFunctionName)
+	fn := reggedFunctions[functionName]
+	if fn == nil {
+		panic(fmt.Errorf("unregistered function name: %v", functionName))
+	}
+	return fn(os.Args[1], os.Args[2:len(os.Args)]...)
+}
+
+// given the output of getFullyQualifiedFunctionName(...) this function returns the actual 'short' function name stripping off the package path and file name.
+func getUnqualifiedFunctionName(fullyQualifiedName string) string {
+	parts := strings.Split(fullyQualifiedName, ".")
+	return parts[len(parts)-1]
+}
+
+// code assumes that the 'fn' parameter has a kind of 'Func'
+func getFullyQualifiedFunctionName(fn interface{}) string {
+	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit ensures that for the lifecycle of gce-machine-controller new machines can enter the cluster and improves the security model used by the join command.

- *New Machines:* Prior to this commit, the gce-machine-controller had a single kubeadm join token passed in as a parameter. The token was given to new machines that gce-machine-controller created. The token was using the default expiration of 24 hours so after 24 hours new machines could not enter the cluster.
- *Security Model:* Prior to this commit, the join command used by new nodes passed in the flag ```discovery-token-unsafe-skip-ca-verification```. This flag disabled checking the validity of the root certificate authority presented by the Master.

For fetching the token the decision was to go with kubeadm as the token creation exists in that command and if it changes over time the command should continue to function the same way. In addition, it is more version agnostic to make use of the command as long as the arguments do not change.

Also, a new type of wrapper for exec.Commands is added named CmdRunner. This wrapper enables us to create an exec implementation specifically for test binaries. Using this wrapper tests can mock exec commands and finely control the output and exit codes. An actual program is exec-ed so it is extremely close to what happens at runtime other than the actual program is not called.

**Which issue(s) this PR fixes**:
This is a partial completion of: https://github.com/kubernetes-sigs/cluster-api/issues/159 and some of the logic will need to be duplicated into tf-deployer.

**Special notes for your reviewer**:
I will follow up with another commit for tf-deployer.

**Release note**:
```release-note
Machine controller support for adding new nodes to clusters after 24 hours. 
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
