### PR TITLE
Add service account user on master node service account

### DIFF
--- a/clusterctl/examples/google/generate-yaml.sh
+++ b/clusterctl/examples/google/generate-yaml.sh
@@ -147,6 +147,7 @@ gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$
 gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$MASTER_SA_EMAIL --role=roles/compute.networkAdmin
 gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$MASTER_SA_EMAIL --role=roles/compute.securityAdmin
 gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$MASTER_SA_EMAIL --role=roles/compute.viewer
+gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$MASTER_SA_EMAIL --role=roles/iam.serviceAccountUser
 gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$MASTER_SA_EMAIL --role=roles/storage.admin
 gcloud projects add-iam-policy-binding $GCLOUD_PROJECT --member=serviceAccount:$MASTER_SA_EMAIL --role=roles/storage.objectViewer
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The core controller manager on the master needs the iam.serviceAccountUser role in order to attach persistent disks to pods. It was added programmatically in the gcp-deployer, but got lost in the move to clusterctl.