### PR TITLE
Use RevisionVersion field instead of CreationTimestamp to decide which MS is new/old

### DIFF
--- a/pkg/controller/machinedeployment/machinedeployment_controller_test.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package machinedeployment
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -153,7 +154,16 @@ func TestReconcile(t *testing.T) {
 	// Wait for the new MachineSet to get scaled up and set .Status.Replicas and .Status.AvailableReplicas
 	// at each step
 	var newMachineSet, oldMachineSet *clusterv1alpha1.MachineSet
-	if machineSets.Items[0].CreationTimestamp.Before(&machineSets.Items[1].CreationTimestamp) {
+	resourceVersion0, err0 := strconv.Atoi(machineSets.Items[0].ResourceVersion)
+	resourceVersion1, err1 := strconv.Atoi(machineSets.Items[1].ResourceVersion)
+	if err0 != nil {
+		t.Fatalf("Unable to convert MS %q ResourceVersion to a number: %v", machineSets.Items[0].Name, err0)
+	}
+	if err1 != nil {
+		t.Fatalf("Unable to convert MS %q ResourceVersion to a number: %v", machineSets.Items[1].Name, err1)
+	}
+
+	if resourceVersion0 > resourceVersion1 {
 		newMachineSet = &machineSets.Items[0]
 		oldMachineSet = &machineSets.Items[1]
 	} else {


### PR DESCRIPTION
The CreationTimestamp is not always the referential value for comparison.
The time.Time.Before method does not always return true when it should.
Leading to new and old MSs to be selected in an opposite way.
Using the RevisionVersion for comparison is more precise and it solves
the case where CreationTimestamp fields of both MSs has the same value.

From observation the following machineset CreationTimestamps led to incorrect ordering of MSs:
item[0]: ResourceVersion:"78", CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63684460660, loc:(*time.Location)(0x2cb5040)}}
item[1]: ResourceVersion:"82", CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63684460661, loc:(*time.Location)(0x2cb5040)}}

Even though item[1]'s ext field has higher value than item[0]'s ext field,
item[1] was selected by time.Time.Before as old MS instead of new one.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
