### PR TITLE
README.md: Add bare metal provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ are also sponsored by SIG-cluster-lifecycle:
   * AWS/Openshift, https://github.com/openshift/cluster-operator
   * Azure, https://github.com/kubernetes-sigs/cluster-api-provider-azure
   * Baidu Cloud, https://github.com/baidu/cluster-api-provider-baiducloud
+  * Bare Metal, https://github.com/metalkube/cluster-api-provider-baremetal
   * DigitalOcean, https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean
   * GCE, https://github.com/kubernetes-sigs/cluster-api-provider-gcp
   * OpenStack, https://github.com/kubernetes-sigs/cluster-api-provider-openstack


### PR DESCRIPTION
List the bare metal provider being developed under
github.com/metalkube/ in the README.md.  This provider aims to
implement automated provisioning of bare metal hosts via the
cluster-api.

More information can be found in github.com/metalkube/metalkube-docs/.