### PR TITLE
Mark required flags of clusterctl as required explicitly

### DIFF
--- a/cmd/clusterctl/cmd/create_cluster.go
+++ b/cmd/clusterctl/cmd/create_cluster.go
@@ -118,12 +118,15 @@ func RunCreate(co *CreateOptions) error {
 
 func init() {
 	// Required flags
-	createClusterCmd.Flags().StringVarP(&co.Cluster, "cluster", "c", "", "A yaml file containing cluster object definition")
-	createClusterCmd.Flags().StringVarP(&co.Machine, "machines", "m", "", "A yaml file containing machine object definition(s)")
-	createClusterCmd.Flags().StringVarP(&co.ProviderComponents, "provider-components", "p", "", "A yaml file containing cluster api provider controllers and supporting objects")
+	createClusterCmd.Flags().StringVarP(&co.Cluster, "cluster", "c", "", "A yaml file containing cluster object definition. Required.")
+	createClusterCmd.MarkFlagRequired("cluster")
+	createClusterCmd.Flags().StringVarP(&co.Machine, "machines", "m", "", "A yaml file containing machine object definition(s). Required.")
+	createClusterCmd.MarkFlagRequired("machines")
+	createClusterCmd.Flags().StringVarP(&co.ProviderComponents, "provider-components", "p", "", "A yaml file containing cluster api provider controllers and supporting objects. Required.")
+	createClusterCmd.MarkFlagRequired("provider-components")
 	// TODO: Remove as soon as code allows https://github.com/kubernetes-sigs/cluster-api/issues/157
-	createClusterCmd.Flags().StringVarP(&co.Provider, "provider", "", "", "Which provider deployment logic to use (google/vsphere/azure)")
-
+	createClusterCmd.Flags().StringVarP(&co.Provider, "provider", "", "", "Which provider deployment logic to use (google/vsphere/azure). Required.")
+	createClusterCmd.MarkFlagRequired("provider")
 	// Optional flags
 	createClusterCmd.Flags().StringVarP(&co.AddonComponents, "addon-components", "a", "", "A yaml file containing cluster addons to apply to the internal cluster")
 	createClusterCmd.Flags().BoolVarP(&co.CleanupBootstrapCluster, "cleanup-bootstrap-cluster", "", true, "Whether to cleanup the bootstrap cluster after bootstrap")

--- a/cmd/clusterctl/testdata/create-cluster-no-args-invalid-flag.golden
+++ b/cmd/clusterctl/testdata/create-cluster-no-args-invalid-flag.golden
@@ -5,14 +5,14 @@ Usage:
 Flags:
   -a, --addon-components string                        A yaml file containing cluster addons to apply to the internal cluster
       --cleanup-bootstrap-cluster                      Whether to cleanup the bootstrap cluster after bootstrap (default true)
-  -c, --cluster string                                 A yaml file containing cluster object definition
+  -c, --cluster string                                 A yaml file containing cluster object definition. Required.
   -e, --existing-bootstrap-cluster-kubeconfig string   Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)
   -h, --help                                           help for cluster
       --kubeconfig-out string                          Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
-  -m, --machines string                                A yaml file containing machine object definition(s)
+  -m, --machines string                                A yaml file containing machine object definition(s). Required.
       --minikube strings                               Minikube options
-      --provider string                                Which provider deployment logic to use (google/vsphere/azure)
-  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects
+      --provider string                                Which provider deployment logic to use (google/vsphere/azure). Required.
+  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects. Required.
       --vm-driver string                               Which vm driver to use for minikube
 
 Global Flags:

--- a/cmd/clusterctl/testdata/create-cluster-no-args.golden
+++ b/cmd/clusterctl/testdata/create-cluster-no-args.golden
@@ -1,20 +1,18 @@
-Please provide yaml file for cluster definition.
-Create a kubernetes cluster with one command
-
+Error: required flag(s) "cluster", "machines", "provider", "provider-components" not set
 Usage:
   clusterctl create cluster [flags]
 
 Flags:
   -a, --addon-components string                        A yaml file containing cluster addons to apply to the internal cluster
       --cleanup-bootstrap-cluster                      Whether to cleanup the bootstrap cluster after bootstrap (default true)
-  -c, --cluster string                                 A yaml file containing cluster object definition
+  -c, --cluster string                                 A yaml file containing cluster object definition. Required.
   -e, --existing-bootstrap-cluster-kubeconfig string   Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)
   -h, --help                                           help for cluster
       --kubeconfig-out string                          Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
-  -m, --machines string                                A yaml file containing machine object definition(s)
+  -m, --machines string                                A yaml file containing machine object definition(s). Required.
       --minikube strings                               Minikube options
-      --provider string                                Which provider deployment logic to use (google/vsphere/azure)
-  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects
+      --provider string                                Which provider deployment logic to use (google/vsphere/azure). Required.
+  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects. Required.
       --vm-driver string                               Which vm driver to use for minikube
 
 Global Flags:
@@ -28,3 +26,5 @@ Global Flags:
       --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
   -v, --v Level                          log level for V logs
       --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+
+required flag(s) "cluster", "machines", "provider", "provider-components" not set


### PR DESCRIPTION
This commit marks the flags -c, -m, -p and --provider
as required explicilty for `clusterctl create cluster`.
It also updates the corresponding help message to show
the flags are required for the command to run.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
'clusterctl create cluster ..' command now marks the 'cluster (-c), machines (-m), provider-components(-p), provider' flags as required explicitly. If any of the flags missed, command fails with error.
```
