### PR TITLE
Set ownerRef / foregroundDeletion on MachineSets/Deployments

### DIFF
--- a/pkg/controller/machinedeployment/controller.go
+++ b/pkg/controller/machinedeployment/controller.go
@@ -200,7 +200,7 @@ func (r *ReconcileMachineDeployment) Reconcile(request reconcile.Request) (recon
 		})
 	}
 
-	// Add foregroundDeletion finalizer if MachineSet isn't deleted and linked to a cluster.
+	// Add foregroundDeletion finalizer if MachineDeployment isn't deleted and linked to a cluster.
 	if cluster != nil && d.ObjectMeta.DeletionTimestamp.IsZero() {
 		if !util.Contains(d.Finalizers, metav1.FinalizerDeleteDependents) {
 			d.Finalizers = append(d.ObjectMeta.Finalizers, metav1.FinalizerDeleteDependents)

--- a/pkg/controller/machinedeployment/controller_test.go
+++ b/pkg/controller/machinedeployment/controller_test.go
@@ -42,7 +42,8 @@ func TestMachineSetToDeployments(t *testing.T) {
 		Spec: v1alpha1.MachineDeploymentSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"foo": "bar",
+					"foo":                            "bar",
+					v1alpha1.MachineClusterLabelName: "test-cluster",
 				},
 			},
 		},
@@ -65,6 +66,9 @@ func TestMachineSetToDeployments(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(&machineDeployment, controllerKind),
 			},
+			Labels: map[string]string{
+				v1alpha1.MachineClusterLabelName: "test-cluster",
+			},
 		},
 	}
 	ms2 := v1alpha1.MachineSet{
@@ -74,6 +78,9 @@ func TestMachineSetToDeployments(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "noOwnerRefNoLabels",
 			Namespace: "test",
+			Labels: map[string]string{
+				v1alpha1.MachineClusterLabelName: "test-cluster",
+			},
 		},
 	}
 	ms3 := v1alpha1.MachineSet{
@@ -84,7 +91,8 @@ func TestMachineSetToDeployments(t *testing.T) {
 			Name:      "withMatchingLabels",
 			Namespace: "test",
 			Labels: map[string]string{
-				"foo": "bar",
+				"foo":                            "bar",
+				v1alpha1.MachineClusterLabelName: "test-cluster",
 			},
 		},
 	}

--- a/pkg/controller/machineset/controller_test.go
+++ b/pkg/controller/machineset/controller_test.go
@@ -46,7 +46,8 @@ func TestMachineSetToMachines(t *testing.T) {
 				Spec: v1alpha1.MachineSetSpec{
 					Selector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"foo": "bar",
+							"foo":                            "bar",
+							v1alpha1.MachineClusterLabelName: "test-cluster",
 						},
 					},
 				},
@@ -61,6 +62,9 @@ func TestMachineSetToMachines(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "withOwnerRef",
 			Namespace: "test",
+			Labels: map[string]string{
+				v1alpha1.MachineClusterLabelName: "test-cluster",
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name:       "Owner",
@@ -77,6 +81,9 @@ func TestMachineSetToMachines(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "noOwnerRefNoLabels",
 			Namespace: "test",
+			Labels: map[string]string{
+				v1alpha1.MachineClusterLabelName: "test-cluster",
+			},
 		},
 	}
 	m3 := v1alpha1.Machine{
@@ -87,7 +94,8 @@ func TestMachineSetToMachines(t *testing.T) {
 			Name:      "withMatchingLabels",
 			Namespace: "test",
 			Labels: map[string]string{
-				"foo": "bar",
+				"foo":                            "bar",
+				v1alpha1.MachineClusterLabelName: "test-cluster",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #758

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
