### PR TITLE
Add foregroundDeletion only if cluster is nil, move label in types

### DIFF
--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -23,8 +23,13 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 )
 
-// Finalizer is set on PrepareForCreate callback
-const MachineFinalizer = "machine.cluster.k8s.io"
+const (
+	// MachineFinalizer is set on PrepareForCreate callback.
+	MachineFinalizer = "machine.cluster.k8s.io"
+
+	// MachineClusterLabelName is the label set on machines linked to a cluster.
+	MachineClusterLabelName = "cluster.k8s.io/cluster-name"
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -37,8 +37,7 @@ import (
 )
 
 const (
-	NodeNameEnvVar          = "NODE_NAME"
-	MachineClusterLabelName = "cluster.k8s.io/cluster-name"
+	NodeNameEnvVar = "NODE_NAME"
 )
 
 var DefaultActuator Actuator
@@ -137,7 +136,7 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 	if m.ObjectMeta.DeletionTimestamp.IsZero() {
 		finalizerCount := len(m.Finalizers)
 
-		if !util.Contains(m.Finalizers, metav1.FinalizerDeleteDependents) {
+		if cluster != nil && !util.Contains(m.Finalizers, metav1.FinalizerDeleteDependents) {
 			m.Finalizers = append(m.ObjectMeta.Finalizers, metav1.FinalizerDeleteDependents)
 		}
 
@@ -226,15 +225,15 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 }
 
 func (r *ReconcileMachine) getCluster(ctx context.Context, machine *clusterv1.Machine) (*clusterv1.Cluster, error) {
-	if machine.Labels[MachineClusterLabelName] == "" {
-		klog.Infof("Machine %q in namespace %q doesn't specify %q label, assuming nil cluster", machine.Name, MachineClusterLabelName, machine.Namespace)
+	if machine.Labels[clusterv1.MachineClusterLabelName] == "" {
+		klog.Infof("Machine %q in namespace %q doesn't specify %q label, assuming nil cluster", machine.Name, clusterv1.MachineClusterLabelName, machine.Namespace)
 		return nil, nil
 	}
 
 	cluster := &clusterv1.Cluster{}
 	key := client.ObjectKey{
 		Namespace: machine.Namespace,
-		Name:      machine.Labels[MachineClusterLabelName],
+		Name:      machine.Labels[clusterv1.MachineClusterLabelName],
 	}
 
 	if err := r.Client.Get(ctx, key, cluster); err != nil {

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -42,7 +42,7 @@ func TestReconcileRequest(t *testing.T) {
 			Namespace:  "default",
 			Finalizers: []string{v1alpha1.MachineFinalizer, metav1.FinalizerDeleteDependents},
 			Labels: map[string]string{
-				MachineClusterLabelName: "testcluster",
+				v1alpha1.MachineClusterLabelName: "testcluster",
 			},
 		},
 	}
@@ -55,7 +55,7 @@ func TestReconcileRequest(t *testing.T) {
 			Namespace:  "default",
 			Finalizers: []string{v1alpha1.MachineFinalizer, metav1.FinalizerDeleteDependents},
 			Labels: map[string]string{
-				MachineClusterLabelName: "testcluster",
+				v1alpha1.MachineClusterLabelName: "testcluster",
 			},
 		},
 	}
@@ -70,7 +70,7 @@ func TestReconcileRequest(t *testing.T) {
 			Finalizers:        []string{v1alpha1.MachineFinalizer, metav1.FinalizerDeleteDependents},
 			DeletionTimestamp: &time,
 			Labels: map[string]string{
-				MachineClusterLabelName: "testcluster",
+				v1alpha1.MachineClusterLabelName: "testcluster",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes an issue where `foregroundDeletion` finalizer was being added regardless if cluster was nil or not. It also moves the label name under v1alpha1 machine types.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
