### PR TITLE
Local defaulting

### DIFF
--- a/pkg/apis/cluster/v1alpha1/BUILD.bazel
+++ b/pkg/apis/cluster/v1alpha1/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cluster_types.go",
         "common_types.go",
+        "defaults.go",
         "doc.go",
         "machine_types.go",
         "machineclass_types.go",

--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -17,18 +17,43 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 )
 
+// PopulateDefaultsMachineDeployment fills in default field values
+// Currently it is called after reading objects, but it could be called in an admission webhook also
 func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
+	if d.Spec.Replicas == nil {
+		d.Spec.Replicas = new(int32)
+		*d.Spec.Replicas = 1
+	}
+
+	if d.Spec.MinReadySeconds == nil {
+		d.Spec.MinReadySeconds = new(int32)
+		*d.Spec.MinReadySeconds = 0
+	}
+
+	if d.Spec.RevisionHistoryLimit == nil {
+		d.Spec.RevisionHistoryLimit = new(int32)
+		*d.Spec.RevisionHistoryLimit = 1
+	}
+
+	if d.Spec.ProgressDeadlineSeconds == nil {
+		d.Spec.ProgressDeadlineSeconds = new(int32)
+		*d.Spec.ProgressDeadlineSeconds = 600
+	}
+
 	if d.Spec.Strategy == nil {
 		d.Spec.Strategy = &MachineDeploymentStrategy{}
 	}
+
 	if d.Spec.Strategy.Type == "" {
 		d.Spec.Strategy.Type = common.RollingUpdateMachineDeploymentStrategyType
 	}
 
+	// Default RollingUpdate strategy only if strategy type is RollingUpdate.
 	if d.Spec.Strategy.Type == common.RollingUpdateMachineDeploymentStrategyType {
 		if d.Spec.Strategy.RollingUpdate == nil {
 			d.Spec.Strategy.RollingUpdate = &MachineRollingUpdateDeployment{}
@@ -43,8 +68,7 @@ func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
 		}
 	}
 
-	if d.Spec.MinReadySeconds == nil {
-		v := int32(0)
-		d.Spec.MinReadySeconds = &v
+	if len(d.Namespace) == 0 {
+		d.Namespace = metav1.NamespaceDefault
 	}
 }

--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
+)
+
+func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
+	if d.Spec.Strategy == nil {
+		d.Spec.Strategy = &MachineDeploymentStrategy{}
+	}
+	if d.Spec.Strategy.Type == "" {
+		d.Spec.Strategy.Type = common.RollingUpdateMachineDeploymentStrategyType
+	}
+
+	if d.Spec.Strategy.Type == common.RollingUpdateMachineDeploymentStrategyType {
+		if d.Spec.Strategy.RollingUpdate == nil {
+			d.Spec.Strategy.RollingUpdate = &MachineRollingUpdateDeployment{}
+		}
+		if d.Spec.Strategy.RollingUpdate.MaxSurge == nil {
+			ios1 := intstr.FromInt(1)
+			d.Spec.Strategy.RollingUpdate.MaxSurge = &ios1
+		}
+		if d.Spec.Strategy.RollingUpdate.MaxUnavailable == nil {
+			ios0 := intstr.FromInt(0)
+			d.Spec.Strategy.RollingUpdate.MaxUnavailable = &ios0
+		}
+	}
+
+	if d.Spec.MinReadySeconds == nil {
+		v := int32(0)
+		d.Spec.MinReadySeconds = &v
+	}
+}

--- a/pkg/controller/machinedeployment/controller.go
+++ b/pkg/controller/machinedeployment/controller.go
@@ -145,6 +145,8 @@ func (r *ReconcileMachineDeployment) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, err
 	}
 
+	v1alpha1.PopulateDefaultsMachineDeployment(d)
+
 	everything := metav1.LabelSelector{}
 	if reflect.DeepEqual(d.Spec.Selector, &everything) {
 		if d.Status.ObservedGeneration < d.Generation {

--- a/pkg/controller/machinedeployment/sync.go
+++ b/pkg/controller/machinedeployment/sync.go
@@ -473,6 +473,8 @@ func updateMachineDeployment(c client.Client, d *clusterv1alpha1.MachineDeployme
 		if err := c.Get(context.Background(), types.NamespacedName{Namespace: d.Namespace, Name: d.Name}, d); err != nil {
 			return err
 		}
+
+		clusterv1alpha1.PopulateDefaultsMachineDeployment(d)
 		// Apply modifications
 		modify(d)
 		// Update the machineDeployment

--- a/pkg/controller/machinedeployment/sync.go
+++ b/pkg/controller/machinedeployment/sync.go
@@ -127,6 +127,11 @@ func (r *ReconcileMachineDeployment) getNewMachineSet(d *clusterv1alpha1.Machine
 	// Add machineTemplateHash label to selector.
 	newMSSelector := dutil.CloneSelectorAndAddLabel(&d.Spec.Selector, dutil.DefaultMachineDeploymentUniqueLabelKey, machineTemplateSpecHash)
 
+	minReadySeconds := int32(0)
+	if d.Spec.MinReadySeconds != nil {
+		minReadySeconds = *d.Spec.MinReadySeconds
+	}
+
 	// Create new MachineSet
 	newMS := clusterv1alpha1.MachineSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -138,7 +143,7 @@ func (r *ReconcileMachineDeployment) getNewMachineSet(d *clusterv1alpha1.Machine
 		},
 		Spec: clusterv1alpha1.MachineSetSpec{
 			Replicas:        new(int32),
-			MinReadySeconds: *d.Spec.MinReadySeconds,
+			MinReadySeconds: minReadySeconds,
 			Selector:        *newMSSelector,
 			Template:        newMSTemplate,
 		},


### PR DESCRIPTION
Until CRDs support defaulting, we can implement defaulting by simply
populating fields with their default values.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```