### PR TITLE
Fix passing context from the start in run validate cluster cmd

### DIFF
--- a/cmd/clusterctl/cmd/validate_cluster.go
+++ b/cmd/clusterctl/cmd/validate_cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -73,7 +74,7 @@ func RunValidateCluster() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create client")
 	}
-	if err = validation.ValidateClusterAPIObjects(os.Stdout, c, vco.KubeconfigOverrides.Context.Cluster, vco.KubeconfigOverrides.Context.Namespace); err != nil {
+	if err := validation.ValidateClusterAPIObjects(context.TODO(), os.Stdout, c, vco.KubeconfigOverrides.Context.Cluster, vco.KubeconfigOverrides.Context.Namespace); err != nil {
 		return err
 	}
 

--- a/cmd/clusterctl/validation/validate_cluster_api_objects_test.go
+++ b/cmd/clusterctl/validation/validate_cluster_api_objects_test.go
@@ -82,7 +82,7 @@ func TestGetClusterObjectWithNoCluster(t *testing.T) {
 	c = mgr.GetClient()
 	defer close(StartTestManager(mgr, t))
 
-	if _, err := getClusterObject(c, "test-cluster", "get-cluster-object-with-no-cluster"); err == nil {
+	if _, err := getClusterObject(context.TODO(), c, "test-cluster", "get-cluster-object-with-no-cluster"); err == nil {
 		t.Error("expected error but didn't get one")
 	}
 }
@@ -139,7 +139,7 @@ func TestGetClusterObjectWithOneCluster(t *testing.T) {
 	}
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			cluster, err := getClusterObject(c, testcase.clusterName, testcase.namespace)
+			cluster, err := getClusterObject(context.TODO(), c, testcase.clusterName, testcase.namespace)
 			if testcase.expectErr && err == nil {
 				t.Fatalf("Expect to get error, but got no returned error.")
 			}
@@ -200,7 +200,7 @@ func TestGetClusterObjectWithMoreThanOneCluster(t *testing.T) {
 	}
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-			cluster, err := getClusterObject(c, testcase.clusterName, testNamespace)
+			cluster, err := getClusterObject(context.TODO(), c, testcase.clusterName, testNamespace)
 			if testcase.expectErr && err == nil {
 				t.Fatalf("Expect to get error, but got no returned error.")
 			}
@@ -335,7 +335,7 @@ func TestValidateMachineObjects(t *testing.T) {
 				},
 			}
 			var b bytes.Buffer
-			err := validateMachineObjects(&b, &machines, c)
+			err := validateMachineObjects(context.TODO(), &b, &machines, c)
 			if testcase.expectErr && err == nil {
 				t.Errorf("Expect to get error, but got no returned error: %v", b.String())
 			}
@@ -400,7 +400,7 @@ func TestValidateMachineObjectWithReferredNode(t *testing.T) {
 				},
 			}
 			var b bytes.Buffer
-			err := validateMachineObjects(&b, &machines, c)
+			err := validateMachineObjects(context.TODO(), &b, &machines, c)
 			if testcase.expectErr && err == nil {
 				t.Fatalf("Expect to get error, but got no returned error.")
 			}
@@ -549,7 +549,7 @@ func TestValidateClusterAPIObjectsOutput(t *testing.T) {
 			}
 
 			var output bytes.Buffer
-			err = ValidateClusterAPIObjects(&output, c, testClusterName, testcase.namespace)
+			err = ValidateClusterAPIObjects(context.TODO(), &output, c, testClusterName, testcase.namespace)
 
 			if testcase.expectErr && err == nil {
 				t.Fatalf("Expect to get error, but got no returned error: %v", output.String())


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix passing context from the start for cluster validation functions. As per @roberthbailey 's review comments [here](https://github.com/kubernetes-sigs/cluster-api/pull/679#discussion_r250725061)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up PR to #679 

**Special notes for your reviewer**:
None
