### PR TITLE
Protect against initialization race and switch ETCD images

### DIFF
--- a/clusterctl/clusterdeployer/clusterapiservertemplate.go
+++ b/clusterctl/clusterdeployer/clusterapiservertemplate.go
@@ -169,8 +169,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: etcd
-        image: quay.io/coreos/etcd:latest
-        imagePullPolicy: Always
+        image: k8s.gcr.io/etcd:3.1.12
         resources:
           requests:
             cpu: 100m

--- a/clusterctl/clusterdeployer/clusterclient.go
+++ b/clusterctl/clusterdeployer/clusterclient.go
@@ -22,6 +22,9 @@ import (
 	"os/exec"
 
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/golang/glog"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,8 +32,6 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 	"sigs.k8s.io/cluster-api/pkg/clientcmd"
 	"sigs.k8s.io/cluster-api/pkg/util"
-	"strings"
-	"time"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
Make `clusterclt create cluster` more resilient to a startup race condition.

**Which issue(s) this PR fixes**:
Fixes #385 
