### PR TITLE
Make vsphere variables map type

### DIFF
--- a/cloud/vsphere/cmd/vsphere-machine-controller/Makefile
+++ b/cloud/vsphere/cmd/vsphere-machine-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = vsphere-machine-controller
-TAG = 0.0.8
+TAG = 0.0.9
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/vsphere/machineactuator.go
+++ b/cloud/vsphere/machineactuator.go
@@ -132,7 +132,12 @@ func (vc *VsphereClient) prepareStageMachineDir(machine *clusterv1.Machine) (str
 	if err := saveFile(matchedMachine.MachineHcl, tfConfigPath, 0644); err != nil {
 		return "", err
 	}
-	if err := saveFile(strings.Join(config.TerraformVariables, "\n"), tfVarsPath, 0644); err != nil {
+
+	var tfVarsContents []string
+	for key, value := range config.MachineVariables {
+		tfVarsContents = append(tfVarsContents, fmt.Sprintf("%s=\"%s\"", key, value))
+	}
+	if err := saveFile(strings.Join(tfVarsContents, "\n"), tfVarsPath, 0644); err != nil {
 		return "", err
 	}
 

--- a/cloud/vsphere/vsphereproviderconfig/types.go
+++ b/cloud/vsphere/vsphereproviderconfig/types.go
@@ -27,9 +27,8 @@ type VsphereMachineProviderConfig struct {
 
 	// Name of the machine that's registered in the NamedMachines ConfigMap.
 	VsphereMachine string `json:"vsphereMachine"`
-	// List of contents of terraform variables used.
-	// HCL variables encoded as string.
-	TerraformVariables []string `json:"terraformVariables"`
+	// List of variables for the chosen machine.
+	MachineVariables map[string]string `json:"machineVariables"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/cloud/vsphere/vsphereproviderconfig/v1alpha1/types.go
+++ b/cloud/vsphere/vsphereproviderconfig/v1alpha1/types.go
@@ -27,9 +27,8 @@ type VsphereMachineProviderConfig struct {
 
 	// Name of the machine that's registered in the NamedMachines ConfigMap.
 	VsphereMachine string `json:"vsphereMachine"`
-	// List of contents of terraform variables used.
-	// HCL variables encoded as string.
-	TerraformVariables []string `json:"terraformVariables"`
+	// List of variables for the chosen machine.
+	MachineVariables map[string]string `json:"machineVariables"`
 }
 
 // +k8s:deepcopy-gen=true

--- a/cloud/vsphere/vsphereproviderconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/cloud/vsphere/vsphereproviderconfig/v1alpha1/zz_generated.deepcopy.go
@@ -54,10 +54,12 @@ func (in *VsphereClusterProviderConfig) DeepCopyObject() runtime.Object {
 func (in *VsphereMachineProviderConfig) DeepCopyInto(out *VsphereMachineProviderConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.TerraformVariables != nil {
-		in, out := &in.TerraformVariables, &out.TerraformVariables
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+	if in.MachineVariables != nil {
+		in, out := &in.MachineVariables, &out.MachineVariables
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	return
 }

--- a/cloud/vsphere/vsphereproviderconfig/zz_generated.deepcopy.go
+++ b/cloud/vsphere/vsphereproviderconfig/zz_generated.deepcopy.go
@@ -54,10 +54,12 @@ func (in *VsphereClusterProviderConfig) DeepCopyObject() runtime.Object {
 func (in *VsphereMachineProviderConfig) DeepCopyInto(out *VsphereMachineProviderConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	if in.TerraformVariables != nil {
-		in, out := &in.TerraformVariables, &out.TerraformVariables
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+	if in.MachineVariables != nil {
+		in, out := &in.MachineVariables, &out.MachineVariables
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	return
 }

--- a/clusterctl/examples/vsphere/machines.yaml.template
+++ b/clusterctl/examples/vsphere/machines.yaml.template
@@ -11,18 +11,17 @@ items:
         apiVersion: "vsphereproviderconfig/v1alpha1"
         kind: "VsphereMachineProviderConfig"
         vsphereMachine: "standard-master"
-        terraformVariables: [
-          "datacenter = \"\"",
-          "datastore = \"\"",
-          "resource_pool = \"\"",
-          "network = \"\"",
-          "num_cpus = \"2\"",
-          "memory = \"2048\"",
-          "vm_template = \"\"",
-          "disk_label = \"\"",
-          "disk_size = \"\"",
-          "virtual_machine_domain = \"\"",
-        ]
+        machineVariables:
+          datacenter: ""
+          datastore: ""
+          resource_pool: ""
+          network: ""
+          num_cpus: "2"
+          memory: "2048"
+          vm_template: ""
+          disk_label: ""
+          disk_size: ""
+          virtual_machine_domain: ""
     versions:
       kubelet: 1.10.1
       controlPlane: 1.10.1
@@ -38,18 +37,17 @@ items:
         apiVersion: "vsphereproviderconfig/v1alpha1"
         kind: "VsphereMachineProviderConfig"
         vsphereMachine: "standard-node"
-        terraformVariables: [
-          "datacenter = \"\"",
-          "datastore = \"\"",
-          "resource_pool = \"\"",
-          "network = \"\"",
-          "num_cpus = \"2\"",
-          "memory = \"2048\"",
-          "vm_template = \"\"",
-          "disk_label = \"\"",
-          "disk_size = \"\"",
-          "virtual_machine_domain = \"\"",
-        ]
+        machineVariables:
+          datacenter: ""
+          datastore: ""
+          resource_pool: ""
+          network: ""
+          num_cpus: "2"
+          memory: "2048"
+          vm_template: ""
+          disk_label: ""
+          disk_size: ""
+          virtual_machine_domain: ""
     versions:
       kubelet: 1.10.1
     roles:

--- a/clusterctl/examples/vsphere/provider-components.yaml.template
+++ b/clusterctl/examples/vsphere/provider-components.yaml.template
@@ -45,7 +45,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: vsphere-machine-controller
-        image: gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.8
+        image: gcr.io/k8s-cluster-api/vsphere-machine-controller:0.0.9
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**: Change type of vsphere variables to map instead of a list of strings. So much better readability and debuggability.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #306
