### PR TITLE
Create a phase for applying the Cluster API components

### DIFF
--- a/cmd/clusterctl/cmd/alpha_phase_apply_cluster_api_components.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_cluster_api_components.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/phases"
+)
+
+type AlphaPhaseApplyClusterAPIComponentsOptions struct {
+	Kubeconfig         string
+	ProviderComponents string
+}
+
+var pacaso = &AlphaPhaseApplyClusterAPIComponentsOptions{}
+
+var alphaPhaseApplyClusterAPIComponentsCmd = &cobra.Command{
+	Use:   "apply-cluster-api-components",
+	Short: "Apply Cluster API components",
+	Long:  `Apply Cluster API components`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if pacaso.ProviderComponents == "" {
+			exitWithHelp(cmd, "Please provide yaml file for provider component definition.")
+		}
+
+		if pacaso.Kubeconfig == "" {
+			exitWithHelp(cmd, "Please provide a kubeconfig file.")
+		}
+
+		if err := RunAlphaPhaseApplyClusterAPIComponents(pacaso); err != nil {
+			glog.Exit(err)
+		}
+	},
+}
+
+func RunAlphaPhaseApplyClusterAPIComponents(pacaso *AlphaPhaseApplyClusterAPIComponentsOptions) error {
+	kubeconfig, err := ioutil.ReadFile(pacaso.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	pc, err := ioutil.ReadFile(pacaso.ProviderComponents)
+	if err != nil {
+		return fmt.Errorf("error loading provider components file '%v': %v", pacaso.ProviderComponents, err)
+	}
+
+	clientFactory := clusterclient.NewFactory()
+	client, err := clientFactory.NewClientFromKubeconfig(string(kubeconfig))
+	if err != nil {
+		return fmt.Errorf("unable to create cluster client: %v", err)
+	}
+
+	return phases.ApplyClusterAPIComponents(client, string(pc))
+}
+
+func init() {
+	// Optional flags
+	alphaPhaseApplyClusterAPIComponentsCmd.Flags().StringVarP(&pacaso.Kubeconfig, "kubeconfig", "", "", "Path for the kubeconfig file to use")
+	alphaPhaseApplyClusterAPIComponentsCmd.Flags().StringVarP(&pacaso.ProviderComponents, "provider-components", "p", "", "A yaml file containing cluster api provider controllers and supporting objects")
+	alphaPhasesCmd.AddCommand(alphaPhaseApplyClusterAPIComponentsCmd)
+}

--- a/cmd/clusterctl/phases/applyclusterapicomponents.go
+++ b/cmd/clusterctl/phases/applyclusterapicomponents.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
+)
+
+func ApplyClusterAPIComponents(client clusterclient.Client, providerComponents string) error {
+	glog.Info("Applying Cluster API Provider Components")
+	if err := client.Apply(providerComponents); err != nil {
+		return fmt.Errorf("unable to apply cluster api controllers: %v", err)
+	}
+
+	return client.WaitForClusterV1alpha1Ready()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- add `alpha phases apply-cluster-api-components` subcommand
- move cluster-api components application out of clusterdeployer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #554 

**Release note**:
```release-note
clusterctl now has an alpha phases apply-cluster-api-components subcommand
```
