### PR TITLE
Avoid get machine when doing MachineToMachineSets

### DIFF
--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -494,12 +494,9 @@ func (r *ReconcileMachineSet) waitForMachineDeletion(machineList []*clusterv1.Ma
 func (r *ReconcileMachineSet) MachineToMachineSets(o handler.MapObject) []reconcile.Request {
 	result := []reconcile.Request{}
 
-	m := &clusterv1.Machine{}
-	key := client.ObjectKey{Namespace: o.Meta.GetNamespace(), Name: o.Meta.GetName()}
-	if err := r.Client.Get(context.Background(), key, m); err != nil {
-		if !apierrors.IsNotFound(err) {
-			klog.Errorf("Unable to retrieve Machine %q for possible MachineSet adoption: %v", key, err)
-		}
+	m, ok := o.Object.(*clusterv1.Machine)
+	if !ok {
+		klog.Errorf("expected a Machine but got a %T", o.Object)
 		return nil
 	}
 


### PR DESCRIPTION
when I am using openstack provider to delete a machie, everything is fine
but got this error log

E0315 07:01:55.431509       1 controller.go:109] Unable to retrieve Machine default/openstack-node-wtwqf from store: Machine.cluster.k8s.io "openstack-node-wtwqf" not found

so we need downgrade as the machine is anyway gone.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
