### PR TITLE
Fix links in Architecture documentation.

### DIFF
--- a/docs/book/common_code/architecture.md
+++ b/docs/book/common_code/architecture.md
@@ -4,8 +4,8 @@
 It may be useful to read at least the following chapters of the Kubebuilder 
 book in order to better understand this section.
 
-- [What is a Resource](https://book.kubebuilder.io/basics/what_is_a_resource.html)
-- [What is a Controller](https://book.kubebuilder.io/basics/what_is_a_controller.html)
+- [What is a Resource](https://book-v1.book.kubebuilder.io/basics/what_is_a_resource.html)
+- [What is a Controller](https://book-v1.book.kubebuilder.io/basics/what_is_a_controller.html)
 {% endpanel %}
 
 {% panel style="warning", title="Architecture Diagram" %}


### PR DESCRIPTION
The links now point to the legacy documentation of Kubebuilder.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**: The links in the documentation were broken, after checking the Kubebuilder documentation it appears that they have been moved to the legacy documentation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
