### PR TITLE
Deletion guide for GCE cloud provider

### DIFF
--- a/cloud/google/README.md
+++ b/cloud/google/README.md
@@ -1,0 +1,64 @@
+# Cluster API GCP Cloud Provider
+
+## Cluster Deletion
+
+This guide explains how to delete all resources that were created as part of
+your Cluster API Kubernetes cluster.
+
+If your cluster was created using the gcp-deployer tool, see the 
+[gcp-deployer docs](../../gcp-deployer/README.md).
+
+1. Remember the service accounts that were created for your cluster
+
+   ```bash
+   export MASTER_SERVICE_ACCOUNT=$(kubectl get cluster -o=jsonpath='{.items[0].metadata.annotations.gce\.clusterapi\.k8s\.io\/service-account-k8s-master}')
+   export WORKER_SERVICE_ACCOUNT=$(kubectl get cluster -o=jsonpath='{.items[0].metadata.annotations.gce\.clusterapi\.k8s\.io\/service-account-k8s-worker}')
+   export INGRESS_CONTROLLER_SERVICE_ACCOUNT=$(kubectl get cluster -o=jsonpath='{.items[0].metadata.annotations.gce\.clusterapi\.k8s\.io\/service-account-k8s-ingress-controller}')
+   export MACHINE_CONTROLLER_SERVICE_ACCOUNT=$(kubectl get cluster -o=jsonpath='{.items[0].metadata.annotations.gce\.clusterapi\.k8s\.io\/service-account-k8s-machine-controller}')
+   ```
+
+1. Remember the name and zone of the master VM
+
+   ```bash
+   export MASTER_VM_NAME=$(kubectl get machines -l set=master | awk '{print $1}' | tail -n +2)
+   export MASTER_VM_ZONE=$(kubectl get machines -l set=master -o=jsonpath='{.items[0].metadata.annotations.gcp-zone}')
+   ```
+
+1. Delete all of the node Machines in the cluster. Make sure to wait for the
+corresponding Nodes to be deleted before moving onto the next step. After this
+step, the master node will be the only remaining node.
+
+   ```bash
+   kubectl delete machines -l set=node
+   kubectl get nodes
+   ```
+
+1. Delete any Kubernetes objects that may have created GCE resources on your
+behalf, make sure to run these commands for each namespace that you created:
+
+   ```bash
+   # See ingress controller docs for information about resources created for
+   # ingress objects: https://github.com/kubernetes/ingress-gce
+   kubectl delete ingress --all
+
+   # Services can create a GCE load balancer if the type of the service is
+   # LoadBalancer. Additionally, both types LoadBalancer and NodePort will
+   # create a firewall rule in your project.
+   kubectl delete svc --all
+
+   # Persistent volume claims can create a GCE disk if the type of the pvc
+   # is gcePersistentDisk.
+   kubectl delete pvc --all
+   ```
+
+1. Delete the VM that is running your cluster's control plane
+
+   ```bash
+   gcloud compute instances delete --zone=$MASTER_VM_ZONE $MASTER_VM_NAME
+   ```
+
+1. Delete the roles and service accounts that were created for your cluster
+
+   ```bash
+   ./delete-service-accounts.sh
+   ```

--- a/cloud/google/delete-service-accounts.sh
+++ b/cloud/google/delete-service-accounts.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+#Delete service accounts
+
+gcloud iam service-accounts delete $MASTER_SERVICE_ACCOUNT
+gcloud iam service-accounts delete $WORKER_SERVICE_ACCOUNT
+gcloud iam service-accounts delete $INGRESS_CONTROLLER_SERVICE_ACCOUNT
+gcloud iam service-accounts delete $MACHINE_CONTROLLER_SERVICE_ACCOUNT
+
+#Delete roles
+
+export PROJECT_ID=$(gcloud config get-value project)
+
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$MASTER_SERVICE_ACCOUNT --role='roles/compute.instanceAdmin'
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$MASTER_SERVICE_ACCOUNT --role='roles/compute.networkAdmin'
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$MASTER_SERVICE_ACCOUNT --role='roles/compute.securityAdmin'
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$MASTER_SERVICE_ACCOUNT --role='roles/compute.viewer'
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$MASTER_SERVICE_ACCOUNT --role='roles/iam.serviceAccountUser'
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$MASTER_SERVICE_ACCOUNT --role='roles/storage.admin'
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$MASTER_SERVICE_ACCOUNT --role='roles/storage.objectViewer'
+
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$INGRESS_CONTROLLER_SERVICE_ACCOUNT --role='roles/compute.instanceAdmin.v1'
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$INGRESS_CONTROLLER_SERVICE_ACCOUNT --role='roles/compute.networkAdmin'
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$INGRESS_CONTROLLER_SERVICE_ACCOUNT --role='roles/compute.securityAdmin'
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$INGRESS_CONTROLLER_SERVICE_ACCOUNT --role='roles/iam.serviceAccountActor'
+
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$MACHINE_CONTROLLER_SERVICE_ACCOUNT --role='roles/compute.instanceAdmin.v1'
+gcloud projects remove-iam-policy-binding $PROJECT_ID --member=serviceAccount:$MACHINE_CONTROLLER_SERVICE_ACCOUNT --role='roles/iam.serviceAccountActor'

--- a/clusterctl/README.md
+++ b/clusterctl/README.md
@@ -61,6 +61,10 @@ $ kubectl --kubeconfig kubeconfig get machines -o yaml
 
 **NOT YET SUPPORTED!**
 
+clusterctl does not yet support deletion, please see provider specific deletion guides:
+
+- [google](../cloud/google/README.md#Cluster-Deletion)
+
 ## Contributing
 
 If you are interested in adding to this project, see the [contributing guide](CONTRIBUTING.md) for information on how you can get involved.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a document that explains how to delete GCE Cluster API clusters. This should be a short-lived document. Once clusterctl supports deletion this doc can be deleted. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #20 
