### PR TITLE
Extend MachineStatus to add ProviderID

### DIFF
--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -78,6 +78,19 @@ type MachineSpec struct {
 	// as-is.
 	// +optional
 	ConfigSource *corev1.NodeConfigSource `json:"configSource,omitempty"`
+
+	// ProviderID is the identification ID of the machine provided by the provider.
+	// This field must match the provider ID as seen on the node object corresponding to this machine.
+	// This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+	// with cluster-api as provider. Clean-up login in the autoscaler compares machines v/s nodes to find out
+	// machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+	// generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+	// able to have a provider view of the list of machines. Another list of nodes is queries from the k8s apiserver
+	// and then comparison is done to find out unregistered machines and are marked for delete.
+	// This field will be set by the actuators and consumed by higher level entities like autoscaler  who will
+	// be interfacing with cluster-api as generic provider.
+	// +optional
+	ProviderID *string `json:"providerID,omitempty"`
 }
 
 /// [MachineSpec]

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -638,6 +638,11 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		*out = new(v1.NodeConfigSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ProviderID != nil {
+		in, out := &in.ProviderID, &out.ProviderID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
A new field, `ProviderID`, is being proposed to add in machine object `Spec`. This field is required by higher level consumers of cluster-api such as autoscaler for the machines v/s nodes reconciliation logic. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of list of machines.

This field will be set by actuators and consumed by higher level entities who will be interfacing with cluster-api as generic provider.

```release-note
Add ProviderID to the machine Spec
```
/cc  @roberthbailey @hardikdr @enxebre @derekwaynecarr 