### PR TITLE
Add MachinePhase type and helper functions

### DIFF
--- a/config/crds/cluster.sigs.k8s.io_machines.yaml
+++ b/config/crds/cluster.sigs.k8s.io_machines.yaml
@@ -590,9 +590,9 @@ spec:
                 - address
                 type: object
               type: array
-            bootstrap:
-              description: Bootstrap is the state of the bootstrap provider.
-              type: string
+            bootstrapReady:
+              description: BootstrapReady is the state of the bootstrap provider.
+              type: boolean
             conditions:
               description: 'Conditions lists the conditions synced from the node conditions
                 of the corresponding node-object. Machine-controller is responsible
@@ -658,9 +658,10 @@ spec:
                 can be added as events to the Machine object and/or logged in the
                 controller's output."
               type: string
-            infrastructure:
-              description: Infrastructure is the state of the infrastructure provider.
-              type: string
+            infrastructureReady:
+              description: InfrastructureReady is the state of the infrastructure
+                provider.
+              type: boolean
             lastUpdated:
               description: LastUpdated identifies when this status was last observed.
               format: date-time

--- a/pkg/apis/cluster/v1alpha2/BUILD.bazel
+++ b/pkg/apis/cluster/v1alpha2/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "common_type.go",
         "defaults.go",
         "doc.go",
+        "machine_phase_types.go",
         "machine_types.go",
         "machinedeployment_types.go",
         "machineset_types.go",

--- a/pkg/apis/cluster/v1alpha2/machine_phase_types.go
+++ b/pkg/apis/cluster/v1alpha2/machine_phase_types.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+// MachinePhase is a string representation of a Machine Phase.
+//
+// This type is a high-level indicator of the status of the Machine as it is provisioned,
+// from the API user’s perspective.
+//
+// The value should not be interpreted by any software components as a reliable indication
+// of the actual state of the Machine, and controllers should not use the Machine Phase field
+// value when making decisions about what action to take.
+//
+// Controllers should always look at the actual state of the Machine’s fields to make those decisions.
+type MachinePhase string
+
+var (
+	// MachinePhasePending is the first state a Machine is assigned by
+	// Cluster API Machine controller after being created.
+	MachinePhasePending = MachinePhase("pending")
+
+	// MachinePhaseProvisioning is the state when the
+	// Machine infrastructure is being created.
+	MachinePhaseProvisioning = MachinePhase("provisioning")
+
+	// MachinePhaseProvisioned is the state when its
+	// infrastructure has been created and configured.
+	MachinePhaseProvisioned = MachinePhase("provisioned")
+
+	// MachinePhaseRunning is the Machine state when it has
+	// become a Kubernetes Node in a Ready state.
+	MachinePhaseRunning = MachinePhase("running")
+
+	// MachinePhaseDeleting is the Machine state when a delete
+	// request has been sent to the API Server,
+	// but its infrastructure has not yet been fully deleted.
+	MachinePhaseDeleting = MachinePhase("deleting")
+
+	// MachinePhaseDeleted is the Machine state when the object
+	// and the related infrastructure is deleted and
+	// ready to be garbage collected by the API Server.
+	MachinePhaseDeleted = MachinePhase("deleted")
+
+	// MachinePhaseFailed is the Machine state when the system
+	// might require user intervention.
+	MachinePhaseFailed = MachinePhase("failed")
+
+	// MachinePhaseUnknown is returned if the Machine state cannot be determined.
+	MachinePhaseUnknown = MachinePhase("")
+)
+
+// MachinePhaseStringPtr is a helper method to convert MachinePhase to a string pointer.
+func MachinePhaseStringPtr(p MachinePhase) *string {
+	s := string(p)
+	return &s
+}

--- a/pkg/apis/cluster/v1alpha2/machine_types.go
+++ b/pkg/apis/cluster/v1alpha2/machine_types.go
@@ -163,11 +163,40 @@ type MachineStatus struct {
 	// +optional
 	Phase *string `json:"phase,omitempty"`
 
-	// Bootstrap is the state of the bootstrap provider.
-	Bootstrap *string `json:"bootstrap,omitempty"`
+	// BootstrapReady is the state of the bootstrap provider.
+	// +optional
+	BootstrapReady *bool `json:"bootstrapReady,omitempty"`
 
-	// Infrastructure is the state of the infrastructure provider.
-	Infrastructure *string `json:"infrastructure,omitempty"`
+	// InfrastructureReady is the state of the infrastructure provider.
+	// +optional
+	InfrastructureReady *bool `json:"infrastructureReady,omitempty"`
+}
+
+// SetTypedPhase sets the Phase field to the string representation of MachinePhase.
+func (m *MachineStatus) SetTypedPhase(p MachinePhase) {
+	m.Phase = MachinePhaseStringPtr(p)
+}
+
+// GetTypedPhase attempts to parse the Phase field and return
+// the typed MachinePhase representation as described in `machine_phase_types.go`.
+func (m *MachineStatus) GetTypedPhase() MachinePhase {
+	if m.Phase == nil {
+		return MachinePhaseUnknown
+	}
+
+	switch phase := MachinePhase(*m.Phase); phase {
+	case
+		MachinePhasePending,
+		MachinePhaseProvisioning,
+		MachinePhaseProvisioned,
+		MachinePhaseRunning,
+		MachinePhaseDeleting,
+		MachinePhaseDeleted,
+		MachinePhaseFailed:
+		return phase
+	default:
+		return MachinePhaseUnknown
+	}
 }
 
 // Bootstrap capsulates fields to configure the Machine’s bootstrapping mechanism.

--- a/pkg/apis/cluster/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha2/zz_generated.deepcopy.go
@@ -608,14 +608,14 @@ func (in *MachineStatus) DeepCopyInto(out *MachineStatus) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.Bootstrap != nil {
-		in, out := &in.Bootstrap, &out.Bootstrap
-		*out = new(string)
+	if in.BootstrapReady != nil {
+		in, out := &in.BootstrapReady, &out.BootstrapReady
+		*out = new(bool)
 		**out = **in
 	}
-	if in.Infrastructure != nil {
-		in, out := &in.Infrastructure, &out.Infrastructure
-		*out = new(string)
+	if in.InfrastructureReady != nil {
+		in, out := &in.InfrastructureReady, &out.InfrastructureReady
+		*out = new(bool)
 		**out = **in
 	}
 	return


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds information to v1alpha2 types about Machine Phases as described in the [bootstrap proposal](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/20190610-machine-states-preboot-bootstrapping.md).

In addition, it adds some helper methods on MachineStatus to ease the interaction with the Phase (*string) field.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1036

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
