### PR TITLE
Create a phase for applying the Addon components

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -131,9 +131,8 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 	defer closeClient(targetClient, "target")
 
 	if d.addonComponents != "" {
-		glog.Info("Creating addons in target cluster.")
-		if err := targetClient.Apply(d.addonComponents); err != nil {
-			return fmt.Errorf("unable to apply addons: %v", err)
+		if err := phases.ApplyAddons(targetClient, d.addonComponents); err != nil {
+			return fmt.Errorf("unable to apply addons to target cluster: %v", err)
 		}
 	}
 

--- a/cmd/clusterctl/cmd/alpha_phase_apply_addons.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_addons.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/phases"
+)
+
+type AlphaPhaseApplyAddonsOptions struct {
+	Kubeconfig string
+	Addons     string
+}
+
+var paao = &AlphaPhaseApplyAddonsOptions{}
+
+var alphaPhaseApplyAddonsCmd = &cobra.Command{
+	Use:   "apply-addons",
+	Short: "Apply Addons",
+	Long:  `Apply Addons`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if paao.Addons == "" {
+			exitWithHelp(cmd, "Please provide yaml file for addons definition.")
+		}
+
+		if paao.Kubeconfig == "" {
+			exitWithHelp(cmd, "Please provide a kubeconfig file.")
+		}
+
+		if err := RunAlphaPhaseApplyAddons(paao); err != nil {
+			glog.Exit(err)
+		}
+	},
+}
+
+func RunAlphaPhaseApplyAddons(paao *AlphaPhaseApplyAddonsOptions) error {
+	kubeconfig, err := ioutil.ReadFile(paao.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	addons, err := ioutil.ReadFile(paao.Addons)
+	if err != nil {
+		return fmt.Errorf("error loading addons file '%v': %v", paao.Addons, err)
+	}
+
+	clientFactory := clusterclient.NewFactory()
+	client, err := clientFactory.NewClientFromKubeconfig(string(kubeconfig))
+	if err != nil {
+		return fmt.Errorf("unable to create cluster client: %v", err)
+	}
+
+	if err := phases.ApplyAddons(client, string(addons)); err != nil {
+		return fmt.Errorf("unable to apply addons: %v", err)
+	}
+
+	return nil
+}
+
+func init() {
+	// Required flags
+	alphaPhaseApplyAddonsCmd.Flags().StringVarP(&paao.Kubeconfig, "kubeconfig", "", "", "Path for the kubeconfig file to use")
+	alphaPhaseApplyAddonsCmd.Flags().StringVarP(&paao.Addons, "addon-components", "a", "", "A yaml file containing cluster addons to apply to the cluster")
+	alphaPhasesCmd.AddCommand(alphaPhaseApplyAddonsCmd)
+}

--- a/cmd/clusterctl/cmd/alpha_phase_apply_cluster_api_components.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_cluster_api_components.go
@@ -73,7 +73,7 @@ func RunAlphaPhaseApplyClusterAPIComponents(pacaso *AlphaPhaseApplyClusterAPICom
 }
 
 func init() {
-	// Optional flags
+	// Required flags
 	alphaPhaseApplyClusterAPIComponentsCmd.Flags().StringVarP(&pacaso.Kubeconfig, "kubeconfig", "", "", "Path for the kubeconfig file to use")
 	alphaPhaseApplyClusterAPIComponentsCmd.Flags().StringVarP(&pacaso.ProviderComponents, "provider-components", "p", "", "A yaml file containing cluster api provider controllers and supporting objects")
 	alphaPhasesCmd.AddCommand(alphaPhaseApplyClusterAPIComponentsCmd)

--- a/cmd/clusterctl/phases/applyaddons.go
+++ b/cmd/clusterctl/phases/applyaddons.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"github.com/golang/glog"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
+)
+
+func ApplyAddons(client clusterclient.Client, addons string) error {
+	glog.Info("Applying Addons")
+	return client.Apply(addons)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- add `alpha phases apply-addons` subcommand
- move addon components application out of clusterdeployer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #554

**Release note**:
```release-note
clusterctl now has an alpha phases apply-addons subcommand
```
