### PR TITLE
minikube: use --profile instead of --p

### DIFF
--- a/cmd/clusterctl/clusterdeployer/bootstrap/minikube/minikube.go
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/minikube/minikube.go
@@ -61,7 +61,7 @@ func WithOptionsAndKubeConfigPath(options []string, kubeconfigpath string) *Mini
 		}
 		return true
 	}() {
-		options = append(options, fmt.Sprintf("p=%s", minikubeClusterName))
+		options = append(options, fmt.Sprintf("profile=%s", minikubeClusterName))
 	}
 
 	return &Minikube{


### PR DESCRIPTION
**What this PR does / why we need it**:

It was reported that "minikube start" fails:
```
  minikube start --bootstrapper=kubeadm --p=clusterapi
  Error: unknown flag: --p
```

From the "minikube start --help":
`  -p, --profile string`

Use --profile in minikube.go as --p does not work.
The alternative is -p.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #874

**Special notes for your reviewer**:
NONE

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
minikube: fix an error related to the usage of the unknown flag --p; use --profile instead.
```

/kind bug
/priority important-longterm
