### PR TITLE
CLUSTER-API-205: Initialize the 'flag' library to remove error message from glog

### DIFF
--- a/cloud/google/cmd/gce-machine-controller/main.go
+++ b/cloud/google/cmd/gce-machine-controller/main.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apiserver/pkg/util/logs"
 	"sigs.k8s.io/cluster-api/cloud/google/cmd/gce-machine-controller/app"
 	"sigs.k8s.io/cluster-api/cloud/google/cmd/gce-machine-controller/app/options"
+	"flag"
 )
 
 func main() {
@@ -30,6 +31,8 @@ func main() {
 	s.AddFlags(pflag.CommandLine)
 
 	pflag.Parse()
+	// the following line exists to make glog happy, for more information, see: https://github.com/kubernetes/kubernetes/issues/17162
+	flag.CommandLine.Parse([]string{})
 
 	logs.InitLogs()
 	defer logs.FlushLogs()


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior to this change, every line of logging had the following error message prefixing the actual log:

  ERROR: logging before flag.Parse

This is because glog has a hard dependency on the flag package. This 'hack' serves to make glog happy.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/205

**Special notes for your reviewer**:
Tested by running a developer gce-machine-controller image. Below is the before & after for this change.

*Before:*
```
ERROR: logging before flag.Parse: I0523 21:53:41.081142       1 queue.go:38] Start Machine Queue
ERROR: logging before flag.Parse: I0523 21:53:41.081442       1 queue.go:38] Start NodeWatcher Queue
ERROR: logging before flag.Parse: E0523 21:53:41.386480       1 reflector.go:205] sigs.k8s.io/cluster-api/pkg/controller/sharedinformers/zz_generated.api.register.go:56: Failed to list *v1alpha1.MachineDeployment: the server could not find the requested resource (get machinedeployments.cluster.k8s.io)
E
```

*After:* 
```
I0523 21:56:26.012299       1 queue.go:38] Start Machine Queue
I0523 21:56:26.017385       1 queue.go:38] Start NodeWatcher Queue
E0523 21:56:26.388359       1 reflector.go:205] sigs.k8s.io/cluster-api/pkg/controller/sharedinformers/zz_generated.api.register.go:55: Failed to list *v1alpha1.Machine: the server could not find the requested resource (get machines.cluster.k8s.io)
E
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
