### PR TITLE
Add firewall rules in cluster controller

### DIFF
--- a/cloud/google/README.md
+++ b/cloud/google/README.md
@@ -17,9 +17,10 @@ If your cluster was created using the gcp-deployer tool, see the
    export MACHINE_CONTROLLER_SERVICE_ACCOUNT=$(kubectl get cluster -o=jsonpath='{.items[0].metadata.annotations.gce\.clusterapi\.k8s\.io\/service-account-k8s-machine-controller}')
    ```
 
-1. Remember the name and zone of the master VM
+1. Remember the name and zone of the master VM and the name of the cluster
 
    ```bash
+   export CLUSTER_NAME=$(kubectl get cluster -o=jsonpath='{.items[0].metadata.name}')
    export MASTER_VM_NAME=$(kubectl get machines -l set=master | awk '{print $1}' | tail -n +2)
    export MASTER_VM_ZONE=$(kubectl get machines -l set=master -o=jsonpath='{.items[0].metadata.annotations.gcp-zone}')
    ```
@@ -61,4 +62,11 @@ behalf, make sure to run these commands for each namespace that you created:
 
    ```bash
    ./delete-service-accounts.sh
+   ```
+
+1. Delete the Firewall rules that were created for the cluster
+
+   ```bash
+   gcloud compute firewall-rules delete $CLUSTER_NAME-allow-cluster-internal
+   gcloud compute firewall-rules delete $CLUSTER_NAME-allow-api-public
    ```

--- a/cloud/google/clientcomputeservice.go
+++ b/cloud/google/clientcomputeservice.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package google
+
+import (
+	compute "google.golang.org/api/compute/v1"
+)
+
+type GCEClientComputeService interface {
+	ImagesGet(project string, image string) (*compute.Image, error)
+	ImagesGetFromFamily(project string, family string) (*compute.Image, error)
+	InstancesDelete(project string, zone string, targetInstance string) (*compute.Operation, error)
+	InstancesGet(project string, zone string, instance string) (*compute.Instance, error)
+	InstancesInsert(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
+	ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error)
+	GlobalOperationsGet(project string, operation string) (*compute.Operation, error)
+	FirewallsGet(project string) (*compute.FirewallList, error)
+	FirewallsInsert(project string, firewallRule *compute.Firewall) (*compute.Operation, error)
+	FirewallsDelete(project string, name string) (*compute.Operation, error)
+	WaitForOperation(project string, op *compute.Operation) error
+}

--- a/cloud/google/clients/computeservice.go
+++ b/cloud/google/clients/computeservice.go
@@ -1,9 +1,35 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package clients
 
 import (
-	compute "google.golang.org/api/compute/v1"
+	"bytes"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
+	"path"
+	"time"
+
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	compute "google.golang.org/api/compute/v1"
+)
+
+const (
+	gceTimeout   = time.Minute * 10
+	gceWaitSleep = time.Second * 5
 )
 
 // ComputeService is a pass through wrapper for google.golang.org/api/compute/v1/compute
@@ -63,4 +89,69 @@ func (c *ComputeService) InstancesInsert(project string, zone string, instance *
 // A pass through wrapper for compute.Service.ZoneOperations.Get(...)
 func (c *ComputeService) ZoneOperationsGet(project string, zone string, operation string) (*compute.Operation, error) {
 	return c.service.ZoneOperations.Get(project, zone, operation).Do()
+}
+
+// A pass through wrapper for compute.Service.GlobalOperations.Get(...)
+func (c *ComputeService) GlobalOperationsGet(project string, operation string) (*compute.Operation, error) {
+	return c.service.GlobalOperations.Get(project, operation).Do()
+}
+
+// A pass through wrapper for compute.Service.Firewalls.List(...)
+func (c *ComputeService) FirewallsGet(project string) (*compute.FirewallList, error) {
+	return c.service.Firewalls.List(project).Do()
+}
+
+// A pass through wrapper for compute.Service.Firewalls.Insert(...)
+func (c *ComputeService) FirewallsInsert(project string, firewallRule *compute.Firewall) (*compute.Operation, error) {
+	return c.service.Firewalls.Insert(project, firewallRule).Do()
+}
+
+// A pass through wrapper for compute.Service.Firewalls.Delete(...)
+func (c *ComputeService) FirewallsDelete(project string, name string) (*compute.Operation, error) {
+	return c.service.Firewalls.Delete(project, name).Do()
+}
+
+func (c *ComputeService) WaitForOperation(project string, op *compute.Operation) error {
+	glog.Infof("Wait for %v %q...", op.OperationType, op.Name)
+	defer glog.Infof("Finish wait for %v %q...", op.OperationType, op.Name)
+
+	start := time.Now()
+	ctx, cf := context.WithTimeout(context.Background(), gceTimeout)
+	defer cf()
+
+	var err error
+	for {
+		if err = c.checkOp(op, err); err != nil || op.Status == "DONE" {
+			return err
+		}
+		glog.V(1).Infof("Wait for %v %q: %v (%d%%): %v", op.OperationType, op.Name, op.Status, op.Progress, op.StatusMessage)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("gce operation %v %q timed out after %v", op.OperationType, op.Name, time.Since(start))
+		case <-time.After(gceWaitSleep):
+		}
+		op, err = c.getOp(project, op)
+	}
+}
+
+// getOp returns an updated operation.
+func (c *ComputeService) getOp(project string, op *compute.Operation) (*compute.Operation, error) {
+	if op.Zone != "" {
+		return c.ZoneOperationsGet(project, path.Base(op.Zone), op.Name)
+	} else {
+		return c.GlobalOperationsGet(project, op.Name)
+	}
+}
+
+func (c *ComputeService) checkOp(op *compute.Operation, err error) error {
+	if err != nil || op.Error == nil || len(op.Error.Errors) == 0 {
+		return err
+	}
+
+	var errs bytes.Buffer
+	for _, v := range op.Error.Errors {
+		errs.WriteString(v.Message)
+		errs.WriteByte('\n')
+	}
+	return errors.New(errs.String())
 }

--- a/cloud/google/clusteractuator.go
+++ b/cloud/google/clusteractuator.go
@@ -15,17 +15,26 @@ package google
 
 import (
 	"fmt"
+	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"sigs.k8s.io/cluster-api/cloud/google/clients"
+	gceconfigv1 "sigs.k8s.io/cluster-api/cloud/google/gceproviderconfig/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
 )
 
+const (
+	firewallRuleAnnotationPrefix = "gce.clusterapi.k8s.io/firewall"
+	firewallRuleInternalSuffix   = "-allow-cluster-internal"
+	firewallRuleApiSuffix        = "-allow-api-public"
+)
+
 type GCEClusterClient struct {
-	computeService GCEClientComputeService
-	clusterClient  client.ClusterInterface
+	computeService         GCEClientComputeService
+	clusterClient          client.ClusterInterface
+	gceProviderConfigCodec *gceconfigv1.GCEProviderConfigCodec
 }
 
 type ClusterActuatorParams struct {
@@ -38,19 +47,63 @@ func NewClusterActuator(params ClusterActuatorParams) (*GCEClusterClient, error)
 	if err != nil {
 		return nil, err
 	}
+	codec, err := gceconfigv1.NewCodec()
+	if err != nil {
+		return nil, err
+	}
 
 	return &GCEClusterClient{
-		computeService: computeService,
-		clusterClient:  params.ClusterClient,
+		computeService:         computeService,
+		clusterClient:          params.ClusterClient,
+		gceProviderConfigCodec: codec,
 	}, nil
 }
 
 func (gce *GCEClusterClient) Reconcile(cluster *clusterv1.Cluster) error {
-	return fmt.Errorf("NYI: Cluster Reconciles are not yet supported")
+	glog.Infof("Reconciling cluster %v.", cluster.Name)
+	err := gce.createFirewallRuleIfNotExists(cluster, &compute.Firewall{
+		Name:    cluster.Name + firewallRuleInternalSuffix,
+		Network: "global/networks/default",
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: "tcp",
+			},
+		},
+		TargetTags: []string{cluster.Name + "-worker"},
+		SourceTags: []string{cluster.Name + "-worker"},
+	})
+	if err != nil {
+		glog.Warningf("Error creating firewall rule for internal cluster traffic: %v", err)
+	}
+	err = gce.createFirewallRuleIfNotExists(cluster, &compute.Firewall{
+		Name:    cluster.Name + firewallRuleApiSuffix,
+		Network: "global/networks/default",
+		Allowed: []*compute.FirewallAllowed{
+			{
+				IPProtocol: "tcp",
+				Ports:      []string{"443"},
+			},
+		},
+		TargetTags:   []string{"https-server"},
+		SourceRanges: []string{"0.0.0.0/0"},
+	})
+	if err != nil {
+		glog.Warningf("Error creating firewall rule for core api server traffic: %v", err)
+	}
+	return nil
 }
 
 func (gce *GCEClusterClient) Delete(cluster *clusterv1.Cluster) error {
-	return fmt.Errorf("NYI: Cluster Deletions are not yet supported")
+	err := gce.deleteFirewallRule(cluster, cluster.Name+firewallRuleInternalSuffix)
+	if err != nil {
+		return fmt.Errorf("error deleting firewall rule for internal cluster traffic: %v", err)
+	}
+	err = gce.deleteFirewallRule(cluster, cluster.Name+firewallRuleApiSuffix)
+	if err != nil {
+		return fmt.Errorf("error deleting firewall rule for core api server traffic: %v", err)
+	}
+
+	return nil
 }
 
 func getOrNewComputeServiceForCluster(params ClusterActuatorParams) (GCEClientComputeService, error) {
@@ -66,4 +119,71 @@ func getOrNewComputeServiceForCluster(params ClusterActuatorParams) (GCEClientCo
 		return nil, err
 	}
 	return computeService, nil
+}
+
+func (gce *GCEClusterClient) createFirewallRuleIfNotExists(cluster *clusterv1.Cluster, firewallRule *compute.Firewall) error {
+	ruleExists, ok := cluster.ObjectMeta.Annotations[firewallRuleAnnotationPrefix+firewallRule.Name]
+	if ok && ruleExists == "true" {
+		// The firewall rule was already created.
+		return nil
+	}
+	clusterConfig, err := gce.clusterproviderconfig(cluster.Spec.ProviderConfig)
+	if err != nil {
+		return fmt.Errorf("error parsing cluster provider config: %v", err)
+	}
+	firewallRules, err := gce.computeService.FirewallsGet(clusterConfig.Project)
+	if err != nil {
+		return fmt.Errorf("error getting firewall rules: %v", err)
+	}
+
+	if !gce.containsFirewallRule(firewallRules, firewallRule.Name) {
+		op, err := gce.computeService.FirewallsInsert(clusterConfig.Project, firewallRule)
+		if err != nil {
+			return fmt.Errorf("error creating firewall rule: %v", err)
+		}
+		err = gce.computeService.WaitForOperation(clusterConfig.Project, op)
+		if err != nil {
+			return fmt.Errorf("error waiting for firewall rule creation: %v", err)
+		}
+	}
+	// TODO (mkjelland) move this to a GCEClusterProviderStatus #347
+	if cluster.ObjectMeta.Annotations == nil {
+		cluster.ObjectMeta.Annotations = make(map[string]string)
+	}
+	cluster.ObjectMeta.Annotations[firewallRuleAnnotationPrefix+firewallRule.Name] = "true"
+	_, err = gce.clusterClient.Update(cluster)
+	if err != nil {
+		fmt.Errorf("error updating cluster annotations %v", err)
+	}
+	return nil
+}
+
+func (gce *GCEClusterClient) containsFirewallRule(firewallRules *compute.FirewallList, ruleName string) bool {
+	for _, rule := range firewallRules.Items {
+		if ruleName == rule.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func (gce *GCEClusterClient) deleteFirewallRule(cluster *clusterv1.Cluster, ruleName string) error {
+	clusterConfig, err := gce.clusterproviderconfig(cluster.Spec.ProviderConfig)
+	if err != nil {
+		return fmt.Errorf("error parsing cluster provider config: %v", err)
+	}
+	op, err := gce.computeService.FirewallsDelete(clusterConfig.Project, ruleName)
+	if err != nil {
+		return fmt.Errorf("error deleting firewall rule: %v", err)
+	}
+	return gce.computeService.WaitForOperation(clusterConfig.Project, op)
+}
+
+func (gce *GCEClusterClient) clusterproviderconfig(providerConfig clusterv1.ProviderConfig) (*gceconfigv1.GCEClusterProviderConfig, error) {
+	var config gceconfigv1.GCEClusterProviderConfig
+	err := gce.gceProviderConfigCodec.DecodeFromProviderConfig(providerConfig, &config)
+	if err != nil {
+		return nil, err
+	}
+	return &config, nil
 }

--- a/cloud/google/cmd/gce-controller/Makefile
+++ b/cloud/google/cmd/gce-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = gce-controller
-TAG = 0.0.13
+TAG = 0.0.14
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/google/machineactuator_test.go
+++ b/cloud/google/machineactuator_test.go
@@ -39,6 +39,11 @@ type GCEClientComputeServiceMock struct {
 	mockInstancesGet        func(project string, zone string, instance string) (*compute.Instance, error)
 	mockInstancesInsert     func(project string, zone string, instance *compute.Instance) (*compute.Operation, error)
 	mockZoneOperationsGet   func(project string, zone string, operation string) (*compute.Operation, error)
+	mockGlobalOperationsGet func(project string, operation string) (*compute.Operation, error)
+	mockFirewallsGet        func(project string) (*compute.FirewallList, error)
+	mockFirewallsInsert     func(project string, firewallRule *compute.Firewall) (*compute.Operation, error)
+	mockFirewallsDelete     func(project string, name string) (*compute.Operation, error)
+	mockWaitForOperation    func(project string, op *compute.Operation) error
 }
 
 func (c *GCEClientComputeServiceMock) ImagesGet(project string, image string) (*compute.Image, error) {
@@ -81,6 +86,41 @@ func (c *GCEClientComputeServiceMock) ZoneOperationsGet(project string, zone str
 		return nil, nil
 	}
 	return c.mockZoneOperationsGet(project, zone, operation)
+}
+
+func (c *GCEClientComputeServiceMock) GlobalOperationsGet(project string, operation string) (*compute.Operation, error) {
+	if c.mockGlobalOperationsGet == nil {
+		return nil, nil
+	}
+	return c.mockGlobalOperationsGet(project, operation)
+}
+
+func (c *GCEClientComputeServiceMock) FirewallsGet(project string) (*compute.FirewallList, error) {
+	if c.mockZoneOperationsGet == nil {
+		return nil, nil
+	}
+	return c.mockFirewallsGet(project)
+}
+
+func (c *GCEClientComputeServiceMock) FirewallsInsert(project string, firewallRule *compute.Firewall) (*compute.Operation, error) {
+	if c.mockZoneOperationsGet == nil {
+		return nil, nil
+	}
+	return c.mockFirewallsInsert(project, firewallRule)
+}
+
+func (c *GCEClientComputeServiceMock) FirewallsDelete(project string, name string) (*compute.Operation, error) {
+	if c.mockZoneOperationsGet == nil {
+		return nil, nil
+	}
+	return c.mockFirewallsDelete(project, name)
+}
+
+func (c *GCEClientComputeServiceMock) WaitForOperation(project string, op *compute.Operation) error {
+	if c.mockZoneOperationsGet == nil {
+		return nil
+	}
+	return c.mockWaitForOperation(project, op)
 }
 
 type GCEClientMachineSetupConfigMock struct {

--- a/cloud/google/pods.go
+++ b/cloud/google/pods.go
@@ -34,7 +34,7 @@ import (
 
 var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.5"
 var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.6"
-var machineControllerImage = "gcr.io/k8s-cluster-api/gce-controller:0.0.13"
+var machineControllerImage = "gcr.io/k8s-cluster-api/gce-controller:0.0.14"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/clusterctl/examples/google/generate-yaml.sh
+++ b/clusterctl/examples/google/generate-yaml.sh
@@ -114,6 +114,7 @@ if [ ! -f $MACHINE_CONTROLLER_SA_FILE ]; then
   echo Generating $MACHINE_CONTROLLER_SA_EMAIL service account for machine controller
   gcloud iam service-accounts create --display-name="machine controller service account" $MACHINE_CONTROLLER_SA_NAME
   gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$MACHINE_CONTROLLER_SA_EMAIL --role=roles/compute.instanceAdmin.v1
+  gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$MACHINE_CONTROLLER_SA_EMAIL --role=roles/compute.securityAdmin
   gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$MACHINE_CONTROLLER_SA_EMAIL --role=roles/iam.serviceAccountActor
   gcloud iam service-accounts keys create $MACHINE_CONTROLLER_SA_FILE --iam-account $MACHINE_CONTROLLER_SA_EMAIL
 fi
@@ -145,12 +146,6 @@ gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$
 
 echo Generating $WORKER_SA_EMAIL service account for workers
 gcloud iam service-accounts create --display-name="worker service account" $WORKER_SA_NAME
-
-FIREWALL_RULE_NAME="cluster-api-open"
-if ! gcloud compute firewall-rules describe ${FIREWALL_RULE_NAME}; then
-  echo "Creating ${FIREWALL_RULE_NAME} firewall rule to enable inbound communication to nodes"
-  gcloud compute firewall-rules create ${FIREWALL_RULE_NAME} --allow=TCP:443 --source-ranges=0.0.0.0/0 --target-tags='https-server'
-fi
 
 if [ ! -f $MACHINE_CONTROLLER_SSH_PRIVATE_FILE ]; then
   echo Generate SSH key files fo machine controller

--- a/clusterctl/examples/google/provider-components.yaml.template
+++ b/clusterctl/examples/google/provider-components.yaml.template
@@ -44,7 +44,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: gce-machine-controller
-        image: gcr.io/k8s-cluster-api/gce-controller:0.0.13
+        image: gcr.io/k8s-cluster-api/gce-controller:0.0.14
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes
@@ -79,7 +79,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: gce-cluster-controller
-        image: gcr.io/k8s-cluster-api/gce-controller:0.0.13
+        image: gcr.io/k8s-cluster-api/gce-controller:0.0.14
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**:
Add 2 firewall rules in the GCE cluster actuator. One is to allow traffic to the api server and the other is to allow traffic between the nodes in the cluster.

Moved some logic out of the machine actuator and into the compute service wrapper to allow for code sharing between the cluster and machine actuators.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #132
