### PR TITLE
clusterctl logs, tf state in no files, base64 encode state

### DIFF
--- a/cloud/vsphere/cmd/vsphere-machine-controller/Makefile
+++ b/cloud/vsphere/cmd/vsphere-machine-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = vsphere-machine-controller
-TAG = 0.0.4
+TAG = 0.0.5
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/vsphere/pods.go
+++ b/cloud/vsphere/pods.go
@@ -34,7 +34,7 @@ import (
 
 var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.5"
 var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.6"
-var machineControllerImage = "gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.2"
+var machineControllerImage = "gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.5"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {
@@ -156,8 +156,6 @@ func CreateApiServerAndController(token string) error {
 	if err != nil {
 		return err
 	}
-
-	ioutil.WriteFile("/tmp/pods.yaml", tmplBuf.Bytes(), 0644)
 
 	maxTries := 30
 	for tries := 0; tries < maxTries; tries++ {

--- a/clusterctl/.gitignore
+++ b/clusterctl/.gitignore
@@ -1,1 +1,3 @@
 clusterctl
+*.yaml
+*kubeconfig

--- a/clusterctl/.gitignore
+++ b/clusterctl/.gitignore
@@ -1,3 +1,2 @@
 clusterctl
-*.yaml
 *kubeconfig

--- a/clusterctl/README.md
+++ b/clusterctl/README.md
@@ -9,6 +9,7 @@ Read the [experience doc here](https://docs.google.com/document/d/1-sYb3EdkRga49
 ### Prerequisites
 
 1. Install [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) 
+2. Install a driver. For Linux, we recommend kvm. For MacOS, we recommend VirtualBox.
 2. Build the `clusterctl` tool
 
 ```bash
@@ -27,7 +28,6 @@ TBD
 ```shell
 clusterctl create cluster --provider [google/vsphere] -c cluster.yaml -m machines.yaml -p provider-components.yaml
 ```
-
 Additional advanced flags can be found via help
 
 ```shell
@@ -40,9 +40,9 @@ Once you have created a cluster, you can interact with the cluster and machine
 resources using kubectl:
 
 ```
-$ kubectl get clusters
-$ kubectl get machines
-$ kubectl get machines -o yaml
+$ kubectl --kubeconfig kubeconfig get clusters
+$ kubectl --kubeconfig kubeconfig get machines
+$ kubectl --kubeconfig kubeconfig get machines -o yaml
 ```
 
 #### Scaling your cluster

--- a/clusterctl/clusterdeployer/clusterclient.go
+++ b/clusterctl/clusterdeployer/clusterclient.go
@@ -35,8 +35,8 @@ const (
 	ApiServerPort              = 443
 	RetryIntervalKubectlApply  = 5 * time.Second
 	RetryIntervalResourceReady = 5 * time.Second
-	TimeoutKubectlApply        = 120 * time.Second
-	TimeoutResourceReady       = 120 * time.Second
+	TimeoutKubectlApply        = 2 * time.Minute
+	TimeoutResourceReady       = 2 * time.Minute
 	TimeoutMachineReady        = 5 * time.Minute
 )
 

--- a/clusterctl/clusterdeployer/clusterclient.go
+++ b/clusterctl/clusterdeployer/clusterclient.go
@@ -31,7 +31,14 @@ import (
 	"time"
 )
 
-const apiserverPort = 443
+const (
+	ApiServerPort              = 443
+	RetryIntervalKubectlApply  = 5 * time.Second
+	RetryIntervalResourceReady = 5 * time.Second
+	TimeoutKubectlApply        = 120 * time.Second
+	TimeoutResourceReady       = 120 * time.Second
+	TimeoutMachineReady        = 5 * time.Minute
+)
 
 type clusterClient struct {
 	clientSet      clientset.Interface
@@ -143,7 +150,7 @@ func (c *clusterClient) UpdateClusterObjectEndpoint(masterIP string) error {
 	cluster.Status.APIEndpoints = append(cluster.Status.APIEndpoints,
 		clusterv1.APIEndpoint{
 			Host: masterIP,
-			Port: apiserverPort,
+			Port: ApiServerPort,
 		})
 	_, err = c.clientSet.ClusterV1alpha1().Clusters(apiv1.NamespaceDefault).UpdateStatus(cluster)
 	return err
@@ -167,12 +174,12 @@ func (c *clusterClient) kubectlApply(manifest string) error {
 }
 
 func (c *clusterClient) waitForKubectlApply(manifest string) error {
-	err := util.Poll(500*time.Millisecond, 120*time.Second, func() (bool, error) {
+	err := util.Poll(RetryIntervalKubectlApply, TimeoutKubectlApply, func() (bool, error) {
 		glog.V(2).Infof("Waiting for kubectl apply...")
 		err := c.kubectlApply(manifest)
 		if err != nil {
 			if strings.Contains(err.Error(), "refused") {
-				// Connection refused probably due to the main apiserver not being up yet.
+				// Connection was refused, probably because the API server is not ready yet.
 				glog.V(4).Infof("Waiting for kubectl apply... server not yet available: %v", err)
 				return false, nil
 			}
@@ -194,7 +201,7 @@ func (c *clusterClient) waitForKubectlApply(manifest string) error {
 }
 
 func waitForClusterResourceReady(cs clientset.Interface) error {
-	err := util.Poll(500*time.Millisecond, 120*time.Second, func() (bool, error) {
+	err := util.Poll(RetryIntervalResourceReady, TimeoutResourceReady, func() (bool, error) {
 		glog.V(2).Info("Waiting for Cluster v1alpha resources to become available...")
 		_, err := cs.Discovery().ServerResourcesForGroupVersion("cluster.k8s.io/v1alpha1")
 		if err == nil {
@@ -207,7 +214,7 @@ func waitForClusterResourceReady(cs clientset.Interface) error {
 }
 
 func waitForMachineReady(cs clientset.Interface, machine *clusterv1.Machine) error {
-	err := util.Poll(time.Second, 5*time.Minute, func() (bool, error) {
+	err := util.Poll(RetryIntervalResourceReady, TimeoutMachineReady, func() (bool, error) {
 		glog.V(2).Infof("Waiting for Machine %v to become ready...", machine.Name)
 		m, err := cs.ClusterV1alpha1().Machines(apiv1.NamespaceDefault).Get(machine.Name, metav1.GetOptions{})
 		if err != nil {

--- a/clusterctl/clusterdeployer/minikube/minikube.go
+++ b/clusterctl/clusterdeployer/minikube/minikube.go
@@ -20,7 +20,7 @@ func New(vmDriver string) *Minikube {
 		minikubeExec: minikubeExec,
 		vmDriver:     vmDriver,
 		// Arbitrary file name. Can potentially be randomly generated.
-		kubeconfigpath: "minikube.config",
+		kubeconfigpath: "minikube.kubeconfig",
 	}
 }
 

--- a/clusterctl/examples/vsphere/provider-components.yaml.template
+++ b/clusterctl/examples/vsphere/provider-components.yaml.template
@@ -45,7 +45,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: vsphere-machine-controller
-        image: gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.4
+        image: gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.5
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Add and move clusterctl logs so the default provides a better view of what's going on.

![image](https://user-images.githubusercontent.com/3261985/41005089-fb82b990-68d0-11e8-81bf-ce550f88d167.png)

2. Remove unneeded vpshere actuator code.

3. base64 encode terraform state in the machine object.

4. Misc documentation, readability changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
#224
