### PR TITLE
Move test_cmd_runner out of the 'cmd_runner' package

### DIFF
--- a/cloud/google/machineactuator_test.go
+++ b/cloud/google/machineactuator_test.go
@@ -9,18 +9,18 @@ import (
 	"sigs.k8s.io/cluster-api/cloud/google"
 	gceconfigv1 "sigs.k8s.io/cluster-api/cloud/google/gceproviderconfig/v1alpha1"
 	"sigs.k8s.io/cluster-api/cloud/google/machinesetup"
-	"sigs.k8s.io/cluster-api/pkg/cmd-runner"
 	"sigs.k8s.io/cluster-api/kubeadm"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/cert"
+	"sigs.k8s.io/cluster-api/pkg/test-cmd-runner"
 	"strings"
 	"testing"
 )
 
 func init() {
-	cmd_runner.RegisterCallback(tokenCreateCommandCallback)
-	cmd_runner.RegisterCallback(tokenCreateErrorCommandCallback)
+	test_cmd_runner.RegisterCallback(tokenCreateCommandCallback)
+	test_cmd_runner.RegisterCallback(tokenCreateErrorCommandCallback)
 }
 
 const (
@@ -29,7 +29,7 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	cmd_runner.TestMain(m)
+	test_cmd_runner.TestMain(m)
 }
 
 type GCEClientComputeServiceMock struct {
@@ -113,7 +113,7 @@ func (m *GCEClientMachineSetupConfigMock) GetMetadata(params *machinesetup.Confi
 func TestKubeadmTokenShouldBeInStartupScript(t *testing.T) {
 	config := newGCEMachineProviderConfigFixture()
 	receivedInstance, computeServiceMock := newInsertInstanceCapturingMock()
-	kubeadm := kubeadm.NewWithCmdRunner(cmd_runner.NewTestRunnerFailOnErr(t, tokenCreateCommandCallback))
+	kubeadm := kubeadm.NewWithCmdRunner(test_cmd_runner.NewTestRunnerFailOnErr(t, tokenCreateCommandCallback))
 	machine := newMachine(t, config, common.NodeRole)
 	err := createCluster(t, machine, computeServiceMock, nil, kubeadm)
 	if err != nil {
@@ -137,7 +137,7 @@ func tokenCreateCommandCallback(cmd string, args ...string) int {
 func TestTokenCreateCommandError(t *testing.T) {
 	config := newGCEMachineProviderConfigFixture()
 	_, computeServiceMock := newInsertInstanceCapturingMock()
-	kubeadm := kubeadm.NewWithCmdRunner(cmd_runner.NewTestRunnerFailOnErr(t, tokenCreateErrorCommandCallback))
+	kubeadm := kubeadm.NewWithCmdRunner(test_cmd_runner.NewTestRunnerFailOnErr(t, tokenCreateErrorCommandCallback))
 	machine := newMachine(t, config, common.NodeRole)
 	err := createCluster(t, machine, computeServiceMock, nil, kubeadm)
 	if err == nil {

--- a/kubeadm/kubeadm_test.go
+++ b/kubeadm/kubeadm_test.go
@@ -3,11 +3,11 @@ package kubeadm_test
 import (
 	"fmt"
 	"os"
-	"sigs.k8s.io/cluster-api/pkg/cmd-runner"
 	"sigs.k8s.io/cluster-api/kubeadm"
 	"strings"
 	"testing"
 	"time"
+	"sigs.k8s.io/cluster-api/pkg/test-cmd-runner"
 )
 
 var (
@@ -17,9 +17,9 @@ var (
 )
 
 func init() {
-	cmd_runner.RegisterCallback(echoCallback)
-	cmd_runner.RegisterCallback(errorCallback)
-	cmd_runner.RegisterCallback(tokenCallback)
+	test_cmd_runner.RegisterCallback(echoCallback)
+	test_cmd_runner.RegisterCallback(errorCallback)
+	test_cmd_runner.RegisterCallback(tokenCallback)
 }
 
 func TestTokenCreateParameters(t *testing.T) {
@@ -44,7 +44,7 @@ func TestTokenCreateParameters(t *testing.T) {
 		{"all", nil, "kubeadm token create --config /my/config --description my description --groups bootstrappers --help --print-join-command --ttl 1h1m1s --usages authentication",
 			kubeadm.TokenCreateParams{Config: "/my/config", Description: "my description", Groups: []string{"bootstrappers"}, Help: true, PrintJoinCommand: true, Ttl: toDuration(1, 1, 1), Usages: []string{"authentication"}}},
 	}
-	kadm := kubeadm.NewWithCmdRunner(cmd_runner.NewTestRunnerFailOnErr(t, echoCallback))
+	kadm := kubeadm.NewWithCmdRunner(test_cmd_runner.NewTestRunnerFailOnErr(t, echoCallback))
 	for _, tst := range tests {
 		output, err := kadm.TokenCreate(tst.params)
 		if err != tst.err {
@@ -57,7 +57,7 @@ func TestTokenCreateParameters(t *testing.T) {
 }
 
 func TestTokenCreateReturnsUnmodifiedOutput(t *testing.T) {
-	kadm := kubeadm.NewWithCmdRunner(cmd_runner.NewTestRunnerFailOnErr(t, tokenCallback))
+	kadm := kubeadm.NewWithCmdRunner(test_cmd_runner.NewTestRunnerFailOnErr(t, tokenCallback))
 	output, err := kadm.TokenCreate(kubeadm.TokenCreateParams{})
 	if err != nil {
 		t.Errorf("unexpected error: wanted nil")
@@ -68,7 +68,7 @@ func TestTokenCreateReturnsUnmodifiedOutput(t *testing.T) {
 }
 
 func TestNonZeroExitCodeResultsInError(t *testing.T) {
-	kadm := kubeadm.NewWithCmdRunner(cmd_runner.NewTestRunnerFailOnErr(t, errorCallback))
+	kadm := kubeadm.NewWithCmdRunner(test_cmd_runner.NewTestRunnerFailOnErr(t, errorCallback))
 	output, err := kadm.TokenCreate(kubeadm.TokenCreateParams{})
 	if err == nil {
 		t.Errorf("expected error: got nil")
@@ -95,7 +95,7 @@ func errorCallback(cmd string, args ...string) int {
 }
 
 func TestMain(m *testing.M) {
-	cmd_runner.TestMain(m)
+	test_cmd_runner.TestMain(m)
 }
 
 func toDuration(hour int, minute int, second int) time.Duration {

--- a/pkg/test-cmd-runner/test_cmd_runner.go
+++ b/pkg/test-cmd-runner/test_cmd_runner.go
@@ -1,4 +1,4 @@
-package cmd_runner
+package test_cmd_runner
 
 import (
 	"flag"

--- a/pkg/test-cmd-runner/test_cmd_runner_test.go
+++ b/pkg/test-cmd-runner/test_cmd_runner_test.go
@@ -1,16 +1,16 @@
-package cmd_runner_test
+package test_cmd_runner_test
 
 import (
 	"fmt"
 	"os"
-	"sigs.k8s.io/cluster-api/pkg/cmd-runner"
+	"sigs.k8s.io/cluster-api/pkg/test-cmd-runner"
 	"strings"
 	"testing"
 )
 
 func init() {
-	cmd_runner.RegisterCallback(callbackWithArgs)
-	cmd_runner.RegisterCallback(callbackWithoutArgs)
+	test_cmd_runner.RegisterCallback(callbackWithArgs)
+	test_cmd_runner.RegisterCallback(callbackWithoutArgs)
 }
 
 var (
@@ -23,7 +23,7 @@ var (
 )
 
 func TestUnregisteredFunctionShouldError(t *testing.T) {
-	_, err := cmd_runner.NewTestRunner(unregisteredFunction)
+	_, err := test_cmd_runner.NewTestRunner(unregisteredFunction)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -34,7 +34,7 @@ func TestUnregisteredFunctionShouldError(t *testing.T) {
 }
 
 func TestCallbackFunctionShouldExecute(t *testing.T) {
-	runner := cmd_runner.NewTestRunnerFailOnErr(t, callbackWithArgs)
+	runner := test_cmd_runner.NewTestRunnerFailOnErr(t, callbackWithArgs)
 	output, err := runner.CombinedOutput(commandName, allArgs...)
 	if err != nil {
 		t.Errorf("invalid error: expected 'nil', got '%v'", err)
@@ -45,7 +45,7 @@ func TestCallbackFunctionShouldExecute(t *testing.T) {
 }
 
 func TestNoArgsShouldNotError(t *testing.T) {
-	runner := cmd_runner.NewTestRunnerFailOnErr(t, callbackWithoutArgs)
+	runner := test_cmd_runner.NewTestRunnerFailOnErr(t, callbackWithoutArgs)
 	output, err := runner.CombinedOutput(commandName)
 	if err != nil {
 		t.Errorf("invalid error: expected 'nil', got '%v'", err)
@@ -56,7 +56,7 @@ func TestNoArgsShouldNotError(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	cmd_runner.TestMain(m)
+	test_cmd_runner.TestMain(m)
 }
 
 func callbackWithoutArgs(cmd string, args ...string) int {


### PR DESCRIPTION
and into the 'test_cmd_runner' package to prevent test flags from being included in binaries that make use of cmd_runner

**What this PR does / why we need it**:
This PR moves the test / mockable implementation out of the cmd_runner package and into its own package. This is to prevent test flags from being included in a production binary. The reason why test flags were included is that if a non-test file has an import "testing" in it the init() / vars() bits from package "testing" will be included. The result will be testing flags are added to your application. 

Output of clusterctl BEFORE the change:
```
$ ./clusterctl 
Simple kubernetes cluster management

Usage:
  clusterctl [flags]
  clusterctl [command]

Available Commands:
  create      Create a cluster API resource
  delete      Delete a cluster API resource
  help        Help about any command
  validate    Validate an API resource created by cluster API.

Flags:
      --alsologtostderr                  log to standard error as well as files
  -h, --help                             help for clusterctl
      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files (default true)
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
      --test.bench regexp                run only benchmarks matching regexp
      --test.benchmem                    print memory allocations for benchmarks
      --test.benchtime d                 run each benchmark for duration d (default 1s)
      --test.blockprofile file           write a goroutine blocking profile to file
      --test.blockprofilerate rate       set blocking profile rate (see runtime.SetBlockProfileRate) (default 1)
      --test.count n                     run tests and benchmarks n times (default 1)
      --test.coverprofile file           write a coverage profile to file
      --test.cpu list                    comma-separated list of cpu counts to run each test with
      --test.cpuprofile file             write a cpu profile to file
      --test.failfast                    do not start new tests after the first test failure
      --test.list regexp                 list tests, examples, and benchmarks matching regexp then exit
      --test.memprofile file             write a memory profile to file
      --test.memprofilerate rate         set memory profiling rate (see runtime.MemProfileRate)
      --test.mutexprofile string         write a mutex contention profile to the named file after execution
      --test.mutexprofilefraction int    if >= 0, calls runtime.SetMutexProfileFraction() (default 1)
      --test.outputdir dir               write profiles to dir
      --test.parallel n                  run at most n tests in parallel (default 8)
      --test.run regexp                  run only tests and examples matching regexp
      --test.short                       run smaller test suite to save time
      --test.testlogfile file            write test action log to file (for use only by cmd/go)
      --test.timeout d                   panic test binary after duration d (default 0, timeout disabled) (default 0s)
      --test.trace file                  write an execution trace to file
      --test.v                           verbose: print additional output
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "clusterctl [command] --help" for more information about a command.
```

Output of clusterctl AFTER the change:
```
$ ./clusterctl 
Simple kubernetes cluster management

Usage:
  clusterctl [flags]
  clusterctl [command]

Available Commands:
  create      Create a cluster API resource
  delete      Delete a cluster API resource
  help        Help about any command
  validate    Validate an API resource created by cluster API.

Flags:
      --alsologtostderr                  log to standard error as well as files
  -h, --help                             help for clusterctl
      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files (default true)
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "clusterctl [command] --help" for more information about a command.
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
