### PR TITLE
Enhance `clusterctl create cluster` to save the provider-components YAML

### DIFF
--- a/clusterctl/clusterdeployer/clientfactory.go
+++ b/clusterctl/clusterdeployer/clientfactory.go
@@ -15,13 +15,22 @@ limitations under the License.
 */
 package clusterdeployer
 
-type clusterClientFactory struct {
+import (
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/pkg/clientcmd"
+)
+
+type clientFactory struct {
 }
 
-func NewClusterClientFactory() ClusterClientFactory {
-	return &clusterClientFactory{}
+func NewClientFactory() ClientFactory {
+	return &clientFactory{}
 }
 
-func (f *clusterClientFactory) ClusterClient(kubeconfig string) (ClusterClient, error) {
+func (f *clientFactory) NewClusterClientFromKubeconfig(kubeconfig string) (ClusterClient, error) {
 	return NewClusterClient(kubeconfig)
+}
+
+func (f *clientFactory) NewCoreClientsetFromKubeconfigFile(kubeconfigPath string) (*kubernetes.Clientset, error) {
+	return clientcmd.NewCoreClientSetForDefaultSearchPath(kubeconfigPath)
 }

--- a/clusterctl/clusterdeployer/providercomponentsstorefactory.go
+++ b/clusterctl/clusterdeployer/providercomponentsstorefactory.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterdeployer
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/cluster-api/clusterctl/providercomponents"
+)
+
+type factory struct {
+}
+
+func NewProviderComponentsStoreFactory() ProviderComponentsStoreFactory {
+	return &factory{}
+}
+
+func (f *factory) NewFromCoreClientset(clientset *kubernetes.Clientset) (ProviderComponentsStore, error) {
+	return providercomponents.NewFromClientset(clientset)
+}

--- a/clusterctl/cmd/create_cluster.go
+++ b/clusterctl/cmd/create_cluster.go
@@ -78,14 +78,15 @@ func RunCreate(co *CreateOptions) error {
 	if err != nil {
 		return err
 	}
+	pcsFactory := clusterdeployer.NewProviderComponentsStoreFactory()
 	d := clusterdeployer.New(
 		mini,
-		clusterdeployer.NewClusterClientFactory(),
+		clusterdeployer.NewClientFactory(),
 		pd,
 		string(pc),
 		co.KubeconfigOutput,
 		co.CleanupExternalCluster)
-	err = d.Create(c, m)
+	err = d.Create(c, m, pcsFactory)
 	return err
 }
 

--- a/clusterctl/providercomponents/providercomponents.go
+++ b/clusterctl/providercomponents/providercomponents.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providercomponents
+
+import (
+	"fmt"
+	"io/ioutil"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	configMapName                  = "clusterctl"
+	configMapProviderComponentsKey = "provider-components"
+)
+
+type Store struct {
+	// If present the provider components will be loaded from and saved to this file
+	ExplicitPath string
+	// If present and ExplicitPath is not present, provider components will be loaded and saved to this store
+	ConfigMap v1.ConfigMapInterface
+}
+
+func NewFromConfigMap(configMap v1.ConfigMapInterface) (*Store, error) {
+	store := Store{
+		ConfigMap: configMap,
+	}
+	return &store, nil
+}
+
+func NewFromClientset(clientset *kubernetes.Clientset) (*Store, error) {
+	return NewFromConfigMap(clientset.CoreV1().ConfigMaps(core.NamespaceDefault))
+}
+
+func (pc *Store) Save(providerComponents string) error {
+	if pc.ExplicitPath == "" {
+		return pc.saveToConfigMap(providerComponents)
+	}
+	return ioutil.WriteFile(pc.ExplicitPath, []byte(providerComponents), 0644)
+}
+
+func (pc *Store) Load() (string, error) {
+	if pc.ExplicitPath == "" {
+		return pc.loadFromConfigMap()
+	}
+	return pc.loadFromFile()
+}
+
+func (pc *Store) loadFromFile() (string, error) {
+	bytes, err := ioutil.ReadFile(pc.ExplicitPath)
+	if err != nil {
+		return "", fmt.Errorf("error when loading provider components from '%v': %v", pc.ExplicitPath, err)
+	}
+	return string(bytes), nil
+}
+
+func (pc *Store) saveToConfigMap(providerComponents string) error {
+	configMap, err := pc.ConfigMap.Get(configMapName, meta.GetOptions{})
+	if errors.IsNotFound(err) {
+		configMap = &core.ConfigMap{
+			ObjectMeta: meta.ObjectMeta{
+				Name: configMapName,
+			},
+		}
+	} else if err != nil {
+		return err
+	}
+	if configMap.Data == nil {
+		configMap.Data = make(map[string]string)
+	}
+	configMap.Data[configMapProviderComponentsKey] = providerComponents
+	if err == nil {
+		_, err = pc.ConfigMap.Update(configMap)
+		if err != nil {
+			return fmt.Errorf("error updating config map '%v': %v", configMapName, err)
+		}
+	} else {
+		_, err = pc.ConfigMap.Create(configMap)
+		if err != nil {
+			return fmt.Errorf("error creating config map '%v': %v", configMapName, err)
+		}
+	}
+	return nil
+}
+
+func (pc *Store) loadFromConfigMap() (string, error) {
+	if pc.ConfigMap == nil {
+		return "", fmt.Errorf("unable to load config map: need a valid ConfigMapInterface")
+	}
+	configMap, err := pc.ConfigMap.Get(configMapName, meta.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error getting configmap named '%v': %v", configMapName, err)
+	}
+	providerComponents, ok := configMap.Data[configMapProviderComponentsKey]
+	if !ok {
+		return "", fmt.Errorf("configmap '%v' does not contain the provider components key '%v'", configMapName, configMapProviderComponentsKey)
+	}
+	return providerComponents, nil
+}

--- a/clusterctl/providercomponents/providercomponents_test.go
+++ b/clusterctl/providercomponents/providercomponents_test.go
@@ -1,0 +1,186 @@
+package providercomponents_test
+
+import (
+	"fmt"
+	"testing"
+
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/cluster-api/clusterctl/providercomponents"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+func TestLoadFromConfigMap(t *testing.T) {
+	providerComponentsContent := "content\nmore content >>"
+	configMapName := "clusterctl"
+	providerComponentsKey := "provider-components"
+	testCases := []struct {
+		name                 string
+		getResult            *core.ConfigMap
+		getErr               error
+		expectedErrorMessage string
+	}{
+		{"config map exists;key exists", newConfigMap(configMapName, map[string]string{providerComponentsKey: providerComponentsContent}), nil, ""},
+		{"get error", nil, fmt.Errorf("this is the error string"), "error getting configmap named 'clusterctl': this is the error string"},
+		{"config map exists;key doesn't exist", newConfigMap(configMapName, map[string]string{}), nil, "configmap 'clusterctl' does not contain the provider components key 'provider-components'"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockConfigMap := newMockConfigMap()
+			mockConfigMap.GetResult = tc.getResult
+			mockConfigMap.GetErr = tc.getErr
+			store, err := providercomponents.NewFromConfigMap(mockConfigMap)
+			if err != nil {
+				t.Fatalf("error creating provider components store: %v", err)
+			}
+			value, err := store.Load()
+			if err == nil {
+				if tc.expectedErrorMessage != "" {
+					t.Fatalf("error mismatch: got '%v', want '%v'", err, tc.expectedErrorMessage)
+				}
+				if value != providerComponentsContent {
+					t.Errorf("provider components content mismatch: got '%v', want '%v'", value, providerComponentsContent)
+				}
+			} else {
+				if err.Error() != tc.expectedErrorMessage {
+					t.Errorf("error message mismatch: got '%v', want '%v'", err, tc.expectedErrorMessage)
+				}
+			}
+		})
+	}
+}
+
+func TestSaveToConfigMap(t *testing.T) {
+	providerComponentsContent := "content\nmore content >>"
+	configMapName := "clusterctl"
+	providerComponentsKey := "provider-components"
+	notFoundErr := errors.NewNotFound(v1alpha1.Resource("configmap"), configMapName)
+	testCases := []struct {
+		name                 string
+		getResult            *core.ConfigMap
+		getErr               error
+		createErr            error
+		updateErr            error
+		expectedDataLen      int
+		expectedErrorMessage string
+	}{
+		{"random error retrieving config map", nil, fmt.Errorf("random config map error"), nil, nil, 1, "random config map error"},
+		{"new config map, success", nil, notFoundErr, nil, nil, 1, ""},
+		{"new config map, error", nil, notFoundErr, fmt.Errorf("create has failed"), nil, 0, "error creating config map 'clusterctl': create has failed"},
+		{"existing config map, error", newConfigMap(configMapName, nil), nil, nil, fmt.Errorf("update has failed"), 1, "error updating config map 'clusterctl': update has failed"},
+		{"existing config map with nil map", newConfigMap(configMapName, nil), nil, nil, nil, 1, ""},
+		{"existing config map with existing, different key", newConfigMap(configMapName, map[string]string{providerComponentsKey: "different value"}), nil, nil, nil, 1, ""},
+		{"existing config map with existing, same key", newConfigMap(configMapName, map[string]string{providerComponentsKey: "different value", "another-key": "another-value"}), nil, nil, nil, 2, ""},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockConfigMap := newMockConfigMap()
+			mockConfigMap.GetResult = tc.getResult
+			mockConfigMap.GetErr = tc.getErr
+			mockConfigMap.CreateErr = tc.createErr
+			mockConfigMap.UpdateErr = tc.updateErr
+			store, err := providercomponents.NewFromConfigMap(mockConfigMap)
+			if err != nil {
+				t.Fatalf("error creating provider components store: %v", err)
+			}
+			err = store.Save(providerComponentsContent)
+			if err != nil || tc.expectedErrorMessage != "" {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if err.Error() != tc.expectedErrorMessage {
+					t.Errorf("error mismatch: got '%v', want '%v'", err, tc.expectedErrorMessage)
+				}
+				return
+			}
+			var capturedConfigMap core.ConfigMap
+			if tc.getErr == nil {
+				capturedConfigMap = mockConfigMap.CapturedUpdateArg
+			} else {
+				capturedConfigMap = mockConfigMap.CapturedCreateArg
+			}
+			if capturedConfigMap.Name != configMapName {
+				t.Errorf("unexpected config map name: got '%v', want '%v'", mockConfigMap.CapturedCreateArg.Name, configMapName)
+			}
+			if capturedConfigMap.Data == nil {
+				t.Fatalf("create argument's 'data' field is nil")
+			}
+			if len(capturedConfigMap.Data) != tc.expectedDataLen {
+				t.Errorf("data map length mismatch: got %v want %v", len(capturedConfigMap.Data), tc.expectedDataLen)
+			}
+			value, ok := capturedConfigMap.Data[providerComponentsKey]
+			if !ok {
+				t.Errorf("missing a value for '%v'", providerComponentsKey)
+			}
+			if value != providerComponentsContent {
+				t.Errorf("provider components content mismatch: got '%v', want '%v'", value, providerComponentsContent)
+			}
+		})
+	}
+}
+
+func newMockConfigMap() *MockConfigMap {
+	return &MockConfigMap{}
+}
+
+func newConfigMap(name string, data map[string]string) *core.ConfigMap {
+	return &core.ConfigMap{
+		ObjectMeta: meta.ObjectMeta{
+			Name: name,
+		},
+		Data: data,
+	}
+}
+
+type MockConfigMap struct {
+	CapturedGetNameArg    string
+	CapturedGetOptionsArg meta.GetOptions
+	GetResult             *core.ConfigMap
+	GetErr                error
+	CapturedCreateArg     core.ConfigMap
+	CreateResult          *core.ConfigMap
+	CreateErr             error
+	CapturedUpdateArg     core.ConfigMap
+	UpdateResult          *core.ConfigMap
+	UpdateErr             error
+}
+
+func (c *MockConfigMap) Get(name string, options meta.GetOptions) (*core.ConfigMap, error) {
+	c.CapturedGetNameArg = name
+	c.CapturedGetOptionsArg = options
+	return c.GetResult, c.GetErr
+}
+
+func (c *MockConfigMap) List(opts meta.ListOptions) (result *core.ConfigMapList, err error) {
+	return
+}
+
+func (c *MockConfigMap) Watch(opts meta.ListOptions) (w watch.Interface, err error) {
+	return
+}
+
+func (c *MockConfigMap) Create(configMap *core.ConfigMap) (*core.ConfigMap, error) {
+	c.CapturedCreateArg = *configMap
+	return c.CreateResult, c.CreateErr
+}
+
+func (c *MockConfigMap) Update(configMap *core.ConfigMap) (*core.ConfigMap, error) {
+	c.CapturedUpdateArg = *configMap
+	return c.UpdateResult, c.UpdateErr
+}
+
+func (c *MockConfigMap) Delete(name string, options *meta.DeleteOptions) (err error) {
+	return
+}
+
+func (c *MockConfigMap) DeleteCollection(options *meta.DeleteOptions, listOptions meta.ListOptions) (err error) {
+	return
+}
+
+// Patch applies the patch and returns the patched configMap.
+func (c *MockConfigMap) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core.ConfigMap, err error) {
+	return
+}

--- a/pkg/client/clientset_generated/clientset/clientset.go
+++ b/pkg/client/clientset_generated/clientset/clientset.go
@@ -42,7 +42,7 @@ func (c *Clientset) ClusterV1alpha1() clusterv1alpha1.ClusterV1alpha1Interface {
 	return c.clusterV1alpha1
 }
 
-// Deprecated: Cluster retrieves the default version of ClusterClient.
+// Deprecated: Cluster retrieves the default version of ClusterClient
 // Please explicitly pick a version.
 func (c *Clientset) Cluster() clusterv1alpha1.ClusterV1alpha1Interface {
 	return c.clusterV1alpha1


### PR DESCRIPTION
to the created cluster.

This commit saves the provider-components.yaml file to the cluster. The
reason to do this is so it can be retrieved for future management of the
cluster from minikube.

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
