### PR TITLE
Fix API group name written in kubebuilder's annotation comments

### DIFF
--- a/docs/book/provider_implementations/register_controllers.md
+++ b/docs/book/provider_implementations/register_controllers.md
@@ -28,7 +28,7 @@ import (
         "sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-//+kubebuilder:rbac:groups=solas.k8s.io,resources=solasclusterproviderspecs;solasclusterproviderstatuses,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=solas.cluster.k8s.io,resources=solasclusterproviderspecs;solasclusterproviderstatuses,verbs=get;list;watch;create;update;patch;delete
 func init() {
         // AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
         AddToManagerFuncs = append(AddToManagerFuncs, func(m manager.Manager) error {
@@ -68,7 +68,7 @@ import (
         "sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-//+kubebuilder:rbac:groups=solas.k8s.io,resources=solasmachineproviderspecs;solasmachineproviderstatuses,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=solas.cluster.k8s.io,resources=solasmachineproviderspecs;solasmachineproviderstatuses,verbs=get;list;watch;create;update;patch;delete
 func init() {
         // AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
         AddToManagerFuncs = append(AddToManagerFuncs, func(m manager.Manager) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: Fix API group name written in kubebuilder's annotation comments appeared in GitBook doc from solas.k8s.io to solas.cluster.k8s.io since the documents assume API groups are generated in cluster.k8s.io.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
