### PR TITLE
Remove references to kubeadm specific locations for kubeconfig.

### DIFF
--- a/pkg/deployer/clusterapiservertemplate.go
+++ b/pkg/deployer/clusterapiservertemplate.go
@@ -99,11 +99,10 @@ spec:
         - "--etcd-servers=http://etcd-clusterapi-svc:2379"
         - "--tls-cert-file=/apiserver.local.config/certificates/tls.crt"
         - "--tls-private-key-file=/apiserver.local.config/certificates/tls.key"
+        - "--requestheader-client-ca-file=/etc/kubernetes/ssl/ca.pem"
         - "--audit-log-path=-"
         - "--audit-log-maxage=0"
         - "--audit-log-maxbackup=0"
-        - "--authorization-kubeconfig=/etc/kubernetes/admin.conf"
-        - "--kubeconfig=/etc/kubernetes/admin.conf"
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Also pass --requestheader-client-ca-file to fix https://goo.gl/qZqmMb

**What this PR does / why we need it**:
The current apiserver manifest used by the shared deployer code makes assumptions which are not true for non-`kubeadm` created clusters. This causes problems when `clusterctl` and `minikube` are not used together unless the bootstrapping cluster was also created with `kubeadm`.

It may not be necessary to fix this given https://github.com/kubernetes-sigs/cluster-api/issues/409

This PR is mainly for documentation purposes for now.
