### PR TITLE
Increase the the polling timeout when waiting for machine delete to c…

### DIFF
--- a/gcp-deployer/deploy/deploy_helper.go
+++ b/gcp-deployer/deploy/deploy_helper.go
@@ -175,7 +175,7 @@ func (d *deployer) delete(name string) error {
 	if err != nil {
 		return err
 	}
-	err = util.Poll(500*time.Millisecond, 120*time.Second, func() (bool, error) {
+	err = util.Poll(500*time.Millisecond, 240*time.Second, func() (bool, error) {
 		if _, err = d.client.Machines(apiv1.NamespaceDefault).Get(name, metav1.GetOptions{}); err == nil {
 			return false, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
In PR https://github.com/kubernetes-sigs/cluster-api/pull/221 an integration test was added for gcp-deployer. This test always fails because the given timeout for deleting a machine in the cluster (120 seconds) is not sufficient right after the cluster is created. This PR increases the timeout from 120 to 240 seconds. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
