### PR TITLE
Add JoinClusterTimeoutMachineError

### DIFF
--- a/pkg/apis/cluster/common/consts.go
+++ b/pkg/apis/cluster/common/consts.go
@@ -62,6 +62,10 @@ const (
 	// This error indicates that the machine did not join the cluster
 	// as a new node within the expected timeframe after instance
 	// creation at the provider succeeded
+	//
+	// Example use case: A controller that deletes Machines which do
+	// not result in a Node joining the cluster within a given timeout
+	// and that are managed by a MachineSet
 	JoinClusterTimeoutMachineError = "JoinClusterTimeoutError"
 )
 

--- a/pkg/apis/cluster/common/consts.go
+++ b/pkg/apis/cluster/common/consts.go
@@ -58,6 +58,11 @@ const (
 	//
 	// Example: cannot resolve EC2 IP address.
 	DeleteMachineError MachineStatusError = "DeleteError"
+
+	// This error indicates that the machine did not join the cluster
+	// as a new node within the expected timeframe after instance
+	// creation at the provider succeeded
+	JoinClusterTimeoutMachineError = "JoinClusterTimeoutError"
 )
 
 type ClusterStatusError string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Adds the `JoinClusterTimeoutMachineError` which can be used to indicate that a node for a given machine did not join the the cluster within the expected timeframe.

The idea is to use this as a basis for a controller/extending an existing controller to delete Machines which have this error set and are owned by a MachineSet. The implementer of the corresponding actuator may then decide if and when to set this error to trigger that re-creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
