### PR TITLE
[clusterctl] Do not fail in waitForKubectlApply if error contains "no such host"

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -923,7 +923,7 @@ func (c *client) waitForKubectlApply(manifest string) error {
 		klog.V(2).Infof("Waiting for kubectl apply...")
 		err := c.kubectlApply(manifest)
 		if err != nil {
-			if strings.Contains(err.Error(), io.EOF.Error()) || strings.Contains(err.Error(), "refused") {
+			if strings.Contains(err.Error(), io.EOF.Error()) || strings.Contains(err.Error(), "refused") || strings.Contains(err.Error(), "no such host") {
 				// Connection was refused, probably because the API server is not ready yet.
 				klog.V(4).Infof("Waiting for kubectl apply... server not yet available: %v", err)
 				return false, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if waitForKubectlApply is run against an apiserver endpoint that doesn't exist yet (as in the case of the AWS provider where the ELB has not yet been created) this method will erroneously return an error instead of retrying. This is easy to trigger using `clusterctl alpha phases` to stand up a cluster instead of the full `clusterctl create cluster` workflow