### PR TITLE
downgrade log of util.ExecuteCommand

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -161,13 +161,14 @@ func Copy(m *clusterv1.Machine) *clusterv1.Machine {
 }
 
 // ExecCommand Executes a local command in the current shell.
-func ExecCommand(name string, args ...string) string {
+func ExecCommand(name string, args ...string) (string, error) {
 	cmdOut, err := exec.Command(name, args...).Output()
 	if err != nil {
 		s := strings.Join(append([]string{name}, args...), " ")
-		klog.Errorf("error executing command %q: %v", s, err)
+		klog.Infof("Executing command %q: %v", s, err)
+		return string(""), err
 	}
-	return string(cmdOut)
+	return string(cmdOut), nil
 }
 
 // Filter filters a list for a string.


### PR DESCRIPTION
As this error E0531 is not that ueful and no need to be mark
this as 'E', use Info level should be fine as this won't affect
return value.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #974 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
