### PR TITLE
Add dynamic watchers to Machine controller

### DIFF
--- a/pkg/controller/machine/BUILD.bazel
+++ b/pkg/controller/machine/BUILD.bazel
@@ -53,7 +53,6 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
-        "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/envtest:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/manager:go_default_library",

--- a/pkg/controller/machine/machine_controller_phases.go
+++ b/pkg/controller/machine/machine_controller_phases.go
@@ -138,6 +138,7 @@ func (r *ReconcileMachine) reconcileExternal(ctx context.Context, m *v1alpha2.Ma
 	// Add watcher for external object, if there isn't one already.
 	_, loaded := r.externalWatchers.LoadOrStore(obj.GroupVersionKind().String(), struct{}{})
 	if !loaded && r.controller != nil {
+		klog.Infof("Adding watcher on external object %q", obj.GroupVersionKind())
 		err := r.controller.Watch(
 			&source.Kind{Type: obj},
 			&handler.EnqueueRequestForOwner{OwnerType: &clusterv1.Machine{}},

--- a/pkg/controller/machine/machine_controller_phases_test.go
+++ b/pkg/controller/machine/machine_controller_phases_test.go
@@ -324,6 +324,14 @@ func TestReconcilePhase(t *testing.T) {
 			if tc.expected != nil {
 				tc.expected(g, tc.machine)
 			}
+
+			// Test that externalWatchers detected the new kinds.
+			if tc.machine.DeletionTimestamp.IsZero() {
+				_, ok := r.externalWatchers.Load(bootstrapConfig.GroupVersionKind().String())
+				g.Expect(ok).To(gomega.BeTrue())
+				_, ok = r.externalWatchers.Load(infraConfig.GroupVersionKind().String())
+				g.Expect(ok).To(gomega.BeTrue())
+			}
 		})
 
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR is a follow-up to #1083, it adds watchers to a controller at runtime, if we haven't seen the object before.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1036 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
