### PR TITLE
Bump kubectl version to v1.13.2 in ci

### DIFF
--- a/scripts/ci-integration.sh
+++ b/scripts/ci-integration.sh
@@ -21,6 +21,7 @@ set -o pipefail
 MAKE="make"
 KUSTOMIZE="kustomize"
 KUBECTL="kubectl"
+KUBECTL_VERSION="v1.13.2"
 CRD_YAML="crd.yaml"
 BOOTSTRAP_CLUSTER_NAME="clusterapi-bootstrap"
 CONTROLLER_REPO="controller-ci" # use arbitrary repo name since we don't need to publish it
@@ -34,7 +35,7 @@ install_kustomize() {
 }
 
 install_kubectl() {
-   wget https://storage.googleapis.com/kubernetes-release/release/v1.10.2/bin/linux/amd64/kubectl \
+   wget https://storage.googleapis.com/kubernetes-release/release/"${KUBECTL_VERSION}"/bin/linux/amd64/kubectl \
      --no-verbose -O /usr/local/bin/kubectl
    chmod +x /usr/local/bin/kubectl
 }


### PR DESCRIPTION
kubectl v1.10.2 does not compatible with cluster v1.14.x anymore


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
fix the failing integration test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

fix the current failing CI, kubectl throw error when run against cluster v1.14.x
```
error: SchemaError(io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec): invalid object doesn't have additional properties
```
**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
N/A
```


cc @vincepri @detiber 