### PR TITLE
nit: fix log to replace Creating with Preparing

### DIFF
--- a/cmd/clusterctl/phases/createbootstrapcluster.go
+++ b/cmd/clusterctl/phases/createbootstrapcluster.go
@@ -24,7 +24,7 @@ import (
 )
 
 func CreateBootstrapCluster(provisioner bootstrap.ClusterProvisioner, cleanupBootstrapCluster bool, clientFactory clusterclient.Factory) (clusterclient.Client, func(), error) {
-	klog.Info("Creating bootstrap cluster")
+	klog.Info("Preparing bootstrap cluster")
 
 	cleanupFn := func() {}
 	if err := provisioner.Create(); err != nil {


### PR DESCRIPTION
saw this log with following flag
--bootstrap-cluster-kubeconfig /root/.kube/config

I0403 17:32:28.339021   31615 createbootstrapcluster.go:27] Creating bootstrap cluster

actually we are reusing ,not creating


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
