### PR TITLE
export getApiServerYaml

### DIFF
--- a/clusterctl/clusterdeployer/BUILD.bazel
+++ b/clusterctl/clusterdeployer/BUILD.bazel
@@ -4,8 +4,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "clientfactory.go",
-        "clusterapiserver.go",
-        "clusterapiservertemplate.go",
         "clusterclient.go",
         "clusterdeployer.go",
         "providercomponentsstorefactory.go",
@@ -17,14 +15,13 @@ go_library(
         "//pkg/apis/cluster/v1alpha1:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/clientcmd:go_default_library",
+        "//pkg/deployer:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
-        "//vendor/k8s.io/client-go/util/cert:go_default_library",
-        "//vendor/k8s.io/client-go/util/cert/triple:go_default_library",
     ],
 )
 

--- a/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/clusterctl/clusterdeployer/clusterdeployer.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/cluster-api/pkg/deployer"
 	"sigs.k8s.io/cluster-api/pkg/util"
 
 	"github.com/golang/glog"
@@ -346,7 +347,7 @@ func (d *ClusterDeployer) applyClusterAPIStackWithPivoting(client ClusterClient,
 }
 
 func (d *ClusterDeployer) applyClusterAPIApiserver(client ClusterClient) error {
-	yaml, err := getApiServerYaml()
+	yaml, err := deployer.GetApiServerYaml()
 	if err != nil {
 		return fmt.Errorf("unable to generate apiserver yaml: %v", err)
 	}

--- a/pkg/deployer/BUILD.bazel
+++ b/pkg/deployer/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "clusterapiserver.go",
+        "clusterapiservertemplate.go",
+    ],
+    importpath = "sigs.k8s.io/cluster-api/pkg/deployer",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert/triple:go_default_library",
+    ],
+)

--- a/pkg/deployer/clusterapiserver.go
+++ b/pkg/deployer/clusterapiserver.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clusterdeployer
+package deployer
 
 import (
 	"bytes"
@@ -73,7 +73,8 @@ func getApiServerCerts() (*caCertParams, error) {
 	return certParams, nil
 }
 
-func getApiServerYaml() (string, error) {
+// GetApiServerYaml returns the clusterapi-apiserver manifest used for deployment
+func GetApiServerYaml() (string, error) {
 	tmpl, err := template.New("config").Parse(ClusterAPIAPIServerConfigTemplate)
 	if err != nil {
 		return "", err

--- a/pkg/deployer/clusterapiservertemplate.go
+++ b/pkg/deployer/clusterapiservertemplate.go
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package clusterdeployer
+package deployer
 
+// ClusterAPIAPIServerConfigTemplate specifies the manifests for the clusterapi-apiserver
 const ClusterAPIAPIServerConfigTemplate = `
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is making the method getApiServerYaml exportable so it can be called by any tool to get the lastest clusterapi-apiserver manifest.  getApiServerYaml returns the manifest needed to install the clusterapi-apiserver.  This is used by clusterctl to deploy the clusterapi-apiserver.  There could be cases (CI/CD) where we don't want to use clusterctl to install the clusterapi-apiserver and provider components, but we want the commonly used manifest.

**Release note:**
```release-note
NONE
```
