### PR TITLE
Fix json tags for API types

### DIFF
--- a/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -55,7 +55,7 @@ type ClusterSpec struct {
 	// their own versioned API types that should be
 	// serialized/deserialized from this field.
 	// +optional
-	ProviderConfig ProviderConfig `json:"providerConfig"`
+	ProviderConfig ProviderConfig `json:"providerConfig,omitempty"`
 }
 
 // ClusterNetworkingConfig specifies the different networking

--- a/pkg/apis/cluster/v1alpha1/common_types.go
+++ b/pkg/apis/cluster/v1alpha1/common_types.go
@@ -33,7 +33,7 @@ type ProviderConfig struct {
 	// Source for the provider configuration. Cannot be used if value is
 	// not empty.
 	// +optional
-	ValueFrom *ProviderConfigSource `json:valueFrom,omitempty`
+	ValueFrom *ProviderConfigSource `json:"valueFrom,omitempty"`
 }
 
 // ProviderConfigSource represents a source for the provider-specific


### PR DESCRIPTION
- Fix JSON tag format for `ValueFrom`
- Add `omitempty` json tag for `ProviderConfig`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
