### PR TITLE
Add wrappers for GCP clients: cloudbilling, cloudresourcemanager, and servicemanagement

### DIFF
--- a/cloud/google/clients/clients.go
+++ b/cloud/google/clients/clients.go
@@ -1,0 +1,22 @@
+package clients
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	projectNamePrefix = "projects/"
+)
+
+// Formats the given project id as a GCP consumer id, there is no validation done on the input
+func GetConsumerIdForProject(projectId string) string {
+	return fmt.Sprintf("project:%v", projectId)
+}
+
+func NormalizeProjectNameOrId(name string) string {
+	if strings.HasPrefix(name, projectNamePrefix) {
+		return name
+	}
+	return fmt.Sprintf("%v%v", projectNamePrefix, name)
+}

--- a/cloud/google/clients/clients_test.go
+++ b/cloud/google/clients/clients_test.go
@@ -1,0 +1,107 @@
+package clients_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"google.golang.org/api/googleapi"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sigs.k8s.io/cluster-api/cloud/google/clients"
+	"testing"
+)
+
+func createMuxAndServer() (*http.ServeMux, *httptest.Server) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	return mux, server
+}
+
+func handler(err *googleapi.Error, obj interface{}) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		handleTestRequest(w, err, obj)
+	}
+}
+
+// this handler maps tokens to return values. This is useful with GCP APIs that use pagination. It is assumed that the API
+// call will have a parameter named "pageToken" as this is standardized across all GCP services
+func paginatedHandler(googleErr *googleapi.Error, tokenToObj map[string]interface{}) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		values, err := url.ParseQuery(req.URL.RawQuery)
+		if err != nil {
+			panic(err)
+		}
+		token := values.Get("pageToken")
+		obj, ok := tokenToObj[token]
+		if !ok {
+			http.Error(w, fmt.Sprintf("invalid / unregistered page token: %v", token), http.StatusInternalServerError)
+			return
+		}
+		handleTestRequest(w, googleErr, obj)
+	}
+}
+
+func handleTestRequest(w http.ResponseWriter, handleErr *googleapi.Error, obj interface{}) {
+	if handleErr != nil {
+		http.Error(w, errMsg(handleErr), handleErr.Code)
+		return
+	}
+	res, err := json.Marshal(obj)
+	if err != nil {
+		http.Error(w, "json marshal error", http.StatusInternalServerError)
+		return
+	}
+	w.Write(res)
+}
+
+func errMsg(e *googleapi.Error) string {
+	res, err := json.Marshal(&errorReply{e})
+	if err != nil {
+		return "json marshal error"
+	}
+	return string(res)
+}
+
+type errorReply struct {
+	Error *googleapi.Error `json:"error"`
+}
+
+func TestGetConsumerIdForProject(t *testing.T) {
+	testCases := []struct {
+		name           string
+		projectIdParam string
+		expectedResult string
+	}{
+		{"basic", "projectId", "project:projectId"},
+		{"odd-project-name", "%#$proj--", "project:%#$proj--"},
+		{"all integers", "123456789", "project:123456789"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := clients.GetConsumerIdForProject(tc.projectIdParam)
+			if result != tc.expectedResult {
+				t.Errorf("unexpected result: got '%v' want '%v'", result, tc.expectedResult)
+			}
+		})
+	}
+}
+
+func TestNormalizeProjectNameOrId(t *testing.T) {
+	testCases := []struct {
+		name           string
+		projectIdParam string
+		expectedResult string
+	}{
+		{"unqualified project id", "projectId", "projects/projectId"},
+		{"fully qualified project id", "projects/projectId", "projects/projectId"},
+		{"projectId name starting with slash", "/projectId", "projects//projectId"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := clients.NormalizeProjectNameOrId(tc.projectIdParam)
+			if result != tc.expectedResult {
+				t.Errorf("unexpected result: got '%v' want '%v'", result, tc.expectedResult)
+			}
+		})
+	}
+}

--- a/cloud/google/clients/cloudbilling.go
+++ b/cloud/google/clients/cloudbilling.go
@@ -1,0 +1,75 @@
+package clients
+
+import (
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/cloudbilling/v1"
+	"net/http"
+	"net/url"
+)
+
+// CloudBillingService is a pass through wrapper for google.golang.org/api/cloudbilling/v1/
+// The purpose of the CloudBillingService's wrap of the cloudbilling.APIService client is to enable tests to mock this struct and control behavior.
+type CloudBillingService struct {
+	service *cloudbilling.APIService
+}
+
+func NewCloudBillingService() (*CloudBillingService, error) {
+	client, err := google.DefaultClient(context.TODO(), cloudbilling.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+	return NewCloudBillingServiceForClient(client)
+}
+
+func NewCloudBillingServiceForClient(client *http.Client) (*CloudBillingService, error) {
+	service, err := cloudbilling.New(client)
+	if err != nil {
+		return nil, err
+	}
+	return &CloudBillingService{
+		service: service,
+	}, nil
+}
+
+func NewCloudBillingServiceForURL(client *http.Client, baseURL string) (*CloudBillingService, error) {
+	billingService, err := NewCloudBillingServiceForClient(client)
+	if err != nil {
+		return nil, err
+	}
+	url, err := url.Parse(billingService.service.BasePath)
+	if err != nil {
+		return nil, err
+	}
+	billingService.service.BasePath = baseURL + url.Path
+	return billingService, err
+}
+
+func (cbs *CloudBillingService) BillingAccountsList() ([]*cloudbilling.BillingAccount, error) {
+	var accounts []*cloudbilling.BillingAccount
+	request := cbs.service.BillingAccounts.List()
+	for {
+		response, err := request.Do()
+		if err != nil {
+			return nil, err
+		}
+		accounts = append(accounts, response.BillingAccounts...)
+		if response.NextPageToken == "" {
+			break
+		}
+		request.PageToken(response.NextPageToken)
+	}
+	return accounts, nil
+}
+
+// A pass through wrapper for cloudbilling.Projects.GetBillingInfo(...)
+func (cbs *CloudBillingService) ProjectsGetBillingInfo(name string) (*cloudbilling.ProjectBillingInfo, error) {
+	name = NormalizeProjectNameOrId(name)
+	return cbs.service.Projects.GetBillingInfo(name).Do()
+}
+
+// A pass through wrapper for cloudbilling.Projects.UpdateBillingInfo(...)
+func (cbs *CloudBillingService) ProjectsUpdateBillingInfo(name string, projectBillingInfo *cloudbilling.ProjectBillingInfo) (*cloudbilling.ProjectBillingInfo, error) {
+	name = NormalizeProjectNameOrId(name)
+	return cbs.service.Projects.UpdateBillingInfo(name, projectBillingInfo).Do()
+}

--- a/cloud/google/clients/cloudbilling_test.go
+++ b/cloud/google/clients/cloudbilling_test.go
@@ -1,0 +1,140 @@
+package clients_test
+
+import (
+	"google.golang.org/api/cloudbilling/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/cluster-api/cloud/google/clients"
+	"testing"
+)
+
+func TestBillingAccountsList(t *testing.T) {
+	account1 := cloudbilling.BillingAccount{
+		Name: "billingaccounts/account1",
+	}
+	account2 := cloudbilling.BillingAccount{
+		Name: "billingaccounts/account2",
+	}
+	accounts1 := []*cloudbilling.BillingAccount{&account1}
+	accounts2 := []*cloudbilling.BillingAccount{&account2}
+	testCases := []struct {
+		name        string
+		projectName string
+		responses   []cloudbilling.ListBillingAccountsResponse
+	}{
+		{"empty project name", "", []cloudbilling.ListBillingAccountsResponse{{}}},
+		{"fully qualified project name", "projects/projectId", []cloudbilling.ListBillingAccountsResponse{{BillingAccounts: accounts1}}},
+		{"unqualified project name", "projectId", []cloudbilling.ListBillingAccountsResponse{{BillingAccounts: accounts1}}},
+		{
+			"paginated response",
+			"project/projectId",
+			[]cloudbilling.ListBillingAccountsResponse{
+				{NextPageToken: "next-token", BillingAccounts: accounts1},
+				{NextPageToken: "", BillingAccounts: accounts2},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux, server, client := createMuxServerAndCloudBillingClient(t)
+			defer server.Close()
+			tokenToResponse := make(map[string]interface{})
+			nextToken := ""
+			for _, response := range tc.responses {
+				tokenToResponse[nextToken] = response
+				nextToken = response.NextPageToken
+			}
+			mux.Handle("/v1/billingAccounts", paginatedHandler(nil, tokenToResponse))
+			accounts, err := client.BillingAccountsList()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			verifyBillingAccountsWithResponses(t, accounts, tc.responses)
+		})
+	}
+}
+
+func TestProjectsGetBillingInfo(t *testing.T) {
+	projectBillingInfo := cloudbilling.ProjectBillingInfo{BillingAccountName: "billingAccountName", ProjectId: "projectId"}
+	testCases := []struct {
+		name               string
+		projectNameParam   string
+		projectBillingInfo cloudbilling.ProjectBillingInfo
+	}{
+		{"fully qualified project name", "projects/projectId", projectBillingInfo},
+		{"unqualified project name", "projectId", projectBillingInfo},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux, server, client := createMuxServerAndCloudBillingClient(t)
+			defer server.Close()
+			mux.Handle("/v1/projects/projectId/billingInfo", handler(nil, &tc.projectBillingInfo))
+			billingInfo, err := client.ProjectsGetBillingInfo(tc.projectNameParam)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if billingInfo == nil {
+				t.Fatalf("expected a valid billingInfo")
+			}
+			if tc.projectBillingInfo.BillingAccountName != billingInfo.BillingAccountName {
+				t.Errorf("ProjectBillingInfo.BillingAccountName mismatch: expected '%v' got '%v'", tc.projectBillingInfo.BillingAccountName, billingInfo.BillingAccountName)
+			}
+			if tc.projectBillingInfo.ProjectId != billingInfo.ProjectId {
+				t.Errorf("ProjectBillingInfo.ProjectId mismatch: expected '%v' got '%v'", tc.projectBillingInfo.ProjectId, billingInfo.ProjectId)
+			}
+		})
+	}
+}
+
+func TestProjectsUpdateBillingInfo(t *testing.T) {
+	projectBillingInfo := cloudbilling.ProjectBillingInfo{BillingAccountName: "billingAccountName", ProjectId: "projectId"}
+	testCases := []struct {
+		name               string
+		projectNameParam   string
+		projectBillingInfo cloudbilling.ProjectBillingInfo
+	}{
+		{"fully qualified project name", "projects/projectId", projectBillingInfo},
+		{"unqualified project name", "projectId", projectBillingInfo},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux, server, client := createMuxServerAndCloudBillingClient(t)
+			defer server.Close()
+			mux.Handle("/v1/projects/projectId/billingInfo", handler(nil, &tc.projectBillingInfo))
+			billingInfo, err := client.ProjectsUpdateBillingInfo(tc.projectNameParam, &tc.projectBillingInfo)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if billingInfo == nil {
+				t.Fatalf("expected a valid billingInfo")
+			}
+			if tc.projectBillingInfo.BillingAccountName != billingInfo.BillingAccountName {
+				t.Errorf("ProjectBillingInfo.BillingAccountName mismatch: expected '%v' got '%v'", tc.projectBillingInfo.BillingAccountName, billingInfo.BillingAccountName)
+			}
+			if tc.projectBillingInfo.ProjectId != billingInfo.ProjectId {
+				t.Errorf("ProjectBillingInfo.ProjectId mismatch: expected '%v' got '%v'", tc.projectBillingInfo.ProjectId, billingInfo.ProjectId)
+			}
+		})
+	}
+}
+
+func verifyBillingAccountsWithResponses(t *testing.T, accounts []*cloudbilling.BillingAccount, responses []cloudbilling.ListBillingAccountsResponse) {
+	t.Helper()
+	responseAccounts := make([]*cloudbilling.BillingAccount, 0)
+	for _, r := range responses {
+		responseAccounts = append(responseAccounts, r.BillingAccounts...)
+	}
+	if len(responseAccounts) != len(accounts) {
+		t.Errorf("billing accounts list length mismatch: expected '%v' got '%v'", len(responseAccounts), len(accounts))
+	}
+}
+
+func createMuxServerAndCloudBillingClient(t *testing.T) (*http.ServeMux, *httptest.Server, *clients.CloudBillingService) {
+	t.Helper()
+	mux, server := createMuxAndServer()
+	client, err := clients.NewCloudBillingServiceForURL(server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("unable to create cloud billing service: %v", err)
+	}
+	return mux, server, client
+}

--- a/cloud/google/clients/cloudresourcemanagerservice.go
+++ b/cloud/google/clients/cloudresourcemanagerservice.go
@@ -1,0 +1,86 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"net/http"
+	"net/url"
+)
+
+// CloudResourceManagerService is a pass through wrapper for google.golang.org/api/cloudresourcemanager/v1/
+// The purpose of the CloudResourceManagerService's wrap of the cloudresourcemanager.Service client is to enable tests to
+// mock this struct and control behavior.
+type CloudResourceManagerService struct {
+	service *cloudresourcemanager.Service
+}
+
+func NewCloudResourceManagerService() (*CloudResourceManagerService, error) {
+	client, err := google.DefaultClient(context.TODO(), cloudresourcemanager.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+	return NewCloudResourceManagerServiceForClient(client)
+}
+
+func NewCloudResourceManagerServiceForClient(client *http.Client) (*CloudResourceManagerService, error) {
+	service, err := cloudresourcemanager.New(client)
+	if err != nil {
+		return nil, err
+	}
+	return &CloudResourceManagerService{
+		service: service,
+	}, nil
+}
+
+func NewCloudResourceManagerServiceForURL(client *http.Client, baseURL string) (*CloudResourceManagerService, error) {
+	crmService, err := NewCloudResourceManagerServiceForClient(client)
+	if err != nil {
+		return nil, err
+	}
+	url, err := url.Parse(crmService.service.BasePath)
+	if err != nil {
+		return nil, err
+	}
+	crmService.service.BasePath = baseURL + url.Path
+	return crmService, err
+}
+
+// A pass through wrapper for cloudresourcemanager.Operations.Get(...)
+func (crm *CloudResourceManagerService) OperationsGet(name string) (*cloudresourcemanager.Operation, error) {
+	return crm.service.Operations.Get(name).Do()
+}
+
+// A pass through wrapper for cloudresourcemanager.Projects.Create(...)
+func (crm *CloudResourceManagerService) ProjectsCreate(project *cloudresourcemanager.Project) (*cloudresourcemanager.Operation, error) {
+	return crm.service.Projects.Create(project).Do()
+}
+
+// A pass through wrapper for cloudresourcemanager.Projects.Get(...)
+func (crm *CloudResourceManagerService) ProjectsGet(id string) (*cloudresourcemanager.Project, error) {
+	project, err := crm.service.Projects.Get(id).Do()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get project with id '%v': %v", id, err)
+	}
+	return project, nil
+}
+
+// Calls cloudresourcemanager.Projects.List(...) with the given filter applied. Paginated results are combined into a single
+// slice. When not applying a filter use with care as every visible project will be returned.
+func (crm *CloudResourceManagerService) ProjectsList(filter string) ([]*cloudresourcemanager.Project, error) {
+	var projects []*cloudresourcemanager.Project
+	request := crm.service.Projects.List().Filter(filter)
+	for {
+		response, err := request.Do()
+		if err != nil {
+			return nil, err
+		}
+		projects = append(projects, response.Projects...)
+		if response.NextPageToken == "" {
+			break
+		}
+		request.PageToken(response.NextPageToken)
+	}
+	return projects, nil
+}

--- a/cloud/google/clients/cloudresourcemanagerservice_test.go
+++ b/cloud/google/clients/cloudresourcemanagerservice_test.go
@@ -1,0 +1,137 @@
+package clients_test
+
+import (
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/cluster-api/cloud/google/clients"
+	"testing"
+)
+
+func TestCRMSOperationsGet(t *testing.T) {
+	mux, server, client := createMuxServerAndCloudResourceManagerClient(t)
+	defer server.Close()
+	responseOp := cloudresourcemanager.Operation{
+		Name: "operations/operationName",
+		Done: true,
+	}
+	mux.Handle("/v1/operations/operationName", handler(nil, &responseOp))
+	op, err := client.OperationsGet("operations/operationName")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if op == nil {
+		t.Fatalf("expected a valid operation")
+	}
+	if "operations/operationName" != op.Name {
+		t.Errorf("expected operations/operationName got %v", op.Name)
+	}
+	if !op.Done {
+		t.Errorf("expected operation's 'Done' flag to be set")
+	}
+}
+
+func TestProjectsCreate(t *testing.T) {
+	mux, server, client := createMuxServerAndCloudResourceManagerClient(t)
+	defer server.Close()
+	responseOperation := cloudresourcemanager.Operation{
+		Name: "operations/operationName",
+		Done: true,
+	}
+	mux.Handle("/v1/projects", handler(nil, &responseOperation))
+	project := cloudresourcemanager.Project{
+		Name:      "projectId",
+		ProjectId: "projectId",
+	}
+	op, err := client.ProjectsCreate(&project)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if op == nil {
+		t.Fatalf("expected a valid operation")
+	}
+	if "operations/operationName" != op.Name {
+		t.Errorf("expected operations/operationName got %v", op.Name)
+	}
+	if !op.Done {
+		t.Errorf("expected operation's 'Done' flag to be set")
+	}
+}
+
+func TestProjectGet(t *testing.T) {
+	mux, server, client := createMuxServerAndCloudResourceManagerClient(t)
+	defer server.Close()
+	responseProject := cloudresourcemanager.Project{
+		Name:      "projects/projectId",
+		ProjectId: "projectId",
+	}
+	mux.Handle("/v1/projects/projectId", handler(nil, &responseProject))
+	project, err := client.ProjectsGet("projectId")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if project == nil {
+		t.Fatalf("expected a valid project")
+	}
+	if responseProject.Name != project.Name {
+		t.Errorf("project.Name mismatch: expected '%v' got '%v'", responseProject.Name, project.Name)
+	}
+	if responseProject.ProjectId != project.ProjectId {
+		t.Errorf("project.ProjectId mismatch: expected '%v' got '%v'", responseProject.ProjectId, project.ProjectId)
+	}
+}
+
+func TestProjectList(t *testing.T) {
+	project1 := cloudresourcemanager.Project{Name: "projects/projectId1", ProjectId: "projectId1"}
+	project2 := cloudresourcemanager.Project{Name: "projects/projectId2", ProjectId: "projectId2"}
+	testCases := []struct {
+		name      string
+		responses []cloudresourcemanager.ListProjectsResponse
+	}{
+		{"empty result", []cloudresourcemanager.ListProjectsResponse{{}}},
+		{"single result", []cloudresourcemanager.ListProjectsResponse{{NextPageToken: "", Projects: []*cloudresourcemanager.Project{&project1}}}},
+		{"multiple results", []cloudresourcemanager.ListProjectsResponse{
+			{NextPageToken: "next-token", Projects: []*cloudresourcemanager.Project{&project1}},
+			{NextPageToken: "", Projects: []*cloudresourcemanager.Project{&project2}},
+		}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux, server, client := createMuxServerAndCloudResourceManagerClient(t)
+			defer server.Close()
+			tokenToResponse := make(map[string]interface{})
+			nextToken := ""
+			for _, response := range tc.responses {
+				tokenToResponse[nextToken] = response
+				nextToken = response.NextPageToken
+			}
+			mux.Handle("/v1/projects", paginatedHandler(nil, tokenToResponse))
+			projChan, err := client.ProjectsList("")
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			verifyProjectsWithResponses(t, projChan, tc.responses)
+		})
+	}
+}
+
+func verifyProjectsWithResponses(t *testing.T, projects []*cloudresourcemanager.Project, responses []cloudresourcemanager.ListProjectsResponse) {
+	t.Helper()
+	responseProjects := make([]*cloudresourcemanager.Project, 0)
+	for _, r := range responses {
+		responseProjects = append(responseProjects, r.Projects...)
+	}
+	if len(responseProjects) != len(projects) {
+		t.Errorf("projects list length mismatch: expected '%v' got '%v'", len(responseProjects), len(projects))
+	}
+}
+
+func createMuxServerAndCloudResourceManagerClient(t *testing.T) (*http.ServeMux, *httptest.Server, *clients.CloudResourceManagerService) {
+	t.Helper()
+	mux, server := createMuxAndServer()
+	client, err := clients.NewCloudResourceManagerServiceForURL(server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("unable to create cloud resource manager service: %v", err)
+	}
+	return mux, server, client
+}

--- a/cloud/google/clients/servicemanagement.go
+++ b/cloud/google/clients/servicemanagement.go
@@ -1,0 +1,80 @@
+package clients
+
+import (
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/servicemanagement/v1"
+	"net/http"
+	"net/url"
+)
+
+// ServiceManagementService is a pass through wrapper for google.golang.org/api/servicemanagement/v1/
+// The purpose of the ServiceManagementService's wrap of the servicemanagement.ServiceManagementService client is to enable tests to
+// mock and control behavior.
+type ServiceManagementService struct {
+	service *servicemanagement.APIService
+}
+
+func NewServiceManagementService() (*ServiceManagementService, error) {
+	client, err := google.DefaultClient(context.TODO(), servicemanagement.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+	return NewServiceManagementServiceForClient(client)
+}
+
+func NewServiceManagementServiceForClient(client *http.Client) (*ServiceManagementService, error) {
+	service, err := servicemanagement.New(client)
+	if err != nil {
+		return nil, err
+	}
+	return &ServiceManagementService{
+		service: service,
+	}, nil
+}
+
+func NewServiceManagementServiceForURL(client *http.Client, baseURL string) (*ServiceManagementService, error) {
+	service, err := NewServiceManagementServiceForClient(client)
+	if err != nil {
+		return nil, err
+	}
+	url, err := url.Parse(service.service.BasePath)
+	if err != nil {
+		return nil, err
+	}
+	service.service.BasePath = baseURL + url.Path
+	return service, err
+}
+
+func (sms *ServiceManagementService) OperationsGet(name string) (*servicemanagement.Operation, error) {
+	return sms.service.Operations.Get(name).Do()
+}
+
+func (sms *ServiceManagementService) ServicesEnableForProject(serviceName string, projectId string) (*servicemanagement.Operation, error) {
+	enableServiceRequest := servicemanagement.EnableServiceRequest{
+		ConsumerId: GetConsumerIdForProject(projectId),
+	}
+	return sms.service.Services.Enable(serviceName, &enableServiceRequest).Do()
+}
+
+// Calls servicemanagement.Services.List(...). If a projectId is supplied results are limited to the services enabled for the given projectId.
+// Paginated results are combined into a single slice. Large results are not a concern because the number of GCP services is limited.
+func (sms *ServiceManagementService) ServicesList(projectId string) ([]*servicemanagement.ManagedService, error) {
+	var services []*servicemanagement.ManagedService
+	request := sms.service.Services.List()
+	if projectId != "" {
+		request.ConsumerId(GetConsumerIdForProject(projectId))
+	}
+	for {
+		response, err := request.Do()
+		if err != nil {
+			return nil, err
+		}
+		services = append(services, response.Services...)
+		if response.NextPageToken == "" {
+			break
+		}
+		request.PageToken(response.NextPageToken)
+	}
+	return services, nil
+}

--- a/cloud/google/clients/servicemanagement_test.go
+++ b/cloud/google/clients/servicemanagement_test.go
@@ -1,0 +1,132 @@
+package clients_test
+
+import (
+	"fmt"
+	"google.golang.org/api/servicemanagement/v1"
+	"net/http"
+	"net/http/httptest"
+	"sigs.k8s.io/cluster-api/cloud/google/clients"
+	"testing"
+)
+
+func TestSMSOperationsGet(t *testing.T) {
+	mux, server, client := createMuxServerAndServiceManagementClient(t)
+	defer server.Close()
+	responseOp := servicemanagement.Operation{
+		Name: "operations/operationName",
+		Done: true,
+	}
+	mux.Handle("/v1/operations/operationName", handler(nil, &responseOp))
+	op, err := client.OperationsGet("operations/operationName")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if op == nil {
+		t.Error("expected a valid operation")
+	}
+	if "operations/operationName" != op.Name {
+		t.Errorf("expected operations/operationName got %v", op.Name)
+	}
+	if !op.Done {
+		t.Errorf("expected operation's 'Done' flag to be set")
+	}
+}
+
+func TestServicesEnableForProject(t *testing.T) {
+	testCases := []struct {
+		name        string
+		serviceName string
+		projectName string
+		operation   servicemanagement.Operation
+	}{
+		{"fully qualified project name", "compute.googleapis.com", "projects/projectId", servicemanagement.Operation{Done: true, Name: "operations/operationName"}},
+		{"unqualified project name", "compute.googleapis.com", "projectId", servicemanagement.Operation{Done: true, Name: "operations/operationName"}},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux, server, client := createMuxServerAndServiceManagementClient(t)
+			defer server.Close()
+			mux.Handle(fmt.Sprintf("/v1/services/%v:enable", tc.serviceName), handler(nil, &tc.operation))
+			op, err := client.ServicesEnableForProject(tc.serviceName, tc.projectName)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if op == nil {
+				t.Fatalf("expected a valid operation")
+			}
+			if tc.operation.Name != op.Name {
+				t.Errorf("operation name mismatch: expected '%v' got '%v'", tc.operation.Name, op.Name)
+			}
+			if tc.operation.Done != op.Done {
+				t.Errorf("expected operation's 'Done' flag to be '%v' instead '%v'", tc.operation.Done, op.Done)
+			}
+		})
+	}
+}
+
+func TestServicesList(t *testing.T) {
+	computeService := servicemanagement.ManagedService{
+		ServiceName: "compute.googleapis.com",
+	}
+	billingService := servicemanagement.ManagedService{
+		ServiceName: "cloudbilling.googleapis.com",
+	}
+	services1 := []*servicemanagement.ManagedService{&computeService}
+	services2 := []*servicemanagement.ManagedService{&billingService}
+	testCases := []struct {
+		name        string
+		projectName string
+		responses   []servicemanagement.ListServicesResponse
+	}{
+		{"empty project name", "", []servicemanagement.ListServicesResponse{{}}},
+		{"fully qualified project name", "projects/projectId", []servicemanagement.ListServicesResponse{{Services: services1}}},
+		{"unqualified project name", "projectId", []servicemanagement.ListServicesResponse{{Services: services1}}},
+		{
+			"paginated response",
+			"project/projectId",
+			[]servicemanagement.ListServicesResponse{
+				{NextPageToken: "next-token", Services: services1},
+				{NextPageToken: "", Services: services2},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux, server, client := createMuxServerAndServiceManagementClient(t)
+			defer server.Close()
+			tokenToResponse := make(map[string]interface{})
+			nextToken := ""
+			for _, response := range tc.responses {
+				tokenToResponse[nextToken] = response
+				nextToken = response.NextPageToken
+			}
+			mux.Handle("/v1/services", paginatedHandler(nil, tokenToResponse))
+			svcs, err := client.ServicesList(tc.projectName)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			verifyServicesWithResponses(t, svcs, tc.responses)
+		})
+	}
+}
+
+func verifyServicesWithResponses(t *testing.T, services []*servicemanagement.ManagedService, responses []servicemanagement.ListServicesResponse) {
+	t.Helper()
+	responseServices := make([]*servicemanagement.ManagedService, 0)
+	for _, r := range responses {
+		responseServices = append(responseServices, r.Services...)
+	}
+	if len(responseServices) != len(services) {
+		t.Errorf("services list length mismatch: expected '%v' got '%v'", len(responseServices), len(services))
+	}
+}
+
+func createMuxServerAndServiceManagementClient(t *testing.T) (*http.ServeMux, *httptest.Server, *clients.ServiceManagementService) {
+	t.Helper()
+	mux, server := createMuxAndServer()
+	client, err := clients.NewServiceManagementServiceForURL(server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("unable to create service management service: %v", err)
+	}
+	return mux, server, client
+}


### PR DESCRIPTION
This change adds cloudbilling, cloudresourcemanager, and servicemanagement wrappers for the associated service clients. The purpose of the wrapper is to enable unit tests to inject their own implementations into packages that depend on GCP.

**What this PR does / why we need it**:
This PR adds wrappers around the afore mentioned three GCP clients. The purpose is to enable mocking of the services by unit tests of packages that have the associated clients for those services as dependencies.

Note that most of the code follows the same patterns laid out in the existing clients/computeservice.go

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
