### PR TITLE
explicity use bash

### DIFF
--- a/clusterctl/examples/vsphere/generate-yaml.sh
+++ b/clusterctl/examples/vsphere/generate-yaml.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 PROVIDERCOMPONENT_TEMPLATE_FILE=provider-components.yaml.template


### PR DESCRIPTION
Explicitly use bash for generate yaml instead of the default shell script.

```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
