### PR TITLE
Add directives for setting ClusterRole permissions in the book

### DIFF
--- a/docs/book/provider_implementations/create_actuators.md
+++ b/docs/book/provider_implementations/create_actuators.md
@@ -35,6 +35,9 @@ import (
         client "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset/typed/cluster/v1alpha1"
 )
 
+// Add RBAC rules to access cluster-api resources
+//+kubebuilder:rbac:groups=cluster.k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
+
 // Actuator is responsible for performing cluster reconciliation
 type Actuator struct {
         clustersGetter client.ClustersGetter
@@ -101,6 +104,11 @@ import (
 const (
         ProviderName = "solas"
 )
+
+// Add RBAC rules to access cluster-api resources
+//+kubebuilder:rbac:groups=cluster.k8s.io,resources=machines;machines/status;machinedeployments;machinedeployments/status;machinesets;machinesets/status;machineclasses,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=cluster.k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=nodes;events,verbs=get;list;watch;create;update;patch;delete
 
 // Actuator is responsible for performing machine reconciliation
 type Actuator struct {


### PR DESCRIPTION
The default ClusterRole created by kubebuilder does not include
all the requried permissions for the controllers to access the
cluster-api objects.

This causes the sample providers developed in the provider implementation
guide to fail when deployed.

This PR adds additional kubebuilder directives for setting these permissions.

Fix #741
 
This PR requires /help for setting the development environment and check the
documentation changes. 

Signed-off-by: Pablo Chacin <pchacin@suse.com