### PR TITLE
Add owners for gh-pages branch

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-cluster-lifecycle-leads
+  - cluster-api-admins
+  - cluster-api-maintainers
+
+reviewers:
+  - cluster-api-maintainers


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an OWNERS file to the gh-pages branch to make the prow automation work.

```release-note
NONE
```
