### PR TITLE
Plumb addon support into clusterctl.

### DIFF
--- a/clusterctl/README.md
+++ b/clusterctl/README.md
@@ -22,11 +22,11 @@ $ go build
 TBD
 
 ### Creating a cluster
-1. Create a `cluster.yaml`, `machines.yaml` and `provider-components.yaml` files configured for your cluster. See the provider specific templates and generation tools at `$GOPATH/src/sigs.k8s.io/cluster-api/clusterctl/examples/<provider>`. 
+1. Create the `cluster.yaml`, `machines.yaml`, `provider-components.yaml`, and `addons.yaml` files configured for your cluster. See the provider specific templates and generation tools at `$GOPATH/src/sigs.k8s.io/cluster-api/clusterctl/examples/<provider>`.
 2. Create a cluster 
 
 ```shell
-clusterctl create cluster --provider [google/vsphere] -c cluster.yaml -m machines.yaml -p provider-components.yaml
+clusterctl create cluster --provider [google/vsphere] -c cluster.yaml -m machines.yaml -p provider-components.yaml -a addons.yaml
 ```
 
 To choose a specific minikube driver, please use the `--vm-driver` command line parameter. For example to use the kvm2 driver with clusterctl you woud add `--vm-driver kvm2`

--- a/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -347,7 +347,7 @@ func TestCreate(t *testing.T) {
 			inputMachines := generateMachines()
 			pcStore := mockProviderComponentsStore{}
 			pcFactory := mockProviderComponentsStoreFactory{NewFromCoreclientsetPCStore: &pcStore}
-			d := clusterdeployer.New(p, f, pd, "", kubeconfigOut, testcase.cleanupExternal)
+			d := clusterdeployer.New(p, f, pd, "", "", kubeconfigOut, testcase.cleanupExternal)
 			err := d.Create(inputCluster, inputMachines, &pcFactory)
 
 			// Validate
@@ -410,7 +410,8 @@ func TestCreateProviderComponentsScenarios(t *testing.T) {
 			inputMachines := generateMachines()
 			pcFactory := mockProviderComponentsStoreFactory{NewFromCoreclientsetPCStore: &tc.pcStore}
 			providerComponentsYaml := "-yaml\ndefinition"
-			d := clusterdeployer.New(p, f, pd, providerComponentsYaml, kubeconfigOut, false)
+			addonsYaml := "-yaml\ndefinition"
+			d := clusterdeployer.New(p, f, pd, providerComponentsYaml, addonsYaml, kubeconfigOut, false)
 			err := d.Create(inputCluster, inputMachines, &pcFactory)
 			if err == nil && tc.expectedError != "" {
 				t.Fatalf("error mismatch: got '%v', want '%v'", err, tc.expectedError)

--- a/clusterctl/examples/vsphere/addons.yaml.template
+++ b/clusterctl/examples/vsphere/addons.yaml.template
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+  datastore: ""

--- a/clusterctl/examples/vsphere/generate-yaml.sh
+++ b/clusterctl/examples/vsphere/generate-yaml.sh
@@ -79,4 +79,4 @@ cat $PROVIDERCOMPONENT_TEMPLATE_FILE \
   > $PROVIDERCOMPONENT_GENERATED_FILE
 
 echo "Done generating $PROVIDERCOMPONENT_GENERATED_FILE"
-echo "You will still need to generate the cluster.yaml and machines.yaml"
+echo "You will still need to generate the cluster.yaml,  machines.yaml, and addons.yaml configuration files"

--- a/clusterctl/testdata/create-cluster-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/create-cluster-no-args-invalid-flag.golden
@@ -3,10 +3,11 @@ Usage:
   clusterctl create cluster [flags]
 
 Flags:
+  -a, --addon-components string      A yaml file containing cluster addons to apply to the internal cluster
       --cleanup-external-cluster     Whether to cleanup the external cluster after bootstrap (default true)
   -c, --cluster string               A yaml file containing cluster object definition
   -h, --help                         help for cluster
-      --kubeconfig-out string        where to output the kubeconfig for the provisioned cluster. (default "kubeconfig")
+      --kubeconfig-out string        Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
   -m, --machines string              A yaml file containing machine object definition(s)
       --provider string              Which provider deployment logic to use (google/vsphere)
   -p, --provider-components string   A yaml file containing cluster api provider controllers and supporting objects

--- a/clusterctl/testdata/create-cluster-no-args.golden
+++ b/clusterctl/testdata/create-cluster-no-args.golden
@@ -5,10 +5,11 @@ Usage:
   clusterctl create cluster [flags]
 
 Flags:
+  -a, --addon-components string      A yaml file containing cluster addons to apply to the internal cluster
       --cleanup-external-cluster     Whether to cleanup the external cluster after bootstrap (default true)
   -c, --cluster string               A yaml file containing cluster object definition
   -h, --help                         help for cluster
-      --kubeconfig-out string        where to output the kubeconfig for the provisioned cluster. (default "kubeconfig")
+      --kubeconfig-out string        Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
   -m, --machines string              A yaml file containing machine object definition(s)
       --provider string              Which provider deployment logic to use (google/vsphere)
   -p, --provider-components string   A yaml file containing cluster api provider controllers and supporting objects


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds yet one more required flag to clusterctl to specify "addons". For the purposes of this PR, "addons" are resources that are applied to the internal cluster (e.g. gce) but *not* the external cluster (minikube). So you can put things that are specific to the environment into addons.yaml (like storageclasses) which would fail if you tried to apply them to minikube. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
clusterctl now requires passing in addons when creating a cluster.
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers