### PR TITLE
Remove double defer for externalProvisioner.Delete

### DIFF
--- a/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/clusterctl/clusterdeployer/clusterdeployer.go
@@ -176,14 +176,6 @@ func (d *ClusterDeployer) createExternalCluster() (ClusterClient, error) {
 	if err = d.externalProvisioner.Create(); err != nil {
 		return nil, fmt.Errorf("could not create external control plane: %v", err)
 	}
-	if d.cleanupExternalCluster {
-		defer func() {
-			if err != nil {
-				glog.Info("Cleaning up external cluster.")
-				d.externalProvisioner.Delete()
-			}
-		}()
-	}
 	externalKubeconfig, err := d.externalProvisioner.GetKubeconfig()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get external cluster kubeconfig: %v", err)

--- a/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -187,6 +187,7 @@ func TestCreate(t *testing.T) {
 			externalClient:          &testClusterClient{},
 			cleanupExternal:         true,
 			expectExternalCreated:   true,
+			expectExternalExists:    true,
 			factoryClusterClientErr: fmt.Errorf("Test failure"),
 			expectErr:               true,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

ClusterDeployer.Create has a defer for d.externalProvisioner.Delete, let's not do that in createExternalCluster as well

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #319

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
