### PR TITLE
Change the reconcile logic to include machines being deleted

### DIFF
--- a/pkg/controller/machineset/controller.go
+++ b/pkg/controller/machineset/controller.go
@@ -257,11 +257,6 @@ func (c *MachineSetControllerImpl) createMachine(machineSet *v1alpha1.MachineSet
 // shoudExcludeMachine returns true if the machine should be filtered out, false otherwise.
 func shouldExcludeMachine(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machine) bool {
 	// Ignore inactive machines.
-	if machine.DeletionTimestamp != nil || !machine.DeletionTimestamp.IsZero() {
-		glog.V(4).Infof("Skipping machine (%v), as it is being deleted.", machine.Name)
-		return true
-	}
-
 	if metav1.GetControllerOf(machine) != nil && !metav1.IsControlledBy(machine, machineSet) {
 		glog.V(4).Infof("%s not controlled by %v", machine.Name, machineSet.Name)
 		return true

--- a/pkg/controller/machineset/reconcile_test.go
+++ b/pkg/controller/machineset/reconcile_test.go
@@ -165,13 +165,12 @@ func TestMachineSetControllerReconcileHandler(t *testing.T) {
 			expectedMachine:     machineFromMachineSet(createMachineSet(1, "foo", "bar2", "acme"), "bar2"),
 		},
 		{
-			name:                "scenario 9: the current machine is being deleted, thus a machine is created.",
+			name:                "scenario 9: the current machine is being deleted, is still counted towards the machine set, no machine resource is created.",
 			startingMachineSets: []*v1alpha1.MachineSet{createMachineSet(1, "foo", "bar2", "acme")},
 			startingMachines:    []*v1alpha1.Machine{setMachineDeleting(machineFromMachineSet(createMachineSet(1, "foo", "bar1", "acme"), "bar1"))},
 			machineSetToSync:    "foo",
 			namespaceToSync:     "acme",
-			expectedActions:     []string{"create"},
-			expectedMachine:     machineFromMachineSet(createMachineSet(1, "foo", "bar2", "acme"), "bar2"),
+			expectedActions:     []string{},
 		},
 		{
 			name:                "scenario 10: the current machine has no controller refs, owner refs preserved, machine should be adopted.",


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This changes the logic from not counting machines that are being deleted
towards the machineset replica to counting them. The reason for the
change is that due to machine deletion taking non-trivial amount of
time, machine deployment rolling update may exceed the expected number
of machines utilized.

For example, for a machine set with 3 replicas and max surge 1, for a
max of 4 machines.
- create new machine in new machineset (4 machines)
- once new machine is ready, delete a machine from old machineset (4 machines, as machine is still being deleted)
- create new machine as deleted machine is not counted (5 machines)

For the duration of the old machine being deleted, we would exceed the
number of machines by 1.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #340

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
