### PR TITLE
Add shortnames for crds.

### DIFF
--- a/config/crds/cluster_v1alpha1_cluster.yaml
+++ b/config/crds/cluster_v1alpha1_cluster.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: Cluster
     plural: clusters
+    shortNames:
+    - cl
   scope: Namespaced
   subresources:
     status: {}

--- a/config/crds/cluster_v1alpha1_machine.yaml
+++ b/config/crds/cluster_v1alpha1_machine.yaml
@@ -24,6 +24,8 @@ spec:
   names:
     kind: Machine
     plural: machines
+    shortNames:
+    - ma
   scope: Namespaced
   subresources:
     status: {}

--- a/config/crds/cluster_v1alpha1_machineclass.yaml
+++ b/config/crds/cluster_v1alpha1_machineclass.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: MachineClass
     plural: machineclasses
+    shortNames:
+    - mc
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/config/crds/cluster_v1alpha1_machinedeployment.yaml
+++ b/config/crds/cluster_v1alpha1_machinedeployment.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: MachineDeployment
     plural: machinedeployments
+    shortNames:
+    - md
   scope: Namespaced
   subresources:
     scale:

--- a/config/crds/cluster_v1alpha1_machineset.yaml
+++ b/config/crds/cluster_v1alpha1_machineset.yaml
@@ -10,6 +10,8 @@ spec:
   names:
     kind: MachineSet
     plural: machinesets
+    shortNames:
+    - ms
   scope: Namespaced
   subresources:
     scale:

--- a/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -31,6 +31,7 @@ const ClusterFinalizer = "cluster.cluster.k8s.io"
 /// [Cluster]
 // Cluster is the Schema for the clusters API
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=cl
 // +kubebuilder:subresource:status
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -37,6 +37,7 @@ const (
 /// [Machine]
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=ma
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Machine status such as Terminating/Pending/Running/Failed etc"

--- a/pkg/apis/cluster/v1alpha1/machineclass_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineclass_types.go
@@ -30,6 +30,7 @@ import (
 // across multiple Machines / MachineSets / MachineDeployments.
 // +k8s:openapi-gen=true
 // +resource:path=machineclasses
+// +kubebuilder:resource:shortName=mc
 type MachineClass struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
@@ -167,6 +167,7 @@ type MachineDeploymentStatus struct {
 /// [MachineDeployment]
 // MachineDeployment is the Schema for the machinedeployments API
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=md
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
 type MachineDeployment struct {

--- a/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -32,6 +32,7 @@ import (
 /// [MachineSet]
 // MachineSet ensures that a specified number of machines replicas are running at any given time.
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=ms
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
 type MachineSet struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds short names for crds.  One may now use cl, ma, mc, md, and ms with kubectl instead of the full names (cluster, machine, machineclass, machinedeployment, machineset).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
short names for crds
```
