### PR TITLE
Correct KEP link so that Gitbook will render and Jekyll will build.

### DIFF
--- a/docs/book/appendices/keps/0003-cluster-api.md
+++ b/docs/book/appendices/keps/0003-cluster-api.md
@@ -1,1 +1,1 @@
-{% include "git+https://github.com/kubernetes/community.git/keps/sig-cluster-lifecycle/0003-cluster-api.md" %}
+{% include "git+https://github.com/kubernetes/enhancements.git/keps/sig-cluster-lifecycle/0003-cluster-api.md" %}


### PR DESCRIPTION
**What this PR does / why we need it**:

Without it, Gitbook will fail to render the pages correctly, and this causes Jekyll to fail to build.
