### PR TITLE
✨ Machine controller: drain node before machine deletion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,3 +21,5 @@ run:
   deadline: 2m
   skip-files:
     - "zz_generated.*\\.go$"
+  skip-dirs:
+    - external-libs

--- a/api/v1alpha2/machine_types.go
+++ b/api/v1alpha2/machine_types.go
@@ -31,6 +31,9 @@ const (
 
 	// MachineControlPlaneLabelName is the label set on machines part of a control plane.
 	MachineControlPlaneLabelName = "cluster.x-k8s.io/control-plane"
+
+	// ExcludeNodeDrainingAnnotation annotation explicitly skips node draining if set
+	ExcludeNodeDrainingAnnotation = "machine.cluster.x-k8s.io.io/exclude-node-draining"
 )
 
 // ANCHOR: MachineSpec

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -29,12 +29,15 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	capierrors "sigs.k8s.io/cluster-api/errors"
+	kubedrain "sigs.k8s.io/cluster-api/external-libs/kubernetes-drain"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -59,6 +62,7 @@ type MachineReconciler struct {
 	Client client.Client
 	Log    logr.Logger
 
+	config           *rest.Config
 	controller       controller.Controller
 	recorder         record.EventRecorder
 	externalWatchers sync.Map
@@ -72,6 +76,7 @@ func (r *MachineReconciler) SetupWithManager(mgr ctrl.Manager, options controlle
 
 	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("machine-controller")
+	r.config = mgr.GetConfig()
 	return err
 }
 
@@ -184,6 +189,15 @@ func (r *MachineReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 			return ctrl.Result{}, err
 		}
 	} else {
+		// Drain node before deletion
+		if _, exists := m.ObjectMeta.Annotations[clusterv1.ExcludeNodeDrainingAnnotation]; !exists {
+			klog.Infof("Draining node %q for machine %q", m.Status.NodeRef.Name, m.Name)
+			if err := r.drainNode(ctx, cluster, m.Status.NodeRef.Name, m.Name); err != nil {
+				r.recorder.Eventf(m, corev1.EventTypeWarning, "FailedDrainNode", "error draining Machine's node: %v", err)
+				return ctrl.Result{}, err
+			}
+			r.recorder.Eventf(m, corev1.EventTypeNormal, "SuccessfulDrainNode", "success draining Machine %q node %q", m.Name, m.Status.NodeRef.Name)
+		}
 		klog.Infof("Deleting node %q for machine %q", m.Status.NodeRef.Name, m.Name)
 
 		var deleteNodeErr error
@@ -240,6 +254,73 @@ func (r *MachineReconciler) isDeleteNodeAllowed(ctx context.Context, machine *cl
 		// Otherwise it is okay to delete the NodeRef.
 		return nil
 	}
+}
+
+func (r *MachineReconciler) drainNode(ctx context.Context, cluster *clusterv1.Cluster, nodeName string, machineName string) error {
+	var kubeClient kubernetes.Interface
+	if cluster == nil {
+		var err error
+		kubeClient, err = kubernetes.NewForConfig(r.config)
+		if err != nil {
+			return errors.Errorf("unable to build kube client: %v", err)
+		}
+	} else {
+		// Otherwise, proceed to get the remote cluster client and get the Node.
+		remoteClient, err := remote.NewClusterClient(r.Client, cluster)
+		if err != nil {
+			klog.Errorf("Error creating a remote client for cluster %q while deleting Machine %q, won't retry: %v",
+				cluster.Name, nodeName, err)
+			return nil
+		}
+		var err2 error
+		kubeClient, err2 = kubernetes.NewForConfig(remoteClient.RESTConfig())
+		if err2 != nil {
+			klog.Errorf("Error creating a remote client for cluster %q while deleting Machine %q, won't retry: %v",
+				cluster.Name, nodeName, err)
+			return nil
+		}
+	}
+
+	node, err := kubeClient.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// If an admin deletes the node directly, we'll end up here.
+			klog.Infof("Machine %v: Could not find node %v from noderef, it may have already been deleted: %v", machineName, nodeName, cluster.Name)
+			return nil
+		}
+		return errors.Errorf("unable to get node %q: %v", nodeName, err)
+	}
+
+	drainer := &kubedrain.Helper{
+		Client:              kubeClient,
+		Force:               true,
+		IgnoreAllDaemonSets: true,
+		DeleteLocalData:     true,
+		GracePeriodSeconds:  -1,
+		// If a pod is not evicted in 20 second, retry the eviction next time the
+		// machine gets reconciled again (to allow other machines to be reconciled)
+		Timeout:               20 * time.Second,
+		OnPodDeletedOrEvicted: onPodDeletedOrEvicted,
+		Out:                   writer{klog.Info},
+		ErrOut:                writer{klog.Error},
+		DryRun:                false,
+	}
+
+	if err := kubedrain.RunCordonOrUncordon(drainer, node, true); err != nil {
+		// Machine still tries to terminate after drain failure
+		klog.Errorf("%q: node cordon failed %q; %v", cluster.Name, nodeName, err)
+		return errors.Errorf("unable to cordon node %s: %v", node.Name, err)
+	}
+
+	if err := kubedrain.RunNodeDrain(drainer, node.Name); err != nil {
+		// Machine still tries to terminate after drain failure
+		klog.Warningf("%q: drain failed for node %q; %v", cluster.Name, nodeName, err)
+		return &capierrors.RequeueAfterError{RequeueAfter: 20 * time.Second}
+	}
+
+	klog.Infof("Drain successful for machine %q", cluster.Name)
+
+	return nil
 }
 
 func (r *MachineReconciler) deleteNode(ctx context.Context, cluster *clusterv1.Cluster, name string) error {
@@ -309,4 +390,26 @@ func (r *MachineReconciler) reconcileDeleteExternal(ctx context.Context, m *clus
 
 func (r *MachineReconciler) shouldAdopt(m *clusterv1.Machine) bool {
 	return !util.HasOwner(m.OwnerReferences, clusterv1.GroupVersion.String(), []string{"MachineSet", "Cluster"})
+}
+
+// writer implements io.Writer interface as a pass-through for klog.
+type writer struct {
+	logFunc func(args ...interface{})
+}
+
+// Write passes string(p) into writer's logFunc and always returns len(p)
+func (w writer) Write(p []byte) (n int, err error) {
+	w.logFunc(string(p))
+	return len(p), nil
+}
+
+// onPodDeletedOrEvicted is called by drain.Helper, when the pod has been deleted or evicted
+func onPodDeletedOrEvicted(pod *corev1.Pod, usingEviction bool) {
+	var verbStr string
+	if usingEviction {
+		verbStr = "evicted"
+	} else {
+		verbStr = "deleted"
+	}
+	klog.Infof("pod %s/%s %s\n", pod.Namespace, pod.Name, verbStr)
 }

--- a/external-libs/README.md
+++ b/external-libs/README.md
@@ -1,0 +1,2 @@
+This directory is used to copy code from other projects in-tree. This
+directory is excluded from linters.

--- a/external-libs/kubernetes-drain/README.md
+++ b/external-libs/kubernetes-drain/README.md
@@ -1,0 +1,2 @@
+The code in this directory has been copied from:
+github.com/kubernetes/kubectl/pkg/drain@75fdf29ade9e535ff5801a9321d55d1adf6a996b

--- a/external-libs/kubernetes-drain/cordon.go
+++ b/external-libs/kubernetes-drain/cordon.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drain
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CordonHelper wraps functionality to cordon/uncordon nodes
+type CordonHelper struct {
+	node    *corev1.Node
+	desired bool
+}
+
+// NewCordonHelper returns a new CordonHelper
+func NewCordonHelper(node *corev1.Node) *CordonHelper {
+	return &CordonHelper{
+		node: node,
+	}
+}
+
+// NewCordonHelperFromRuntimeObject returns a new CordonHelper, or an error if given object is not a
+// node or cannot be encoded as JSON
+func NewCordonHelperFromRuntimeObject(nodeObject runtime.Object, scheme *runtime.Scheme, gvk schema.GroupVersionKind) (*CordonHelper, error) {
+	nodeObject, err := scheme.ConvertToVersion(nodeObject, gvk.GroupVersion())
+	if err != nil {
+		return nil, err
+	}
+
+	node, ok := nodeObject.(*corev1.Node)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type %T", nodeObject)
+	}
+
+	return NewCordonHelper(node), nil
+}
+
+// UpdateIfRequired returns true if c.node.Spec.Unschedulable isn't already set,
+// or false when no change is needed
+func (c *CordonHelper) UpdateIfRequired(desired bool) bool {
+	c.desired = desired
+	if c.node.Spec.Unschedulable == c.desired {
+		return false
+	}
+	return true
+}
+
+// PatchOrReplace uses given clientset to update the node status, either by patching or
+// updating the given node object; it may return error if the object cannot be encoded as
+// JSON, or if either patch or update calls fail; it will also return a second error
+// whenever creating a patch has failed
+func (c *CordonHelper) PatchOrReplace(clientset kubernetes.Interface) (error, error) {
+	client := clientset.CoreV1().Nodes()
+
+	oldData, err := json.Marshal(c.node)
+	if err != nil {
+		return err, nil
+	}
+
+	c.node.Spec.Unschedulable = c.desired
+
+	newData, err := json.Marshal(c.node)
+	if err != nil {
+		return err, nil
+	}
+
+	patchBytes, patchErr := strategicpatch.CreateTwoWayMergePatch(oldData, newData, c.node)
+	if patchErr == nil {
+		_, err = client.Patch(c.node.Name, types.StrategicMergePatchType, patchBytes)
+	} else {
+		_, err = client.Update(c.node)
+	}
+	return err, patchErr
+}

--- a/external-libs/kubernetes-drain/default.go
+++ b/external-libs/kubernetes-drain/default.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drain
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// This file contains default implementations of how to
+// drain/cordon/uncordon nodes.  These functions may be called
+// directly, or their functionality copied into your own code, for
+// example if you want different output behaviour.
+
+// RunNodeDrain shows the canonical way to drain a node.
+// You should first cordon the node, e.g. using RunCordonOrUncordon
+func RunNodeDrain(drainer *Helper, nodeName string) error {
+	// TODO(justinsb): Ensure we have adequate e2e coverage of this function in library consumers
+	list, errs := drainer.GetPodsForDeletion(nodeName)
+	if errs != nil {
+		return utilerrors.NewAggregate(errs)
+	}
+	if warnings := list.Warnings(); warnings != "" {
+		fmt.Fprintf(drainer.ErrOut, "WARNING: %s\n", warnings)
+	}
+
+	if err := drainer.DeleteOrEvictPods(list.Pods()); err != nil {
+		// Maybe warn about non-deleted pods here
+		return err
+	}
+	return nil
+}
+
+// RunCordonOrUncordon demonstrates the canonical way to cordon or uncordon a Node
+func RunCordonOrUncordon(drainer *Helper, node *corev1.Node, desired bool) error {
+	// TODO(justinsb): Ensure we have adequate e2e coverage of this function in library consumers
+	c := NewCordonHelper(node)
+
+	if updateRequired := c.UpdateIfRequired(desired); !updateRequired {
+		// Already done
+		return nil
+	}
+
+	err, patchErr := c.PatchOrReplace(drainer.Client)
+	if patchErr != nil {
+		return patchErr
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/external-libs/kubernetes-drain/drain.go
+++ b/external-libs/kubernetes-drain/drain.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drain
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// EvictionKind represents the kind of evictions object
+	EvictionKind = "Eviction"
+	// EvictionSubresource represents the kind of evictions object as pod's subresource
+	EvictionSubresource = "pods/eviction"
+)
+
+// Helper contains the parameters to control the behaviour of drainer
+type Helper struct {
+	Client              kubernetes.Interface
+	Force               bool
+	GracePeriodSeconds  int
+	IgnoreAllDaemonSets bool
+	Timeout             time.Duration
+	DeleteLocalData     bool
+	Selector            string
+	PodSelector         string
+	Out                 io.Writer
+	ErrOut              io.Writer
+
+	// TODO(justinsb): unnecessary?
+	DryRun bool
+
+	// OnPodDeletedOrEvicted is called when a pod is evicted/deleted; for printing progress output
+	OnPodDeletedOrEvicted func(pod *corev1.Pod, usingEviction bool)
+}
+
+// CheckEvictionSupport uses Discovery API to find out if the server support
+// eviction subresource If support, it will return its groupVersion; Otherwise,
+// it will return an empty string
+func CheckEvictionSupport(clientset kubernetes.Interface) (string, error) {
+	discoveryClient := clientset.Discovery()
+	groupList, err := discoveryClient.ServerGroups()
+	if err != nil {
+		return "", err
+	}
+	foundPolicyGroup := false
+	var policyGroupVersion string
+	for _, group := range groupList.Groups {
+		if group.Name == "policy" {
+			foundPolicyGroup = true
+			policyGroupVersion = group.PreferredVersion.GroupVersion
+			break
+		}
+	}
+	if !foundPolicyGroup {
+		return "", nil
+	}
+	resourceList, err := discoveryClient.ServerResourcesForGroupVersion("v1")
+	if err != nil {
+		return "", err
+	}
+	for _, resource := range resourceList.APIResources {
+		if resource.Name == EvictionSubresource && resource.Kind == EvictionKind {
+			return policyGroupVersion, nil
+		}
+	}
+	return "", nil
+}
+
+func (d *Helper) makeDeleteOptions() *metav1.DeleteOptions {
+	deleteOptions := &metav1.DeleteOptions{}
+	if d.GracePeriodSeconds >= 0 {
+		gracePeriodSeconds := int64(d.GracePeriodSeconds)
+		deleteOptions.GracePeriodSeconds = &gracePeriodSeconds
+	}
+	return deleteOptions
+}
+
+// DeletePod will delete the given pod, or return an error if it couldn't
+func (d *Helper) DeletePod(pod corev1.Pod) error {
+	return d.Client.CoreV1().Pods(pod.Namespace).Delete(pod.Name, d.makeDeleteOptions())
+}
+
+// EvictPod will evict the give pod, or return an error if it couldn't
+func (d *Helper) EvictPod(pod corev1.Pod, policyGroupVersion string) error {
+	eviction := &policyv1beta1.Eviction{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: policyGroupVersion,
+			Kind:       EvictionKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+		DeleteOptions: d.makeDeleteOptions(),
+	}
+	// Remember to change change the URL manipulation func when Eviction's version change
+	return d.Client.PolicyV1beta1().Evictions(eviction.Namespace).Evict(eviction)
+}
+
+// GetPodsForDeletion receives resource info for a node, and returns those pods as PodDeleteList,
+// or error if it cannot list pods. All pods that are ready to be deleted can be obtained with .Pods(),
+// and string with all warning can be obtained with .Warnings(), and .Errors() for all errors that
+// occurred during deletion.
+func (d *Helper) GetPodsForDeletion(nodeName string) (*podDeleteList, []error) {
+	labelSelector, err := labels.Parse(d.PodSelector)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	podList, err := d.Client.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{
+		LabelSelector: labelSelector.String(),
+		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nodeName}).String()})
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	pods := []podDelete{}
+
+	for _, pod := range podList.Items {
+		var status podDeleteStatus
+		for _, filter := range d.makeFilters() {
+			status = filter(pod)
+			if !status.delete {
+				// short-circuit as soon as pod is filtered out
+				// at that point, there is no reason to run pod
+				// through any additional filters
+				break
+			}
+		}
+		pods = append(pods, podDelete{
+			pod:    pod,
+			status: status,
+		})
+	}
+
+	list := &podDeleteList{items: pods}
+
+	if errs := list.errors(); len(errs) > 0 {
+		return list, errs
+	}
+
+	return list, nil
+}
+
+// DeleteOrEvictPods deletes or evicts the pods on the api server
+func (d *Helper) DeleteOrEvictPods(pods []corev1.Pod) error {
+	if len(pods) == 0 {
+		return nil
+	}
+
+	policyGroupVersion, err := CheckEvictionSupport(d.Client)
+	if err != nil {
+		return err
+	}
+
+	// TODO(justinsb): unnecessary?
+	getPodFn := func(namespace, name string) (*corev1.Pod, error) {
+		return d.Client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+	}
+
+	if len(policyGroupVersion) > 0 {
+		return d.evictPods(pods, policyGroupVersion, getPodFn)
+	}
+
+	return d.deletePods(pods, getPodFn)
+}
+
+func (d *Helper) evictPods(pods []corev1.Pod, policyGroupVersion string, getPodFn func(namespace, name string) (*corev1.Pod, error)) error {
+	returnCh := make(chan error, 1)
+
+	for _, pod := range pods {
+		go func(pod corev1.Pod, returnCh chan error) {
+			for {
+				fmt.Fprintf(d.Out, "evicting pod %q\n", pod.Name)
+				err := d.EvictPod(pod, policyGroupVersion)
+				if err == nil {
+					break
+				} else if apierrors.IsNotFound(err) {
+					returnCh <- nil
+					return
+				} else if apierrors.IsTooManyRequests(err) {
+					fmt.Fprintf(d.ErrOut, "error when evicting pod %q (will retry after 5s): %v\n", pod.Name, err)
+					time.Sleep(5 * time.Second)
+				} else {
+					returnCh <- fmt.Errorf("error when evicting pod %q: %v", pod.Name, err)
+					return
+				}
+			}
+			_, err := waitForDelete([]corev1.Pod{pod}, 1*time.Second, time.Duration(math.MaxInt64), true, getPodFn, d.OnPodDeletedOrEvicted)
+			if err == nil {
+				returnCh <- nil
+			} else {
+				returnCh <- fmt.Errorf("error when waiting for pod %q terminating: %v", pod.Name, err)
+			}
+		}(pod, returnCh)
+	}
+
+	doneCount := 0
+	var errors []error
+
+	// 0 timeout means infinite, we use MaxInt64 to represent it.
+	var globalTimeout time.Duration
+	if d.Timeout == 0 {
+		globalTimeout = time.Duration(math.MaxInt64)
+	} else {
+		globalTimeout = d.Timeout
+	}
+	globalTimeoutCh := time.After(globalTimeout)
+	numPods := len(pods)
+	for doneCount < numPods {
+		select {
+		case err := <-returnCh:
+			doneCount++
+			if err != nil {
+				errors = append(errors, err)
+			}
+		case <-globalTimeoutCh:
+			return fmt.Errorf("drain did not complete within %v", globalTimeout)
+		}
+	}
+	return utilerrors.NewAggregate(errors)
+}
+
+func (d *Helper) deletePods(pods []corev1.Pod, getPodFn func(namespace, name string) (*corev1.Pod, error)) error {
+	// 0 timeout means infinite, we use MaxInt64 to represent it.
+	var globalTimeout time.Duration
+	if d.Timeout == 0 {
+		globalTimeout = time.Duration(math.MaxInt64)
+	} else {
+		globalTimeout = d.Timeout
+	}
+	for _, pod := range pods {
+		err := d.DeletePod(pod)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	_, err := waitForDelete(pods, 1*time.Second, globalTimeout, false, getPodFn, d.OnPodDeletedOrEvicted)
+	return err
+}
+
+func waitForDelete(pods []corev1.Pod, interval, timeout time.Duration, usingEviction bool, getPodFn func(string, string) (*corev1.Pod, error), onDoneFn func(pod *corev1.Pod, usingEviction bool)) ([]corev1.Pod, error) {
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		pendingPods := []corev1.Pod{}
+		for i, pod := range pods {
+			p, err := getPodFn(pod.Namespace, pod.Name)
+			if apierrors.IsNotFound(err) || (p != nil && p.ObjectMeta.UID != pod.ObjectMeta.UID) {
+				if onDoneFn != nil {
+					onDoneFn(&pod, usingEviction)
+				}
+				continue
+			} else if err != nil {
+				return false, err
+			} else {
+				pendingPods = append(pendingPods, pods[i])
+			}
+		}
+		pods = pendingPods
+		if len(pendingPods) > 0 {
+			return false, nil
+		}
+		return true, nil
+	})
+	return pods, err
+}

--- a/external-libs/kubernetes-drain/filters.go
+++ b/external-libs/kubernetes-drain/filters.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package drain
+
+import (
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	daemonSetFatal      = "DaemonSet-managed Pods (use --ignore-daemonsets to ignore)"
+	daemonSetWarning    = "ignoring DaemonSet-managed Pods"
+	localStorageFatal   = "Pods with local storage (use --delete-local-data to override)"
+	localStorageWarning = "deleting Pods with local storage"
+	unmanagedFatal      = "Pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet (use --force to override)"
+	unmanagedWarning    = "deleting Pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet"
+)
+
+type podDelete struct {
+	pod    corev1.Pod
+	status podDeleteStatus
+}
+
+type podDeleteList struct {
+	items []podDelete
+}
+
+func (l *podDeleteList) Pods() []corev1.Pod {
+	pods := []corev1.Pod{}
+	for _, i := range l.items {
+		if i.status.delete {
+			pods = append(pods, i.pod)
+		}
+	}
+	return pods
+}
+
+func (l *podDeleteList) Warnings() string {
+	ps := make(map[string][]string)
+	for _, i := range l.items {
+		if i.status.reason == podDeleteStatusTypeWarning {
+			ps[i.status.message] = append(ps[i.status.message], fmt.Sprintf("%s/%s", i.pod.Namespace, i.pod.Name))
+		}
+	}
+
+	msgs := []string{}
+	for key, pods := range ps {
+		msgs = append(msgs, fmt.Sprintf("%s: %s", key, strings.Join(pods, ", ")))
+	}
+	return strings.Join(msgs, "; ")
+}
+
+func (l *podDeleteList) errors() []error {
+	failedPods := make(map[string][]string)
+	for _, i := range l.items {
+		if i.status.reason == podDeleteStatusTypeError {
+			msg := i.status.message
+			if msg == "" {
+				msg = "unexpected error"
+			}
+			failedPods[msg] = append(failedPods[msg], fmt.Sprintf("%s/%s", i.pod.Namespace, i.pod.Name))
+		}
+	}
+	errs := make([]error, 0)
+	for msg, pods := range failedPods {
+		errs = append(errs, fmt.Errorf("cannot delete %s: %s", msg, strings.Join(pods, ", ")))
+	}
+	return errs
+}
+
+type podDeleteStatus struct {
+	delete  bool
+	reason  string
+	message string
+}
+
+// Takes a pod and returns a PodDeleteStatus
+type podFilter func(corev1.Pod) podDeleteStatus
+
+const (
+	podDeleteStatusTypeOkay    = "Okay"
+	podDeleteStatusTypeSkip    = "Skip"
+	podDeleteStatusTypeWarning = "Warning"
+	podDeleteStatusTypeError   = "Error"
+)
+
+func makePodDeleteStatusOkay() podDeleteStatus {
+	return podDeleteStatus{
+		delete: true,
+		reason: podDeleteStatusTypeOkay,
+	}
+}
+
+func makePodDeleteStatusSkip() podDeleteStatus {
+	return podDeleteStatus{
+		delete: false,
+		reason: podDeleteStatusTypeSkip,
+	}
+}
+
+func makePodDeleteStatusWithWarning(delete bool, message string) podDeleteStatus {
+	return podDeleteStatus{
+		delete:  delete,
+		reason:  podDeleteStatusTypeWarning,
+		message: message,
+	}
+}
+
+func makePodDeleteStatusWithError(message string) podDeleteStatus {
+	return podDeleteStatus{
+		delete:  false,
+		reason:  podDeleteStatusTypeError,
+		message: message,
+	}
+}
+
+func (d *Helper) makeFilters() []podFilter {
+	return []podFilter{
+		d.daemonSetFilter,
+		d.mirrorPodFilter,
+		d.localStorageFilter,
+		d.unreplicatedFilter,
+	}
+}
+
+func hasLocalStorage(pod corev1.Pod) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.EmptyDir != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (d *Helper) daemonSetFilter(pod corev1.Pod) podDeleteStatus {
+	// Note that we return false in cases where the pod is DaemonSet managed,
+	// regardless of flags.
+	//
+	// The exception is for pods that are orphaned (the referencing
+	// management resource - including DaemonSet - is not found).
+	// Such pods will be deleted if --force is used.
+	controllerRef := metav1.GetControllerOf(&pod)
+	if controllerRef == nil || controllerRef.Kind != appsv1.SchemeGroupVersion.WithKind("DaemonSet").Kind {
+		return makePodDeleteStatusOkay()
+	}
+	// Any finished pod can be removed.
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return makePodDeleteStatusOkay()
+	}
+
+	if _, err := d.Client.AppsV1().DaemonSets(pod.Namespace).Get(controllerRef.Name, metav1.GetOptions{}); err != nil {
+		// remove orphaned pods with a warning if --force is used
+		if apierrors.IsNotFound(err) && d.Force {
+			return makePodDeleteStatusWithWarning(true, err.Error())
+		}
+
+		return makePodDeleteStatusWithError(err.Error())
+	}
+
+	if !d.IgnoreAllDaemonSets {
+		return makePodDeleteStatusWithError(daemonSetFatal)
+	}
+
+	return makePodDeleteStatusWithWarning(false, daemonSetWarning)
+}
+
+func (d *Helper) mirrorPodFilter(pod corev1.Pod) podDeleteStatus {
+	if _, found := pod.ObjectMeta.Annotations[corev1.MirrorPodAnnotationKey]; found {
+		return makePodDeleteStatusSkip()
+	}
+	return makePodDeleteStatusOkay()
+}
+
+func (d *Helper) localStorageFilter(pod corev1.Pod) podDeleteStatus {
+	if !hasLocalStorage(pod) {
+		return makePodDeleteStatusOkay()
+	}
+	// Any finished pod can be removed.
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return makePodDeleteStatusOkay()
+	}
+	if !d.DeleteLocalData {
+		return makePodDeleteStatusWithError(localStorageFatal)
+	}
+
+	return makePodDeleteStatusWithWarning(true, localStorageWarning)
+}
+
+func (d *Helper) unreplicatedFilter(pod corev1.Pod) podDeleteStatus {
+	// any finished pod can be removed
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+		return makePodDeleteStatusOkay()
+	}
+
+	controllerRef := metav1.GetControllerOf(&pod)
+	if controllerRef != nil {
+		return makePodDeleteStatusOkay()
+	}
+	if d.Force {
+		return makePodDeleteStatusWithWarning(true, unmanagedWarning)
+	}
+	return makePodDeleteStatusWithError(unmanagedFatal)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Centralizes node-drain behavior into cluster-api instead of down-stream actuators.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/994

The node draining code is copied from
github.com/kubernetes/kubectl/pkg/drain
@75fdf29ade9e535ff5801a9321d55d1adf6a996b

This PR also includes a commit to disable linters for the imported drain code.

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required: machine-controller now attempts to cordon and drain nodes before deletion.  Actuators should be updated to remove this behavior.
```
