### PR TITLE
WIP - Add support for reconciling machine taints with nodes - do not merge

### DIFF
--- a/pkg/controller/node/node.go
+++ b/pkg/controller/node/node.go
@@ -81,8 +81,20 @@ func (c *ReconcileNode) link(node *corev1.Node) error {
 			machine.ObjectMeta.Name, node.ObjectMeta.Name)
 		c.linkedNodes[node.ObjectMeta.Name] = true
 		c.cachedReadiness[node.ObjectMeta.Name] = nodeReady
+		if err := c.reconcileTaintsWithNode(*machine); err != nil {
+			klog.Infof("failed to reconcile machine object %v taints with its node due to error %v.", machine.Name, err)
+			return err
+		}
 	}
 	return err
+}
+
+func (r *ReconcileNode) reconcileTaintsWithNode(machine v1alpha1.Machine) error {
+	if node := machine.Status.NodeRef; node != nil {
+		// TODO: sync taints logic and unit test
+		return r.Client.Update(context.Background(), node)
+	}
+	return nil
 }
 
 func (c *ReconcileNode) unlink(node *corev1.Node) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Add support for reconciling taints from machines to nodes
Related to https://github.com/kubernetes-sigs/cluster-api/pull/651

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
