### PR TITLE
Convert machineSpec.Versions to a pointer

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -1194,7 +1194,7 @@ func generateTestControlPlaneMachine(name string) *clusterv1.Machine {
 			Name: name,
 		},
 		Spec: clusterv1.MachineSpec{
-			Versions: clusterv1.MachineVersionInfo{
+			Versions: &clusterv1.MachineVersionInfo{
 				ControlPlane: "1.10.1",
 			},
 		},

--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -70,7 +70,7 @@ type MachineSpec struct {
 	// should populate the values it uses when persisting Machine objects.
 	// A Machine spec missing this field at runtime is invalid.
 	// +optional
-	Versions MachineVersionInfo `json:"versions,omitempty"`
+	Versions *MachineVersionInfo `json:"versions,omitempty"`
 
 	// ConfigSource is used to populate in the associated Node for dynamic kubelet config. This
 	// field already exists in Node, so any updates to it in the Machine

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -632,7 +632,11 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		}
 	}
 	in.ProviderSpec.DeepCopyInto(&out.ProviderSpec)
-	out.Versions = in.Versions
+	if in.Versions != nil {
+		in, out := &in.Versions, &out.Versions
+		*out = new(MachineVersionInfo)
+		**out = **in
+	}
 	if in.ConfigSource != nil {
 		in, out := &in.ConfigSource, &out.ConfigSource
 		*out = new(v1.NodeConfigSource)

--- a/pkg/controller/machine/machine_controller_test.go
+++ b/pkg/controller/machine/machine_controller_test.go
@@ -39,7 +39,7 @@ func TestReconcile(t *testing.T) {
 	instance := &clusterv1alpha1.Machine{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
 		Spec: clusterv1alpha1.MachineSpec{
-			Versions: clusterv1alpha1.MachineVersionInfo{Kubelet: "1.10.3"},
+			Versions: &clusterv1alpha1.MachineVersionInfo{Kubelet: "1.10.3"},
 		},
 	}
 

--- a/pkg/controller/machinedeployment/machinedeployment_controller_test.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller_test.go
@@ -60,7 +60,7 @@ func TestReconcile(t *testing.T) {
 					Labels: labels,
 				},
 				Spec: clusterv1alpha1.MachineSpec{
-					Versions: clusterv1alpha1.MachineVersionInfo{Kubelet: "1.10.3"},
+					Versions: &clusterv1alpha1.MachineVersionInfo{Kubelet: "1.10.3"},
 				},
 			},
 		},

--- a/pkg/controller/machineset/machineset_controller_test.go
+++ b/pkg/controller/machineset/machineset_controller_test.go
@@ -43,7 +43,7 @@ func TestReconcile(t *testing.T) {
 			Replicas: &replicas,
 			Template: clusterv1alpha1.MachineTemplateSpec{
 				Spec: clusterv1alpha1.MachineSpec{
-					Versions: clusterv1alpha1.MachineVersionInfo{Kubelet: "1.10.3"},
+					Versions: &clusterv1alpha1.MachineVersionInfo{Kubelet: "1.10.3"},
 				},
 			},
 		},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -118,7 +118,10 @@ func GetMachineIfExists(c client.Client, namespace, name string) (*clusterv1.Mac
 
 // TODO(robertbailey): Remove this function
 func IsControlPlaneMachine(machine *clusterv1.Machine) bool {
-	return machine.Spec.Versions.ControlPlane != ""
+	if machine.Spec.Versions != nil {
+		return machine.Spec.Versions.ControlPlane != ""
+	}
+	return false
 }
 
 func IsNodeReady(node *v1.Node) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Convert machineSpec.Versions to a pointer so `omitempty` does not actually marshals the field since it's optional consistently with Status.Versions.
For use cases where the machine config aka kubelet is managed orthogonally to the machine infra the field in the spec wouldn't trigger a moving forward reconciliation hence it wouldn't be leveraged. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
