### PR TITLE
Add an initial integration test for gcp-deployer.

### DIFF
--- a/gcp-deployer/CONTRIBUTING.md
+++ b/gcp-deployer/CONTRIBUTING.md
@@ -78,42 +78,35 @@ $ git clone https://github.com/<GITHUB_USERNAME>/cluster-api.git
 
 ```bash
 $ cd $GOPATH/src/sigs.k8s.io/cluster-api/gcp-deployer/
-$ go build
+$ go build .
 ```
 
 This will create a binary `gcp-deployer` in the same directory. You can use that binary to manage a GCP cluster.
 
 ## Developing
 
-When making changes to the machine controller, it's generally a good idea to delete any existing cluster created with an older version of the cluster-api.
-
-```bash
-$ ./gcp-deployer delete
-```
-
-After making changes to the controllers or the actuator, you need to follow these two steps:
-
-1. Rebuild the machine-controller image. Also change `machineControllerImage` in `cloud/google/pods.go` to the new image path (make sure the version in the Makefile and `pods.go` match if you want to use the new image). Then, rebuild and push the image.
-
-	```bash
-	$ cd $GOPATH/src/sigs.k8s.io/cluster-api/cloud/google/cmd/gce-machine-controller
-	$ make dev_push
-	```
-
-NOTE: that the image will be pushed to `gcr.io/$(GCLOUD_PROJECT)/apiserver-controller`. Image storage is a billable resource.
-
-2. Rebuild gcp-deployer
-
-	```bash
-    $ cd $GOPATH/src/sigs.k8s.io/cluster-api/gcp-deployer/
-	$ go build
-	```
-
-The new `gcp-deployer` will have your changes.
+Before submitting an PR you should run the unit and integration tests. Instructions for doing so are given below.
 
 ## Testing
 
-We do not have unit tests or integration tests currently. For any changes, it is recommended that you test a create-edit-delete sequence using the new machine controller image and the new `gcp-deployer` binary.
+### Unit Tests
+When changing this application, you will often end up modifying other packages above this folder in the project tree. You
+should run all the unit tests in the repository. To run the unit tests, run the following command from the root,
+```cluster-api```, folder of the repo.
+
+```
+go test ./...
+```
+
+### Integration Tests
+
+To run the gcp-deployer integration tests, run the following command from this folder. The integration tests are for sanity checking
+that gcp-deployer's basic functionality is working.
+```
+go test -tags=integration -v
+```
+
+### Manual Tests
 
 1. Generate machines configuration file.
 

--- a/gcp-deployer/README.md
+++ b/gcp-deployer/README.md
@@ -104,3 +104,6 @@ The yaml is unmarshalled into a [machinesetup.configList](../cloud/google/machin
 Right now, the startup scripts must be bash scripts. 
 There is a set of environment variables that is concatenated to the beginning of the startup script.
 You can find them [here](../cloud/google/metadata.go) and use them in your startup script as needed.
+
+## Contributing
+Please see the [contributing guide](CONTRIBUTING.md) for information on how you can get involved.

--- a/gcp-deployer/main_integration_test.go
+++ b/gcp-deployer/main_integration_test.go
@@ -1,0 +1,159 @@
+// +build integration
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main_test
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+)
+
+const (
+	gcpDeployerBinaryName = "gcp-deployer"
+	workingDirectoryName  = "gcp-deployer"
+	machinesFileName      = "machines.yaml"
+	clusterFileName       = "cluster.yaml"
+	generateScriptName    = "generate-yaml.sh"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	err := setupPrerequisites()
+	if err != nil {
+		fmt.Printf("unable to setup prerequisites: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
+
+func TestSmokeCreateAndDelete(t *testing.T) {
+	fmt.Println("Creating cluster...")
+	runCreate(t)
+	fmt.Println("Cluster successfully created")
+	fmt.Println("Deleting cluster...")
+	runDelete(t)
+}
+
+func runCreate(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", workingDirectoryName)
+	if err != nil {
+		t.Fatalf("unable to create temporary folder: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+	clusterPath, machinesPath, err := generateYaml(tempDir)
+	if err != nil {
+		t.Fatalf("unable to create yaml files: %v", err)
+	}
+	err = runGcpDeployerPipeOuputs("create", "-c", clusterPath, "-m", machinesPath)
+	if err != nil {
+		t.Fatalf("unable to successfully run create: %v", err)
+	}
+}
+
+func runDelete(t *testing.T) {
+	err := runGcpDeployerPipeOuputs("delete")
+	if err != nil {
+		t.Fatalf("unable to successfully run delete: %v", err)
+	}
+}
+
+func generateYaml(dir string) (clusterPath string, machinesPath string, err error) {
+	paths := make(map[string]string)
+	for _, file := range []string{machinesFileName + ".template", clusterFileName + ".template", generateScriptName} {
+		p, err := copyFileToDir(file, dir)
+		if err != nil {
+			return "", "", fmt.Errorf("unable to copy '%v': %v", file, err)
+		}
+		paths[file] = p
+	}
+	err = runCmdPipeOutput(dir, paths[generateScriptName])
+	if err != nil {
+		return "", "", fmt.Errorf("unable to run generate script at '%v': %v", paths[generateScriptName], err)
+	}
+	return path.Join(dir, clusterFileName), path.Join(dir, machinesFileName), nil
+}
+
+func copyFileToDir(src string, dstDir string) (fpath string, err error) {
+	bytes, err := ioutil.ReadFile(src)
+	if err != nil {
+		return "", fmt.Errorf("unable to read file: %v", err)
+	}
+	info, err := os.Stat(src)
+	if err != nil {
+		return "", err
+	}
+	_, fname := path.Split(src)
+	fpath = path.Join(dstDir, fname)
+	err = ioutil.WriteFile(fpath, bytes, info.Mode())
+	if err != nil {
+		return "", fmt.Errorf("unable to write file: %v", err)
+	}
+	return fpath, nil
+}
+
+func setupPrerequisites() error {
+	workDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve working directory: %v", err)
+	}
+	_, dir := path.Split(workDir)
+	if dir != workingDirectoryName {
+		return fmt.Errorf("invalid working directory name: want %v, got %v", workingDirectoryName, dir)
+	}
+	err = cleanAndBuildGcpDeployer()
+	if err != nil {
+		return fmt.Errorf("unable to build gcp-deployer: %v", err)
+	}
+	return nil
+}
+
+func cleanAndBuildGcpDeployer() error {
+	err := exec.Command("go", "clean", "./...").Run()
+	if err != nil {
+		return fmt.Errorf("unable to run go clean: %v", err)
+	}
+	err = exec.Command("go", "build", ".").Run()
+	if err != nil {
+		return fmt.Errorf("unable to run go build: %v", err)
+	}
+	return nil
+}
+
+func runGcpDeployerPipeOuputs(args ...string) error {
+	workDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve working directory: %v", err)
+	}
+	return runCmdPipeOutput("", path.Join(workDir, gcpDeployerBinaryName), args...)
+}
+
+func runCmdPipeOutput(workDir string, cmd string, args ...string) error {
+	command := exec.Command(cmd, args...)
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Dir = workDir
+	cmdStr := fmt.Sprintf("%v %v", cmd, strings.Join(args, " "))
+	fmt.Printf("Running command: %v\n", cmdStr)
+	return command.Run()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an integration test for gcp-deployer. The test simply creates and destroys a cluster. This is an incremental step towards running integration tests as part of the continuous integration build.

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
