### PR TITLE
Support cluster API objects in multiple namespaces

### DIFF
--- a/clusterctl/clusterdeployer/BUILD.bazel
+++ b/clusterctl/clusterdeployer/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/clusterctl/clusterdeployer/clusterclient.go
+++ b/clusterctl/clusterdeployer/clusterclient.go
@@ -171,8 +171,9 @@ func (c *clusterClient) GetClusterObjectsInNamespace(namespace string) ([]*clust
 	return clusters, nil
 }
 
+// Deprecated API. Please do not extend or use.
 func (c *clusterClient) GetClusterObjects() ([]*clusterv1.Cluster, error) {
-	// TODO: Iterate over all namespaces where we could have Cluster API Objects https://github.com/kubernetes-sigs/cluster-api/issues/252
+	glog.V(2).Info("GetClusterObjects API is deprecated, use GetClusterObjectsInNamespace instead")
 	return c.GetClusterObjectsInNamespace(apiv1.NamespaceDefault)
 }
 
@@ -188,8 +189,9 @@ func (c *clusterClient) GetMachineDeploymentObjectsInNamespace(namespace string)
 	return machineDeployments, nil
 }
 
+// Deprecated API. Please do not extend or use.
 func (c *clusterClient) GetMachineDeploymentObjects() ([]*clusterv1.MachineDeployment, error) {
-	// TODO: Iterate over all namespaces where we could have Cluster API Objects https://github.com/kubernetes-sigs/cluster-api/issues/252
+	glog.V(2).Info("GetMachineDeploymentObjects API is deprecated, use GetMachineDeploymentObjectsInNamespace instead")
 	return c.GetMachineDeploymentObjectsInNamespace(apiv1.NamespaceDefault)
 }
 
@@ -205,8 +207,9 @@ func (c *clusterClient) GetMachineSetObjectsInNamespace(namespace string) ([]*cl
 	return machineSets, nil
 }
 
+// Deprecated API. Please do not extend or use.
 func (c *clusterClient) GetMachineSetObjects() ([]*clusterv1.MachineSet, error) {
-	// TODO: Iterate over all namespaces where we could have Cluster API Objects https://github.com/kubernetes-sigs/cluster-api/issues/252
+	glog.V(2).Info("GetMachineSetObjects API is deprecated, use GetMachineSetObjectsInNamespace instead")
 	return c.GetMachineSetObjectsInNamespace(apiv1.NamespaceDefault)
 }
 
@@ -223,8 +226,9 @@ func (c *clusterClient) GetMachineObjectsInNamespace(namespace string) ([]*clust
 	return machines, nil
 }
 
+// Deprecated API. Please do not extend or use.
 func (c *clusterClient) GetMachineObjects() ([]*clusterv1.Machine, error) {
-	// TODO: Iterate over all namespaces where we could have Cluster API Objects https://github.com/kubernetes-sigs/cluster-api/issues/252
+	glog.V(2).Info("GetMachineObjects API is deprecated, use GetMachineObjectsInNamespace instead")
 	return c.GetMachineObjectsInNamespace(apiv1.NamespaceDefault)
 }
 
@@ -278,7 +282,9 @@ func (c *clusterClient) CreateMachineObjects(machines []*clusterv1.Machine, name
 	return nil
 }
 
+// Deprecated API. Please do not extend or use.
 func (c *clusterClient) DeleteClusterObjects() error {
+	glog.V(2).Info("DeleteClusterObjects API is deprecated, use DeleteClusterObjectsInNamespace instead")
 	return c.DeleteClusterObjectsInNamespace(apiv1.NamespaceDefault)
 }
 
@@ -294,7 +300,9 @@ func (c *clusterClient) DeleteClusterObjectsInNamespace(namespace string) error 
 	return nil
 }
 
+// Deprecated API. Please do not extend or use.
 func (c *clusterClient) DeleteMachineDeploymentObjects() error {
+	glog.V(2).Info("DeleteMachineDeploymentObjects API is deprecated, use DeleteMachineDeploymentObjectsInNamespace instead")
 	return c.DeleteMachineDeploymentObjectsInNamespace(apiv1.NamespaceDefault)
 }
 
@@ -310,7 +318,9 @@ func (c *clusterClient) DeleteMachineDeploymentObjectsInNamespace(namespace stri
 	return nil
 }
 
+// Deprecated API. Please do not extend or use.
 func (c *clusterClient) DeleteMachineSetObjects() error {
+	glog.V(2).Info("DeleteMachineSetObjects API is deprecated, use DeleteMachineSetObjectsInNamespace instead")
 	return c.DeleteMachineSetObjectsInNamespace(apiv1.NamespaceDefault)
 }
 
@@ -326,7 +336,9 @@ func (c *clusterClient) DeleteMachineSetObjectsInNamespace(namespace string) err
 	return nil
 }
 
+// Deprecated API. Please do not extend or use.
 func (c *clusterClient) DeleteMachineObjects() error {
+	glog.V(2).Info("DeleteMachineObjects API is deprecated, use DeleteMachineObjectsInNamespace instead")
 	return c.DeleteMachineObjectsInNamespace(apiv1.NamespaceDefault)
 }
 

--- a/clusterctl/clusterdeployer/clusterclient.go
+++ b/clusterctl/clusterdeployer/clusterclient.go
@@ -93,6 +93,9 @@ func (c *clusterClient) EnsureNamespace(namespaceName string) error {
 }
 
 func (c *clusterClient) DeleteNamespace(namespaceName string) error {
+	if namespaceName == apiv1.NamespaceDefault {
+		return nil
+	}
 	clientset, err := clientcmd.NewCoreClientSetForKubeconfig(c.kubeconfigFile)
 	if err != nil {
 		return fmt.Errorf("error creating core clientset: %v", err)
@@ -138,7 +141,7 @@ func (c *clusterClient) Apply(manifest string) error {
 
 func (c *clusterClient) GetContextNamespace() string {
 	if c.configOverrides.Context.Namespace == "" {
-		c.configOverrides.Context.Namespace = apiv1.NamespaceDefault
+		return apiv1.NamespaceDefault
 	}
 	return c.configOverrides.Context.Namespace
 }

--- a/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/clusterctl/clusterdeployer/clusterdeployer.go
@@ -123,7 +123,7 @@ const (
 	timeoutKubeconfigReady = 20 * time.Minute
 )
 
-// Create the a cluster from the provided cluster definition and machine list.
+// Create the cluster from the provided cluster definition and machine list.
 func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*clusterv1.Machine, provider ProviderDeployer, kubeconfigOutput string, providerComponentsStoreFactory ProviderComponentsStoreFactory) error {
 	master, nodes, err := extractMasterMachine(machines)
 	if err != nil {
@@ -154,17 +154,17 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 
 	glog.Info("Provisioning target cluster via bootstrap cluster")
 
-	glog.Infof("Creating cluster object %v on bootstrap cluster in namespace %v", cluster.Name, cluster.Namespace)
+	glog.Infof("Creating cluster object %v on bootstrap cluster in namespace %q", cluster.Name, cluster.Namespace)
 	if err := bootstrapClient.CreateClusterObject(cluster); err != nil {
 		return fmt.Errorf("unable to create cluster object: %v", err)
 	}
 
-	glog.Infof("Creating master %v in namespace %v", master.Name, cluster.Namespace)
+	glog.Infof("Creating master %v in namespace %q", master.Name, cluster.Namespace)
 	if err := bootstrapClient.CreateMachineObjects([]*clusterv1.Machine{master}, cluster.Namespace); err != nil {
 		return fmt.Errorf("unable to create master machine: %v", err)
 	}
 
-	glog.Infof("Updating bootstrap cluster object for cluster %v in namespace %v with master (%s) endpoint", cluster.Name, cluster.Namespace, master.Name)
+	glog.Infof("Updating bootstrap cluster object for cluster %v in namespace %q with master (%s) endpoint", cluster.Name, cluster.Namespace, master.Name)
 	if err := d.updateClusterEndpoint(bootstrapClient, provider, cluster.Name, cluster.Namespace); err != nil {
 		return fmt.Errorf("unable to update bootstrap cluster endpoint: %v", err)
 	}

--- a/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/clusterctl/clusterdeployer/clusterdeployer.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/deployer"
@@ -49,22 +50,32 @@ type ClusterProvisioner interface {
 
 // Provides interaction with a cluster
 type ClusterClient interface {
+	GetContextNamespace() string
 	Apply(string) error
 	Delete(string) error
 	WaitForClusterV1alpha1Ready() error
 	GetClusterObjects() ([]*clusterv1.Cluster, error)
+	GetClusterObjectsInNamespace(string) ([]*clusterv1.Cluster, error)
+	GetClusterObject(string, string) (*clusterv1.Cluster, error)
 	GetMachineDeploymentObjects() ([]*clusterv1.MachineDeployment, error)
+	GetMachineDeploymentObjectsInNamespace(string) ([]*clusterv1.MachineDeployment, error)
 	GetMachineSetObjects() ([]*clusterv1.MachineSet, error)
+	GetMachineSetObjectsInNamespace(string) ([]*clusterv1.MachineSet, error)
 	GetMachineObjects() ([]*clusterv1.Machine, error)
+	GetMachineObjectsInNamespace(ns string) ([]*clusterv1.Machine, error)
 	CreateClusterObject(*clusterv1.Cluster) error
-	CreateMachineDeploymentObjects([]*clusterv1.MachineDeployment) error
-	CreateMachineSetObjects([]*clusterv1.MachineSet) error
-	CreateMachineObjects([]*clusterv1.Machine) error
+	CreateMachineDeploymentObjects([]*clusterv1.MachineDeployment, string) error
+	CreateMachineSetObjects([]*clusterv1.MachineSet, string) error
+	CreateMachineObjects([]*clusterv1.Machine, string) error
+	DeleteClusterObjectsInNamespace(string) error
 	DeleteClusterObjects() error
+	DeleteMachineDeploymentObjectsInNamespace(string) error
 	DeleteMachineDeploymentObjects() error
+	DeleteMachineSetObjectsInNamespace(string) error
 	DeleteMachineSetObjects() error
+	DeleteMachineObjectsInNamespace(string) error
 	DeleteMachineObjects() error
-	UpdateClusterObjectEndpoint(string) error
+	UpdateClusterObjectEndpoint(string, string, string) error
 	Close() error
 }
 
@@ -111,12 +122,11 @@ const (
 	timeoutKubeconfigReady = 20 * time.Minute
 )
 
-// Creates the a cluster from the provided cluster definition and machine list.
-
+// Create the a cluster from the provided cluster definition and machine list.
 func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*clusterv1.Machine, provider ProviderDeployer, kubeconfigOutput string, providerComponentsStoreFactory ProviderComponentsStoreFactory) error {
 	master, nodes, err := extractMasterMachine(machines)
 	if err != nil {
-		return fmt.Errorf("unable to seperate master machines from node machines: %v", err)
+		return fmt.Errorf("unable to separate master machines from node machines: %v", err)
 	}
 
 	glog.Info("Creating bootstrap cluster")
@@ -127,37 +137,42 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 	}
 	defer closeClient(bootstrapClient, "bootstrap")
 
+	if cluster.Namespace == "" {
+		cluster.Namespace = bootstrapClient.GetContextNamespace()
+	}
+	// TODO: @ashisha Create cluster.Namespace in bootstrap and target clusters?
+
 	glog.Info("Applying Cluster API stack to bootstrap cluster")
-	if err := d.applyClusterAPIStack(bootstrapClient); err != nil {
+	if err := d.applyClusterAPIStack(bootstrapClient, cluster.Namespace); err != nil {
 		return fmt.Errorf("unable to apply cluster api stack to bootstrap cluster: %v", err)
 	}
 
 	glog.Info("Provisioning target cluster via bootstrap cluster")
 
-	glog.Infof("Creating cluster object %v on bootstrap cluster", cluster.Name)
+	glog.Infof("Creating cluster object %v on bootstrap cluster in namespace %v", cluster.Name, cluster.Namespace)
 	if err := bootstrapClient.CreateClusterObject(cluster); err != nil {
 		return fmt.Errorf("unable to create cluster object: %v", err)
 	}
 
-	glog.Infof("Creating master %v", master.Name)
-	if err := bootstrapClient.CreateMachineObjects([]*clusterv1.Machine{master}); err != nil {
+	glog.Infof("Creating master %v in namespace %v", master.Name, cluster.Namespace)
+	if err := bootstrapClient.CreateMachineObjects([]*clusterv1.Machine{master}, cluster.Namespace); err != nil {
 		return fmt.Errorf("unable to create master machine: %v", err)
 	}
 
-	glog.Infof("Updating bootstrap cluster object with master (%s) endpoint", master.Name)
-	if err := d.updateClusterEndpoint(bootstrapClient, provider); err != nil {
+	glog.Infof("Updating bootstrap cluster object for cluster %v in namespace %v with master (%s) endpoint", cluster.Name, cluster.Namespace, master.Name)
+	if err := d.updateClusterEndpoint(bootstrapClient, provider, cluster.Name, cluster.Namespace); err != nil {
 		return fmt.Errorf("unable to update bootstrap cluster endpoint: %v", err)
 	}
 
 	glog.Info("Creating target cluster")
-	targetClient, err := d.createTargetClusterClient(bootstrapClient, provider, kubeconfigOutput)
+	targetClient, err := d.createTargetCluster(bootstrapClient, provider, kubeconfigOutput, cluster.Name, cluster.Namespace)
 	if err != nil {
 		return fmt.Errorf("unable to create target cluster: %v", err)
 	}
 	defer closeClient(targetClient, "target")
 
 	glog.Info("Applying Cluster API stack to target cluster")
-	if err := d.applyClusterAPIStackWithPivoting(targetClient, bootstrapClient); err != nil {
+	if err := d.applyClusterAPIStackWithPivoting(targetClient, bootstrapClient, cluster.Namespace); err != nil {
 		return fmt.Errorf("unable to apply cluster api stack to target cluster: %v", err)
 	}
 
@@ -170,12 +185,12 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 	// For some reason, endpoint doesn't get updated in bootstrap cluster sometimes. So we
 	// update the target cluster endpoint as well to be sure.
 	glog.Infof("Updating target cluster object with master (%s) endpoint", master.Name)
-	if err := d.updateClusterEndpoint(targetClient, provider); err != nil {
+	if err := d.updateClusterEndpoint(targetClient, provider, cluster.Name, cluster.Namespace); err != nil {
 		return fmt.Errorf("unable to update target cluster endpoint: %v", err)
 	}
 
 	glog.Info("Creating node machines in target cluster.")
-	if err := targetClient.CreateMachineObjects(nodes); err != nil {
+	if err := targetClient.CreateMachineObjects(nodes, cluster.Namespace); err != nil {
 		return fmt.Errorf("unable to create node machines: %v", err)
 	}
 
@@ -191,7 +206,7 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 	return nil
 }
 
-func (d *ClusterDeployer) Delete(targetClient ClusterClient) error {
+func (d *ClusterDeployer) Delete(targetClient ClusterClient, namespace string) error {
 	glog.Info("Creating bootstrap cluster")
 	bootstrapClient, cleanupBootstrapCluster, err := d.createBootstrapCluster()
 	defer cleanupBootstrapCluster()
@@ -201,7 +216,7 @@ func (d *ClusterDeployer) Delete(targetClient ClusterClient) error {
 	defer closeClient(bootstrapClient, "bootstrap")
 
 	glog.Info("Applying Cluster API stack to bootstrap cluster")
-	if err = d.applyClusterAPIStack(bootstrapClient); err != nil {
+	if err = d.applyClusterAPIStack(bootstrapClient, namespace); err != nil {
 		return fmt.Errorf("unable to apply cluster api stack to bootstrap cluster: %v", err)
 	}
 
@@ -212,12 +227,12 @@ func (d *ClusterDeployer) Delete(targetClient ClusterClient) error {
 	}
 
 	glog.Info("Copying objects from target cluster to bootstrap cluster")
-	if err = pivot(targetClient, bootstrapClient); err != nil {
+	if err = pivotNamespace(targetClient, bootstrapClient, namespace); err != nil {
 		return fmt.Errorf("unable to copy objects from target to bootstrap cluster: %v", err)
 	}
 
 	glog.Info("Deleting objects from bootstrap cluster")
-	if err = deleteObjects(bootstrapClient); err != nil {
+	if err = deleteObjectsInNamespace(bootstrapClient, namespace); err != nil {
 		return fmt.Errorf("unable to finish deleting objects in bootstrap cluster, resources may have been leaked: %v", err)
 	}
 	glog.Info("Deletion of cluster complete")
@@ -250,8 +265,8 @@ func (d *ClusterDeployer) createBootstrapCluster() (ClusterClient, func(), error
 	return bootstrapClient, cleanupFn, nil
 }
 
-func (d *ClusterDeployer) createTargetClusterClient(bootstrapClient ClusterClient, provider ProviderDeployer, kubeconfigOutput string) (ClusterClient, error) {
-	cluster, master, _, err := getClusterAPIObjects(bootstrapClient)
+func (d *ClusterDeployer) createTargetCluster(bootstrapClient ClusterClient, provider ProviderDeployer, kubeconfigOutput, clusterName, namespace string) (ClusterClient, error) {
+	cluster, master, _, err := getClusterAPIObject(bootstrapClient, clusterName, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -274,11 +289,11 @@ func (d *ClusterDeployer) createTargetClusterClient(bootstrapClient ClusterClien
 	return targetClient, nil
 }
 
-func (d *ClusterDeployer) updateClusterEndpoint(client ClusterClient, provider ProviderDeployer) error {
+func (d *ClusterDeployer) updateClusterEndpoint(client ClusterClient, provider ProviderDeployer, clusterName, namespace string) error {
 	// Update cluster endpoint. Needed till this logic moves into cluster controller.
 	// TODO: https://github.com/kubernetes-sigs/cluster-api/issues/158
 	// Fetch fresh objects.
-	cluster, master, _, err := getClusterAPIObjects(client)
+	cluster, master, _, err := getClusterAPIObject(client, clusterName, namespace)
 	if err != nil {
 		return err
 	}
@@ -286,7 +301,7 @@ func (d *ClusterDeployer) updateClusterEndpoint(client ClusterClient, provider P
 	if err != nil {
 		return fmt.Errorf("unable to get master IP: %v", err)
 	}
-	err = client.UpdateClusterObjectEndpoint(masterIP)
+	err = client.UpdateClusterObjectEndpoint(masterIP, clusterName, namespace)
 	if err != nil {
 		return fmt.Errorf("unable to update cluster endpoint: %v", err)
 	}
@@ -309,36 +324,36 @@ func (d *ClusterDeployer) saveProviderComponentsToCluster(factory ProviderCompon
 	return nil
 }
 
-func (d *ClusterDeployer) applyClusterAPIStack(client ClusterClient) error {
-	glog.Info("Applying Cluster API APIServer")
-	err := d.applyClusterAPIApiserver(client)
+func (d *ClusterDeployer) applyClusterAPIStack(client ClusterClient, namespace string) error {
+	glog.Infof("Applying Cluster API APIServer in namespace %v", namespace)
+	err := d.applyClusterAPIApiserver(client, namespace)
 	if err != nil {
-		return fmt.Errorf("unable to apply cluster apiserver: %v", err)
+		return fmt.Errorf("unable to apply cluster apiserver in namespace %v: %v", namespace, err)
 	}
 
 	glog.Info("Applying Cluster API Provider Components")
-	err = d.applyClusterAPIControllers(client)
+	err = d.applyClusterAPIControllers(client, namespace)
 	if err != nil {
 		return fmt.Errorf("unable to apply cluster api controllers: %v", err)
 	}
 	return nil
 }
 
-func (d *ClusterDeployer) applyClusterAPIStackWithPivoting(client ClusterClient, source ClusterClient) error {
+func (d *ClusterDeployer) applyClusterAPIStackWithPivoting(client, source ClusterClient, namespace string) error {
 	glog.Info("Applying Cluster API APIServer")
-	err := d.applyClusterAPIApiserver(client)
+	err := d.applyClusterAPIApiserver(client, namespace)
 	if err != nil {
 		return fmt.Errorf("unable to apply cluster api apiserver: %v", err)
 	}
 
 	glog.Info("Pivoting Cluster API objects from bootstrap to target cluster.")
-	err = pivot(source, client)
+	err = pivotNamespace(source, client, namespace)
 	if err != nil {
 		return fmt.Errorf("unable to pivot cluster API objects: %v", err)
 	}
 
 	glog.Info("Applying Cluster API Provider Components.")
-	err = d.applyClusterAPIControllers(client)
+	err = d.applyClusterAPIControllers(client, namespace)
 	if err != nil {
 		return fmt.Errorf("unable to apply cluster api controllers: %v", err)
 	}
@@ -346,7 +361,7 @@ func (d *ClusterDeployer) applyClusterAPIStackWithPivoting(client ClusterClient,
 	return nil
 }
 
-func (d *ClusterDeployer) applyClusterAPIApiserver(client ClusterClient) error {
+func (d *ClusterDeployer) applyClusterAPIApiserver(client ClusterClient, namespace string) error {
 	yaml, err := deployer.GetApiServerYaml()
 	if err != nil {
 		return fmt.Errorf("unable to generate apiserver yaml: %v", err)
@@ -359,7 +374,7 @@ func (d *ClusterDeployer) applyClusterAPIApiserver(client ClusterClient) error {
 	return client.WaitForClusterV1alpha1Ready()
 }
 
-func (d *ClusterDeployer) applyClusterAPIControllers(client ClusterClient) error {
+func (d *ClusterDeployer) applyClusterAPIControllers(client ClusterClient, namespace string) error {
 	return client.Apply(d.providerComponents)
 }
 
@@ -388,7 +403,7 @@ func waitForKubeconfigReady(provider ProviderDeployer, cluster *clusterv1.Cluste
 	return kubeconfig, err
 }
 
-func pivot(from, to ClusterClient) error {
+func pivotNamespace(from, to ClusterClient, namespace string) error {
 	if err := from.WaitForClusterV1alpha1Ready(); err != nil {
 		return fmt.Errorf("cluster v1alpha1 resource not ready on source cluster")
 	}
@@ -397,7 +412,7 @@ func pivot(from, to ClusterClient) error {
 		return fmt.Errorf("cluster v1alpha1 resource not ready on target cluster")
 	}
 
-	clusters, err := from.GetClusterObjects()
+	clusters, err := from.GetClusterObjectsInNamespace(namespace)
 	if err != nil {
 		return err
 	}
@@ -411,33 +426,33 @@ func pivot(from, to ClusterClient) error {
 		glog.Infof("Moved Cluster '%s'", cluster.GetName())
 	}
 
-	fromDeployments, err := from.GetMachineDeploymentObjects()
+	fromDeployments, err := from.GetMachineDeploymentObjectsInNamespace(namespace)
 	if err != nil {
 		return err
 	}
 	for _, deployment := range fromDeployments {
 		// New objects cannot have a specified resource version. Clear it out.
 		deployment.SetResourceVersion("")
-		if err = to.CreateMachineDeploymentObjects([]*clusterv1.MachineDeployment{deployment}); err != nil {
+		if err = to.CreateMachineDeploymentObjects([]*clusterv1.MachineDeployment{deployment}, namespace); err != nil {
 			return fmt.Errorf("error moving MachineDeployment '%v': %v", deployment.GetName(), err)
 		}
 		glog.Infof("Moved MachineDeployment %v", deployment.GetName())
 	}
 
-	fromMachineSets, err := from.GetMachineSetObjects()
+	fromMachineSets, err := from.GetMachineSetObjectsInNamespace(namespace)
 	if err != nil {
 		return err
 	}
 	for _, machineSet := range fromMachineSets {
 		// New objects cannot have a specified resource version. Clear it out.
 		machineSet.SetResourceVersion("")
-		if err := to.CreateMachineSetObjects([]*clusterv1.MachineSet{machineSet}); err != nil {
+		if err := to.CreateMachineSetObjects([]*clusterv1.MachineSet{machineSet}, namespace); err != nil {
 			return fmt.Errorf("error moving MachineSet '%v': %v", machineSet.GetName(), err)
 		}
 		glog.Infof("Moved MachineSet %v", machineSet.GetName())
 	}
 
-	machines, err := from.GetMachineObjects()
+	machines, err := from.GetMachineObjectsInNamespace(namespace)
 	if err != nil {
 		return err
 	}
@@ -445,7 +460,7 @@ func pivot(from, to ClusterClient) error {
 	for _, machine := range machines {
 		// New objects cannot have a specified resource version. Clear it out.
 		machine.SetResourceVersion("")
-		if err = to.CreateMachineObjects([]*clusterv1.Machine{machine}); err != nil {
+		if err = to.CreateMachineObjects([]*clusterv1.Machine{machine}, namespace); err != nil {
 			return fmt.Errorf("error moving Machine '%v': %v", machine.GetName(), err)
 		}
 		glog.Infof("Moved Machine '%s'", machine.GetName())
@@ -453,25 +468,25 @@ func pivot(from, to ClusterClient) error {
 	return nil
 }
 
-func deleteObjects(client ClusterClient) error {
+func deleteObjectsInNamespace(client ClusterClient, namespace string) error {
 	var errors []string
 	glog.Infof("Deleting machine deployments")
-	if err := client.DeleteMachineDeploymentObjects(); err != nil {
+	if err := client.DeleteMachineDeploymentObjectsInNamespace(namespace); err != nil {
 		err = fmt.Errorf("error deleting machine deployments: %v", err)
 		errors = append(errors, err.Error())
 	}
 	glog.Infof("Deleting machine sets")
-	if err := client.DeleteMachineSetObjects(); err != nil {
+	if err := client.DeleteMachineSetObjectsInNamespace(namespace); err != nil {
 		err = fmt.Errorf("error deleting machine sets: %v", err)
 		errors = append(errors, err.Error())
 	}
 	glog.Infof("Deleting machines")
-	if err := client.DeleteMachineObjects(); err != nil {
+	if err := client.DeleteMachineObjectsInNamespace(namespace); err != nil {
 		err = fmt.Errorf("error deleting machines: %v", err)
 		errors = append(errors, err.Error())
 	}
 	glog.Infof("Deleting clusters")
-	if err := client.DeleteClusterObjects(); err != nil {
+	if err := client.DeleteClusterObjectsInNamespace(namespace); err != nil {
 		err = fmt.Errorf("error deleting clusters: %v", err)
 		errors = append(errors, err.Error())
 	}
@@ -481,22 +496,23 @@ func deleteObjects(client ClusterClient) error {
 	return nil
 }
 
-func getClusterAPIObjects(client ClusterClient) (*clusterv1.Cluster, *clusterv1.Machine, []*clusterv1.Machine, error) {
-	machines, err := client.GetMachineObjects()
+func deleteObjects(client ClusterClient) error {
+	return deleteObjectsInNamespace(client, apiv1.NamespaceDefault)
+}
+
+func getClusterAPIObject(client ClusterClient, clusterName, namespace string) (*clusterv1.Cluster, *clusterv1.Machine, []*clusterv1.Machine, error) {
+	machines, err := client.GetMachineObjectsInNamespace(namespace)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to fetch machines: %v", err)
 	}
-	clusters, err := client.GetClusterObjects()
+	cluster, err := client.GetClusterObject(clusterName, namespace)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to fetch clusters: %v", err)
+		return nil, nil, nil, fmt.Errorf("unable to fetch cluster %v in namespace %v: %v", clusterName, namespace, err)
 	}
-	if len(clusters) != 1 {
-		return nil, nil, nil, fmt.Errorf("fetched not exactly one cluster object. Count %v", len(clusters))
-	}
-	cluster := clusters[0]
+
 	master, nodes, err := extractMasterMachine(machines)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to fetch master machine: %v", err)
+		return nil, nil, nil, fmt.Errorf("unable to fetch master machine in cluster %v in namespace %v: %v", clusterName, namespace, err)
 	}
 	return cluster, master, nodes, nil
 }

--- a/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/clusterctl/clusterdeployer/clusterdeployer.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/deployer"
@@ -511,10 +510,6 @@ func deleteObjectsInNamespace(client ClusterClient, namespace string) error {
 		return fmt.Errorf("error(s) encountered deleting objects from bootstrap cluster: [%v]", strings.Join(errors, ", "))
 	}
 	return nil
-}
-
-func deleteObjects(client ClusterClient) error {
-	return deleteObjectsInNamespace(client, apiv1.NamespaceDefault)
 }
 
 func getClusterAPIObject(client ClusterClient, clusterName, namespace string) (*clusterv1.Cluster, *clusterv1.Machine, []*clusterv1.Machine, error) {

--- a/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"testing"
 
+	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -294,6 +295,10 @@ func (c *testClusterClient) EnsureNamespace(nsName string) error {
 }
 
 func (c *testClusterClient) DeleteNamespace(namespaceName string) error {
+	if namespaceName == apiv1.NamespaceDefault {
+		return nil
+	}
+
 	var ns []string
 	for _, n := range c.namespaces {
 		if n == namespaceName {
@@ -1173,7 +1178,7 @@ func TestClusterDelete(t *testing.T) {
 				if contains(testCase.bootstrapClient.namespaces, testCase.namespace) {
 					t.Fatalf("Unexpected remaining namespace %q in bootstrap cluster. Got: Found, Want: NotFound", testCase.namespace)
 				}
-				if contains(testCase.targetClient.namespaces, testCase.namespace) {
+				if testCase.namespace != apiv1.NamespaceDefault && contains(testCase.targetClient.namespaces, testCase.namespace) {
 					t.Fatalf("Unexpected remaining namespace %q in target cluster. Got: Found, Want: NotFound", testCase.namespace)
 				}
 			}

--- a/clusterctl/cmd/delete_cluster.go
+++ b/clusterctl/cmd/delete_cluster.go
@@ -33,6 +33,7 @@ import (
 type DeleteOptions struct {
 	KubeconfigPath      string
 	ProviderComponents  string
+	ClusterNamespace    string
 	KubeconfigOverrides tcmd.ConfigOverrides
 }
 
@@ -52,6 +53,7 @@ var deleteClusterCmd = &cobra.Command{
 func init() {
 	deleteClusterCmd.Flags().StringVarP(&do.KubeconfigPath, "kubeconfig", "", "", "Path to the kubeconfig file to use for connecting to the cluster to be deleted, if empty, the default KUBECONFIG load path is used.")
 	deleteClusterCmd.Flags().StringVarP(&do.ProviderComponents, "provider-components", "p", "", "A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.")
+	deleteClusterCmd.Flags().StringVarP(&do.ClusterNamespace, "cluster-namespace", "", v1.NamespaceDefault, "Namespace where the cluster to be deleted resides")
 	// BindContextFlags will bind the flags cluster, namespace, and user
 	tcmd.BindContextFlags(&do.KubeconfigOverrides.Context, deleteClusterCmd.Flags(), tcmd.RecommendedContextOverrideFlags(""))
 	deleteCmd.AddCommand(deleteClusterCmd)
@@ -73,7 +75,7 @@ func RunDelete() error {
 		providerComponents,
 		"",
 		true)
-	return deployer.Delete(clusterClient)
+	return deployer.Delete(clusterClient, do.ClusterNamespace)
 }
 
 func loadProviderComponents() (string, error) {

--- a/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
+++ b/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
@@ -4,6 +4,7 @@ Usage:
 
 Flags:
       --cluster string               The name of the kubeconfig cluster to use
+      --cluster-namespace string     Namespace where the cluster to be deleted resides (default "default")
   -h, --help                         help for cluster
       --kubeconfig string            Path to the kubeconfig file to use for connecting to the cluster to be deleted, if empty, the default KUBECONFIG load path is used.
   -n, --namespace string             If present, the namespace scope for this CLI request

--- a/vendor/k8s.io/kube-openapi/example/openapi-gen/BUILD.bazel
+++ b/vendor/k8s.io/kube-openapi/example/openapi-gen/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importmap = "sigs.k8s.io/cluster-api/vendor/k8s.io/kube-openapi/example/openapi-gen",
+    importpath = "k8s.io/kube-openapi/example/openapi-gen",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/gengo/args:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/generators:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "openapi-gen",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/k8s.io/kube-openapi/pkg/aggregator/BUILD.bazel
+++ b/vendor/k8s.io/kube-openapi/pkg/aggregator/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["aggregator.go"],
+    importmap = "sigs.k8s.io/cluster-api/vendor/k8s.io/kube-openapi/pkg/aggregator",
+    importpath = "k8s.io/kube-openapi/pkg/aggregator",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/go-openapi/spec:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/util:go_default_library",
+    ],
+)

--- a/vendor/k8s.io/kube-openapi/pkg/builder/BUILD.bazel
+++ b/vendor/k8s.io/kube-openapi/pkg/builder/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "openapi.go",
+        "util.go",
+    ],
+    importmap = "sigs.k8s.io/cluster-api/vendor/k8s.io/kube-openapi/pkg/builder",
+    importpath = "k8s.io/kube-openapi/pkg/builder",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/emicklei/go-restful:go_default_library",
+        "//vendor/github.com/go-openapi/spec:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/util:go_default_library",
+    ],
+)

--- a/vendor/k8s.io/kube-openapi/pkg/common/BUILD.bazel
+++ b/vendor/k8s.io/kube-openapi/pkg/common/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "common.go",
+        "doc.go",
+    ],
+    importmap = "sigs.k8s.io/cluster-api/vendor/k8s.io/kube-openapi/pkg/common",
+    importpath = "k8s.io/kube-openapi/pkg/common",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/emicklei/go-restful:go_default_library",
+        "//vendor/github.com/go-openapi/spec:go_default_library",
+    ],
+)

--- a/vendor/k8s.io/kube-openapi/pkg/generators/BUILD.bazel
+++ b/vendor/k8s.io/kube-openapi/pkg/generators/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["openapi.go"],
+    importmap = "sigs.k8s.io/cluster-api/vendor/k8s.io/kube-openapi/pkg/generators",
+    importpath = "k8s.io/kube-openapi/pkg/generators",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/gengo/args:go_default_library",
+        "//vendor/k8s.io/gengo/generator:go_default_library",
+        "//vendor/k8s.io/gengo/namer:go_default_library",
+        "//vendor/k8s.io/gengo/types:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
+    ],
+)

--- a/vendor/k8s.io/kube-openapi/pkg/handler/BUILD.bazel
+++ b/vendor/k8s.io/kube-openapi/pkg/handler/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["handler.go"],
+    importmap = "sigs.k8s.io/cluster-api/vendor/k8s.io/kube-openapi/pkg/handler",
+    importpath = "k8s.io/kube-openapi/pkg/handler",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/bitbucket.org/ww/goautoneg:go_default_library",
+        "//vendor/github.com/NYTimes/gziphandler:go_default_library",
+        "//vendor/github.com/emicklei/go-restful:go_default_library",
+        "//vendor/github.com/go-openapi/spec:go_default_library",
+        "//vendor/github.com/golang/protobuf/proto:go_default_library",
+        "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
+        "//vendor/github.com/googleapis/gnostic/compiler:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/builder:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
+    ],
+)

--- a/vendor/k8s.io/kube-openapi/pkg/util/BUILD.bazel
+++ b/vendor/k8s.io/kube-openapi/pkg/util/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "trie.go",
+        "util.go",
+    ],
+    importmap = "sigs.k8s.io/cluster-api/vendor/k8s.io/kube-openapi/pkg/util",
+    importpath = "k8s.io/kube-openapi/pkg/util",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/k8s.io/kube-openapi/pkg/util/proto/BUILD.bazel
+++ b/vendor/k8s.io/kube-openapi/pkg/util/proto/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "document.go",
+        "openapi.go",
+    ],
+    importmap = "sigs.k8s.io/cluster-api/vendor/k8s.io/kube-openapi/pkg/util/proto",
+    importpath = "k8s.io/kube-openapi/pkg/util/proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
+    ],
+)

--- a/vendor/k8s.io/kube-openapi/pkg/util/proto/testing/BUILD.bazel
+++ b/vendor/k8s.io/kube-openapi/pkg/util/proto/testing/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["openapi.go"],
+    importmap = "sigs.k8s.io/cluster-api/vendor/k8s.io/kube-openapi/pkg/util/proto/testing",
+    importpath = "k8s.io/kube-openapi/pkg/util/proto/testing",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/googleapis/gnostic/OpenAPIv2:go_default_library",
+        "//vendor/github.com/googleapis/gnostic/compiler:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
+    ],
+)

--- a/vendor/k8s.io/kube-openapi/pkg/util/proto/validation/BUILD.bazel
+++ b/vendor/k8s.io/kube-openapi/pkg/util/proto/validation/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "errors.go",
+        "types.go",
+        "validation.go",
+    ],
+    importmap = "sigs.k8s.io/cluster-api/vendor/k8s.io/kube-openapi/pkg/util/proto/validation",
+    importpath = "k8s.io/kube-openapi/pkg/util/proto/validation",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library"],
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Supporting multiple clusters requires, cluster and machine to be stored in multiple namespaces, clusterctl create currently assumes default namespace which will not work in a multi-cluster setup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #252 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
