### PR TITLE
Refactor bootstrapper flags

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -946,6 +946,7 @@
   input-imports = [
     "github.com/davecgh/go-spew/spew",
     "github.com/emicklei/go-restful",
+    "github.com/pkg/errors",
     "github.com/sergi/go-diff/diffmatchpatch",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",

--- a/cmd/clusterctl/clusterdeployer/bootstrap/BUILD.bazel
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/BUILD.bazel
@@ -2,7 +2,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["provisioner.go"],
+    srcs = [
+        "options.go",
+        "provisioner.go",
+    ],
     importpath = "sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap",
     visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/clusterctl/clusterdeployer/bootstrap/existing:go_default_library",
+        "//cmd/clusterctl/clusterdeployer/bootstrap/minikube:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
 )

--- a/cmd/clusterctl/clusterdeployer/bootstrap/options.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/options.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import "github.com/spf13/pflag"
+
+type Options struct {
+	Type       string
+	Cleanup    bool
+	ExtraFlags []string
+	KubeConfig string
+}
+
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVarP(&o.Type, "bootstrap-type", "", "none", "The cluster bootstrapper to use.")
+	fs.BoolVarP(&o.Cleanup, "bootstrap-cluster-cleanup", "", true, "Whether to cleanup the bootstrap cluster after bootstrap.")
+	fs.StringVarP(&o.KubeConfig, "bootstrap-cluster-kubeconfig", "e", "", "Sets the bootstrap cluster to be an existing Kubernetes cluster.")
+	fs.StringSliceVarP(&o.ExtraFlags, "bootstrap-flags", "", []string{}, "Command line flags to be passed to the chosen bootstrapper")
+}

--- a/cmd/clusterctl/clusterdeployer/bootstrap/provisioner.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/provisioner.go
@@ -38,6 +38,6 @@ func Get(o Options) (ClusterProvisioner, error) {
 			return existing.NewExistingCluster(o.KubeConfig)
 		}
 
-		return nil, errors.New("Cannot get bootstrapper, specify `--bootstrap-cluster-kubeconfig` to use an existing Kubernetes cluster or specify `--bootstrap-type` to use a built-in ephemeral cluster.")
+		return nil, errors.New("no bootstrap provisioner specified, you can specify `--bootstrap-cluster-kubeconfig` to use an existing Kubernetes cluster or `--bootstrap-type` to use a built-in ephemeral cluster.")
 	}
 }

--- a/cmd/clusterctl/clusterdeployer/bootstrap/provisioner.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/provisioner.go
@@ -16,9 +16,28 @@ limitations under the License.
 
 package bootstrap
 
+import (
+	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/minikube"
+)
+
 // Can provision a kubernetes cluster
 type ClusterProvisioner interface {
 	Create() error
 	Delete() error
 	GetKubeconfig() (string, error)
+}
+
+func Get(o Options) (ClusterProvisioner, error) {
+	switch o.Type {
+	case "minikube":
+		return minikube.WithOptions(o.ExtraFlags), nil
+	default:
+		if o.KubeConfig != "" {
+			return existing.NewExistingCluster(o.KubeConfig)
+		}
+
+		return nil, errors.New("Cannot get bootstrapper, specify `--bootstrap-cluster-kubeconfig` to use an existing Kubernetes cluster or specify `--bootstrap-type` to use a built-in ephemeral cluster.")
+	}
 }

--- a/cmd/clusterctl/cmd/BUILD.bazel
+++ b/cmd/clusterctl/cmd/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//cmd/clusterctl/clientcmd:go_default_library",
         "//cmd/clusterctl/clusterdeployer:go_default_library",
         "//cmd/clusterctl/clusterdeployer/bootstrap:go_default_library",
-        "//cmd/clusterctl/clusterdeployer/bootstrap/existing:go_default_library",
         "//cmd/clusterctl/clusterdeployer/bootstrap/minikube:go_default_library",
         "//cmd/clusterctl/clusterdeployer/clusterclient:go_default_library",
         "//cmd/clusterctl/phases:go_default_library",

--- a/cmd/clusterctl/cmd/delete_cluster.go
+++ b/cmd/clusterctl/cmd/delete_cluster.go
@@ -19,13 +19,11 @@ package cmd
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	tcmd "k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clientcmd"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap"
-	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/existing"
-	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/minikube"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/providercomponents"
 
@@ -34,14 +32,11 @@ import (
 )
 
 type DeleteOptions struct {
-	KubeconfigPath                string
-	ProviderComponents            string
-	ClusterNamespace              string
-	CleanupBootstrapCluster       bool
-	MiniKube                      []string
-	VmDriver                      string
-	ExistingClusterKubeconfigPath string
-	KubeconfigOverrides           tcmd.ConfigOverrides
+	KubeconfigPath      string
+	ProviderComponents  string
+	ClusterNamespace    string
+	KubeconfigOverrides tcmd.ConfigOverrides
+	BootstrapFlags      bootstrap.Options
 }
 
 var do = &DeleteOptions{}
@@ -70,12 +65,11 @@ func init() {
 
 	// Optional flags
 	deleteClusterCmd.Flags().StringVarP(&do.ClusterNamespace, "cluster-namespace", "", v1.NamespaceDefault, "Namespace where the cluster to be deleted resides")
-	deleteClusterCmd.Flags().BoolVarP(&do.CleanupBootstrapCluster, "cleanup-bootstrap-cluster", "", true, "Whether to cleanup the bootstrap cluster after bootstrap")
-	deleteClusterCmd.Flags().StringSliceVarP(&do.MiniKube, "minikube", "", []string{}, "Minikube options")
-	deleteClusterCmd.Flags().StringVarP(&do.VmDriver, "vm-driver", "", "", "Which vm driver to use for minikube")
-	deleteClusterCmd.Flags().StringVarP(&do.ExistingClusterKubeconfigPath, "existing-bootstrap-cluster-kubeconfig", "e", "", "Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)")
+
 	// BindContextFlags will bind the flags cluster, namespace, and user
 	tcmd.BindContextFlags(&do.KubeconfigOverrides.Context, deleteClusterCmd.Flags(), tcmd.RecommendedContextOverrideFlags(""))
+
+	do.BootstrapFlags.AddFlags(deleteClusterCmd.Flags())
 	deleteCmd.AddCommand(deleteClusterCmd)
 }
 
@@ -90,18 +84,9 @@ func RunDelete() error {
 	}
 	defer clusterClient.Close()
 
-	var bootstrapProvider bootstrap.ClusterProvisioner
-	if do.ExistingClusterKubeconfigPath != "" {
-		bootstrapProvider, err = existing.NewExistingCluster(do.ExistingClusterKubeconfigPath)
-		if err != nil {
-			return err
-		}
-	} else {
-		if do.VmDriver != "" {
-			do.MiniKube = append(do.MiniKube, fmt.Sprintf("vm-driver=%s", do.VmDriver))
-		}
-
-		bootstrapProvider = minikube.WithOptions(do.MiniKube)
+	bootstrapProvider, err := bootstrap.Get(do.BootstrapFlags)
+	if err != nil {
+		return err
 	}
 
 	deployer := clusterdeployer.New(
@@ -109,7 +94,8 @@ func RunDelete() error {
 		clusterclient.NewFactory(),
 		providerComponents,
 		"",
-		do.CleanupBootstrapCluster)
+		do.BootstrapFlags.Cleanup)
+
 	return deployer.Delete(clusterClient, do.ClusterNamespace)
 }
 

--- a/cmd/clusterctl/testdata/create-cluster-no-args-invalid-flag.golden
+++ b/cmd/clusterctl/testdata/create-cluster-no-args-invalid-flag.golden
@@ -3,17 +3,17 @@ Usage:
   clusterctl create cluster [flags]
 
 Flags:
-  -a, --addon-components string                        A yaml file containing cluster addons to apply to the internal cluster
-      --cleanup-bootstrap-cluster                      Whether to cleanup the bootstrap cluster after bootstrap (default true)
-  -c, --cluster string                                 A yaml file containing cluster object definition. Required.
-  -e, --existing-bootstrap-cluster-kubeconfig string   Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)
-  -h, --help                                           help for cluster
-      --kubeconfig-out string                          Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
-  -m, --machines string                                A yaml file containing machine object definition(s). Required.
-      --minikube strings                               Minikube options
-      --provider string                                Which provider deployment logic to use (google/vsphere/azure). Required.
-  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects. Required.
-      --vm-driver string                               Which vm driver to use for minikube
+  -a, --addon-components string               A yaml file containing cluster addons to apply to the internal cluster
+      --bootstrap-cluster-cleanup             Whether to cleanup the bootstrap cluster after bootstrap. (default true)
+  -e, --bootstrap-cluster-kubeconfig string   Sets the bootstrap cluster to be an existing Kubernetes cluster.
+      --bootstrap-flags strings               Command line flags to be passed to the chosen bootstrapper
+      --bootstrap-type string                 The cluster bootstrapper to use. (default "none")
+  -c, --cluster string                        A yaml file containing cluster object definition. Required.
+  -h, --help                                  help for cluster
+      --kubeconfig-out string                 Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
+  -m, --machines string                       A yaml file containing machine object definition(s). Required.
+      --provider string                       Which provider deployment logic to use (google/vsphere/azure). Required.
+  -p, --provider-components string            A yaml file containing cluster api provider controllers and supporting objects. Required.
 
 Global Flags:
       --alsologtostderr                  log to standard error as well as files

--- a/cmd/clusterctl/testdata/create-cluster-no-args.golden
+++ b/cmd/clusterctl/testdata/create-cluster-no-args.golden
@@ -3,17 +3,17 @@ Usage:
   clusterctl create cluster [flags]
 
 Flags:
-  -a, --addon-components string                        A yaml file containing cluster addons to apply to the internal cluster
-      --cleanup-bootstrap-cluster                      Whether to cleanup the bootstrap cluster after bootstrap (default true)
-  -c, --cluster string                                 A yaml file containing cluster object definition. Required.
-  -e, --existing-bootstrap-cluster-kubeconfig string   Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)
-  -h, --help                                           help for cluster
-      --kubeconfig-out string                          Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
-  -m, --machines string                                A yaml file containing machine object definition(s). Required.
-      --minikube strings                               Minikube options
-      --provider string                                Which provider deployment logic to use (google/vsphere/azure). Required.
-  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects. Required.
-      --vm-driver string                               Which vm driver to use for minikube
+  -a, --addon-components string               A yaml file containing cluster addons to apply to the internal cluster
+      --bootstrap-cluster-cleanup             Whether to cleanup the bootstrap cluster after bootstrap. (default true)
+  -e, --bootstrap-cluster-kubeconfig string   Sets the bootstrap cluster to be an existing Kubernetes cluster.
+      --bootstrap-flags strings               Command line flags to be passed to the chosen bootstrapper
+      --bootstrap-type string                 The cluster bootstrapper to use. (default "none")
+  -c, --cluster string                        A yaml file containing cluster object definition. Required.
+  -h, --help                                  help for cluster
+      --kubeconfig-out string                 Where to output the kubeconfig for the provisioned cluster (default "kubeconfig")
+  -m, --machines string                       A yaml file containing machine object definition(s). Required.
+      --provider string                       Which provider deployment logic to use (google/vsphere/azure). Required.
+  -p, --provider-components string            A yaml file containing cluster api provider controllers and supporting objects. Required.
 
 Global Flags:
       --alsologtostderr                  log to standard error as well as files

--- a/cmd/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
+++ b/cmd/clusterctl/testdata/delete-cluster-no-args-invalid-flag.golden
@@ -3,16 +3,16 @@ Usage:
   clusterctl delete cluster [flags]
 
 Flags:
-      --cleanup-bootstrap-cluster                      Whether to cleanup the bootstrap cluster after bootstrap (default true)
-      --cluster string                                 The name of the kubeconfig cluster to use
-      --cluster-namespace string                       Namespace where the cluster to be deleted resides (default "default")
-  -e, --existing-bootstrap-cluster-kubeconfig string   Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)
-  -h, --help                                           help for cluster
-      --minikube strings                               Minikube options
-  -n, --namespace string                               If present, the namespace scope for this CLI request
-  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.
-      --user string                                    The name of the kubeconfig user to use
-      --vm-driver string                               Which vm driver to use for minikube
+      --bootstrap-cluster-cleanup             Whether to cleanup the bootstrap cluster after bootstrap. (default true)
+  -e, --bootstrap-cluster-kubeconfig string   Sets the bootstrap cluster to be an existing Kubernetes cluster.
+      --bootstrap-flags strings               Command line flags to be passed to the chosen bootstrapper
+      --bootstrap-type string                 The cluster bootstrapper to use. (default "none")
+      --cluster string                        The name of the kubeconfig cluster to use
+      --cluster-namespace string              Namespace where the cluster to be deleted resides (default "default")
+  -h, --help                                  help for cluster
+  -n, --namespace string                      If present, the namespace scope for this CLI request
+  -p, --provider-components string            A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.
+      --user string                           The name of the kubeconfig user to use
 
 Global Flags:
       --alsologtostderr                  log to standard error as well as files

--- a/cmd/clusterctl/testdata/delete-cluster-no-args.golden
+++ b/cmd/clusterctl/testdata/delete-cluster-no-args.golden
@@ -5,16 +5,16 @@ Usage:
   clusterctl delete cluster [flags]
 
 Flags:
-      --cleanup-bootstrap-cluster                      Whether to cleanup the bootstrap cluster after bootstrap (default true)
-      --cluster string                                 The name of the kubeconfig cluster to use
-      --cluster-namespace string                       Namespace where the cluster to be deleted resides (default "default")
-  -e, --existing-bootstrap-cluster-kubeconfig string   Path to an existing cluster's kubeconfig for bootstrapping (intead of using minikube)
-  -h, --help                                           help for cluster
-      --minikube strings                               Minikube options
-  -n, --namespace string                               If present, the namespace scope for this CLI request
-  -p, --provider-components string                     A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.
-      --user string                                    The name of the kubeconfig user to use
-      --vm-driver string                               Which vm driver to use for minikube
+      --bootstrap-cluster-cleanup             Whether to cleanup the bootstrap cluster after bootstrap. (default true)
+  -e, --bootstrap-cluster-kubeconfig string   Sets the bootstrap cluster to be an existing Kubernetes cluster.
+      --bootstrap-flags strings               Command line flags to be passed to the chosen bootstrapper
+      --bootstrap-type string                 The cluster bootstrapper to use. (default "none")
+      --cluster string                        The name of the kubeconfig cluster to use
+      --cluster-namespace string              Namespace where the cluster to be deleted resides (default "default")
+  -h, --help                                  help for cluster
+  -n, --namespace string                      If present, the namespace scope for this CLI request
+  -p, --provider-components string            A yaml file containing cluster api provider controllers and supporting objects, if empty the value is loaded from the cluster's configuration store.
+      --user string                           The name of the kubeconfig user to use
 
 Global Flags:
       --alsologtostderr                  log to standard error as well as files

--- a/cmd/manager/BUILD.bazel
+++ b/cmd/manager/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/apis:go_default_library",
         "//pkg/controller:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client/config:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/runtime/signals:go_default_library",

--- a/hack/verify_boilerplate.py
+++ b/hack/verify_boilerplate.py
@@ -157,7 +157,7 @@ def get_regexs():
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
     # dates can be 2014, 2015, 2016, 2017 or 2018, company holder names can be anything
-    regexs["date"] = re.compile('(2014|2015|2016|2017|2018)')
+    regexs["date"] = re.compile('(2014|2015|2016|2017|2018|2019)')
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell/python scripts


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->
⚠️ Breaking changes ahead!

**What this PR does / why we need it**:
This PR streamlines bootstrapper flags and provides a single point to get and configure a bootstrap cluster.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NEW: `--bootstrap-type` defaults to `none` and can be extended later to offer more types of bootstrappers.
NEW: `--bootstrap-flags` is a list of flags that are passed to the chosen bootstrapper, if supported.
CHANGE: `--existing-bootstrap-cluster-kubeconfig` is renamed to `--bootstrap-cluster-kubeconfig`
CHANGE: `--bootstrap-cluster-cleanup` replaces `--cleanup-bootstrap-cluster`.
CHANGE: `--minikube` is removed, please use `--bootstrap-flags`.
CHANGE: `--vmdriver` is removed, please use `--bootstrap-flags`.
```
