### PR TITLE
pkg/util: Add RFC3531 subnet allocation function

### DIFF
--- a/pkg/util/rfc3531.go
+++ b/pkg/util/rfc3531.go
@@ -1,0 +1,156 @@
+// Copyright © 2018 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Some of the implementation of this package was borrowed from
+// https://github.com/dspinhirne/netaddr-rb/tree/version-1.5.2
+
+package util
+
+import (
+	"encoding/binary"
+	"errors"
+	"math"
+	"net"
+)
+
+const (
+	// LEFTMOST assigns subnets from the left-most bits of the super network.
+	LEFTMOST = 0
+
+	// CENTERMOST assigns subnets from the centre-most bits of the super network.
+	CENTERMOST = 1
+
+	// RIGHTMOST assigns subnets from the right-most bits of the super network.
+	RIGHTMOST = 2
+)
+
+// AllocateRFC3531 allocates IPv4 subnets from a supernetwork using RFC 3531
+// where super is the super network from which subnets will be allocated
+// and size is the desired subnet mask.
+//
+// See https://tools.ietf.org/html/rfc3531 for more information.
+func AllocateRFC3531(super string, size int, strategy int) ([]string, error) {
+
+	_, cidr, err := net.ParseCIDR(super)
+	if err != nil {
+		return nil, errors.New("could not parse IP address")
+	}
+	superBits, ipBits := cidr.Mask.Size()
+	subnetBits := size - superBits
+
+	if subnetBits < 0 {
+		return nil, errors.New("cannot allocate subnet larger than supernetwork")
+	}
+
+	if strategy == LEFTMOST {
+		return rfc3531Leftmost(cidr, size, subnetBits, ipBits), nil
+	} else if strategy == CENTERMOST {
+		return rfc3531Centermost(cidr, size, subnetBits, ipBits), nil
+	} else if strategy == RIGHTMOST {
+		return rfc3531Rightmost(cidr, size, subnetBits, ipBits), nil
+	} else {
+		return nil, errors.New("no valid strategy was selected")
+	}
+}
+
+func rfc3531Rightmost(super *net.IPNet, size int, subnetBits int, ipBits int) []string {
+	leftMost := rfc3531Leftmost(super, size, subnetBits, ipBits)
+
+	// Reverse the result of rfc3531Leftmost
+	for i := 0; i < len(leftMost)/2; i++ {
+		j := len(leftMost) - i - 1
+		leftMost[i], leftMost[j] = leftMost[j], leftMost[i]
+	}
+	return leftMost
+}
+
+func rfc3531Leftmost(super *net.IPNet, size int, subnetBits int, ipBits int) []string {
+	var list []string
+	lShift := ipBits - size
+
+	// Mirror binary counting using the left most bits
+	for i := 0; i < (int(math.Pow(2, float64(subnetBits)))); i++ {
+		shift := binaryMirror(i, subnetBits) << uint(lShift)
+		baseInt := binary.BigEndian.Uint32(super.IP) | uint32(shift)
+		base := make(net.IP, 4)
+		binary.BigEndian.PutUint32(base, baseInt)
+		subnet := net.IPNet{
+			IP:   base,
+			Mask: net.CIDRMask(size, ipBits)}
+		list = append(list, subnet.String())
+	}
+	return list
+
+}
+
+func rfc3531Centermost(super *net.IPNet, size int, subnetBits int, ipBits int) []string {
+	var list []string
+
+	/*
+	 		1.  The first round is to select only the middle bit (and if there is
+	        an even number of bits  pick the bit following the center)
+	*/
+	round := 1
+	netlShift := uint(ipBits - size)
+	lShift := subnetBits / 2
+	if subnetBits&1 == 0 {
+		lShift--
+	}
+	uniques := make(map[int]bool)
+	for bitCount := 1; bitCount <= subnetBits; bitCount++ {
+
+		/*
+			2.  Create all combinations using the selected bits that haven't yet
+					been created.
+		*/
+
+		for i := 0; i < (int(math.Pow(2, float64(bitCount)))); i++ {
+			shifted := i << uint(lShift)
+			if !uniques[shifted] {
+				baseInt := binary.BigEndian.Uint32(super.IP) | uint32(shifted)<<netlShift
+				base := make(net.IP, 4)
+				binary.BigEndian.PutUint32(base, baseInt)
+				subnet := net.IPNet{
+					IP:   base,
+					Mask: net.CIDRMask(size, ipBits)}
+				list = append(list, subnet.String())
+				uniques[shifted] = true
+			}
+		}
+		/*
+		   3.  Start a new round by adding one more bit to the set.  In even
+		       rounds add the preceding bit to the set.  In odd rounds add the
+		       subsequent bit to the set.
+		*/
+		if round&1 == 0 {
+			lShift--
+		}
+		round++
+
+		/*
+			4.  Repeat 2 and 3 until there are no more bits to consider.
+		*/
+	}
+
+	return list
+}
+
+func binaryMirror(num int, bitCount int) int {
+	mirror := 0
+	for i := 0; i < bitCount; i++ {
+		lsb := num & 1
+		num = num >> 1
+		mirror = (mirror << 1) | lsb
+	}
+	return mirror
+}

--- a/pkg/util/rfc3531_test.go
+++ b/pkg/util/rfc3531_test.go
@@ -1,0 +1,187 @@
+// Copyright © 2018 The Kubernetes Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	util "sigs.k8s.io/cluster-api/pkg/util"
+)
+
+func expectedLeftmost() []string {
+	return []string{
+		"10.3.0.0/21",
+		"10.3.128.0/21",
+		"10.3.64.0/21",
+		"10.3.192.0/21",
+		"10.3.32.0/21",
+		"10.3.160.0/21",
+		"10.3.96.0/21",
+		"10.3.224.0/21",
+		"10.3.16.0/21",
+		"10.3.144.0/21",
+		"10.3.80.0/21",
+		"10.3.208.0/21",
+		"10.3.48.0/21",
+		"10.3.176.0/21",
+		"10.3.112.0/21",
+		"10.3.240.0/21",
+		"10.3.8.0/21",
+		"10.3.136.0/21",
+		"10.3.72.0/21",
+		"10.3.200.0/21",
+		"10.3.40.0/21",
+		"10.3.168.0/21",
+		"10.3.104.0/21",
+		"10.3.232.0/21",
+		"10.3.24.0/21",
+		"10.3.152.0/21",
+		"10.3.88.0/21",
+		"10.3.216.0/21",
+		"10.3.56.0/21",
+		"10.3.184.0/21",
+		"10.3.120.0/21",
+		"10.3.248.0/21",
+	}
+}
+
+func expectedRightmost() []string {
+	return []string{
+		"10.3.248.0/21",
+		"10.3.120.0/21",
+		"10.3.184.0/21",
+		"10.3.56.0/21",
+		"10.3.216.0/21",
+		"10.3.88.0/21",
+		"10.3.152.0/21",
+		"10.3.24.0/21",
+		"10.3.232.0/21",
+		"10.3.104.0/21",
+		"10.3.168.0/21",
+		"10.3.40.0/21",
+		"10.3.200.0/21",
+		"10.3.72.0/21",
+		"10.3.136.0/21",
+		"10.3.8.0/21",
+		"10.3.240.0/21",
+		"10.3.112.0/21",
+		"10.3.176.0/21",
+		"10.3.48.0/21",
+		"10.3.208.0/21",
+		"10.3.80.0/21",
+		"10.3.144.0/21",
+		"10.3.16.0/21",
+		"10.3.224.0/21",
+		"10.3.96.0/21",
+		"10.3.160.0/21",
+		"10.3.32.0/21",
+		"10.3.192.0/21",
+		"10.3.64.0/21",
+		"10.3.128.0/21",
+		"10.3.0.0/21",
+	}
+}
+
+func expectedCentermost() []string {
+	return []string{
+		"10.3.0.0/21",
+		"10.3.32.0/21",
+		"10.3.64.0/21",
+		"10.3.96.0/21",
+		"10.3.16.0/21",
+		"10.3.48.0/21",
+		"10.3.80.0/21",
+		"10.3.112.0/21",
+		"10.3.128.0/21",
+		"10.3.144.0/21",
+		"10.3.160.0/21",
+		"10.3.176.0/21",
+		"10.3.192.0/21",
+		"10.3.208.0/21",
+		"10.3.224.0/21",
+		"10.3.240.0/21",
+		"10.3.8.0/21",
+		"10.3.24.0/21",
+		"10.3.40.0/21",
+		"10.3.56.0/21",
+		"10.3.72.0/21",
+		"10.3.88.0/21",
+		"10.3.104.0/21",
+		"10.3.120.0/21",
+		"10.3.136.0/21",
+		"10.3.152.0/21",
+		"10.3.168.0/21",
+		"10.3.184.0/21",
+		"10.3.200.0/21",
+		"10.3.216.0/21",
+		"10.3.232.0/21",
+		"10.3.248.0/21",
+	}
+}
+
+func TestRFC3531InvalidCIDR(t *testing.T) {
+	_, err := util.AllocateRFC3531("10.3.0.0/16a", 21, util.LEFTMOST)
+	if err == nil {
+		t.Fatalf("Expected error with invalid CIDR")
+	}
+}
+
+func TestRFC3531SizeTooLarge(t *testing.T) {
+	_, err := util.AllocateRFC3531("10.3.0.0/16", 8, util.LEFTMOST)
+	if err == nil {
+		t.Fatalf("Expected error with subnet size too large")
+	}
+}
+
+func TestRFC3531LeftMostAllocation(t *testing.T) {
+	expected := expectedLeftmost()
+	actual, _ := util.AllocateRFC3531("10.3.0.0/16", 21, util.LEFTMOST)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Did not get expected subnets\nExpected: %v\nActual: %v",
+			strings.Join(expected, ", "),
+			strings.Join(actual, ", "),
+		)
+	}
+}
+
+func TestRFC3531CenterMostAllocation(t *testing.T) {
+	expected := expectedCentermost()
+	actual, _ := util.AllocateRFC3531("10.3.0.0/16", 21, util.CENTERMOST)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Did not get expected subnets\nExpected: %v\nActual: %v",
+			strings.Join(expected, ", "),
+			strings.Join(actual, ", "),
+		)
+	}
+}
+
+func TestRFC3531RightMostAllocation(t *testing.T) {
+	expected := expectedRightmost()
+	actual, _ := util.AllocateRFC3531("10.3.0.0/16", 21, util.RIGHTMOST)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Did not get expected subnets\nExpected: %v\nActual: %v",
+			strings.Join(expected, ", "),
+			strings.Join(actual, ", "),
+		)
+	}
+}
+
+func TestRFC3531InvalidStrategy(t *testing.T) {
+	_, err := util.AllocateRFC3531("10.3.0.0/16", 21, 10)
+	if err == nil {
+		t.Fatalf("Expected error with invalid strategy")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Provides common functionality to allocate smaller subnets from a larger super network,
which is useful for multi-datacentre subnet allocation for a number of cloud providers

https://github.com/kubernetes-sigs/cluster-api-provider-aws will be a downstream
consumer in the first instance.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #502 

**Special notes for your reviewer**:

In an example use, a `10.0.0.0/13` CIDR block is allocated by a NOC for use 
for a particular cloud provider.
The user wants to split this into three regions, using 3 availability zones in each region,
with each AZ having public and private subnets.

The user would also like to have the ability to expand the size of the subnets if needed.

We might then choose the following allocation strategies:
For each region: Leftmost (probably allocated externally from a Cluster API provider)
For each AZ within a region: Centermost
For each subnet type within an AZ: Rightmost

``` golang
package main

import (
	"fmt"

	"sigs.k8s.io/cluster-api/pkg/util"
)

func main() {

	regions := []string{"eu-west-2", "eu-central-1", "us-west-2"}
	vpcs, _ := util.AllocateRFC3531("10.0.0.0/13", 16, util.LEFTMOST)
	azSuffixes := []string{"a", "b", "c"}
	subnetTypes := []string{"public", "private"}

	for i := 0; i < len(regions); i++ {
		region := regions[i]
		vpc := vpcs[i]
		fmt.Println("\n============")
		fmt.Printf("Region: %v\n", region)
		fmt.Printf("VPC: %v\n", vpc)
		azNets, _ := util.AllocateRFC3531(vpcs[i], 19, util.CENTERMOST)
		for j := 0; j < len(azSuffixes); j++ {
			az := fmt.Sprintf("%v%v", region, azSuffixes[j])
			azNet := azNets[j]
			fmt.Printf("\nAvailability Zone: %v\n", az)
			fmt.Printf("AZ Network: %v\n", azNet)
			subnets, _ := util.AllocateRFC3531(azNet, 21, util.RIGHTMOST)
			for k := 0; k < len(subnetTypes); k++ {
				fmt.Printf("%v subnet: %v\n", subnetTypes[k], subnets[k])
			}
		}
	}
}
```

This would provide the following:
```
============

Region: eu-west-2
VPC: 10.0.0.0/16

Availability Zone: eu-west-2a
AZ Network: 10.0.0.0/19
public subnet: 10.0.24.0/21
private subnet: 10.0.8.0/21

Availability Zone: eu-west-2b
AZ Network: 10.0.64.0/19
public subnet: 10.0.88.0/21
private subnet: 10.0.72.0/21

Availability Zone: eu-west-2c
AZ Network: 10.0.128.0/19
public subnet: 10.0.152.0/21
private subnet: 10.0.136.0/21

============

Region: us-east-1
VPC: 10.4.0.0/16

Availability Zone: us-east-1a
AZ Network: 10.4.0.0/19
public subnet: 10.4.24.0/21
private subnet: 10.4.8.0/21

Availability Zone: us-east-1b
AZ Network: 10.4.64.0/19
public subnet: 10.4.88.0/21
private subnet: 10.4.72.0/21

Availability Zone: us-east-1c
AZ Network: 10.4.128.0/19
public subnet: 10.4.152.0/21
private subnet: 10.4.136.0/21

============

Region: us-west-2
VPC: 10.2.0.0/16

Availability Zone: us-west-2a
AZ Network: 10.2.0.0/19
public subnet: 10.2.24.0/21
private subnet: 10.2.8.0/21

Availability Zone: us-west-2b
AZ Network: 10.2.64.0/19
public subnet: 10.2.88.0/21
private subnet: 10.2.72.0/21

Availability Zone: us-west-2c
AZ Network: 10.2.128.0/19
public subnet: 10.2.152.0/21
private subnet: 10.2.136.0/21
```



_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
