### PR TITLE
Update `Taints` field comment in the machine spec

### DIFF
--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -57,9 +57,12 @@ type MachineSpec struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Taints is the full, authoritative list of taints to apply to the corresponding
-	// Node. This list will overwrite any modifications made to the Node on
-	// an ongoing basis.
+	// The list of the taints to be applied to the corresponding Node in additive
+	// manner. This list will not overwrite any other taints added to the Node on
+	// an ongoing basis by other entities. These taints should be actively reconciled
+	// e.g. if you ask the machine controller to apply a taint and then manually remove
+	// the taint the machine controller will put it back) but not have the machine controller
+	// remove any taints
 	// +optional
 	Taints []corev1.Taint `json:"taints,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes description of a field, Taints, in the machine spec. Current description mentions that the list of taints in the machine spec should be applied to the node in a "authoritative" manner and should overwrite any other existing taints on the node with this list of the taints. This is not correct because it conflicts with existing features such as [taint-nodes-by-condition](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/#taint-nodes-by-condition) and upcoming features like [shutdown taint](https://docs.google.com/document/d/1V7y9Boagev2LwQTSI1SaatMOdRC2gSQ9PBcESaITVEA)

 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update expected handling of Taints field in machine spec 
```


/cc @roberthbailey @derekwaynecarr @enxebre 