### PR TITLE
Fix a race condition where machineset reconciles too quickly

### DIFF
--- a/pkg/controller/machineset/reconcile_test.go
+++ b/pkg/controller/machineset/reconcile_test.go
@@ -132,6 +132,7 @@ func TestMachineSetControllerReconcileHandler(t *testing.T) {
 		},
 	}
 
+	reconcileMutexSleepSec = 0
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// setup the test scenario


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The race condition is where the machineset reconciles on the same key
too quickly, where the creation/deletion of machines is not detected by
the second reconcilation, causing it create/delete additional machines.

I attempted to use WaitForCacheSync, but that is also insufficient in
preventing the race condition.

The fix here is to add 1 second sleep before releasing the mutex lock
when reconciling, which gives the system a chance to recognize the
changes made from the first reconciliation.

Issue #245 was created to improve this hacky fix.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
