### PR TITLE
Fix for KIND kubeconfig returning with newline

### DIFF
--- a/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
@@ -99,7 +99,13 @@ func (k *Kind) getKubeConfigPath() (string, error) {
 	for _, opt := range k.options {
 		args = append(args, fmt.Sprintf("--%v", opt))
 	}
-	return k.exec(args...)
+
+	out, err := k.exec(args...)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(out), nil
 }
 
 func (k *Kind) exec(args ...string) (string, error) {

--- a/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind_test.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind_test.go
@@ -91,6 +91,10 @@ func TestGetKubeconfig(t *testing.T) {
 	}
 	defer os.Remove(f)
 	t.Run("file does not exist", func(t *testing.T) {
+		m.execFunc = func(args ...string) (string, error) {
+			return "/tmp/nope", nil
+		}
+
 		c, err := m.GetKubeconfig()
 		if err == nil {
 			t.Fatal("Able to read a file that does not exist")
@@ -102,6 +106,20 @@ func TestGetKubeconfig(t *testing.T) {
 	t.Run("file exists", func(t *testing.T) {
 		m.execFunc = func(args ...string) (string, error) {
 			return f, nil
+		}
+
+		c, err := m.GetKubeconfig()
+		if err != nil {
+			t.Fatalf("Unexpected err, got: %v", err)
+			return
+		}
+		if c != contents {
+			t.Fatalf("Unexpected contents, got: %v, want: %v", c, contents)
+		}
+	})
+	t.Run("file exists, output with newline", func(t *testing.T) {
+		m.execFunc = func(args ...string) (string, error) {
+			return f + "\n", nil
 		}
 
 		c, err := m.GetKubeconfig()


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
KIND returns the path to the local kubeconfig including a `\n` at the end of the string. This PR makes sure to trim any space in the string and adds a unit test for it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
