### PR TITLE
Update GitBook URL to point to netlify served pages instead of

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Following are the implementations managed by third-parties adopting the standard
 
 ### Resources
 
-* GitBook: cluster-api.sigs.k8s.io
+* GitBook: [cluster-api.sigs.k8s.io](cluster-api.sigs.k8s.io)
 
 ### Prerequisites
 * `kubectl` is required, see [here](http://kubernetes.io/docs/user-guide/prereqs/).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Following are the implementations managed by third-parties adopting the standard
 
 ### Resources
 
-* GitBook: [kubernetes-sigs.github.io/cluster-api](https://kubernetes-sigs.github.io/cluster-api)
+* GitBook: cluster-api.sigs.k8s.io
 
 ### Prerequisites
 * `kubectl` is required, see [here](http://kubernetes.io/docs/user-guide/prereqs/).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Following are the implementations managed by third-parties adopting the standard
 
 ### Resources
 
-* GitBook: [cluster-api.sigs.k8s.io](cluster-api.sigs.k8s.io)
+* GitBook: [cluster-api.sigs.k8s.io](https://cluster-api.sigs.k8s.io)
 
 ### Prerequisites
 * `kubectl` is required, see [here](http://kubernetes.io/docs/user-guide/prereqs/).

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -57,7 +57,7 @@ reliability.
 
 ## Resources
 
-- GitBook: cluster-api.sigs.k8s.io
+- GitBook: [cluster-api.sigs.k8s.io](cluster-api.sigs.k8s.io)
 - GitHub Repo: [kubernetes-sigs/cluster-api](https://github.com/kubernetes-sigs/cluster-api)
 - Slack channel: [#cluster-api](http://slack.k8s.io/#cluster-api)
 - Google Group: [kubernetes-sig-cluster-lifecycle@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -57,7 +57,7 @@ reliability.
 
 ## Resources
 
-- GitBook: [kubernetes-sigs.github.io/cluster-api](https://kubernetes-sigs.github.io/cluster-api)
+- GitBook: cluster-api.sigs.k8s.io
 - GitHub Repo: [kubernetes-sigs/cluster-api](https://github.com/kubernetes-sigs/cluster-api)
 - Slack channel: [#cluster-api](http://slack.k8s.io/#cluster-api)
 - Google Group: [kubernetes-sig-cluster-lifecycle@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -57,7 +57,7 @@ reliability.
 
 ## Resources
 
-- GitBook: [cluster-api.sigs.k8s.io](cluster-api.sigs.k8s.io)
+- GitBook: [cluster-api.sigs.k8s.io](https://cluster-api.sigs.k8s.io)
 - GitHub Repo: [kubernetes-sigs/cluster-api](https://github.com/kubernetes-sigs/cluster-api)
 - Slack channel: [#cluster-api](http://slack.k8s.io/#cluster-api)
 - Google Group: [kubernetes-sig-cluster-lifecycle@googlegroups.com](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)


### PR DESCRIPTION
gh-pages.

**What this PR does / why we need it**:

Since https://github.com/kubernetes-sigs/cluster-api/pull/659 we use Netlify instead of gh-pages.

**Special notes for your reviewer**:

Once this is merged I plan to disable gh-pages within the `cluster-api`'s GitHub settings.

**Release note**:
```release-note
The GitBook is now published at cluster-api.sigs.k8s.io using Netlify.
```
