### PR TITLE
[docs] Update RBAC annotations for example provider

### DIFF
--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -53,7 +53,7 @@ Including the ability to:
 
 - Create reproducible Kubernetes clusters.
 - Create hybrid cloud environments which optimize for cost, performance, and
-reliability. 
+reliability.
 
 ## Resources
 

--- a/docs/book/provider_implementations/create_actuators.md
+++ b/docs/book/provider_implementations/create_actuators.md
@@ -36,7 +36,7 @@ import (
 )
 
 // Add RBAC rules to access cluster-api resources
-//+kubebuilder:rbac:groups=cluster.k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.k8s.io,resources=clusters;clusters/status,verbs=get;list;watch;update;patch
 
 // Actuator is responsible for performing cluster reconciliation
 type Actuator struct {
@@ -106,7 +106,8 @@ const (
 )
 
 // Add RBAC rules to access cluster-api resources
-//+kubebuilder:rbac:groups=cluster.k8s.io,resources=machines;machines/status;machinedeployments;machinedeployments/status;machinesets;machinesets/status;machineclasses,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=cluster.k8s.io,resources=machines;machines/status,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=cluster.k8s.io,resources=machineClasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=nodes;events,verbs=get;list;watch;create;update;patch;delete
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The docs currently list incorrect RBAC annotations for the example provider

**Release note**:
```release-note
NONE
```
