### PR TITLE
Comment cleanup

### DIFF
--- a/pkg/apis/cluster/common/consts.go
+++ b/pkg/apis/cluster/common/consts.go
@@ -18,12 +18,14 @@ package common
 
 // Constants aren't automatically generated for unversioned packages.
 // Instead share the same constant for all versioned packages
+
 type MachineStatusError string
 
 const (
-	// Represents that the combination of configuration in the MachineSpec
-	// is not supported by this cluster. This is not a transient error, but
-	// indicates a state that must be fixed before progress can be made.
+	// InvalidConfigurationMachineError represents that the combination of
+	// configuration in the MachineSpec is not supported by this cluster.
+	// This is not a transient error, but indicates a state that must be fixed
+	// before progress can be made.
 	//
 	// Example: the ProviderSpec specifies an instance type that doesn't exist,
 	InvalidConfigurationMachineError MachineStatusError = "InvalidConfiguration"

--- a/pkg/apis/cluster/common/plugins.go
+++ b/pkg/apis/cluster/common/plugins.go
@@ -40,6 +40,8 @@ func RegisterClusterProvisioner(name string, provisioner interface{}) {
 	providers[name] = provisioner
 }
 
+// ClusterProvisioner finds and returns a previously registered
+// ClusterProvisioner by name.
 func ClusterProvisioner(name string) (interface{}, error) {
 	providersMutex.Lock()
 	defer providersMutex.Unlock()

--- a/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -29,6 +29,7 @@ const ClusterFinalizer = "cluster.cluster.k8s.io"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 /// [Cluster]
+
 // Cluster is the Schema for the clusters API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
@@ -43,6 +44,7 @@ type Cluster struct {
 /// [Cluster]
 
 /// [ClusterSpec]
+
 // ClusterSpec defines the desired state of Cluster
 type ClusterSpec struct {
 	// Cluster network configuration
@@ -59,6 +61,7 @@ type ClusterSpec struct {
 /// [ClusterSpec]
 
 /// [ClusterNetworkingConfig]
+
 // ClusterNetworkingConfig specifies the different networking
 // parameters for a cluster.
 type ClusterNetworkingConfig struct {
@@ -75,6 +78,7 @@ type ClusterNetworkingConfig struct {
 /// [ClusterNetworkingConfig]
 
 /// [NetworkRanges]
+
 // NetworkRanges represents ranges of network addresses.
 type NetworkRanges struct {
 	CIDRBlocks []string `json:"cidrBlocks"`
@@ -83,6 +87,7 @@ type NetworkRanges struct {
 /// [NetworkRanges]
 
 /// [ClusterStatus]
+
 // ClusterStatus defines the observed state of Cluster
 type ClusterStatus struct {
 	// APIEndpoint represents the endpoint to communicate with the IP.
@@ -115,6 +120,7 @@ type ClusterStatus struct {
 /// [ClusterStatus]
 
 /// [APIEndpoint]
+
 // APIEndpoint represents a reachable Kubernetes API endpoint.
 type APIEndpoint struct {
 	// The hostname on which the API server is serving.

--- a/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -132,6 +132,7 @@ type APIEndpoint struct {
 
 /// [APIEndpoint]
 
+// Validate looks at the network config of a Cluster and returns any errors.
 func (o *Cluster) Validate() field.ErrorList {
 	errors := field.ErrorList{}
 	// perform validation here and add to errors using field.Invalid

--- a/pkg/apis/cluster/v1alpha1/defaults.go
+++ b/pkg/apis/cluster/v1alpha1/defaults.go
@@ -22,8 +22,8 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 )
 
-// PopulateDefaultsMachineDeployment fills in default field values
-// Currently it is called after reading objects, but it could be called in an admission webhook also
+// PopulateDefaultsMachineDeployment fills in default field values.
+// Currently, it is called after reading objects, but it could be called in an admission webhook also.
 func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
 	if d.Spec.Replicas == nil {
 		d.Spec.Replicas = new(int32)

--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -227,6 +227,7 @@ type LastOperation struct {
 
 /// [MachineVersionInfo]
 
+// MachineVersionInfo contains semantic versions of software to run on the Machine.
 type MachineVersionInfo struct {
 	// Kubelet is the semantic version of kubelet to run
 	Kubelet string `json:"kubelet"`

--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -54,7 +54,7 @@ type Machine struct {
 
 /// [MachineSpec]
 
-// MachineSpec defines the desired state of Machine
+// MachineSpec defines the desired state of Machine.
 type MachineSpec struct {
 	// ObjectMeta will autopopulate the Node created. Use this to
 	// indicate what labels, annotations, name prefix, etc., should be used
@@ -110,7 +110,7 @@ type MachineSpec struct {
 
 /// [MachineStatus]
 
-// MachineStatus defines the observed state of Machine
+// MachineStatus defines the observed state of Machine.
 type MachineStatus struct {
 	// NodeRef will point to the corresponding Node if it exists.
 	// +optional

--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -35,6 +35,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 /// [Machine]
+
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
@@ -52,6 +53,7 @@ type Machine struct {
 /// [Machine]
 
 /// [MachineSpec]
+
 // MachineSpec defines the desired state of Machine
 type MachineSpec struct {
 	// ObjectMeta will autopopulate the Node created. Use this to
@@ -107,6 +109,7 @@ type MachineSpec struct {
 /// [MachineSpec]
 
 /// [MachineStatus]
+
 // MachineStatus defines the observed state of Machine
 type MachineStatus struct {
 	// NodeRef will point to the corresponding Node if it exists.
@@ -223,6 +226,7 @@ type LastOperation struct {
 /// [MachineStatus]
 
 /// [MachineVersionInfo]
+
 type MachineVersionInfo struct {
 	// Kubelet is the semantic version of kubelet to run
 	Kubelet string `json:"kubelet"`

--- a/pkg/apis/cluster/v1alpha1/machineclass_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineclass_types.go
@@ -26,6 +26,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 /// [MachineClass]
+
 // MachineClass can be used to templatize and re-use provider configuration
 // across multiple Machines / MachineSets / MachineDeployments.
 // +k8s:openapi-gen=true
@@ -64,6 +65,7 @@ type MachineClass struct {
 	// MachineTemplate corev1.ObjectReference `json:machineTemplate`
 }
 
+/// [MachineClass]
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MachineClassList contains a list of MachineClasses

--- a/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
@@ -24,7 +24,7 @@ import (
 
 /// [MachineDeploymentSpec]
 
-// MachineDeploymentSpec defines the desired state of MachineDeployment
+// MachineDeploymentSpec defines the desired state of MachineDeployment.
 type MachineDeploymentSpec struct {
 	// Number of desired machines. Defaults to 1.
 	// This is a pointer to distinguish between explicit zero and not specified.
@@ -91,7 +91,7 @@ type MachineDeploymentStrategy struct {
 
 /// [MachineRollingUpdateDeployment]
 
-// Spec to control the desired behavior of rolling update.
+// MachineRollingUpdateDeployment respresents the desired behavior of rolling update.
 type MachineRollingUpdateDeployment struct {
 	// The maximum number of machines that can be unavailable during the update.
 	// Value can be an absolute number (ex: 5) or a percentage of desired
@@ -129,7 +129,7 @@ type MachineRollingUpdateDeployment struct {
 
 /// [MachineDeploymentStatus]
 
-// MachineDeploymentStatus defines the observed state of MachineDeployment
+// MachineDeploymentStatus defines the observed state of MachineDeployment.
 type MachineDeploymentStatus struct {
 	// The generation observed by the deployment controller.
 	// +optional

--- a/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
@@ -22,6 +22,9 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 )
 
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 /// [MachineDeploymentSpec]
 
 // MachineDeploymentSpec defines the desired state of MachineDeployment.
@@ -164,9 +167,6 @@ type MachineDeploymentStatus struct {
 }
 
 /// [MachineDeploymentStatus]
-
-// +genclient
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 /// [MachineDeployment]
 

--- a/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
@@ -23,6 +23,7 @@ import (
 )
 
 /// [MachineDeploymentSpec]
+
 // MachineDeploymentSpec defines the desired state of MachineDeployment
 type MachineDeploymentSpec struct {
 	// Number of desired machines. Defaults to 1.
@@ -70,6 +71,7 @@ type MachineDeploymentSpec struct {
 /// [MachineDeploymentSpec]
 
 /// [MachineDeploymentStrategy]
+
 // MachineDeploymentStrategy describes how to replace existing machines
 // with new ones.
 type MachineDeploymentStrategy struct {
@@ -88,6 +90,7 @@ type MachineDeploymentStrategy struct {
 /// [MachineDeploymentStrategy]
 
 /// [MachineRollingUpdateDeployment]
+
 // Spec to control the desired behavior of rolling update.
 type MachineRollingUpdateDeployment struct {
 	// The maximum number of machines that can be unavailable during the update.
@@ -125,6 +128,7 @@ type MachineRollingUpdateDeployment struct {
 /// [MachineRollingUpdateDeployment]
 
 /// [MachineDeploymentStatus]
+
 // MachineDeploymentStatus defines the observed state of MachineDeployment
 type MachineDeploymentStatus struct {
 	// The generation observed by the deployment controller.
@@ -165,6 +169,7 @@ type MachineDeploymentStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 /// [MachineDeployment]
+
 // MachineDeployment is the Schema for the machinedeployments API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -47,7 +47,7 @@ type MachineSet struct {
 
 /// [MachineSetSpec]
 
-// MachineSetSpec defines the desired state of MachineSet
+// MachineSetSpec defines the desired state of MachineSet.
 type MachineSetSpec struct {
 	// Replicas is the number of desired replicas.
 	// This is a pointer to distinguish between explicit zero and unspecified.
@@ -105,7 +105,7 @@ const (
 
 /// [MachineTemplateSpec] // doxygen marker
 
-// MachineTemplateSpec describes the data needed to create a Machine from a template
+// MachineTemplateSpec describes the data needed to create a Machine from a template.
 type MachineTemplateSpec struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
@@ -122,7 +122,7 @@ type MachineTemplateSpec struct {
 
 /// [MachineSetStatus]
 
-// MachineSetStatus defines the observed state of MachineSet
+// MachineSetStatus defines the observed state of MachineSet.
 type MachineSetStatus struct {
 	// Replicas is the most recently observed number of replicas.
 	Replicas int32 `json:"replicas"`
@@ -191,7 +191,7 @@ func (m *MachineSet) Validate() field.ErrorList {
 	return errors
 }
 
-// DefaultingFunction sets default MachineSet field values
+// Default sets default MachineSet field values.
 func (m *MachineSet) Default() {
 	log.Printf("Defaulting fields for MachineSet %s\n", m.Name)
 
@@ -213,7 +213,7 @@ func (m *MachineSet) Default() {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// MachineSetList contains a list of MachineSet
+// MachineSetList contains a list of MachineSet.
 type MachineSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -169,6 +169,7 @@ type MachineSetStatus struct {
 
 /// [MachineSetStatus]
 
+// Validate checks the MachineSet's selectors and returns any errors.
 func (m *MachineSet) Validate() field.ErrorList {
 	errors := field.ErrorList{}
 

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -30,6 +30,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 /// [MachineSet]
+
 // MachineSet ensures that a specified number of machines replicas are running at any given time.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
@@ -45,6 +46,7 @@ type MachineSet struct {
 /// [MachineSet]
 
 /// [MachineSetSpec]
+
 // MachineSetSpec defines the desired state of MachineSet
 type MachineSetSpec struct {
 	// Replicas is the number of desired replicas.
@@ -102,6 +104,7 @@ const (
 /// [MachineSetSpec] // doxygen marker
 
 /// [MachineTemplateSpec] // doxygen marker
+
 // MachineTemplateSpec describes the data needed to create a Machine from a template
 type MachineTemplateSpec struct {
 	// Standard object's metadata.
@@ -118,6 +121,7 @@ type MachineTemplateSpec struct {
 /// [MachineTemplateSpec]
 
 /// [MachineSetStatus]
+
 // MachineSetStatus defines the observed state of MachineSet
 type MachineSetStatus struct {
 	// Replicas is the most recently observed number of replicas.


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleans up comments on exported functions and types:
1. Adds new lines between Doxygen marker lines and types/functions to prevent GoDoc from rendering them.
2. Add a closing marker for `MachineClass`, since it appeared to be missing.
3. Make more comments begin with the name of the type/function and end with a period.
4. Add a couple comments for exported types/functions that don't have them.

**Special notes for your reviewer**:
I'm not sure how to test that the added new lines definitely don't hurt the GitBook rendering. It doesn't seem like there should be a problem, but I haven't tried rendering it, so I can't be sure.

**Release note**:
```release-note
NONE
```

cc @davidewatson since he responded on slack
