### PR TITLE
Add node-conditions to the MachineStatus

### DIFF
--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -141,6 +141,14 @@ type MachineStatus struct {
 	// Addresses is a list of addresses assigned to the machine. Queried from cloud provider, if available.
 	// +optional
 	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
+
+	// List of conditions synced from the node-conditions of the corresponding node-object.
+	// Machine-controller would be responsible for keeping conditions up-to-date.
+	// Machine-set controller will be taking these conditions as a signal to decide if
+	// machine is healthy or needs to be replaced.
+	// Refer: https://kubernetes.io/docs/concepts/architecture/nodes/#condition
+	// +optional
+	Conditions []corev1.NodeCondition `json:"conditions,omitempty"`
 }
 
 type MachineVersionInfo struct {

--- a/pkg/apis/cluster/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.conversion.go
@@ -778,6 +778,7 @@ func autoConvert_v1alpha1_MachineStatus_To_cluster_MachineStatus(in *MachineStat
 	out.ErrorMessage = (*string)(unsafe.Pointer(in.ErrorMessage))
 	out.ProviderStatus = (*runtime.RawExtension)(unsafe.Pointer(in.ProviderStatus))
 	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Conditions = *(*[]v1.NodeCondition)(unsafe.Pointer(&in.Conditions))
 	return nil
 }
 
@@ -794,6 +795,7 @@ func autoConvert_cluster_MachineStatus_To_v1alpha1_MachineStatus(in *cluster.Mac
 	out.ErrorMessage = (*string)(unsafe.Pointer(in.ErrorMessage))
 	out.ProviderStatus = (*runtime.RawExtension)(unsafe.Pointer(in.ProviderStatus))
 	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Conditions = *(*[]v1.NodeCondition)(unsafe.Pointer(&in.Conditions))
 	return nil
 }
 

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -633,6 +633,13 @@ func (in *MachineStatus) DeepCopyInto(out *MachineStatus) {
 		*out = make([]v1.NodeAddress, len(*in))
 		copy(*out, *in)
 	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.NodeCondition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/cluster/zz_generated.api.register.go
+++ b/pkg/apis/cluster/zz_generated.api.register.go
@@ -118,6 +118,95 @@ func Resource(resource string) schema.GroupResource {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+type MachineDeployment struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	Spec   MachineDeploymentSpec
+	Status MachineDeploymentStatus
+}
+
+// +genclient
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+type Machine struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	Spec   MachineSpec
+	Status MachineStatus
+}
+
+type MachineDeploymentStatus struct {
+	ObservedGeneration  int64
+	Replicas            int32
+	UpdatedReplicas     int32
+	ReadyReplicas       int32
+	AvailableReplicas   int32
+	UnavailableReplicas int32
+}
+
+type MachineStatus struct {
+	NodeRef        *corev1.ObjectReference
+	LastUpdated    metav1.Time
+	Versions       *MachineVersionInfo
+	ErrorReason    *clustercommon.MachineStatusError
+	ErrorMessage   *string
+	ProviderStatus *pkgruntime.RawExtension
+	Addresses      []corev1.NodeAddress
+	Conditions     []corev1.NodeCondition
+}
+
+type MachineSpec struct {
+	metav1.ObjectMeta
+	Taints         []corev1.Taint
+	ProviderConfig ProviderConfig
+	Versions       MachineVersionInfo
+	ConfigSource   *corev1.NodeConfigSource
+}
+
+type MachineVersionInfo struct {
+	Kubelet      string
+	ControlPlane string
+}
+
+type ProviderConfig struct {
+	Value     *pkgruntime.RawExtension
+	ValueFrom *ProviderConfigSource
+}
+
+type MachineDeploymentSpec struct {
+	Replicas                *int32
+	Selector                metav1.LabelSelector
+	Template                MachineTemplateSpec
+	Strategy                MachineDeploymentStrategy
+	MinReadySeconds         *int32
+	RevisionHistoryLimit    *int32
+	Paused                  bool
+	ProgressDeadlineSeconds *int32
+}
+
+type ProviderConfigSource struct {
+}
+
+type MachineDeploymentStrategy struct {
+	Type          clustercommon.MachineDeploymentStrategyType
+	RollingUpdate *MachineRollingUpdateDeployment
+}
+
+type MachineTemplateSpec struct {
+	metav1.ObjectMeta
+	Spec MachineSpec
+}
+
+type MachineRollingUpdateDeployment struct {
+	MaxUnavailable *utilintstr.IntOrString
+	MaxSurge       *utilintstr.IntOrString
+}
+
+// +genclient
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 type Cluster struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
@@ -170,102 +259,14 @@ type ClusterSpec struct {
 	ProviderConfig ProviderConfig
 }
 
-type MachineTemplateSpec struct {
-	metav1.ObjectMeta
-	Spec MachineSpec
-}
-
-type ProviderConfig struct {
-	Value     *pkgruntime.RawExtension
-	ValueFrom *ProviderConfigSource
-}
-
-type MachineSpec struct {
-	metav1.ObjectMeta
-	Taints         []corev1.Taint
-	ProviderConfig ProviderConfig
-	Versions       MachineVersionInfo
-	ConfigSource   *corev1.NodeConfigSource
-}
-
-type ProviderConfigSource struct {
-}
-
-type MachineVersionInfo struct {
-	Kubelet      string
-	ControlPlane string
-}
-
 type ClusterNetworkingConfig struct {
 	Services      NetworkRanges
 	Pods          NetworkRanges
 	ServiceDomain string
 }
 
-// +genclient
-// +genclient
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-type MachineDeployment struct {
-	metav1.TypeMeta
-	metav1.ObjectMeta
-	Spec   MachineDeploymentSpec
-	Status MachineDeploymentStatus
-}
-
 type NetworkRanges struct {
 	CIDRBlocks []string
-}
-
-type MachineDeploymentStatus struct {
-	ObservedGeneration  int64
-	Replicas            int32
-	UpdatedReplicas     int32
-	ReadyReplicas       int32
-	AvailableReplicas   int32
-	UnavailableReplicas int32
-}
-
-type MachineDeploymentSpec struct {
-	Replicas                *int32
-	Selector                metav1.LabelSelector
-	Template                MachineTemplateSpec
-	Strategy                MachineDeploymentStrategy
-	MinReadySeconds         *int32
-	RevisionHistoryLimit    *int32
-	Paused                  bool
-	ProgressDeadlineSeconds *int32
-}
-
-type MachineDeploymentStrategy struct {
-	Type          clustercommon.MachineDeploymentStrategyType
-	RollingUpdate *MachineRollingUpdateDeployment
-}
-
-type MachineRollingUpdateDeployment struct {
-	MaxUnavailable *utilintstr.IntOrString
-	MaxSurge       *utilintstr.IntOrString
-}
-
-// +genclient
-// +genclient
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-
-type Machine struct {
-	metav1.TypeMeta
-	metav1.ObjectMeta
-	Spec   MachineSpec
-	Status MachineStatus
-}
-
-type MachineStatus struct {
-	NodeRef        *corev1.ObjectReference
-	LastUpdated    metav1.Time
-	Versions       *MachineVersionInfo
-	ErrorReason    *clustercommon.MachineStatusError
-	ErrorMessage   *string
-	ProviderStatus *pkgruntime.RawExtension
-	Addresses      []corev1.NodeAddress
 }
 
 //

--- a/pkg/apis/cluster/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/zz_generated.deepcopy.go
@@ -633,6 +633,13 @@ func (in *MachineStatus) DeepCopyInto(out *MachineStatus) {
 		*out = make([]v1.NodeAddress, len(*in))
 		copy(*out, *in)
 	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.NodeCondition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -24261,12 +24261,25 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"conditions": {
+							SchemaProps: spec.SchemaProps{
+								Description: "List of conditions synced from the node-conditions of the corresponding node-object. Machine-controller would be responsible for keeping conditions up-to-date. Machine-set controller will be taking these conditions as a signal to decide if machine is healthy or needs to be replaced. Refer: https://kubernetes.io/docs/concepts/architecture/nodes/#condition",
+								Type:        []string{"array"},
+								Items: &spec.SchemaOrArray{
+									Schema: &spec.Schema{
+										SchemaProps: spec.SchemaProps{
+											Ref: ref("k8s.io/api/core/v1.NodeCondition"),
+										},
+									},
+								},
+							},
+						},
 					},
 					Required: []string{"providerStatus"},
 				},
 			},
 			Dependencies: []string{
-				"k8s.io/api/core/v1.NodeAddress", "k8s.io/api/core/v1.ObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "k8s.io/apimachinery/pkg/runtime.RawExtension", "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1.MachineVersionInfo"},
+				"k8s.io/api/core/v1.NodeAddress", "k8s.io/api/core/v1.NodeCondition", "k8s.io/api/core/v1.ObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Time", "k8s.io/apimachinery/pkg/runtime.RawExtension", "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1.MachineVersionInfo"},
 		},
 		"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1.MachineStatusStrategy": {
 			Schema: spec.Schema{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: Based on the discussion in the last sig-call, adding node-conditions into Machine-status. Basically Machine-set controller will be able to understand the Machine-health from these conditions- few of them are`DiskPressure`, `KubeleteReady`, `MemoryPressure` and so on. Based on these conditions - Machineset can decide whether Machine . needs to be replaced/udpated - eg. DiskPressure from X minutes, KubeleteNotReady from Y minutes so on.
Refer: https://kubernetes.io/docs/concepts/architecture/nodes/#condition
 
**Which issue(s) this PR fixes** :
This PR will partially resolve #47, though we need to rediscuss the current approach where machineset is pulling the node-object to understand the machine-health.

**Special notes for your reviewer**: Executed `make generate`, `make build`, to mention explicitly `make depend` is getting stuck[for long] at dep issues due to api-builder- so avoided that for now.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added node-conditions into api for MachineStatus.

```
