### PR TITLE
Fix delete post pivoting changes

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -159,6 +159,11 @@ func (d *ClusterDeployer) Delete(targetClient clusterclient.Client) error {
 		return errors.Wrap(err, "unable to pivot Cluster API stack to bootstrap cluster")
 	}
 
+	// Verify that all pivoted resources have a status
+	if err := bootstrapClient.WaitForResourceStatuses(); err != nil {
+		return errors.Wrap(err, "error while waiting for Cluster API resources to contain statuses")
+	}
+
 	klog.Info("Deleting objects from bootstrap cluster")
 	if err := deleteClusterAPIObjectsInAllNamespaces(bootstrapClient); err != nil {
 		return errors.Wrap(err, "unable to finish deleting objects in bootstrap cluster, resources may have been leaked")

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -486,6 +486,10 @@ func (c *testClusterClient) GetMachinesForMachineSet(ms *clusterv1.MachineSet) (
 	return results, nil
 }
 
+func (c *testClusterClient) WaitForResourceStatuses() error {
+	return nil
+}
+
 // TODO: implement GetMachineClasses for testClusterClient and add tests
 func (c *testClusterClient) GetMachineClasses(namespace string) ([]*clusterv1.MachineClass, error) {
 	return c.machineClasses[namespace], c.GetMachineClassesErr


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses a couple of issues that have cropped up with the `clusterctl delete workflow` after the recent pivot changes.
- Properly handle delete of all cluster-api objects across all namespaces when namespace is not provided on delete
- Add a sleep to delete to allow for the cluster-api objects to be reconciled before deleting objects post-pivot.

**Release note**:
```release-note
NONE
```
