### PR TITLE
Standardize location of AddCommand(...) call

### DIFF
--- a/clusterctl/cmd/create.go
+++ b/clusterctl/cmd/create.go
@@ -27,5 +27,5 @@ var createCmd = &cobra.Command{
 }
 
 func init() {
-	createCmd.AddCommand(createClusterCmd)
+	RootCmd.AddCommand(createCmd)
 }

--- a/clusterctl/cmd/create_cluster.go
+++ b/clusterctl/cmd/create_cluster.go
@@ -77,6 +77,7 @@ func init() {
 	// Optional flags
 	createClusterCmd.Flags().BoolVarP(&co.CleanupExternalCluster, "cleanup-external-cluster", "", true, "Whether to cleanup the external cluster after bootstrap")
 	createClusterCmd.Flags().StringVarP(&co.VmDriver, "vm-driver", "", "", "Which vm driver to use for minikube")
+	createCmd.AddCommand(createClusterCmd)
 }
 
 func parseClusterYaml(file string) (*clusterv1.Cluster, error) {

--- a/clusterctl/cmd/delete.go
+++ b/clusterctl/cmd/delete.go
@@ -27,6 +27,5 @@ var deleteCmd = &cobra.Command{
 }
 
 func init() {
-	deleteCmd.AddCommand(NewCmdDeleteCluster())
 	RootCmd.AddCommand(deleteCmd)
 }

--- a/clusterctl/cmd/delete_cluster.go
+++ b/clusterctl/cmd/delete_cluster.go
@@ -46,6 +46,10 @@ func NewCmdDeleteCluster() *cobra.Command {
 	return cmd
 }
 
+func init() {
+	deleteCmd.AddCommand(NewCmdDeleteCluster())
+}
+
 func RunDelete() error {
 	return errors.NotImplementedError
 }

--- a/clusterctl/cmd/root.go
+++ b/clusterctl/cmd/root.go
@@ -54,5 +54,4 @@ func init() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	logs.InitLogs()
-	RootCmd.AddCommand(createCmd)
 }


### PR DESCRIPTION
All AddCommand(...) calls are now made from the sub-command which adds itself to its root / parent command.

**What this PR does / why we need it**:
This PR standardizes the location of the AddCommand call to reduce confusion and make it easier to developers to understand the codebase. The choice was made to add call AddCommand in the sub command's init() method as that matches the examples given on the cobra github README.md.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
