### PR TITLE
Don't swallow errors from ExecCommand

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -144,7 +144,11 @@ func Copy(m *clusterv1.Machine) *clusterv1.Machine {
 }
 
 func ExecCommand(name string, args ...string) string {
-	cmdOut, _ := exec.Command(name, args...).Output()
+	cmdOut, err := exec.Command(name, args...).Output()
+	if err != nil {
+		s := strings.Join(append([]string{name}, args...), " ")
+		klog.Errorf("error executing command %q: %v", s, err)
+	}
 	return string(cmdOut)
 }
 


### PR DESCRIPTION
The whole function should probably be deprecated, but we can start by logging the error.

```release-note
NONE
```