### PR TITLE
Fix machine object pivoting to the target cluster

### DIFF
--- a/cmd/clusterctl/phases/pivot.go
+++ b/cmd/clusterctl/phases/pivot.go
@@ -369,11 +369,18 @@ func moveMachineSet(from sourceClient, to targetClient, ms *clusterv1.MachineSet
 func moveMachines(from sourceClient, to targetClient, machines []*clusterv1.Machine) error {
 	machineNames := make([]string, 0, len(machines))
 	for _, m := range machines {
+		if m.DeletionTimestamp != nil {
+			klog.V(4).Infof("Skipping to move deleted machine: %q", m.Name)
+			continue
+		}
 		machineNames = append(machineNames, m.Name)
 	}
 	klog.V(4).Infof("Preparing to move Machines: %v", machineNames)
 
 	for _, m := range machines {
+		if m.DeletionTimestamp != nil {
+			continue
+		}
 		if err := moveMachine(from, to, m); err != nil {
 			return errors.Wrapf(err, "failed to move Machine %s:%s", m.Namespace, m.Name)
 		}


### PR DESCRIPTION
```
create_cluster.go:61] unable to pivot cluster api stack to target cluster: unable to pivot cluster API objects: failed to move Machine default:controlplane-0: error copying Machine default/controlplane-0 to target cluster: error creating a machine object in namespace default: machines.cluster.k8s.io "controlplane-0" already exists
```
This is a fix for an issue in the pivoting of machine api object from the bootstrap cluster to the target cluster. Machines objects are pivoted in two phases. First, the ones which are owned by higher objects like machinesets and second, the ones which are not owned by higher entities. After first phase pivoting(moveCluster()), machine objects are deleted from the bootstrap cluster. However Delete call is async and does not guarantee machine object will not be there for sure after the return of Delete.

For second phase, pivoting when machine objects are listed, machine objects which are under deletion, also gets listed and when tried to move such a object, it fails with the above error.
This PR is fixing the issue by skipping pivoting of such machine objects using deletion timestamp in the machine object.
/cc @detiber 