### PR TITLE
Fix `make verify` failure after #802

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ lint-full: dep-ensure ## Run slower linters to detect possible issues
 .PHONY: generate
 generate: clientset dep-ensure ## Generate code
 	go generate ./pkg/... ./cmd/...
+	$(MAKE) gazelle
 
 .PHONY: clientset
 clientset: ## Generate a typed clientset
@@ -100,7 +101,6 @@ clientset: ## Generate a typed clientset
 		--listers-package sigs.k8s.io/cluster-api/pkg/client/listers_generated \
 		--output-package sigs.k8s.io/cluster-api/pkg/client/informers_generated \
 		--go-header-file=./hack/boilerplate.go.txt
-	$(MAKE) gazelle
 
 .PHONY: clean
 clean: ## Remove all generated files

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -16,7 +16,6 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-set -o verbose
 
 if ! which bazel &>/dev/null; then echo "Bazel not available, skipping validation"; exit; fi
 

--- a/hack/verify_clientset.sh
+++ b/hack/verify_clientset.sh
@@ -35,6 +35,7 @@ mkdir -p "${TMP_DIFFROOT}"
 cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
 
 make clientset
+find "${TMP_DIFFROOT}" -name *.bazel -delete
 
 echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes an issue introduce in #802 where running gazelle after clientset would break `make verify` target for Bazel. The issue is resolved by removing the BAZEL files generated in the tmp directory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
As part of this PR we also remove the verbose option in `bazel-verify` script which causes error messages to be printed out even though the code succeeds.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
