### PR TITLE
Use remote NodeRef in Machine and MachineSet controllers

### DIFF
--- a/pkg/controller/machine/BUILD.bazel
+++ b/pkg/controller/machine/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/apis/cluster/v1alpha1:go_default_library",
         "//pkg/controller/error:go_default_library",
+        "//pkg/controller/remote:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/controller/machineset/BUILD.bazel
+++ b/pkg/controller/machineset/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/apis/cluster/v1alpha1:go_default_library",
         "//pkg/controller/noderefutil:go_default_library",
+        "//pkg/controller/remote:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR is a follow-up to #1011 and allows the Machine and MachineSet controllers to use the remote client to access and retrieve a Node.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #520 
Fixes #930
Fixes #1055

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
