### PR TITLE
Fixed nil pointer crash in machine deployment controller

### DIFF
--- a/pkg/controller/machinedeployment/rolling.go
+++ b/pkg/controller/machinedeployment/rolling.go
@@ -34,6 +34,9 @@ func (r *ReconcileMachineDeployment) rolloutRolling(d *v1alpha1.MachineDeploymen
 	if err != nil {
 		return err
 	}
+	if newMS == nil {
+		return nil
+	}
 	allMSs := append(oldMSs, newMS)
 
 	// Scale up, if we can.

--- a/pkg/controller/machinedeployment/rolling.go
+++ b/pkg/controller/machinedeployment/rolling.go
@@ -34,6 +34,9 @@ func (r *ReconcileMachineDeployment) rolloutRolling(d *v1alpha1.MachineDeploymen
 	if err != nil {
 		return err
 	}
+	// newMS can be nil in case there is already a MachineSet associated with this deployment,
+	// but there are only either changes in annotations or MinReadySeconds. Or in other words,
+	// this can be nil if there are changes, but no replacement of existing machines is needed.
 	if newMS == nil {
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

In case of only updated annotations or `Spec.MinReadySeconds`,
`func (r *ReconcileMachineDeployment) getNewMachineSet` returns nil as
new MachineSet.
See
https://github.com/kubernetes-sigs/cluster-api/blob/9c0f9874a7d759a8a7d714dd9073947eca53bb24/pkg/controller/machinedeployment/sync.go#L107

But the rest of the code in `rolloutRolling` expects to work on a real
newMS. So just leving `rolloutRolling` in case `newMS == nil`.
 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #614 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
