### PR TITLE
Fix broken links to Kubebuilder documentation

### DIFF
--- a/docs/book/common_code/architecture.md
+++ b/docs/book/common_code/architecture.md
@@ -4,8 +4,8 @@
 It may be useful to read at least the following chapters of the Kubebuilder 
 book in order to better understand this section.
 
-- [What is a Resource](https://book.kubebuilder.io/basics/what_is_a_resource.html)
-- [What is a Controller](https://book.kubebuilder.io/basics/what_is_a_controller.html)
+- [What is a Resource](https://book-v1.book.kubebuilder.io/basics/what_is_a_resource.html)
+- [What is a Controller](https://book-v1.book.kubebuilder.io/basics/what_is_a_controller.html)
 {% endpanel %}
 
 {% panel style="warning", title="Architecture Diagram" %}


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes broken Kubebuilder documentation URLs in `Architecture` page of [Cluster API documentation](https://kubernetes-sigs.github.io/cluster-api/common_code/architecture.html).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
