### PR TITLE
updates Google Cloud branding to mach other usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ are also sponsored by SIG-cluster-lifecycle:
   * Bare Metal, https://github.com/metal3-io/cluster-api-provider-baremetal
   * DigitalOcean, https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean
   * Exoscale, https://github.com/exoscale/cluster-api-provider-exoscale
-  * GCE, https://github.com/kubernetes-sigs/cluster-api-provider-gcp
+  * GCP, https://github.com/kubernetes-sigs/cluster-api-provider-gcp
   * IBM Cloud, https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud
   * OpenStack, https://github.com/kubernetes-sigs/cluster-api-provider-openstack
   * Talos, https://github.com/talos-systems/cluster-api-provider-talos


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
I noticed that the branding for the cloud provider was used in all other cases, but the branding for the compute offering was used only in the case of Google Cloud.  Just thought I would send in a quick change. :)

**Special notes for your reviewer**:
perhaps, if you wish, just saying `Google Cloud` instead of `GCP` would be better?  your call.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
