### PR TITLE
break out provider deployer logic

### DIFF
--- a/cloud/vsphere/cmd/vsphere-machine-controller/Makefile
+++ b/cloud/vsphere/cmd/vsphere-machine-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = vsphere-machine-controller
-TAG = 0.0.6
+TAG = 0.0.7
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/vsphere/deployer.go
+++ b/cloud/vsphere/deployer.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/golang/glog"
+
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+// Contains vsphere-specific deployment logic
+// intended to eventually implement ProviderDeployer interface at
+// sigs.k8s.io/cluster-api/clusterctl/clusterdeployer/clusterdeployer.go
+// Currently implements a subset of the machineDeployer interface at
+// sigs.k8s.io/cluster-api/vsphere-deployer/deploy/machinedeployer.go
+// till vsphere-deployer gets deleted
+type DeploymentClient struct {}
+
+func NewDeploymentClient() *DeploymentClient {
+	return &DeploymentClient{}
+}
+
+func (*DeploymentClient) GetIP(machine *clusterv1.Machine) (string, error) {
+	if machine.ObjectMeta.Annotations != nil {
+		if ip, ok := machine.ObjectMeta.Annotations[MasterIpAnnotationKey]; ok {
+			glog.Infof("Returning IP from machine annotation %s", ip)
+			return ip, nil
+		}
+	}
+
+	ipBytes, _ := ioutil.ReadFile(path.Join(fmt.Sprintf(MachinePathStageFormat, machine.ObjectMeta.Name), MasterIpFilename))
+	if ipBytes != nil {
+		glog.Infof("Returning IP from file %s", string(ipBytes))
+		return string(ipBytes), nil
+	}
+
+	return "", errors.New("could not get IP")
+}
+
+func (d *DeploymentClient) GetKubeConfig(master *clusterv1.Machine) (string, error) {
+	ip, err := d.GetIP(master)
+	if err != nil {
+		return "", err
+	}
+
+	var out bytes.Buffer
+	cmd := exec.Command(
+		"ssh", "-i", "~/.ssh/vsphere_tmp",
+		"-q",
+		"-o", "StrictHostKeyChecking no",
+		"-o", "UserKnownHostsFile /dev/null",
+		fmt.Sprintf("ubuntu@%s", ip),
+		"sudo cat /etc/kubernetes/admin.conf")
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	cmd.Run()
+	result := strings.TrimSpace(out.String())
+	return result, nil
+}

--- a/clusterctl/cmd/create_cluster.go
+++ b/clusterctl/cmd/create_cluster.go
@@ -144,11 +144,7 @@ func getProvider(provider string) (clusterdeployer.ProviderDeployer, error) {
 	case "google":
 		return google.NewMachineActuator(google.MachineActuatorParams{})
 	case "vsphere":
-		t, err := vsphere.NewMachineActuator("", nil, "")
-		if err != nil {
-			return nil, err
-		}
-		return &vsphereAdapter{t}, nil
+		return &vsphereAdapter{vsphere.NewDeploymentClient()}, nil
 	default:
 		return nil, fmt.Errorf("Unrecognized provider %v", provider)
 	}
@@ -158,13 +154,13 @@ func getProvider(provider string) (clusterdeployer.ProviderDeployer, error) {
 // Long term, these providers should converge or the need for a provider will go away.
 // Whichever comes first.
 type vsphereAdapter struct {
-	*vsphere.VsphereClient
+	*vsphere.DeploymentClient
 }
 
 func (a *vsphereAdapter) GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
-	return a.VsphereClient.GetIP(machine)
+	return a.DeploymentClient.GetIP(machine)
 }
 
 func (a *vsphereAdapter) GetKubeConfig(cluster *clusterv1.Cluster, master *clusterv1.Machine) (string, error) {
-	return a.VsphereClient.GetKubeConfig(master)
+	return a.DeploymentClient.GetKubeConfig(master)
 }

--- a/clusterctl/examples/vsphere/provider-components.yaml.template
+++ b/clusterctl/examples/vsphere/provider-components.yaml.template
@@ -45,7 +45,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: vsphere-machine-controller
-        image: gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.6
+        image: gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.7
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes


### PR DESCRIPTION
Breaking out clusterctl requirements for provider-specific logic.

Context:
What machineactuator needs to implement for machine controller, vsphere-deployer and clusterctl are different. Having one class implement it all leads to each use case having extra checks, overhead etc. that is not needed. 

For example, when using the macineactuator for clusterctl, there are logs stating 
`error creating named machine config watch: stat : no such file or directory`. There is not actually an issue because clusterctl does not directly provision machines. However, this has been confusing to users of clusterctl.

/hold
so I can build official image right before merge.

```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
