### PR TITLE
Port commit '8168f74afc2508e5b10fba5fc4eb1c69e89c32e4' to the new controller main.go

### DIFF
--- a/cloud/google/cmd/gce-controller/main.go
+++ b/cloud/google/cmd/gce-controller/main.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/cluster-api/cloud/google/cmd/gce-controller/machine-controller-app"
 	machineoptions "sigs.k8s.io/cluster-api/cloud/google/cmd/gce-controller/machine-controller-app/options"
 	"sigs.k8s.io/cluster-api/pkg/controller/config"
+	"flag"
 )
 
 func main() {
@@ -34,6 +35,8 @@ func main() {
 	fs.StringVar(&controllerType, "controller", controllerType, "specify whether this should run the machine or cluster controller")
 	fs.StringVar(&machineSetupConfigsPath, "machinesetup", machineSetupConfigsPath, "path to machine setup configs file")
 	config.ControllerConfig.AddFlags(pflag.CommandLine)
+	// the following line exists to make glog happy, for more information, see: https://github.com/kubernetes/kubernetes/issues/17162
+	flag.CommandLine.Parse([]string{})
 	pflag.Parse()
 
 	logs.InitLogs()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is simply a re-do of PR https://github.com/kubernetes-sigs/cluster-api/pull/206 and issue https://github.com/kubernetes-sigs/cluster-api/issues/205. The change was lost in the move to the new combined main.go for machine-controller and cluster-controller.

**Release note**:
```release-note
Fixed an issue where controller logs would all be proceeded by the following error output: `ERROR: logging before flag.Parse: `
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
