### PR TITLE
Update releasing doc for better go module support

### DIFF
--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -11,20 +11,25 @@
 
 1. The container image is found in the registry `gcr.io/k8s-cluster-api` with an
    image name of `cluster-api-controller` and a tag that matches the release
-   version. For example, in the `0.0.0-alpha.4` release, the container image
-   location is `gcr.io/k8s-cluster-api/cluster-api-controller:0.0.0-alpha.4`
+   version. For example, in the `v0.1.4` release, the container image
+   location is `gcr.io/k8s-cluster-api/cluster-api-controller:v0.1.4`
+
+1. Prior to the `v0.1.4` release, the container image is found in the
+   registry `gcr.io/k8s-cluster-api` with an image name of `cluster-api-controller`
+   and a tag that matches the release version. For example, in the `0.1.3` release,
+   the container image location is `gcr.io/k8s-cluster-api/cluster-api-controller:0.1.3`
 
 ## Process
 
-For version 0.x.y:
+For version v0.x.y:
 
-1. We will target a branch called `release-0.x`.  If this is `0.x.0` then we'll
+1. We will target a branch called `release-0.x`.  If this is `v0.x.0` then we'll
    create a branch from master using `git push origin master:release-0.x`, otherwise
    simply checkout the existing branch `git checkout release-0.x`
 2. Make two changes:
    1. Change [the cluster api controller manager image
    tag][managerimg] from `:latest` to whatever version is being released
-   2. Change the `CONTROLLER_IMG` variable in the [Makefile][makefile] to the
+   1. Change the `CONTROLLER_IMG` variable in the [Makefile][makefile] to the
       version being released
    (Note that we do not release the example-provider image, so we don't tag that)
 3. Commit it using `git commit -m "Release 0.x.y"`
@@ -34,7 +39,7 @@ For version 0.x.y:
    checkout release 0.x && git pull`).  From there build and push the container
    images and fat manifest with `REGISTRY="gcr.io/k8s-cluster-api" make all-push` (on the 0.1 release branch, we
    do `make docker-push`)
-7. Create a tag from this same commit `git tag 0.x.y` and push the tag to the github repository `git push origin 0.x.y`
+7. Create an annotated tag from this same commit `git tag -a v0.x.y -m v0.x.y` and push the tag to the github repository `git push origin v0.x.y`
 8. Create a release in github based on the tag created above
 9. Manually create the release notes by going through the merged PRs since the
    last release


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the releasing doc for better go module support

**Release note**:
```release-note
NONE
```
