### PR TITLE
Add SECURITY_CONTACTS file. The list of contacts is equal to the 'sig-cluster-lifecycle-leads' alias from the OWNERS_ALIASES file.

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,0 +1,16 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Team to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+lukemarsden
+luxas
+roberthbailey
+timothysc


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds a SECURITY_OWNERS file to the repository. It is a list of contacts for when a security issue arises. See issue https://github.com/kubernetes-sigs/cluster-api/issues/208 for more context.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/208

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
