### PR TITLE
Bump memory and cpu for apiserver

### DIFF
--- a/clusterctl/clusterdeployer/clusterapiservertemplate.go
+++ b/clusterctl/clusterdeployer/clusterapiservertemplate.go
@@ -106,10 +106,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 50Mi
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 300m
+            memory: 200Mi
       volumes:
       - name: cluster-apiserver-certs
         secret:


### PR DESCRIPTION
**What this PR does / why we need it**: apiserver runs around 30mb so bumping the memory
