### PR TITLE
Remove duplicate checks for deletionTimestamp

### DIFF
--- a/pkg/controller/machinedeployment/machinedeployment_controller.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller.go
@@ -210,10 +210,6 @@ func (r *ReconcileMachineDeployment) reconcile(ctx context.Context, d *v1alpha1.
 		return reconcile.Result{}, err
 	}
 
-	if d.DeletionTimestamp != nil {
-		return reconcile.Result{}, r.sync(d, msList, machineMap)
-	}
-
 	if d.Spec.Paused {
 		return reconcile.Result{}, r.sync(d, msList, machineMap)
 	}

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -197,11 +197,6 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	// Return early if the MachineSet is deleted.
-	if !machineSet.ObjectMeta.DeletionTimestamp.IsZero() {
-		return reconcile.Result{}, nil
-	}
-
 	// Filter out irrelevant machines (deleting/mismatch labels) and claim orphaned machines.
 	filteredMachines := make([]*clusterv1alpha1.Machine, 0, len(allMachines.Items))
 	for idx := range allMachines.Items {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Removes duplicate checks in MachineDeployment and MachineSet controllers for deletionTimestamp. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
