### PR TITLE
Rev the controller manager version to pick up machine deployment controller

### DIFF
--- a/cloud/google/pods.go
+++ b/cloud/google/pods.go
@@ -33,7 +33,7 @@ import (
 )
 
 var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.5"
-var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.5"
+var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.6"
 var machineControllerImage = "gcr.io/k8s-cluster-api/gce-machine-controller:0.0.12"
 
 func init() {

--- a/cloud/terraform/pods.go
+++ b/cloud/terraform/pods.go
@@ -33,7 +33,7 @@ import (
 )
 
 var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.5"
-var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.5"
+var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.6"
 var machineControllerImage = "gcr.io/k8s-cluster-api/terraform-machine-controller:0.0.6"
 
 func init() {

--- a/cloud/vsphere/pods.go
+++ b/cloud/vsphere/pods.go
@@ -32,8 +32,8 @@ import (
 	"sigs.k8s.io/cluster-api/cloud/vsphere/config"
 )
 
-var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.4"
-var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.4"
+var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.5"
+var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.6"
 var machineControllerImage = "gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.1"
 
 func init() {

--- a/cmd/controller-manager/Makefile
+++ b/cmd/controller-manager/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = controller-manager
-TAG = 0.0.5
+TAG = 0.0.6
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../..
@@ -31,7 +31,7 @@ fix_gcs_permissions:
 	gsutil acl ch -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
 	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
 
-dev_image: 
+dev_image:
 	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../..
 
 dev_push: dev_image


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This is to pick up PR #143, which allows for the creation of machine
deployments. Rolling update should now work.

This also updates the apiserver to be the same as the one used for gce and terraform provider

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
