### PR TITLE
link to the gitbook published version of the docs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Following are the implementations managed by third-parties adopting the standard
   * Machine-controller-manager, https://github.com/gardener/machine-controller-manager/tree/cluster-api
 
 ## Getting Started
+
+### Resources
+
+* GitBook: [kubernetes-sigs.github.io/cluster-api](https://kubernetes-sigs.github.io/cluster-api)
+
 ### Prerequisites
 * `kubectl` is required, see [here](http://kubernetes.io/docs/user-guide/prereqs/).
 * `clusterctl` is a SIG-cluster-lifecycle sponsored tool to manage Cluster API clusters. See [here](cmd/clusterctl)


### PR DESCRIPTION
This change links to the published version of the documentation
from the toplevel README.md file. There is a similar link in
docs/book/README.md, but as a new contributor that wasn't an
obvious spot for me to find it.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>