### PR TITLE
Fix fmt strings

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -589,7 +589,7 @@ func createTempFile(contents string) (string, error) {
 func ifErrRemove(pErr *error, path string) {
 	if *pErr != nil {
 		if err := os.Remove(path); err != nil {
-			glog.Warningf("Error removing file '%v': %v", err)
+			glog.Warningf("Error removing file '%s': %v", path, err)
 		}
 	}
 }

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -771,60 +771,60 @@ func TestExtractMasterMachine(t *testing.T) {
 	multipleNodeNames := []string{"test-node-1", "test-node-2", "test-node-3"}
 
 	testCases := []struct {
-		name            string
-		inputMachines   []*clusterv1.Machine
-		expectedMasters *clusterv1.Machine
-		expectedNodes   []*clusterv1.Machine
-		expectedError   error
+		name           string
+		inputMachines  []*clusterv1.Machine
+		expectedMaster *clusterv1.Machine
+		expectedNodes  []*clusterv1.Machine
+		expectedError  error
 	}{
 		{
-			name:            "success_1_master_1_node",
-			inputMachines:   generateMachines(),
-			expectedMasters: generateTestMasterMachine(singleMasterName),
-			expectedNodes:   generateTestNodeMachines([]string{singleNodeName}),
-			expectedError:   nil,
+			name:           "success_1_master_1_node",
+			inputMachines:  generateMachines(),
+			expectedMaster: generateTestMasterMachine(singleMasterName),
+			expectedNodes:  generateTestNodeMachines([]string{singleNodeName}),
+			expectedError:  nil,
 		},
 		{
-			name:            "success_1_master_multiple_nodes",
-			inputMachines:   generateValidExtractMasterMachineInput([]string{singleMasterName}, multipleNodeNames),
-			expectedMasters: generateTestMasterMachine(singleMasterName),
-			expectedNodes:   generateTestNodeMachines(multipleNodeNames),
-			expectedError:   nil,
+			name:           "success_1_master_multiple_nodes",
+			inputMachines:  generateValidExtractMasterMachineInput([]string{singleMasterName}, multipleNodeNames),
+			expectedMaster: generateTestMasterMachine(singleMasterName),
+			expectedNodes:  generateTestNodeMachines(multipleNodeNames),
+			expectedError:  nil,
 		},
 		{
-			name:            "fail_more_than_1_master_not_allowed",
-			inputMachines:   generateInvalidExtractMasterMachine(multpleMasterNames, multipleNodeNames),
-			expectedMasters: nil,
-			expectedNodes:   nil,
-			expectedError:   fmt.Errorf("expected one master, got: 2"),
+			name:           "fail_more_than_1_master_not_allowed",
+			inputMachines:  generateInvalidExtractMasterMachine(multpleMasterNames, multipleNodeNames),
+			expectedMaster: nil,
+			expectedNodes:  nil,
+			expectedError:  fmt.Errorf("expected one master, got: 2"),
 		},
 		{
-			name:            "fail_0_master_not_allowed",
-			inputMachines:   generateTestNodeMachines(multipleNodeNames),
-			expectedMasters: nil,
-			expectedNodes:   nil,
-			expectedError:   fmt.Errorf("expected one master, got: 0"),
+			name:           "fail_0_master_not_allowed",
+			inputMachines:  generateTestNodeMachines(multipleNodeNames),
+			expectedMaster: nil,
+			expectedNodes:  nil,
+			expectedError:  fmt.Errorf("expected one master, got: 0"),
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualMasters, actualNodes, actualError := extractMasterMachine(tc.inputMachines)
+			actualMaster, actualNodes, actualError := extractMasterMachine(tc.inputMachines)
 
 			if tc.expectedError == nil && actualError != nil {
-				t.Fatalf("%s: extractMasterMachine(%q): gotError %q; wantError [nil]", tc.name, tc.inputMachines, actualError)
+				t.Fatalf("%s: extractMasterMachine(%q): gotError %q; wantError [nil]", tc.name, len(tc.inputMachines), actualError)
 			}
 
 			if tc.expectedError != nil && tc.expectedError.Error() != actualError.Error() {
-				t.Fatalf("%s: extractMasterMachine(%q): gotError %q; wantError %q", tc.name, tc.inputMachines, actualError, tc.expectedError)
+				t.Fatalf("%s: extractMasterMachine(%q): gotError %q; wantError %q", tc.name, len(tc.inputMachines), actualError, tc.expectedError)
 			}
 
-			if (tc.expectedMasters == nil && actualMasters != nil) ||
-				(tc.expectedMasters != nil && actualMasters == nil) {
-				t.Fatalf("%s: extractMasterMachine(%q): gotMasters = %q; wantMasters = %q", tc.name, tc.inputMachines, actualMasters, tc.expectedMasters)
+			if (tc.expectedMaster == nil && actualMaster != nil) ||
+				(tc.expectedMaster != nil && actualMaster == nil) {
+				t.Fatalf("%s: extractMasterMachine(%q): gotMaster = %v; wantMaster = %v", tc.name, len(tc.inputMachines), actualMaster != nil, tc.expectedMaster != nil)
 			}
 
 			if len(tc.expectedNodes) != len(actualNodes) {
-				t.Fatalf("%s: extractMasterMachine(%q): gotNodes = %q; wantNodes = %q", tc.name, tc.inputMachines, actualNodes, tc.expectedNodes)
+				t.Fatalf("%s: extractMasterMachine(%q): gotNodes = %q; wantNodes = %q", tc.name, len(tc.inputMachines), len(actualNodes), len(tc.expectedNodes))
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Without this patch, `make`  fails on go 1.11 with a 
```
# sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient
cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go:592: Warningf format %v reads arg #2, but call has 1 arg
# sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer
cmd/clusterctl/clusterdeployer/clusterdeployer_test.go:814: T.Fatalf format %q has arg tc.inputMachines of wrong type []*sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1.Machine
cmd/clusterctl/clusterdeployer/clusterdeployer_test.go:818: T.Fatalf format %q has arg tc.inputMachines of wrong type []*sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1.Machine
cmd/clusterctl/clusterdeployer/clusterdeployer_test.go:823: T.Fatalf format %q has arg tc.inputMachines of wrong type []*sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1.Machine
cmd/clusterctl/clusterdeployer/clusterdeployer_test.go:827: T.Fatalf format %q has arg tc.inputMachines of wrong type []*sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1.Machine
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
