### PR TITLE
Set the image version back to latest for development on master.

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/k8s-cluster-api/cluster-api-controller:0.0.0-alpha.4
+      - image: gcr.io/k8s-cluster-api/cluster-api-controller:latest
         name: manager


### PR DESCRIPTION
**What this PR does / why we need it**: Now that the repo is tagged for the 0.0.0-alpha.4 release this reverts #635 by setting the container version back to latest. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign @detiber @chaosaffe 