### PR TITLE
Default kubebuilder test controlplane timeouts to 60s

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -754,7 +754,7 @@
   revision = "e3762e86a74c878ffed47484592986685639c2cd"
 
 [[projects]]
-  digest = "1:4c3be496e0e0977b54e265fea184b57e9928fed12a1a14687c04b5d42e044abc"
+  digest = "1:ca3f51201a90f3a23bf35938ee910d2fb3095ece453cf56c8b723e935c194ebd"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -786,8 +786,8 @@
     "pkg/webhook/types",
   ]
   pruneopts = "T"
-  revision = "53fc44b56078cd095b11bd44cfa0288ee4cf718f"
-  version = "v0.1.4"
+  revision = "5fd1e9e9fac5261e9ad9d47c375afc014fc31d21"
+  version = "v0.1.7"
 
 [[projects]]
   digest = "1:92290e452e328ffe6bd62f969e51d3aadd57a30a68b5fcf31ccdeda62068bb5d"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Default timeout for starting/stopping the Kubebuilder test controlplane
+export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?=60s
+export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?=60s
+
 # Image URL to use all building/pushing image targets
 IMG ?= gcr.io/k8s-cluster-api/cluster-api-controller:latest
 

--- a/vendor/sigs.k8s.io/controller-runtime/Gopkg.lock
+++ b/vendor/sigs.k8s.io/controller-runtime/Gopkg.lock
@@ -1129,7 +1129,7 @@
   revision = "c106140daf37a5d2b7a513726091a5eb8107e8b9"
 
 [[projects]]
-  digest = "1:b08a45828b09ce543aea649464635291107f53fd21465c0ab00a867b4418fa15"
+  digest = "1:5919b80013fe2204af836990cf255fc100d7d7cb077ec524c7518ff272e9a633"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1343,12 +1343,14 @@
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/selection",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/uuid",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
+    "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/core/v1",

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/typed_client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/typed_client.go
@@ -30,7 +30,7 @@ type typedClient struct {
 }
 
 // Create implements client.Client
-func (c *typedClient) Create(_ context.Context, obj runtime.Object) error {
+func (c *typedClient) Create(ctx context.Context, obj runtime.Object) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
@@ -39,12 +39,13 @@ func (c *typedClient) Create(_ context.Context, obj runtime.Object) error {
 		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
 		Resource(o.resource()).
 		Body(obj).
+		Context(ctx).
 		Do().
 		Into(obj)
 }
 
 // Update implements client.Client
-func (c *typedClient) Update(_ context.Context, obj runtime.Object) error {
+func (c *typedClient) Update(ctx context.Context, obj runtime.Object) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
@@ -54,12 +55,13 @@ func (c *typedClient) Update(_ context.Context, obj runtime.Object) error {
 		Resource(o.resource()).
 		Name(o.GetName()).
 		Body(obj).
+		Context(ctx).
 		Do().
 		Into(obj)
 }
 
 // Delete implements client.Client
-func (c *typedClient) Delete(_ context.Context, obj runtime.Object, opts ...DeleteOptionFunc) error {
+func (c *typedClient) Delete(ctx context.Context, obj runtime.Object, opts ...DeleteOptionFunc) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
@@ -71,12 +73,13 @@ func (c *typedClient) Delete(_ context.Context, obj runtime.Object, opts ...Dele
 		Resource(o.resource()).
 		Name(o.GetName()).
 		Body(deleteOpts.ApplyOptions(opts).AsDeleteOptions()).
+		Context(ctx).
 		Do().
 		Error()
 }
 
 // Get implements client.Client
-func (c *typedClient) Get(_ context.Context, key ObjectKey, obj runtime.Object) error {
+func (c *typedClient) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error {
 	r, err := c.cache.getResource(obj)
 	if err != nil {
 		return err
@@ -84,11 +87,12 @@ func (c *typedClient) Get(_ context.Context, key ObjectKey, obj runtime.Object) 
 	return r.Get().
 		NamespaceIfScoped(key.Namespace, r.isNamespaced()).
 		Resource(r.resource()).
+		Context(ctx).
 		Name(key.Name).Do().Into(obj)
 }
 
 // List implements client.Client
-func (c *typedClient) List(_ context.Context, opts *ListOptions, obj runtime.Object) error {
+func (c *typedClient) List(ctx context.Context, opts *ListOptions, obj runtime.Object) error {
 	r, err := c.cache.getResource(obj)
 	if err != nil {
 		return err
@@ -102,12 +106,13 @@ func (c *typedClient) List(_ context.Context, opts *ListOptions, obj runtime.Obj
 		Resource(r.resource()).
 		Body(obj).
 		VersionedParams(opts.AsListOptions(), c.paramCodec).
+		Context(ctx).
 		Do().
 		Into(obj)
 }
 
 // UpdateStatus used by StatusWriter to write status.
-func (c *typedClient) UpdateStatus(_ context.Context, obj runtime.Object) error {
+func (c *typedClient) UpdateStatus(ctx context.Context, obj runtime.Object) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
@@ -122,6 +127,7 @@ func (c *typedClient) UpdateStatus(_ context.Context, obj runtime.Object) error 
 		Name(o.GetName()).
 		SubResource("status").
 		Body(obj).
+		Context(ctx).
 		Do().
 		Into(obj)
 }

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/server.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/envtest/server.go
@@ -17,8 +17,12 @@ limitations under the License.
 package envtest
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/client-go/rest"
@@ -32,9 +36,14 @@ const (
 	envEtcdBin             = "TEST_ASSET_ETCD"
 	envKubectlBin          = "TEST_ASSET_KUBECTL"
 	envKubebuilderPath     = "KUBEBUILDER_ASSETS"
+	envStartTimeout        = "KUBEBUILDER_CONTROLPLANE_START_TIMEOUT"
+	envStopTimeout         = "KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT"
 	defaultKubebuilderPath = "/usr/local/kubebuilder/bin"
 	StartTimeout           = 60
 	StopTimeout            = 60
+
+	defaultKubebuilderControlPlaneStartTimeout = 20 * time.Second
+	defaultKubebuilderControlPlaneStopTimeout  = 20 * time.Second
 )
 
 func defaultAssetPath(binary string) string {
@@ -76,6 +85,16 @@ type Environment struct {
 	// existing kubeconfig, instead of trying to stand up a new control plane.
 	// This is useful in cases that need aggregated API servers and the like.
 	UseExistingCluster bool
+
+	// ControlPlaneStartTimeout is the the maximum duration each controlplane component
+	// may take to start. It defaults to the KUBEBUILDER_CONTROLPLANE_START_TIMEOUT
+	// environment variable or 20 seconds if unspecified
+	ControlPlaneStartTimeout time.Duration
+
+	// ControlPlaneStopTimeout is the the maximum duration each controlplane component
+	// may take to stop. It defaults to the KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT
+	// environment variable or 20 seconds if unspecified
+	ControlPlaneStopTimeout time.Duration
 }
 
 // Stop stops a running server
@@ -102,11 +121,13 @@ func (te *Environment) Start() (*rest.Config, error) {
 	} else {
 		te.ControlPlane = integration.ControlPlane{}
 		te.ControlPlane.APIServer = &integration.APIServer{Args: defaultKubeAPIServerFlags}
+		te.ControlPlane.Etcd = &integration.Etcd{}
+
 		if os.Getenv(envKubeAPIServerBin) == "" {
 			te.ControlPlane.APIServer.Path = defaultAssetPath("kube-apiserver")
 		}
 		if os.Getenv(envEtcdBin) == "" {
-			te.ControlPlane.Etcd = &integration.Etcd{Path: defaultAssetPath("etcd")}
+			te.ControlPlane.Etcd.Path = defaultAssetPath("etcd")
 		}
 		if os.Getenv(envKubectlBin) == "" {
 			// we can't just set the path manually (it's behind a function), so set the environment variable instead
@@ -115,8 +136,15 @@ func (te *Environment) Start() (*rest.Config, error) {
 			}
 		}
 
-		// Start the control plane - retry if it fails
-		if err := te.ControlPlane.Start(); err != nil {
+		if err := te.defaultTimeouts(); err != nil {
+			return nil, fmt.Errorf("failed to default controlplane timeouts: %v", err)
+		}
+		te.ControlPlane.Etcd.StartTimeout = te.ControlPlaneStartTimeout
+		te.ControlPlane.Etcd.StopTimeout = te.ControlPlaneStopTimeout
+		te.ControlPlane.APIServer.StartTimeout = te.ControlPlaneStartTimeout
+		te.ControlPlane.APIServer.StopTimeout = te.ControlPlaneStopTimeout
+
+		if err := te.startControlPlane(); err != nil {
 			return nil, err
 		}
 
@@ -131,4 +159,56 @@ func (te *Environment) Start() (*rest.Config, error) {
 		CRDs:  te.CRDs,
 	})
 	return te.Config, err
+}
+
+func (te *Environment) startControlPlane() error {
+	numTries, maxRetries := 0, 5
+	for ; numTries < maxRetries; numTries++ {
+		// Start the control plane - retry if it fails
+		err := te.ControlPlane.Start()
+		if err == nil {
+			break
+		}
+		// code snippet copied from following answer on stackoverflow
+		// https://stackoverflow.com/questions/51151973/catching-bind-address-already-in-use-in-golang
+		if opErr, ok := err.(*net.OpError); ok {
+			if opErr.Op == "listen" && strings.Contains(opErr.Error(), "address already in use") {
+				if stopErr := te.ControlPlane.Stop(); stopErr != nil {
+					return fmt.Errorf("failed to stop controlplane in response to bind error 'address already in use'")
+				}
+			}
+		} else {
+			return err
+		}
+	}
+	if numTries == maxRetries {
+		return fmt.Errorf("failed to start the controlplane. retried %d times", numTries)
+	}
+	return nil
+}
+
+func (te *Environment) defaultTimeouts() error {
+	var err error
+	if te.ControlPlaneStartTimeout == 0 {
+		if envVal := os.Getenv(envStartTimeout); envVal != "" {
+			te.ControlPlaneStartTimeout, err = time.ParseDuration(envVal)
+			if err != nil {
+				return err
+			}
+		} else {
+			te.ControlPlaneStartTimeout = defaultKubebuilderControlPlaneStartTimeout
+		}
+	}
+
+	if te.ControlPlaneStopTimeout == 0 {
+		if envVal := os.Getenv(envStopTimeout); envVal != "" {
+			te.ControlPlaneStopTimeout, err = time.ParseDuration(envVal)
+			if err != nil {
+				return err
+			}
+		} else {
+			te.ControlPlaneStopTimeout = defaultKubebuilderControlPlaneStopTimeout
+		}
+	}
+	return nil
 }

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/source/source.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/source/source.go
@@ -20,16 +20,21 @@ import (
 	"fmt"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source/internal"
 
+	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
+
+var log = logf.KBLog.WithName("source")
 
 const (
 	// defaultBufferSize is the default number of event notifications that can be buffered.
@@ -39,7 +44,7 @@ const (
 // Source is a source of events (eh.g. Create, Update, Delete operations on Kubernetes Objects, Webhook callbacks, etc)
 // which should be processed by event.EventHandlers to enqueue reconcile.Requests.
 //
-// * Use Kind for events originating in the cluster (eh.g. Pod Create, Pod Update, Deployment Update).
+// * Use Kind for events originating in the cluster (e.g. Pod Create, Pod Update, Deployment Update).
 //
 // * Use Channel for events originating outside the cluster (eh.g. GitHub Webhook callback, Polling external urls).
 //
@@ -51,7 +56,7 @@ type Source interface {
 	Start(handler.EventHandler, workqueue.RateLimitingInterface, ...predicate.Predicate) error
 }
 
-// Kind is used to provide a source of events originating inside the cluster from Watches (eh.g. Pod Create)
+// Kind is used to provide a source of events originating inside the cluster from Watches (e.g. Pod Create)
 type Kind struct {
 	// Type is the type of object to watch.  e.g. &v1.Pod{}
 	Type runtime.Object
@@ -80,10 +85,21 @@ func (ks *Kind) Start(handler handler.EventHandler, queue workqueue.RateLimiting
 	// Lookup the Informer from the Cache and add an EventHandler which populates the Queue
 	i, err := ks.cache.GetInformer(ks.Type)
 	if err != nil {
+		if kindMatchErr, ok := err.(*meta.NoKindMatchError); ok {
+			log.Error(err, "if %s is a CRD, should install it before calling Start",
+				kindMatchErr.GroupKind)
+		}
 		return err
 	}
 	i.AddEventHandler(internal.EventHandler{Queue: queue, EventHandler: handler, Predicates: prct})
 	return nil
+}
+
+func (ks *Kind) String() string {
+	if ks.Type != nil && ks.Type.GetObjectKind() != nil {
+		return fmt.Sprintf("kind source: %v", ks.Type.GetObjectKind().GroupVersionKind().String())
+	}
+	return fmt.Sprintf("kind source: unknown GVK")
 }
 
 var _ inject.Cache = &Kind{}
@@ -100,7 +116,7 @@ func (ks *Kind) InjectCache(c cache.Cache) error {
 var _ Source = &Channel{}
 
 // Channel is used to provide a source of events originating outside the cluster
-// (eh.g. GitHub Webhook callback).  Channel requires the user to wire the external
+// (e.g. GitHub Webhook callback).  Channel requires the user to wire the external
 // source (eh.g. http handler) to write GenericEvents to the underlying channel.
 type Channel struct {
 	// once ensures the event distribution goroutine will be performed only once
@@ -121,6 +137,10 @@ type Channel struct {
 
 	// destLock is to ensure the destination channels are safely added/removed
 	destLock sync.Mutex
+}
+
+func (cs *Channel) String() string {
+	return fmt.Sprintf("channel source: %p", cs)
 }
 
 var _ inject.Stoppable = &Channel{}
@@ -221,6 +241,32 @@ func (cs *Channel) syncLoop() {
 	}
 }
 
+// Informer is used to provide a source of events originating inside the cluster from Watches (e.g. Pod Create)
+type Informer struct {
+	// Informer is the generated client-go Informer
+	Informer toolscache.SharedIndexInformer
+}
+
+var _ Source = &Informer{}
+
+// Start is internal and should be called only by the Controller to register an EventHandler with the Informer
+// to enqueue reconcile.Requests.
+func (is *Informer) Start(handler handler.EventHandler, queue workqueue.RateLimitingInterface,
+	prct ...predicate.Predicate) error {
+
+	// Informer should have been specified by the user.
+	if is.Informer == nil {
+		return fmt.Errorf("must specify Informer.Informer")
+	}
+
+	is.Informer.AddEventHandler(internal.EventHandler{Queue: queue, EventHandler: handler, Predicates: prct})
+	return nil
+}
+
+func (is *Informer) String() string {
+	return fmt.Sprintf("informer source: %p", is.Informer)
+}
+
 // Func is a function that implements Source
 type Func func(handler.EventHandler, workqueue.RateLimitingInterface, ...predicate.Predicate) error
 
@@ -228,4 +274,8 @@ type Func func(handler.EventHandler, workqueue.RateLimitingInterface, ...predica
 func (f Func) Start(evt handler.EventHandler, queue workqueue.RateLimitingInterface,
 	pr ...predicate.Predicate) error {
 	return f(evt, queue, pr...)
+}
+
+func (f Func) String() string {
+	return fmt.Sprintf("func source: %p", f)
 }

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator/certgenerator.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator/certgenerator.go
@@ -23,6 +23,8 @@ type Artifacts struct {
 	Key []byte
 	// PEM encoded serving certificate
 	Cert []byte
+	// PEM encoded CA private key
+	CAKey []byte
 	// PEM encoded CA certificate
 	CACert []byte
 }
@@ -31,4 +33,6 @@ type Artifacts struct {
 type CertGenerator interface {
 	// Generate returns a Artifacts struct.
 	Generate(CommonName string) (*Artifacts, error)
+	// SetCA sets the PEM-encoded CA private key and CA cert for signing the generated serving cert.
+	SetCA(caKey, caCert []byte)
 }

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator/fake/certgenerator.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator/fake/certgenerator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fake
 
 import (
+	"bytes"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator"
@@ -24,16 +25,29 @@ import (
 
 // CertGenerator is a certGenerator for testing.
 type CertGenerator struct {
+	CAKey                  []byte
+	CACert                 []byte
 	DNSNameToCertArtifacts map[string]*generator.Artifacts
 }
 
 var _ generator.CertGenerator = &CertGenerator{}
+
+// SetCA sets the PEM-encoded CA private key and CA cert for signing the generated serving cert.
+func (cp *CertGenerator) SetCA(CAKey, CACert []byte) {
+	cp.CAKey = CAKey
+	cp.CACert = CACert
+}
 
 // Generate generates certificates by matching a common name.
 func (cp *CertGenerator) Generate(commonName string) (*generator.Artifacts, error) {
 	certs, found := cp.DNSNameToCertArtifacts[commonName]
 	if !found {
 		return nil, fmt.Errorf("failed to find common name %q in the certGenerator", commonName)
+	}
+	if cp.CAKey != nil && cp.CACert != nil &&
+		!bytes.Contains(cp.CAKey, []byte("invalid")) && !bytes.Contains(cp.CACert, []byte("invalid")) {
+		certs.CAKey = cp.CAKey
+		certs.CACert = cp.CACert
 	}
 	return certs, nil
 }

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator/selfsigned.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator/selfsigned.go
@@ -17,8 +17,10 @@ limitations under the License.
 package generator
 
 import (
+	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
+	"time"
 
 	"k8s.io/client-go/util/cert"
 )
@@ -30,9 +32,18 @@ func ServiceToCommonName(serviceNamespace, serviceName string) string {
 
 // SelfSignedCertGenerator implements the certGenerator interface.
 // It provisions self-signed certificates.
-type SelfSignedCertGenerator struct{}
+type SelfSignedCertGenerator struct {
+	caKey  []byte
+	caCert []byte
+}
 
 var _ CertGenerator = &SelfSignedCertGenerator{}
+
+// SetCA sets the PEM-encoded CA private key and CA cert for signing the generated serving cert.
+func (cp *SelfSignedCertGenerator) SetCA(caKey, caCert []byte) {
+	cp.caKey = caKey
+	cp.caCert = caCert
+}
 
 // Generate creates and returns a CA certificate, certificate and
 // key for the server. serverKey and serverCert are used by the server
@@ -40,14 +51,23 @@ var _ CertGenerator = &SelfSignedCertGenerator{}
 // client to verify the server authentication chain.
 // The cert will be valid for 365 days.
 func (cp *SelfSignedCertGenerator) Generate(commonName string) (*Artifacts, error) {
-	signingKey, err := cert.NewPrivateKey()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the CA private key: %v", err)
+	var signingKey *rsa.PrivateKey
+	var signingCert *x509.Certificate
+	var valid bool
+	var err error
+
+	valid, signingKey, signingCert = cp.validCACert()
+	if !valid {
+		signingKey, err = cert.NewPrivateKey()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the CA private key: %v", err)
+		}
+		signingCert, err = cert.NewSelfSignedCACert(cert.Config{CommonName: "webhook-cert-ca"}, signingKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create the CA cert: %v", err)
+		}
 	}
-	signingCert, err := cert.NewSelfSignedCACert(cert.Config{CommonName: "webhook-cert-ca"}, signingKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the CA cert: %v", err)
-	}
+
 	key, err := cert.NewPrivateKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the private key: %v", err)
@@ -65,6 +85,33 @@ func (cp *SelfSignedCertGenerator) Generate(commonName string) (*Artifacts, erro
 	return &Artifacts{
 		Key:    cert.EncodePrivateKeyPEM(key),
 		Cert:   cert.EncodeCertPEM(signedCert),
+		CAKey:  cert.EncodePrivateKeyPEM(signingKey),
 		CACert: cert.EncodeCertPEM(signingCert),
 	}, nil
+}
+
+func (cp *SelfSignedCertGenerator) validCACert() (bool, *rsa.PrivateKey, *x509.Certificate) {
+	if !ValidCACert(cp.caKey, cp.caCert, cp.caCert, "",
+		time.Now().AddDate(1, 0, 0)) {
+		return false, nil, nil
+	}
+
+	var ok bool
+	key, err := cert.ParsePrivateKeyPEM(cp.caKey)
+	if err != nil {
+		return false, nil, nil
+	}
+	privateKey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return false, nil, nil
+	}
+
+	certs, err := cert.ParseCertsPEM(cp.caCert)
+	if err != nil {
+		return false, nil, nil
+	}
+	if len(certs) != 1 {
+		return false, nil, nil
+	}
+	return true, privateKey, certs[0]
 }

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator/util.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/generator/util.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"time"
+)
+
+// ValidCACert think cert and key are valid if they meet the following requirements:
+// - key and cert are valid pair
+// - caCert is the root ca of cert
+// - cert is for dnsName
+// - cert won't expire before time
+func ValidCACert(key, cert, caCert []byte, dnsName string, time time.Time) bool {
+	if len(key) == 0 || len(cert) == 0 || len(caCert) == 0 {
+		return false
+	}
+	// Verify key and cert are valid pair
+	_, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return false
+	}
+
+	// Verify cert is valid for at least 1 year.
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCert) {
+		return false
+	}
+	block, _ := pem.Decode([]byte(cert))
+	if block == nil {
+		return false
+	}
+	c, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false
+	}
+	ops := x509.VerifyOptions{
+		DNSName:     dnsName,
+		Roots:       pool,
+		CurrentTime: time,
+	}
+	_, err = c.Verify(ops)
+	return err == nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/provisioner.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/provisioner.go
@@ -46,8 +46,6 @@ type Options struct {
 	ClientConfig *admissionregistrationv1beta1.WebhookClientConfig
 	// Objects are the objects that will use the ClientConfig above.
 	Objects []runtime.Object
-	// Dryrun controls if the objects are sent to the API server or write to io.Writer
-	Dryrun bool
 }
 
 // Provision provisions certificates for for the WebhookClientConfig.
@@ -68,7 +66,7 @@ func (cp *Provisioner) Provision(options Options) (bool, error) {
 		return false, err
 	}
 
-	certs, changed, err := cp.CertWriter.EnsureCert(dnsName, options.Dryrun)
+	certs, changed, err := cp.CertWriter.EnsureCert(dnsName)
 	if err != nil {
 		return false, err
 	}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/writer/certwriter.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/writer/certwriter.go
@@ -28,6 +28,8 @@ import (
 )
 
 const (
+	// CAKeyName is the name of the CA private key
+	CAKeyName = "ca-key.pem"
 	// CACertName is the name of the CA certificate
 	CACertName = "ca-cert.pem"
 	// ServerKeyName is the name of the server private key
@@ -39,7 +41,7 @@ const (
 // CertWriter provides method to handle webhooks.
 type CertWriter interface {
 	// EnsureCert provisions the cert for the webhookClientConfig.
-	EnsureCert(dnsName string, dryrun bool) (*generator.Artifacts, bool, error)
+	EnsureCert(dnsName string) (*generator.Artifacts, bool, error)
 	// Inject injects the necessary information given the objects.
 	// It supports MutatingWebhookConfiguration and ValidatingWebhookConfiguration.
 	Inject(objs ...runtime.Object) error

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/writer/fs.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/internal/cert/writer/fs.go
@@ -72,8 +72,7 @@ func NewFSCertWriter(ops FSCertWriterOptions) (CertWriter, error) {
 }
 
 // EnsureCert provisions certificates for a webhookClientConfig by writing the certificates in the filesystem.
-// fsCertWriter doesn't support dryrun.
-func (f *fsCertWriter) EnsureCert(dnsName string, _ bool) (*generator.Artifacts, bool, error) {
+func (f *fsCertWriter) EnsureCert(dnsName string) (*generator.Artifacts, bool, error) {
 	// create or refresh cert and write it to fs
 	f.dnsName = dnsName
 	return handleCommon(f.dnsName, f)
@@ -125,7 +124,7 @@ func prepareToWrite(dir string) error {
 		return err
 	}
 
-	filenames := []string{CACertName, ServerCertName, ServerKeyName}
+	filenames := []string{CAKeyName, CACertName, ServerCertName, ServerKeyName}
 	for _, f := range filenames {
 		abspath := path.Join(dir, f)
 		_, err := os.Stat(abspath)
@@ -150,7 +149,11 @@ func (f *fsCertWriter) read() (*generator.Artifacts, error) {
 	if err := ensureExist(f.Path); err != nil {
 		return nil, err
 	}
-	caBytes, err := ioutil.ReadFile(path.Join(f.Path, CACertName))
+	caKeyBytes, err := ioutil.ReadFile(path.Join(f.Path, CAKeyName))
+	if err != nil {
+		return nil, err
+	}
+	caCertBytes, err := ioutil.ReadFile(path.Join(f.Path, CACertName))
 	if err != nil {
 		return nil, err
 	}
@@ -163,14 +166,15 @@ func (f *fsCertWriter) read() (*generator.Artifacts, error) {
 		return nil, err
 	}
 	return &generator.Artifacts{
-		CACert: caBytes,
+		CAKey:  caKeyBytes,
+		CACert: caCertBytes,
 		Cert:   certBytes,
 		Key:    keyBytes,
 	}, nil
 }
 
 func ensureExist(dir string) error {
-	filenames := []string{CACertName, ServerCertName, ServerKeyName}
+	filenames := []string{CAKeyName, CACertName, ServerCertName, ServerKeyName}
 	for _, filename := range filenames {
 		_, err := os.Stat(path.Join(dir, filename))
 		switch {
@@ -188,6 +192,10 @@ func ensureExist(dir string) error {
 func certToProjectionMap(cert *generator.Artifacts) map[string]atomic.FileProjection {
 	// TODO: figure out if we can reduce the permission. (Now it's 0666)
 	return map[string]atomic.FileProjection{
+		CAKeyName: {
+			Data: cert.CAKey,
+			Mode: 0666,
+		},
 		CACertName: {
 			Data: cert.CACert,
 			Mode: 0666,

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/server.go
@@ -54,10 +54,10 @@ type ServerOptions struct {
 	// Client will be injected by the manager if not set.
 	Client client.Client
 
-	// Dryrun controls if the server will install the webhookConfiguration and service if any.
-	// If true, it will print the objects in yaml format.
-	// If false, it will install the objects in the cluster.
-	Dryrun bool
+	// DisableWebhookConfigInstaller controls if the server will automatically create webhook related objects
+	// during bootstrapping. e.g. webhookConfiguration, service and secret.
+	// If false, the server will install the webhook config objects. It is defaulted to false.
+	DisableWebhookConfigInstaller *bool
 
 	// BootstrapOptions contains the options for bootstrapping the admission server.
 	*BootstrapOptions
@@ -75,7 +75,8 @@ type BootstrapOptions struct {
 	// This is optional. If unspecified, it will write to the filesystem.
 	// It the secret already exists and is different from the desired, it will be replaced.
 	Secret *apitypes.NamespacedName
-	// Writer is used in dryrun mode for writing the objects in yaml format.
+
+	// Deprecated: Writer will not be used anywhere.
 	Writer io.Writer
 
 	// Service is k8s service fronting the webhook server pod(s).
@@ -187,15 +188,28 @@ func (s *Server) Handle(pattern string, handler http.Handler) {
 
 var _ manager.Runnable = &Server{}
 
-// Start runs the server if s.Dryrun is false.
-// Otherwise, it will print the objects in yaml format.
+// Start runs the server.
+// It will install the webhook related resources depend on the server configuration.
 func (s *Server) Start(stop <-chan struct{}) error {
-	err := s.installWebhookConfig()
-	// if encounter an error or it's in dryrun mode, return.
-	if err != nil || s.Dryrun {
-		return err
+	s.once.Do(s.setDefault)
+	if s.err != nil {
+		return s.err
 	}
 
+	if s.DisableWebhookConfigInstaller != nil && !*s.DisableWebhookConfigInstaller {
+		log.Info("installing webhook configuration in cluster")
+		err := s.InstallWebhookManifests()
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Info("webhook installer is disabled")
+	}
+
+	return s.run(stop)
+}
+
+func (s *Server) run(stop <-chan struct{}) error {
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%v", s.Port),
 		Handler: s.sMux,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This defaults the timeouts for starting/stopping the kubebuilder test controlplane to 60s, up from the default of 20s. This will hopefully prevent tests flaking with a `timeout waiting for process kube-apiserver to start` like e.G. observed in #579

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @roberthbailey 