### PR TITLE
Align controller actuator interface with machine actuator

### DIFF
--- a/pkg/controller/cluster/actuator.go
+++ b/pkg/controller/cluster/actuator.go
@@ -23,8 +23,12 @@ import (
 // Actuator controls clusters on a specific infrastructure. All
 // methods should be idempotent unless otherwise specified.
 type Actuator interface {
-	// Create or update the cluster
-	Reconcile(*clusterv1.Cluster) error
+	// Create the cluster
+	Create(*clusterv1.Cluster) error
 	// Delete the cluster.
 	Delete(*clusterv1.Cluster) error
+	// Update the cluster
+	Update(*clusterv1.Cluster) error
+	// Checks if the cluster currently exists
+	Exists(*clusterv1.Cluster) (bool, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the Machine Actuator and Cluster Actuator interfaces differ in the handling of the informer provided object and also with the methods exposed by the interface. This PR aligns the Cluster Actuator interface and informer provided object handling to match that of the Machine Actuator.

Changes:
- Provide the cluster actuator methods with a deep copy of the informer provided cluster object rather than the informer provided object directly.
  - This reduces error prone handling of the informer provided object in the cluster actuator
  - This also matches the current behavior of the machine controller
- Update the Cluster Actuator Interface to expose Create, Delete, Update, and Exists methods instead of Reconcile and Delete.
  - This allows for a user writing a cluster actuator to more easily differentiate and manage creates/updates, especially when creating numerous cluster resources in the cluster. 


**Which issue(s) this PR fixes**format, will close the issue(s) when PR gets merged)*:
Fixes #420, fixes #421

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- The Cluster Actuator Interface has been updated to expose Create, Delete, Update, and Exists methods as opposed to Reconcile and Update.
- The Cluster Actuator is now passed a deep copy of the informer-provided cluster object instead of the informer-provided cluster object directly.
```
<!-- All reviews default to cc'ing the kube-deploy-reviewers github group. -->
@kubernetes/kube-deploy-reviewers
