### PR TITLE
Add reviewers section to OWNERS and alias

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,3 +4,5 @@ approvers:
   - sig-cluster-lifecycle-leads
   - cluster-api-admins
   - cluster-api-maintainers
+reviewers:
+  - cluster-api-collaborators

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,3 +20,6 @@ aliases:
     - medinatiger
     - roberthbailey
     - rsdcastro
+  cluster-api-collaborators
+    - k4leung4
+    - spew


### PR DESCRIPTION
**What this PR does / why we need it**:
Add reviewers sections so we can get more people to review/approve PRs

This adds @k4leung4 and @spew as reviewers

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
@kubernetes/kube-deploy-reviewers
