### PR TITLE
update golang docker builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.11.2 as builder
+FROM golang:1.11.4 as builder
 
 # Copy in the go src
 WORKDIR $GOPATH/src/sigs.k8s.io/cluster-api


### PR DESCRIPTION
Use the latest patch release of go 1.11