### PR TITLE
docs: add link to digitalocean provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ are also sponsored by SIG-cluster-lifecycle:
   * AWS, https://github.com/kubernetes-sigs/cluster-api-provider-aws
   * AWS/Openshift, https://github.com/openshift/cluster-operator
   * Azure, https://github.com/platform9/azure-provider
+  * DigitalOcean, https://github.com/kubermatic/cluster-api-provider-digitalocean
   * GCE, https://github.com/kubernetes-sigs/cluster-api-provider-gcp
   * OpenStack, https://github.com/kubernetes-sigs/cluster-api-provider-openstack
   * vSphere, https://github.com/kubernetes-sigs/cluster-api-provider-vsphere


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds link to cluster-api-provider-digitalocean to README.

**Release note**:
```release-note
NONE
```

/assign @roberthbailey 
