### PR TITLE
Add create and delete events for in vsphere machine actuator

### DIFF
--- a/cloud/vsphere/machineactuator.go
+++ b/cloud/vsphere/machineactuator.go
@@ -27,8 +27,10 @@ import (
 
 	"github.com/golang/glog"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/tools/record"
 
 	"encoding/base64"
 	"sigs.k8s.io/cluster-api/cloud/vsphere/namedmachines"
@@ -52,6 +54,9 @@ const (
 
 	// The contents of the tfstate file for a machine.
 	StatusMachineTerraformState = "tf-state"
+
+	createEventAction = "Create"
+	deleteEventAction = "Delete"
 )
 
 const (
@@ -69,12 +74,13 @@ type VsphereClient struct {
 	codecFactory      *serializer.CodecFactory
 	machineClient     client.MachineInterface
 	namedMachineWatch *namedmachines.ConfigWatch
+	eventRecorder     record.EventRecorder
 	// Once the vsphere-deployer is deleted, both DeploymentClient and VsphereClient can depend on
 	// something that implements GetIP instead of the VsphereClient depending on DeploymentClient.
 	*DeploymentClient
 }
 
-func NewMachineActuator(machineClient client.MachineInterface, namedMachinePath string) (*VsphereClient, error) {
+func NewMachineActuator(machineClient client.MachineInterface, eventRecorder record.EventRecorder, namedMachinePath string) (*VsphereClient, error) {
 	scheme, codecFactory, err := vsphereconfigv1.NewSchemeAndCodecs()
 	if err != nil {
 		return nil, err
@@ -91,6 +97,7 @@ func NewMachineActuator(machineClient client.MachineInterface, namedMachinePath 
 		codecFactory:      codecFactory,
 		machineClient:     machineClient,
 		namedMachineWatch: nmWatch,
+		eventRecorder:     eventRecorder,
 		DeploymentClient:  NewDeploymentClient(),
 	}, nil
 }
@@ -101,7 +108,7 @@ func saveFile(contents, path string, perm os.FileMode) error {
 
 // Stage the machine for running terraform.
 // Return: machine's staging dir path, error
-func (vc *VsphereClient) prepareStageMachineDir(machine *clusterv1.Machine) (string, error) {
+func (vc *VsphereClient) prepareStageMachineDir(machine *clusterv1.Machine, eventAction string) (string, error) {
 	err := vc.cleanUpStagingDir(machine)
 	if err != nil {
 		return "", err
@@ -111,7 +118,7 @@ func (vc *VsphereClient) prepareStageMachineDir(machine *clusterv1.Machine) (str
 	config, err := vc.machineproviderconfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return "", vc.handleMachineError(machine, apierrors.InvalidMachineConfiguration(
-			"Cannot unmarshal providerConfig field: %v", err))
+			"Cannot unmarshal providerConfig field: %v", err), eventAction)
 	}
 
 	machinePath := fmt.Sprintf(MachinePathStageFormat, machineName)
@@ -201,7 +208,7 @@ func (vc *VsphereClient) saveStartupScript(cluster *clusterv1.Cluster, machine *
 	if util.IsMaster(machine) {
 		if machine.Spec.Versions.ControlPlane == "" {
 			return "", vc.handleMachineError(machine, apierrors.InvalidMachineConfiguration(
-				"invalid master configuration: missing Machine.Spec.Versions.ControlPlane"))
+				"invalid master configuration: missing Machine.Spec.Versions.ControlPlane"), createEventAction)
 		}
 		var err error
 		startupScript, err = getMasterStartupScript(
@@ -250,7 +257,7 @@ func (vc *VsphereClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.M
 	config, err := vc.machineproviderconfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return vc.handleMachineError(machine, apierrors.InvalidMachineConfiguration(
-			"Cannot unmarshal providerConfig field: %v", err))
+			"Cannot unmarshal providerConfig field: %v", err), createEventAction)
 	}
 
 	clusterConfig, err := vc.clusterproviderconfig(cluster.Spec.ProviderConfig)
@@ -259,14 +266,14 @@ func (vc *VsphereClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.M
 	}
 
 	if verr := vc.validateMachine(machine, config); verr != nil {
-		return vc.handleMachineError(machine, verr)
+		return vc.handleMachineError(machine, verr, createEventAction)
 	}
 
 	if verr := vc.validateCluster(cluster); verr != nil {
 		return verr
 	}
 
-	machinePath, err := vc.prepareStageMachineDir(machine)
+	machinePath, err := vc.prepareStageMachineDir(machine, createEventAction)
 	if err != nil {
 		return errors.New(fmt.Sprintf("error while staging machine: %+v", err))
 	}
@@ -321,6 +328,7 @@ func (vc *VsphereClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.M
 		// Annotate the machine so that we remember exactly what VM we created for it.
 		tfState, _ := vc.GetTfState(machine)
 		vc.cleanUpStagingDir(machine)
+		vc.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Created", "Created Machine %v", machine.Name)
 		return vc.updateAnnotations(machine, vmIp, tfState)
 	} else {
 		glog.Infof("Skipped creating a VM for machine %s that already exists.", machine.ObjectMeta.Name)
@@ -399,7 +407,7 @@ func (vc *VsphereClient) Delete(cluster *clusterv1.Cluster, machine *clusterv1.M
 		return err
 	}
 
-	machinePath, err := vc.prepareStageMachineDir(machine)
+	machinePath, err := vc.prepareStageMachineDir(machine, deleteEventAction)
 
 	// destroy it
 	args := []string{
@@ -424,6 +432,10 @@ func (vc *VsphereClient) Delete(cluster *clusterv1.Cluster, machine *clusterv1.M
 	machine.ObjectMeta.Annotations[StatusMachineTerraformState] = ""
 	machine.ObjectMeta.Finalizers = util.Filter(machine.ObjectMeta.Finalizers, clusterv1.MachineFinalizer)
 	_, err = vc.machineClient.Update(machine)
+
+	if err == nil {
+		vc.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Killing", "Killing machine %v", machine.Name)
+	}
 
 	return err
 }
@@ -729,13 +741,16 @@ func getKubeadmToken() (string, error) {
 // the appropriate reason/message on the Machine.Status. If not, such as during
 // cluster installation, it will operate as a no-op. It also returns the
 // original error for convenience, so callers can do "return handleMachineError(...)".
-func (vc *VsphereClient) handleMachineError(machine *clusterv1.Machine, err *apierrors.MachineError) error {
+func (vc *VsphereClient) handleMachineError(machine *clusterv1.Machine, err *apierrors.MachineError, eventAction string) error {
 	if vc.machineClient != nil {
 		reason := err.Reason
 		message := err.Message
 		machine.Status.ErrorReason = &reason
 		machine.Status.ErrorMessage = &message
 		vc.machineClient.UpdateStatus(machine)
+	}
+	if eventAction != "" {
+		vc.eventRecorder.Eventf(machine, corev1.EventTypeWarning, "Failed"+eventAction, "%v", err.Reason)
 	}
 
 	glog.Errorf("Machine error: %v", err.Message)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR emits events in the vsphere-machine-controller. This will emit events for successful creations, failed creations, successful deletions and failed deletions of machine obejcts on vsphere.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of fix for #364 