### PR TITLE
Remove `omitempty` tag from Machine.Spec.Taints

### DIFF
--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -61,7 +61,7 @@ type MachineSpec struct {
 	// Node. This list will overwrite any modifications made to the Node on
 	// an ongoing basis.
 	// +optional
-	Taints []corev1.Taint `json:"taints,omitempty"`
+	Taints []corev1.Taint `json:"taints"`
 
 	// ProviderSpec details Provider-specific configuration to use during node creation.
 	// +optional


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the user to specify an empty set of taints (as opposed to specifying nothing at all).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #707

**Special notes for your reviewer**:
This is a breaking API change, please hold until after v1alpha1.

```release-note
Remove `omitempty` tag from `Machine.Spec.Taints` field to allow users to specify an empty set of taints.
```
