### PR TITLE
docker image: move manager binary to root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager sigs.k8s.io/clu
 # Copy the controller-manager into a thin image
 # TODO: Build this on scratch
 FROM debian:latest
-WORKDIR /root/
+WORKDIR /
 COPY --from=builder /go/src/sigs.k8s.io/cluster-api/manager .
-ENTRYPOINT ["./manager"]
+ENTRYPOINT ["/manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,7 +53,7 @@ spec:
         operator: Exists
       containers:
       - command:
-        - /root/manager
+        - /manager
         image: controller:latest
         name: manager
         resources:


### PR DESCRIPTION
/root/ encourages use of the root user, and / feels more the accepted
pattern for thin images.


```release-note
NONE
```