### PR TITLE
Switch the base image to debian stretch slim

### DIFF
--- a/cloud/google/cmd/gce-machine-controller/Dockerfile
+++ b/cloud/google/cmd/gce-machine-controller/Dockerfile
@@ -23,8 +23,8 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api/cloud/google/cmd/gce-machine-controller
 
 # Final container
-FROM alpine:3.7
-RUN apk --no-cache add ca-certificates bash openssh 
+FROM debian:stretch-slim
+RUN apt-get update && apt-get install -y ca-certificates openssh-server && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/bin/gce-machine-controller .
 

--- a/cloud/google/cmd/gce-machine-controller/Makefile
+++ b/cloud/google/cmd/gce-machine-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = gce-machine-controller
-TAG = 0.0.10
+TAG = 0.0.11
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/google/pods.go
+++ b/cloud/google/pods.go
@@ -32,9 +32,9 @@ import (
 	"sigs.k8s.io/cluster-api/cloud/google/config"
 )
 
-var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.3"
-var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.3"
-var machineControllerImage = "gcr.io/k8s-cluster-api/gce-machine-controller:0.0.10"
+var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.4"
+var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.4"
+var machineControllerImage = "gcr.io/k8s-cluster-api/gce-machine-controller:0.0.11"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/cloud/terraform/cmd/terraform-machine-controller/Dockerfile
+++ b/cloud/terraform/cmd/terraform-machine-controller/Dockerfile
@@ -23,19 +23,20 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api/cloud/terraform/cmd/terraform-machine-controller
 
 # Final container
-FROM alpine:3.7
+FROM debian:stretch-slim
 
 ENV TERRAFORM_VERSION=0.11.7
 ENV TERRAFORM_ZIP=terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ENV TERRAFORM_SHA256SUM=6b8ce67647a59b2a3f70199c304abca0ddec0e49fd060944c26f666298e23418
 ENV TERRAFORM_SHAFILE=terraform_${TERRAFORM_VERSION}_SHA256SUMS
 
-RUN apk --no-cache add --update bash ca-certificates curl openssh && \
+RUN apt-get update && apt-get install -y ca-certificates curl openssh-server unzip && \
     curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ZIP} > ${TERRAFORM_ZIP} && \
     echo "${TERRAFORM_SHA256SUM}  ${TERRAFORM_ZIP}" > ${TERRAFORM_SHAFILE} && \
-    sha256sum -cs ${TERRAFORM_SHAFILE} && \
+    sha256sum --quiet -c ${TERRAFORM_SHAFILE} && \
     unzip ${TERRAFORM_ZIP} -d /bin && \
     rm -f ${TERRAFORM_ZIP} ${TERRAFORM_SHAFILE} && \
-    echo 'plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"' >> ~/.terraformrc
+    echo 'plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"' >> ~/.terraformrc && \
+    rm -rf /var/lib/apt/lists/*
     
 COPY --from=builder /go/bin/terraform-machine-controller .

--- a/cloud/terraform/cmd/terraform-machine-controller/Makefile
+++ b/cloud/terraform/cmd/terraform-machine-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = terraform-machine-controller
-TAG = 0.0.4
+TAG = 0.0.5
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/terraform/pods.go
+++ b/cloud/terraform/pods.go
@@ -32,9 +32,9 @@ import (
 	"sigs.k8s.io/cluster-api/cloud/terraform/config"
 )
 
-var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.3"
-var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.3"
-var machineControllerImage = "gcr.io/k8s-cluster-api/terraform-machine-controller:0.0.4"
+var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.4"
+var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.4"
+var machineControllerImage = "gcr.io/k8s-cluster-api/terraform-machine-controller:0.0.5"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/cmd/apiserver/Dockerfile
+++ b/cmd/apiserver/Dockerfile
@@ -23,7 +23,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api/cmd/apiserver
 
 # Final container
-FROM alpine:3.7
-RUN apk --no-cache add ca-certificates bash
+FROM debian:stretch-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/bin/apiserver .

--- a/cmd/apiserver/Makefile
+++ b/cmd/apiserver/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = cluster-apiserver
-TAG = 0.0.3
+TAG = 0.0.4
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../..

--- a/cmd/controller-manager/Dockerfile
+++ b/cmd/controller-manager/Dockerfile
@@ -23,7 +23,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api/cmd/controller-manager
 
 # Final container
-FROM alpine:3.7
-RUN apk --no-cache add ca-certificates bash
+FROM debian:stretch-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/bin/controller-manager .

--- a/cmd/controller-manager/Makefile
+++ b/cmd/controller-manager/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = controller-manager
-TAG = 0.0.3
+TAG = 0.0.4
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../..


### PR DESCRIPTION
**What this PR does / why we need it**: Changes the base image for the cluster api repo to debian.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The base layer for cluster api containers changed from alpine to debian.
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
