### PR TITLE
[clusterctl] add phases for apply-machines and apply-cluster

### DIFF
--- a/cmd/clusterctl/cmd/alpha_phase_apply_cluster.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_cluster.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/phases"
+	"sigs.k8s.io/cluster-api/pkg/util"
+)
+
+type AlphaPhaseApplyClusterOptions struct {
+	Kubeconfig string
+	Cluster    string
+}
+
+var paco = &AlphaPhaseApplyClusterOptions{}
+
+var alphaPhaseApplyClusterCmd = &cobra.Command{
+	Use:   "apply-cluster",
+	Short: "Apply Cluster",
+	Long:  `Apply Cluster`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if paco.Cluster == "" {
+			exitWithHelp(cmd, "Please provide yaml file for cluster definition.")
+		}
+
+		if paco.Kubeconfig == "" {
+			exitWithHelp(cmd, "Please provide a kubeconfig file.")
+		}
+
+		if err := RunAlphaPhaseApplyCluster(paco); err != nil {
+			glog.Exit(err)
+		}
+	},
+}
+
+func RunAlphaPhaseApplyCluster(paco *AlphaPhaseApplyClusterOptions) error {
+	kubeconfig, err := ioutil.ReadFile(paco.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := util.ParseClusterYaml(paco.Cluster)
+	if err != nil {
+		return err
+	}
+
+	clientFactory := clusterclient.NewFactory()
+	client, err := clientFactory.NewClientFromKubeconfig(string(kubeconfig))
+	if err != nil {
+		return fmt.Errorf("unable to create cluster client: %v", err)
+	}
+
+	if err := phases.ApplyCluster(client, cluster); err != nil {
+		return fmt.Errorf("unable to apply cluster: %v", err)
+	}
+
+	return nil
+}
+
+func init() {
+	// Required flags
+	alphaPhaseApplyClusterCmd.Flags().StringVarP(&paco.Kubeconfig, "kubeconfig", "", "", "Path for the kubeconfig file to use")
+	alphaPhaseApplyClusterCmd.Flags().StringVarP(&paco.Cluster, "cluster", "c", "", "A yaml file containing cluster object definition")
+	alphaPhasesCmd.AddCommand(alphaPhaseApplyClusterCmd)
+}

--- a/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/phases"
+	"sigs.k8s.io/cluster-api/pkg/util"
+)
+
+type AlphaPhaseApplyMachinesOptions struct {
+	Kubeconfig string
+	Machines   string
+	Namespace  string
+}
+
+var pamo = &AlphaPhaseApplyMachinesOptions{}
+
+var alphaPhaseApplyMachinesCmd = &cobra.Command{
+	Use:   "apply-machines",
+	Short: "Apply Machines",
+	Long:  `Apply Machines`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if pamo.Machines == "" {
+			exitWithHelp(cmd, "Please provide yaml file for machines definition.")
+		}
+
+		if pamo.Kubeconfig == "" {
+			exitWithHelp(cmd, "Please provide a kubeconfig file.")
+		}
+
+		if err := RunAlphaPhaseApplyMachines(pamo); err != nil {
+			glog.Exit(err)
+		}
+	},
+}
+
+func RunAlphaPhaseApplyMachines(pamo *AlphaPhaseApplyMachinesOptions) error {
+	kubeconfig, err := ioutil.ReadFile(pamo.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	machines, err := util.ParseMachinesYaml(pamo.Machines)
+	if err != nil {
+		return err
+	}
+
+	clientFactory := clusterclient.NewFactory()
+	client, err := clientFactory.NewClientFromKubeconfig(string(kubeconfig))
+	if err != nil {
+		return fmt.Errorf("unable to create cluster client: %v", err)
+	}
+
+	if err := phases.ApplyMachines(client, pamo.Namespace, machines); err != nil {
+		return fmt.Errorf("unable to apply machines: %v", err)
+	}
+
+	return nil
+}
+
+func init() {
+	// Required flags
+	alphaPhaseApplyMachinesCmd.Flags().StringVarP(&pamo.Kubeconfig, "kubeconfig", "", "", "Path for the kubeconfig file to use")
+	alphaPhaseApplyMachinesCmd.Flags().StringVarP(&pamo.Machines, "machines", "m", "", "A yaml file containing machine object definitions")
+
+	// Optional flags
+	alphaPhaseApplyMachinesCmd.Flags().StringVarP(&pamo.Namespace, "namespace", "n", "", "Namespace")
+	alphaPhasesCmd.AddCommand(alphaPhaseApplyMachinesCmd)
+}

--- a/cmd/clusterctl/cmd/create_cluster.go
+++ b/cmd/clusterctl/cmd/create_cluster.go
@@ -28,9 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/minikube"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
 	clustercommon "sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
-	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/util"
-	"sigs.k8s.io/yaml"
 )
 
 type CreateOptions struct {
@@ -69,11 +67,11 @@ var createClusterCmd = &cobra.Command{
 }
 
 func RunCreate(co *CreateOptions) error {
-	c, err := parseClusterYaml(co.Cluster)
+	c, err := util.ParseClusterYaml(co.Cluster)
 	if err != nil {
 		return err
 	}
-	m, err := parseMachinesYaml(co.Machine)
+	m, err := util.ParseMachinesYaml(co.Machine)
 	if err != nil {
 		return err
 	}
@@ -135,40 +133,6 @@ func init() {
 	createClusterCmd.Flags().StringVarP(&co.ExistingClusterKubeconfigPath, "existing-bootstrap-cluster-kubeconfig", "e", "", "Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)")
 
 	createCmd.AddCommand(createClusterCmd)
-}
-
-func parseClusterYaml(file string) (*clusterv1.Cluster, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, err
-	}
-
-	cluster := &clusterv1.Cluster{}
-	err = yaml.Unmarshal(bytes, cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	return cluster, nil
-}
-
-func parseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
-	bytes, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, err
-	}
-
-	list := &clusterv1.MachineList{}
-	err = yaml.Unmarshal(bytes, &list)
-	if err != nil {
-		return nil, err
-	}
-
-	if list == nil {
-		return []*clusterv1.Machine{}, nil
-	}
-
-	return util.MachineP(list.Items), nil
 }
 
 func getProvider(name string) (clusterdeployer.ProviderDeployer, error) {

--- a/cmd/clusterctl/cmd/create_cluster_test.go
+++ b/cmd/clusterctl/cmd/create_cluster_test.go
@@ -17,123 +17,8 @@ limitations under the License.
 package cmd
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 )
-
-const validCluster = `
-apiVersion: "cluster.k8s.io/v1alpha1"
-kind: Cluster
-metadata:
-  name: cluster1 
-spec:`
-
-const validMachines = `
-items:
-- apiVersion: "cluster.k8s.io/v1alpha1"
-  kind: Machine
-  metadata:
-    name: machine1
-  spec:`
-
-func TestParseClusterYaml(t *testing.T) {
-	t.Run("File does not exist", func(t *testing.T) {
-		_, err := parseClusterYaml("fileDoesNotExist")
-		if err == nil {
-			t.Fatal("Was able to parse a file that does not exist")
-		}
-	})
-	var testcases = []struct {
-		name         string
-		contents     string
-		expectedName string
-		expectErr    bool
-	}{
-		{
-			name:         "valid file",
-			contents:     validCluster,
-			expectedName: "cluster1",
-		},
-		{
-			name:      "gibberish in file",
-			contents:  `blah ` + validCluster + ` blah`,
-			expectErr: true,
-		},
-	}
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			file, err := createTempFile(testcase.contents)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.Remove(file)
-
-			c, err := parseClusterYaml(file)
-			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
-				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
-			}
-			if err != nil {
-				return
-			}
-			if c == nil {
-				t.Fatalf("No cluster returned in success case.")
-			}
-			if c.Name != testcase.expectedName {
-				t.Fatalf("Unexpected name. Got: %v, Want:%v", c.Name, testcase.expectedName)
-			}
-		})
-	}
-}
-
-func TestParseMachineYaml(t *testing.T) {
-	t.Run("File does not exist", func(t *testing.T) {
-		_, err := parseMachinesYaml("fileDoesNotExist")
-		if err == nil {
-			t.Fatal("Was able to parse a file that does not exist")
-		}
-	})
-	var testcases = []struct {
-		name                 string
-		contents             string
-		expectErr            bool
-		expectedMachineCount int
-	}{
-		{
-			name:                 "valid file",
-			contents:             validMachines,
-			expectedMachineCount: 1,
-		},
-		{
-			name:      "gibberish in file",
-			contents:  `blah ` + validMachines + ` blah`,
-			expectErr: true,
-		},
-	}
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			file, err := createTempFile(testcase.contents)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.Remove(file)
-
-			m, err := parseMachinesYaml(file)
-			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
-				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
-			}
-			if err != nil {
-				return
-			}
-			if m == nil {
-				t.Fatalf("No machines returned in success case.")
-			}
-			if len(m) != testcase.expectedMachineCount {
-				t.Fatalf("Unexpected machine count. Got: %v, Want: %v", len(m), testcase.expectedMachineCount)
-			}
-		})
-	}
-}
 
 func TestGetProvider(t *testing.T) {
 	var testcases = []struct {
@@ -153,14 +38,4 @@ func TestGetProvider(t *testing.T) {
 			}
 		})
 	}
-}
-
-func createTempFile(contents string) (string, error) {
-	f, err := ioutil.TempFile("", "")
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-	f.WriteString(contents)
-	return f.Name(), nil
 }

--- a/cmd/clusterctl/phases/applycluster.go
+++ b/cmd/clusterctl/phases/applycluster.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+func ApplyCluster(client clusterclient.Client, cluster *clusterv1.Cluster) error {
+	if cluster.Namespace == "" {
+		cluster.Namespace = client.GetContextNamespace()
+	}
+
+	err := client.EnsureNamespace(cluster.Namespace)
+	if err != nil {
+		return fmt.Errorf("unable to ensure namespace %q: %v", cluster.Namespace, err)
+	}
+
+	glog.Infof("Creating cluster object %v in namespace %q", cluster.Name, cluster.Namespace)
+	if err := client.CreateClusterObject(cluster); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/clusterctl/phases/applymachines.go
+++ b/cmd/clusterctl/phases/applymachines.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+func ApplyMachines(client clusterclient.Client, namespace string, machines []*clusterv1.Machine) error {
+	if namespace == "" {
+		namespace = client.GetContextNamespace()
+	}
+
+	err := client.EnsureNamespace(namespace)
+	if err != nil {
+		return fmt.Errorf("unable to ensure namespace %q: %v", namespace, err)
+	}
+
+	glog.Infof("Creating machines in namespace %q", namespace)
+	if err := client.CreateMachineObjects(machines, namespace); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -19,6 +19,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -29,9 +30,9 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -170,4 +171,36 @@ func GetNamespaceOrDefault(namespace string) string {
 		return v1.NamespaceDefault
 	}
 	return namespace
+}
+
+func ParseClusterYaml(file string) (*clusterv1.Cluster, error) {
+	bytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster := &clusterv1.Cluster{}
+	if err := yaml.Unmarshal(bytes, cluster); err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
+}
+
+func ParseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
+	bytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	list := &clusterv1.MachineList{}
+	if err := yaml.Unmarshal(bytes, &list); err != nil {
+		return nil, err
+	}
+
+	if list == nil {
+		return []*clusterv1.Machine{}, nil
+	}
+
+	return MachineP(list.Items), nil
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+const validCluster = `
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Cluster
+metadata:
+  name: cluster1 
+spec:`
+
+const validMachines = `
+items:
+- apiVersion: "cluster.k8s.io/v1alpha1"
+  kind: Machine
+  metadata:
+    name: machine1
+  spec:`
+
+func TestParseClusterYaml(t *testing.T) {
+	t.Run("File does not exist", func(t *testing.T) {
+		_, err := ParseClusterYaml("fileDoesNotExist")
+		if err == nil {
+			t.Fatal("Was able to parse a file that does not exist")
+		}
+	})
+	var testcases = []struct {
+		name         string
+		contents     string
+		expectedName string
+		expectErr    bool
+	}{
+		{
+			name:         "valid file",
+			contents:     validCluster,
+			expectedName: "cluster1",
+		},
+		{
+			name:      "gibberish in file",
+			contents:  `blah ` + validCluster + ` blah`,
+			expectErr: true,
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			file, err := createTempFile(testcase.contents)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(file)
+
+			c, err := ParseClusterYaml(file)
+			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
+				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
+			}
+			if err != nil {
+				return
+			}
+			if c == nil {
+				t.Fatalf("No cluster returned in success case.")
+			}
+			if c.Name != testcase.expectedName {
+				t.Fatalf("Unexpected name. Got: %v, Want:%v", c.Name, testcase.expectedName)
+			}
+		})
+	}
+}
+
+func TestParseMachineYaml(t *testing.T) {
+	t.Run("File does not exist", func(t *testing.T) {
+		_, err := ParseMachinesYaml("fileDoesNotExist")
+		if err == nil {
+			t.Fatal("Was able to parse a file that does not exist")
+		}
+	})
+	var testcases = []struct {
+		name                 string
+		contents             string
+		expectErr            bool
+		expectedMachineCount int
+	}{
+		{
+			name:                 "valid file",
+			contents:             validMachines,
+			expectedMachineCount: 1,
+		},
+		{
+			name:      "gibberish in file",
+			contents:  `blah ` + validMachines + ` blah`,
+			expectErr: true,
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			file, err := createTempFile(testcase.contents)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(file)
+
+			m, err := ParseMachinesYaml(file)
+			if (testcase.expectErr && err == nil) || (!testcase.expectErr && err != nil) {
+				t.Fatalf("Unexpected returned error. Got: %v, Want Err: %v", err, testcase.expectErr)
+			}
+			if err != nil {
+				return
+			}
+			if m == nil {
+				t.Fatalf("No machines returned in success case.")
+			}
+			if len(m) != testcase.expectedMachineCount {
+				t.Fatalf("Unexpected machine count. Got: %v, Want: %v", len(m), testcase.expectedMachineCount)
+			}
+		})
+	}
+}
+
+func createTempFile(contents string) (string, error) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	f.WriteString(contents)
+	return f.Name(), nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add `clusterctl alpha phase apply-cluster`
- Add `clusterctl alpha phase apply-machines`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #554 

**Release note**:
```release-note
clusterctl now has an alpha phases apply-cluster subcommand
clusterctl now has an alpha phases apply-machines subcommand
```
