### PR TITLE
Add integration tests for clusterctl's basic 'help / usage messsage'scenarios; update the contributing guide with testing instructions; remove glog from usage output.

### DIFF
--- a/clusterctl/CONTRIBUTING.md
+++ b/clusterctl/CONTRIBUTING.md
@@ -1,3 +1,26 @@
 # Contributing Guidelines
 
 1. Follow the [Getting Started]((https://github.com/kubernetes-sigs/cluster-api/blob/master/cluster-api/clusterctl/README.md)) steps to create a cluster.
+
+# Development
+
+Before submitting an PR you should run the unit and integration tests. Instructions for doing so are given in the [Testing](#Testing) section.
+
+## Testing
+
+### Unit Tests
+When changing this application, you will often end up modifying other packages above this folder in the project tree. You
+should run all the unit tests in the repository. To run the unit tests, run the following command from the root,
+`cluster-api`, folder of the repo.
+
+```
+go test ./...
+```
+
+### Integration Tests
+
+To run the integration tests, run the following command from this folder. The integration tests are for sanity checking
+that clusterctl's basic functionality is working.
+```
+go test -tags=integration -v
+```

--- a/clusterctl/README.md
+++ b/clusterctl/README.md
@@ -58,3 +58,7 @@ $ kubectl get machines -o yaml
 ### Deleting a cluster
 
 **NOT YET SUPPORTED!**
+
+## Contributing
+
+If you are interested in adding to this project, see the [contributing guide](CONTRIBUTING.md) for information on how you can get involved.

--- a/clusterctl/cmd/root.go
+++ b/clusterctl/cmd/root.go
@@ -18,7 +18,7 @@ package cmd
 
 import (
 	"flag"
-	"github.com/golang/glog"
+	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apiserver/pkg/util/logs"
@@ -37,12 +37,13 @@ var RootCmd = &cobra.Command{
 
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
-		glog.Exit(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }
 
 func exitWithHelp(cmd *cobra.Command, err string) {
-	glog.Error(err)
+	fmt.Fprintln(os.Stderr, err)
 	cmd.Help()
 	os.Exit(1)
 }

--- a/clusterctl/main_integration_test.go
+++ b/clusterctl/main_integration_test.go
@@ -1,0 +1,184 @@
+// +build integration
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main_test
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+const (
+	clusterctlBinaryName = "clusterctl"
+	workingDirectoryName = "clusterctl"
+)
+
+// run these tests with the flag "-update" to update the values stored in all of the golden files
+var update = flag.Bool("update", false, "update .golden files")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	err := setupPrerequisites()
+	if err != nil {
+		fmt.Printf("unable to setup prerequisites: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
+
+func TestEmptyAndInvalidArgs(t *testing.T) {
+	testCases := []struct {
+		name            string
+		args            []string
+		exitCode        int
+		fixtureFilename string
+	}{
+		{"no arguments", []string{}, 0, "no-args.golden"},
+		{"no arguments with invalid flag", []string{"--invalid-flag"}, 1, "no-args-invalid-flag.golden"},
+		{"create with no arguments", []string{"create"}, 0, "create-no-args.golden"},
+		{"create with no arguments with invalid flag", []string{"create", "--invalid-flag"}, 1, "create-no-args-invalid-flag.golden"},
+		{"create cluster with no arguments", []string{"create", "cluster"}, 1, "create-cluster-no-args.golden"},
+		{"create cluster with no arguments with invalid flag", []string{"create", "cluster", "--invalid-flag"}, 1, "create-cluster-no-args-invalid-flag.golden"},
+		{"delete with no arguments", []string{"delete"}, 0, "delete-no-args.golden"},
+		{"delete with no arguments with invalid flag", []string{"delete", "--invalid-flag"}, 1, "delete-no-args-invalid-flag.golden"},
+		{"delete cluster with no arguments", []string{"delete", "delete"}, 1, "delete-cluster-no-args.golden"},
+		{"delete cluster with no arguments with invalid flag", []string{"delete", "delete", "--invalid-flag"}, 1, "delete-cluster-no-args-invalid-flag.golden"},
+		{"validate with no arguments", []string{"validate"}, 0, "validate-no-args.golden"},
+		{"validate with no arguments with invalid flag", []string{"validate", "--invalid-flag"}, 1, "validate-no-args-invalid-flag.golden"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := runClusterctl(t, tc.args...)
+			compareExitCode(t, err, tc.exitCode)
+			compareOutput(t, output, tc.fixtureFilename)
+		})
+	}
+}
+
+func compareExitCode(t *testing.T, err error, expectedExitCode int) {
+	if expectedExitCode == 0 {
+		if err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+	} else {
+		actualExitCode := extractExitCode(t, err)
+		if actualExitCode != expectedExitCode {
+			t.Errorf("unexpected exit code: want %v, got %v", expectedExitCode, actualExitCode)
+		}
+	}
+}
+
+func extractExitCode(t *testing.T, err error) int {
+	t.Helper()
+	if err == nil {
+		t.Errorf("expected error exit code, got nil")
+	} else if exitError, ok := err.(*exec.ExitError); ok {
+		ws := exitError.Sys().(syscall.WaitStatus)
+		return ws.ExitStatus()
+	} else {
+		t.Fatalf("unable to retrieve exit code from error: %v", err)
+	}
+	return 0
+}
+
+func compareOutput(t *testing.T, actualOutput string, goldenFileName string) {
+	t.Helper()
+	if *update {
+		writeFixture(t, goldenFileName, actualOutput)
+	}
+	expectedOutput := loadFixture(t, goldenFileName)
+	if actualOutput != expectedOutput {
+		// TODO: format this using a diff tool / library (issue 255)
+		t.Errorf("unexpected output, want %v, got %v", expectedOutput, actualOutput)
+	}
+}
+
+func writeFixture(t *testing.T, fixtureFilename string, value string) {
+	t.Helper()
+	path := getFixturePath(fixtureFilename)
+	err := ioutil.WriteFile(path, []byte(value), 0644)
+	if err != nil {
+		t.Fatalf("unable to update value of fixture '%v': %v", path, err)
+	}
+}
+
+func loadFixture(t *testing.T, fixtureFilename string) string {
+	t.Helper()
+	path := getFixturePath(fixtureFilename)
+	output, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("unable to read fixture file '%v': %v", path, err)
+	}
+	return string(output)
+}
+
+func getFixturePath(filename string) string {
+	return path.Join("testdata", filename)
+}
+
+func setupPrerequisites() error {
+	workDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("unable to retrieve working directory: %v", err)
+	}
+	_, dir := path.Split(workDir)
+	if dir != workingDirectoryName {
+		return fmt.Errorf("invalid working directory name: want %v, got %v", workingDirectoryName, dir)
+	}
+	err = cleanAndBuildClusterctl()
+	if err != nil {
+		return fmt.Errorf("unable to build gcp-deployer: %v", err)
+	}
+	return nil
+}
+
+func cleanAndBuildClusterctl() error {
+	err := exec.Command("go", "clean", "./...").Run()
+	if err != nil {
+		return fmt.Errorf("unable to run go clean: %v", err)
+	}
+	err = exec.Command("go", "build", ".").Run()
+	if err != nil {
+		return fmt.Errorf("unable to run go build: %v", err)
+	}
+	return nil
+}
+
+func runClusterctl(t *testing.T, args ...string) (string, error) {
+	workDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("unable to retrieve working directory: %v", err)
+	}
+	return runCmd("", path.Join(workDir, clusterctlBinaryName), args...)
+}
+
+func runCmd(workDir string, cmd string, args ...string) (string, error) {
+	command := exec.Command(cmd, args...)
+	command.Dir = workDir
+	cmdStr := fmt.Sprintf("%v %v", cmd, strings.Join(args, " "))
+	fmt.Printf("Running command: %v\n", cmdStr)
+	output, err := command.CombinedOutput()
+	return string(output), err
+}

--- a/clusterctl/testdata/create-cluster-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/create-cluster-no-args-invalid-flag.golden
@@ -1,0 +1,25 @@
+Error: unknown flag: --invalid-flag
+Usage:
+  clusterctl create cluster [flags]
+
+Flags:
+      --cleanup-external-cluster     Whether to cleanup the external cluster after bootstrap (default true)
+  -c, --cluster string               A yaml file containing cluster object definition
+  -h, --help                         help for cluster
+      --kubeconfig-out string        where to output the kubeconfig for the provisioned cluster. (default "kubeconfig")
+  -m, --machines string              A yaml file containing machine object definition(s)
+      --provider string              Which provider deployment logic to use (google/vsphere)
+  -p, --provider-components string   A yaml file containing cluster api provider controllers and supporting objects
+      --vm-driver string             Which vm driver to use for minikube
+
+Global Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+unknown flag: --invalid-flag

--- a/clusterctl/testdata/create-cluster-no-args.golden
+++ b/clusterctl/testdata/create-cluster-no-args.golden
@@ -1,0 +1,25 @@
+Please provide yaml file for cluster definition.
+Create a kubernetes cluster with one command
+
+Usage:
+  clusterctl create cluster [flags]
+
+Flags:
+      --cleanup-external-cluster     Whether to cleanup the external cluster after bootstrap (default true)
+  -c, --cluster string               A yaml file containing cluster object definition
+  -h, --help                         help for cluster
+      --kubeconfig-out string        where to output the kubeconfig for the provisioned cluster. (default "kubeconfig")
+  -m, --machines string              A yaml file containing machine object definition(s)
+      --provider string              Which provider deployment logic to use (google/vsphere)
+  -p, --provider-components string   A yaml file containing cluster api provider controllers and supporting objects
+      --vm-driver string             Which vm driver to use for minikube
+
+Global Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/clusterctl/testdata/create-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/create-no-args-invalid-flag.golden
@@ -1,0 +1,23 @@
+Error: unknown flag: --invalid-flag
+Usage:
+  clusterctl create [command]
+
+Available Commands:
+  cluster     Create kubernetes cluster
+
+Flags:
+  -h, --help   help for create
+
+Global Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+Use "clusterctl create [command] --help" for more information about a command.
+
+unknown flag: --invalid-flag

--- a/clusterctl/testdata/create-no-args.golden
+++ b/clusterctl/testdata/create-no-args.golden
@@ -1,0 +1,22 @@
+Create a cluster API resource with one command
+
+Usage:
+  clusterctl create [command]
+
+Available Commands:
+  cluster     Create kubernetes cluster
+
+Flags:
+  -h, --help   help for create
+
+Global Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+Use "clusterctl create [command] --help" for more information about a command.

--- a/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
@@ -1,0 +1,18 @@
+Error: unknown flag: --invalid-flag
+Usage:
+  clusterctl delete delete [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+unknown flag: --invalid-flag

--- a/clusterctl/testdata/delete-cluster-no-args.golden
+++ b/clusterctl/testdata/delete-cluster-no-args.golden
@@ -1,0 +1,18 @@
+Please provide cluster name.
+Delete a kubernetes cluster with one command
+
+Usage:
+  clusterctl delete delete [flags]
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

--- a/clusterctl/testdata/delete-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/delete-no-args-invalid-flag.golden
@@ -1,0 +1,23 @@
+Error: unknown flag: --invalid-flag
+Usage:
+  clusterctl delete [command]
+
+Available Commands:
+  delete      Delete kubernetes cluster
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+Use "clusterctl delete [command] --help" for more information about a command.
+
+unknown flag: --invalid-flag

--- a/clusterctl/testdata/delete-no-args.golden
+++ b/clusterctl/testdata/delete-no-args.golden
@@ -1,0 +1,22 @@
+Delete a cluster API resource with one command
+
+Usage:
+  clusterctl delete [command]
+
+Available Commands:
+  delete      Delete kubernetes cluster
+
+Flags:
+  -h, --help   help for delete
+
+Global Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+Use "clusterctl delete [command] --help" for more information about a command.

--- a/clusterctl/testdata/no-args-invalid-flag.golden
+++ b/clusterctl/testdata/no-args-invalid-flag.golden
@@ -1,0 +1,25 @@
+Error: unknown flag: --invalid-flag
+Usage:
+  clusterctl [flags]
+  clusterctl [command]
+
+Available Commands:
+  create      Create a cluster API resource
+  delete      Delete a cluster API resource
+  help        Help about any command
+  validate    Validate an API resource created by cluster API.
+
+Flags:
+      --alsologtostderr                  log to standard error as well as files
+  -h, --help                             help for clusterctl
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+Use "clusterctl [command] --help" for more information about a command.
+
+unknown flag: --invalid-flag

--- a/clusterctl/testdata/no-args.golden
+++ b/clusterctl/testdata/no-args.golden
@@ -1,0 +1,24 @@
+Simple kubernetes cluster management
+
+Usage:
+  clusterctl [flags]
+  clusterctl [command]
+
+Available Commands:
+  create      Create a cluster API resource
+  delete      Delete a cluster API resource
+  help        Help about any command
+  validate    Validate an API resource created by cluster API.
+
+Flags:
+      --alsologtostderr                  log to standard error as well as files
+  -h, --help                             help for clusterctl
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+Use "clusterctl [command] --help" for more information about a command.

--- a/clusterctl/testdata/validate-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/validate-no-args-invalid-flag.golden
@@ -1,0 +1,23 @@
+Error: unknown flag: --invalid-flag
+Usage:
+  clusterctl validate [command]
+
+Available Commands:
+  cluster     Validate a cluster created by cluster API.
+
+Flags:
+  -h, --help   help for validate
+
+Global Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+Use "clusterctl validate [command] --help" for more information about a command.
+
+unknown flag: --invalid-flag

--- a/clusterctl/testdata/validate-no-args.golden
+++ b/clusterctl/testdata/validate-no-args.golden
@@ -1,0 +1,22 @@
+Validate an API resource created by cluster API. See subcommands for supported API resources.
+
+Usage:
+  clusterctl validate [command]
+
+Available Commands:
+  cluster     Validate a cluster created by cluster API.
+
+Flags:
+  -h, --help   help for validate
+
+Global Flags:
+      --alsologtostderr                  log to standard error as well as files
+      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
+      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log_dir string                   If non-empty, write log files in this directory
+      --logtostderr                      log to standard error instead of files (default true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          log level for V logs
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+Use "clusterctl validate [command] --help" for more information about a command.


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds a few basic integration tests to clusterctl. This will enable developers to verify their functionality when making changes. To start the only tests that are added are verifying help / usage output. This was to make this PR easier to reason about. We will follow up with more tests quickly. Some of the code was copied & pasted from PR https://github.com/kubernetes-sigs/cluster-api/pull/221. This was done because gcp-deployer will be removed within a short time so it isn't worth refactoring out to share code.

In addition, the contributing guide was updated with instructions on how to run the tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
