### PR TITLE
Cluster-API apiserver should be namespace-ed

### DIFF
--- a/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/clusterctl/clusterdeployer/clusterdeployer.go
@@ -335,7 +335,7 @@ func (d *ClusterDeployer) applyClusterAPIStackWithPivoting(client, source cluste
 }
 
 func (d *ClusterDeployer) applyClusterAPIApiserver(client clusterclient.Client, namespace string) error {
-	yaml, err := deployer.GetApiServerYaml()
+	yaml, err := deployer.GetApiServerYamlForNamespace(namespace)
 	if err != nil {
 		return fmt.Errorf("unable to generate apiserver yaml: %v", err)
 	}

--- a/pkg/deployer/clusterapiserver.go
+++ b/pkg/deployer/clusterapiserver.go
@@ -43,9 +43,8 @@ type caCertParams struct {
 	tlsKey   string
 }
 
-func getApiServerCerts() (*caCertParams, error) {
+func getApiServerCertsForNamespace(namespace string) (*caCertParams, error) {
 	const name = "clusterapi"
-	const namespace = corev1.NamespaceDefault
 
 	caKeyPair, err := triple.NewCA(fmt.Sprintf("%s-certificate-authority", name))
 	if err != nil {
@@ -73,14 +72,19 @@ func getApiServerCerts() (*caCertParams, error) {
 	return certParams, nil
 }
 
-// GetApiServerYaml returns the clusterapi-apiserver manifest used for deployment
+// GetApiServerYaml returns the clusterapi-apiserver manifest for deployment in the default namespace
 func GetApiServerYaml() (string, error) {
+	return GetApiServerYamlForNamespace(corev1.NamespaceDefault)
+}
+
+// GetApiServerYamlForNamespace returns the clusterapi-apiserver manifest used for deployment in the supplied namespace
+func GetApiServerYamlForNamespace(namespace string) (string, error) {
 	tmpl, err := template.New("config").Parse(ClusterAPIAPIServerConfigTemplate)
 	if err != nil {
 		return "", err
 	}
 
-	certParms, err := getApiServerCerts()
+	certParms, err := getApiServerCertsForNamespace(namespace)
 	if err != nil {
 		glog.Errorf("Error: %v", err)
 		return "", err
@@ -94,6 +98,7 @@ func GetApiServerYaml() (string, error) {
 		CABundle               string
 		TLSCrt                 string
 		TLSKey                 string
+		Namespace              string
 	}
 
 	var tmplBuf bytes.Buffer
@@ -102,6 +107,7 @@ func GetApiServerYaml() (string, error) {
 		CABundle:       certParms.caBundle,
 		TLSCrt:         certParms.tlsCrt,
 		TLSKey:         certParms.tlsKey,
+		Namespace:      namespace,
 	})
 	if err != nil {
 		return "", err

--- a/pkg/deployer/clusterapiservertemplate.go
+++ b/pkg/deployer/clusterapiservertemplate.go
@@ -31,7 +31,7 @@ spec:
   groupPriorityMinimum: 2000
   service:
     name: clusterapi
-    namespace: default
+    namespace: {{ .Namespace }}
   versionPriority: 10
   caBundle: {{ .CABundle }}
 ---
@@ -39,7 +39,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: clusterapi
-  namespace: default
+  namespace: {{ .Namespace }}
   labels:
     api: clusterapi
     apiserver: "true"
@@ -56,7 +56,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: clusterapi-apiserver
-  namespace: default
+  namespace: {{ .Namespace }}
   labels:
     api: clusterapi
     apiserver: "true"
@@ -126,12 +126,12 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: apiserver
-  namespace: default
+  namespace: {{ .Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: default:system:auth-delegator
+  name: {{ .Namespace }}:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -139,7 +139,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: apiserver
-  namespace: default
+  namespace: {{ .Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -153,13 +153,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: apiserver
-  namespace: default
+  namespace: {{ .Namespace }}
 ---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: etcd-clusterapi
-  namespace: default
+  namespace: {{ .Namespace }}
 spec:
   serviceName: "etcd"
   replicas: 1
@@ -234,7 +234,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: etcd-clusterapi-svc
-  namespace: default
+  namespace: {{ .Namespace }}
   labels:
     app: etcd
 spec:
@@ -250,7 +250,7 @@ kind: Secret
 type: kubernetes.io/tls
 metadata:
   name: cluster-apiserver-certs
-  namespace: default
+  namespace: {{ .Namespace }}
   labels:
     api: clusterapi
     apiserver: "true"


### PR DESCRIPTION
* templatize Namespace in ClusterAPIAPIServerConfigTemplate
* pass namespace to templating
* accept gen file edit

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Identified a bug /gap in PR #481 has a gap where the cluster-api apiserver, for all clusters, would get created in the `default` namespace. This PR fixes that by passing the `namespace` to the manifest templating.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #252

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This PR makes the namespace per cluster fully functional.
```
