### PR TITLE
Make addons.yaml optional input

### DIFF
--- a/cloud/vsphere/machineactuator.go
+++ b/cloud/vsphere/machineactuator.go
@@ -767,14 +767,6 @@ func getSubnet(netRange clusterv1.NetworkRanges) string {
 	return netRange.CIDRBlocks[0]
 }
 
-// TODO: We need to change this when we create dedicated service account for apiserver/controller
-// pod.
-func CreateExtApiServerRoleBinding() error {
-	return run("kubectl", "create", "rolebinding",
-		"-n", "kube-system", "machine-controller", "--role=extension-apiserver-authentication-reader",
-		"--serviceaccount=default:default")
-}
-
 func run(cmd string, args ...string) error {
 	c := exec.Command(cmd, args...)
 	if out, err := c.CombinedOutput(); err != nil {

--- a/clusterctl/cmd/create_cluster.go
+++ b/clusterctl/cmd/create_cluster.go
@@ -59,9 +59,6 @@ var createClusterCmd = &cobra.Command{
 		if co.ProviderComponents == "" {
 			exitWithHelp(cmd, "Please provide yaml file for provider component definition.")
 		}
-		if co.AddonComponents == "" {
-			exitWithHelp(cmd, "Please provide yaml file for addon component definition.")
-		}
 		if err := RunCreate(co); err != nil {
 			glog.Exit(err)
 		}
@@ -87,9 +84,12 @@ func RunCreate(co *CreateOptions) error {
 	if err != nil {
 		return fmt.Errorf("error loading provider components file '%v': %v", co.ProviderComponents, err)
 	}
-	ac, err := ioutil.ReadFile(co.AddonComponents)
-	if err != nil {
-		return fmt.Errorf("error loading addons file '%v': %v", co.AddonComponents, err)
+	var ac []byte
+	if co.AddonComponents != "" {
+		ac, err = ioutil.ReadFile(co.AddonComponents)
+		if err != nil {
+			return fmt.Errorf("error loading addons file '%v': %v", co.AddonComponents, err)
+		}
 	}
 	pcsFactory := clusterdeployer.NewProviderComponentsStoreFactory()
 	d := clusterdeployer.New(
@@ -108,11 +108,11 @@ func init() {
 	createClusterCmd.Flags().StringVarP(&co.Cluster, "cluster", "c", "", "A yaml file containing cluster object definition")
 	createClusterCmd.Flags().StringVarP(&co.Machine, "machines", "m", "", "A yaml file containing machine object definition(s)")
 	createClusterCmd.Flags().StringVarP(&co.ProviderComponents, "provider-components", "p", "", "A yaml file containing cluster api provider controllers and supporting objects")
-	createClusterCmd.Flags().StringVarP(&co.AddonComponents, "addon-components", "a", "", "A yaml file containing cluster addons to apply to the internal cluster")
 	// TODO: Remove as soon as code allows https://github.com/kubernetes-sigs/cluster-api/issues/157
 	createClusterCmd.Flags().StringVarP(&co.Provider, "provider", "", "", "Which provider deployment logic to use (google/vsphere/azure)")
 
 	// Optional flags
+	createClusterCmd.Flags().StringVarP(&co.AddonComponents, "addon-components", "a", "", "A yaml file containing cluster addons to apply to the internal cluster")
 	createClusterCmd.Flags().BoolVarP(&co.CleanupExternalCluster, "cleanup-external-cluster", "", true, "Whether to cleanup the external cluster after bootstrap")
 	createClusterCmd.Flags().StringVarP(&co.VmDriver, "vm-driver", "", "", "Which vm driver to use for minikube")
 	createClusterCmd.Flags().StringVarP(&co.KubeconfigOutput, "kubeconfig-out", "", "kubeconfig", "Where to output the kubeconfig for the provisioned cluster")

--- a/clusterctl/examples/vsphere/README.md
+++ b/clusterctl/examples/vsphere/README.md
@@ -19,6 +19,9 @@ manually edit `machineVariables`. If needed, adjust `replicas` as well.
 4. Copy `cluster.yaml.template` to `cluster.yaml` and
 manually edit `providerConfig`.
 
+5. *Optional*: Copy `addons.yaml.template` to `addons.yaml` and
++manually edit `parameters`.
+
 ## Manual Modification
 You may always manually curate files based on the examples provided.
 

--- a/clusterctl/examples/vsphere/generate-yaml.sh
+++ b/clusterctl/examples/vsphere/generate-yaml.sh
@@ -79,4 +79,4 @@ cat $PROVIDERCOMPONENT_TEMPLATE_FILE \
   > $PROVIDERCOMPONENT_GENERATED_FILE
 
 echo "Done generating $PROVIDERCOMPONENT_GENERATED_FILE"
-echo "You will still need to generate the cluster.yaml,  machines.yaml, and addons.yaml configuration files"
+echo "You will still need to generate the cluster.yaml,  machines.yaml, and addons.yaml (if needed) configuration files"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

1. The addons.yaml file is not currently required. Making this a required flag is thus too restrictive.
2. Make some constants package-local.
3. Remove some dead code

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
