### PR TITLE
Add validate cluster command to clusterctl

### DIFF
--- a/clusterctl/cmd/validate.go
+++ b/clusterctl/cmd/validate.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate an API resource created by cluster API.",
+	Long:  `Validate an API resource created by cluster API. See subcommands for supported API resources.`,
+}
+
+func init() {
+	RootCmd.AddCommand(validateCmd)
+}

--- a/clusterctl/cmd/validate_cluster.go
+++ b/clusterctl/cmd/validate_cluster.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/errors"
+)
+
+var validateClusterCmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Validate a cluster created by cluster API.",
+	Long:  `Validate a cluster created by cluster API.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := RunValidateCluster(); err != nil {
+			glog.Exit(err)
+		}
+	},
+}
+
+func init() {
+	validateCmd.AddCommand(validateClusterCmd)
+}
+
+func RunValidateCluster() error {
+	return errors.NotImplementedError
+}

--- a/clusterctl/cmd/validate_cluster_test.go
+++ b/clusterctl/cmd/validate_cluster_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"sigs.k8s.io/cluster-api/errors"
+)
+
+func TestRunValidateCluster(t *testing.T) {
+	err := RunValidateCluster()
+	if (err != errors.NotImplementedError) {
+		t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, errors.NotImplementedError)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR adds validate cluster command to clusterctl. It does not have real implementations yet. This is part of #168 and there will be follow-up PRs. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
