### PR TITLE
Add events to MachineDeployment operations

### DIFF
--- a/cmd/clusterctl/clusterdeployer/bootstrap/kind/BUILD.bazel
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/kind/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/kind",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/cmd/clusterctl/clusterdeployer/bootstrap/minikube/BUILD.bazel
+++ b/cmd/clusterctl/clusterdeployer/bootstrap/minikube/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/bootstrap/minikube",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/controller/machinedeployment/machinedeployment_controller.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller.go
@@ -276,9 +276,11 @@ func (r *ReconcileMachineDeployment) getMachineSetsForDeployment(d *v1alpha1.Mac
 		// Attempt to adopt machine if it meets previous conditions and it has no controller references.
 		if metav1.GetControllerOf(ms) == nil {
 			if err := r.adoptOrphan(d, ms); err != nil {
+				r.recorder.Eventf(d, corev1.EventTypeWarning, "FailedAdopt", "Failed to adopt MachineSet %q: %v", ms.Name, err)
 				klog.Warningf("Failed to adopt MachineSet %q into MachineDeployment %q: %v", ms.Name, d.Name, err)
 				continue
 			}
+			r.recorder.Eventf(d, corev1.EventTypeNormal, "SuccessfulAdopt", "Adopted MachineSet %q", ms.Name)
 		}
 
 		if !metav1.IsControlledBy(ms, d) {

--- a/pkg/controller/machinedeployment/machinedeployment_controller_test.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -132,8 +133,9 @@ func TestMachineSetToDeployments(t *testing.T) {
 
 	v1alpha1.AddToScheme(scheme.Scheme)
 	r := &ReconcileMachineDeployment{
-		Client: fake.NewFakeClient(&ms1, &ms2, &ms3, machineDeplopymentList),
-		scheme: scheme.Scheme,
+		Client:   fake.NewFakeClient(&ms1, &ms2, &ms3, machineDeplopymentList),
+		scheme:   scheme.Scheme,
+		recorder: record.NewFakeRecorder(32),
 	}
 
 	for _, tc := range testsCases {
@@ -206,8 +208,9 @@ func TestGetMachineDeploymentsForMachineSet(t *testing.T) {
 	}
 	v1alpha1.AddToScheme(scheme.Scheme)
 	r := &ReconcileMachineDeployment{
-		Client: fake.NewFakeClient(&ms1, &ms2, machineDeplopymentList),
-		scheme: scheme.Scheme,
+		Client:   fake.NewFakeClient(&ms1, &ms2, machineDeplopymentList),
+		scheme:   scheme.Scheme,
+		recorder: record.NewFakeRecorder(32),
 	}
 
 	for _, tc := range testCases {
@@ -327,8 +330,9 @@ func TestGetMachineSetsForDeployment(t *testing.T) {
 
 	v1alpha1.AddToScheme(scheme.Scheme)
 	r := &ReconcileMachineDeployment{
-		Client: fake.NewFakeClient(machineSetList),
-		scheme: scheme.Scheme,
+		Client:   fake.NewFakeClient(machineSetList),
+		scheme:   scheme.Scheme,
+		recorder: record.NewFakeRecorder(32),
 	}
 	for _, tc := range testCases {
 		got, err := r.getMachineSetsForDeployment(&tc.machineDeployment)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds events to MachineDeployment operations

**Release note**:
```release-note
MachineDeployments now emit events when adopting, creating, and deleting MachineSets
```
