### PR TITLE
Improve generate-* targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,49 +39,37 @@ all: test manager clusterctl
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-.PHONY: gazelle
-gazelle: ## Run Bazel Gazelle
-	(which bazel && ./hack/update-bazel.sh) || true
-
-.PHONY: dep-ensure
-dep-ensure: ## Runs dep-ensure and rebuilds Bazel gazelle files.
-	find vendor -name 'BUILD.bazel' -delete
-	(which dep && dep ensure -v) || true
-	$(MAKE) gazelle
+## --------------------------------------
+## Testing
+## --------------------------------------
 
 .PHONY: test
-test: gazelle verify generate fmt vet manifests ## Run tests
+test: generate lint ## Run tests
+	$(MAKE) test-go
+
+.PHONY: test
+test-go: ## Run tests
 	go test -v -tags=integration ./pkg/... ./cmd/...
 
+## --------------------------------------
+## Binaries
+## --------------------------------------
+
 .PHONY: manager
-manager: generate fmt vet ## Build manager binary
+manager: lint-full ## Build manager binary
 	go build -o bin/manager sigs.k8s.io/cluster-api/cmd/manager
 
 .PHONY: clusterctl
-clusterctl: generate fmt vet ## Build clusterctl binary
+clusterctl: lint-full ## Build clusterctl binary
 	go build -o bin/clusterctl sigs.k8s.io/cluster-api/cmd/clusterctl
 
 .PHONY: run
-run: generate fmt vet ## Run against the configured Kubernetes cluster in ~/.kube/config
+run: lint ## Run against the configured Kubernetes cluster in ~/.kube/config
 	go run ./cmd/manager/main.go
 
-.PHONY: deploy
-deploy: manifests ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-	kustomize build config/default | kubectl apply -f -
-
-.PHONY: manifests
-manifests: ## Generate manifests e.g. CRD, RBAC etc.
-	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
-	cp -f ./config/rbac/manager*.yaml ./config/ci/rbac/
-	cp -f ./config/manager/manager*.yaml ./config/ci/manager/
-
-.PHONY: fmt
-fmt: ## Run go fmt against code
-	go fmt ./pkg/... ./cmd/...
-
-.PHONY: vet
-vet: ## Run go vet against code
-	go vet ./pkg/... ./cmd/...
+## --------------------------------------
+## Linting
+## --------------------------------------
 
 .PHONY: lint
 lint: dep-ensure ## Lint codebase
@@ -90,13 +78,27 @@ lint: dep-ensure ## Lint codebase
 lint-full: dep-ensure ## Run slower linters to detect possible issues
 	bazel run //:lint-full $(BAZEL_ARGS)
 
+## --------------------------------------
+## Generate / Manifests
+## --------------------------------------
+
 .PHONY: generate
-generate: clientset dep-ensure ## Generate code
-	go generate ./pkg/... ./cmd/...
+generate: ## Generate code
+	$(MAKE) generate-manifests
+	$(MAKE) generate-go
 	$(MAKE) gazelle
 
-.PHONY: clientset
-clientset: ## Generate a typed clientset
+.PHONY: generate-full
+generate-full: dep-ensure ## Generate code
+	$(MAKE) generate-clientset
+	$(MAKE) generate
+
+.PHONY: generate-go
+generate-go: ## Runs go generate
+	go generate ./pkg/... ./cmd/...
+
+.PHONY: generate-clientset
+generate-clientset: ## Generate a typed clientset
 	rm -rf pkg/client
 	cd ./vendor/k8s.io/code-generator/cmd && go install ./client-gen ./lister-gen ./informer-gen
 	$$GOPATH/bin/client-gen --clientset-name clientset --input-base sigs.k8s.io/cluster-api/pkg/apis \
@@ -110,11 +112,36 @@ clientset: ## Generate a typed clientset
 		--listers-package sigs.k8s.io/cluster-api/pkg/client/listers_generated \
 		--output-package sigs.k8s.io/cluster-api/pkg/client/informers_generated \
 		--go-header-file=./hack/boilerplate/boilerplate.generatego.txt
+
+.PHONY: generate-manifests
+generate-manifests: ## Generate manifests e.g. CRD, RBAC etc.
+	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
+	cp -f ./config/rbac/manager*.yaml ./config/ci/rbac/
+	cp -f ./config/manager/manager*.yaml ./config/ci/manager/
+
+.PHONY: gazelle
+gazelle: ## Run Bazel Gazelle
+	(which bazel && ./hack/update-bazel.sh) || true
+
+.PHONY: dep-ensure
+dep-ensure: ## Runs dep-ensure and rebuilds Bazel gazelle files.
+	find vendor -name 'BUILD.bazel' -delete
+	(which dep && dep ensure -v) || true
 	$(MAKE) gazelle
 
-.PHONY: clean
-clean: ## Remove all generated files
-	rm -f bazel-*
+## --------------------------------------
+## Docker
+## --------------------------------------
+
+.PHONY: docker-build
+docker-build: generate lint-full ## Build the docker image for controller-manager
+	docker build --pull --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
+	@echo "updating kustomize image patch file for manager resource"
+	hack/sed.sh -i.tmp -e 's@image: .*@image: '"${CONTROLLER_IMG}-$(ARCH):$(TAG)"'@' ./config/default/manager_image_patch.yaml
+
+.PHONY: docker-push
+docker-push: docker-build ## Push the docker image
+	docker push $(CONTROLLER_IMG)-$(ARCH):$(TAG)
 
 .PHONY: all-docker-build
 all-docker-build: $(addprefix sub-docker-build-,$(ALL_ARCH))
@@ -124,14 +151,8 @@ all-docker-build: $(addprefix sub-docker-build-,$(ALL_ARCH))
 sub-docker-build-%:
 	$(MAKE) ARCH=$* docker-build
 
-.PHONY: docker-build
-docker-build: generate fmt vet manifests ## Build the docker image for controller-manager
-	docker build --pull --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG)
-	@echo "updating kustomize image patch file for manager resource"
-	hack/sed.sh -i.tmp -e 's@image: .*@image: '"${CONTROLLER_IMG}-$(ARCH):$(TAG)"'@' ./config/default/manager_image_patch.yaml
-
 .PHONY:all-push ## Push all the architecture docker images and fat manifest docker image
-all-push: all-docker-push push-manifest
+all-push: all-docker-push docker-push-manifest
 
 .PHONY:all-docker-push ## Push all the architecture docker images
 all-docker-push: $(addprefix sub-docker-push-,$(ALL_ARCH))
@@ -139,19 +160,8 @@ all-docker-push: $(addprefix sub-docker-push-,$(ALL_ARCH))
 sub-docker-push-%:
 	$(MAKE) ARCH=$* docker-push
 
-.PHONY: push-manifest
-push-manifest: ## Push the fat manifest docker image. TODO: Update bazel build to push manifest once https://github.com/bazelbuild/rules_docker/issues/300 get merged
-	## Minimum docker version 18.06.0 is required for creating and pushing manifest images
-	docker manifest create --amend $(CONTROLLER_IMG):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(CONTROLLER_IMG)\-&:$(TAG)~g")
-	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${CONTROLLER_IMG}:${TAG} ${CONTROLLER_IMG}-$${arch}:${TAG}; done
-	docker manifest push --purge ${CONTROLLER_IMG}:${TAG}
-
-.PHONY: docker-push
-docker-push: docker-build ## Push the docker image
-	docker push $(CONTROLLER_IMG)-$(ARCH):$(TAG)
-
 .PHONY: docker-build-ci
-docker-build-ci: generate fmt vet manifests ## Build the docker image for example provider
+docker-build-ci: generate lint-full ## Build the docker image for example provider
 	docker build --pull --build-arg ARCH=$(ARCH) . -f ./pkg/provider/example/container/Dockerfile -t $(EXAMPLE_PROVIDER_IMG)-$(ARCH):$(TAG)
 	@echo "updating kustomize image patch file for ci"
 	hack/sed.sh -i.tmp -e 's@image: .*@image: '"${EXAMPLE_PROVIDER_IMG}-$(ARCH):$(TAG)"'@' ./config/ci/manager_image_patch.yaml
@@ -159,6 +169,21 @@ docker-build-ci: generate fmt vet manifests ## Build the docker image for exampl
 .PHONY: docker-push-ci
 docker-push-ci: docker-build-ci  ## Build the docker image for ci
 	docker push "$(EXAMPLE_PROVIDER_IMG)-$(ARCH):$(TAG)"
+
+.PHONY: docker-push-manifest
+docker-push-manifest: ## Push the fat manifest docker image. TODO: Update bazel build to push manifest once https://github.com/bazelbuild/rules_docker/issues/300 get merged
+	## Minimum docker version 18.06.0 is required for creating and pushing manifest images
+	docker manifest create --amend $(CONTROLLER_IMG):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(CONTROLLER_IMG)\-&:$(TAG)~g")
+	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${CONTROLLER_IMG}:${TAG} ${CONTROLLER_IMG}-$${arch}:${TAG}; done
+	docker manifest push --purge ${CONTROLLER_IMG}:${TAG}
+
+## --------------------------------------
+## Cleanup / Verification
+## --------------------------------------
+
+.PHONY: clean
+clean: ## Remove all generated files
+	rm -f bazel-*
 
 .PHONY: verify
 verify:

--- a/hack/verify_clientset.sh
+++ b/hack/verify_clientset.sh
@@ -35,7 +35,7 @@ cleanup
 mkdir -p "${TMP_DIFFROOT}"
 cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
 
-make clientset
+make generate-clientset gazelle
 
 echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR attempts to cleanup the Makefile targets specifically around the generation. It reduces build time and the amount of times we call `dep-ensure` and `gazelle`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #945  

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
