### PR TITLE
config: Adjust to new version of kustomize.

### DIFF
--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -18,14 +18,14 @@ namePrefix: cluster-api-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../crds/cluster_v1alpha1_cluster.yaml
-- ../crds/cluster_v1alpha1_machine.yaml
-- ../crds/cluster_v1alpha1_machineclass.yaml
-- ../crds/cluster_v1alpha1_machinedeployment.yaml
-- ../crds/cluster_v1alpha1_machineset.yaml
-- ../rbac/rbac_role.yaml
-- ../rbac/rbac_role_binding.yaml
-- ../manager/manager.yaml
+- crds/cluster_v1alpha1_cluster.yaml
+- crds/cluster_v1alpha1_machine.yaml
+- crds/cluster_v1alpha1_machineclass.yaml
+- crds/cluster_v1alpha1_machinedeployment.yaml
+- crds/cluster_v1alpha1_machineset.yaml
+- rbac/rbac_role.yaml
+- rbac/rbac_role_binding.yaml
+- manager/manager.yaml
 
 patches:
-- manager_image_patch.yaml
+- default/manager_image_patch.yaml


### PR DESCRIPTION
The newest versions of kustomize block the use of relative paths, so
the "kustomize build config/default/" command now fails with the
following error message:

Error: rawResources failed to read Resources: Load from path ../crds/cluster_v1alpha1_cluster.yaml failed: security; file '../crds/cluster_v1alpha1_cluster.yaml' is not in or below '.../github.com/kubernetes-sigs/cluster-api/config/default'

This patch resolves this by moving kustomization.yaml down a
directory, so that all files it points to are in the same or
sub-directories of its location.

Signed-off-by: Russell Bryant <rbryant@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

As described by the commit message, this resolves compatibility with the newest versions of kustomize.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No github issue filed.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
