### PR TITLE
Allow to record machine update error

### DIFF
--- a/pkg/apis/cluster/common/consts.go
+++ b/pkg/apis/cluster/common/consts.go
@@ -51,6 +51,13 @@ const (
 	// Example: timeout trying to connect to GCE.
 	CreateMachineError MachineStatusError = "CreateError"
 
+	// There was an error while trying to update a Node that this
+	// Machine represents. This may indicate a transient problem that will be
+	// fixed automatically with time, such as a service outage,
+	//
+	// Example: error updating load balancers
+	UpdateMachineError MachineStatusError = "UpdateError"
+
 	// An error was encountered while trying to delete the Node that this
 	// Machine represents. This could be a transient or terminal error, but
 	// will only be observable if the provider's Machine controller has

--- a/pkg/errors/machines.go
+++ b/pkg/errors/machines.go
@@ -53,6 +53,13 @@ func CreateMachine(msg string, args ...interface{}) *MachineError {
 	}
 }
 
+func UpdateMachine(msg string, args ...interface{}) *MachineError {
+	return &MachineError{
+		Reason:  commonerrors.UpdateMachineError,
+		Message: fmt.Sprintf(msg, args...),
+	}
+}
+
 func DeleteMachine(msg string, args ...interface{}) *MachineError {
 	return &MachineError{
 		Reason:  commonerrors.DeleteMachineError,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

In case a machine provider configuration is invalidated,
it's handful to record InvalidConfigurationMachineError event error.
So a human (or third party controller) can notice the fact without reading
machine controller logs and react accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
