### PR TITLE
Kustomization needs to work with relative directories

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -11,8 +11,11 @@ filegroup(
 
 genrule(
     name = "cluster-api-yaml",
-    cmd = "$(location @io_k8s_sigs_kustomize//:kustomize) build config/default > $@",
-    srcs = [":kustomize-yaml"],
+    cmd = "$(location @io_k8s_sigs_kustomize//:kustomize) build $$(dirname $(location :default/kustomization.yaml)) > $@",
+    srcs = [
+        ":kustomize-yaml",
+        ":default/kustomization.yaml",
+    ],
     tools = ["@io_k8s_sigs_kustomize//:kustomize"],
     outs = ["cluster_api.yaml"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Unfortunately required follow up to #628. The previous rule worked just fine when running inside the cluster-api properly, but if the path was nested deeper it didn't work properly.

This fixes that, and should be more robust in general to configuration changes.