### PR TITLE
Fixup glossary to match GitBook conventions.

### DIFF
--- a/docs/book/GLOSSARY.md
+++ b/docs/book/GLOSSARY.md
@@ -17,100 +17,92 @@ last-updated: 2019-06-10
 
   Formatting instructions for this document:
 
-  - Create level 3 section for each glossary entry so other documents can consistently link to the definition.
+  - GitBook will make each two-level section a glossary entry. For example, `# foo` is not an entry, whereas `## foo` is.
   - Use a bullet list to define sub-entries or variations.
   - Wrap each sub-entry or variation in double underscores to have it rendered with emphasis.
   - Use semantic linefeeds (https://rhodesmill.org/brandon/2012/one-sentence-per-line/)
 
 -->
 
-# Glossary
-
-This document defines the terms used in other documents created by the Cluster API group.
-
-## Table of Contents
+# Table of Contents
 
 [A](#a) | [B](#b) | [C](#c) | [D](#d) | [H](#h) | [I](#i) | [K](#k) | [M](#m) | [O](#o) | [P](#p) | [S](#s) | [W](#w)
 
-## A
+# A
 
-### Add-ons
+## Add-ons
 
 Services beyond the fundamental components of Kubernetes.
 
 * __Core Add-ons__: Addons that are required to deploy a Kubernetes-conformant cluster: DNS, kube-proxy, CNI.
 * __Additional Add-ons__: Addons that are not required for a Kubernetes-conformant cluster (e.g. metrics/Heapster, Dashboard).
 
-## B
-
-### Bootstrap
+## Bootstrap
 
 The process of turning a server into a Kubernetes node. This may involve assembling data to provide when creating the server that backs the Machine, as well as runtime configuration of the software running on that server.
 
-## C
-
-### Cluster
+## Cluster
 
 A full Kubernetes deployment. See Management Cluster and Workload Cluster
 
-### Cluster API
+## Cluster API
 
 Or __Cluster API project__
 
 The Cluster API sub-project of the SIG-cluster-lifecycle. It is also used to refer to the software components, APIs, and community that produce them.
 
-### Control plane
+## Control plane
 
 The set of Kubernetes services that form the basis of a cluster. See also https://kubernetes.io/docs/concepts/#kubernetes-control-plane There are two variants:
 
 * __Self-provisioned__: A Kubernetes control plane consisting of pods or machines wholly managed by a single Cluster API deployment.
 * __External__: A control plane offered and controlled by some system other than Cluster API (e.g., GKE, AKS, EKS, IKS).
 
-## D
+# D
 
-### Default implementation
+## Default implementation
 
 A feature implementation offered as part of the Cluster API project, infrastructure providers can swap it out for a different one.
 
-## H
-
-### Horizontal Scaling
+## Horizontal Scaling
 
 The ability to add more machines based on policy and well defined metrics. For example, add a machine to a cluster when CPU load average > (X) for a period of time (Y).
 
-### Host
+# H
+
+## Host
 
 see [Server](#server)
 
-## I
+# I
 
-### Infrastructure provider
+## Infrastructure provider
 
 A source of computational resources (e.g. machines, networking, etc.). Examples for cloud include AWS, Azure, Google, etc.; for bare metal include VMware, MAAS, metal3.io, etc. When there is more than one way to obtain resources from the same infrastructure provider (e.g. EC2 vs. EKS) each way is referred to as a variant.
 
-### Instance
+## Instance
 
 see [Server](#server)
 
-### Immutability
+## Immutability
 
 A resource that does not mutate.  In kubernetes we often state the instance of a running pod is immutable or does not change once it is run.  In order to make a change, a new pod is run.  In the context of [Cluster API](#cluster-api) we often refer to an running instance of a [Machine](#machine) is considered immutable, from a [Cluster API](#cluster-api) perspective.
 
-## K
+# K
 
-### Kubernetes-conformant
+## Kubernetes-conformant
 
 Or __Kubernetes-compliant__
 
 A cluster that passes the Kubernetes conformance tests.
 
-### K/K
+## K/K
 
 Refers to the [main Kubernetes git repository](https://github.com/kubernetes/kubernetes) or the main Kubernetes project.
 
-## M
+# M
 
-### Machine
+## Machine
 
 Or __Machine Resource__
 
@@ -118,44 +110,44 @@ The Custom Resource for Kubernetes that represents a request to have a place to 
 
 See also: [Server](#server)
 
-### Manage a cluster
+## Manage a cluster
 
 Perform create, scale, upgrade, or destroy operations on the cluster.
 
-### Management cluster
+## Management cluster
 
 The cluster where one or more Infrastructure Providers run, and where resources (e.g. Machines) are stored.  Typically referred to when you are provisioning multiple clusters.
 
-## O
+# O
 
-### Operating system
+## Operating system
 
 Or __OS__
 
 A generically understood combination of a kernel and system-level userspace interface, such as Linux or Windows, as opposed to a particular distribution.
 
-## P
+# P
 
-### Provider
+## Provider
 
 See [Infrastructure Provider](#user-content-infrastructure-provider)
 
-### Provider implementation
+#### Provider implementation
 
 Existing Cluster API implementations consist of generic and infrastructure provider-specific logic. The [infrastructure provider](#infrastructure-provider)-specific logic is currently maintained in infrastructure provider repositories.
 
-## S
+# S
 
-### Scaling
+## Scaling
 
 Unless otherwise specified, this refers to horizontal scaling.
 
-### Server
+## Server
 
 The infrastructure that backs a [Machine Resource](#user-content-machine), typically either a cloud instance, virtual machine, or physical host.
 
-## W
+# W
 
-### Workload cluster
+## Workload cluster
 
 A cluster whose lifecycle is managed by the Management cluster.

--- a/docs/book/npm-shrinkwrap.json
+++ b/docs/book/npm-shrinkwrap.json
@@ -298,9 +298,9 @@
       "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY="
     },
     "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escodegen": {
       "version": "1.11.0",

--- a/docs/scope-and-objectives.md
+++ b/docs/scope-and-objectives.md
@@ -40,7 +40,7 @@ We are building a set of Kubernetes cluster management APIs to enable common clu
 
 ## Glossary
 
-[See glossary.md](glossary.md)
+[See ./book/GLOSSARY.md](./book/GLOSSARY.md)
 
 - __Cluster API__: Unless otherwise specified, this refers to the project as a whole.
 - __Infrastructure provider__: Refers to the source of computational resources (e.g. machines, networking, etc.). Examples for cloud include AWS, Azure, Google, etc.; for bare metal include VMware, MAAS, etc. When there is more than one way to obtain resources from the same infrastructure provider (e.g. EC2 vs. EKS) each way is referred to as a variant.


### PR DESCRIPTION
**What this PR does / why we need it**:

Gitbook expects the `GLOSSARY.md` file to have limited markdown syntax.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

To see the current behavior notice that the letter `a` is a glossary term in the current book here: https://cluster-api.sigs.k8s.io/
