### PR TITLE
Fix broken links to kubebuilder book

### DIFF
--- a/docs/book/common_code/architecture.md
+++ b/docs/book/common_code/architecture.md
@@ -4,8 +4,8 @@
 It may be useful to read at least the following chapters of the Kubebuilder 
 book in order to better understand this section.
 
-- [What is a Resource](https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/basics/what_is_a_resource.md)
-- [What is a Controller](https://github.com/kubernetes-sigs/kubebuilder/blob/master/docs/book/basics/what_is_a_controller.md)
+- [What is a Resource](https://book.kubebuilder.io/basics/what_is_a_resource.html)
+- [What is a Controller](https://book.kubebuilder.io/basics/what_is_a_controller.html)
 {% endpanel %}
 
 {% panel style="warning", title="Architecture Diagram" %}


### PR DESCRIPTION
**What this PR does / why we need it**: Fix broken links in the Cluster API book.

```release-note
NONE
```
