### PR TITLE
Add event recording package

### DIFF
--- a/pkg/record/BUILD.bazel
+++ b/pkg/record/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["record.go"],
+    importpath = "sigs.k8s.io/cluster-api/pkg/record",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/manager:go_default_library",
+    ],
+)

--- a/pkg/record/record.go
+++ b/pkg/record/record.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var (
+	initOnce        sync.Once
+	defaultRecorder record.EventRecorder
+)
+
+func init() {
+	defaultRecorder = new(record.FakeRecorder)
+}
+
+// Init initializes the global default recorder from a manager.
+// It can only be called once, subsequent calls are considered noops.
+func Init(mgr manager.Manager, name string) {
+	initOnce.Do(func() {
+		defaultRecorder = mgr.GetRecorder(name)
+	})
+}
+
+// Event constructs an event from the given information and puts it in the queue for sending.
+func Event(object runtime.Object, reason, message string) {
+	defaultRecorder.Event(object, corev1.EventTypeNormal, strings.Title(reason), message)
+}
+
+// Eventf is just like Event, but with Sprintf for the message field.
+func Eventf(object runtime.Object, reason, message string, args ...interface{}) {
+	defaultRecorder.Eventf(object, corev1.EventTypeNormal, strings.Title(reason), message, args...)
+}
+
+// Event constructs a warning event from the given information and puts it in the queue for sending.
+func Warn(object runtime.Object, reason, message string) {
+	defaultRecorder.Event(object, corev1.EventTypeWarning, strings.Title(reason), message)
+}
+
+// Eventf is just like Event, but with Sprintf for the message field.
+func Warnf(object runtime.Object, reason, message string, args ...interface{}) {
+	defaultRecorder.Eventf(object, corev1.EventTypeWarning, strings.Title(reason), message, args...)
+}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@vincepri.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR adds the `record` package to be used as a global event recorder. This is a port from the [aws provider](https://github.com/kubernetes-sigs/cluster-api-provider-aws/tree/master/pkg/record). 

The goal of this package is to offer a generic and global solution to event recording to reduce boilerplate and friction.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
