### PR TITLE
Add an optional provider-components flag to `clusterctl delete cluster`

### DIFF
--- a/clusterctl/cmd/delete_cluster.go
+++ b/clusterctl/cmd/delete_cluster.go
@@ -23,7 +23,8 @@ import (
 )
 
 type DeleteOptions struct {
-	ClusterName string
+	ClusterName        string
+	ProviderComponents string
 }
 
 var do = &DeleteOptions{}
@@ -43,6 +44,7 @@ var deleteClusterCmd = &cobra.Command{
 }
 
 func init() {
+	deleteClusterCmd.Flags().StringVarP(&do.ProviderComponents, "provider-components", "p", "", "A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.")
 	deleteCmd.AddCommand(deleteClusterCmd)
 }
 

--- a/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
@@ -3,7 +3,8 @@ Usage:
   clusterctl delete cluster [flags]
 
 Flags:
-  -h, --help   help for cluster
+  -h, --help                         help for cluster
+  -p, --provider-components string   A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.
 
 Global Flags:
       --alsologtostderr                  log to standard error as well as files

--- a/clusterctl/testdata/delete-cluster-no-args.golden
+++ b/clusterctl/testdata/delete-cluster-no-args.golden
@@ -5,7 +5,8 @@ Usage:
   clusterctl delete cluster [flags]
 
 Flags:
-  -h, --help   help for cluster
+  -h, --help                         help for cluster
+  -p, --provider-components string   A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.
 
 Global Flags:
       --alsologtostderr                  log to standard error as well as files


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an override flag for the path to the provider-components when running `clusterctl delete cluster`. This is needed because delete needs to be able to run the same provider components on the minikube cluster. Note that this flag is optional as we will save the provider components to the cluster, however, in the event that there is an error saving to the cluster, the cluster is in an invalid state of being almost deleted, or some other issue this will be potentially useful. 

**Special notes for your reviewer**:

**Release note**:
```release-note
Added flag to `clusterctl delete cluster` to optionally override the provider components YAML associated with the cluster. 
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
