### PR TITLE
Improve YAML processing in clusterctl

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -983,6 +983,7 @@
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/apis/meta/v1/validation",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
@@ -990,10 +991,12 @@
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/json",
     "k8s.io/apimachinery/pkg/util/rand",
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/validation/field",
     "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/util/yaml",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/apiserver/pkg/storage/names",
     "k8s.io/client-go/discovery",
@@ -1029,7 +1032,6 @@
     "sigs.k8s.io/controller-runtime/pkg/source",
     "sigs.k8s.io/controller-tools/cmd/controller-gen",
     "sigs.k8s.io/testing_frameworks/integration",
-    "sigs.k8s.io/yaml",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -10,11 +10,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/cluster/v1alpha1:go_default_library",
-        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -10,12 +10,16 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/cluster/v1alpha1:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
-        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,13 +17,9 @@ limitations under the License.
 package util
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
-	"io/ioutil"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 	"math/rand"
 	"os"
@@ -42,6 +38,7 @@ import (
 )
 
 const (
+	// CharSet defines the alphanumeric set for random string generation
 	CharSet = "0123456789abcdefghijklmnopqrstuvwxyz"
 )
 
@@ -49,10 +46,12 @@ var (
 	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
 
+// RandomToken returns a random token
 func RandomToken() string {
 	return fmt.Sprintf("%s.%s", RandomString(6), RandomString(16))
 }
 
+// RandomString returns a random alphanumeric string
 func RandomString(n int) string {
 	result := make([]byte, n)
 	for i := range result {
@@ -61,6 +60,7 @@ func RandomString(n int) string {
 	return string(result)
 }
 
+// GetControlPlaneMachine returns the control plane machine from a slice
 func GetControlPlaneMachine(machines []*clusterv1.Machine) *clusterv1.Machine {
 	for _, machine := range machines {
 		if IsControlPlaneMachine(machine) {
@@ -70,6 +70,7 @@ func GetControlPlaneMachine(machines []*clusterv1.Machine) *clusterv1.Machine {
 	return nil
 }
 
+// MachineP converts a slice of machines into a slice of machine pointers
 func MachineP(machines []clusterv1.Machine) []*clusterv1.Machine {
 	// Convert to list of pointers
 	var ret []*clusterv1.Machine
@@ -79,6 +80,7 @@ func MachineP(machines []clusterv1.Machine) []*clusterv1.Machine {
 	return ret
 }
 
+// Home returns the user home directory
 func Home() string {
 	home := os.Getenv("HOME")
 	if strings.Contains(home, "root") {
@@ -93,6 +95,7 @@ func Home() string {
 	return usr.HomeDir
 }
 
+// GetDefaultKubeConfigPath returns the standard user kubeconfig
 func GetDefaultKubeConfigPath() string {
 	localDir := fmt.Sprintf("%s/.kube", Home())
 	if _, err := os.Stat(localDir); os.IsNotExist(err) {
@@ -103,6 +106,7 @@ func GetDefaultKubeConfigPath() string {
 	return fmt.Sprintf("%s/config", localDir)
 }
 
+// GetMachineIfExists gets a machine from the API server if it exists
 func GetMachineIfExists(c client.Client, namespace, name string) (*clusterv1.Machine, error) {
 	if c == nil {
 		// Being called before k8s is setup as part of control plane VM creation
@@ -122,11 +126,13 @@ func GetMachineIfExists(c client.Client, namespace, name string) (*clusterv1.Mac
 	return machine, nil
 }
 
+// IsControlPlaneMachine checks machine is a control plane node
 // TODO(robertbailey): Remove this function
 func IsControlPlaneMachine(machine *clusterv1.Machine) bool {
 	return machine.Spec.Versions.ControlPlane != ""
 }
 
+// IsNodeReader returns true if a node is ready
 func IsNodeReady(node *v1.Node) bool {
 	for _, condition := range node.Status.Conditions {
 		if condition.Type == v1.NodeReady {
@@ -137,6 +143,7 @@ func IsNodeReady(node *v1.Node) bool {
 	return false
 }
 
+// Copy deep copies a Machine object
 func Copy(m *clusterv1.Machine) *clusterv1.Machine {
 	ret := &clusterv1.Machine{}
 	ret.APIVersion = m.APIVersion
@@ -149,6 +156,7 @@ func Copy(m *clusterv1.Machine) *clusterv1.Machine {
 	return ret
 }
 
+// ExecCommand Executes a local command in the current shell
 func ExecCommand(name string, args ...string) string {
 	cmdOut, err := exec.Command(name, args...).Output()
 	if err != nil {
@@ -158,6 +166,7 @@ func ExecCommand(name string, args ...string) string {
 	return string(cmdOut)
 }
 
+// Filter filters a list for a string
 func Filter(list []string, strToFilter string) (newList []string) {
 	for _, item := range list {
 		if item != strToFilter {
@@ -167,6 +176,7 @@ func Filter(list []string, strToFilter string) (newList []string) {
 	return
 }
 
+// Contains returns true if a list contains a string
 func Contains(list []string, strToSearch string) bool {
 	for _, item := range list {
 		if item == strToSearch {
@@ -176,6 +186,8 @@ func Contains(list []string, strToSearch string) bool {
 	return false
 }
 
+// GetNamespaceOrDefault returns the default namespace if given empty
+// output
 func GetNamespaceOrDefault(namespace string) string {
 	if namespace == "" {
 		return v1.NamespaceDefault
@@ -183,8 +195,17 @@ func GetNamespaceOrDefault(namespace string) string {
 	return namespace
 }
 
+// ParseClusterYaml parses a YAML file for cluster objects
 func ParseClusterYaml(file string) (*clusterv1.Cluster, error) {
-	bytes, err := FindGVKInFile(file, "Cluster")
+	reader, err := os.Open(file)
+
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := yaml.NewYAMLOrJSONDecoder(reader, 32)
+
+	bytes, err := decodeClusterV1Kinds(decoder, "Cluster")
 	if err != nil {
 		return nil, err
 	}
@@ -200,18 +221,30 @@ func ParseClusterYaml(file string) (*clusterv1.Cluster, error) {
 	return &cluster, nil
 }
 
+// ParseMachinesYaml extracts machine objects from a file
 func ParseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
-	machineList, err := ParseMachineListYaml(file)
+	reader, err := os.Open(file)
 
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
-	bytes, err := FindGVKInFile(file, "Machine")
+	decoder := yaml.NewYAMLOrJSONDecoder(reader, 32)
+	machineList, err := decodeMachineLists(decoder)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Will reread the file to find items which aren't a list.
+	// TODO: Make the Kind field mandatory on machines.yaml and then use the
+	// universal decoder instead of doing this.
+	reader.Seek(0, 0)
+	bytes, err := decodeClusterV1Kinds(decoder, "Machine")
 
 	// Original set of MachineLists did not have Kind field
 	if err != nil && !isMissingKind(err) {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	machines := []clusterv1.Machine{}
@@ -220,7 +253,7 @@ func ParseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
 		var machine clusterv1.Machine
 		err = json.Unmarshal(m, &machine)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 		machines = append(machines, machine)
 	}
@@ -230,64 +263,55 @@ func ParseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
 	return append(machinesP, machineList...), nil
 }
 
-func ParseMachineListYaml(file string) ([]*clusterv1.Machine, error) {
-	b, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
+// decodeMachineLists extracts MachineLists from a byte reader
+func decodeMachineLists(decoder *yaml.YAMLOrJSONDecoder) ([]*clusterv1.Machine, error) {
 
 	outs := []clusterv1.Machine{}
 
-	reader := bytes.NewReader(b)
-	decoder := yaml.NewYAMLOrJSONDecoder(reader, 32)
-
 	for {
 		var out clusterv1.MachineList
-		err = decoder.Decode(&out)
+		err := decoder.Decode(&out)
 
-		if err != io.EOF && err != nil {
-		} else if err == io.EOF {
-			return MachineP(outs), nil
+		if err == io.EOF {
+			break
 		}
 		outs = append(outs, out.Items...)
 	}
+	return MachineP(outs), nil
 }
 
+// isMissingKind reimplements runtime.IsMissingKind as the YAMLOrJSONDecoder
+// hides the error type
 func isMissingKind(err error) bool {
 	return strings.Contains(err.Error(), "Object 'Kind' is missing in")
 }
 
-func FindGVKInFile(file string, kind string) ([][]byte, error) {
-	b, err := ioutil.ReadFile(file)
-	if err != nil {
-		return [][]byte{}, errors.WithStack(err)
-	}
+// decodeClusterV1Kinds returns a slice of objects matching the clusterv1 kind
+func decodeClusterV1Kinds(decoder *yaml.YAMLOrJSONDecoder, kind string) ([][]byte, error) {
 
 	outs := [][]byte{}
 
-	reader := bytes.NewReader(b)
-	decoder := yaml.NewYAMLOrJSONDecoder(reader, 32)
-
 	for {
 		var out unstructured.Unstructured
-		err = decoder.Decode(&out)
+		err := decoder.Decode(&out)
 
-		if runtime.IsMissingKind(err) || err == io.EOF {
-			return outs, nil
+		if err == io.EOF {
+			break
 		}
 
 		if err != nil {
-			return outs, errors.WithStack(err)
+			return outs, err
 		}
 
 		if out.GetKind() == kind && out.GetAPIVersion() == clusterv1.SchemeGroupVersion.String() {
 			var marshaled []byte
 			marshaled, err = out.MarshalJSON()
-			fmt.Printf("%T", err)
 			if err != nil {
-				return outs, errors.WithStack(err)
+				return outs, err
 			}
 			outs = append(outs, marshaled)
 		}
 	}
+
+	return outs, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -241,6 +241,7 @@ func ParseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
 	// Will reread the file to find items which aren't a list.
 	// TODO: Make the Kind field mandatory on machines.yaml and then use the
 	// universal decoder instead of doing this.
+	// https://github.com/kubernetes-sigs/cluster-api/issues/717
 	if _, err := reader.Seek(0, 0); err != nil {
 		return nil, err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -201,7 +201,6 @@ func ParseClusterYaml(file string) (*clusterv1.Cluster, error) {
 }
 
 func ParseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
-
 	machineList, err := ParseMachineListYaml(file)
 
 	if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/json"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -31,6 +30,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
@@ -241,7 +241,10 @@ func ParseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
 	// Will reread the file to find items which aren't a list.
 	// TODO: Make the Kind field mandatory on machines.yaml and then use the
 	// universal decoder instead of doing this.
-	reader.Seek(0, 0)
+	if _, err := reader.Seek(0, 0); err != nil {
+		return nil, err
+	}
+
 	bytes, err := decodeClusterV1Kinds(decoder, "Machine")
 
 	// Original set of MachineLists did not have Kind field

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -49,6 +49,15 @@ kind: Machine
 metadata:
   name: machine2`
 
+const validMachines3 = `
+items:
+- metadata:
+    name: machine1
+  spec:
+- metadata:
+    name: machine2
+`
+
 const validUnified1 = `
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Cluster
@@ -106,6 +115,33 @@ kind: Machine
 metadata:
   name: machine2`
 
+const validUnified4 = `
+apiVersion: v1
+data:
+  cluster_name: cluster1
+  cluster_network_pods_cidrBlock: 192.168.0.0/16
+  cluster_network_services_cidrBlock: 10.96.0.0/12
+  cluster_sshKeyName: default
+kind: ConfigMap
+metadata:
+  name: cluster-api-shared-configuration
+  namespace: cluster-api-test
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Cluster
+metadata:
+  name: cluster1
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineList
+items:
+- metadata:
+    name: machine1
+  spec:
+- metadata:
+    name: machine2
+`
+
 func TestParseClusterYaml(t *testing.T) {
 	t.Run("File does not exist", func(t *testing.T) {
 		_, err := ParseClusterYaml("fileDoesNotExist")
@@ -137,6 +173,11 @@ func TestParseClusterYaml(t *testing.T) {
 		{
 			name:         "valid unified file with separate machines and a configmap",
 			contents:     validUnified3,
+			expectedName: "cluster1",
+		},
+		{
+			name:         "valid unified file with machinelist (only with type info) and a configmap",
+			contents:     validUnified4,
 			expectedName: "cluster1",
 		},
 		{
@@ -194,6 +235,11 @@ func TestParseMachineYaml(t *testing.T) {
 			expectedMachineCount: 2,
 		},
 		{
+			name:                 "valid file using MachineList without type info",
+			contents:             validMachines3,
+			expectedMachineCount: 2,
+		},
+		{
 			name:                 "valid unified file with machine list",
 			contents:             validUnified1,
 			expectedMachineCount: 1,
@@ -206,6 +252,11 @@ func TestParseMachineYaml(t *testing.T) {
 		{
 			name:                 "valid unified file with separate machines and a configmap",
 			contents:             validUnified3,
+			expectedMachineCount: 2,
+		},
+		{
+			name:                 "valid unified file with machinelist (only with type info) and a configmap",
+			contents:             validUnified4,
 			expectedMachineCount: 2,
 		},
 		{

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -26,16 +26,85 @@ const validCluster = `
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Cluster
 metadata:
-  name: cluster1 
+  name: cluster1
 spec:`
 
-const validMachines = `
+const validMachines1 = `
 items:
 - apiVersion: "cluster.k8s.io/v1alpha1"
   kind: Machine
   metadata:
     name: machine1
   spec:`
+
+const validMachines2 = `
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Machine
+metadata:
+  name: machine1
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Machine
+metadata:
+  name: machine2`
+
+const validUnified1 = `
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Cluster
+metadata:
+  name: cluster1
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineList
+items:
+- apiVersion: "cluster.k8s.io/v1alpha1"
+  kind: Machine
+  metadata:
+    name: machine1`
+
+const validUnified2 = `
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Cluster
+metadata:
+  name: cluster1
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Machine
+metadata:
+  name: machine1
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Machine
+metadata:
+  name: machine2`
+
+const validUnified3 = `
+apiVersion: v1
+data:
+  cluster_name: cluster1
+  cluster_network_pods_cidrBlock: 192.168.0.0/16
+  cluster_network_services_cidrBlock: 10.96.0.0/12
+  cluster_sshKeyName: default
+kind: ConfigMap
+metadata:
+  name: cluster-api-shared-configuration
+  namespace: cluster-api-test
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Cluster
+metadata:
+  name: cluster1
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Machine
+metadata:
+  name: machine1
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: Machine
+metadata:
+  name: machine2`
 
 func TestParseClusterYaml(t *testing.T) {
 	t.Run("File does not exist", func(t *testing.T) {
@@ -53,6 +122,21 @@ func TestParseClusterYaml(t *testing.T) {
 		{
 			name:         "valid file",
 			contents:     validCluster,
+			expectedName: "cluster1",
+		},
+		{
+			name:         "valid unified file with machine list",
+			contents:     validUnified1,
+			expectedName: "cluster1",
+		},
+		{
+			name:         "valid unified file with separate machines",
+			contents:     validUnified2,
+			expectedName: "cluster1",
+		},
+		{
+			name:         "valid unified file with separate machines and a configmap",
+			contents:     validUnified3,
 			expectedName: "cluster1",
 		},
 		{
@@ -100,13 +184,33 @@ func TestParseMachineYaml(t *testing.T) {
 		expectedMachineCount int
 	}{
 		{
-			name:                 "valid file",
-			contents:             validMachines,
+			name:                 "valid file using MachineList",
+			contents:             validMachines1,
 			expectedMachineCount: 1,
 		},
 		{
+			name:                 "valid file using Machines",
+			contents:             validMachines2,
+			expectedMachineCount: 2,
+		},
+		{
+			name:                 "valid unified file with machine list",
+			contents:             validUnified1,
+			expectedMachineCount: 1,
+		},
+		{
+			name:                 "valid unified file with separate machines",
+			contents:             validUnified2,
+			expectedMachineCount: 2,
+		},
+		{
+			name:                 "valid unified file with separate machines and a configmap",
+			contents:             validUnified3,
+			expectedMachineCount: 2,
+		},
+		{
 			name:      "gibberish in file",
-			contents:  `blah ` + validMachines + ` blah`,
+			contents:  `blah ` + validMachines1 + ` blah`,
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Part of UX improvements for https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/276 and https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/371, this allows clusterctl to search for relevant objects within manifests instead of assuming the first document in the YAML file is the correct one.

This enables the use of common configuration to be handled by kustomize, which will typically add elements to a YAML file.

Potentially, this will allow removal of the separate machines and cluster manifest, as they can now be the
same file.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
clusterctl: Can now use Machines as well as MachineLists for `clusterctl create cluster --machines`
```
