### PR TITLE
use gnu sed on all platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ clean: ## Remove all generated files
 docker-build: generate fmt vet manifests ## Build the docker image for controller-manager
 	docker build . -t ${CONTROLLER_IMG}
 	@echo "updating kustomize image patch file for manager resource"
-	sed -i.tmp -e 's@image: .*@image: '"${CONTROLLER_IMG}"'@' ./config/default/manager_image_patch.yaml
+	hack/sed.sh -i.tmp -e 's@image: .*@image: '"${CONTROLLER_IMG}"'@' ./config/default/manager_image_patch.yaml
 
 .PHONY: docker-push
 docker-push: docker-build ## Push the docker image
@@ -121,7 +121,7 @@ docker-push: docker-build ## Push the docker image
 docker-build-ci: generate fmt vet manifests ## Build the docker image for example provider
 	docker build . -f ./pkg/provider/example/container/Dockerfile -t ${EXAMPLE_PROVIDER_IMG}
 	@echo "updating kustomize image patch file for ci"
-	sed -i.tmp -e 's@image: .*@image: '"${EXAMPLE_PROVIDER_IMG}"'@' ./config/ci/manager_image_patch.yaml
+	hack/sed.sh -i.tmp -e 's@image: .*@image: '"${EXAMPLE_PROVIDER_IMG}"'@' ./config/ci/manager_image_patch.yaml
 
 .PHONY: docker-push-ci
 docker-push-ci: docker-build-ci  ## Build the docker image for ci

--- a/hack/sed.sh
+++ b/hack/sed.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this script is a drop in wrapper around gnu-sed that will attempt to only
+# use gnu sed (as opposed to E.G. the default sed on macOS)
+
+# darwin is great
+SED="sed"
+if command -v gsed >/dev/null 2>&1; then
+  SED="gsed"
+fi
+if ! (${SED} --version 2>&1 | grep -q GNU); then
+  echo "!!! GNU sed is required.  If on OS X, use 'brew install gnu-sed'." >&2
+  exit 1
+fi
+
+"${SED}" "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: Adds a small wrapper script as a drop in `sed` replacement that will use gnu-sed on mac / linux. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #661

**Special notes for your reviewer**: There seem to be some mitigations in place already, however the current makefile will still append a superfluous newline to `./config/default/manager_image_patch.yaml` even when there are no changes.

Kubernetes/Kubernetes avoids this kind of inconsistency by simply requiring gnu-sed. The snippet to select & require gnu-sed used in this PR is present throughout many Kubernetes projects.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
