### PR TITLE
Regen bazel rules when running make depend

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1012,6 +1012,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b950caa303849ce241ac0b88cecb340f1ba19f3bfca65fc036b235c044cbc4f2"
+  inputs-digest = "f1d5f276bba258a8c2aae2c96c74c973c218437d85705da103b38036e655d0d7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,14 @@ all: generate build images
 
 depend:
 	dep version || go get -u github.com/golang/dep/cmd/dep
+	dep ensure -v
+
+	# go libraries often ship BUILD and BUILD.bazel files, but they often don't work.
+	# We delete them and regenerate them
+	find vendor -name "BUILD" -delete
+	find vendor -name "BUILD.bazel" -delete
+
+	bazel run //:gazelle
 
 generate: genapi genconversion genclientset gendeepcopy
 

--- a/clusterctl/clusterdeployer/externalclusterprovisioner/BUILD.bazel
+++ b/clusterctl/clusterdeployer/externalclusterprovisioner/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["externalbootstrapcluster.go"],
+    importpath = "sigs.k8s.io/cluster-api/clusterctl/clusterdeployer/externalclusterprovisioner",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["externalbootstrapcluster_test.go"],
+    embed = [":go_default_library"],
+)

--- a/clusterctl/cmd/BUILD.bazel
+++ b/clusterctl/cmd/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//clusterctl/clusterdeployer:go_default_library",
+        "//clusterctl/clusterdeployer/externalclusterprovisioner:go_default_library",
         "//clusterctl/clusterdeployer/minikube:go_default_library",
         "//clusterctl/providercomponents:go_default_library",
         "//clusterctl/validation:go_default_library",

--- a/vendor/github.com/kubernetes-incubator/apiserver-builder/cmd/apiregister-gen/BUILD.bazel
+++ b/vendor/github.com/kubernetes-incubator/apiserver-builder/cmd/apiregister-gen/BUILD.bazel
@@ -17,6 +17,5 @@ go_library(
 go_binary(
     name = "apiregister-gen",
     embed = [":go_default_library"],
-    importpath = "github.com/kubernetes-incubator/apiserver-builder/cmd/apiregister-gen",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
**What this PR does / why we need it**: Without this change, running `dep ensure` causes a bunch of files to be marked for deletion. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: Makefile changes copied from https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/25. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @justinsb 