### PR TITLE
Bump gce-controller image version to 0.0.15

### DIFF
--- a/cloud/google/cmd/gce-controller/Makefile
+++ b/cloud/google/cmd/gce-controller/Makefile
@@ -18,7 +18,7 @@ GCR_BUCKET = k8s-cluster-api
 PREFIX = gcr.io/$(GCR_BUCKET)
 DEV_PREFIX ?= gcr.io/$(shell gcloud config get-value project)
 NAME = gce-controller
-TAG = 0.0.14
+TAG = 0.0.15
 
 image:
 	docker build -t "$(PREFIX)/$(NAME):$(TAG)" -f ./Dockerfile ../../../..

--- a/cloud/google/pods.go
+++ b/cloud/google/pods.go
@@ -34,7 +34,7 @@ import (
 
 var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.5"
 var controllerManagerImage = "gcr.io/k8s-cluster-api/controller-manager:0.0.6"
-var machineControllerImage = "gcr.io/k8s-cluster-api/gce-controller:0.0.14"
+var machineControllerImage = "gcr.io/k8s-cluster-api/gce-controller:0.0.15"
 
 func init() {
 	if img, ok := os.LookupEnv("MACHINE_CONTROLLER_IMAGE"); ok {

--- a/clusterctl/examples/google/provider-components.yaml.template
+++ b/clusterctl/examples/google/provider-components.yaml.template
@@ -44,7 +44,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: gce-machine-controller
-        image: gcr.io/k8s-cluster-api/gce-controller:0.0.14
+        image: gcr.io/k8s-cluster-api/gce-controller:0.0.15
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes
@@ -79,7 +79,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: gce-cluster-controller
-        image: gcr.io/k8s-cluster-api/gce-controller:0.0.14
+        image: gcr.io/k8s-cluster-api/gce-controller:0.0.15
         volumeMounts:
           - name: config
             mountPath: /etc/kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to bump the image version to gain all the latest changes to the controllers. The primary motivation is to pick up the changes in PR https://github.com/kubernetes-sigs/cluster-api/pull/378.

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
