### PR TITLE
Short circuit return when adding finalizers

### DIFF
--- a/pkg/controller/cluster/controller.go
+++ b/pkg/controller/cluster/controller.go
@@ -97,6 +97,9 @@ func (r *ReconcileCluster) Reconcile(request reconcile.Request) (reconcile.Resul
 			klog.Infof("failed to add finalizer to cluster object %v due to error %v.", name, err)
 			return reconcile.Result{}, err
 		}
+
+		// Since adding the finalizer updates the object return to avoid later update issues
+		return reconcile.Result{}, nil
 	}
 
 	if !cluster.ObjectMeta.DeletionTimestamp.IsZero() {

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -122,6 +122,9 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 			klog.Infof("failed to add finalizer to machine object %v due to error %v.", name, err)
 			return reconcile.Result{}, err
 		}
+
+		// Since adding the finalizer updates the object return to avoid later update issues
+		return reconcile.Result{}, nil
 	}
 
 	if !m.ObjectMeta.DeletionTimestamp.IsZero() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Return after updating finalizers in Cluster and Machine controllers to
avoid passing an outdated object to actuators.

This fixes issues that are seen in provider implementations where Updates fail on the first reconciliation.

Fixes: kubernetes-sigs/cluster-api-provider-aws#430