### PR TITLE
Include links to known implementations of Cluster API provisioners.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,16 @@ To learn more, see the [Cluster API KEP][cluster-api-kep].
 * Join our Cluster API working group sessions
   * Weekly on Wednesdays @ 10:00 PT on [Zoom][zoomMeeting]
   * Previous meetings: \[ [notes][notes] | [recordings][recordings] \]
+
 * Chat with us on [Slack](http://slack.k8s.io/): #cluster-api
+
+* Pointers to repositories and PRs where some Cluster API provisioners are being
+  developed.
+  * AWS/Openshift, https://github.com/openshift/cluster-operator
+  * Azure, https://github.com/platform9/azure-provider
+  * GCE, https://github.com/kubernetes-sigs/cluster-api/tree/master/cloud/google
+  * VSphere, https://github.com/kubernetes-sigs/cluster-api/tree/master/cloud/vsphere
+  * OpenStack, https://github.com/kubernetes-sigs/cluster-api/pull/176
 
 ## Getting Started
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To learn more, see the [Cluster API KEP][cluster-api-kep].
   * Azure, https://github.com/platform9/azure-provider
   * GCE, https://github.com/kubernetes-sigs/cluster-api/tree/master/cloud/google
   * VSphere, https://github.com/kubernetes-sigs/cluster-api/tree/master/cloud/vsphere
-  * OpenStack, https://github.com/kubernetes-sigs/cluster-api/pull/176
+  * OpenStack, https://github.com/kubernetes-sigs/cluster-api-provider-openstack
 
 ## Getting Started
 ### Prerequisites


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed during the weekly cluster-api-wg meeting, there are multiple Cluster API provisioners in various stages of development. In order to provide a common rallying point for shared development efforts, we are working on creating sig-lifecycle sponsored repositories. This README update is to document those efforts until we have shared and/or well-known repositories.

**Which issue(s) this PR fixes**:
Related to  https://github.com/kubernetes-sigs/cluster-api/issues/383

**Special notes for your reviewer**:
NONE

**Release note**:
NONE

@kubernetes/kube-deploy-reviewers
