### PR TITLE
[clusterctl] add phases create-bootstrap-cluster subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ bazel-cluster-api
 bazel-genfiles
 bazel-out
 bazel-testlogs
+
+# kubeconfigs
+minikube.kubeconfig

--- a/cmd/clusterctl/clusterdeployer/bootstrap/minikube/minikube.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/minikube/minikube.go
@@ -18,11 +18,12 @@ package minikube
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/golang/glog"
 )
 
 type Minikube struct {
@@ -37,11 +38,18 @@ func New() *Minikube {
 }
 
 func WithOptions(options []string) *Minikube {
-	return &Minikube{
-		minikubeExec: minikubeExec,
-		options:      options,
+	return WithOptionsAndKubeConfigPath(options, "")
+}
+
+func WithOptionsAndKubeConfigPath(options []string, kubeconfigpath string) *Minikube {
+	if kubeconfigpath == "" {
 		// Arbitrary file name. Can potentially be randomly generated.
-		kubeconfigpath: "minikube.kubeconfig",
+		kubeconfigpath = "minikube.kubeconfig"
+	}
+	return &Minikube{
+		minikubeExec:   minikubeExec,
+		options:        options,
+		kubeconfigpath: kubeconfigpath,
 	}
 }
 

--- a/cmd/clusterctl/clusterdeployer/bootstrap/provisioner.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/provisioner.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+// Can provision a kubernetes cluster
+type ClusterProvisioner interface {
+	Create() error
+	Delete() error
+	GetKubeconfig() (string, error)
+}

--- a/cmd/clusterctl/cmd/alpha.go
+++ b/cmd/clusterctl/cmd/alpha.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var alphaCmd = &cobra.Command{
+	Use:   "alpha",
+	Short: "Alpha/Experimental features",
+	Long:  `Alpha/Experimental features`,
+}
+
+func init() {
+	RootCmd.AddCommand(alphaCmd)
+}

--- a/cmd/clusterctl/cmd/alpha_phase_create_bootstrap_cluster.go
+++ b/cmd/clusterctl/cmd/alpha_phase_create_bootstrap_cluster.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/minikube"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/phases"
+)
+
+type AlphaPhaseCreateBootstrapClusterOptions struct {
+	MiniKube         []string
+	VmDriver         string
+	KubeconfigOutput string
+}
+
+var pcbco = &AlphaPhaseCreateBootstrapClusterOptions{}
+
+var alphaPhaseCreateBootstrapClusterCmd = &cobra.Command{
+	Use:   "create-bootstrap-cluster",
+	Short: "Create a bootstrap cluster",
+	Long:  `Create a bootstrap cluster`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := RunAlphaPhaseCreateBootstrapCluster(pcbco); err != nil {
+			glog.Exit(err)
+		}
+	},
+}
+
+func RunAlphaPhaseCreateBootstrapCluster(pcbco *AlphaPhaseCreateBootstrapClusterOptions) error {
+	if pcbco.VmDriver != "" {
+		pcbco.MiniKube = append(pcbco.MiniKube, fmt.Sprintf("vm-driver=%s", pcbco.VmDriver))
+	}
+
+	bootstrapProvider := minikube.WithOptionsAndKubeConfigPath(pcbco.MiniKube, pcbco.KubeconfigOutput)
+
+	_, _, err := phases.CreateBootstrapCluster(bootstrapProvider, false, clusterclient.NewFactory())
+	if err != nil {
+		return fmt.Errorf("failed to create bootstrap cluster: %v", err)
+	}
+
+	glog.Infof("Created bootstrap cluster, path to kubeconfig: %q", pcbco.KubeconfigOutput)
+	return nil
+}
+
+func init() {
+	// Optional flags
+	alphaPhaseCreateBootstrapClusterCmd.Flags().StringSliceVarP(&pcbco.MiniKube, "minikube", "", []string{}, "Minikube options")
+	alphaPhaseCreateBootstrapClusterCmd.Flags().StringVarP(&pcbco.VmDriver, "vm-driver", "", "", "Which vm driver to use for minikube")
+	alphaPhaseCreateBootstrapClusterCmd.Flags().StringVarP(&pcbco.KubeconfigOutput, "kubeconfig-out", "", "minikube.kubeconfig", "Where to output the kubeconfig for the bootstrap cluster")
+
+	alphaPhasesCmd.AddCommand(alphaPhaseCreateBootstrapClusterCmd)
+}

--- a/cmd/clusterctl/cmd/alpha_phases.go
+++ b/cmd/clusterctl/cmd/alpha_phases.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var alphaPhasesCmd = &cobra.Command{
+	Use:   "phases",
+	Short: "Run an individual phase",
+	Long:  `Run an individual phase`,
+}
+
+func init() {
+	alphaCmd.AddCommand(alphaPhasesCmd)
+}

--- a/cmd/clusterctl/cmd/create_cluster.go
+++ b/cmd/clusterctl/cmd/create_cluster.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/minikube"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
@@ -77,7 +78,7 @@ func RunCreate(co *CreateOptions) error {
 		return err
 	}
 
-	var bootstrapProvider clusterdeployer.ClusterProvisioner
+	var bootstrapProvider bootstrap.ClusterProvisioner
 	if co.ExistingClusterKubeconfigPath != "" {
 		bootstrapProvider, err = existing.NewExistingCluster(co.ExistingClusterKubeconfigPath)
 		if err != nil {

--- a/cmd/clusterctl/cmd/delete_cluster.go
+++ b/cmd/clusterctl/cmd/delete_cluster.go
@@ -23,6 +23,7 @@ import (
 	tcmd "k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clientcmd"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/minikube"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
@@ -89,7 +90,7 @@ func RunDelete() error {
 	}
 	defer clusterClient.Close()
 
-	var bootstrapProvider clusterdeployer.ClusterProvisioner
+	var bootstrapProvider bootstrap.ClusterProvisioner
 	if do.ExistingClusterKubeconfigPath != "" {
 		bootstrapProvider, err = existing.NewExistingCluster(do.ExistingClusterKubeconfigPath)
 		if err != nil {

--- a/cmd/clusterctl/phases/createbootstrapcluster.go
+++ b/cmd/clusterctl/phases/createbootstrapcluster.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
+)
+
+func CreateBootstrapCluster(provisioner bootstrap.ClusterProvisioner, cleanupBootstrapCluster bool, clientFactory clusterclient.Factory) (clusterclient.Client, func(), error) {
+	glog.Info("Creating bootstrap cluster")
+
+	cleanupFn := func() {}
+	if err := provisioner.Create(); err != nil {
+		return nil, cleanupFn, fmt.Errorf("could not create bootstrap control plane: %v", err)
+	}
+
+	if cleanupBootstrapCluster {
+		cleanupFn = func() {
+			glog.Info("Cleaning up bootstrap cluster.")
+			provisioner.Delete()
+		}
+	}
+
+	bootstrapKubeconfig, err := provisioner.GetKubeconfig()
+	if err != nil {
+		return nil, cleanupFn, fmt.Errorf("unable to get bootstrap cluster kubeconfig: %v", err)
+	}
+	bootstrapClient, err := clientFactory.NewClientFromKubeconfig(bootstrapKubeconfig)
+	if err != nil {
+		return nil, cleanupFn, fmt.Errorf("unable to create bootstrap client: %v", err)
+	}
+
+	return bootstrapClient, cleanupFn, nil
+}

--- a/cmd/clusterctl/testdata/no-args-invalid-flag.golden
+++ b/cmd/clusterctl/testdata/no-args-invalid-flag.golden
@@ -4,6 +4,7 @@ Usage:
   clusterctl [command]
 
 Available Commands:
+  alpha       Alpha/Experimental features
   create      Create a cluster API resource
   delete      Delete a cluster API resource
   help        Help about any command

--- a/cmd/clusterctl/testdata/no-args.golden
+++ b/cmd/clusterctl/testdata/no-args.golden
@@ -5,6 +5,7 @@ Usage:
   clusterctl [command]
 
 Available Commands:
+  alpha       Alpha/Experimental features
   create      Create a cluster API resource
   delete      Delete a cluster API resource
   help        Help about any command


### PR DESCRIPTION
**What this PR does / why we need it**:

Starts to add phases support to clusterctl to allow for a user to run a subset of steps.

Related to: #554 

**Release note**:
```release-note
- `clusterctl` now has an alpha phases create-bootstrap-cluster subcommand
```
