### PR TITLE
clusterctl: match kubeconfig by path instead of content

### DIFF
--- a/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -108,7 +108,7 @@ func (c *client) removeKubeconfigFile() error {
 }
 
 func (c *client) EnsureNamespace(namespaceName string) error {
-	clientset, err := clientcmd.NewCoreClientSetForKubeconfig(c.kubeconfigFile)
+	clientset, err := clientcmd.NewCoreClientSetForDefaultSearchPath(c.kubeconfigFile, clientcmd.NewConfigOverrides())
 	if err != nil {
 		return fmt.Errorf("error creating core clientset: %v", err)
 	}
@@ -129,7 +129,7 @@ func (c *client) DeleteNamespace(namespaceName string) error {
 	if namespaceName == apiv1.NamespaceDefault {
 		return nil
 	}
-	clientset, err := clientcmd.NewCoreClientSetForKubeconfig(c.kubeconfigFile)
+	clientset, err := clientcmd.NewCoreClientSetForDefaultSearchPath(c.kubeconfigFile, clientcmd.NewConfigOverrides())
 	if err != nil {
 		return fmt.Errorf("error creating core clientset: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Using `clusterctl` to bootstrap an cluster, potentially as of #481, causes the following error:

```
I0913 18:12:56.063907    4605 clusterdeployer.go:133] Creating bootstrap cluster
F0913 18:15:17.617105    4605 create_cluster.go:63] unable to ensure namespace "default" in bootstrap cluster: error creating core clientset: couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }
exit status 1
```

After debugging, I found out that functions [`EnsureNamespace`](https://github.com/kubernetes-sigs/cluster-api/blob/3b6365b480ef09006adea2c4f3131b824acff706/clusterctl/clusterdeployer/clusterclient.go#L77-L93) and [`DeleteNamespace`](https://github.com/kubernetes-sigs/cluster-api/blob/3b6365b480ef09006adea2c4f3131b824acff706/clusterctl/clusterdeployer/clusterclient.go#L95-L109) use the [`NewCoreClientSetForKubeconfig`](https://github.com/kubernetes-sigs/cluster-api/blob/3784fb37e847e17b6e5972c74fc8125ef54c4727/pkg/clientcmd/configutil.go#L46-L53) which expects the Kubeconfig content, instead of Kubeconfig File path (which is provided by the `EnsureNamespace` and `DeleteNamespace` functions).

Instead, it might be better to use the [`NewCoreClientSetForDefaultSearchPath`](https://github.com/kubernetes-sigs/cluster-api/blob/3784fb37e847e17b6e5972c74fc8125ef54c4727/pkg/clientcmd/configutil.go#L35-L44) function, which expects the path to the Kubeconfig file.

The only thing I'm unsure about, is what should be the second argument to the function. I searched the code base little bit, and found out that `clientcmd.NewConfigOverrides()` is being used, and it seems to work as expected.

**Release note**:
```release-note
NONE
```
