### PR TITLE
Add a Bazel rule to generate yaml

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,12 @@ go_rules_dependencies()
 
 go_register_toolchains()
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
+
+go_repository(
+    name = "io_k8s_sigs_kustomize",
+    commit = "58492e2d83c59ed63881311f46ad6251f77dabc3",
+    importpath = "sigs.k8s.io/kustomize",
+)

--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -1,0 +1,19 @@
+filegroup(
+    name = "kustomize-yaml",
+    srcs = glob([
+        "crds/*.yaml",
+        "rbac/*.yaml",
+        "manager/*.yaml",
+        "default/*.yaml",
+    ]),
+    visibility = ["//visibility:private"],
+)
+
+genrule(
+    name = "cluster-api-yaml",
+    cmd = "$(location @io_k8s_sigs_kustomize//:kustomize) build config/default > $@",
+    srcs = [":kustomize-yaml"],
+    tools = ["@io_k8s_sigs_kustomize//:kustomize"],
+    outs = ["cluster_api.yaml"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION

**What this PR does / why we need it**:

Adds a bazel command to generate the kustomize yaml: `bazel build vendor/sigs.k8s.io/cluster-api/config/`

**Special notes for your reviewer**:

We've been using this in cluster-api-provider-aws, but the switch to bazel in this repo broke it. Rather than try to fix it, I figured it'd be easier just to upstream it!

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
