### PR TITLE
CLUSTER-API-159: Enhance vsphere-machine-controller to fetch kubeadm join token

### DIFF
--- a/cloud/vsphere/cmd/vsphere-machine-controller/Makefile
+++ b/cloud/vsphere/cmd/vsphere-machine-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = vsphere-machine-controller
-TAG = 0.0.9
+TAG = 0.0.10
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/vsphere/cmd/vsphere-machine-controller/main.go
+++ b/cloud/vsphere/cmd/vsphere-machine-controller/main.go
@@ -31,7 +31,6 @@ import (
 )
 
 var (
-	kubeadmToken      = pflag.String("token", "", "Kubeadm token to use to join new machines")
 	namedMachinesPath = pflag.String("namedmachines", "", "path to named machines yaml file")
 )
 
@@ -55,7 +54,7 @@ func main() {
 		glog.Fatalf("Could not create client for talking to the apiserver: %v", err)
 	}
 
-	actuator, err := vsphere.NewMachineActuator(*kubeadmToken, client.ClusterV1alpha1().Machines(corev1.NamespaceDefault), *namedMachinesPath)
+	actuator, err := vsphere.NewMachineActuator(client.ClusterV1alpha1().Machines(corev1.NamespaceDefault), *namedMachinesPath)
 	if err != nil {
 		glog.Fatalf("Could not create vSphere machine actuator: %v", err)
 	}

--- a/cloud/vsphere/templates.go
+++ b/cloud/vsphere/templates.go
@@ -262,7 +262,6 @@ chmod a+rx /usr/bin/kubeadm.dl
 
 {{ define "configure" -}}
 KUBELET_VERSION={{ .Machine.Spec.Versions.Kubelet }}
-TOKEN={{ .Token }}
 PORT=443
 MACHINE={{ .Machine.ObjectMeta.Name }}
 CONTROL_PLANE_VERSION={{ .Machine.Spec.Versions.ControlPlane }}
@@ -323,7 +322,6 @@ networking:
   serviceSubnet: ${SERVICE_CIDR}
   podSubnet: ${POD_CIDR}
 kubernetesVersion: v${CONTROL_PLANE_VERSION}
-token: ${TOKEN}
 apiServerCertSANs:
 - ${PUBLICIP}
 - ${PRIVATEIP}

--- a/clusterctl/examples/vsphere/provider-components.yaml.template
+++ b/clusterctl/examples/vsphere/provider-components.yaml.template
@@ -45,7 +45,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: vsphere-machine-controller
-        image: gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.9
+        image: gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.10
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes
@@ -61,6 +61,8 @@ spec:
             subPath: vsphere_tmp.pub
           - name: named-machines
             mountPath: /etc/named-machines
+          - name: kubeadm
+            mountPath: /usr/bin/kubeadm
         env:
           - name: NODE_NAME
             valueFrom:
@@ -70,8 +72,6 @@ spec:
         - "./vsphere-machine-controller"
         args:
         - --kubeconfig=/etc/kubernetes/admin.conf
-        # Hardedcoded token can be removed as part of https://github.com/kubernetes-sigs/cluster-api/issues/159
-        - --token=e6uqfr.5zkanzwfdclsbn7p
         - --namedmachines=/etc/named-machines/vsphere_named_machines.yaml
         resources:
           requests:
@@ -96,6 +96,9 @@ spec:
       - name: named-machines
         configMap:
           name: named-machines
+      - name: kubeadm
+        hostPath:
+          path: /usr/bin/kubeadm
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the vsphere machine controller to generate kubeadm join tokens at machine creation time. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #159

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
