### PR TITLE
add error log for machine update

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -211,7 +211,7 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 				return reconcile.Result{Requeue: true, RequeueAfter: requeueErr.RequeueAfter}, nil
 			}
 
-			klog.Errorf("Error updating machine %q: %v", name, err)
+			klog.Errorf("Error updating machine "%s/%s": %v", m.Namespace, name, err)
 			return reconcile.Result{}, err
 		}
 

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -211,7 +211,7 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 				return reconcile.Result{Requeue: true, RequeueAfter: requeueErr.RequeueAfter}, nil
 			}
 
-			klog.Errorf("Error updating machine "%s/%s": %v", m.Namespace, name, err)
+			klog.Errorf(`Error updating machine "%s/%s": %v`, m.Namespace, name, err)
 			return reconcile.Result{}, err
 		}
 

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -211,6 +211,7 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 				return reconcile.Result{Requeue: true, RequeueAfter: requeueErr.RequeueAfter}, nil
 			}
 
+			klog.Errorf("Error updating machine %q: %v", name, err)
 			return reconcile.Result{}, err
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

This PR adds logging when an error is returned by machine actuator Update().

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
additional logging on machine update errors
```
