### PR TITLE
Bump gce machine controller image version

### DIFF
--- a/cloud/google/cmd/gce-machine-controller/Makefile
+++ b/cloud/google/cmd/gce-machine-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = gce-machine-controller
-TAG = 0.0.12
+TAG = 0.0.13
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/google/pods.go
+++ b/cloud/google/pods.go
@@ -34,7 +34,7 @@ import (
 
 var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.5"
 var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.6"
-var machineControllerImage = "gcr.io/k8s-cluster-api/gce-machine-controller:0.0.12"
+var machineControllerImage = "gcr.io/k8s-cluster-api/gce-machine-controller:0.0.13"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumping gce-machine-controller image to grab changes to how kubeadm token is generated

Image was built off of master at commit 6ef7148c37f4fdd84c77a550d2b641c0a1b12b03