### PR TITLE
provider/vSphere: Fixed case for vSphere in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To learn more, see the [Cluster API KEP][cluster-api-kep].
   * AWS/Openshift, https://github.com/openshift/cluster-operator
   * Azure, https://github.com/platform9/azure-provider
   * GCE, https://github.com/kubernetes-sigs/cluster-api/tree/master/cloud/google
-  * VSphere, https://github.com/kubernetes-sigs/cluster-api/tree/master/cloud/vsphere
+  * vSphere, https://github.com/kubernetes-sigs/cluster-api/tree/master/cloud/vsphere
   * OpenStack, https://github.com/kubernetes-sigs/cluster-api-provider-openstack
 
 ## Getting Started


### PR DESCRIPTION
This patch fixes the case for "VSphere" in the README file. The case has been corrected to "vSphere."