### PR TITLE
Refactor: move clientset / rest.Config methods out of util and into clientcmd. Add convenience methods for loading api and rest Configs and creating clients.

### DIFF
--- a/clusterctl/clusterdeployer/clusterclient.go
+++ b/clusterctl/clusterdeployer/clusterclient.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+	"sigs.k8s.io/cluster-api/pkg/clientcmd"
 	"sigs.k8s.io/cluster-api/util"
 	"strings"
 	"time"
@@ -64,7 +65,7 @@ func (c *clusterClient) removeKubeconfigFile() error {
 }
 
 func NewClusterClientFromFile(kubeconfigFile string) (*clusterClient, error) {
-	c, err := util.NewClientSet(kubeconfigFile)
+	c, err := clientcmd.NewClusterApiClientForDefaultSearchPath(kubeconfigFile)
 	if err != nil {
 		return nil, err
 	}

--- a/gcp-deployer/deploy/deploy_helper.go
+++ b/gcp-deployer/deploy/deploy_helper.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/pkg/clientcmd"
 	"sigs.k8s.io/cluster-api/util"
 )
 
@@ -257,11 +258,11 @@ func (d *deployer) copyKubeConfig(cluster *clusterv1.Cluster, master *clusterv1.
 }
 
 func (d *deployer) initApiClient() error {
-	c, err := util.NewClientSet(d.configPath)
+	c, err := clientcmd.NewClusterApiClientForDefaultSearchPath(d.configPath)
 	if err != nil {
 		return err
 	}
-	kubernetesClientSet, err := util.NewKubernetesClient(d.configPath)
+	kubernetesClientSet, err := clientcmd.NewCoreClientSetForDefaultSearchPath(d.configPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/clientcmd/configutil.go
+++ b/pkg/clientcmd/configutil.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package clientcmd contains convenience methods for working with the kubeconfig and loading specific configurations
+// of api.Config and rest.Config.
+package clientcmd
+
+import (
+	"fmt"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
+)
+
+// NewCoreClientSetForDefaultSearchPath creates a core kubernetes clientset. If the kubeconfigPath is specified then the configuration is loaded from that path.
+// Otherwise the default kubeconfig search path is used.
+func NewCoreClientSetForDefaultSearchPath(kubeconfigPath string) (*kubernetes.Clientset, error) {
+	config, err := newRestConfigForDefaultSearchPath(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+// NewCoreClientSetForKubeconfig creates a core kubernetes clientset for the given kubeconfig string.
+func NewCoreClientSetForKubeconfig(kubeconfig string) (*kubernetes.Clientset, error) {
+	config, err := newRestConfigForKubeconfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+// NewClusterApiClientForDefaultSearchPath creates a Cluster API clientset. If the kubeconfigPath is specified then the configuration is loaded from that path.
+// Otherwise the default kubeconfig search path is used.
+func NewClusterApiClientForDefaultSearchPath(kubeconfigPath string) (*clientset.Clientset, error) {
+	config, err := newRestConfigForDefaultSearchPath(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.NewForConfig(config)
+}
+
+// NewClusterApiClientForKubeconfig creates a Cluster API clientset for the given kubeconfig string.
+func NewClusterApiClientForKubeconfig(kubeconfig string) (*clientset.Clientset, error) {
+	config, err := newRestConfigForKubeconfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.NewForConfig(config)
+}
+
+// NewClientsForDefaultSearchpath creates both a core kubernetes clientset and a cluster-api clientset. If the kubeconfigPath
+// is specified then the configuration is loaded from that path. Otherwise the default kubeconfig search path is used.
+func NewClientsForDefaultSearchpath(kubeconfigPath string) (*kubernetes.Clientset, *clientset.Clientset, error) {
+	config, err := newRestConfigForDefaultSearchPath(kubeconfigPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return newClientsFromRestConfig(config)
+}
+
+// NewClientsForKubeconfig creates both a core kubernetes clientset and a cluster-api clientset.
+func NewClientsForKubeconfig(kubeconfig string) (*kubernetes.Clientset, *clientset.Clientset, error) {
+	config, err := newRestConfigForKubeconfig(kubeconfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	return newClientsFromRestConfig(config)
+}
+
+// newClientsFromRestConfig creates both a core kubernetes clientset and a cluster-api clientset from a given rest.Config
+func newClientsFromRestConfig(config *rest.Config) (*kubernetes.Clientset, *clientset.Clientset, error) {
+	coreClients, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating core clients: %v", err)
+	}
+	clusterApiClient, err := clientset.NewForConfig(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating cluster-api clients: %v", err)
+	}
+	return coreClients, clusterApiClient, nil
+}
+
+// newRestConfig creates a rest.Config for the given apiConfig
+func newRestConfig(apiConfig *api.Config) (*rest.Config, error) {
+	return clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}).ClientConfig()
+}
+
+// newRestConfigForDefaultSearchPath creates a rest.Config by searching for the kubeconfig on the default search path. If an override 'kubeconfigPath' is
+// given then that path is used instead of the default path. If no override is given, an attempt is made to load the
+// 'in cluster' config. If this fails, then the default search path is used.
+func newRestConfigForDefaultSearchPath(kubeconfigPath string) (*rest.Config, error) {
+	if kubeconfigPath == "" {
+		config, err := rest.InClusterConfig()
+		// if there is no err, continue because InClusterConfig is only expected to succeed if running inside of a pod.
+		if err == nil {
+			return config, nil
+		}
+	}
+	apiConfig, err := newApiConfigForDefaultSearchPath(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return newRestConfig(apiConfig)
+}
+
+// newRestConfigForKubeconfig creates a rest.Config for a given kubeconfig string.
+func newRestConfigForKubeconfig(kubeconfig string) (*rest.Config, error) {
+	apiConfig, err := newApiConfigForDefaultSearchPath(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return newRestConfig(apiConfig)
+}
+
+// newApiConfigForDefaultSearchPath creates an api.Config by searching for the kubeconfig on the default search path. If an override 'kubeconfigPath' is
+// given then that path is used instead of the default path.
+func newApiConfigForDefaultSearchPath(kubeconfigPath string) (*api.Config, error) {
+	configLoader := clientcmd.NewDefaultClientConfigLoadingRules()
+	configLoader.ExplicitPath = kubeconfigPath
+	return configLoader.Load()
+}
+
+// newApiConfigForKubeconfig creates an api.Config for a given kubeconfig string.
+func newApiConfigForKubeconfig(kubeconfig string) (*api.Config, error) {
+	return clientcmd.Load([]byte(kubeconfig))
+}

--- a/tools/repair/util/repair.go
+++ b/tools/repair/util/repair.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/pkg/clientcmd"
 	"sigs.k8s.io/cluster-api/util"
 )
 
@@ -36,7 +37,7 @@ func NewRepairer(dryRun bool, configPath string) (*repairer, error) {
 		configPath = util.GetDefaultKubeConfigPath()
 	}
 
-	c, err := util.NewClientSet(configPath)
+	c, err := clientcmd.NewClusterApiClientForDefaultSearchPath(configPath)
 	if err != nil {
 		return nil, err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -29,11 +29,8 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 	clustercommon "sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
 )
 
@@ -97,37 +94,6 @@ func GetDefaultKubeConfigPath() string {
 		}
 	}
 	return fmt.Sprintf("%s/config", localDir)
-}
-
-func NewClientSet(configPath string) (*clientset.Clientset, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", configPath)
-	if err != nil {
-		return nil, err
-	}
-
-	cs, err := clientset.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	return cs, nil
-}
-
-func NewKubernetesClient(configPath string) (*kubernetes.Clientset, error) {
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("kubectl config file %s doesn't exist. Is kubectl configured to access a cluster?", configPath)
-	}
-
-	config, err := clientcmd.BuildConfigFromFlags("", configPath)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
 }
 
 func GetMachineIfExists(machineClient client.MachineInterface, name string) (*clusterv1.Machine, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR standardizes the loading of clientsets from either file or in-memory kubeconfigs and removes some code for the catch all util package.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
