### PR TITLE
Bind cmd/delete_cluster.go to 'clusterctl delete cluster' instead of …

### DIFF
--- a/clusterctl/cmd/delete_cluster.go
+++ b/clusterctl/cmd/delete_cluster.go
@@ -30,7 +30,7 @@ var do = &DeleteOptions{}
 
 func NewCmdDeleteCluster() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "cluster",
 		Short: "Delete kubernetes cluster",
 		Long:  `Delete a kubernetes cluster with one command`,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/clusterctl/main_integration_test.go
+++ b/clusterctl/main_integration_test.go
@@ -63,8 +63,8 @@ func TestEmptyAndInvalidArgs(t *testing.T) {
 		{"create cluster with no arguments with invalid flag", []string{"create", "cluster", "--invalid-flag"}, 1, "create-cluster-no-args-invalid-flag.golden"},
 		{"delete with no arguments", []string{"delete"}, 0, "delete-no-args.golden"},
 		{"delete with no arguments with invalid flag", []string{"delete", "--invalid-flag"}, 1, "delete-no-args-invalid-flag.golden"},
-		{"delete cluster with no arguments", []string{"delete", "delete"}, 1, "delete-cluster-no-args.golden"},
-		{"delete cluster with no arguments with invalid flag", []string{"delete", "delete", "--invalid-flag"}, 1, "delete-cluster-no-args-invalid-flag.golden"},
+		{"delete cluster with no arguments", []string{"delete", "cluster"}, 1, "delete-cluster-no-args.golden"},
+		{"delete cluster with no arguments with invalid flag", []string{"delete", "cluster", "--invalid-flag"}, 1, "delete-cluster-no-args-invalid-flag.golden"},
 		{"validate with no arguments", []string{"validate"}, 0, "validate-no-args.golden"},
 		{"validate with no arguments with invalid flag", []string{"validate", "--invalid-flag"}, 1, "validate-no-args-invalid-flag.golden"},
 	}

--- a/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
@@ -1,9 +1,9 @@
 Error: unknown flag: --invalid-flag
 Usage:
-  clusterctl delete delete [flags]
+  clusterctl delete cluster [flags]
 
 Flags:
-  -h, --help   help for delete
+  -h, --help   help for cluster
 
 Global Flags:
       --alsologtostderr                  log to standard error as well as files

--- a/clusterctl/testdata/delete-cluster-no-args.golden
+++ b/clusterctl/testdata/delete-cluster-no-args.golden
@@ -2,10 +2,10 @@ Please provide cluster name.
 Delete a kubernetes cluster with one command
 
 Usage:
-  clusterctl delete delete [flags]
+  clusterctl delete cluster [flags]
 
 Flags:
-  -h, --help   help for delete
+  -h, --help   help for cluster
 
 Global Flags:
       --alsologtostderr                  log to standard error as well as files

--- a/clusterctl/testdata/delete-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/delete-no-args-invalid-flag.golden
@@ -3,7 +3,7 @@ Usage:
   clusterctl delete [command]
 
 Available Commands:
-  delete      Delete kubernetes cluster
+  cluster     Delete kubernetes cluster
 
 Flags:
   -h, --help   help for delete

--- a/clusterctl/testdata/delete-no-args.golden
+++ b/clusterctl/testdata/delete-no-args.golden
@@ -4,7 +4,7 @@ Usage:
   clusterctl delete [command]
 
 Available Commands:
-  delete      Delete kubernetes cluster
+  cluster     Delete kubernetes cluster
 
 Flags:
   -h, --help   help for delete


### PR DESCRIPTION
…'clusterctl delete delete'

**What this PR does / why we need it**:
This PR fixes a bug where "cmd/cluster_delete.go" was bound to the command ```clusterctl delete delete``` instead of ```clusterctl delete cluster```

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
