### PR TITLE
Remove priority field from the APIService manifest to make it compatible with 1.11+ bootstrap clusters

### DIFF
--- a/pkg/deployer/clusterapiservertemplate.go
+++ b/pkg/deployer/clusterapiservertemplate.go
@@ -29,7 +29,6 @@ spec:
   version: v1alpha1
   group: cluster.k8s.io
   groupPriorityMinimum: 2000
-  priority: 200
   service:
     name: clusterapi
     namespace: default


### PR DESCRIPTION
**What this PR does / why we need it**:

As of Kubernetes 1.11, the `priority` field has been removed from the APIService resource. The `priority` field have been replaced with `groupPriority` and `versionPriority` fields.

More about those fields can be found in [godoc comments](https://github.com/kubernetes/kubernetes/blob/d08e68e75974eb31fd65422c969b352ed8397edc/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/types.go#L59-L77).

Those fields have been backported to older Kubernetes versions, including 1.10 used by Minikube. Here's a commit that introduced that change: https://github.com/kubernetes/kubernetes/commit/d13ad28420ff3e0f0a01202dc5aa96bfe6101376

Trying to create a cluster using `clusterctl` with a bootstrap cluster version 1.11 or newer, results in the following error:
```
[marko@xmudrii-1 clusterctl (master)]$ go run main.go create cluster --provider digitalocean -c examples/digitalocean/out/cluster.yaml -m examples/digitalocean/out/machines.yaml -p examples/digitalocean/out/provider-components.yaml --cleanup-bootstrap-cluster false --existing-bootstrap-cluster-kubeconfig /var/run/kubernetes/admin.kubeconfig
I0829 12:45:28.516323   13818 clusterdeployer.go:122] Creating bootstrap cluster
I0829 12:45:28.520057   13818 clusterdeployer.go:130] Applying Cluster API stack to bootstrap cluster
I0829 12:45:28.520078   13818 clusterdeployer.go:313] Applying Cluster API APIServer
I0829 12:45:29.952983   13818 clusterdeployer.go:236] Cleaning up bootstrap cluster.
F0829 12:45:29.953000   13818 create_cluster.go:63] unable to apply cluster api stack to bootstrap cluster: unable to apply cluster apiserver: unable to apply apiserver yaml: couldn't kubectl apply: exit status 1, output: error: error validating "STDIN": error validating data: ValidationError(APIService.spec): unknown field "priority" in io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

After the fix is in place, this part passes without any other problem. We already have both `versionPriority` and `groupPriority`, so I believe we don't need any other change.

I have tested with both external cluster version 1.11, 1.12 (current master), 1.10, and Minikube 1.10.

**Release note**:
```release-note
Remove priority field from the APIService manifest to make it compatible with 1.11+ bootstrap clusters.
```
