### PR TITLE
APIEndpoint to ClusterNetworkingConfig cluster-types

### DIFF
--- a/clusterctl/clusterdeployer/clusterclient.go
+++ b/clusterctl/clusterdeployer/clusterclient.go
@@ -271,11 +271,17 @@ func (c *clusterClient) UpdateClusterObjectEndpoint(masterIP string) error {
 		// TODO: Do not assume default namespace nor single cluster https://github.com/kubernetes-sigs/cluster-api/issues/252
 		return fmt.Errorf("More than the one expected cluster found %v", clusters)
 	}
+
 	cluster := clusters[0]
+	port := cluster.Spec.ClusterNetwork.APIEndpoint.Port
+	if port == 0 {
+		port = apiServerPort
+	}
+
 	cluster.Status.APIEndpoints = append(cluster.Status.APIEndpoints,
 		clusterv1.APIEndpoint{
 			Host: masterIP,
-			Port: apiServerPort,
+			Port: port,
 		})
 	_, err = c.clientSet.ClusterV1alpha1().Clusters(apiv1.NamespaceDefault).UpdateStatus(cluster)
 	return err

--- a/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -69,6 +69,9 @@ type ClusterNetworkingConfig struct {
 
 	// Domain name for services.
 	ServiceDomain string `json:"serviceDomain"`
+
+	// Defines endpoint of api server to use
+	APIEndpoint APIEndpoint `json:"apiEndpoint"`
 }
 
 // NetworkRanges represents ranges of network addresses.
@@ -104,10 +107,10 @@ type ClusterStatus struct {
 // APIEndpoint represents a reachable Kubernetes API endpoint.
 type APIEndpoint struct {
 	// The hostname on which the API server is serving.
-	Host string `json:"host"`
+	Host string `json:"host,omitempty"`
 
 	// The port on which the API server is serving.
-	Port int `json:"port"`
+	Port int `json:"port,omitempty"`
 }
 
 // Validate checks that an instance of Cluster is well formed

--- a/pkg/apis/cluster/zz_generated.api.register.go
+++ b/pkg/apis/cluster/zz_generated.api.register.go
@@ -118,11 +118,77 @@ func Resource(resource string) schema.GroupResource {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+type Machine struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	Spec   MachineSpec
+	Status MachineStatus
+}
+
+// +genclient
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type Cluster struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
 	Spec   ClusterSpec
 	Status ClusterStatus
+}
+
+type MachineStatus struct {
+	NodeRef        *corev1.ObjectReference
+	LastUpdated    metav1.Time
+	Versions       *MachineVersionInfo
+	ErrorReason    *clustercommon.MachineStatusError
+	ErrorMessage   *string
+	ProviderStatus *pkgruntime.RawExtension
+	Addresses      []corev1.NodeAddress
+}
+
+type ClusterStatus struct {
+	APIEndpoints   []APIEndpoint
+	ErrorReason    clustercommon.ClusterStatusError
+	ErrorMessage   string
+	ProviderStatus *pkgruntime.RawExtension
+}
+
+type MachineVersionInfo struct {
+	Kubelet      string
+	ControlPlane string
+}
+
+type APIEndpoint struct {
+	Host string
+	Port int
+}
+
+type ClusterSpec struct {
+	ClusterNetwork ClusterNetworkingConfig
+	ProviderConfig ProviderConfig
+}
+
+type MachineSpec struct {
+	metav1.ObjectMeta
+	Taints         []corev1.Taint
+	ProviderConfig ProviderConfig
+	Versions       MachineVersionInfo
+	ConfigSource   *corev1.NodeConfigSource
+}
+
+type ProviderConfig struct {
+	Value     *pkgruntime.RawExtension
+	ValueFrom *ProviderConfigSource
+}
+
+type ProviderConfigSource struct {
+}
+
+type ClusterNetworkingConfig struct {
+	Services      NetworkRanges
+	Pods          NetworkRanges
+	ServiceDomain string
+	APIEndpoint   APIEndpoint
 }
 
 // +genclient
@@ -136,13 +202,6 @@ type MachineSet struct {
 	Status MachineSetStatus
 }
 
-type ClusterStatus struct {
-	APIEndpoints   []APIEndpoint
-	ErrorReason    clustercommon.ClusterStatusError
-	ErrorMessage   string
-	ProviderStatus *pkgruntime.RawExtension
-}
-
 type MachineSetStatus struct {
 	Replicas             int32
 	FullyLabeledReplicas int32
@@ -153,11 +212,6 @@ type MachineSetStatus struct {
 	ErrorMessage         *string
 }
 
-type APIEndpoint struct {
-	Host string
-	Port int
-}
-
 type MachineSetSpec struct {
 	Replicas        *int32
 	MinReadySeconds int32
@@ -165,41 +219,13 @@ type MachineSetSpec struct {
 	Template        MachineTemplateSpec
 }
 
-type ClusterSpec struct {
-	ClusterNetwork ClusterNetworkingConfig
-	ProviderConfig ProviderConfig
+type NetworkRanges struct {
+	CIDRBlocks []string
 }
 
 type MachineTemplateSpec struct {
 	metav1.ObjectMeta
 	Spec MachineSpec
-}
-
-type ProviderConfig struct {
-	Value     *pkgruntime.RawExtension
-	ValueFrom *ProviderConfigSource
-}
-
-type MachineSpec struct {
-	metav1.ObjectMeta
-	Taints         []corev1.Taint
-	ProviderConfig ProviderConfig
-	Versions       MachineVersionInfo
-	ConfigSource   *corev1.NodeConfigSource
-}
-
-type ProviderConfigSource struct {
-}
-
-type MachineVersionInfo struct {
-	Kubelet      string
-	ControlPlane string
-}
-
-type ClusterNetworkingConfig struct {
-	Services      NetworkRanges
-	Pods          NetworkRanges
-	ServiceDomain string
 }
 
 // +genclient
@@ -213,19 +239,6 @@ type MachineDeployment struct {
 	Status MachineDeploymentStatus
 }
 
-type NetworkRanges struct {
-	CIDRBlocks []string
-}
-
-type MachineDeploymentStatus struct {
-	ObservedGeneration  int64
-	Replicas            int32
-	UpdatedReplicas     int32
-	ReadyReplicas       int32
-	AvailableReplicas   int32
-	UnavailableReplicas int32
-}
-
 type MachineDeploymentSpec struct {
 	Replicas                *int32
 	Selector                metav1.LabelSelector
@@ -237,6 +250,15 @@ type MachineDeploymentSpec struct {
 	ProgressDeadlineSeconds *int32
 }
 
+type MachineDeploymentStatus struct {
+	ObservedGeneration  int64
+	Replicas            int32
+	UpdatedReplicas     int32
+	ReadyReplicas       int32
+	AvailableReplicas   int32
+	UnavailableReplicas int32
+}
+
 type MachineDeploymentStrategy struct {
 	Type          clustercommon.MachineDeploymentStrategyType
 	RollingUpdate *MachineRollingUpdateDeployment
@@ -245,27 +267,6 @@ type MachineDeploymentStrategy struct {
 type MachineRollingUpdateDeployment struct {
 	MaxUnavailable *utilintstr.IntOrString
 	MaxSurge       *utilintstr.IntOrString
-}
-
-// +genclient
-// +genclient
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-type Machine struct {
-	metav1.TypeMeta
-	metav1.ObjectMeta
-	Spec   MachineSpec
-	Status MachineStatus
-}
-
-type MachineStatus struct {
-	NodeRef        *corev1.ObjectReference
-	LastUpdated    metav1.Time
-	Versions       *MachineVersionInfo
-	ErrorReason    *clustercommon.MachineStatusError
-	ErrorMessage   *string
-	ProviderStatus *pkgruntime.RawExtension
-	Addresses      []corev1.NodeAddress
 }
 
 //


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: clusterclient.go assumes that the port to be used to contact apiserver is 443, meanwhile the default value for kubeadm is 6443. Meaning that a user would have to manually configure on their script the 443 value, which may not be what they want. Here we allow the cluster-type to contain and APIEndpoint object under the clusternetwork configuration so that it can be passed to kubeadm or whatever provisioning tool of choice. 

The change will also keep us from making breaking changes to cluster-client, though It suspect that in the many clusters case some additional changes may be required (as of yet unknown). Currently without this change, most users who are unaware of the need to set kubeadm to bindPort 443 may not be able to have nodes join their cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
cluster-type change to allow APIEndpoint object under clusternetworkconfig. Should allow one to define what port to use and pass that to the kubernetes provisioning tool or fall back to the default 443.
```
