### PR TITLE
Add the node's UID to the machine's noderef.

### DIFF
--- a/pkg/controller/machine/node.go
+++ b/pkg/controller/machine/node.go
@@ -154,5 +154,6 @@ func objectRef(node *corev1.Node) *corev1.ObjectReference {
 	return &corev1.ObjectReference{
 		Kind: "Node",
 		Name: node.ObjectMeta.Name,
+		UID:  node.UID,
 	}
 }

--- a/pkg/controller/machine/node_test.go
+++ b/pkg/controller/machine/node_test.go
@@ -137,6 +137,7 @@ func TestReconcileNode(t *testing.T) {
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "bar",
+					UID:         "the-uid",
 					Annotations: make(map[string]string),
 				},
 			}
@@ -239,6 +240,9 @@ func TestReconcileNode(t *testing.T) {
 				}
 				if actualMachine.Status.NodeRef.Name != "bar" {
 					t.Errorf("got %v node ref name, expected bar node ref name.", actualMachine.Status.NodeRef.Name)
+				}
+				if actualMachine.Status.NodeRef.UID != "the-uid" {
+					t.Errorf("got '%v' node ref uid, expected 'the-uid' node ref uid", actualMachine.Status.NodeRef.UID)
 				}
 			}
 			if !test.expectLinked {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the node's UID to the machine's noderef field. This will allow the machine controller to definitively know what node belongs to a machine.

To test I ran a custom machine-controller, after doing so, the ouput of kubectl get machines:

```
$ kubectl get machines -o json | jq '.items[].status'
{
  "lastUpdated": "2018-06-14T23:02:09Z",
  "nodeRef": {
    "kind": "Node",
    "name": "gce-master-qqn5q",
    "uid": "18afd236-7023-11e8-b23f-42010a8a0002"
  },
  "providerStatus": null
}
{
  "lastUpdated": "2018-06-14T23:03:45Z",
  "nodeRef": {
    "kind": "Node",
    "name": "gce-node-47lts",
    "uid": "51546457-7026-11e8-b23f-42010a8a0002"
  },
  "providerStatus": null
}
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Now populate the associated node's UID in the machine.status.nodeRef field. 
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
