### PR TITLE
Fix typo in minikube_test.go: call Fatalf instead of Fatal.

### DIFF
--- a/clusterctl/clusterdeployer/minikube/minikube_test.go
+++ b/clusterctl/clusterdeployer/minikube/minikube_test.go
@@ -86,11 +86,11 @@ func TestGetKubeconfig(t *testing.T) {
 		m.kubeconfigpath = f
 		c, err := m.GetKubeconfig()
 		if err != nil {
-			t.Fatal("Unexpected err. Got: %v", err)
+			t.Fatalf("Unexpected err. Got: %v", err)
 			return
 		}
 		if c != contents {
-			t.Fatal("Unexpected contents. Got: %v, Want: %v", c, contents)
+			t.Fatalf("Unexpected contents. Got: %v, Want: %v", c, contents)
 		}
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a small typo in the minikube_test.go file which was causing test builds to fail. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
