### PR TITLE
Changed MachineDeployment MinReadySeconds to int32

### DIFF
--- a/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
@@ -48,7 +48,7 @@ type MachineDeploymentSpec struct {
 	// Defaults to 0 (machine will be considered available as soon as it
 	// is ready)
 	// +optional
-	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
+	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
 
 	// The number of old MachineSets to retain to allow rollback.
 	// This is a pointer to distinguish between explicit zero and not specified.

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -386,11 +386,6 @@ func (in *MachineDeploymentSpec) DeepCopyInto(out *MachineDeploymentSpec) {
 		*out = new(MachineDeploymentStrategy)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.MinReadySeconds != nil {
-		in, out := &in.MinReadySeconds, &out.MinReadySeconds
-		*out = new(int32)
-		**out = **in
-	}
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
 		*out = new(int32)

--- a/pkg/controller/machinedeployment/machinedeployment_controller_test.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller_test.go
@@ -43,7 +43,7 @@ func TestReconcile(t *testing.T) {
 	instance := &clusterv1alpha1.MachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
 		Spec: clusterv1alpha1.MachineDeploymentSpec{
-			MinReadySeconds:      int32Ptr(0),
+			MinReadySeconds:      0,
 			Replicas:             int32Ptr(2),
 			RevisionHistoryLimit: int32Ptr(0),
 			Selector:             metav1.LabelSelector{MatchLabels: labels},

--- a/pkg/controller/machinedeployment/sync.go
+++ b/pkg/controller/machinedeployment/sync.go
@@ -103,9 +103,9 @@ func (r *ReconcileMachineDeployment) getNewMachineSet(d *clusterv1alpha1.Machine
 		// Set existing new machine set's annotation
 		annotationsUpdated := dutil.SetNewMachineSetAnnotations(d, msCopy, newRevision, true)
 
-		minReadySecondsNeedsUpdate := msCopy.Spec.MinReadySeconds != *d.Spec.MinReadySeconds
+		minReadySecondsNeedsUpdate := msCopy.Spec.MinReadySeconds != d.Spec.MinReadySeconds
 		if annotationsUpdated || minReadySecondsNeedsUpdate {
-			msCopy.Spec.MinReadySeconds = *d.Spec.MinReadySeconds
+			msCopy.Spec.MinReadySeconds = d.Spec.MinReadySeconds
 			return nil, r.Update(context.Background(), msCopy)
 		}
 
@@ -138,7 +138,7 @@ func (r *ReconcileMachineDeployment) getNewMachineSet(d *clusterv1alpha1.Machine
 		},
 		Spec: clusterv1alpha1.MachineSetSpec{
 			Replicas:        new(int32),
-			MinReadySeconds: *d.Spec.MinReadySeconds,
+			MinReadySeconds: d.Spec.MinReadySeconds,
 			Selector:        *newMSSelector,
 			Template:        newMSTemplate,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

MachineDeployment crashes when no MinReadySeconds are provided. See #612

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #612 

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
