### PR TITLE
Improve machine/controller.Reconcile to intelligently block deleting …

### DIFF
--- a/cloud/google/config/configtemplate.go
+++ b/cloud/google/config/configtemplate.go
@@ -146,6 +146,10 @@ spec:
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/credentials/service-account.json
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         command:
         - "./gce-controller"
         args:

--- a/clusterctl/examples/google/provider-components.yaml.template
+++ b/clusterctl/examples/google/provider-components.yaml.template
@@ -61,6 +61,10 @@ spec:
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/credentials/service-account.json
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         command:
         - "./gce-controller"
         args:

--- a/clusterctl/examples/vsphere/provider-components.yaml.template
+++ b/clusterctl/examples/vsphere/provider-components.yaml.template
@@ -61,6 +61,11 @@ spec:
             subPath: vsphere_tmp.pub
           - name: named-machines
             mountPath: /etc/named-machines
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         command:
         - "./vsphere-machine-controller"
         args:

--- a/pkg/controller/config/configuration.go
+++ b/pkg/controller/config/configuration.go
@@ -56,7 +56,6 @@ type LeaderElectionConfiguration struct {
 
 type Configuration struct {
 	Kubeconfig           string
-	InCluster            bool
 	WorkerCount          int
 	leaderElectionConfig *LeaderElectionConfiguration
 }
@@ -71,7 +70,6 @@ const (
 )
 
 var ControllerConfig = Configuration{
-	InCluster:   true,
 	WorkerCount: 5, // Default 5 worker.
 	leaderElectionConfig: &LeaderElectionConfiguration{
 		LeaderElect:   false,
@@ -88,7 +86,6 @@ func GetLeaderElectionConfig() *LeaderElectionConfiguration {
 
 func (c *Configuration) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.Kubeconfig, "kubeconfig", c.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
-	fs.BoolVar(&c.InCluster, "incluster", c.InCluster, "Controller will be running inside the cluster.")
 	fs.IntVar(&c.WorkerCount, "workers", c.WorkerCount, "The number of workers for controller.")
 
 	AddLeaderElectionFlags(c.leaderElectionConfig, fs)

--- a/pkg/controller/machine/node_test.go
+++ b/pkg/controller/machine/node_test.go
@@ -113,7 +113,7 @@ func TestReconcileNode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			m := getMachine("foo", false, false, false)
+			m := getMachine("foo", nil, false, false)
 			if test.nodeRefName != "" {
 				m.Status.NodeRef = &corev1.ObjectReference{
 					Kind: "Node",


### PR DESCRIPTION
…a node associated with the controller machine. This will enable external machine controllers to delete any machine/node, including masters.

**What this PR does / why we need it**:
This PR improves the machine/controller package's deletion protection to only apply if the node that the machine controller is located on is the node associated with the machine to be deleted. This makes it possible for master nodes to be deleted by machine controller. This also removes the need for the "InCluster" flag so it has been removed.

The way that the machine controller determines if it is on the same node is by using the downward API to inject the name of the actual node that the pod is running on into a NODE_NAME environment variable. You can see that this environment variable is loaded in the controller.Init function. An edge case is handled where the node's name matches but the UID does not match (imagine that our external cluster has a node name of "minikube" and for whatever reason our node in the cluster has a name of "minikube", we'll still be able to delete because the UIDs won't match. 

**Special notes for your reviewer**:

**Release note**:
```release-note
MachineController can now delete nodes associated with master machines. 
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
