### PR TITLE
Build multi-arch image and push manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@
 # Build the manager binary
 FROM golang:1.11.6 as builder
 
+ARG ARCH
+
 # Copy in the go src
 WORKDIR $GOPATH/src/sigs.k8s.io/cluster-api
 COPY pkg/    pkg/
@@ -22,7 +24,7 @@ COPY cmd/    cmd/
 COPY vendor/ vendor/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-extldflags "-static"' -o manager sigs.k8s.io/cluster-api/cmd/manager
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o manager sigs.k8s.io/cluster-api/cmd/manager
 
 # Copy the controller-manager into a thin image
 FROM gcr.io/distroless/static:latest

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -23,7 +23,7 @@
       version being released
 2. Get the pull request merged
 3. From the commit in step 1 (that is now in the master branch), build and push
-   the container image with `make docker-push`
+   the container images and fat manifest with `make all-push`
 4. Create a tag from this same commit and push the tag to the github repository
 5. Revert the commit made in step 1
 6. Open a pull request with the revert change

--- a/pkg/provider/example/container/Dockerfile
+++ b/pkg/provider/example/container/Dockerfile
@@ -15,6 +15,8 @@
 # Build the manager binary
 FROM golang:1.11.5 as builder
 
+ARG ARCH
+
 # Copy in the go src
 WORKDIR $GOPATH/src/sigs.k8s.io/cluster-api
 COPY pkg/    pkg/
@@ -22,7 +24,7 @@ COPY vendor/ vendor/
 COPY cmd/    cmd/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-extldflags "-static"' -o ./cmd/example-provider/manager sigs.k8s.io/cluster-api/cmd/example-provider
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-extldflags "-static"' -o ./cmd/example-provider/manager sigs.k8s.io/cluster-api/cmd/example-provider
 
 # Copy the controller-manager into a thin image
 FROM gcr.io/distroless/static:latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR will build the cluster-api-controller image for `amd64 arm arm64 ppc64le s390x` and push the fat manifest docker image
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #852 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
