### PR TITLE
Expose Kubernetes scheduler and controller manager to the cluster on Terraform

### DIFF
--- a/cloud/terraform/templates.go
+++ b/cloud/terraform/templates.go
@@ -336,6 +336,9 @@ apiServerExtraVolumes:
 controllerManagerExtraArgs:
   cloud-provider: vsphere
   cloud-config: /etc/kubernetes/cloud-config/cloud-config.yaml
+  address: 0.0.0.0
+schedulerExtraArgs:
+  address: 0.0.0.0
 controllerManagerExtraVolumes:
   - name: cloud-config
     hostPath: /etc/kubernetes/cloud-config


### PR DESCRIPTION
**What this PR does / why we need it**:
Exposes Scheduler and Controller Manager to the cluster on Terraform.

**Release note**:
```release-note
Expose Scheduler and Controller Manager to the cluster on Terraform.
```

@kubernetes/kube-deploy-reviewers