### PR TITLE
gazelle: specify proto disable_global

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 load("//build:run_in_workspace_with_goroot.bzl", "workspace_binary")
 
 # gazelle:prefix sigs.k8s.io/cluster-api
+# gazelle:proto disable_global
 gazelle(
     name = "gazelle",
     external = "vendored",

--- a/vendor/github.com/golang/protobuf/ptypes/BUILD.bazel
+++ b/vendor/github.com/golang/protobuf/ptypes/BUILD.bazel
@@ -13,8 +13,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:any_go_proto",
-        "@io_bazel_rules_go//proto/wkt:duration_go_proto",
-        "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
+        "//vendor/github.com/golang/protobuf/ptypes/any:go_default_library",
+        "//vendor/github.com/golang/protobuf/ptypes/duration:go_default_library",
+        "//vendor/github.com/golang/protobuf/ptypes/timestamp:go_default_library",
     ],
 )

--- a/vendor/github.com/googleapis/gnostic/OpenAPIv2/BUILD.bazel
+++ b/vendor/github.com/googleapis/gnostic/OpenAPIv2/BUILD.bazel
@@ -11,8 +11,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
+        "//vendor/github.com/golang/protobuf/ptypes/any:go_default_library",
         "//vendor/github.com/googleapis/gnostic/compiler:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:any_go_proto",
     ],
 )

--- a/vendor/github.com/googleapis/gnostic/compiler/BUILD.bazel
+++ b/vendor/github.com/googleapis/gnostic/compiler/BUILD.bazel
@@ -15,8 +15,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
+        "//vendor/github.com/golang/protobuf/ptypes/any:go_default_library",
         "//vendor/github.com/googleapis/gnostic/extensions:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",
-        "@io_bazel_rules_go//proto/wkt:any_go_proto",
     ],
 )

--- a/vendor/github.com/googleapis/gnostic/extensions/BUILD.bazel
+++ b/vendor/github.com/googleapis/gnostic/extensions/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
-        "@io_bazel_rules_go//proto/wkt:any_go_proto",
+        "//vendor/github.com/golang/protobuf/ptypes:go_default_library",
+        "//vendor/github.com/golang/protobuf/ptypes/any:go_default_library",
     ],
 )


### PR DESCRIPTION
Turns off gazelle's special handling of proto, which makes us much
more consistent with `go get` (at the expensive of not auto-generating
go code from .proto files)

```release-note
NONE
```