### PR TITLE
update docs to point to relevant google groups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ All changes must be code reviewed. Coding conventions and standards are explaine
 
 Cluster API maintainers may add "LGTM" (Looks Good To Me) or an equivalent comment to indicate that a PR is acceptable. Any change requires at least one LGTM.  No pull requests can be merged until at least one Cluster API maintainer signs off with an LGTM.
 
+### Google Doc Viewing Permissions
+
+To gain viewing permissions to google docs in this project, please join either the [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) or [kubernetes-sig-cluster-lifecycle](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle) google group.
+
 ## Cloud Provider Developer Guide
 
 ### Overview

--- a/cmd/clusterctl/README.md
+++ b/cmd/clusterctl/README.md
@@ -2,7 +2,7 @@
 
 `clusterctl` is the SIG-cluster-lifecycle sponsored tool that implements the Cluster API.
 
-Read the [experience doc here](https://docs.google.com/document/d/1-sYb3EdkRga49nULH1kSwuQFf1o6GvAw_POrsNo5d8c/edit#).
+Read the [experience doc here](https://docs.google.com/document/d/1-sYb3EdkRga49nULH1kSwuQFf1o6GvAw_POrsNo5d8c/edit#). To gain viewing permissions, please join either the [kubernetes-dev](https://groups.google.com/forum/#!forum/kubernetes-dev) or [kubernetes-sig-cluster-lifecycle](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle) google group.
 
 ## Getting Started
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Documents which Google Groups you need to join in order to see the google docs.

**Which issue(s) this PR fixes** 
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/823


**Release note**:
```release-note
NONE
```
