### PR TITLE
Updating release docs for branching approach now that we are 0.x

### DIFF
--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -16,18 +16,25 @@
 
 ## Process
 
-1. Create a pull request that contains two changes:
+For version 0.x.y:
+
+1. We will target a branch called `release-0.x`.  If this is `0.x.0` then we'll
+   create a branch from master using `git push origin master:release-0.x`, otherwise
+   simply checkout the existing branch `git checkout release-0.x`
+2. Make two changes:
    1. Change [the cluster api controller manager image
    tag][managerimg] from `:latest` to whatever version is being released
-   2. Change the `CONTROLLER_IMAGE` variable in the [Makefile][makefile] to the
+   2. Change the `CONTROLLER_IMG` variable in the [Makefile][makefile] to the
       version being released
-2. Get the pull request merged
-3. From the commit in step 1 (that is now in the master branch), build and push
-   the container images and fat manifest with `make all-push`
-4. Create a tag from this same commit and push the tag to the github repository
-5. Revert the commit made in step 1
-6. Open a pull request with the revert change
-7. Get that pull request merged
+   (Note that we do not release the example-provider image, so we don't tag that)
+3. Commit it using `git commit -m "Release 0.x.y"`
+4. Submit a PR to the `release-0.x` branch, e.g. `git push $USER; hub pull-request -b release-0.x`
+5. Get the pull request merged
+6. Switch to the release branch and update to pick up the commit.  (e.g. `git
+   checkout release 0.x && git pull`).  From there build and push the container
+   images and fat manifest with `make all-push` (on the 0.1 release branch, we
+   do `make docker-push`)
+7. Create a tag from this same commit `git tag 0.x.y` and push the tag to the github repository `git push origin 0.x.y`
 8. Create a release in github based on the tag created above
 9. Manually create the release notes by going through the merged PRs since the
    last release


### PR DESCRIPTION
I think the previous approach was for pre-versioned branches, but now
we probably want to start maintaining release branches - even if in
practice we would cut 0.2.0 instead of 0.1.1



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```