### PR TITLE
Make ClusterNetwork ClusterNetworkingConfig field optional within

### DIFF
--- a/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -46,6 +46,7 @@ type Cluster struct {
 // ClusterSpec defines the desired state of Cluster
 type ClusterSpec struct {
 	// Cluster network configuration
+	// +optional
 	ClusterNetwork ClusterNetworkingConfig `json:"clusterNetwork"`
 
 	// Provider-specific serialized configuration to use during


### PR DESCRIPTION
Cluster resources. This is useful for Managed Control Planes and
Bare Metal where networking configuration options may be limited.

**What this PR does / why we need it**:

Kubeadm has a default value for `PodCIDRs`. This change enables providers which use it to take advantage of the default. Further, in Managed and Bare Metal environments it may not be clear to the user what the podCIDR and serviceCIDR configuration should be.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Note that it is not possible to set defaults using `kubebuilder` at this time. Also, I am not sure how we want to manage changes for `v1alpha2`. Will we make many small changes like this, or do small PRs at this stage clutter up the queue?

**Release note**:
```release-note
Cluster.Spec.ClusterNetwork is now optional.
```
