### PR TITLE
Add requeueing support to cluster actuator

### DIFF
--- a/pkg/controller/error/requeue_error.go
+++ b/pkg/controller/error/requeue_error.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package error
+
+import (
+	"fmt"
+	"time"
+)
+
+// RequeueAfterError represents that an actuator managed object should be
+// requeued for further processing after the given RequeueAfter time has
+// passed.
+type RequeueAfterError struct {
+	RequeueAfter time.Duration
+}
+
+// Error implements the error interface
+func (e *RequeueAfterError) Error() string {
+	return fmt.Sprintf("requeue cluster in: %s", e.RequeueAfter)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Ports the machine requeuing logic introduced in #487 to the cluster actuator as well

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
