### PR TITLE
Ensure machine path exists

### DIFF
--- a/cloud/vsphere/cmd/vsphere-machine-controller/Makefile
+++ b/cloud/vsphere/cmd/vsphere-machine-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = vsphere-machine-controller
-TAG = 0.0.3
+TAG = 0.0.4
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/vsphere/machineactuator.go
+++ b/cloud/vsphere/machineactuator.go
@@ -193,8 +193,20 @@ func (vc *VsphereClient) stageTfState(machine *clusterv1.Machine) (string, error
 	machinePath := fmt.Sprintf(MachinePathStageFormat, machine.ObjectMeta.Name)
 	tfStateFilePath := path.Join(machinePath, TfStateFilename)
 
+	// Ensure machinePath exists
+	exists, err := pathExists(machinePath)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		err = os.Mkdir(machinePath, os.ModePerm)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	// Check if the tfstate file already exists.
-	exists, err := pathExists(tfStateFilePath)
+	exists, err = pathExists(tfStateFilePath)
 	if err != nil {
 		return "", err
 	}

--- a/clusterctl/examples/vsphere/provider-components.yaml.template
+++ b/clusterctl/examples/vsphere/provider-components.yaml.template
@@ -45,7 +45,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: vsphere-machine-controller
-        image: gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.3
+        image: gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.4
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes bug described in #224 where the machine controller was outputting errors on existence check.
`ERROR: logging before flag.Parse: E0601 20:51:39.442443 1 controller.go:120] Error checking existance of machine instance for machine object jesschen-tf-test-vptpd; open /tmp/cluster-api/machines/jesschen-tf-test-vptpd/terraform.tfstate: no such file or directory`

/hold 
so I can push official image right before merge.
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
