### PR TITLE
Create docker releases of clusterctl (fixes #289).

### DIFF
--- a/clusterctl/Dockerfile
+++ b/clusterctl/Dockerfile
@@ -18,7 +18,7 @@ ARG KUBECTL_VERSION=1.11.1
 
 # Reproducible builder image
 FROM golang:${GOLANG_VERSION} as builder
-WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-ssh
+WORKDIR /go/src/sigs.k8s.io/cluster-api
 # This expects that the context passed to the docker build command is
 # the cluster-api directory.
 # e.g. docker build -t <tag> -f <this_Dockerfile> <path_to_cluster-api>

--- a/clusterctl/Dockerfile
+++ b/clusterctl/Dockerfile
@@ -15,6 +15,7 @@
 ARG GOLANG_VERSION=1.10.3
 ARG MINIKUBE_VERSION=0.28.0
 ARG KUBECTL_VERSION=1.11.1
+ARG DOCKER_VERSION=17.03.2
 
 # Reproducible builder image
 FROM golang:${GOLANG_VERSION} as builder
@@ -24,20 +25,30 @@ WORKDIR /go/src/sigs.k8s.io/cluster-api
 # e.g. docker build -t <tag> -f <this_Dockerfile> <path_to_cluster-api>
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-ssh/clusterctl
+RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api/clusterctl
 
 # Final container
-FROM docker:18.06-dind
+FROM debian:stretch-slim
 
 ARG MINIKUBE_VERSION
 ARG KUBECTL_VERSION
-
-COPY --from=builder /go/bin/clusterctl .
+ARG DOCKER_VERSION
 
 ADD https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 ADD https://github.com/kubernetes/minikube/releases/download/v${MINIKUBE_VERSION}/minikube-linux-amd64 /usr/local/bin/minikube
+ADD https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}-ce.tgz /tmp/docker.tgz
 
-RUN md5sum -c ./md5sum && \
-    chmod +x /usr/local/bin/kubectl /usr/local/bin/minikube
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api/clusterctl/sha256sums /tmp/
+
+RUN sha256sum -c /tmp/sha256sums && \
+    tar xzf /tmp/docker.tgz -C /usr/local/bin docker/docker && \
+    rm /tmp/sha256sums /tmp/docker.tgz && \
+    chmod 755 /usr/local/bin/kubectl /usr/local/bin/minikube /usr/local/bin/docker
+
+RUN apt-get update -y && \
+    apt-get install -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /go/bin/clusterctl .
 
 CMD [ "/clusterctl" ]

--- a/clusterctl/Dockerfile
+++ b/clusterctl/Dockerfile
@@ -12,19 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG GOLANG_VERSION=1.10.3
+ARG MINIKUBE_VERSION=0.28.0
+ARG KUBECTL_VERSION=1.11.1
+
 # Reproducible builder image
-FROM golang:1.10.0 as builder
-WORKDIR /go/src/sigs.k8s.io/cluster-api
+FROM golang:${GOLANG_VERSION} as builder
+WORKDIR /go/src/sigs.k8s.io/cluster-api-provider-ssh
 # This expects that the context passed to the docker build command is
 # the cluster-api directory.
 # e.g. docker build -t <tag> -f <this_Dockerfile> <path_to_cluster-api>
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api/clusterctl
+RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api-provider-ssh/clusterctl
 
 # Final container
-FROM debian:stretch-slim
-RUN apt-get update && apt-get install -y ca-certificates openssh-server && rm -rf /var/lib/apt/lists/*
+FROM docker:18.06-dind
+
+ARG MINIKUBE_VERSION
+ARG KUBECTL_VERSION
 
 COPY --from=builder /go/bin/clusterctl .
 
+ADD https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://github.com/kubernetes/minikube/releases/download/v${MINIKUBE_VERSION}/minikube-linux-amd64 /usr/local/bin/minikube
+
+RUN md5sum -c ./md5sum && \
+    chmod +x /usr/local/bin/kubectl /usr/local/bin/minikube
+
+CMD [ "/clusterctl" ]

--- a/clusterctl/Dockerfile
+++ b/clusterctl/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2018 The Kubernetes Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reproducible builder image
+FROM golang:1.10.0 as builder
+WORKDIR /go/src/sigs.k8s.io/cluster-api
+# This expects that the context passed to the docker build command is
+# the cluster-api directory.
+# e.g. docker build -t <tag> -f <this_Dockerfile> <path_to_cluster-api>
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' sigs.k8s.io/cluster-api/clusterctl
+
+# Final container
+FROM debian:stretch-slim
+RUN apt-get update && apt-get install -y ca-certificates openssh-server && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /go/bin/clusterctl .
+

--- a/clusterctl/Makefile
+++ b/clusterctl/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = clusterctl
-TAG = 0.1.0
+TAG = 0.0.0
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../

--- a/clusterctl/Makefile
+++ b/clusterctl/Makefile
@@ -1,0 +1,38 @@
+# Copyright 2018 The Kubernetes Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: image push dev_image dev_push fix_gcs_permissions
+
+GCR_BUCKET = k8s-cluster-api
+PREFIX = gcr.io/$(GCR_BUCKET)
+DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
+NAME = clusterctl
+TAG = 0.1.0
+
+image:
+	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../
+
+push: image
+	docker push "$(PREFIX)/$(NAME):$(TAG)"
+	$(MAKE) fix_gcs_permissions
+
+fix_gcs_permissions:
+	gsutil acl ch -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
+	gsutil -m acl ch -r -u AllUsers:READ gs://artifacts.$(GCR_BUCKET).appspot.com
+
+dev_image:
+	docker build -t "$(DEV_PREFIX)/$(NAME):$(TAG)-dev" -f ./Dockerfile ../
+
+dev_push: dev_image
+	docker push "$(DEV_PREFIX)/$(NAME):$(TAG)-dev"

--- a/clusterctl/md5sums
+++ b/clusterctl/md5sums
@@ -1,2 +1,0 @@
-75fd51c605b6e8ef50816dff8cee6d40  /usr/local/bin/kubectl
-78355b859a3ba5c427dac4024dd35235  /usr/local/bin/minikube"

--- a/clusterctl/md5sums
+++ b/clusterctl/md5sums
@@ -1,0 +1,2 @@
+75fd51c605b6e8ef50816dff8cee6d40  /usr/local/bin/kubectl
+78355b859a3ba5c427dac4024dd35235  /usr/local/bin/minikube"

--- a/clusterctl/sha256sums
+++ b/clusterctl/sha256sums
@@ -1,0 +1,2 @@
+d16a4e7bfe0033ea5f56f8d11e74f7a2dec5ff8832a046a643c8355b79b4ba5c  /usr/local/bin/kubectl
+dfe361f86288a4cedcdc3bffbbe5b4716c7ee19cbb82d70696b0f20596a15c65  /usr/local/bin/minikube


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements a Dockerfile and Makefile for building and packaging `clusterctl` into a container. Currently, this is mostly a straight copy of existing files in ./cmd/apiserver/, ./cmd/controller-manager/, and ./cloud/vsphere/cmd/vsphere-machine-controller, etc.

**Which issue(s) this PR fixes**:
Fixes #289 

**Special notes for your reviewer**:

**Release note**:
Releases of `clusterctl` packaged within a container are available at gcr.io/k8s-cluster-api/clusterctl.

@kubernetes/kube-deploy-reviewers
