### PR TITLE
Add Context to Actuator

### DIFF
--- a/pkg/controller/machine/actuator.go
+++ b/pkg/controller/machine/actuator.go
@@ -17,6 +17,8 @@ limitations under the License.
 package machine
 
 import (
+	"context"
+
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
@@ -25,13 +27,13 @@ import (
 // methods should be idempotent unless otherwise specified.
 type Actuator interface {
 	// Create the machine.
-	Create(*clusterv1.Cluster, *clusterv1.Machine) error
+	Create(context.Context, *clusterv1.Cluster, *clusterv1.Machine) error
 	// Delete the machine. If no error is returned, it is assumed that all dependent resources have been cleaned up.
-	Delete(*clusterv1.Cluster, *clusterv1.Machine) error
+	Delete(context.Context, *clusterv1.Cluster, *clusterv1.Machine) error
 	// Update the machine to the provided definition.
-	Update(*clusterv1.Cluster, *clusterv1.Machine) error
+	Update(context.Context, *clusterv1.Cluster, *clusterv1.Machine) error
 	// Checks if the machine currently exists.
-	Exists(*clusterv1.Cluster, *clusterv1.Machine) (bool, error)
+	Exists(context.Context, *clusterv1.Cluster, *clusterv1.Machine) (bool, error)
 }
 
 /// [Actuator]

--- a/pkg/controller/machine/testactuator.go
+++ b/pkg/controller/machine/testactuator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package machine
 
 import (
+	"context"
 	"sync"
 
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -36,7 +37,7 @@ type TestActuator struct {
 	Lock            sync.Mutex
 }
 
-func (a *TestActuator) Create(*v1alpha1.Cluster, *v1alpha1.Machine) error {
+func (a *TestActuator) Create(context.Context, *v1alpha1.Cluster, *v1alpha1.Machine) error {
 	defer func() {
 		if a.BlockOnCreate {
 			<-a.unblock
@@ -49,7 +50,7 @@ func (a *TestActuator) Create(*v1alpha1.Cluster, *v1alpha1.Machine) error {
 	return nil
 }
 
-func (a *TestActuator) Delete(*v1alpha1.Cluster, *v1alpha1.Machine) error {
+func (a *TestActuator) Delete(context.Context, *v1alpha1.Cluster, *v1alpha1.Machine) error {
 	defer func() {
 		if a.BlockOnDelete {
 			<-a.unblock
@@ -62,20 +63,19 @@ func (a *TestActuator) Delete(*v1alpha1.Cluster, *v1alpha1.Machine) error {
 	return nil
 }
 
-func (a *TestActuator) Update(c *v1alpha1.Cluster, machine *v1alpha1.Machine) error {
+func (a *TestActuator) Update(ctx context.Context, c *v1alpha1.Cluster, machine *v1alpha1.Machine) error {
 	defer func() {
 		if a.BlockOnUpdate {
 			<-a.unblock
 		}
 	}()
-
 	a.Lock.Lock()
 	defer a.Lock.Unlock()
 	a.UpdateCallCount++
 	return nil
 }
 
-func (a *TestActuator) Exists(*v1alpha1.Cluster, *v1alpha1.Machine) (bool, error) {
+func (a *TestActuator) Exists(context.Context, *v1alpha1.Cluster, *v1alpha1.Machine) (bool, error) {
 	defer func() {
 		if a.BlockOnExists {
 			<-a.unblock


### PR DESCRIPTION
**What this PR does / why we need it**: 

Having `context.Context` provides a way for providers to handle deadlines, cancelation signals and other request(reconcile)-scoped values across processes.

**Which issue(s) this PR fixes** n/a

**Special notes for your reviewer**:

We must make sure that every provider is notified for this breaking change.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[action required] All functions in the Actuator interface now have a `context.Contex` argument. Providers should adapt to their implementations to support deadlines, cancelation signals and other request(reconcile)-scoped values.
```
