### PR TITLE
Add Machine API Operator reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Following are the implementations managed by third-parties adopting the standard
 
   * Machine-controller-manager, https://github.com/gardener/machine-controller-manager/tree/cluster-api
   * Kubermatic machine-controller, https://github.com/kubermatic/machine-controller/tree/master
+  * Machine API Operator, https://github.com/openshift/machine-api-operator/tree/master
 
 ## Getting Started
 ### Prerequisites


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
We are leveraging the Cluster API Project (particularly what refers to the machine API) in OpenShift for conveying desired stated of machines and building upper level tooling on top of it e.g autoscaler/node-remediation. This adds API Adoption reference to Machine API Operator