### PR TITLE
Update lodash to 4.17.11 to fix CVE-2018-3721 (fixes #576).

### DIFF
--- a/docs/book/package-lock.json
+++ b/docs/book/package-lock.json
@@ -601,9 +601,9 @@
       "integrity": "sha1-Xee/afqisPnYXoMyCZtw5BmoRdU="
     },
     "lodash": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz",
-      "integrity": "sha1-K9bcRqBA9Z5obJcu0h2T3FkFMlg="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "mime-db": {
       "version": "1.37.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

Update lodash to 4.17.11 to fix CVE-2018-3721.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Fixes #576.