### PR TITLE
Ability to deploy multiple control plane machines

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -1019,17 +1019,16 @@ func GetClusterAPIObject(client Client, clusterName, namespace string) (*cluster
 		return nil, nil, nil, errors.Wrapf(err, "unable to fetch cluster %s/%s", namespace, clusterName)
 	}
 
-	controlPlane, nodes, err := ExtractControlPlaneMachine(machines)
+	controlPlane, nodes, err := ExtractControlPlaneMachines(machines)
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "unable to fetch control plane machine in cluster %s/%s", namespace, clusterName)
 	}
-	return cluster, controlPlane, nodes, nil
+	return cluster, controlPlane[0], nodes, nil
 }
 
-// ExtractControlPlaneMachine separates the machines running the control plane (singular) from the incoming machines.
+// ExtractControlPlaneMachines separates the machines running the control plane from the incoming machines.
 // This is currently done by looking at which machine specifies the control plane version.
-// TODO: Cleanup.
-func ExtractControlPlaneMachine(machines []*clusterv1.Machine) (*clusterv1.Machine, []*clusterv1.Machine, error) {
+func ExtractControlPlaneMachines(machines []*clusterv1.Machine) ([]*clusterv1.Machine, []*clusterv1.Machine, error) {
 	nodes := []*clusterv1.Machine{}
 	controlPlaneMachines := []*clusterv1.Machine{}
 	for _, machine := range machines {
@@ -1039,8 +1038,8 @@ func ExtractControlPlaneMachine(machines []*clusterv1.Machine) (*clusterv1.Machi
 			nodes = append(nodes, machine)
 		}
 	}
-	if len(controlPlaneMachines) != 1 {
-		return nil, nil, errors.Errorf("expected one control plane machine, got: %v", len(controlPlaneMachines))
+	if len(controlPlaneMachines) < 1 {
+		return nil, nil, errors.Errorf("expected one or more control plane machines, got: %v", len(controlPlaneMachines))
 	}
-	return controlPlaneMachines[0], nodes, nil
+	return controlPlaneMachines, nodes, nil
 }

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -57,7 +57,7 @@ func New(
 
 // Create the cluster from the provided cluster definition and machine list.
 func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*clusterv1.Machine, provider provider.Deployer, kubeconfigOutput string, providerComponentsStoreFactory provider.ComponentsStoreFactory) error {
-	controlPlaneMachine, nodes, err := clusterclient.ExtractControlPlaneMachine(machines)
+	controlPlaneMachines, nodes, err := clusterclient.ExtractControlPlaneMachines(machines)
 	if err != nil {
 		return errors.Wrap(err, "unable to separate control plane machines from node machines")
 	}
@@ -89,12 +89,12 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 		cluster.Namespace = bootstrapClient.GetContextNamespace()
 	}
 
-	klog.Infof("Creating control plane %v in namespace %q", controlPlaneMachine.Name, cluster.Namespace)
-	if err := phases.ApplyMachines(bootstrapClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachine}); err != nil {
+	klog.Infof("Creating control plane %v in namespace %q", controlPlaneMachines[0].Name, cluster.Namespace)
+	if err := phases.ApplyMachines(bootstrapClient, cluster.Namespace, []*clusterv1.Machine{controlPlaneMachines[0]}); err != nil {
 		return errors.Wrap(err, "unable to create control plane machine")
 	}
 
-	klog.Infof("Updating bootstrap cluster object for cluster %v in namespace %q with control plane endpoint running on %s", cluster.Name, cluster.Namespace, controlPlaneMachine.Name)
+	klog.Infof("Updating bootstrap cluster object for cluster %v in namespace %q with control plane endpoint running on %s", cluster.Name, cluster.Namespace, controlPlaneMachines[0].Name)
 	if err := d.updateClusterEndpoint(bootstrapClient, provider, cluster.Name, cluster.Namespace); err != nil {
 		return errors.Wrap(err, "unable to update bootstrap cluster endpoint")
 	}
@@ -130,9 +130,16 @@ func (d *ClusterDeployer) Create(cluster *clusterv1.Cluster, machines []*cluster
 
 	// For some reason, endpoint doesn't get updated in bootstrap cluster sometimes. So we
 	// update the target cluster endpoint as well to be sure.
-	klog.Infof("Updating target cluster object with control plane endpoint running on %s", controlPlaneMachine.Name)
+	klog.Infof("Updating target cluster object with control plane endpoint running on %s", controlPlaneMachines[0].Name)
 	if err := d.updateClusterEndpoint(targetClient, provider, cluster.Name, cluster.Namespace); err != nil {
 		return errors.Wrap(err, "unable to update target cluster endpoint")
+	}
+
+	if len(controlPlaneMachines) > 1 {
+		klog.Info("Creating additional controlplane machines in target cluster.")
+		if err := phases.ApplyMachines(targetClient, cluster.Namespace, controlPlaneMachines[1:]); err != nil {
+			return errors.Wrap(err, "unable to create additional controlplane machines")
+		}
 	}
 
 	klog.Info("Creating node machines in target cluster.")

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -996,42 +996,49 @@ func TestExtractControlPlaneMachine(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		inputMachines        []*clusterv1.Machine
-		expectedControlPlane *clusterv1.Machine
-		expectedNodes        []*clusterv1.Machine
+		expectedCPMachines   []*clusterv1.Machine
+		expectedNodeMachines []*clusterv1.Machine
 		expectedError        error
 	}{
 		{
 			name:                 "success_1_control_plane_1_node",
 			inputMachines:        generateMachines(nil, metav1.NamespaceDefault),
-			expectedControlPlane: generateTestControlPlaneMachine(nil, metav1.NamespaceDefault, singleControlPlaneName),
-			expectedNodes:        generateTestNodeMachines(nil, metav1.NamespaceDefault, []string{singleNodeName}),
+			expectedCPMachines:   generateTestControlPlaneMachines(nil, metav1.NamespaceDefault, []string{singleControlPlaneName}),
+			expectedNodeMachines: generateTestNodeMachines(nil, metav1.NamespaceDefault, []string{singleNodeName}),
 			expectedError:        nil,
 		},
 		{
 			name:                 "success_1_control_plane_multiple_nodes",
-			inputMachines:        generateValidExtractControlPlaneMachineInput(nil, metav1.NamespaceDefault, singleControlPlaneName, multipleNodeNames),
-			expectedControlPlane: generateTestControlPlaneMachine(nil, metav1.NamespaceDefault, singleControlPlaneName),
-			expectedNodes:        generateTestNodeMachines(nil, metav1.NamespaceDefault, multipleNodeNames),
+			inputMachines:        generateValidExtractControlPlaneMachineInput(nil, metav1.NamespaceDefault, []string{singleControlPlaneName}, multipleNodeNames),
+			expectedCPMachines:   generateTestControlPlaneMachines(nil, metav1.NamespaceDefault, []string{singleControlPlaneName}),
+			expectedNodeMachines: generateTestNodeMachines(nil, metav1.NamespaceDefault, multipleNodeNames),
 			expectedError:        nil,
 		},
 		{
-			name:                 "fail_more_than_1_control_plane_not_allowed",
-			inputMachines:        generateInvalidExtractControlPlaneMachine(nil, metav1.NamespaceDefault, multipleControlPlaneNames, multipleNodeNames),
-			expectedControlPlane: nil,
-			expectedNodes:        nil,
-			expectedError:        errors.New("expected one control plane machine, got: 2"),
+			name:                 "success_2_control_planes_1_node",
+			inputMachines:        generateValidExtractControlPlaneMachineInput(nil, metav1.NamespaceDefault, multipleControlPlaneNames, []string{singleNodeName}),
+			expectedCPMachines:   generateTestControlPlaneMachines(nil, metav1.NamespaceDefault, multipleControlPlaneNames),
+			expectedNodeMachines: generateTestNodeMachines(nil, metav1.NamespaceDefault, []string{singleNodeName}),
+			expectedError:        nil,
+		},
+		{
+			name:                 "success_2_control_planes_multiple_nodes",
+			inputMachines:        generateValidExtractControlPlaneMachineInput(nil, metav1.NamespaceDefault, multipleControlPlaneNames, multipleNodeNames),
+			expectedCPMachines:   generateTestControlPlaneMachines(nil, metav1.NamespaceDefault, multipleControlPlaneNames),
+			expectedNodeMachines: generateTestNodeMachines(nil, metav1.NamespaceDefault, multipleNodeNames),
+			expectedError:        nil,
 		},
 		{
 			name:                 "fail_0_control_plane_not_allowed",
 			inputMachines:        generateTestNodeMachines(nil, metav1.NamespaceDefault, multipleNodeNames),
-			expectedControlPlane: nil,
-			expectedNodes:        nil,
-			expectedError:        errors.New("expected one control plane machine, got: 0"),
+			expectedCPMachines:   nil,
+			expectedNodeMachines: nil,
+			expectedError:        errors.New("expected one or more control plane machines, got: 0"),
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualControlPlanes, actualNodes, actualError := clusterclient.ExtractControlPlaneMachines(tc.inputMachines)
+			actualCPMachines, actualNodes, actualError := clusterclient.ExtractControlPlaneMachines(tc.inputMachines)
 
 			if tc.expectedError == nil && actualError != nil {
 				t.Fatalf("%s: extractControlPlaneMachine(%q): gotError %q; wantError [nil]", tc.name, len(tc.inputMachines), actualError)
@@ -1041,13 +1048,13 @@ func TestExtractControlPlaneMachine(t *testing.T) {
 				t.Fatalf("%s: extractControlPlaneMachine(%q): gotError %q; wantError %q", tc.name, len(tc.inputMachines), actualError, tc.expectedError)
 			}
 
-			if (tc.expectedControlPlane == nil && actualControlPlanes[0] != nil) ||
-				(tc.expectedControlPlane != nil && actualControlPlanes[0] == nil) {
-				t.Fatalf("%s: extractControlPlaneMachines(%q): gotControlPlane = %v; wantControlPlane = %v", tc.name, len(tc.inputMachines), actualControlPlanes[0] != nil, tc.expectedControlPlane != nil)
+			if (tc.expectedCPMachines == nil && actualCPMachines != nil) ||
+				(tc.expectedCPMachines != nil && actualCPMachines == nil) {
+				t.Fatalf("%s: extractControlPlaneMachine(%q): gotControlPlane = %v; wantControlPlane = %v", tc.name, len(tc.inputMachines), actualCPMachines[0] != nil, tc.expectedCPMachines != nil)
 			}
 
-			if len(tc.expectedNodes) != len(actualNodes) {
-				t.Fatalf("%s: extractControlPlaneMachines(%q): gotNodes = %q; wantNodes = %q", tc.name, len(tc.inputMachines), len(actualNodes), len(tc.expectedNodes))
+			if len(tc.expectedNodeMachines) != len(actualNodes) {
+				t.Fatalf("%s: extractControlPlaneMachine(%q): gotNodes = %q; wantNodes = %q", tc.name, len(tc.inputMachines), len(actualNodes), len(tc.expectedNodeMachines))
 			}
 		})
 	}
@@ -1434,14 +1441,18 @@ func TestClusterDelete(t *testing.T) {
 	}
 }
 
-func generateTestControlPlaneMachine(cluster *clusterv1.Cluster, ns, name string) *clusterv1.Machine {
-	machine := generateTestNodeMachine(cluster, ns, name)
-	machine.Spec = clusterv1.MachineSpec{
-		Versions: clusterv1.MachineVersionInfo{
-			ControlPlane: "1.10.1",
-		},
+func generateTestControlPlaneMachines(cluster *clusterv1.Cluster, ns string, names []string) []*clusterv1.Machine {
+	machines := make([]*clusterv1.Machine, 0, len(names))
+	for _, name := range names {
+		machine := generateTestNodeMachine(cluster, ns, name)
+		machine.Spec = clusterv1.MachineSpec{
+			Versions: clusterv1.MachineVersionInfo{
+				ControlPlane: "1.10.1",
+			},
+		}
+		machines = append(machines, machine)
 	}
-	return machine
+	return machines
 }
 
 func generateTestNodeMachine(cluster *clusterv1.Cluster, ns, name string) *clusterv1.Machine {
@@ -1473,18 +1484,9 @@ func generateTestNodeMachines(cluster *clusterv1.Cluster, ns string, nodeNames [
 	return nodes
 }
 
-func generateInvalidExtractControlPlaneMachine(cluster *clusterv1.Cluster, ns string, controlPlaneNames, nodeNames []string) []*clusterv1.Machine {
-	var machines []*clusterv1.Machine // nolint
-	for _, name := range controlPlaneNames {
-		machines = append(machines, generateTestControlPlaneMachine(cluster, ns, name))
-	}
-	machines = append(machines, generateTestNodeMachines(cluster, ns, nodeNames)...)
-	return machines
-}
-
-func generateValidExtractControlPlaneMachineInput(cluster *clusterv1.Cluster, ns, controlPlaneName string, nodeNames []string) []*clusterv1.Machine {
+func generateValidExtractControlPlaneMachineInput(cluster *clusterv1.Cluster, ns string, controlPlaneName []string, nodeNames []string) []*clusterv1.Machine {
 	var machines []*clusterv1.Machine
-	machines = append(machines, generateTestControlPlaneMachine(cluster, ns, controlPlaneName))
+	machines = append(machines, generateTestControlPlaneMachines(cluster, ns, controlPlaneName)...)
 	machines = append(machines, generateTestNodeMachines(cluster, ns, nodeNames)...)
 	return machines
 }
@@ -1497,7 +1499,7 @@ func generateMachines(cluster *clusterv1.Cluster, ns string) []*clusterv1.Machin
 		controlPlaneName = cluster.Name + controlPlaneName
 		workerName = cluster.Name + workerName
 	}
-	machines = append(machines, generateTestControlPlaneMachine(cluster, ns, controlPlaneName))
+	machines = append(machines, generateTestControlPlaneMachines(cluster, ns, []string{controlPlaneName})...)
 	machines = append(machines, generateTestNodeMachine(cluster, ns, workerName))
 	return machines
 }

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -661,17 +661,6 @@ func TestClusterCreate(t *testing.T) {
 			expectExternalCreated:               true,
 		},
 		{
-			name:                                "fail provision multiple clusters in a namespace",
-			targetClient:                        &testClusterClient{ApplyFunc: func(yaml string) error { return nil }},
-			bootstrapClient:                     &testClusterClient{},
-			namespaceToExpectedInternalMachines: make(map[string]int),
-			namespaceToInputCluster:             map[string][]*clusterv1.Cluster{"foo": getClustersForNamespace("foo", 3)},
-			expectErr:                           true,
-			cleanupExternal:                     true,
-			expectExternalExists:                false,
-			expectExternalCreated:               true,
-		},
-		{
 			name:                                "fail provision bootstrap cluster",
 			targetClient:                        &testClusterClient{ApplyFunc: func(yaml string) error { return nil }},
 			bootstrapClient:                     &testClusterClient{},

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -1031,7 +1031,7 @@ func TestExtractControlPlaneMachine(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualControlPlane, actualNodes, actualError := clusterclient.ExtractControlPlaneMachine(tc.inputMachines)
+			actualControlPlanes, actualNodes, actualError := clusterclient.ExtractControlPlaneMachines(tc.inputMachines)
 
 			if tc.expectedError == nil && actualError != nil {
 				t.Fatalf("%s: extractControlPlaneMachine(%q): gotError %q; wantError [nil]", tc.name, len(tc.inputMachines), actualError)
@@ -1041,13 +1041,13 @@ func TestExtractControlPlaneMachine(t *testing.T) {
 				t.Fatalf("%s: extractControlPlaneMachine(%q): gotError %q; wantError %q", tc.name, len(tc.inputMachines), actualError, tc.expectedError)
 			}
 
-			if (tc.expectedControlPlane == nil && actualControlPlane != nil) ||
-				(tc.expectedControlPlane != nil && actualControlPlane == nil) {
-				t.Fatalf("%s: extractControlPlaneMachine(%q): gotControlPlane = %v; wantControlPlane = %v", tc.name, len(tc.inputMachines), actualControlPlane != nil, tc.expectedControlPlane != nil)
+			if (tc.expectedControlPlane == nil && actualControlPlanes[0] != nil) ||
+				(tc.expectedControlPlane != nil && actualControlPlanes[0] == nil) {
+				t.Fatalf("%s: extractControlPlaneMachines(%q): gotControlPlane = %v; wantControlPlane = %v", tc.name, len(tc.inputMachines), actualControlPlanes[0] != nil, tc.expectedControlPlane != nil)
 			}
 
 			if len(tc.expectedNodes) != len(actualNodes) {
-				t.Fatalf("%s: extractControlPlaneMachine(%q): gotNodes = %q; wantNodes = %q", tc.name, len(tc.inputMachines), len(actualNodes), len(tc.expectedNodes))
+				t.Fatalf("%s: extractControlPlaneMachines(%q): gotNodes = %q; wantNodes = %q", tc.name, len(tc.inputMachines), len(actualNodes), len(tc.expectedNodes))
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
If multiple control-plane machines are defined in the YAML file passed to the `--machines` flag then:
- `clusterctl` will deploy the first control-plane machine as the initiator.
- `clusterctl` will deploy the remaining control-plane machines to join the first one.
 
<!-- **Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
-->

**Special notes for your reviewer**:

```
I0404 12:49:19.616845   27362 createbootstrapcluster.go:27] Creating bootstrap cluster
I0404 12:49:19.616884   27362 kind.go:69] Running: kind [create cluster --name=mv1a --wait=1m]
I0404 12:50:47.057737   27362 kind.go:72] Ran: kind [create cluster --name=mv1a --wait=1m] Output: Creating cluster "mv1a" ...
 • Ensuring node image (kindest/node:v1.13.3) 🖼  ...
 ✓ Ensuring node image (kindest/node:v1.13.3) 🖼
 • Preparing nodes 📦  ...
 ✓ Preparing nodes 📦
 • Creating kubeadm config 📜  ...
 ✓ Creating kubeadm config 📜
 • Starting control-plane 🕹️  ...
 ✓ Starting control-plane 🕹️
 • Waiting ≤ 1m0s for control-plane = Ready ⏳  ...
 ✓ Waiting ≤ 1m0s for control-plane = Ready ⏳
 • Ready after 44s 💚
Cluster creation complete. You can now use the cluster with:

export KUBECONFIG="$(kind get kubeconfig-path --name="mv1a")"
kubectl cluster-info
I0404 12:50:47.057953   27362 kind.go:69] Running: kind [get kubeconfig-path --name=mv1a]
I0404 12:50:47.127964   27362 kind.go:72] Ran: kind [get kubeconfig-path --name=mv1a] Output: /Users/mvillacorta/.kube/kind-config-mv1a
I0404 12:50:47.192207   27362 clusterdeployer.go:78] Applying Cluster API stack to bootstrap cluster
I0404 12:50:47.192225   27362 applyclusterapicomponents.go:26] Applying Cluster API Provider Components
I0404 12:50:47.192236   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:50:48.655777   27362 clusterclient.go:948] Waiting for Cluster v1alpha resources to become available...
I0404 12:50:48.681805   27362 clusterclient.go:961] Waiting for Cluster v1alpha resources to be listable...
I0404 12:50:48.714678   27362 clusterdeployer.go:83] Provisioning target cluster via bootstrap cluster
I0404 12:50:48.736907   27362 applycluster.go:36] Creating cluster object mv1a in namespace "mv1a"
I0404 12:50:48.774212   27362 clusterdeployer.go:92] Creating control plane mv1a-controlplane-0 in namespace "mv1a"
I0404 12:50:48.783901   27362 applymachines.go:36] Creating machines in namespace "mv1a"
I0404 12:50:48.807399   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-0 to become ready...
I0404 12:50:58.814356   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-0 to become ready...
I0404 12:51:08.815211   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-0 to become ready...
I0404 12:51:18.816522   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-0 to become ready...
I0404 12:51:28.816787   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-0 to become ready...
I0404 12:51:38.816529   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-0 to become ready...
I0404 12:51:48.816480   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-0 to become ready...
I0404 12:51:58.816512   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-0 to become ready...
I0404 12:52:08.816481   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-0 to become ready...
I0404 12:52:08.825120   27362 clusterdeployer.go:97] Updating bootstrap cluster object for cluster mv1a in namespace "mv1a" with control plane endpoint running on mv1a-controlplane-0
I0404 12:52:08.863356   27362 clusterdeployer.go:102] Creating target cluster
I0404 12:52:08.863377   27362 getkubeconfig.go:38] Getting target cluster kubeconfig.
I0404 12:52:08.875339   27362 getkubeconfig.go:59] Waiting for kubeconfig on mv1a-controlplane-0 to become ready...
I0404 12:52:08.945165   27362 applyaddons.go:25] Applying Addons
I0404 12:52:08.945180   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:52:19.199868   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:52:29.198408   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:52:39.198340   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:52:49.198344   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:52:59.199415   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:53:09.200720   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:53:19.198383   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:53:29.200800   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:53:39.358911   27362 clusterdeployer.go:120] Pivoting Cluster API stack to target cluster
I0404 12:53:39.358972   27362 pivot.go:67] Applying Cluster API Provider Components to Target Cluster
I0404 12:53:39.359014   27362 clusterclient.go:919] Waiting for kubectl apply...
I0404 12:53:47.267966   27362 pivot.go:72] Pivoting Cluster API objects from bootstrap to target cluster.
I0404 12:53:47.268018   27362 clusterclient.go:948] Waiting for Cluster v1alpha resources to become available...
I0404 12:53:47.271672   27362 clusterclient.go:961] Waiting for Cluster v1alpha resources to be listable...
I0404 12:53:47.278935   27362 clusterclient.go:948] Waiting for Cluster v1alpha resources to become available...
I0404 12:53:47.731131   27362 clusterclient.go:961] Waiting for Cluster v1alpha resources to be listable...
I0404 12:53:48.874236   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-0 to become ready...
I0404 12:54:02.481011   27362 clusterdeployer.go:125] Saving provider components to the target cluster
I0404 12:54:04.911587   27362 clusterdeployer.go:133] Updating target cluster object with control plane endpoint running on mv1a-controlplane-0
I0404 12:54:07.085775   27362 clusterdeployer.go:139] Creating additional controlplane machines in target cluster.
I0404 12:54:07.229433   27362 applymachines.go:36] Creating machines in namespace "mv1a"
I0404 12:54:07.351162   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:54:07.351163   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:54:17.467157   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:54:17.467531   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:54:27.470500   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:54:27.472469   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:54:37.467212   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:54:37.469134   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:54:47.467261   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:54:47.468155   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:54:57.467232   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:54:57.467479   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:55:07.471465   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:55:07.471465   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:55:17.471431   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:55:17.471430   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:55:27.472126   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:55:27.472126   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:55:37.468391   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:55:37.468384   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:55:47.467226   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:55:47.467512   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:56:17.467165   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:56:17.467603   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:56:27.468377   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-1 to become ready...
I0404 12:56:27.468393   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:56:37.467655   27362 clusterclient.go:972] Waiting for Machine mv1a-controlplane-2 to become ready...
I0404 12:56:37.591291   27362 clusterdeployer.go:145] Creating node machines in target cluster.
I0404 12:56:37.750303   27362 applymachines.go:36] Creating machines in namespace "mv1a"
I0404 12:56:37.750322   27362 clusterdeployer.go:150] Done provisioning cluster. You can now access your cluster with kubectl --kubeconfig kubeconfig
I0404 12:56:37.751630   27362 createbootstrapcluster.go:36] Cleaning up bootstrap cluster.
I0404 12:56:37.751655   27362 kind.go:69] Running: kind [delete cluster --name=mv1a]
I0404 12:56:39.539406   27362 kind.go:72] Ran: kind [delete cluster --name=mv1a] Output: Deleting cluster "mv1a" ...
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
clusterctl can deploy multiple control-plane machines to achieve HA
```
