### PR TITLE
Improve reliability of saving provider-components to configmap

### DIFF
--- a/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/clusterctl/clusterdeployer/clusterdeployer.go
@@ -154,16 +154,16 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 		}
 	}()
 
-	glog.Info("Saving provider components to the internal cluster")
-	err = d.saveProviderComponentsToCluster(providerComponentsStoreFactory, d.kubeconfigOutput)
-	if err != nil {
-		return fmt.Errorf("unable to save provider components to internal cluster: %v", err)
-	}
-
 	glog.Info("Applying Cluster API stack to internal cluster")
 	err = d.applyClusterAPIStackWithPivoting(internalClient, externalClient)
 	if err != nil {
 		return fmt.Errorf("unable to apply cluster api stack to internal cluster: %v", err)
+	}
+
+	glog.Info("Saving provider components to the internal cluster")
+	err = d.saveProviderComponentsToCluster(providerComponentsStoreFactory, d.kubeconfigOutput)
+	if err != nil {
+		return fmt.Errorf("unable to save provider components to internal cluster: %v", err)
 	}
 
 	// For some reason, endpoint doesn't get updated in external cluster sometimes. So we

--- a/clusterctl/providercomponents/providercomponents.go
+++ b/clusterctl/providercomponents/providercomponents.go
@@ -80,7 +80,7 @@ func (pc *Store) saveToConfigMap(providerComponents string) error {
 			},
 		}
 	} else if err != nil {
-		return err
+		return fmt.Errorf("unable to get configmap '%v': %v", configMapName, err)
 	}
 	if configMap.Data == nil {
 		configMap.Data = make(map[string]string)

--- a/clusterctl/providercomponents/providercomponents_test.go
+++ b/clusterctl/providercomponents/providercomponents_test.go
@@ -67,7 +67,7 @@ func TestSaveToConfigMap(t *testing.T) {
 		expectedDataLen      int
 		expectedErrorMessage string
 	}{
-		{"random error retrieving config map", nil, fmt.Errorf("random config map error"), nil, nil, 1, "random config map error"},
+		{"random error retrieving config map", nil, fmt.Errorf("random config map error"), nil, nil, 1, "unable to get configmap 'clusterctl': random config map error"},
 		{"new config map, success", nil, notFoundErr, nil, nil, 1, ""},
 		{"new config map, error", nil, notFoundErr, fmt.Errorf("create has failed"), nil, 0, "error creating config map 'clusterctl': create has failed"},
 		{"existing config map, error", newConfigMap(configMapName, nil), nil, nil, fmt.Errorf("update has failed"), 1, "error updating config map 'clusterctl': update has failed"},


### PR DESCRIPTION
This change increases the reliability of saving the provider components
to the cluster by moving the save to be below the apply of the
cluster API stack to the cluster. That apply process waits for the
cluster API server to be ready on some level so it improves the
reliability of saving the provider-components.

Ideally we should probably follow up with a wait process that ensures
the core kubernetes API server is ready to go.

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
