### PR TITLE
Move tf-state to machine object, and remove file system dependency

### DIFF
--- a/cloud/vsphere/cmd/vsphere-machine-controller/Dockerfile
+++ b/cloud/vsphere/cmd/vsphere-machine-controller/Dockerfile
@@ -36,7 +36,33 @@ RUN apt-get update && apt-get install -y ca-certificates curl openssh-server unz
     sha256sum --quiet -c ${TERRAFORM_SHAFILE} && \
     unzip ${TERRAFORM_ZIP} -d /bin && \
     rm -f ${TERRAFORM_ZIP} ${TERRAFORM_SHAFILE} && \
-    echo 'plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"' >> ~/.terraformrc && \
     rm -rf /var/lib/apt/lists/*
+
+# Setup template provider
+# Setup template provider
+ENV TEMPLATE_PROVIDER_VERSION=1.0.0
+ENV TEMPLATE_PROVIDER_ZIP=terraform-provider-template_${TEMPLATE_PROVIDER_VERSION}_linux_amd64.zip
+ENV TEMPLATE_PROVIDER_SHA256SUM=f54c2764bd4d4c62c1c769681206dde7aa94b64b814a43cb05680f1ec8911977
+ENV TEMPLATE_PROVIDER_SHAFILE=terraform-provider-template_${TEMPLATE_PROVIDER_VERSION}_SHA256SUMS
+
+RUN curl https://releases.hashicorp.com/terraform-provider-template/${TEMPLATE_PROVIDER_VERSION}/${TEMPLATE_PROVIDER_ZIP} > ${TEMPLATE_PROVIDER_ZIP} && \
+  echo "${TEMPLATE_PROVIDER_SHA256SUM}  ${TEMPLATE_PROVIDER_ZIP}" > ${TEMPLATE_PROVIDER_SHAFILE} && \
+  sha256sum --quiet -c ${TEMPLATE_PROVIDER_SHAFILE} && \
+  mkdir -p ~/.terraform.d/plugins/linux_amd64/ && \
+  unzip ${TEMPLATE_PROVIDER_ZIP} -d ~/.terraform.d/plugins/linux_amd64/ && \
+  rm -f ${TEMPLATE_PROVIDER_ZIP} ${TEMPLATE_PROVIDER_SHAFILE}
+
+# Setup vsphere provider
+ENV VSPHERE_PROVIDER_VERSION=1.5.0
+ENV VSPHERE_PROVIDER_ZIP=terraform-provider-vsphere_${VSPHERE_PROVIDER_VERSION}_linux_amd64.zip
+ENV VSPHERE_PROVIDER_SHA256SUM=6dd495feeb83aa8b098d4e9b0224b9e18b758153504449ff4ac2c6510ed4bb52
+ENV VSPHERE_PROVIDER_SHAFILE=terraform-provider-vsphere_${VSPHERE_PROVIDER_VERSION}_SHA256SUMS
+
+RUN curl https://releases.hashicorp.com/terraform-provider-vsphere/${VSPHERE_PROVIDER_VERSION}/${VSPHERE_PROVIDER_ZIP} > ${VSPHERE_PROVIDER_ZIP} && \
+  echo "${VSPHERE_PROVIDER_SHA256SUM}  ${VSPHERE_PROVIDER_ZIP}" > ${VSPHERE_PROVIDER_SHAFILE} && \
+  sha256sum --quiet -c ${VSPHERE_PROVIDER_SHAFILE} && \
+  mkdir -p ~/.terraform.d/plugins/linux_amd64/ && \
+  unzip ${VSPHERE_PROVIDER_ZIP} -d ~/.terraform.d/plugins/linux_amd64/ && \
+  rm -f ${VSPHERE_PROVIDER_ZIP} ${VSPHERE_PROVIDER_SHAFILE}
 
 COPY --from=builder /go/bin/vsphere-machine-controller .

--- a/cloud/vsphere/cmd/vsphere-machine-controller/Dockerfile
+++ b/cloud/vsphere/cmd/vsphere-machine-controller/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update && apt-get install -y ca-certificates curl openssh-server unz
     rm -rf /var/lib/apt/lists/*
 
 # Setup template provider
-# Setup template provider
 ENV TEMPLATE_PROVIDER_VERSION=1.0.0
 ENV TEMPLATE_PROVIDER_ZIP=terraform-provider-template_${TEMPLATE_PROVIDER_VERSION}_linux_amd64.zip
 ENV TEMPLATE_PROVIDER_SHA256SUM=f54c2764bd4d4c62c1c769681206dde7aa94b64b814a43cb05680f1ec8911977

--- a/cloud/vsphere/config/configtemplate.go
+++ b/cloud/vsphere/config/configtemplate.go
@@ -135,8 +135,8 @@ spec:
             mountPath: /etc/kubernetes
           - name: certs
             mountPath: /etc/ssl/certs
-          - name: terraform-config
-            mountPath: /root/.terraform.d
+          - name: machines-stage
+            mountPath: /tmp/cluster-api/machines/
           - name: sshkeys
             mountPath: /root/.ssh
           - name: named-machines
@@ -164,9 +164,9 @@ spec:
       - name: certs
         hostPath:
           path: /etc/ssl/certs
-      - name: terraform-config
+      - name: machines-stage
         hostPath:
-          path: /home/ubuntu/.terraform.d
+          path: /tmp/cluster-api/machines/
       - name: sshkeys
         hostPath:
           path: /home/ubuntu/.ssh

--- a/cloud/vsphere/machineactuator.go
+++ b/cloud/vsphere/machineactuator.go
@@ -653,12 +653,6 @@ func (vc *VsphereClient) machineproviderconfig(providerConfig clusterv1.Provider
 
 func (vc *VsphereClient) clusterproviderconfig(providerConfig clusterv1.ProviderConfig) (*vsphereconfig.VsphereClusterProviderConfig, error) {
 	obj, gvk, err := vc.codecFactory.UniversalDecoder().Decode(providerConfig.Value.Raw, nil, nil)
-<<<<<<< HEAD
-=======
-	glog.Infof("obj === %+v", obj)
-	glog.Infof("gvk === %+v", gvk)
-
->>>>>>> 30e25fbe... make the new broken type work, pass user, pass to tf
 	if err != nil {
 		return nil, fmt.Errorf("cluster providerconfig decoding failure: %v", err)
 	}

--- a/cloud/vsphere/machineactuator.go
+++ b/cloud/vsphere/machineactuator.go
@@ -653,6 +653,12 @@ func (vc *VsphereClient) machineproviderconfig(providerConfig clusterv1.Provider
 
 func (vc *VsphereClient) clusterproviderconfig(providerConfig clusterv1.ProviderConfig) (*vsphereconfig.VsphereClusterProviderConfig, error) {
 	obj, gvk, err := vc.codecFactory.UniversalDecoder().Decode(providerConfig.Value.Raw, nil, nil)
+<<<<<<< HEAD
+=======
+	glog.Infof("obj === %+v", obj)
+	glog.Infof("gvk === %+v", gvk)
+
+>>>>>>> 30e25fbe... make the new broken type work, pass user, pass to tf
 	if err != nil {
 		return nil, fmt.Errorf("cluster providerconfig decoding failure: %v", err)
 	}

--- a/cloud/vsphere/machineactuator.go
+++ b/cloud/vsphere/machineactuator.go
@@ -466,7 +466,7 @@ func (vc *VsphereClient) Update(cluster *clusterv1.Cluster, goalMachine *cluster
 	// This can only happen right after bootstrapping.
 	if goalMachine.ObjectMeta.Annotations == nil {
 		ip, _ := vc.GetIP(goalMachine)
-		glog.Info("Annotations do not exist. This happens when for a newly bootstrapped machine.")
+		glog.Info("Annotations do not exist. This happens for a newly bootstrapped machine.")
 		tfState, _ := vc.GetTfState(goalMachine)
 		return vc.updateAnnotations(goalMachine, ip, tfState)
 	}
@@ -614,7 +614,7 @@ func (vc *VsphereClient) GetTfState(machine *clusterv1.Machine) (string, error) 
 		return string(tfStateBytes), nil
 	}
 
-	return "", errors.New("could not get tfstatae")
+	return "", errors.New("could not get tfstate")
 }
 
 func (vc *VsphereClient) GetKubeConfig(master *clusterv1.Machine) (string, error) {
@@ -673,6 +673,9 @@ func (vc *VsphereClient) SetupRemoteMaster(master *clusterv1.Machine) error {
 	return nil
 }
 
+// We are storing these as annotations and not in Machine Status because that's intended for
+// "Provider-specific status" that will usually be used to detect updates. Additionally,
+// Status requires yet another version API resource which is too heavy to store IP and TF state.
 func (vc *VsphereClient) updateAnnotations(machine *clusterv1.Machine, masterEndpointIp, tfState string) error {
 	glog.Infof("Updating annotations for machine %s", machine.ObjectMeta.Name)
 	if machine.ObjectMeta.Annotations == nil {

--- a/cloud/vsphere/pods.go
+++ b/cloud/vsphere/pods.go
@@ -34,7 +34,9 @@ import (
 
 var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.5"
 var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.6"
-var machineControllerImage = "gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.1"
+
+//var machineControllerImage = "gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.2"
+var machineControllerImage = "gcr.io/karangoel-gke-1/vsphere-machine-controller:0.0.2-dev"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/cloud/vsphere/pods.go
+++ b/cloud/vsphere/pods.go
@@ -34,9 +34,7 @@ import (
 
 var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.5"
 var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.6"
-
-//var machineControllerImage = "gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.2"
-var machineControllerImage = "gcr.io/karangoel-gke-1/vsphere-machine-controller:0.0.2-dev"
+var machineControllerImage = "gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.2"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/vsphere-deployer/vsphere_named_machines.yaml
+++ b/vsphere-deployer/vsphere_named_machines.yaml
@@ -60,8 +60,8 @@ items:
     insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
 
     [VirtualCenter "$${vsphere_server}"]
-            user = "$${user}"
-            password = "$${password}"
+            user = "$${vsphere_user}"
+            password = "$${vsphere_password}"
 
     [Workspace]
             server = "$${vsphere_server}"

--- a/vsphere-deployer/vsphere_named_machines.yaml
+++ b/vsphere-deployer/vsphere_named_machines.yaml
@@ -26,13 +26,17 @@ items:
     }
 
     provider "vsphere" {
-      version        = "~> 1.4"
+      version        = "~> 1.5.0"
       user           = "${var.vsphere_user}"
       password       = "${var.vsphere_password}"
       vsphere_server = "${var.vsphere_server}"
 
       # if you have a self-signed cert
       allow_unverified_ssl = true
+    }
+
+    provider "template" {
+      version = "~> 1.0.0"
     }
 
     data "vsphere_datacenter" "dc" {
@@ -194,13 +198,17 @@ items:
     }
 
     provider "vsphere" {
-      version        = "~> 1.4"
+      version        = "~> 1.5.0"
       user           = "${var.vsphere_user}"
       password       = "${var.vsphere_password}"
       vsphere_server = "${var.vsphere_server}"
 
       # if you have a self-signed cert
       allow_unverified_ssl = true
+    }
+
+    provider "template" {
+      version = "~> 1.0.0"
     }
 
     data "vsphere_datacenter" "dc" {

--- a/vsphere-deployer/vsphere_named_machines.yaml
+++ b/vsphere-deployer/vsphere_named_machines.yaml
@@ -1,9 +1,15 @@
 items:
 - machineName: standard-master
   machineHcl: |
-    variable "vsphere_user" {}
-    variable "vsphere_password" {}
-    variable "vsphere_server" {}
+    variable "vsphere_user" {
+      type = "string"
+    }
+    variable "vsphere_password" {
+      type = "string"
+    }
+    variable "vsphere_server" {
+      type = "string"
+    }
 
     variable "datacenter" {}
     variable "datastore" {}
@@ -60,8 +66,8 @@ items:
     insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
 
     [VirtualCenter "$${vsphere_server}"]
-            user = "$${vsphere_user}"
-            password = "$${vsphere_password}"
+            user = "$${user}"
+            password = "$${password}"
 
     [Workspace]
             server = "$${vsphere_server}"

--- a/vsphere-deployer/vsphere_named_machines.yaml
+++ b/vsphere-deployer/vsphere_named_machines.yaml
@@ -1,15 +1,9 @@
 items:
 - machineName: standard-master
   machineHcl: |
-    variable "vsphere_user" {
-      type = "string"
-    }
-    variable "vsphere_password" {
-      type = "string"
-    }
-    variable "vsphere_server" {
-      type = "string"
-    }
+    variable "vsphere_user" {}
+    variable "vsphere_password" {}
+    variable "vsphere_server" {}
 
     variable "datacenter" {}
     variable "datastore" {}


### PR DESCRIPTION
**What this PR does / why we need it**:

#224

1. Bake the terraform providers in the controller image.
2. Instead of storing the terraform config and state on disk, rely on the named machine config map and machine object. See below for a little more details.
3. Lots of other refactors for readability.

**Special notes for your reviewer**:

0. The only thing I have supported using this model, and tested is cluster create. Update will be done after we move to clusterctl and delete vsphere-deployer.

1. During bootstrap, the machineClient does not exist (we are not in K8s land). This means that to transfer the state for the master machine, we still need to scp the directory to master. This will be fixed after #263 -- in minikube, machineClient will always exist, so we can simply pivot the machine object and remove the volume mount entirely. Expect a follow-up PR.

2. The current flow now is that when we need to create a new machine, we create a staging directory `/tmp/cluster-api/machines/$MACHINE_NAME/`. After the machine is created, the tfstate is populated in the Machine object as an annotation. Then the staging directory is deleted.

3. There are a lot of other refactors I want to do, but let's leave those our of this PR.

4. I am not updating the image. That will happen after I integrate and test cluster creation with clusterctl (and jess's bootstrap change).
