### PR TITLE
Remove machine role from the MachineSpec in the Cluster API

### DIFF
--- a/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/cluster-api/clusterctl/clusterdeployer"
-	clustercommon "sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
@@ -582,7 +581,7 @@ func TestDeleteBasicScenarios(t *testing.T) {
 func generateMachines() []*clusterv1.Machine {
 	master := &clusterv1.Machine{}
 	master.Name = "test-master"
-	master.Spec.Roles = []clustercommon.MachineRole{clustercommon.MasterRole}
+	master.Spec.Versions.ControlPlane = "1.10.1"
 	node := &clusterv1.Machine{}
 	node.Name = "test.Node"
 	return []*clusterv1.Machine{master, node}

--- a/pkg/apis/cluster/common/consts.go
+++ b/pkg/apis/cluster/common/consts.go
@@ -85,32 +85,6 @@ const (
 	DeleteClusterError ClusterStatusError = "DeleteError"
 )
 
-// The MachineRole indicates the purpose of the Machine, and will determine
-// what software and configuration will be used when provisioning and managing
-// the Machine. A single Machine may have more than one role, and the list and
-// definitions of supported roles is expected to evolve over time.
-//
-// Currently, only two roles are supported: Master and Node. In the future, we
-// expect user needs to drive the evolution and granularity of these roles,
-// with new additions accommodating common cluster patterns, like dedicated
-// etcd Machines.
-//
-//                 +-----------------------+------------------------+
-//                 | Master present        | Master absent          |
-// +---------------+-----------------------+------------------------|
-// | Node present: | Install control plane | Join the cluster as    |
-// |               | and be schedulable    | just a node            |
-// |---------------+-----------------------+------------------------|
-// | Node absent:  | Install control plane | Invalid configuration  |
-// |               | and be unscheduleable |                        |
-// +---------------+-----------------------+------------------------+
-type MachineRole string
-
-const (
-	MasterRole MachineRole = "Master"
-	NodeRole   MachineRole = "Node"
-)
-
 type MachineSetStatusError string
 
 const (

--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -65,9 +65,6 @@ type MachineSpec struct {
 	// +optional
 	ProviderConfig ProviderConfig `json:"providerConfig"`
 
-	// A list of roles for this Machine to use.
-	Roles []clustercommon.MachineRole `json:"roles,omitempty"`
-
 	// Versions of key software to use. This field is optional at cluster
 	// creation time, and omitting the field indicates that the cluster
 	// installation tool should select defaults for the user. These

--- a/pkg/apis/cluster/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.conversion.go
@@ -740,7 +740,6 @@ func autoConvert_v1alpha1_MachineSpec_To_cluster_MachineSpec(in *MachineSpec, ou
 	if err := Convert_v1alpha1_ProviderConfig_To_cluster_ProviderConfig(&in.ProviderConfig, &out.ProviderConfig, s); err != nil {
 		return err
 	}
-	out.Roles = *(*[]common.MachineRole)(unsafe.Pointer(&in.Roles))
 	if err := Convert_v1alpha1_MachineVersionInfo_To_cluster_MachineVersionInfo(&in.Versions, &out.Versions, s); err != nil {
 		return err
 	}
@@ -759,7 +758,6 @@ func autoConvert_cluster_MachineSpec_To_v1alpha1_MachineSpec(in *cluster.Machine
 	if err := Convert_cluster_ProviderConfig_To_v1alpha1_ProviderConfig(&in.ProviderConfig, &out.ProviderConfig, s); err != nil {
 		return err
 	}
-	out.Roles = *(*[]common.MachineRole)(unsafe.Pointer(&in.Roles))
 	if err := Convert_cluster_MachineVersionInfo_To_v1alpha1_MachineVersionInfo(&in.Versions, &out.Versions, s); err != nil {
 		return err
 	}

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -556,11 +556,6 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		}
 	}
 	in.ProviderConfig.DeepCopyInto(&out.ProviderConfig)
-	if in.Roles != nil {
-		in, out := &in.Roles, &out.Roles
-		*out = make([]common.MachineRole, len(*in))
-		copy(*out, *in)
-	}
 	out.Versions = in.Versions
 	if in.ConfigSource != nil {
 		in, out := &in.ConfigSource, &out.ConfigSource

--- a/pkg/apis/cluster/zz_generated.api.register.go
+++ b/pkg/apis/cluster/zz_generated.api.register.go
@@ -118,77 +118,11 @@ func Resource(resource string) schema.GroupResource {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-type Machine struct {
-	metav1.TypeMeta
-	metav1.ObjectMeta
-	Spec   MachineSpec
-	Status MachineStatus
-}
-
-// +genclient
-// +genclient
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
 type Cluster struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
 	Spec   ClusterSpec
 	Status ClusterStatus
-}
-
-type MachineStatus struct {
-	NodeRef        *corev1.ObjectReference
-	LastUpdated    metav1.Time
-	Versions       *MachineVersionInfo
-	ErrorReason    *clustercommon.MachineStatusError
-	ErrorMessage   *string
-	ProviderStatus *pkgruntime.RawExtension
-	Addresses      []corev1.NodeAddress
-}
-
-type ClusterStatus struct {
-	APIEndpoints   []APIEndpoint
-	ErrorReason    clustercommon.ClusterStatusError
-	ErrorMessage   string
-	ProviderStatus *pkgruntime.RawExtension
-}
-
-type MachineVersionInfo struct {
-	Kubelet      string
-	ControlPlane string
-}
-
-type APIEndpoint struct {
-	Host string
-	Port int
-}
-
-type ClusterSpec struct {
-	ClusterNetwork ClusterNetworkingConfig
-	ProviderConfig ProviderConfig
-}
-
-type MachineSpec struct {
-	metav1.ObjectMeta
-	Taints         []corev1.Taint
-	ProviderConfig ProviderConfig
-	Roles          []clustercommon.MachineRole
-	Versions       MachineVersionInfo
-	ConfigSource   *corev1.NodeConfigSource
-}
-
-type ProviderConfig struct {
-	Value     *pkgruntime.RawExtension
-	ValueFrom *ProviderConfigSource
-}
-
-type ProviderConfigSource struct {
-}
-
-type ClusterNetworkingConfig struct {
-	Services      NetworkRanges
-	Pods          NetworkRanges
-	ServiceDomain string
 }
 
 // +genclient
@@ -202,8 +136,11 @@ type MachineSet struct {
 	Status MachineSetStatus
 }
 
-type NetworkRanges struct {
-	CIDRBlocks []string
+type ClusterStatus struct {
+	APIEndpoints   []APIEndpoint
+	ErrorReason    clustercommon.ClusterStatusError
+	ErrorMessage   string
+	ProviderStatus *pkgruntime.RawExtension
 }
 
 type MachineSetStatus struct {
@@ -216,6 +153,11 @@ type MachineSetStatus struct {
 	ErrorMessage         *string
 }
 
+type APIEndpoint struct {
+	Host string
+	Port int
+}
+
 type MachineSetSpec struct {
 	Replicas        *int32
 	MinReadySeconds int32
@@ -223,9 +165,41 @@ type MachineSetSpec struct {
 	Template        MachineTemplateSpec
 }
 
+type ClusterSpec struct {
+	ClusterNetwork ClusterNetworkingConfig
+	ProviderConfig ProviderConfig
+}
+
 type MachineTemplateSpec struct {
 	metav1.ObjectMeta
 	Spec MachineSpec
+}
+
+type ProviderConfig struct {
+	Value     *pkgruntime.RawExtension
+	ValueFrom *ProviderConfigSource
+}
+
+type MachineSpec struct {
+	metav1.ObjectMeta
+	Taints         []corev1.Taint
+	ProviderConfig ProviderConfig
+	Versions       MachineVersionInfo
+	ConfigSource   *corev1.NodeConfigSource
+}
+
+type ProviderConfigSource struct {
+}
+
+type MachineVersionInfo struct {
+	Kubelet      string
+	ControlPlane string
+}
+
+type ClusterNetworkingConfig struct {
+	Services      NetworkRanges
+	Pods          NetworkRanges
+	ServiceDomain string
 }
 
 // +genclient
@@ -237,6 +211,10 @@ type MachineDeployment struct {
 	metav1.ObjectMeta
 	Spec   MachineDeploymentSpec
 	Status MachineDeploymentStatus
+}
+
+type NetworkRanges struct {
+	CIDRBlocks []string
 }
 
 type MachineDeploymentStatus struct {
@@ -267,6 +245,27 @@ type MachineDeploymentStrategy struct {
 type MachineRollingUpdateDeployment struct {
 	MaxUnavailable *utilintstr.IntOrString
 	MaxSurge       *utilintstr.IntOrString
+}
+
+// +genclient
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+type Machine struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	Spec   MachineSpec
+	Status MachineStatus
+}
+
+type MachineStatus struct {
+	NodeRef        *corev1.ObjectReference
+	LastUpdated    metav1.Time
+	Versions       *MachineVersionInfo
+	ErrorReason    *clustercommon.MachineStatusError
+	ErrorMessage   *string
+	ProviderStatus *pkgruntime.RawExtension
+	Addresses      []corev1.NodeAddress
 }
 
 //

--- a/pkg/apis/cluster/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/zz_generated.deepcopy.go
@@ -556,11 +556,6 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		}
 	}
 	in.ProviderConfig.DeepCopyInto(&out.ProviderConfig)
-	if in.Roles != nil {
-		in, out := &in.Roles, &out.Roles
-		*out = make([]common.MachineRole, len(*in))
-		copy(*out, *in)
-	}
 	out.Versions = in.Versions
 	if in.ConfigSource != nil {
 		in, out := &in.ConfigSource, &out.ConfigSource

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,7 +29,6 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clustercommon "sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
 )
@@ -115,17 +114,9 @@ func GetMachineIfExists(machineClient client.MachineInterface, name string) (*cl
 	return machine, nil
 }
 
-func RoleContains(a clustercommon.MachineRole, list []clustercommon.MachineRole) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
-}
-
+// TODO(robertbailey): Remove this function
 func IsMaster(machine *clusterv1.Machine) bool {
-	return RoleContains(clustercommon.MasterRole, machine.Spec.Roles)
+	return machine.Spec.Versions.ControlPlane != ""
 }
 
 func IsNodeReady(node *v1.Node) bool {

--- a/sample/machinedeployment.yaml
+++ b/sample/machinedeployment.yaml
@@ -24,8 +24,3 @@ spec:
           os: "ubuntu-1604-lts"
       versions:
         kubelet: 1.9.4
-        containerRuntime:
-          name: docker
-          version: 1.12.0
-      roles:
-      - Node

--- a/sample/machineset.yaml
+++ b/sample/machineset.yaml
@@ -23,5 +23,3 @@ spec:
           os: "ubuntu-1604-lts"
       versions:
         kubelet: 1.9.4
-      roles:
-      - Node

--- a/tools/upgrader/util/upgrade.go
+++ b/tools/upgrader/util/upgrade.go
@@ -95,7 +95,7 @@ func UpgradeCluster(kubeversion string, kubeconfig string) error {
 
 	glog.Info("Upgrading the control plane.")
 
-	// Update the control plan first. It assumes single master.
+	// Update the control plane first. It assumes single master.
 	var master *clusterv1.Machine = nil
 	for _, mach := range machine_list.Items {
 		if util.IsMaster(&mach) {


### PR DESCRIPTION
**What this PR does / why we need it**: As discussed in the [June 13th WG meeting](https://docs.google.com/document/d/16ils69KImmE94RlmzjWDrkmFZysgB2J4lGnYMRN89WM/edit#heading=h.xil9madvokmo) this change demotes the MachineRole from the MachineSpec in the cluster API. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #338

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
**Breaking API Change**: MachineSpec no longer includes MachineRoles
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
