### PR TITLE
Update docs to record `etcd` requirement for all unit tests to pass

### DIFF
--- a/clusterctl/CONTRIBUTING.md
+++ b/clusterctl/CONTRIBUTING.md
@@ -25,3 +25,21 @@ You should run all the tests in the repository. To run the tests, run the follow
 ```shell
 ./scripts/ci-test.sh
 ```
+
+To get all the tests to pass, it is required that you have `etcd` installed in your development environment. Specifically,
+the `TestMachineSet` tests will fail if you don't have `etcd` installed and the failure will look like this
+
+``` 
+=== RUN   TestMachineSet
+[::]:58989
+[::]:58990
+[::]:58991
+panic: exec: "etcd": executable file not found in $PATH
+
+goroutine 131 [running]:
+sigs.k8s.io/cluster-api/vendor/github.com/kubernetes-incubator/apiserver-builder/pkg/test.(*TestEnvironment).startEtcd(0xc420704000, 0xc4206c8de0)
+.
+.
+.
+FAIL	sigs.k8s.io/cluster-api/pkg/controller/machineset	0.077s
+```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR improves developer getting started documentation.

For all the unit tests in the repo to pass there is a dependency on `etcd` being present in the PATH in the development environment.  If `etcd` isn't available in the PATH, then this unit test will fail
```
=== RUN   TestMachineSet
[::]:58989
[::]:58990
[::]:58991
panic: exec: "etcd": executable file not found in $PATH

goroutine 131 [running]:
sigs.k8s.io/cluster-api/vendor/github.com/kubernetes-incubator/apiserver-builder/pkg/test.(*TestEnvironment).startEtcd(0xc420704000, 0xc4206c8de0)
```
Refer https://github.com/kubernetes-sigs/cluster-api/pull/439#issuecomment-407877159

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
https://github.com/kubernetes-sigs/cluster-api/pull/439#issuecomment-407877159

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
