### PR TITLE
Fix an issue with verify_client.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ clientset: ## Generate a typed clientset
 		--listers-package sigs.k8s.io/cluster-api/pkg/client/listers_generated \
 		--output-package sigs.k8s.io/cluster-api/pkg/client/informers_generated \
 		--go-header-file=./hack/boilerplate.go.txt
+	$(MAKE) gazelle
 
 .PHONY: clean
 clean: ## Remove all generated files

--- a/hack/verify_clientset.sh
+++ b/hack/verify_clientset.sh
@@ -35,12 +35,10 @@ mkdir -p "${TMP_DIFFROOT}"
 cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
 
 make clientset
-find "${TMP_DIFFROOT}" -name *.bazel -delete
 
 echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0
 diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" -x '*.bazel' -x 'BUILD' || ret=$?
-cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
 if [[ $ret -eq 0 ]]
 then
     echo "${DIFFROOT} up to date."


### PR DESCRIPTION
no need to copy files back from tmp folder.
also CI will call make clientset, so we need to
run make gazelle on clientset target.


**What this PR does / why we need it**:
run `script/ci-test.sh` failed, the current ci reporting pass only because
bazel is not available at CI image, bazel been skipped,  fix is opened at https://github.com/kubernetes/test-infra/pull/11642, 



```release-note
N/A
```


cc @vincepri  @detiber 