### PR TITLE
clusterdeployer: Apply addons before pivot

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -137,6 +137,13 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 	}
 	defer closeClient(targetClient, "target")
 
+	if d.addonComponents != "" {
+		glog.Info("Creating addons in target cluster.")
+		if err := targetClient.Apply(d.addonComponents); err != nil {
+			return fmt.Errorf("unable to apply addons: %v", err)
+		}
+	}
+
 	glog.Info("Applying Cluster API stack to target cluster")
 	if err := d.applyClusterAPIStackWithPivoting(targetClient, bootstrapClient, cluster.Namespace); err != nil {
 		return fmt.Errorf("unable to apply cluster api stack to target cluster: %v", err)
@@ -163,13 +170,6 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 	glog.Info("Creating node machines in target cluster.")
 	if err := targetClient.CreateMachineObjects(nodes, cluster.Namespace); err != nil {
 		return fmt.Errorf("unable to create node machines: %v", err)
-	}
-
-	if d.addonComponents != "" {
-		glog.Info("Creating addons in target cluster.")
-		if err := targetClient.Apply(d.addonComponents); err != nil {
-			return fmt.Errorf("unable to apply addons: %v", err)
-		}
 	}
 
 	glog.Infof("Done provisioning cluster. You can now access your cluster with kubectl --kubeconfig %v", kubeconfigOutput)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Move the application of add-ons to happen immediately after the target API Server
is available, and before the cluster is pivoted, thus supporting cluster initialisation
components like CNI in the short term.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #534 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Application of add-ons happens immediately after cluster creation, and before pivoting.
```
