### PR TITLE
Use development gcr.io project as default registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?=60s
 export DOCKER_CLI_EXPERIMENTAL := enabled
 
 # Image URL to use all building/pushing image targets
-REGISTRY ?= gcr.io/k8s-cluster-api
+REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
 CONTROLLER_IMG ?= $(REGISTRY)/cluster-api-controller
 EXAMPLE_PROVIDER_IMG ?= $(REGISTRY)/example-provider-controller
 

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ export DOCKER_CLI_EXPERIMENTAL := enabled
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
 CONTROLLER_IMG ?= $(REGISTRY)/cluster-api-controller
 EXAMPLE_PROVIDER_IMG ?= $(REGISTRY)/example-provider-controller
-
-TAG ?= latest
+TAG ?= dev
 
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -32,7 +32,7 @@ For version 0.x.y:
 5. Get the pull request merged
 6. Switch to the release branch and update to pick up the commit.  (e.g. `git
    checkout release 0.x && git pull`).  From there build and push the container
-   images and fat manifest with `make all-push` (on the 0.1 release branch, we
+   images and fat manifest with `REGISTRY="gcr.io/k8s-cluster-api" make all-push` (on the 0.1 release branch, we
    do `make docker-push`)
 7. Create a tag from this same commit `git tag 0.x.y` and push the tag to the github repository `git push origin 0.x.y`
 8. Create a release in github based on the tag created above


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
To follow [CAPA](https://github.com/kubernetes-sigs/cluster-api-provider-aws) focus on having Makefile to target developers, this PR switches the default `REGISTRY` flag in the Makefile to target the user's local default project instead of the release.

It also updates the release docs with the new command that needs to be used. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
