### PR TITLE
Rev the version of golangci-lint used

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,5 +35,5 @@ go_repository(
     name = "com_github_golangci_golangci-lint",
     build_file_generation = "on",
     importpath = "github.com/golangci/golangci-lint",
-    tag = "v1.13",
+    tag = "v1.15.0",
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the version of golangci-lint we are using

**Release note**:
```release-note
NONE
```
