### PR TITLE
refresh cluster object while waiting for kubeconfig

### DIFF
--- a/cmd/clusterctl/phases/getkubeconfig.go
+++ b/cmd/clusterctl/phases/getkubeconfig.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/provider"
-	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/util"
 )
 
@@ -36,13 +35,8 @@ const (
 
 // GetKubeconfig returns a kubeconfig for the target cluster
 func GetKubeconfig(bootstrapClient clusterclient.Client, provider provider.Deployer, kubeconfigOutput string, clusterName, namespace string) (string, error) {
-	cluster, controlPlane, _, err := clusterclient.GetClusterAPIObject(bootstrapClient, clusterName, namespace)
-	if err != nil {
-		return "", err
-	}
-
 	klog.V(1).Info("Getting target cluster kubeconfig.")
-	targetKubeconfig, err := waitForKubeconfigReady(provider, cluster, controlPlane)
+	targetKubeconfig, err := waitForKubeconfigReady(bootstrapClient, provider, clusterName, namespace)
 	if err != nil {
 		return "", fmt.Errorf("unable to get target cluster kubeconfig: %v", err)
 	}
@@ -54,11 +48,16 @@ func GetKubeconfig(bootstrapClient clusterclient.Client, provider provider.Deplo
 	return targetKubeconfig, nil
 }
 
-func waitForKubeconfigReady(provider provider.Deployer, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (string, error) {
+func waitForKubeconfigReady(bootstrapClient clusterclient.Client, provider provider.Deployer, clusterName, namespace string) (string, error) {
 	kubeconfig := ""
 	err := util.PollImmediate(retryKubeConfigReady, timeoutKubeconfigReady, func() (bool, error) {
-		klog.V(2).Infof("Waiting for kubeconfig on %v to become ready...", machine.Name)
-		k, err := provider.GetKubeConfig(cluster, machine)
+		cluster, controlPlane, _, err := clusterclient.GetClusterAPIObject(bootstrapClient, clusterName, namespace)
+		if err != nil {
+			return false, err
+		}
+
+		klog.V(2).Infof("Waiting for kubeconfig on %v to become ready...", controlPlane.Name)
+		k, err := provider.GetKubeConfig(cluster, controlPlane)
 		if err != nil {
 			klog.V(4).Infof("error getting kubeconfig: %v", err)
 			return false, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Currently, the `get-kubeconfig` phase fetches the cluster object and then repeatedly calls provider.GetKubeConfig() until a kubeconfig is returned, but a kubeconfig never returns if the provider builds the kubeconfig from values in the cluster provider spec that may not exist yet. 

For example, the AWS provider builds the kubeconfig from the cluster object's cert data, but that cert data may not initially exist:
```
clusterctl alpha phases get-kubeconfig --cluster-name my-cluster --kubeconfig-out kubeconfig2 --kubeconfig  kubeconfig1 -v 4 --provider aws -n my-cluster
I0321 08:16:24.069048   91989 getkubeconfig.go:38] Getting target cluster kubeconfig.
I0321 08:16:24.095381   91989 getkubeconfig.go:59] Waiting for kubeconfig on my-cluster-controlplane-0 to become ready...
I0321 08:16:24.095570   91989 getkubeconfig.go:62] error getting kubeconfig: certificate not found in config
I0321 08:16:34.110520   91989 getkubeconfig.go:59] Waiting for kubeconfig on my-cluster-controlplane-0 to become ready...
I0321 08:16:34.110625   91989 getkubeconfig.go:62] error getting kubeconfig: certificate not found in config
I0321 08:16:44.104851   91989 getkubeconfig.go:59] Waiting for kubeconfig on my-cluster-controlplane-0 to become ready...
I0321 08:16:44.105000   91989 getkubeconfig.go:62] error getting kubeconfig: certificate not found in config
```

As part of the bootstrapping process, the AWS provider will update the cluster object with cert data. If the above command is run before that happens, it will loop until timeout. The loop must include fetching the API object in order to be aware of these updates.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes bug where polling for kubeconfig may use stale cluster object
```
