### PR TITLE
clusterctl: kind should ignore some extra flags

### DIFF
--- a/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
@@ -31,6 +31,11 @@ const (
 	kindClusterName  = "clusterapi"
 )
 
+var (
+	// ignoredOptions lists the options not supported by delete and kubeconfig-path.
+	ignoredOptions = []string{"config", "image", "retain"}
+)
+
 type Kind struct {
 	options []string
 	// execFunc implemented as function variable for testing hooks
@@ -72,7 +77,14 @@ func (k *Kind) Create() error {
 
 func (k *Kind) Delete() error {
 	args := []string{"delete", "cluster"}
+
+outer:
 	for _, opt := range k.options {
+		for _, ignoredOption := range ignoredOptions {
+			if strings.HasPrefix(opt, ignoredOption) {
+				continue outer
+			}
+		}
 		args = append(args, fmt.Sprintf("--%v", opt))
 	}
 
@@ -96,7 +108,14 @@ func (k *Kind) GetKubeconfig() (string, error) {
 
 func (k *Kind) getKubeConfigPath() (string, error) {
 	args := []string{"get", "kubeconfig-path"}
+
+outer:
 	for _, opt := range k.options {
+		for _, ignoredOption := range ignoredOptions {
+			if strings.HasPrefix(opt, ignoredOption) {
+				continue outer
+			}
+		}
 		args = append(args, fmt.Sprintf("--%v", opt))
 	}
 

--- a/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
@@ -67,9 +67,8 @@ var execFunc = func(args ...string) (string, error) {
 
 func (k *Kind) Create() error {
 	args := []string{"create", "cluster"}
-	for _, opt := range k.options {
-		args = append(args, fmt.Sprintf("--%v", opt))
-	}
+
+	args = k.appendOptions(args)
 
 	_, err := k.exec(args...)
 	return err
@@ -78,15 +77,7 @@ func (k *Kind) Create() error {
 func (k *Kind) Delete() error {
 	args := []string{"delete", "cluster"}
 
-outer:
-	for _, opt := range k.options {
-		for _, ignoredOption := range ignoredOptions {
-			if strings.HasPrefix(opt, ignoredOption) {
-				continue outer
-			}
-		}
-		args = append(args, fmt.Sprintf("--%v", opt))
-	}
+	args = k.appendOptions(args, ignoredOptions...)
 
 	_, err := k.exec(args...)
 	return err
@@ -109,15 +100,7 @@ func (k *Kind) GetKubeconfig() (string, error) {
 func (k *Kind) getKubeConfigPath() (string, error) {
 	args := []string{"get", "kubeconfig-path"}
 
-outer:
-	for _, opt := range k.options {
-		for _, ignoredOption := range ignoredOptions {
-			if strings.HasPrefix(opt, ignoredOption) {
-				continue outer
-			}
-		}
-		args = append(args, fmt.Sprintf("--%v", opt))
-	}
+	args = k.appendOptions(args, ignoredOptions...)
 
 	out, err := k.exec(args...)
 	if err != nil {
@@ -129,4 +112,19 @@ outer:
 
 func (k *Kind) exec(args ...string) (string, error) {
 	return k.execFunc(args...)
+}
+
+// appendOptions enriches the args with all options but the ignored ones
+func (k *Kind) appendOptions(args []string, ignoredOptions ...string) []string {
+outer:
+	for _, opt := range k.options {
+		for _, ignoredOption := range ignoredOptions {
+			if strings.HasPrefix(opt, ignoredOption) {
+				continue outer
+			}
+		}
+		args = append(args, fmt.Sprintf("--%v", opt))
+	}
+
+	return args
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

When using `--bootstrap-type kind`, the extra flags are forwarded to all commands. `delete` and `kubeconfig-path` don't support some of them, e.g. `image` or `retain`.

```console
$ clusterctl create cluster ... \
    --bootstrap-type kind \
    --bootstrap-flags "image=kindest/node:v1.12.3" \
    --bootstrap-flags "config=kind-config.yaml" \
    --bootstrap-flags "loglevel=debug"

...
```

> I0125 13:28:47.453232   32424 kind.go:58] Running: kind [get kubeconfig-path --image=kindest/node:v1.12.3 --config=kind-config.yaml --loglevel=debug --name=clusterapi]
I0125 13:28:47.517692   32424 kind.go:61] Ran: kind [get kubeconfig-path --image=kindest/node:v1.12.3 --config=kind-config.yaml --loglevel=debug --name=clusterapi] Output: Error: unknown flag: --image

Fixes: #719 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
