### PR TITLE
Add golint to CI linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable:
     - govet
+    - golint
     - gofmt
     - goimports
     - structcheck

--- a/cmd/clusterctl/clusterdeployer/clusterclient/clientfactory.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clientfactory.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clientcmd"
 )
 
-// Factory can create cluster clients
+// Factory can create cluster clients.
 type Factory interface {
 	NewClientFromKubeconfig(string) (Client, error)
 	NewCoreClientsetFromKubeconfigFile(string) (*kubernetes.Clientset, error)
@@ -30,14 +30,17 @@ type Factory interface {
 type clientFactory struct {
 }
 
-func NewFactory() *clientFactory {
+// NewFactory returns a new cluster client factory.
+func NewFactory() *clientFactory { // nolint
 	return &clientFactory{}
 }
 
+// NewClientFromKubeConfig returns a new Client from the Kubeconfig passed as argument.
 func (f *clientFactory) NewClientFromKubeconfig(kubeconfig string) (Client, error) {
 	return New(kubeconfig)
 }
 
+// NewCoreClientsetFromKubeconfigFile returns a new ClientSet from the Kubeconfig path passed as argument.
 func (f *clientFactory) NewCoreClientsetFromKubeconfigFile(kubeconfigPath string) (*kubernetes.Clientset, error) {
 	return clientcmd.NewCoreClientSetForDefaultSearchPath(kubeconfigPath, clientcmd.NewConfigOverrides())
 }

--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -88,7 +88,7 @@ type client struct {
 
 // New creates and returns a Client, the kubeconfig argument is expected to be the string representation
 // of a valid kubeconfig.
-func New(kubeconfig string) (*client, error) {
+func New(kubeconfig string) (*client, error) { //nolint
 	f, err := createTempFile(kubeconfig)
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (c *client) DeleteNamespace(namespaceName string) error {
 
 // NewFromDefaultSearchPath creates and returns a Client.  The kubeconfigFile argument is expected to be the path to a
 // valid kubeconfig file.
-func NewFromDefaultSearchPath(kubeconfigFile string, overrides tcmd.ConfigOverrides) (*client, error) {
+func NewFromDefaultSearchPath(kubeconfigFile string, overrides tcmd.ConfigOverrides) (*client, error) { //nolint
 	c, err := clientcmd.NewClusterAPIClientForDefaultSearchPath(kubeconfigFile, overrides)
 	if err != nil {
 		return nil, err

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -136,22 +136,22 @@ type MachineSetStatus struct {
 
 /// [MachineSetStatus]
 
-func (machineSet *MachineSet) Validate() field.ErrorList {
+func (m *MachineSet) Validate() field.ErrorList {
 	errors := field.ErrorList{}
 
 	// validate spec.selector and spec.template.labels
 	fldPath := field.NewPath("spec")
-	errors = append(errors, metav1validation.ValidateLabelSelector(&machineSet.Spec.Selector, fldPath.Child("selector"))...)
-	if len(machineSet.Spec.Selector.MatchLabels)+len(machineSet.Spec.Selector.MatchExpressions) == 0 {
-		errors = append(errors, field.Invalid(fldPath.Child("selector"), machineSet.Spec.Selector, "empty selector is not valid for MachineSet."))
+	errors = append(errors, metav1validation.ValidateLabelSelector(&m.Spec.Selector, fldPath.Child("selector"))...)
+	if len(m.Spec.Selector.MatchLabels)+len(m.Spec.Selector.MatchExpressions) == 0 {
+		errors = append(errors, field.Invalid(fldPath.Child("selector"), m.Spec.Selector, "empty selector is not valid for MachineSet."))
 	}
-	selector, err := metav1.LabelSelectorAsSelector(&machineSet.Spec.Selector)
+	selector, err := metav1.LabelSelectorAsSelector(&m.Spec.Selector)
 	if err != nil {
-		errors = append(errors, field.Invalid(fldPath.Child("selector"), machineSet.Spec.Selector, "invalid label selector."))
+		errors = append(errors, field.Invalid(fldPath.Child("selector"), m.Spec.Selector, "invalid label selector."))
 	} else {
-		labels := labels.Set(machineSet.Spec.Template.Labels)
+		labels := labels.Set(m.Spec.Template.Labels)
 		if !selector.Matches(labels) {
-			errors = append(errors, field.Invalid(fldPath.Child("template", "metadata", "labels"), machineSet.Spec.Template.Labels, "`selector` does not match template `labels`"))
+			errors = append(errors, field.Invalid(fldPath.Child("template", "metadata", "labels"), m.Spec.Template.Labels, "`selector` does not match template `labels`"))
 		}
 	}
 
@@ -159,16 +159,16 @@ func (machineSet *MachineSet) Validate() field.ErrorList {
 }
 
 // DefaultingFunction sets default MachineSet field values
-func (obj *MachineSet) Default() {
-	log.Printf("Defaulting fields for MachineSet %s\n", obj.Name)
+func (m *MachineSet) Default() {
+	log.Printf("Defaulting fields for MachineSet %s\n", m.Name)
 
-	if obj.Spec.Replicas == nil {
-		obj.Spec.Replicas = new(int32)
-		*obj.Spec.Replicas = 1
+	if m.Spec.Replicas == nil {
+		m.Spec.Replicas = new(int32)
+		*m.Spec.Replicas = 1
 	}
 
-	if len(obj.Namespace) == 0 {
-		obj.Namespace = metav1.NamespaceDefault
+	if len(m.Namespace) == 0 {
+		m.Namespace = metav1.NamespaceDefault
 	}
 }
 

--- a/pkg/apis/cluster/v1alpha1/register.go
+++ b/pkg/apis/cluster/v1alpha1/register.go
@@ -30,12 +30,13 @@ import (
 )
 
 var (
-	// SchemeGroupVersion is group version used to register these objects
+	// SchemeGroupVersion is group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: "cluster.k8s.io", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
 
+	// AddToScheme adds registered types to the builder.
 	// Required by pkg/client/...
 	// TODO(pwittrock): Remove this after removing pkg/client/...
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/cmdrunner/cmd_runner.go
+++ b/pkg/cmdrunner/cmd_runner.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 )
 
+// Runner has one method that executes a command and returns stdout and stderr.
 type Runner interface {
 	CombinedOutput(cmd string, args ...string) (output string, err error)
 }
@@ -27,7 +28,8 @@ type Runner interface {
 type realRunner struct {
 }
 
-func New() *realRunner {
+// New returns a command runner.
+func New() *realRunner { // nolint
 	return &realRunner{}
 }
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR is a follow-up from #699 that adds `golint` to the list of linters. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

NOTE: Although `golint` is being added here, `golangci-lint` excludes some output from it such as:

```
# golint: Annoying issue about not having a comment. The rare codebase has such comments
- (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
                                    
# golint: False positive when tests are defined in package 'test'
- func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
```


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
