### PR TITLE
Change default image to Ubuntu 1604 for GCP

### DIFF
--- a/cloud/google/machineactuator.go
+++ b/cloud/google/machineactuator.go
@@ -729,7 +729,7 @@ func (gce *GCEClient) handleMachineError(machine *clusterv1.Machine, err *apierr
 }
 
 func (gce *GCEClient) getImagePath(img string) (imagePath string) {
-	defaultImg := "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710"
+	defaultImg := "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts"
 
 	// A full image path must match the regex format. If it doesn't, we will fall back to a default base image.
 	matches := regexp.MustCompile("projects/(.+)/global/images/(family/)*(.+)").FindStringSubmatch(img)

--- a/cloud/google/machineactuator_test.go
+++ b/cloud/google/machineactuator_test.go
@@ -171,7 +171,7 @@ func TestMinimumSizeShouldBeEnforced(t *testing.T) {
 	receivedInstance, computeServiceMock := newInsertInstanceCapturingMock()
 	createClusterAndFailOnError(t, config, computeServiceMock, nil)
 	checkInstanceValues(t, receivedInstance, 1)
-	checkDiskValues(t, receivedInstance.Disks[0], true, 30, "pd-ssd", "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710")
+	checkDiskValues(t, receivedInstance.Disks[0], true, 30, "pd-ssd", "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts")
 }
 
 func TestOneDisk(t *testing.T) {
@@ -187,7 +187,7 @@ func TestOneDisk(t *testing.T) {
 	receivedInstance, computeServiceMock := newInsertInstanceCapturingMock()
 	createClusterAndFailOnError(t, config, computeServiceMock, nil)
 	checkInstanceValues(t, receivedInstance, 1)
-	checkDiskValues(t, receivedInstance.Disks[0], true, 37, "pd-ssd", "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710")
+	checkDiskValues(t, receivedInstance.Disks[0], true, 37, "pd-ssd", "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts")
 }
 
 func TestTwoDisks(t *testing.T) {
@@ -209,7 +209,7 @@ func TestTwoDisks(t *testing.T) {
 	receivedInstance, computeServiceMock := newInsertInstanceCapturingMock()
 	createClusterAndFailOnError(t, config, computeServiceMock, nil)
 	checkInstanceValues(t, receivedInstance, 2)
-	checkDiskValues(t, receivedInstance.Disks[0], true, 32, "pd-ssd", "projects/ubuntu-os-cloud/global/images/family/ubuntu-1710")
+	checkDiskValues(t, receivedInstance.Disks[0], true, 32, "pd-ssd", "projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts")
 	checkDiskValues(t, receivedInstance.Disks[1], false, 45, "pd-standard", "")
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR changes the default image from Ubuntu 1710 to Ubuntu 1604-lts in the google machine actuator since that is the image we mostly use for testing. The machine setup configmap is already set up to use Ubuntu 1604.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #90 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
