### PR TITLE
Support for wrapped RequeueAfterError/interface

### DIFF
--- a/pkg/controller/error/requeue_error.go
+++ b/pkg/controller/error/requeue_error.go
@@ -21,6 +21,15 @@ import (
 	"time"
 )
 
+// HasRequeueAfterError represents that an actuator managed object should
+// be requeued for further processing after the given RequeueAfter time has
+// passed.
+type HasRequeueAfterError interface {
+	// GetRequeueAfter gets the duration to wait until the managed object is
+	// requeued for further processing.
+	GetRequeueAfter() time.Duration
+}
+
 // RequeueAfterError represents that an actuator managed object should be
 // requeued for further processing after the given RequeueAfter time has
 // passed.
@@ -31,4 +40,10 @@ type RequeueAfterError struct {
 // Error implements the error interface
 func (e *RequeueAfterError) Error() string {
 	return fmt.Sprintf("requeue in: %s", e.RequeueAfter)
+}
+
+// GetRequeueAfter gets the duration to wait until the managed object is
+// requeued for further processing.
+func (e *RequeueAfterError) GetRequeueAfter() time.Duration {
+	return e.RequeueAfter
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch fixes #1018 and supports wrapped "RequeueAfterError" errors as well as a new interface for supporting custom "RequeueAfterError" errors.

**Which issue(s) this PR fixes**:
Fixes #1018

**Special notes for your reviewer**:
Hi there. I hope all is well in your neck of the woods.

**Release note**:
```release-note
NONE
```
