### PR TITLE
Fix an issue where cluster actuator was incorrectly using the kubernetes errors library to determine if an GCE error should be classified as NotFound.

### DIFF
--- a/cloud/google/clients/errors/errors.go
+++ b/cloud/google/clients/errors/errors.go
@@ -1,0 +1,15 @@
+package errors
+
+import (
+	"net/http"
+	"google.golang.org/api/googleapi"
+)
+
+// IsNotFound reports whether err is the result of the server replying with http.StatusNotFound.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	ae, ok := err.(*googleapi.Error)
+	return ok && ae.Code == http.StatusNotFound
+}

--- a/cloud/google/clusteractuator.go
+++ b/cloud/google/clusteractuator.go
@@ -23,10 +23,10 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 	"sigs.k8s.io/cluster-api/cloud/google/clients"
+	"sigs.k8s.io/cluster-api/cloud/google/clients/errors"
 	gceconfigv1 "sigs.k8s.io/cluster-api/cloud/google/gceproviderconfig/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (

--- a/cloud/google/clusteractuator_test.go
+++ b/cloud/google/clusteractuator_test.go
@@ -17,15 +17,12 @@ limitations under the License.
 package google_test
 
 import (
-	"fmt"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/cluster-api/cloud/google"
 	"sigs.k8s.io/cluster-api/pkg/controller/cluster"
-	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
-
 	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 )
 
 func TestDelete(t *testing.T) {
@@ -36,8 +33,8 @@ func TestDelete(t *testing.T) {
 		expectedErrorMessage    string
 	}{
 		{"successs", &compute.Operation{}, nil, ""},
-		{"error", nil, fmt.Errorf("random error"), "error deleting firewall rule for internal cluster traffic: error deleting firewall rule: random error"},
-		{"404/NotFound error should succeed", nil, errors.NewNotFound(v1alpha1.Resource("cluster"), "404 not found"), ""},
+		{"error", nil, &googleapi.Error{Code: 408, Message: "request timeout"}, "error deleting firewall rule for internal cluster traffic: error deleting firewall rule: googleapi: Error 408: request timeout"},
+		{"404/NotFound error should succeed", nil, &googleapi.Error{Code: 404, Message: "not found"}, ""},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
In PR https://github.com/kubernetes-sigs/cluster-api/pull/378 a change was made to ignore NotFound errors. Something went wrong with my manual testing and therefore I believed it worked, however, it was actually using a Kubernetes library to classify the error even though it was coming from GCP. This PR fixes the issue by adding a new convinience method for determining if an error is an HTTP 404 or not. NOte that there does not appear to be an existing utility function for doing this out of the google golang SDK.

I have manually tested this and verified that the cluster object can now be deleted. See the output of the command below, which successfully moved past the delete cluster step. That would only happen if the cluster object was actually deleted in the system. The mininkube error is not important and the command did work correctly:

```
$ clusterctl delete cluster
I0625 12:45:22.050782   13676 clusterdeployer.go:186] Creating external cluster
I0625 12:47:08.748623   13676 clusterdeployer.go:197] Applying Cluster API stack to external cluster
I0625 12:47:08.748663   13676 clusterdeployer.go:308] Applying Cluster API APIServer
I0625 12:47:47.665517   13676 clusterdeployer.go:314] Applying Cluster API Provider Components
I0625 12:47:47.918873   13676 clusterdeployer.go:203] Deleting Cluster API Provider Components from internal cluster
I0625 12:47:48.247069   13676 clusterdeployer.go:209] Copying objects from internal cluster to external cluster
I0625 12:47:48.397594   13676 clusterdeployer.go:412] Moved Cluster 'test1-yp5ey'
I0625 12:47:48.473161   13676 clusterdeployer.go:455] Moved Machine 'gce-master-ml96h'
I0625 12:47:48.488988   13676 clusterdeployer.go:455] Moved Machine 'gce-node-b2n8h'
I0625 12:47:48.489009   13676 clusterdeployer.go:215] Deleting objects from external cluster
I0625 12:47:48.489014   13676 clusterdeployer.go:462] Deleting machine deployments
I0625 12:47:48.502557   13676 clusterdeployer.go:468] Deleting machine sets
I0625 12:47:48.514049   13676 clusterdeployer.go:474] Deleting machines
I0625 12:48:48.557534   13676 clusterdeployer.go:481] Deleting clusters
I0625 12:48:58.576378   13676 clusterdeployer.go:220] Deletion of cluster complete
I0625 12:48:58.583456   13676 clusterdeployer.go:368] Cleaning up external cluster.
I0625 12:48:59.180937   13676 clusterdeployer.go:232] Cleaning up external cluster.
E0625 12:48:59.213947   13676 minikube.go:52] Deleting local Kubernetes cluster...
Errors occurred deleting machine:  Error deleting host: minikube: Error loading host from store: Docker machine "minikube" does not exist. Use "docker-machine ls" to list machines. Use "docker-machine create" to add a new one.
```

**Release note**:
```release-note
NONE
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
