### PR TITLE
Better way to register and lookup provisioners

### DIFF
--- a/cloud/google/machineactuator.go
+++ b/cloud/google/machineactuator.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/cluster-api/cloud/google/clients"
 	gceconfigv1 "sigs.k8s.io/cluster-api/cloud/google/gceproviderconfig/v1alpha1"
 	"sigs.k8s.io/cluster-api/cloud/google/machinesetup"
+	clustercommon "sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/cert"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
@@ -62,6 +63,7 @@ const (
 	// This file is a yaml that will be used to create the machine-setup configmap on the machine controller.
 	// It contains the supported machine configurations along with the startup scripts and OS image paths that correspond to each supported configuration.
 	MachineSetupConfigsFilename = "machine_setup_configs.yaml"
+	ProviderName                = "google"
 )
 
 const (
@@ -69,6 +71,14 @@ const (
 	deleteEventAction = "Delete"
 	noEventAction     = ""
 )
+
+func init() {
+	actuator, err := NewMachineActuator(MachineActuatorParams{})
+	if err != nil {
+		glog.Fatalf("Error creating cluster provisioner for google : %v", err)
+	}
+	clustercommon.RegisterClusterProvisioner(ProviderName, actuator)
+}
 
 type SshCreds struct {
 	user           string

--- a/cloud/vsphere/machineactuator.go
+++ b/cloud/vsphere/machineactuator.go
@@ -449,7 +449,7 @@ func (vc *VsphereClient) PostDelete(cluster *clusterv1.Cluster) error {
 func (vc *VsphereClient) Update(cluster *clusterv1.Cluster, goalMachine *clusterv1.Machine) error {
 	// Check if the annotations we want to track exist, if not, the user likely created a master machine with their own annotation.
 	if _, ok := goalMachine.ObjectMeta.Annotations[ControlPlaneVersionAnnotationKey]; !ok {
-		ip, _ := vc.DeploymentClient.GetIP(goalMachine)
+		ip, _ := vc.DeploymentClient.GetIP(nil, goalMachine)
 		glog.Info("Version annotations do not exist. Populating existing state for bootstrapped machine.")
 		tfState, _ := vc.GetTfState(goalMachine)
 		return vc.updateAnnotations(goalMachine, ip, tfState)
@@ -571,7 +571,7 @@ func (vc *VsphereClient) updateMasterInPlace(machine *clusterv1.Machine) error {
 func (vc *VsphereClient) remoteSshCommand(m *clusterv1.Machine, cmd, privateKeyPath, sshUser string) (string, error) {
 	glog.Infof("Remote SSH execution '%s' on %s", cmd, m.ObjectMeta.Name)
 
-	publicIP, err := vc.DeploymentClient.GetIP(m)
+	publicIP, err := vc.DeploymentClient.GetIP(nil, m)
 	if err != nil {
 		return "", err
 	}

--- a/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/clusterctl/clusterdeployer/clusterdeployer.go
@@ -29,7 +29,8 @@ import (
 	"time"
 )
 
-// Provider specific logic. Logic here should eventually be optional & additive.
+// Deprecated interface for Provider specific logic. Please do not extend or add. This interface should be removed
+// once issues/158 and issues/160 below are fixed.
 type ProviderDeployer interface {
 	// TODO: This requirement can be removed once after: https://github.com/kubernetes-sigs/cluster-api/issues/158
 	GetIP(cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error)

--- a/clusterctl/cmd/create_cluster_test.go
+++ b/clusterctl/cmd/create_cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	_ "sigs.k8s.io/cluster-api/cloud/google"
 )
 
 const validCluster = `

--- a/clusterctl/main.go
+++ b/clusterctl/main.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package main
 
-import "sigs.k8s.io/cluster-api/clusterctl/cmd"
+import (
+	_ "sigs.k8s.io/cluster-api/cloud/google"
+	_ "sigs.k8s.io/cluster-api/cloud/vsphere"
+	"sigs.k8s.io/cluster-api/clusterctl/cmd"
+)
 
 func main() {
 	cmd.Execute()

--- a/pkg/apis/cluster/common/plugins.go
+++ b/pkg/apis/cluster/common/plugins.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/golang/glog"
+)
+
+var (
+	providersMutex sync.Mutex
+	providers      = make(map[string]interface{})
+)
+
+// RegisterClusterProvisioner registers a ClusterProvisioner by name.  This
+// is expected to happen during app startup.
+func RegisterClusterProvisioner(name string, provisioner interface{}) {
+	providersMutex.Lock()
+	defer providersMutex.Unlock()
+	if _, found := providers[name]; found {
+		glog.Fatalf("Cluster provisioner %q was registered twice", name)
+	}
+	glog.V(1).Infof("Registered cluster provisioner %q", name)
+	providers[name] = provisioner
+}
+
+func ClusterProvisioner(name string) (interface{}, error) {
+	providersMutex.Lock()
+	defer providersMutex.Unlock()
+	provisioner, found := providers[name]
+	if !found {
+		return nil, fmt.Errorf("unable to find provisioner for %s", name)
+	}
+	return provisioner, nil
+}


### PR DESCRIPTION
Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Currently we hard code the vsphere and google provisioners in create_cluster.go, this makes it hard to add new provisioners as it is an invasive change. So let us use the patterns from k/k for plugins and add RegisterClusterProvisioner/GetClusterProvisioner to make it easy to register and lookup. Also remove the vsphereAdapter now that vsphere-deployer is already removed.

We are using a pattern similar to how we deal with cloud providers in the main k/k repository. Longer term plan is to fully eliminate ProviderDeployer interface, so this registration mechanism is temporarily needed. To enable this support in your provider, please add a init method in your provider and use `RegisterClusterProvisioner` like so:

```
clustercommon.RegisterClusterProvisioner(ProviderName, actuator)
```

To use this you will need to edit clusterctl/main.go and add the package that contains the init() method. You can just edit the copy of clusterctl/main.go for trying things out during development or vendor this file to your repo until we get rid of ProviderDeployer and this registration mechanism.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
