### PR TITLE
Make MachineDeployment.Spec.Strategy a pointer

### DIFF
--- a/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
@@ -40,7 +40,7 @@ type MachineDeploymentSpec struct {
 	// The deployment strategy to use to replace existing machines with
 	// new ones.
 	// +optional
-	Strategy MachineDeploymentStrategy `json:"strategy,omitempty"`
+	Strategy *MachineDeploymentStrategy `json:"strategy,omitempty"`
 
 	// Minimum number of seconds for which a newly created machine should
 	// be ready.

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -265,7 +265,11 @@ func (in *MachineDeploymentSpec) DeepCopyInto(out *MachineDeploymentSpec) {
 	}
 	in.Selector.DeepCopyInto(&out.Selector)
 	in.Template.DeepCopyInto(&out.Template)
-	in.Strategy.DeepCopyInto(&out.Strategy)
+	if in.Strategy != nil {
+		in, out := &in.Strategy, &out.Strategy
+		*out = new(MachineDeploymentStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MinReadySeconds != nil {
 		in, out := &in.MinReadySeconds, &out.MinReadySeconds
 		*out = new(int32)

--- a/pkg/controller/machinedeployment/machinedeployment_controller_test.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller_test.go
@@ -48,7 +48,7 @@ func TestReconcile(t *testing.T) {
 			Replicas:             int32Ptr(2),
 			RevisionHistoryLimit: int32Ptr(0),
 			Selector:             metav1.LabelSelector{MatchLabels: labels},
-			Strategy: clusterv1alpha1.MachineDeploymentStrategy{
+			Strategy: &clusterv1alpha1.MachineDeploymentStrategy{
 				Type: common.RollingUpdateMachineDeploymentStrategyType,
 				RollingUpdate: &clusterv1alpha1.MachineRollingUpdateDeployment{
 					MaxUnavailable: intstrPtr(0),


### PR DESCRIPTION
This is required in order to allow defaulting it via a MutatingWebhook.

When it is a literal and the user creates a MachineDeployment where that
property does not exist, the creation of a jsonpatch will happen based
on a representation where that field exists, since literals always gets
marshaled. This means a generated jsonpatch will get refused by the
APIServer which doesn't know anything about that field with an error
like this: `doc is missing path: "/spec/strategy/type"`

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This is required to allow defaulting `MachineDeployment.Spec.Strategy` via a `MutatingWebhook`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @roberthbailey 