### PR TITLE
Use EnsureOwnerRef in MachineDeployment and MachineSet controllers

### DIFF
--- a/pkg/controller/machinedeployment/machinedeployment_controller.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha2"
 	"sigs.k8s.io/cluster-api/pkg/util"
@@ -175,14 +176,13 @@ func (r *ReconcileMachineDeployment) reconcile(ctx context.Context, d *v1alpha2.
 	}
 
 	// Set the ownerRef with foreground deletion if there is a linked cluster.
-	if cluster != nil && len(d.OwnerReferences) == 0 {
-		blockOwnerDeletion := true
-		d.OwnerReferences = append(d.OwnerReferences, metav1.OwnerReference{
+	if cluster != nil {
+		d.OwnerReferences = util.EnsureOwnerRef(d.OwnerReferences, metav1.OwnerReference{
 			APIVersion:         cluster.APIVersion,
 			Kind:               cluster.Kind,
 			Name:               cluster.Name,
 			UID:                cluster.UID,
-			BlockOwnerDeletion: &blockOwnerDeletion,
+			BlockOwnerDeletion: pointer.BoolPtr(true),
 		})
 	}
 

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
+	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha2"
 	"sigs.k8s.io/cluster-api/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -172,14 +173,13 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 	}
 
 	// Set the ownerRef with foreground deletion if there is a linked cluster.
-	if cluster != nil && len(machineSet.OwnerReferences) == 0 {
-		blockOwnerDeletion := true
-		machineSet.OwnerReferences = append(machineSet.OwnerReferences, metav1.OwnerReference{
+	if cluster != nil {
+		machineSet.OwnerReferences = util.EnsureOwnerRef(machineSet.OwnerReferences, metav1.OwnerReference{
 			APIVersion:         cluster.APIVersion,
 			Kind:               cluster.Kind,
 			Name:               cluster.Name,
 			UID:                cluster.UID,
-			BlockOwnerDeletion: &blockOwnerDeletion,
+			BlockOwnerDeletion: pointer.BoolPtr(true),
 		})
 	}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR updates the other controllers to use util.EnsureOwnerRef and remove the size check.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
