### PR TITLE
Updated godoc for machine_types.go to align with best practices

### DIFF
--- a/config/crds/cluster_v1alpha1_machine.yaml
+++ b/config/crds/cluster_v1alpha1_machine.yaml
@@ -31,19 +31,20 @@ spec:
         spec:
           properties:
             configSource:
-              description: To populate in the associated Node for dynamic kubelet
-                config. This field already exists in Node, so any updates to it in
-                the Machine spec will be automatically copied to the linked NodeRef
-                from the status. The rest of dynamic kubelet config support should
-                then work as-is.
+              description: ConfigSource is used to populate in the associated Node
+                for dynamic kubelet config. This field already exists in Node, so
+                any updates to it in the Machine spec will be automatically copied
+                to the linked NodeRef from the status. The rest of dynamic kubelet
+                config support should then work as-is.
               type: object
             metadata:
-              description: This ObjectMeta will autopopulate the Node created. Use
-                this to indicate what labels, annotations, name prefix, etc., should
-                be used when creating the Node.
+              description: ObjectMeta will autopopulate the Node created. Use this
+                to indicate what labels, annotations, name prefix, etc., should be
+                used when creating the Node.
               type: object
             providerSpec:
-              description: Provider-specific configuration to use during node creation.
+              description: ProviderSpec details Provider-specific configuration to
+                use during node creation.
               properties:
                 value:
                   description: Value is an inlined, serialized representation of the
@@ -67,9 +68,9 @@ spec:
                   type: object
               type: object
             taints:
-              description: The full, authoritative list of taints to apply to the
-                corresponding Node. This list will overwrite any modifications made
-                to the Node on an ongoing basis.
+              description: Taints is the full, authoritative list of taints to apply
+                to the corresponding Node. This list will overwrite any modifications
+                made to the Node on an ongoing basis.
               items:
                 type: object
               type: array
@@ -82,11 +83,12 @@ spec:
                 spec missing this field at runtime is invalid.
               properties:
                 controlPlane:
-                  description: Semantic version of the Kubernetes control plane to
-                    run. This should only be populated when the machine is a master.
+                  description: ControlPlane is the semantic version of the Kubernetes
+                    control plane to run. This should only be populated when the machine
+                    is a master.
                   type: string
                 kubelet:
-                  description: Semantic version of kubelet to run
+                  description: Kubelet is the semantic version of kubelet to run
                   type: string
               required:
               - kubelet
@@ -103,9 +105,9 @@ spec:
                 type: object
               type: array
             conditions:
-              description: 'List of conditions synced from the node conditions of
-                the corresponding node-object. Machine-controller is responsible for
-                keeping conditions up-to-date. MachineSet controller will be taking
+              description: 'Conditions lists the conditions synced from the node conditions
+                of the corresponding node-object. Machine-controller is responsible
+                for keeping conditions up-to-date. MachineSet controller will be taking
                 these conditions as a signal to decide if machine is healthy or needs
                 to be replaced. Refer: https://kubernetes.io/docs/concepts/architecture/nodes/#condition'
               items:
@@ -114,8 +116,8 @@ spec:
             errorMessage:
               type: string
             errorReason:
-              description: In the event that there is a terminal problem reconciling
-                the Machine, both ErrorReason and ErrorMessage will be set. ErrorReason
+              description: ErrorReason and ErrorMessage will both be set in the event
+                that there is a terminal problem reconciling the Machine. ErrorReason
                 will be populated with a succinct value suitable for machine interpretation,
                 while ErrorMessage will contain a more verbose string suitable for
                 logging and human consumption.  These fields should not be set for
@@ -142,7 +144,7 @@ spec:
                     last operation.
                   type: string
                 lastUpdated:
-                  description: LastUpdateTime is the timestamp at which LastOperation
+                  description: LastUpdated is the timestamp at which LastOperation
                     API was last-updated.
                   format: date-time
                   type: string
@@ -156,27 +158,26 @@ spec:
                   type: string
               type: object
             lastUpdated:
-              description: When was this status last observed
+              description: LastUpdated identifies when this status was last observed.
               format: date-time
               type: string
             nodeRef:
-              description: If the corresponding Node exists, this will point to its
-                object.
+              description: NodeRef will point to the corresponding Node if it exists.
               type: object
             phase:
               description: Phase represents the current phase of machine actuation.
                 E.g. Pending, Running, Terminating, Failed etc.
               type: string
             providerStatus:
-              description: Provider-specific status. It is recommended that providers
-                maintain their own versioned API types that should be serialized/deserialized
-                from this field.
+              description: ProviderStatus details a Provider-specific status. It is
+                recommended that providers maintain their own versioned API types
+                that should be serialized/deserialized from this field.
               type: object
             versions:
-              description: 'The current versions of software on the corresponding
-                Node (if it exists). This is provided for a few reasons:  1) It is
-                more convenient than checking the NodeRef, traversing it to    the
-                Node, and finding the appropriate field in Node.Status.NodeInfo    (which
+              description: 'Versions specifies the current versions of software on
+                the corresponding Node (if it exists). This is provided for a few
+                reasons:  1) It is more convenient than checking the NodeRef, traversing
+                it to    the Node, and finding the appropriate field in Node.Status.NodeInfo    (which
                 uses different field names and formatting). 2) It removes some of
                 the dependency on the structure of the Node,    so that if the structure
                 of Node.Status.NodeInfo changes, only    machine controllers need
@@ -186,11 +187,12 @@ spec:
                 on the target node in order to find out its version.'
               properties:
                 controlPlane:
-                  description: Semantic version of the Kubernetes control plane to
-                    run. This should only be populated when the machine is a master.
+                  description: ControlPlane is the semantic version of the Kubernetes
+                    control plane to run. This should only be populated when the machine
+                    is a master.
                   type: string
                 kubelet:
-                  description: Semantic version of kubelet to run
+                  description: Kubelet is the semantic version of kubelet to run
                   type: string
               required:
               - kubelet

--- a/config/crds/cluster_v1alpha1_machine.yaml
+++ b/config/crds/cluster_v1alpha1_machine.yaml
@@ -114,15 +114,26 @@ spec:
                 type: object
               type: array
             errorMessage:
+              description: ErrorMessage will be set in the event that there is a terminal
+                problem reconciling the Machine and will contain a more verbose string
+                suitable for logging and human consumption.  This field should not
+                be set for transitive errors that a controller faces that are expected
+                to be fixed automatically over time (like service outages), but instead
+                indicate that something is fundamentally wrong with the Machine's
+                spec or the configuration of the controller, and that manual intervention
+                is required. Examples of terminal errors would be invalid combinations
+                of settings in the spec, values that are unsupported by the controller,
+                or the responsible controller itself being critically misconfigured.  Any
+                transient errors that occur during the reconciliation of Machines
+                can be added as events to the Machine object and/or logged in the
+                controller's output.
               type: string
             errorReason:
-              description: ErrorReason and ErrorMessage will both be set in the event
-                that there is a terminal problem reconciling the Machine. ErrorReason
-                will be populated with a succinct value suitable for machine interpretation,
-                while ErrorMessage will contain a more verbose string suitable for
-                logging and human consumption.  These fields should not be set for
-                transitive errors that a controller faces that are expected to be
-                fixed automatically over time (like service outages), but instead
+              description: ErrorReason will be set in the event that there is a terminal
+                problem reconciling the Machine and will contain a succinct value
+                suitable for machine interpretation.  This field should not be set
+                for transitive errors that a controller faces that are expected to
+                be fixed automatically over time (like service outages), but instead
                 indicate that something is fundamentally wrong with the Machine's
                 spec or the configuration of the controller, and that manual intervention
                 is required. Examples of terminal errors would be invalid combinations

--- a/config/crds/cluster_v1alpha1_machinedeployment.yaml
+++ b/config/crds/cluster_v1alpha1_machinedeployment.yaml
@@ -124,20 +124,21 @@ spec:
                     More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
                   properties:
                     configSource:
-                      description: To populate in the associated Node for dynamic
-                        kubelet config. This field already exists in Node, so any
-                        updates to it in the Machine spec will be automatically copied
-                        to the linked NodeRef from the status. The rest of dynamic
-                        kubelet config support should then work as-is.
+                      description: ConfigSource is used to populate in the associated
+                        Node for dynamic kubelet config. This field already exists
+                        in Node, so any updates to it in the Machine spec will be
+                        automatically copied to the linked NodeRef from the status.
+                        The rest of dynamic kubelet config support should then work
+                        as-is.
                       type: object
                     metadata:
-                      description: This ObjectMeta will autopopulate the Node created.
+                      description: ObjectMeta will autopopulate the Node created.
                         Use this to indicate what labels, annotations, name prefix,
                         etc., should be used when creating the Node.
                       type: object
                     providerSpec:
-                      description: Provider-specific configuration to use during node
-                        creation.
+                      description: ProviderSpec details Provider-specific configuration
+                        to use during node creation.
                       properties:
                         value:
                           description: Value is an inlined, serialized representation
@@ -162,9 +163,9 @@ spec:
                           type: object
                       type: object
                     taints:
-                      description: The full, authoritative list of taints to apply
-                        to the corresponding Node. This list will overwrite any modifications
-                        made to the Node on an ongoing basis.
+                      description: Taints is the full, authoritative list of taints
+                        to apply to the corresponding Node. This list will overwrite
+                        any modifications made to the Node on an ongoing basis.
                       items:
                         type: object
                       type: array
@@ -178,12 +179,13 @@ spec:
                         this field at runtime is invalid.
                       properties:
                         controlPlane:
-                          description: Semantic version of the Kubernetes control
-                            plane to run. This should only be populated when the machine
-                            is a master.
+                          description: ControlPlane is the semantic version of the
+                            Kubernetes control plane to run. This should only be populated
+                            when the machine is a master.
                           type: string
                         kubelet:
-                          description: Semantic version of kubelet to run
+                          description: Kubelet is the semantic version of kubelet
+                            to run
                           type: string
                       required:
                       - kubelet

--- a/config/crds/cluster_v1alpha1_machineset.yaml
+++ b/config/crds/cluster_v1alpha1_machineset.yaml
@@ -64,20 +64,21 @@ spec:
                     More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
                   properties:
                     configSource:
-                      description: To populate in the associated Node for dynamic
-                        kubelet config. This field already exists in Node, so any
-                        updates to it in the Machine spec will be automatically copied
-                        to the linked NodeRef from the status. The rest of dynamic
-                        kubelet config support should then work as-is.
+                      description: ConfigSource is used to populate in the associated
+                        Node for dynamic kubelet config. This field already exists
+                        in Node, so any updates to it in the Machine spec will be
+                        automatically copied to the linked NodeRef from the status.
+                        The rest of dynamic kubelet config support should then work
+                        as-is.
                       type: object
                     metadata:
-                      description: This ObjectMeta will autopopulate the Node created.
+                      description: ObjectMeta will autopopulate the Node created.
                         Use this to indicate what labels, annotations, name prefix,
                         etc., should be used when creating the Node.
                       type: object
                     providerSpec:
-                      description: Provider-specific configuration to use during node
-                        creation.
+                      description: ProviderSpec details Provider-specific configuration
+                        to use during node creation.
                       properties:
                         value:
                           description: Value is an inlined, serialized representation
@@ -102,9 +103,9 @@ spec:
                           type: object
                       type: object
                     taints:
-                      description: The full, authoritative list of taints to apply
-                        to the corresponding Node. This list will overwrite any modifications
-                        made to the Node on an ongoing basis.
+                      description: Taints is the full, authoritative list of taints
+                        to apply to the corresponding Node. This list will overwrite
+                        any modifications made to the Node on an ongoing basis.
                       items:
                         type: object
                       type: array
@@ -118,12 +119,13 @@ spec:
                         this field at runtime is invalid.
                       properties:
                         controlPlane:
-                          description: Semantic version of the Kubernetes control
-                            plane to run. This should only be populated when the machine
-                            is a master.
+                          description: ControlPlane is the semantic version of the
+                            Kubernetes control plane to run. This should only be populated
+                            when the machine is a master.
                           type: string
                         kubelet:
-                          description: Semantic version of kubelet to run
+                          description: Kubelet is the semantic version of kubelet
+                            to run
                           type: string
                       required:
                       - kubelet

--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -47,19 +47,19 @@ type Machine struct {
 /// [MachineSpec]
 // MachineSpec defines the desired state of Machine
 type MachineSpec struct {
-	// This ObjectMeta will autopopulate the Node created. Use this to
+	// ObjectMeta will autopopulate the Node created. Use this to
 	// indicate what labels, annotations, name prefix, etc., should be used
 	// when creating the Node.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// The full, authoritative list of taints to apply to the corresponding
+	// Taints is the full, authoritative list of taints to apply to the corresponding
 	// Node. This list will overwrite any modifications made to the Node on
 	// an ongoing basis.
 	// +optional
 	Taints []corev1.Taint `json:"taints,omitempty"`
 
-	// Provider-specific configuration to use during node creation.
+	// ProviderSpec details Provider-specific configuration to use during node creation.
 	// +optional
 	ProviderSpec ProviderSpec `json:"providerSpec"`
 
@@ -72,7 +72,7 @@ type MachineSpec struct {
 	// +optional
 	Versions MachineVersionInfo `json:"versions,omitempty"`
 
-	// To populate in the associated Node for dynamic kubelet config. This
+	// ConfigSource is used to populate in the associated Node for dynamic kubelet config. This
 	// field already exists in Node, so any updates to it in the Machine
 	// spec will be automatically copied to the linked NodeRef from the
 	// status. The rest of dynamic kubelet config support should then work
@@ -86,15 +86,15 @@ type MachineSpec struct {
 /// [MachineStatus]
 // MachineStatus defines the observed state of Machine
 type MachineStatus struct {
-	// If the corresponding Node exists, this will point to its object.
+	// NodeRef will point to the corresponding Node if it exists.
 	// +optional
 	NodeRef *corev1.ObjectReference `json:"nodeRef,omitempty"`
 
-	// When was this status last observed
+	// LastUpdated identifies when this status was last observed.
 	// +optional
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`
 
-	// The current versions of software on the corresponding Node (if it
+	// Versions specifies the current versions of software on the corresponding Node (if it
 	// exists). This is provided for a few reasons:
 	//
 	// 1) It is more convenient than checking the NodeRef, traversing it to
@@ -110,9 +110,9 @@ type MachineStatus struct {
 	// +optional
 	Versions *MachineVersionInfo `json:"versions,omitempty"`
 
-	// In the event that there is a terminal problem reconciling the
-	// Machine, both ErrorReason and ErrorMessage will be set. ErrorReason
-	// will be populated with a succinct value suitable for machine
+	// ErrorReason and ErrorMessage will both be set in the event that there is
+	// a terminal problem reconciling the Machine.
+	// ErrorReason will be populated with a succinct value suitable for machine
 	// interpretation, while ErrorMessage will contain a more verbose
 	// string suitable for logging and human consumption.
 	//
@@ -133,7 +133,7 @@ type MachineStatus struct {
 	// +optional
 	ErrorMessage *string `json:"errorMessage,omitempty"`
 
-	// Provider-specific status.
+	// ProviderStatus details a Provider-specific status.
 	// It is recommended that providers maintain their
 	// own versioned API types that should be
 	// serialized/deserialized from this field.
@@ -144,7 +144,7 @@ type MachineStatus struct {
 	// +optional
 	Addresses []corev1.NodeAddress `json:"addresses,omitempty"`
 
-	// List of conditions synced from the node conditions of the corresponding node-object.
+	// Conditions lists the conditions synced from the node conditions of the corresponding node-object.
 	// Machine-controller is responsible for keeping conditions up-to-date.
 	// MachineSet controller will be taking these conditions as a signal to decide if
 	// machine is healthy or needs to be replaced.
@@ -170,7 +170,7 @@ type LastOperation struct {
 	// Description is the human-readable description of the last operation.
 	Description *string `json:"description,omitempty"`
 
-	// LastUpdateTime is the timestamp at which LastOperation API was last-updated.
+	// LastUpdated is the timestamp at which LastOperation API was last-updated.
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`
 
 	// State is the current status of the last performed operation.
@@ -186,10 +186,10 @@ type LastOperation struct {
 
 /// [MachineVersionInfo]
 type MachineVersionInfo struct {
-	// Semantic version of kubelet to run
+	// Kubelet is the semantic version of kubelet to run
 	Kubelet string `json:"kubelet"`
 
-	// Semantic version of the Kubernetes control plane to
+	// ControlPlane is the semantic version of the Kubernetes control plane to
 	// run. This should only be populated when the machine is a
 	// master.
 	// +optional

--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -110,14 +110,12 @@ type MachineStatus struct {
 	// +optional
 	Versions *MachineVersionInfo `json:"versions,omitempty"`
 
-	// ErrorReason and ErrorMessage will both be set in the event that there is
-	// a terminal problem reconciling the Machine.
-	// ErrorReason will be populated with a succinct value suitable for machine
-	// interpretation, while ErrorMessage will contain a more verbose
-	// string suitable for logging and human consumption.
+	// ErrorReason will be set in the event that there is a terminal problem
+	// reconciling the Machine and will contain a succinct value suitable
+	// for machine interpretation.
 	//
-	// These fields should not be set for transitive errors that a
-	// controller faces that are expected to be fixed automatically over
+	// This field should not be set for transitive errors that a controller
+	// faces that are expected to be fixed automatically over
 	// time (like service outages), but instead indicate that something is
 	// fundamentally wrong with the Machine's spec or the configuration of
 	// the controller, and that manual intervention is required. Examples
@@ -130,6 +128,23 @@ type MachineStatus struct {
 	// controller's output.
 	// +optional
 	ErrorReason *common.MachineStatusError `json:"errorReason,omitempty"`
+
+	// ErrorMessage will be set in the event that there is a terminal problem
+	// reconciling the Machine and will contain a more verbose string suitable
+	// for logging and human consumption.
+	//
+	// This field should not be set for transitive errors that a controller
+	// faces that are expected to be fixed automatically over
+	// time (like service outages), but instead indicate that something is
+	// fundamentally wrong with the Machine's spec or the configuration of
+	// the controller, and that manual intervention is required. Examples
+	// of terminal errors would be invalid combinations of settings in the
+	// spec, values that are unsupported by the controller, or the
+	// responsible controller itself being critically misconfigured.
+	//
+	// Any transient errors that occur during the reconciliation of Machines
+	// can be added as events to the Machine object and/or logged in the
+	// controller's output.
 	// +optional
 	ErrorMessage *string `json:"errorMessage,omitempty"`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR cleans up godoc comments for machine_types to align with best practices, specifically to include the name of the thing being documented first.

**Which issue(s) this PR fixes**:
Fixes #570

**Release note**:

```release-note
NONE
```