### PR TITLE
Enhance the error messages returned by minikube to include the command that was run

### DIFF
--- a/clusterctl/clusterdeployer/minikube/minikube.go
+++ b/clusterctl/clusterdeployer/minikube/minikube.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 type Minikube struct {
@@ -31,6 +32,9 @@ var minikubeExec = func(env []string, args ...string) (string, error) {
 	cmd.Env = env
 	cmdOut, err := cmd.CombinedOutput()
 	glog.V(2).Infof("Ran: %v %v Output: %v", executable, args, string(cmdOut))
+	if err != nil {
+		err = fmt.Errorf("error running command '%v %v': %v", executable, strings.Join(args, " "), err)
+	}
 	return string(cmdOut), err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes debugging minikube related failures a bit easier by improving the error message returned in minikube.go to include the command that was execed.

Output BEFORE:
```
F0606 12:59:44.667934   83188 create_cluster.go:57] could not create external client: could not create external control plane: exit status 1
```

Output AFTER:
```
F0606 13:15:47.629055   83797 create_cluster.go:57] could not create external client: could not create external control plane: error running command 'minikube start --bootstrapper=kubeadm': exit status 1
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
