### PR TITLE
Bazel updates

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,19 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-http_archive(
+# Use the git repository for bazel rules until a released version contains https://github.com/bazelbuild/rules_go/pull/2090
+# http_archive(
+#     name = "io_bazel_rules_go",
+#     urls = [
+#         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+#         "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
+#     ],
+#     sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
+# )
+git_repository(
     name = "io_bazel_rules_go",
-    urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz",
-    ],
-    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+    commit = "f2373c9fbd09586d8e591dda3c43d66445b2d7ca",
 )
 
 http_archive(
@@ -15,6 +21,20 @@ http_archive(
     sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
 )
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
+    type = "tar.gz",
+    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
+)
+
+load("@bazel_skylib//lib:versions.bzl", "versions")
+
+versions.check(
+    minimum_bazel_version = "0.23.0",
+    maximum_bazel_version = "1.0.0",
+)  # fails if not within range
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 

--- a/build/run_in_workspace_with_goroot.bzl
+++ b/build/run_in_workspace_with_goroot.bzl
@@ -51,18 +51,15 @@ _workspace_binary_script = rule(
     attrs = {
         "cmd": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "root_file": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "go_bin": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
     },
     executable = True,


### PR DESCRIPTION
**What this PR does / why we need it**:

- Remove use of deprecated bazel attribute label single_file
- Add bazel version checking
- Include go_rules fix for cross-compiling darwin binaries


```release-note
NONE
```
