### PR TITLE
Set MachineDeployment status

### DIFF
--- a/pkg/controller/machinedeployment/sync.go
+++ b/pkg/controller/machinedeployment/sync.go
@@ -24,10 +24,13 @@ import (
 	"strconv"
 
 	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	apirand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/util/retry"
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -108,16 +111,10 @@ func (r *ReconcileMachineDeployment) getNewMachineSet(d *clusterv1alpha1.Machine
 		}
 
 		// Apply revision annotation from existingNewMS if it is missing from the deployment.
-		// needsUpdate is false if there is not annotation or is already present.
-		needsUpdate := dutil.SetDeploymentRevision(d, msCopy.Annotations[dutil.RevisionAnnotation])
-
-		if needsUpdate {
-			err := r.Status().Update(context.Background(), d)
-			if err != nil {
-				return nil, err
-			}
-		}
-		return msCopy, nil
+		err := r.updateMachineDeployment(d, func(innerDeployment *clusterv1alpha1.MachineDeployment) {
+			dutil.SetDeploymentRevision(d, msCopy.Annotations[dutil.RevisionAnnotation])
+		})
+		return msCopy, err
 	}
 
 	if !createIfNotExisted {
@@ -190,13 +187,12 @@ func (r *ReconcileMachineDeployment) getNewMachineSet(d *clusterv1alpha1.Machine
 		return nil, err
 	}
 
-	needsUpdate := dutil.SetDeploymentRevision(d, newRevision)
 	if !alreadyExists {
 		glog.V(4).Infof("Created new machine set %q", createdMS.Name)
 	}
-	if needsUpdate {
-		err = r.Status().Update(context.Background(), d)
-	}
+	err = r.updateMachineDeployment(d, func(innerDeployment *clusterv1alpha1.MachineDeployment) {
+		dutil.SetDeploymentRevision(d, newRevision)
+	})
 	return createdMS, err
 }
 
@@ -218,7 +214,7 @@ func (r *ReconcileMachineDeployment) scale(deployment *clusterv1alpha1.MachineDe
 		if *(activeOrLatest.Spec.Replicas) == *(deployment.Spec.Replicas) {
 			return nil
 		}
-		_, _, err := r.scaleMachineSet(activeOrLatest, *(deployment.Spec.Replicas), deployment)
+		_, err := r.scaleMachineSet(activeOrLatest, *(deployment.Spec.Replicas), deployment)
 		return err
 	}
 
@@ -226,7 +222,7 @@ func (r *ReconcileMachineDeployment) scale(deployment *clusterv1alpha1.MachineDe
 	// This case handles machine set adoption during a saturated new machine set.
 	if dutil.IsSaturated(deployment, newMS) {
 		for _, old := range dutil.FilterActiveMachineSets(oldMSs) {
-			if _, _, err := r.scaleMachineSet(old, 0, deployment); err != nil {
+			if _, err := r.scaleMachineSet(old, 0, deployment); err != nil {
 				return err
 			}
 		}
@@ -304,7 +300,7 @@ func (r *ReconcileMachineDeployment) scale(deployment *clusterv1alpha1.MachineDe
 			}
 
 			// TODO: Use transactions when we have them.
-			if _, _, err := r.scaleMachineSetOperation(ms, nameToSize[ms.Name], deployment, scalingOperation); err != nil {
+			if _, err := r.scaleMachineSetOperation(ms, nameToSize[ms.Name], deployment, scalingOperation); err != nil {
 				// Return as soon as we fail, the deployment is requeued
 				return err
 			}
@@ -321,10 +317,8 @@ func (r *ReconcileMachineDeployment) syncDeploymentStatus(allMSs []*clusterv1alp
 		return nil
 	}
 
-	newDeployment := d
-	newDeployment.Status = newStatus
-	err := r.Status().Update(context.Background(), newDeployment)
-	return err
+	d.Status = newStatus
+	return r.Status().Update(context.Background(), d)
 }
 
 // calculateStatus calculates the latest status for the provided deployment by looking into the provided machine sets.
@@ -351,13 +345,13 @@ func calculateStatus(allMSs []*clusterv1alpha1.MachineSet, newMS *clusterv1alpha
 	return status
 }
 
-func (r *ReconcileMachineDeployment) scaleMachineSet(ms *clusterv1alpha1.MachineSet, newScale int32, deployment *clusterv1alpha1.MachineDeployment) (bool, *clusterv1alpha1.MachineSet, error) {
+func (r *ReconcileMachineDeployment) scaleMachineSet(ms *clusterv1alpha1.MachineSet, newScale int32, deployment *clusterv1alpha1.MachineDeployment) (bool, error) {
 	if ms.Spec.Replicas == nil {
-		return false, nil, fmt.Errorf("spec replicas for machine set %v is nil, this is unexpected", ms.Name)
+		return false, fmt.Errorf("spec replicas for machine set %v is nil, this is unexpected", ms.Name)
 	}
 	// No need to scale
 	if *(ms.Spec.Replicas) == newScale {
-		return false, ms, nil
+		return false, nil
 	}
 	var scalingOperation string
 	if *(ms.Spec.Replicas) < newScale {
@@ -366,13 +360,13 @@ func (r *ReconcileMachineDeployment) scaleMachineSet(ms *clusterv1alpha1.Machine
 		scalingOperation = "down"
 	}
 
-	scaled, newMS, err := r.scaleMachineSetOperation(ms, newScale, deployment, scalingOperation)
-	return scaled, newMS, err
+	scaled, err := r.scaleMachineSetOperation(ms, newScale, deployment, scalingOperation)
+	return scaled, err
 }
 
-func (r *ReconcileMachineDeployment) scaleMachineSetOperation(ms *clusterv1alpha1.MachineSet, newScale int32, deployment *clusterv1alpha1.MachineDeployment, scaleOperation string) (bool, *clusterv1alpha1.MachineSet, error) {
+func (r *ReconcileMachineDeployment) scaleMachineSetOperation(ms *clusterv1alpha1.MachineSet, newScale int32, deployment *clusterv1alpha1.MachineDeployment, scaleOperation string) (bool, error) {
 	if ms.Spec.Replicas == nil {
-		return false, nil, fmt.Errorf("spec replicas for machine set %v is nil, this is unexpected", ms.Name)
+		return false, fmt.Errorf("spec replicas for machine set %v is nil, this is unexpected", ms.Name)
 	}
 	sizeNeedsUpdate := *(ms.Spec.Replicas) != newScale
 
@@ -381,19 +375,14 @@ func (r *ReconcileMachineDeployment) scaleMachineSetOperation(ms *clusterv1alpha
 	scaled := false
 	var err error
 	if sizeNeedsUpdate || annotationsNeedUpdate {
-		// TODO(droot): we don't need deepcopy with new client, so revisit this
-		// to clean up
-		msCopy := ms.DeepCopy()
-		*(msCopy.Spec.Replicas) = newScale
-		dutil.SetReplicasAnnotations(msCopy, *(deployment.Spec.Replicas), *(deployment.Spec.Replicas)+dutil.MaxSurge(*deployment))
-		// ms, err = dc.machineClient.ClusterV1alpha1().MachineSets(msCopy.Namespace).Update(msCopy)
-		err = r.Update(context.Background(), msCopy)
-		ms = msCopy
+		*(ms.Spec.Replicas) = newScale
+		dutil.SetReplicasAnnotations(ms, *(deployment.Spec.Replicas), *(deployment.Spec.Replicas)+dutil.MaxSurge(*deployment))
+		err = r.Update(context.Background(), ms)
 		if err == nil && sizeNeedsUpdate {
 			scaled = true
 		}
 	}
-	return scaled, ms, err
+	return scaled, err
 }
 
 // cleanupDeployment is responsible for cleaning up a deployment ie. retains all but the latest N old machine sets
@@ -462,4 +451,28 @@ func (r *ReconcileMachineDeployment) isScalingEvent(d *clusterv1alpha1.MachineDe
 		}
 	}
 	return false, nil
+}
+
+func (r *ReconcileMachineDeployment) updateMachineDeployment(d *clusterv1alpha1.MachineDeployment, modify func(*clusterv1alpha1.MachineDeployment)) error {
+	return updateMachineDeployment(r.Client, d, modify)
+}
+
+// We have this as standalone variant to be able to use it from the tests
+func updateMachineDeployment(c client.Client, d *clusterv1alpha1.MachineDeployment, modify func(*clusterv1alpha1.MachineDeployment)) error {
+	dCopy := d.DeepCopy()
+	modify(dCopy)
+	if equality.Semantic.DeepEqual(dCopy, d) {
+		return nil
+	}
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		//Get latest version from API
+		if err := c.Get(context.Background(), types.NamespacedName{Namespace: d.Namespace, Name: d.Name}, d); err != nil {
+			return err
+		}
+		// Apply modifications
+		modify(d)
+		// Update the machineDeployment
+		return c.Update(context.Background(), d)
+	})
+	return err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

* Makes the MachineDeployment controller set the MachineDeployments status
* Makes the MachineDeployment controller clean up old MachineSets

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #543 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
