### PR TITLE
Support MachineDeployment adoption of MachineSets

### DIFF
--- a/pkg/controller/machineset/controller.go
+++ b/pkg/controller/machineset/controller.go
@@ -225,10 +225,10 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 			continue
 		}
 
-		// Attempt to adopt machine if it meets previous conditions and it has no controller ref.
+		// Attempt to adopt machine if it meets previous conditions and it has no controller references.
 		if metav1.GetControllerOf(machine) == nil {
 			if err := r.adoptOrphan(machineSet, machine); err != nil {
-				klog.Warningf("failed to adopt machine %v into machineset %v. %v", machine.Name, machineSet.Name, err)
+				klog.Warningf("Failed to adopt MachineSet %q into MachineSet %q: %v", machine.Name, machineSet.Name, err)
 				continue
 			}
 		}
@@ -307,12 +307,12 @@ func (r *ReconcileMachineSet) syncReplicas(ms *clusterv1alpha1.MachineSet, machi
 		var machineList []*clusterv1alpha1.Machine
 		var errstrings []string
 		for i := 0; i < diff; i++ {
-			klog.Infof("creating machine %d of %d, ( spec.replicas(%d) > currentMachineCount(%d) )",
+			klog.Infof("Creating machine %d of %d, ( spec.replicas(%d) > currentMachineCount(%d) )",
 				i+1, diff, *(ms.Spec.Replicas), len(machines))
 
 			machine := r.createMachine(ms)
 			if err := r.Client.Create(context.Background(), machine); err != nil {
-				klog.Errorf("unable to create a machine = %s, due to %v", machine.Name, err)
+				klog.Errorf("Unable to create Machine %q: %v", machine.Name, err)
 				errstrings = append(errstrings, err.Error())
 				continue
 			}
@@ -341,7 +341,7 @@ func (r *ReconcileMachineSet) syncReplicas(ms *clusterv1alpha1.MachineSet, machi
 				defer wg.Done()
 				err := r.Client.Delete(context.Background(), targetMachine)
 				if err != nil {
-					klog.Errorf("unable to delete a machine = %s, due to %v", targetMachine.Name, err)
+					klog.Errorf("Unable to delete Machine %s: %v", targetMachine.Name, err)
 					errCh <- err
 				}
 			}(machine)
@@ -402,22 +402,9 @@ func shouldExcludeMachine(machineSet *clusterv1alpha1.MachineSet, machine *clust
 }
 
 func (r *ReconcileMachineSet) adoptOrphan(machineSet *clusterv1alpha1.MachineSet, machine *clusterv1alpha1.Machine) error {
-	// Add controller reference.
-	ownerRefs := machine.ObjectMeta.GetOwnerReferences()
-	if ownerRefs == nil {
-		ownerRefs = []metav1.OwnerReference{}
-	}
-
 	newRef := *metav1.NewControllerRef(machineSet, controllerKind)
-	ownerRefs = append(ownerRefs, newRef)
-	machine.ObjectMeta.SetOwnerReferences(ownerRefs)
-
-	if err := r.Client.Update(context.Background(), machine); err != nil {
-		klog.Warningf("Failed to update machine owner reference. %v", err)
-		return err
-	}
-
-	return nil
+	machine.OwnerReferences = append(machine.OwnerReferences, newRef)
+	return r.Client.Update(context.Background(), machine)
 }
 
 func (r *ReconcileMachineSet) waitForMachineCreation(machineList []*clusterv1alpha1.Machine) error {

--- a/pkg/controller/machineset/machine.go
+++ b/pkg/controller/machineset/machine.go
@@ -60,14 +60,17 @@ func hasMatchingLabels(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machin
 		klog.Warningf("unable to convert selector: %v", err)
 		return false
 	}
+
 	// If a deployment with a nil or empty selector creeps in, it should match nothing, not everything.
 	if selector.Empty() {
 		klog.V(2).Infof("%v machineset has empty selector", machineSet.Name)
 		return false
 	}
+
 	if !selector.Matches(labels.Set(machine.Labels)) {
 		klog.V(4).Infof("%v machine has mismatch labels", machine.Name)
 		return false
 	}
+
 	return true
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds support in MachineDeployments to adopt existing MachineSets without a controller reference.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #746 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
