### PR TITLE
Add status (phase and provider id) to get output

### DIFF
--- a/config/crds/cluster_v1alpha1_machine.yaml
+++ b/config/crds/cluster_v1alpha1_machine.yaml
@@ -6,6 +6,15 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: machines.cluster.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.providerID
+    description: Provider ID
+    name: ProviderID
+    type: string
+  - JSONPath: .status.phase
+    description: Machine status such as Terminating/Pending/Running/Failed etc
+    name: Phase
+    type: string
   group: cluster.k8s.io
   names:
     kind: Machine

--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -38,6 +38,8 @@ const (
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Machine status such as Terminating/Pending/Running/Failed etc"
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Add output to get command about the status of machine and provider ID as well

part of bug #820


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
