### PR TITLE
Fix boilerplate

### DIFF
--- a/cloud/google/clients/errors/errors.go
+++ b/cloud/google/clients/errors/errors.go
@@ -1,7 +1,24 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package errors
 
 import (
 	"net/http"
+
 	"google.golang.org/api/googleapi"
 )
 


### PR DESCRIPTION
**Release note**:
```release-note
None
```

<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
