### PR TITLE
Fix GetMachinesForCluster returning duplicate results

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -388,17 +388,18 @@ func (c *client) GetMachinesForCluster(cluster *clusterv1.Cluster) ([]*clusterv1
 		return nil, errors.Wrapf(err, "error listing Machines for Cluster %s/%s", cluster.Namespace, cluster.Name)
 	}
 	var machines []*clusterv1.Machine
-	for _, m := range machineslist.Items {
+
+	for i := 0; i < len(machineslist.Items); i++ {
+		m := &machineslist.Items[i]
+
 		for _, or := range m.GetOwnerReferences() {
 			if or.Kind == cluster.Kind && or.Name == cluster.Name {
-				machines = append(machines, &m)
-				continue
+				machines = append(machines, m)
+				break
 			}
 		}
 	}
-	for i := 0; i < len(machineslist.Items); i++ {
-		machines = append(machines, &machineslist.Items[i])
-	}
+
 	return machines, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR fixes an issue where `clusterctl` pivot phase would be presented with two equal machines to be created. The duplicate fix is part of `clusterclient` where `GetMachinesForCluster` had a duplicate `for` loop.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #815 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
