### PR TITLE
[book] Fix rbac of the provider implementations in the book

### DIFF
--- a/docs/book/provider_implementations/building_running_and_testing.md
+++ b/docs/book/provider_implementations/building_running_and_testing.md
@@ -6,24 +6,24 @@ Apply the following patch:
 
 ```bash
 diff --git a/Makefile b/Makefile
-index ac12c7e..9b4f945 100644
+index ac12c7e..cf44312 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -22,12 +22,14 @@ install: manifests
+@@ -22,12 +22,15 @@ install: manifests
  
  # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
  deploy: manifests
--       kubectl apply -f config/crds
--       kustomize build config/default | kubectl apply -f -
-+       cat provider-components.yaml | kubectl apply -f -
+-	kubectl apply -f config/crds
+-	kustomize build config/default | kubectl apply -f -
++	cat provider-components.yaml | kubectl apply -f -
  
  # Generate manifests e.g. CRD, RBAC etc.
  manifests:
--       go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
-+       go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd
-+       kustomize build config/default/ > provider-components.yaml
-+       echo "---" >> provider-components.yaml
-+       kustomize build vendor/sigs.k8s.io/cluster-api/config/default/ >> provider-components.yaml
+ 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
++	sed -i'' -e 's@^- manager_auth_proxy_patch.yaml.*@#&@' config/default/kustomization.yaml
++	kustomize build config/default/ > provider-components.yaml
++	echo "---" >> provider-components.yaml
++	kustomize build vendor/sigs.k8s.io/cluster-api/config/default/ >> provider-components.yaml
  
  # Run go fmt against code
  fmt:


### PR DESCRIPTION
Signed-off-by: Alex Yang <yangyang1@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
For the provider implementations in the book,
1. ClusterRole permissions were added in PR https://github.com/kubernetes-sigs/cluster-api/pull/750. But the Makefile only generates crds. It should generate RBAC from the code also.
2. kubebuilder adds "--metrics-addr" flag in manager_auth_proxy_patch.yaml for now. But this flag was not mentioned in register_schemes.md.
3. Replace blanks with TAB in Makefile.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
