### PR TITLE
additionalPrinterColumns for Machine, added correctly.

### DIFF
--- a/config/crds/cluster_v1alpha1_machine.yaml
+++ b/config/crds/cluster_v1alpha1_machine.yaml
@@ -18,8 +18,8 @@ spec:
   - JSONPath: .status.nodeRef.name
     description: Node name associated with this machine
     name: NodeName
-    type: string
     priority: 1
+    type: string
   group: cluster.k8s.io
   names:
     kind: Machine

--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -40,6 +40,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Machine status such as Terminating/Pending/Running/Failed etc"
+// +kubebuilder:printcolumn:name="NodeName",type="string",JSONPath=".status.nodeRef.name",description="Node name associated with this machine",priority=1
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Correction of PR #895: that PR edited the CRD yaml file directly, but the correct way is to add a kubebuilder comment in the go file and let `make manifests` regenerate the yaml file.

This prevents the change from being lost the next time someone runs `make manifests`.

**Release note**:
```release-note
NONE
```

cc @detiber @vincepri since they approved the original PR.