### PR TITLE
Create machines in parallel in clusterctl create

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -303,7 +303,7 @@ func (c *client) CreateMachineObjects(machines []*clusterv1.Machine, namespace s
 		errOnce sync.Once
 		gerr    error
 	)
-	// the approach to concurrency here comes from golang.org/x/sync/errgroup
+	// The approach to concurrency here comes from golang.org/x/sync/errgroup.
 	for _, machine := range machines {
 		wg.Add(1)
 
@@ -317,8 +317,8 @@ func (c *client) CreateMachineObjects(machines []*clusterv1.Machine, namespace s
 				})
 				return
 			}
-			err = waitForMachineReady(c.clientSet, createdMachine)
-			if err != nil {
+
+			if err := waitForMachineReady(c.clientSet, createdMachine); err != nil {
 				errOnce.Do(func() { gerr = err })
 			}
 		}(machine)

--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -297,18 +298,33 @@ func (c *client) CreateMachineSetObjects(machineSets []*clusterv1.MachineSet, na
 }
 
 func (c *client) CreateMachineObjects(machines []*clusterv1.Machine, namespace string) error {
+	var (
+		wg      sync.WaitGroup
+		errOnce sync.Once
+		gerr    error
+	)
+	// the approach to concurrency here comes from golang.org/x/sync/errgroup
 	for _, machine := range machines {
-		// TODO: Run in parallel https://github.com/kubernetes-sigs/cluster-api/issues/258
-		createdMachine, err := c.clientSet.ClusterV1alpha1().Machines(namespace).Create(machine)
-		if err != nil {
-			return fmt.Errorf("error creating a machine object in namespace %v: %v", namespace, err)
-		}
-		err = waitForMachineReady(c.clientSet, createdMachine)
-		if err != nil {
-			return err
-		}
+		wg.Add(1)
+
+		go func(machine *clusterv1.Machine) {
+			defer wg.Done()
+
+			createdMachine, err := c.clientSet.ClusterV1alpha1().Machines(namespace).Create(machine)
+			if err != nil {
+				errOnce.Do(func() {
+					gerr = fmt.Errorf("error creating a machine object in namespace %v: %v", namespace, err)
+				})
+				return
+			}
+			err = waitForMachineReady(c.clientSet, createdMachine)
+			if err != nil {
+				errOnce.Do(func() { gerr = err })
+			}
+		}(machine)
 	}
-	return nil
+	wg.Wait()
+	return gerr
 }
 
 // Deprecated API. Please do not extend or use.


### PR DESCRIPTION
**What this PR does / why we need it**:
To speed up overall machine creation. Note that there were no tests for `clusterclient`. Creating tests at this point is a bit beyond my current understanding of cluster-api, so this may need to stay unmerged until tests can prove its validity. The note in the placeholder says (and refers to #254):

```go
// TODO: Test clusterclient. To do this properly, etcd and kubectl need to be on the box running the test.
// Placeholder till the presubmit images have the needed binaries.
// https://github.com/kubernetes-sigs/cluster-api/issues/254
```

Also, note that the approach to concurrency was taken from `golang.org/x/sync/errgroup` which was not included directly to avoid another dependency. If this isn't preferred, I can add the dependency and update this PR.

**Which issue(s) this PR fixes** :
Fixes #258

**Release note**:
```release-note
NONE
```
