### PR TITLE
Fix machineDeployment CRD for kube 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
 	@# Kubebuilder CRD generation can't handle intstr.IntOrString properly:
 	@# https://github.com/kubernetes-sigs/kubebuilder/issues/442
-	sed -i '/maxSurge:/{n;d}' config/crds/cluster_v1alpha1_machinedeployment.yaml
-	sed -i '/maxUnavailable:/{n;d}' config/crds/cluster_v1alpha1_machinedeployment.yaml
+	sed -i -e 's/maxSurge:/maxSurge: {}/g' -e '/maxSurge:/{n;d};' config/crds/cluster_v1alpha1_machinedeployment.yaml
+	sed -i -e 's/maxUnavailable:/maxUnavailable: {}/g' -e '/maxUnavailable:/{n;d};' config/crds/cluster_v1alpha1_machinedeployment.yaml
 
 # Run go fmt against code
 fmt:

--- a/config/crds/cluster_v1alpha1_machinedeployment.yaml
+++ b/config/crds/cluster_v1alpha1_machinedeployment.yaml
@@ -44,8 +44,8 @@ spec:
               properties:
                 rollingUpdate:
                   properties:
-                    maxSurge:
-                    maxUnavailable:
+                    maxSurge: {}
+                    maxUnavailable: {}
                   type: object
                 type:
                   type: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Current `MachineDeployment` crd fails validation on Kube 1.12: `error validating data: [unknown object type "nil" in CustomResourceDefinition.spec.validation.openAPIV3Schema.properties.spec.properties.strategy.properties.rollingUpdate.properties.maxSurge, unknown object type "nil" in CustomResourceDefinition.spec.validation.openAPIV3Schema.properties.spec.properties.strategy.properties.rollingUpdate.properties.maxUnavailable]; if you choose to ignore these errors, turn validation off with --validate=false`

This fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

CC @chaosaffe 

/assign @roberthbailey 
