### PR TITLE
Remove the NewCmdDeleteCluster method from delete_cluster.go to match the other Cmd implementations

### DIFF
--- a/clusterctl/cmd/delete_cluster.go
+++ b/clusterctl/cmd/delete_cluster.go
@@ -28,26 +28,22 @@ type DeleteOptions struct {
 
 var do = &DeleteOptions{}
 
-func NewCmdDeleteCluster() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "cluster",
-		Short: "Delete kubernetes cluster",
-		Long:  `Delete a kubernetes cluster with one command`,
-		Run: func(cmd *cobra.Command, args []string) {
-			if do.ClusterName == "" {
-				exitWithHelp(cmd, "Please provide cluster name.")
-			}
-			if err := RunDelete(); err != nil {
-				glog.Exit(err)
-			}
-		},
-	}
-
-	return cmd
+var deleteClusterCmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Delete kubernetes cluster",
+	Long:  `Delete a kubernetes cluster with one command`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if do.ClusterName == "" {
+			exitWithHelp(cmd, "Please provide cluster name.")
+		}
+		if err := RunDelete(); err != nil {
+			glog.Exit(err)
+		}
+	},
 }
 
 func init() {
-	deleteCmd.AddCommand(NewCmdDeleteCluster())
+	deleteCmd.AddCommand(deleteClusterCmd)
 }
 
 func RunDelete() error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR standardizes delete_cluster.go so that it matches the way the other commands in clusterctl make use of cobra. 

**Special notes for your reviewer**:
Please take a look at the other files in the clusterctl/cmd folder.

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
