### PR TITLE
clusterctl - Allow for disabling pivoting of cluster

### DIFF
--- a/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -239,6 +239,7 @@ func TestCreate(t *testing.T) {
 		bootstrapClient          *testClusterClient
 		targetClient             *testClusterClient
 		cleanupExternal          bool
+		pivotCluster             bool
 		expectErr                bool
 		expectExternalExists     bool
 		expectExternalCreated    bool
@@ -250,6 +251,7 @@ func TestCreate(t *testing.T) {
 			targetClient:             &testClusterClient{},
 			bootstrapClient:          &testClusterClient{},
 			cleanupExternal:          true,
+			pivotCluster:             true,
 			expectExternalExists:     false,
 			expectExternalCreated:    true,
 			expectedInternalClusters: 1,
@@ -260,6 +262,7 @@ func TestCreate(t *testing.T) {
 			targetClient:             &testClusterClient{},
 			bootstrapClient:          &testClusterClient{},
 			cleanupExternal:          false,
+			pivotCluster:             true,
 			expectExternalExists:     true,
 			expectExternalCreated:    true,
 			expectedInternalClusters: 1,
@@ -277,6 +280,7 @@ func TestCreate(t *testing.T) {
 			targetClient:            &testClusterClient{},
 			bootstrapClient:         &testClusterClient{},
 			cleanupExternal:         true,
+			pivotCluster:            true,
 			expectExternalCreated:   true,
 			factoryClusterClientErr: fmt.Errorf("Test failure"),
 			expectErr:               true,
@@ -286,6 +290,7 @@ func TestCreate(t *testing.T) {
 			targetClient:          &testClusterClient{},
 			bootstrapClient:       &testClusterClient{ApplyErr: fmt.Errorf("Test failure")},
 			cleanupExternal:       true,
+			pivotCluster:          true,
 			expectExternalCreated: true,
 			expectErr:             true,
 		},
@@ -294,6 +299,7 @@ func TestCreate(t *testing.T) {
 			targetClient:          &testClusterClient{},
 			bootstrapClient:       &testClusterClient{WaitForClusterV1alpha1ReadyErr: fmt.Errorf("Test failure")},
 			cleanupExternal:       true,
+			pivotCluster:          true,
 			expectExternalCreated: true,
 			expectErr:             true,
 		},
@@ -302,6 +308,7 @@ func TestCreate(t *testing.T) {
 			targetClient:          &testClusterClient{},
 			bootstrapClient:       &testClusterClient{GetClusterObjectsErr: fmt.Errorf("Test failure")},
 			cleanupExternal:       true,
+			pivotCluster:          true,
 			expectExternalCreated: true,
 			expectErr:             true,
 		},
@@ -310,6 +317,7 @@ func TestCreate(t *testing.T) {
 			targetClient:          &testClusterClient{},
 			bootstrapClient:       &testClusterClient{GetMachineObjectsErr: fmt.Errorf("Test failure")},
 			cleanupExternal:       true,
+			pivotCluster:          true,
 			expectExternalCreated: true,
 			expectErr:             true,
 		},
@@ -318,6 +326,7 @@ func TestCreate(t *testing.T) {
 			targetClient:          &testClusterClient{},
 			bootstrapClient:       &testClusterClient{CreateClusterObjectErr: fmt.Errorf("Test failure")},
 			cleanupExternal:       true,
+			pivotCluster:          true,
 			expectExternalCreated: true,
 			expectErr:             true,
 		},
@@ -326,6 +335,7 @@ func TestCreate(t *testing.T) {
 			targetClient:          &testClusterClient{},
 			bootstrapClient:       &testClusterClient{CreateMachineObjectsErr: fmt.Errorf("Test failure")},
 			cleanupExternal:       true,
+			pivotCluster:          true,
 			expectExternalCreated: true,
 			expectErr:             true,
 		},
@@ -334,6 +344,7 @@ func TestCreate(t *testing.T) {
 			targetClient:          &testClusterClient{},
 			bootstrapClient:       &testClusterClient{UpdateClusterObjectEndpointErr: fmt.Errorf("Test failure")},
 			cleanupExternal:       true,
+			pivotCluster:          true,
 			expectExternalCreated: true,
 			expectErr:             true,
 		},
@@ -342,6 +353,7 @@ func TestCreate(t *testing.T) {
 			targetClient:          &testClusterClient{ApplyErr: fmt.Errorf("Test failure")},
 			bootstrapClient:       &testClusterClient{},
 			cleanupExternal:       true,
+			pivotCluster:          true,
 			expectExternalCreated: true,
 			expectErr:             true,
 		},
@@ -350,6 +362,7 @@ func TestCreate(t *testing.T) {
 			targetClient:          &testClusterClient{WaitForClusterV1alpha1ReadyErr: fmt.Errorf("Test failure")},
 			bootstrapClient:       &testClusterClient{},
 			cleanupExternal:       true,
+			pivotCluster:          true,
 			expectExternalCreated: true,
 			expectErr:             true,
 		},
@@ -358,6 +371,7 @@ func TestCreate(t *testing.T) {
 			targetClient:          &testClusterClient{CreateClusterObjectErr: fmt.Errorf("Test failure")},
 			bootstrapClient:       &testClusterClient{},
 			cleanupExternal:       true,
+			pivotCluster:          true,
 			expectExternalCreated: true,
 			expectErr:             true,
 		},
@@ -366,6 +380,7 @@ func TestCreate(t *testing.T) {
 			targetClient:             &testClusterClient{CreateMachineObjectsErr: fmt.Errorf("Test failure")},
 			bootstrapClient:          &testClusterClient{},
 			cleanupExternal:          true,
+			pivotCluster:             true,
 			expectExternalCreated:    true,
 			expectedInternalClusters: 1,
 			expectErr:                true,
@@ -375,6 +390,7 @@ func TestCreate(t *testing.T) {
 			targetClient:             &testClusterClient{UpdateClusterObjectEndpointErr: fmt.Errorf("Test failure")},
 			bootstrapClient:          &testClusterClient{},
 			cleanupExternal:          true,
+			pivotCluster:             true,
 			expectExternalCreated:    true,
 			expectedInternalClusters: 1,
 			expectedInternalMachines: 1,
@@ -404,7 +420,7 @@ func TestCreate(t *testing.T) {
 			inputMachines := generateMachines()
 			pcStore := mockProviderComponentsStore{}
 			pcFactory := mockProviderComponentsStoreFactory{NewFromCoreclientsetPCStore: &pcStore}
-			d := New(p, f, "", "", testcase.cleanupExternal)
+			d := New(p, f, "", "", testcase.cleanupExternal, testcase.pivotCluster)
 			err := d.Create(inputCluster, inputMachines, pd, kubeconfigOut, &pcFactory)
 
 			// Validate
@@ -447,7 +463,7 @@ func TestCreateProviderComponentsScenarios(t *testing.T) {
 		expectedError string
 	}{
 		{"success", mockProviderComponentsStore{SaveErr: nil}, ""},
-		{"error when saving", mockProviderComponentsStore{SaveErr: fmt.Errorf("pcstore save error")}, "unable to save provider components to target cluster: error saving provider components: pcstore save error"},
+		{"error when saving", mockProviderComponentsStore{SaveErr: fmt.Errorf("pcstore save error")}, "unable to save provider components to provisioned cluster: error saving provider components: pcstore save error"},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -468,7 +484,7 @@ func TestCreateProviderComponentsScenarios(t *testing.T) {
 			pcFactory := mockProviderComponentsStoreFactory{NewFromCoreclientsetPCStore: &tc.pcStore}
 			providerComponentsYaml := "-yaml\ndefinition"
 			addonsYaml := "-yaml\ndefinition"
-			d := New(p, f, providerComponentsYaml, addonsYaml, false)
+			d := New(p, f, providerComponentsYaml, addonsYaml, false, true)
 			err := d.Create(inputCluster, inputMachines, pd, kubeconfigOut, &pcFactory)
 			if err == nil && tc.expectedError != "" {
 				t.Fatalf("error mismatch: got '%v', want '%v'", err, tc.expectedError)
@@ -574,7 +590,7 @@ func TestDeleteCleanupExternalCluster(t *testing.T) {
 			f := newTestClusterClientFactory()
 			f.clusterClients[bootstrapKubeconfig] = tc.bootstrapClient
 			f.clusterClients[targetKubeconfig] = tc.targetClient
-			d := New(p, f, "", "", tc.cleanupExternalCluster)
+			d := New(p, f, "", "", tc.cleanupExternalCluster, true)
 			err := d.Delete(tc.targetClient)
 			if err != nil || tc.expectedErrorMessage != "" {
 				if err == nil {
@@ -630,7 +646,7 @@ func TestDeleteBasicScenarios(t *testing.T) {
 			f.clusterClients[bootstrapKubeconfig] = tc.bootstrapClient
 			f.clusterClients[targetKubeconfig] = tc.targetClient
 			f.ClusterClientErr = tc.NewCoreClientsetErr
-			d := New(p, f, "", "", true)
+			d := New(p, f, "", "", true, true)
 			err := d.Delete(tc.targetClient)
 			if err != nil || tc.expectedErrorMessage != "" {
 				if err == nil {

--- a/clusterctl/cmd/create_cluster.go
+++ b/clusterctl/cmd/create_cluster.go
@@ -41,6 +41,7 @@ type CreateOptions struct {
 	Provider                      string
 	KubeconfigOutput              string
 	ExistingClusterKubeconfigPath string
+	NoPivotCluster                bool
 }
 
 var co = &CreateOptions{}
@@ -107,7 +108,8 @@ func RunCreate(co *CreateOptions) error {
 		clusterdeployer.NewClientFactory(),
 		string(pc),
 		string(ac),
-		co.CleanupBootstrapCluster)
+		co.CleanupBootstrapCluster,
+		!co.NoPivotCluster)
 	return d.Create(c, m, pd, co.KubeconfigOutput, pcsFactory)
 }
 
@@ -122,6 +124,7 @@ func init() {
 	// Optional flags
 	createClusterCmd.Flags().StringVarP(&co.AddonComponents, "addon-components", "a", "", "A yaml file containing cluster addons to apply to the internal cluster")
 	createClusterCmd.Flags().BoolVarP(&co.CleanupBootstrapCluster, "cleanup-bootstrap-cluster", "", true, "Whether to cleanup the bootstrap cluster after bootstrap")
+	createClusterCmd.Flags().BoolVarP(&co.NoPivotCluster, "no-pivot-cluster", "", false, "Whether skip pivoting the cluster-api to the provisioned cluster")
 	createClusterCmd.Flags().StringVarP(&co.VmDriver, "vm-driver", "", "", "Which vm driver to use for minikube")
 	createClusterCmd.Flags().StringVarP(&co.KubeconfigOutput, "kubeconfig-out", "", "kubeconfig", "Where to output the kubeconfig for the provisioned cluster")
 	createClusterCmd.Flags().StringVarP(&co.ExistingClusterKubeconfigPath, "existing-bootstrap-cluster-kubeconfig", "", "", "Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)")

--- a/clusterctl/cmd/delete_cluster.go
+++ b/clusterctl/cmd/delete_cluster.go
@@ -72,6 +72,7 @@ func RunDelete() error {
 		clusterdeployer.NewClientFactory(),
 		providerComponents,
 		"",
+		true,
 		true)
 	return deployer.Delete(clusterClient)
 }

--- a/clusterctl/testdata/create-cluster-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/create-cluster-no-args-invalid-flag.golden
@@ -10,6 +10,7 @@ Flags:
   -h, --help                                           help for cluster
       --kubeconfig-out string                          Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
   -m, --machines string                                A yaml file containing machine object definition(s)
+      --no-pivot-cluster                               Whether skip pivoting the cluster-api to the provisioned cluster
       --provider string                                Which provider deployment logic to use (google/vsphere/azure)
   -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects
       --vm-driver string                               Which vm driver to use for minikube

--- a/clusterctl/testdata/create-cluster-no-args.golden
+++ b/clusterctl/testdata/create-cluster-no-args.golden
@@ -12,6 +12,7 @@ Flags:
   -h, --help                                           help for cluster
       --kubeconfig-out string                          Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
   -m, --machines string                                A yaml file containing machine object definition(s)
+      --no-pivot-cluster                               Whether skip pivoting the cluster-api to the provisioned cluster
       --provider string                                Which provider deployment logic to use (google/vsphere/azure)
   -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects
       --vm-driver string                               Which vm driver to use for minikube

--- a/pkg/deployer/clusterapiserver.go
+++ b/pkg/deployer/clusterapiserver.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/util/cert/triple"
 )
 
-var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.5"
+var apiServerImage = "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.6"
 
 func init() {
 	if img, ok := os.LookupEnv("CLUSTER_API_SERVER_IMAGE"); ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add --no-pivot-cluster flag to disable pivoting of the cluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #450

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- clusterctl adds the --no-pivot-cluster flag to 'clusterctl create cluster' that allows for disabling pivoting of cluster-api components.
```
