### PR TITLE
Add missing flags into cluster delete command

### DIFF
--- a/cmd/clusterctl/cmd/create_cluster.go
+++ b/cmd/clusterctl/cmd/create_cluster.go
@@ -131,7 +131,7 @@ func init() {
 	createClusterCmd.Flags().StringSliceVarP(&co.MiniKube, "minikube", "", []string{}, "Minikube options")
 	createClusterCmd.Flags().StringVarP(&co.VmDriver, "vm-driver", "", "", "Which vm driver to use for minikube")
 	createClusterCmd.Flags().StringVarP(&co.KubeconfigOutput, "kubeconfig-out", "", "kubeconfig", "Where to output the kubeconfig for the provisioned cluster")
-	createClusterCmd.Flags().StringVarP(&co.ExistingClusterKubeconfigPath, "existing-bootstrap-cluster-kubeconfig", "", "", "Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)")
+	createClusterCmd.Flags().StringVarP(&co.ExistingClusterKubeconfigPath, "existing-bootstrap-cluster-kubeconfig", "e", "", "Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)")
 
 	createCmd.AddCommand(createClusterCmd)
 }

--- a/cmd/clusterctl/main_integration_test.go
+++ b/cmd/clusterctl/main_integration_test.go
@@ -63,6 +63,7 @@ func TestEmptyAndInvalidArgs(t *testing.T) {
 		{"create cluster with no arguments with invalid flag", []string{"create", "cluster", "--invalid-flag"}, 1, "create-cluster-no-args-invalid-flag.golden"},
 		{"delete with no arguments", []string{"delete"}, 0, "delete-no-args.golden"},
 		{"delete with no arguments with invalid flag", []string{"delete", "--invalid-flag"}, 1, "delete-no-args-invalid-flag.golden"},
+		{"delete cluster with no arguments", []string{"delete", "cluster"}, 1, "delete-cluster-no-args.golden"},
 		{"delete cluster with no arguments with invalid flag", []string{"delete", "cluster", "--invalid-flag"}, 1, "delete-cluster-no-args-invalid-flag.golden"},
 		{"validate with no arguments", []string{"validate"}, 0, "validate-no-args.golden"},
 		{"validate with no arguments with invalid flag", []string{"validate", "--invalid-flag"}, 1, "validate-no-args-invalid-flag.golden"},

--- a/cmd/clusterctl/testdata/create-cluster-no-args.golden
+++ b/cmd/clusterctl/testdata/create-cluster-no-args.golden
@@ -8,7 +8,7 @@ Flags:
   -a, --addon-components string                        A yaml file containing cluster addons to apply to the internal cluster
       --cleanup-bootstrap-cluster                      Whether to cleanup the bootstrap cluster after bootstrap (default true)
   -c, --cluster string                                 A yaml file containing cluster object definition
-      --existing-bootstrap-cluster-kubeconfig string   Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)
+  -e, --existing-bootstrap-cluster-kubeconfig string   Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)
   -h, --help                                           help for cluster
       --kubeconfig-out string                          Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
   -m, --machines string                                A yaml file containing machine object definition(s)

--- a/cmd/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
+++ b/cmd/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
@@ -3,13 +3,16 @@ Usage:
   clusterctl delete cluster [flags]
 
 Flags:
-      --cluster string               The name of the kubeconfig cluster to use
-      --cluster-namespace string     Namespace where the cluster to be deleted resides (default "default")
-  -h, --help                         help for cluster
-  -n, --namespace string             If present, the namespace scope for this CLI request
-  -p, --provider-components string   A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.
-      --user string                  The name of the kubeconfig user to use
-      --vm-driver string             Which vm driver to use for minikube
+      --cleanup-bootstrap-cluster                      Whether to cleanup the bootstrap cluster after bootstrap (default true)
+      --cluster string                                 The name of the kubeconfig cluster to use
+      --cluster-namespace string                       Namespace where the cluster to be deleted resides (default "default")
+  -e, --existing-bootstrap-cluster-kubeconfig string   Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)
+  -h, --help                                           help for cluster
+      --minikube strings                               Minikube options
+  -n, --namespace string                               If present, the namespace scope for this CLI request
+  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.
+      --user string                                    The name of the kubeconfig user to use
+      --vm-driver string                               Which vm driver to use for minikube
 
 Global Flags:
       --alsologtostderr                  log to standard error as well as files

--- a/cmd/clusterctl/testdata/delete-cluster-no-args.golden
+++ b/cmd/clusterctl/testdata/delete-cluster-no-args.golden
@@ -1,18 +1,19 @@
-Error: unknown flag: --invalid-flag
+Please provide kubeconfig file for cluster to delete.
+Delete a kubernetes cluster with one command
+
 Usage:
-  clusterctl create cluster [flags]
+  clusterctl delete cluster [flags]
 
 Flags:
-  -a, --addon-components string                        A yaml file containing cluster addons to apply to the internal cluster
       --cleanup-bootstrap-cluster                      Whether to cleanup the bootstrap cluster after bootstrap (default true)
-  -c, --cluster string                                 A yaml file containing cluster object definition
+      --cluster string                                 The name of the kubeconfig cluster to use
+      --cluster-namespace string                       Namespace where the cluster to be deleted resides (default "default")
   -e, --existing-bootstrap-cluster-kubeconfig string   Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)
   -h, --help                                           help for cluster
-      --kubeconfig-out string                          Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
-  -m, --machines string                                A yaml file containing machine object definition(s)
       --minikube strings                               Minikube options
-      --provider string                                Which provider deployment logic to use (google/vsphere/azure)
-  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects
+  -n, --namespace string                               If present, the namespace scope for this CLI request
+  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.
+      --user string                                    The name of the kubeconfig user to use
       --vm-driver string                               Which vm driver to use for minikube
 
 Global Flags:
@@ -26,5 +27,3 @@ Global Flags:
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
-
-unknown flag: --invalid-flag


### PR DESCRIPTION
**What this PR does / why we need it**:

Added a few missing flags that were added to the create cluster
operation that would also be useful for delete cluster, such
as existing cluster, minikube options, and an option to clean
up the bootstrap cluster.  Also added a short hand for the
existing cluster for both create and delete cluster so users
don't have to type the whole flag name.

Also added a test for when delete cluster is called with no flags.
Currently, clusterctl will just hang.  Fixed that and added the
golden file for the test.

Fixes #560

