### PR TITLE
Fix a bug in ClusterClient's GetClusterObjects() and GetMachineObjects()

### DIFF
--- a/clusterctl/clusterdeployer/clusterclient.go
+++ b/clusterctl/clusterdeployer/clusterclient.go
@@ -95,8 +95,8 @@ func (c *clusterClient) GetClusterObjects() ([]*clusterv1.Cluster, error) {
 		return nil, err
 	}
 
-	for _, cluster := range clusterlist.Items {
-		clusters = append(clusters, &cluster)
+	for i := 0; i < len(clusterlist.Items); i++ {
+		clusters = append(clusters, &clusterlist.Items[i])
 	}
 	return clusters, nil
 }
@@ -109,8 +109,8 @@ func (c *clusterClient) GetMachineObjects() ([]*clusterv1.Machine, error) {
 		return nil, err
 	}
 
-	for _, machine := range machineslist.Items {
-		machines = append(machines, &machine)
+	for i := 0; i < len(machineslist.Items); i++ {
+		machines = append(machines, &machineslist.Items[i])
 	}
 	return machines, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The previous implementation took the address of the iteration variable. While the value of the iteration value changes on each iteration, the address does not change for the entirety of the loop. Previously, the slice returned by these functions would be a collection of the exact same iterator variable address and which of course would be filled with a value of the last value in the loop iteration.

This is the same behavior that is explained here: https://github.com/golang/go/issues/22791. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
