### PR TITLE
Run gazelle after updating generated clientset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ clientset: ## Generate a typed clientset
 		--listers-package sigs.k8s.io/cluster-api/pkg/client/listers_generated \
 		--output-package sigs.k8s.io/cluster-api/pkg/client/informers_generated \
 		--go-header-file=./hack/boilerplate.go.txt
+	$(MAKE) gazelle
 
 .PHONY: clean
 clean: ## Remove all generated files


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently after running `scripts/ci-make.sh` all gazelle generated `.build` files will be missing after regenerating the generated clientset, this PR will re-run gazelle after generating the clientset so that the `.build` files will be present after the run.

**Release note**:
```release-note
NONE
```
