### PR TITLE
Index metadata.name for cluster-name label

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -58,6 +58,10 @@ func newReconciler(mgr manager.Manager, actuator Actuator) reconcile.Reconciler 
 		actuator: actuator,
 	}
 
+	mgr.GetFieldIndexer().IndexField(&clusterv1.Cluster{}, "metadata.name", func(obj runtime.Object) []string {
+		return []string{obj.(*clusterv1.Cluster).Name}
+	})
+
 	if r.nodeName == "" {
 		klog.Warningf("environment variable %v is not set, this controller will not protect against deleting its own machine", NodeNameEnvVar)
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

#728 introduced a bug where the `metadata.name` field cannot be queried because the client uses a cached-index implementation to retrieve results. This bug prevents providers to successfully spin up clusters when using the `Cluster` resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The branch has been successfully tested on the AWS and vSphere providers.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
