### PR TITLE
Add KinD --wait flag to ignoredOptions

### DIFF
--- a/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	// ignoredOptions lists the options not supported by delete and kubeconfig-path.
-	ignoredOptions = []string{"config", "image", "retain"}
+	ignoredOptions = []string{"config", "image", "retain", "wait"}
 )
 
 type Kind struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Fixes the error below:
```
I0321 11:38:55.784683    2752 kind.go:60] Ran: kind [get kubeconfig-path --wait=30s --name=clusterapi] Output: Error: unknown flag: --wait
F0321 11:38:55.784786    2752 create_cluster.go:61] could not create bootstrap cluster: unable to get bootstrap cluster kubeconfig: error running command 'kind get kubeconfig-path --wait=30s --name=clusterapi': exit status 1
```

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added --wait to the list of options not supported by delete and kubeconfig-path.
```
