### PR TITLE
Fix typo in gitbook include

### DIFF
--- a/docs/book/common_code/machineset_controller.md
+++ b/docs/book/common_code/machineset_controller.md
@@ -23,7 +23,7 @@ which implement their intent by modifying provider-specific `Cluster` and
 ## MachineSetTemplateSpec
 
 {% sample lang="go" %}
-[import:'MachineSetSpec'](../../../pkg/apis/cluster/v1alpha1/machineset_types.go)
+[import:'MachineSetTemplateSpec'](../../../pkg/apis/cluster/v1alpha1/machineset_types.go)
 {% endmethod %}
 
 {% method %}


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This fixes a typo in the machineset_controller page where it included the wrong type documentation

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No issue associated

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```
