### PR TITLE
Delete specific machine from a machineset when scaling down

### DIFF
--- a/pkg/controller/machineset/delete_policy.go
+++ b/pkg/controller/machineset/delete_policy.go
@@ -31,8 +31,14 @@ const (
 
 type deletePriorityFunc func(machine *v1alpha1.Machine) deletePriority
 
+// machineDeleteAnnotationKey annotates machines to be delete among first ones
+var machineDeleteAnnotationKey = "sigs.k8s.io/cluster-api-delete-machine"
+
 func simpleDeletePriority(machine *v1alpha1.Machine) deletePriority {
 	if machine.DeletionTimestamp != nil && !machine.DeletionTimestamp.IsZero() {
+		return mustDelete
+	}
+	if _, exists := machine.Annotations[machineDeleteAnnotationKey]; exists {
 		return mustDelete
 	}
 	if machine.Status.ErrorReason != nil || machine.Status.ErrorMessage != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

When cluster autoscaler decreases size of a node group,
it selects a list of specific nodes that needs to be deleted from the node group.
Given a node is managed by a machine, machineset controller needs to allow to
delete specific machine rather than taking the first machine in machineset's list
of machines. The idea is to:
- annotation a machine that is to be deleted with sigs.k8s.io/cluster-api-delete-machine=""
- decrease the number of machineset replicas by one and have the `getMachinesToDelete`
  method to first pick machines that are annotated with sigs.k8s.io/cluster-api-delete-machine=""


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Related to https://github.com/kubernetes-sigs/cluster-api/issues/75

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Delete machine(s) with `sigs.k8s.io/cluster-api-delete-machine=""` annotation first when decreasing machineset's number of replicas.
```
