### PR TITLE
GCE Cluster Controller Events

### DIFF
--- a/cloud/google/clusteractuator.go
+++ b/cloud/google/clusteractuator.go
@@ -22,28 +22,38 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+
 	"sigs.k8s.io/cluster-api/cloud/google/clients"
 	"sigs.k8s.io/cluster-api/cloud/google/clients/errors"
 	gceconfigv1 "sigs.k8s.io/cluster-api/cloud/google/gceproviderconfig/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
+	apierrors "sigs.k8s.io/cluster-api/pkg/errors"
 )
 
 const (
 	firewallRuleAnnotationPrefix = "gce.clusterapi.k8s.io/firewall"
 	firewallRuleInternalSuffix   = "-allow-cluster-internal"
 	firewallRuleApiSuffix        = "-allow-api-public"
+
+	createClusterEventAction = "Create"
+	deleteClusterEventAction = "Delete"
 )
 
 type GCEClusterClient struct {
 	computeService         GCEClientComputeService
 	clusterClient          client.ClusterInterface
 	gceProviderConfigCodec *gceconfigv1.GCEProviderConfigCodec
+	eventRecorder          record.EventRecorder
 }
 
 type ClusterActuatorParams struct {
 	ComputeService GCEClientComputeService
 	ClusterClient  client.ClusterInterface
+	EventRecorder  record.EventRecorder
 }
 
 func NewClusterActuator(params ClusterActuatorParams) (*GCEClusterClient, error) {
@@ -60,12 +70,39 @@ func NewClusterActuator(params ClusterActuatorParams) (*GCEClusterClient, error)
 		computeService:         computeService,
 		clusterClient:          params.ClusterClient,
 		gceProviderConfigCodec: codec,
+		eventRecorder:          params.EventRecorder,
 	}, nil
 }
 
 func (gce *GCEClusterClient) Reconcile(cluster *clusterv1.Cluster) error {
 	glog.Infof("Reconciling cluster %v.", cluster.Name)
-	err := gce.createFirewallRuleIfNotExists(cluster, &compute.Firewall{
+	created := gce.createClusterIfNeeded(cluster)
+	if created {
+		gce.eventRecorder.Eventf(cluster, corev1.EventTypeNormal, "Created", "Created Cluster %v", cluster.Name)
+	}
+	return nil
+}
+
+func (gce *GCEClusterClient) Delete(cluster *clusterv1.Cluster) error {
+	err := gce.deleteFirewallRule(cluster, cluster.Name+firewallRuleInternalSuffix)
+	if err != nil {
+		gce.fireErrorEvent(cluster, err, deleteClusterEventAction)
+		return gce.handleError(cluster, apierrors.DeleteCluster("Error deleting firewall rule for internal cluster traffic: %v", err), deleteClusterEventAction)
+	}
+	if err := gce.deleteFirewallRule(cluster, cluster.Name+firewallRuleApiSuffix); err != nil {
+		gce.fireErrorEvent(cluster, err, deleteClusterEventAction)
+		return gce.handleError(cluster, apierrors.DeleteCluster("Error deleting firewall rule for core api server traffic: %v", err), deleteClusterEventAction)
+	}
+
+	gce.eventRecorder.Eventf(cluster, corev1.EventTypeNormal, "Deleted", "Deleted Cluster %v", cluster.Name)
+
+	return nil
+}
+
+// Creates cluster resources if they don't already exist. Returns true if any
+// resources were successfully created for this cluster.
+func (gce *GCEClusterClient) createClusterIfNeeded(cluster *clusterv1.Cluster) bool {
+	createdInternalRule, err := gce.createFirewallRuleIfNotExists(cluster, &compute.Firewall{
 		Name:    cluster.Name + firewallRuleInternalSuffix,
 		Network: "global/networks/default",
 		Allowed: []*compute.FirewallAllowed{
@@ -77,9 +114,10 @@ func (gce *GCEClusterClient) Reconcile(cluster *clusterv1.Cluster) error {
 		SourceTags: []string{cluster.Name + "-worker"},
 	})
 	if err != nil {
+		gce.fireErrorEvent(cluster, err, createClusterEventAction)
 		glog.Warningf("Error creating firewall rule for internal cluster traffic: %v", err)
 	}
-	err = gce.createFirewallRuleIfNotExists(cluster, &compute.Firewall{
+	createdApiRule, err := gce.createFirewallRuleIfNotExists(cluster, &compute.Firewall{
 		Name:    cluster.Name + firewallRuleApiSuffix,
 		Network: "global/networks/default",
 		Allowed: []*compute.FirewallAllowed{
@@ -92,22 +130,11 @@ func (gce *GCEClusterClient) Reconcile(cluster *clusterv1.Cluster) error {
 		SourceRanges: []string{"0.0.0.0/0"},
 	})
 	if err != nil {
+		gce.fireErrorEvent(cluster, err, createClusterEventAction)
 		glog.Warningf("Error creating firewall rule for core api server traffic: %v", err)
 	}
-	return nil
-}
 
-func (gce *GCEClusterClient) Delete(cluster *clusterv1.Cluster) error {
-	err := gce.deleteFirewallRule(cluster, cluster.Name+firewallRuleInternalSuffix)
-	if err != nil {
-		return fmt.Errorf("error deleting firewall rule for internal cluster traffic: %v", err)
-	}
-	err = gce.deleteFirewallRule(cluster, cluster.Name+firewallRuleApiSuffix)
-	if err != nil {
-		return fmt.Errorf("error deleting firewall rule for core api server traffic: %v", err)
-	}
-
-	return nil
+	return createdInternalRule || createdApiRule
 }
 
 func getOrNewComputeServiceForCluster(params ClusterActuatorParams) (GCEClientComputeService, error) {
@@ -125,29 +152,30 @@ func getOrNewComputeServiceForCluster(params ClusterActuatorParams) (GCEClientCo
 	return computeService, nil
 }
 
-func (gce *GCEClusterClient) createFirewallRuleIfNotExists(cluster *clusterv1.Cluster, firewallRule *compute.Firewall) error {
-	ruleExists, ok := cluster.ObjectMeta.Annotations[firewallRuleAnnotationPrefix+firewallRule.Name]
-	if ok && ruleExists == "true" {
+func (gce *GCEClusterClient) createFirewallRuleIfNotExists(cluster *clusterv1.Cluster, firewallRule *compute.Firewall) (bool, error) {
+	ruleExistsAnnotation, ok := cluster.ObjectMeta.Annotations[firewallRuleAnnotationPrefix+firewallRule.Name]
+	if ok && ruleExistsAnnotation == "true" {
 		// The firewall rule was already created.
-		return nil
+		return false, nil
 	}
 	clusterConfig, err := gce.clusterproviderconfig(cluster.Spec.ProviderConfig)
 	if err != nil {
-		return fmt.Errorf("error parsing cluster provider config: %v", err)
+		return false, gce.handleError(cluster, apierrors.InvalidClusterConfiguration("Error parsing cluster provider config: %v", err), createClusterEventAction)
 	}
 	firewallRules, err := gce.computeService.FirewallsGet(clusterConfig.Project)
 	if err != nil {
-		return fmt.Errorf("error getting firewall rules: %v", err)
+		return false, gce.handleError(cluster, apierrors.CreateCluster("Error getting firewall rules: %v", err), createClusterEventAction)
 	}
 
-	if !gce.containsFirewallRule(firewallRules, firewallRule.Name) {
+	gceContainsRule := gce.containsFirewallRule(firewallRules, firewallRule.Name)
+	if !gceContainsRule {
 		op, err := gce.computeService.FirewallsInsert(clusterConfig.Project, firewallRule)
 		if err != nil {
-			return fmt.Errorf("error creating firewall rule: %v", err)
+			return false, gce.handleError(cluster, apierrors.CreateCluster("Error creating firewall rule: %v", err), createClusterEventAction)
 		}
 		err = gce.computeService.WaitForOperation(clusterConfig.Project, op)
 		if err != nil {
-			return fmt.Errorf("error waiting for firewall rule creation: %v", err)
+			return false, gce.handleError(cluster, apierrors.CreateCluster("Error waiting for firewall rule creation: %v", err), createClusterEventAction)
 		}
 	}
 	// TODO (mkjelland) move this to a GCEClusterProviderStatus #347
@@ -159,7 +187,7 @@ func (gce *GCEClusterClient) createFirewallRuleIfNotExists(cluster *clusterv1.Cl
 	if err != nil {
 		fmt.Errorf("error updating cluster annotations %v", err)
 	}
-	return nil
+	return !gceContainsRule, nil
 }
 
 func (gce *GCEClusterClient) containsFirewallRule(firewallRules *compute.FirewallList, ruleName string) bool {
@@ -184,6 +212,23 @@ func (gce *GCEClusterClient) deleteFirewallRule(cluster *clusterv1.Cluster, rule
 		return fmt.Errorf("error deleting firewall rule: %v", err)
 	}
 	return gce.computeService.WaitForOperation(clusterConfig.Project, op)
+}
+
+func (gce *GCEClusterClient) handleError(cluster *clusterv1.Cluster, err *apierrors.ClusterError, eventAction string) error {
+	if gce.clusterClient != nil {
+		cluster.Status.ErrorReason = err.Reason
+		cluster.Status.ErrorMessage = err.Message
+		if _, clusterError := gce.clusterClient.UpdateStatus(cluster); clusterError != nil {
+			glog.Warningf("Error updating Cluster Status ErrorReason and Error Message: %v", clusterError)
+		}
+	}
+
+	glog.Errorf("Cluster error: %v", err.Message)
+	return err
+}
+
+func (gce *GCEClusterClient) fireErrorEvent(cluster *clusterv1.Cluster, err error, eventAction string) {
+	gce.eventRecorder.Eventf(cluster, corev1.EventTypeWarning, "Failed"+eventAction, "%v", err)
 }
 
 func (gce *GCEClusterClient) clusterproviderconfig(providerConfig clusterv1.ProviderConfig) (*gceconfigv1.GCEClusterProviderConfig, error) {

--- a/cloud/google/cmd/gce-controller/cluster-controller-app/controller.go
+++ b/cloud/google/cmd/gce-controller/cluster-controller-app/controller.go
@@ -44,7 +44,7 @@ const (
 	gceClusterControllerName = "gce-cluster-controller"
 )
 
-func StartClusterController(server *options.ClusterControllerServer, shutdown <-chan struct{}) {
+func StartClusterController(server *options.ClusterControllerServer, eventRecorder record.EventRecorder, shutdown <-chan struct{}) {
 	config, err := controller.GetConfig(server.CommonConfig.Kubeconfig)
 	if err != nil {
 		glog.Fatalf("Could not create Config for talking to the apiserver: %v", err)
@@ -56,7 +56,8 @@ func StartClusterController(server *options.ClusterControllerServer, shutdown <-
 	}
 
 	params := google.ClusterActuatorParams{
-		ClusterClient: client.ClusterV1alpha1().Clusters(corev1.NamespaceDefault),
+		ClusterClient:  client.ClusterV1alpha1().Clusters(corev1.NamespaceDefault),
+		EventRecorder:  eventRecorder,
 	}
 	actuator, err := google.NewClusterActuator(params)
 	if err != nil {
@@ -97,7 +98,7 @@ func RunClusterController(server *options.ClusterControllerServer) error {
 
 	// run function will block and never return.
 	run := func(stop <-chan struct{}) {
-		StartClusterController(server, stop)
+		StartClusterController(server, recorder, stop)
 	}
 
 	leaderElectConfig := config.GetLeaderElectionConfig()

--- a/cloud/google/machineactuator.go
+++ b/cloud/google/machineactuator.go
@@ -65,9 +65,9 @@ const (
 )
 
 const (
-	createEventAction = "Create"
-	deleteEventAction = "Delete"
-	noEventAction     = ""
+	createMachineEventAction = "Create"
+	deleteMachineEventAction = "Delete"
+	noMachineEventAction     = ""
 )
 
 type SshCreds struct {
@@ -211,16 +211,16 @@ func (gce *GCEClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 	machineConfig, err := gce.machineproviderconfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return gce.handleMachineError(machine, apierrors.InvalidMachineConfiguration(
-			"Cannot unmarshal machine's providerConfig field: %v", err), createEventAction)
+			"Cannot unmarshal machine's providerConfig field: %v", err), createMachineEventAction)
 	}
 	clusterConfig, err := gce.gceProviderConfigCodec.ClusterProviderFromProviderConfig(cluster.Spec.ProviderConfig)
 	if err != nil {
 		return gce.handleMachineError(machine, apierrors.InvalidMachineConfiguration(
-			"Cannot unmarshal cluster's providerConfig field: %v", err), createEventAction)
+			"Cannot unmarshal cluster's providerConfig field: %v", err), createMachineEventAction)
 	}
 
 	if verr := gce.validateMachine(machine, machineConfig); verr != nil {
-		return gce.handleMachineError(machine, verr, createEventAction)
+		return gce.handleMachineError(machine, verr, createMachineEventAction)
 	}
 
 	configParams := &machinesetup.ConfigParams{
@@ -296,7 +296,7 @@ func (gce *GCEClient) Create(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 
 		if err != nil {
 			return gce.handleMachineError(machine, apierrors.CreateMachine(
-				"error creating GCE instance: %v", err), createEventAction)
+				"error creating GCE instance: %v", err), createMachineEventAction)
 		}
 
 		gce.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Created", "Created Machine %v", machine.Name)
@@ -326,17 +326,17 @@ func (gce *GCEClient) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 	machineConfig, err := gce.machineproviderconfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return gce.handleMachineError(machine,
-			apierrors.InvalidMachineConfiguration("Cannot unmarshal machine's providerConfig field: %v", err), deleteEventAction)
+			apierrors.InvalidMachineConfiguration("Cannot unmarshal machine's providerConfig field: %v", err), deleteMachineEventAction)
 	}
 
 	clusterConfig, err := gce.gceProviderConfigCodec.ClusterProviderFromProviderConfig(cluster.Spec.ProviderConfig)
 	if err != nil {
 		return gce.handleMachineError(machine,
-			apierrors.InvalidMachineConfiguration("Cannot unmarshal cluster's providerConfig field: %v", err), deleteEventAction)
+			apierrors.InvalidMachineConfiguration("Cannot unmarshal cluster's providerConfig field: %v", err), deleteMachineEventAction)
 	}
 
 	if verr := gce.validateMachine(machine, machineConfig); verr != nil {
-		return gce.handleMachineError(machine, verr, deleteEventAction)
+		return gce.handleMachineError(machine, verr, deleteMachineEventAction)
 	}
 
 	var project, zone, name string
@@ -360,7 +360,7 @@ func (gce *GCEClient) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 	}
 	if err != nil {
 		return gce.handleMachineError(machine, apierrors.DeleteMachine(
-			"error deleting GCE instance: %v", err), deleteEventAction)
+			"error deleting GCE instance: %v", err), deleteMachineEventAction)
 	}
 
 	gce.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Deleted", "Deleted Machine %v", name)
@@ -412,10 +412,10 @@ func (gce *GCEClient) Update(cluster *clusterv1.Cluster, goalMachine *clusterv1.
 	goalConfig, err := gce.machineproviderconfig(goalMachine.Spec.ProviderConfig)
 	if err != nil {
 		return gce.handleMachineError(goalMachine,
-			apierrors.InvalidMachineConfiguration("Cannot unmarshal machine's providerConfig field: %v", err), noEventAction)
+			apierrors.InvalidMachineConfiguration("Cannot unmarshal machine's providerConfig field: %v", err), noMachineEventAction)
 	}
 	if verr := gce.validateMachine(goalMachine, goalConfig); verr != nil {
-		return gce.handleMachineError(goalMachine, verr, noEventAction)
+		return gce.handleMachineError(goalMachine, verr, noMachineEventAction)
 	}
 
 	status, err := gce.instanceStatus(goalMachine)
@@ -440,7 +440,7 @@ func (gce *GCEClient) Update(cluster *clusterv1.Cluster, goalMachine *clusterv1.
 	currentConfig, err := gce.machineproviderconfig(currentMachine.Spec.ProviderConfig)
 	if err != nil {
 		return gce.handleMachineError(currentMachine, apierrors.InvalidMachineConfiguration(
-			"Cannot unmarshal machine's providerConfig field: %v", err), noEventAction)
+			"Cannot unmarshal machine's providerConfig field: %v", err), noMachineEventAction)
 	}
 
 	if !gce.requiresUpdate(currentMachine, goalMachine) {
@@ -541,14 +541,14 @@ func (gce *GCEClient) updateAnnotations(cluster *clusterv1.Cluster, machine *clu
 	zone := machineConfig.Zone
 	if err != nil {
 		return gce.handleMachineError(machine,
-			apierrors.InvalidMachineConfiguration("Cannot unmarshal machine's providerConfig field: %v", err), noEventAction)
+			apierrors.InvalidMachineConfiguration("Cannot unmarshal machine's providerConfig field: %v", err), noMachineEventAction)
 	}
 
 	clusterConfig, err := gce.gceProviderConfigCodec.ClusterProviderFromProviderConfig(cluster.Spec.ProviderConfig)
 	project := clusterConfig.Project
 	if err != nil {
 		return gce.handleMachineError(machine,
-			apierrors.InvalidMachineConfiguration("Cannot unmarshal cluster's providerConfig field: %v", err), noEventAction)
+			apierrors.InvalidMachineConfiguration("Cannot unmarshal cluster's providerConfig field: %v", err), noMachineEventAction)
 	}
 
 	if machine.ObjectMeta.Annotations == nil {
@@ -685,7 +685,7 @@ func (gce *GCEClient) handleMachineError(machine *clusterv1.Machine, err *apierr
 		gce.v1Alpha1Client.Machines(machine.Namespace).UpdateStatus(machine)
 	}
 
-	if eventAction != noEventAction {
+	if eventAction != noMachineEventAction {
 		gce.eventRecorder.Eventf(machine, corev1.EventTypeWarning, "Failed"+eventAction, "%v", err.Reason)
 	}
 
@@ -802,7 +802,7 @@ func (gce *GCEClient) getMetadata(cluster *clusterv1.Cluster, machine *clusterv1
 	if isMaster(configParams.Roles) {
 		if machine.Spec.Versions.ControlPlane == "" {
 			return nil, gce.handleMachineError(machine, apierrors.InvalidMachineConfiguration(
-				"invalid master configuration: missing Machine.Spec.Versions.ControlPlane"), createEventAction)
+				"invalid master configuration: missing Machine.Spec.Versions.ControlPlane"), createMachineEventAction)
 		}
 		var err error
 		metadataMap, err = masterMetadata(cluster, machine, clusterConfig.Project, &machineSetupMetadata)

--- a/pkg/errors/clusters.go
+++ b/pkg/errors/clusters.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+
+	commonerrors "sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
+)
+
+// A more descriptive kind of error that represents an error condition that
+// should be set in the Cluster.Status. The "Reason" field is meant for short,
+// enum-style constants meant to be interpreted by clusters. The "Message"
+// field is meant to be read by humans.
+type ClusterError struct {
+	Reason  commonerrors.ClusterStatusError
+	Message string
+}
+
+func (e *ClusterError) Error() string {
+	return e.Message
+}
+
+// Some error builders for ease of use. They set the appropriate "Reason"
+// value, and all arguments are Printf-style varargs fed into Sprintf to
+// construct the Message.
+
+func InvalidClusterConfiguration(format string, args ...interface{}) *ClusterError {
+	return &ClusterError{
+		Reason:  commonerrors.InvalidConfigurationClusterError,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+func CreateCluster(format string, args ...interface{}) *ClusterError {
+	return &ClusterError{
+		Reason:  commonerrors.CreateClusterError,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+func DeleteCluster(format string, args ...interface{}) *ClusterError {
+	return &ClusterError{
+		Reason:  commonerrors.DeleteClusterError,
+		Message: fmt.Sprintf(format, args...),
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Emit events in the cluster actuator for GCE. This will emit a creation event if any resources are created in the reconcile method. If delete finishes, a delete event will fire. In the case that something fails in either the reconcile or delete methods, a Warning event will fire, and the resource status of the cluster object will be updated with information about the failure.

**Which issue(s) this PR fixes**:
Part of fix for #364
