### PR TITLE
Expose Kubernetes scheduler and controller manager to the cluster on GCP

### DIFF
--- a/gcp-deployer/machine_setup_configs.yaml
+++ b/gcp-deployer/machine_setup_configs.yaml
@@ -103,6 +103,9 @@ items:
         cluster-cidr: ${POD_CIDR}
         service-cluster-ip-range: ${SERVICE_CIDR}
         allocate-node-cidrs: "true"
+        address: 0.0.0.0
+      schedulerExtraArgs:
+        address: 0.0.0.0
       apiServerCertSANs:
       - ${PUBLICIP}
       - ${PRIVATEIP}


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes Scheduler and Controller Manager to the cluster. This is needed for Prometheus to scrape metrics from these components.

**Release note**:
```release-note
Exposes Scheduler and Controller Manager to the cluster on GCP.
```

@kubernetes/kube-deploy-reviewers
