### PR TITLE
Enable Capacity and Allocatable fields in the MachineClass type

### DIFF
--- a/pkg/apis/cluster/v1alpha1/machineclass_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineclass_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -41,8 +42,7 @@ type MachineClass struct {
 	// this field is consistent with the underlying machine that will
 	// be provisioned when this class is used, to inform higher level
 	// automation (e.g. the cluster autoscaler).
-	// TODO(hardikdr) Add allocatable field once requirements are clear from autoscaler-clusterapi // integration topic.
-	// Capacity corev1.ResourceList `json:"capacity"`
+	Capacity corev1.ResourceList `json:"capacity"`
 
 	// How much capacity is actually allocatable on this machine.
 	// Must be equal to or less than the capacity, and when less
@@ -52,8 +52,7 @@ type MachineClass struct {
 	// this field is consistent with the underlying machine that will
 	// be provisioned when this class is used, to inform higher level
 	// automation (e.g. the cluster autoscaler).
-	// TODO(hardikdr) Add allocatable field once requirements are clear from autoscaler-clusterapi // integration topic.
-	// Allocatable corev1.ResourceList `json:"allocatable"`
+	Allocatable corev1.ResourceList `json:"allocatable"`
 
 	// Provider-specific configuration to use during node creation.
 	ProviderSpec runtime.RawExtension `json:"providerSpec"`

--- a/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha1/zz_generated.deepcopy.go
@@ -234,6 +234,20 @@ func (in *MachineClass) DeepCopyInto(out *MachineClass) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.Capacity != nil {
+		in, out := &in.Capacity, &out.Capacity
+		*out = make(v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
+	if in.Allocatable != nil {
+		in, out := &in.Allocatable, &out.Allocatable
+		*out = make(v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
 	in.ProviderSpec.DeepCopyInto(&out.ProviderSpec)
 	return
 }


### PR DESCRIPTION
This enables the `Capacity` and `Allocatable` fields on the
`MachineClass` type. I did a proof of concept[1] using the autoscaler
to see if adding these types would be sufficient to support
scale-from-0 - and they seemed sufficient for this use case which was
explicitly called out in the previous TODO comments.

[1] https://github.com/openshift/kubernetes-autoscaler/pull/89