### PR TITLE
Honour the KinD --name flag

### DIFF
--- a/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
@@ -46,9 +46,21 @@ func New() *Kind {
 }
 
 func WithOptions(options []string) *Kind {
+	// Set name if it is not provided.
+	if func() bool {
+		for _, opt := range options {
+			if strings.HasPrefix(opt, "name=") {
+				return false
+			}
+		}
+		return true
+	}() {
+		options = append(options, fmt.Sprintf("name=%s", kindClusterName))
+	}
+
 	return &Kind{
 		execFunc: execFunc,
-		options:  append(options, fmt.Sprintf("name=%s", kindClusterName)),
+		options:  options,
 	}
 }
 

--- a/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	// ignoredOptions lists the options not supported by delete and kubeconfig-path.
-	ignoredOptions = []string{"config", "image", "retain"}
+	ignoredOptions = []string{"config", "image", "retain", "wait"}
 )
 
 type Kind struct {

--- a/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	// ignoredOptions lists the options not supported by delete and kubeconfig-path.
-	ignoredOptions = []string{"config", "image", "retain", "wait"}
+	ignoredOptions = []string{"config", "image", "retain" }
 )
 
 type Kind struct {

--- a/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/kind/kind.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	// ignoredOptions lists the options not supported by delete and kubeconfig-path.
-	ignoredOptions = []string{"config", "image", "retain" }
+	ignoredOptions = []string{"config", "image", "retain"}
 )
 
 type Kind struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

User is unable to provide a KinD `--name=` because it is always overwritten by `--name=clusterapi`:
```
I0321 12:35:20.957026    6399 kind.go:66] Running: kind [create cluster --name=foo --config=/tmp/cluster-api.rFu9/kind-config.json --image=kindest/node:v1.13.3 --wait=1m --name=clusterapi]
```

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Honour the KinD --name= flag if it is provided by the user.
```
