### PR TITLE
cloud: google: inspect error type to determine 404

### DIFF
--- a/cloud/google/machineactuator.go
+++ b/cloud/google/machineactuator.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"reflect"
 	"strings"
@@ -26,6 +27,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -579,8 +581,7 @@ func (gce *GCEClient) instanceIfExists(cluster *clusterv1.Cluster, machine *clus
 
 	instance, err := gce.computeService.InstancesGet(clusterConfig.Project, machineConfig.Zone, identifyingMachine.ObjectMeta.Name)
 	if err != nil {
-		// TODO: Use formal way to check for error code 404
-		if strings.Contains(err.Error(), "Error 404") {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == http.StatusNotFound {
 			return nil, nil
 		}
 		return nil, err


### PR DESCRIPTION
Instead of checking for a string in the error output, we can check that
the error we get from the GCE client is a record of a 404 response to
determine that the object was not found.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

```release-note
NONE
```

/cc @k4leung4 