### PR TITLE
[clusterctl] Fix create cluster workflow

### DIFF
--- a/cmd/clusterctl/cmd/create_cluster.go
+++ b/cmd/clusterctl/cmd/create_cluster.go
@@ -71,7 +71,7 @@ func RunCreate(co *CreateOptions) error {
 		return err
 	}
 
-	bootstrapProvider, err := bootstrap.Get(do.BootstrapFlags)
+	bootstrapProvider, err := bootstrap.Get(co.BootstrapFlags)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a minor typo to fix the `clusterctl create` workflow

**Special notes for your reviewer**:
This has been tested at least by hand using the cluster-api-provider-aws

**Release note**:
```release-note
NONE
```

/assign @vincepri 