### PR TITLE
Make a deep copy of cluster prior to calling actuator

### DIFF
--- a/pkg/controller/cluster/reconcile_test.go
+++ b/pkg/controller/cluster/reconcile_test.go
@@ -108,7 +108,14 @@ func TestClusterSetControllerReconcileHandler(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			finalizerRemoved := clusterUpdated && !util.Contains(clusterToTest.ObjectMeta.Finalizers, v1alpha1.ClusterFinalizer)
+			finalizerRemoved := false
+			if clusterUpdated {
+				updatedCluster, err := fakeClient.ClusterV1alpha1().Clusters(clusterToTest.Namespace).Get(clusterToTest.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("failed to get updated cluster.")
+				}
+				finalizerRemoved = !util.Contains(updatedCluster.ObjectMeta.Finalizers, v1alpha1.ClusterFinalizer)
+			}
 
 			if finalizerRemoved != test.expectFinalizerRemoved {
 				t.Errorf("Got finalizer removed %v, expected finalizer removed %v", finalizerRemoved, test.expectFinalizerRemoved)


### PR DESCRIPTION
What this PR does / why we need it:

Currently the Machine Controller and Custer Controller differ in the handling of the informer provided object that they pass into the Actuators. This PR aligns the Cluster Controller handling of the informer provided object to match that of the Machine Controller.

Changes:

- Provide the cluster actuator methods with a deep copy of the informer provided cluster object rather than the informer provided object directly.
  - This reduces error prone handling of the informer provided object in the cluster actuator
  - This also matches the current behavior of the machine controller

Which issue(s) this PR fixes:
Fixes #420

Release note:

```
- The Cluster Actuator is now passed a deep copy of the informer-provided cluster object instead of the informer-provided cluster object directly.
```

@kubernetes/kube-deploy-reviewers