### PR TITLE
Revert changes to generated files

### DIFF
--- a/pkg/controller/machineset/zz_generated.api.register.go
+++ b/pkg/controller/machineset/zz_generated.api.register.go
@@ -54,6 +54,14 @@ func NewMachineSetController(config *rest.Config, si *sharedinformers.SharedInfo
 	uc := &MachineSetControllerImpl{}
 	var ci sharedinformers.Controller = uc
 
+	// Call the Init method that is implemented.
+	// Support multiple Init methods for backwards compatibility
+	if i, ok := ci.(sharedinformers.LegacyControllerInit); ok {
+		i.Init(config, si, c.LookupAndReconcile)
+	} else if i, ok := ci.(sharedinformers.ControllerInit); ok {
+		i.Init(&sharedinformers.ControllerInitArgumentsImpl{si, config, c.LookupAndReconcile})
+	}
+
 	c.controller = uc
 
 	queue.Reconcile = c.reconcile
@@ -63,15 +71,6 @@ func NewMachineSetController(config *rest.Config, si *sharedinformers.SharedInfo
 	c.Informers.WorkerQueues["MachineSet"] = queue
 	si.Factory.Cluster().V1alpha1().MachineSets().Informer().
 		AddEventHandler(&controller.QueueingEventHandler{q, nil, false})
-
-	// Call the Init method that is implemented.
-	// Support multiple Init methods for backwards compatibility
-	if i, ok := ci.(sharedinformers.LegacyControllerInit); ok {
-		i.Init(config, si, c.LookupAndReconcile)
-	} else if i, ok := ci.(sharedinformers.ControllerInit); ok {
-		i.Init(&sharedinformers.ControllerInitArgumentsImpl{si, config, c.LookupAndReconcile})
-	}
-
 	return c
 }
 
@@ -118,8 +117,8 @@ func (c *MachineSetController) reconcile(key string) (err error) {
 }
 
 func (c *MachineSetController) Run(stopCh <-chan struct{}) {
-	controller.GetDefaults(c.controller).Run(stopCh)
 	for _, q := range c.Informers.WorkerQueues {
 		q.Run(stopCh)
 	}
+	controller.GetDefaults(c.controller).Run(stopCh)
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This will revert modifications to the generated files, and we work
around the initial reasons why we needed to modify them.

WaitForCacheSync can be called with a new channel, as it isn't really
used any more.

We store the shared informers for access to the queue instead of
storing the queue in Init.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
