### PR TITLE
Don't require bootstrap providers to write to disk

### DIFF
--- a/cmd/clusterctl/clusterdeployer/bootstrap/existing/exisingcluster.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/existing/exisingcluster.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Represents an existing cluster being used for bootstrapping, should not be able to
@@ -65,4 +68,14 @@ func (e *ExistingCluster) GetKubeconfig() (string, error) {
 	}
 
 	return e.kubeconfigFile, nil
+}
+
+// GetConfig implements clusterdeployer.ClusterProvisioner interface
+func (e *ExistingCluster) GetConfig() (*rest.Config, error) {
+	s, err := e.GetKubeconfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return clientcmd.RESTConfigFromKubeConfig([]byte(s))
 }

--- a/cmd/clusterctl/clusterdeployer/bootstrap/minikube/minikube.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/minikube/minikube.go
@@ -23,6 +23,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 )
 
@@ -87,6 +89,16 @@ func (m *Minikube) GetKubeconfig() (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+// GetConfig implements clusterdeployer.ClusterProvisioner interface
+func (m *Minikube) GetConfig() (*rest.Config, error) {
+	s, err := m.GetKubeconfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return clientcmd.RESTConfigFromKubeConfig([]byte(s))
 }
 
 func (m *Minikube) exec(args ...string) (string, error) {

--- a/cmd/clusterctl/clusterdeployer/bootstrap/provisioner.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/provisioner.go
@@ -16,9 +16,13 @@ limitations under the License.
 
 package bootstrap
 
-// Can provision a kubernetes cluster
+import (
+	"k8s.io/client-go/rest"
+)
+
+// ClusterProvisioner can provision a kubernetes cluster
 type ClusterProvisioner interface {
 	Create() error
 	Delete() error
-	GetKubeconfig() (string, error)
+	GetConfig() (*rest.Config, error)
 }

--- a/cmd/clusterctl/clusterdeployer/clusterclient/clientfactory.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clientfactory.go
@@ -23,6 +23,7 @@ import (
 
 // Factory can create cluster clients
 type Factory interface {
+	NewClient(config *rest.Config) (Client, error)
 	NewClientFromKubeconfig(string) (Client, error)
 	NewCoreClientsetFromKubeconfigFile(string) (*kubernetes.Clientset, error)
 }
@@ -32,6 +33,10 @@ type clientFactory struct {
 
 func NewFactory() *clientFactory {
 	return &clientFactory{}
+}
+
+func (f *clientFactory) NewClient(config *rest.Config) (Client, error) {
+	return NewClient(config)
 }
 
 func (f *clientFactory) NewClientFromKubeconfig(kubeconfig string) (Client, error) {

--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -28,6 +28,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 	tcmd "k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clientcmd"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -101,6 +102,21 @@ func New(kubeconfig string) (*client, error) {
 	}
 	c.closeFn = c.removeKubeconfigFile
 	return c, nil
+}
+
+// NewClient creates and returns a Client for the given config
+func NewClient(config *rest.Config) (*client, error) {
+	overrides := clientcmd.NewConfigOverrides()
+
+	c, err := clientset.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{
+		clientSet:       c,
+		configOverrides: overrides,
+	}, nil
 }
 
 func (c *client) removeKubeconfigFile() error {

--- a/cmd/clusterctl/phases/createbootstrapcluster.go
+++ b/cmd/clusterctl/phases/createbootstrapcluster.go
@@ -39,11 +39,11 @@ func CreateBootstrapCluster(provisioner bootstrap.ClusterProvisioner, cleanupBoo
 		}
 	}
 
-	bootstrapKubeconfig, err := provisioner.GetKubeconfig()
+	bootstrapKubeconfig, err := provisioner.GetConfig()
 	if err != nil {
 		return nil, cleanupFn, fmt.Errorf("unable to get bootstrap cluster kubeconfig: %v", err)
 	}
-	bootstrapClient, err := clientFactory.NewClientFromKubeconfig(bootstrapKubeconfig)
+	bootstrapClient, err := clientFactory.NewClient(bootstrapKubeconfig)
 	if err != nil {
 		return nil, cleanupFn, fmt.Errorf("unable to create bootstrap client: %v", err)
 	}


### PR DESCRIPTION
Paving the way for more ephemeral control planes.

```release-note
NONE
```