### PR TITLE
Move from (f *File).WriteString(...) to ioutil.WriteFile(...) to Fix a bug where WriteString fails because the file is closed before writing.

### DIFF
--- a/clusterctl/clusterdeployer/clusterclient.go
+++ b/clusterctl/clusterdeployer/clusterclient.go
@@ -260,7 +260,7 @@ func createTempFile(contents string) (string, error) {
 	if err = f.Close(); err != nil {
 		return "", err
 	}
-	_, err = f.WriteString(contents)
+	err = ioutil.WriteFile(f.Name(), []byte(contents), 0644)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
In a previous commit in PR https://github.com/kubernetes-sigs/cluster-api/pull/390 we started closing the file in createTempFile after having it returned to ensure that the os.Remove(...) would not result in error due to an open file handle. This caused WriteString to start failing.

**What this PR does / why we need it**:
Without this PR `clusterctl create cluster` consistently fails. For some reason in my testing of PR https://github.com/kubernetes-sigs/cluster-api/pull/390 I did not see this issue. I think I likely didn't build clusterctl correctly (another reason why we need unit tests for this file!)

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
