### PR TITLE
Add Dockerfile for plantuml image used to generate proposal diagrams

### DIFF
--- a/docs/proposals/images/machine-states-preboot/Dockerfile
+++ b/docs/proposals/images/machine-states-preboot/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2019 The Kubernetes Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Recommended usage:
+#
+# - Run an ephemeral container
+# - Mount the current working directory into the container.
+# - Run the entrypoint as the user invoking docker run. Otherwise the output
+#   files will be owned by root, the default user.
+#
+# - Example:
+# docker run \
+# 	--rm \
+# 	--volume ${PWD}:/figures \
+# 	--user $(shell id --user):$(shell id --group) \
+# 	${IMAGE_TAG} \
+# 	-v /figures/*.plantuml
+
+FROM maven:3-jdk-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends graphviz fonts-symbola fonts-wqy-zenhei && rm -rf /var/lib/apt/lists/*
+RUN wget -O /plantuml.jar http://sourceforge.net/projects/plantuml/files/plantuml.1.2019.6.jar/download
+
+# By default, java writes a 'hsperfdata_<username>' directory in the work dir.
+# This directory is not needed; to ensure it is not written, we set `-XX:-UsePerfData`
+ENTRYPOINT [ "java", "-XX:-UsePerfData", "-jar", "/plantuml.jar" ]

--- a/docs/proposals/images/machine-states-preboot/README.md
+++ b/docs/proposals/images/machine-states-preboot/README.md
@@ -1,0 +1,20 @@
+# Figures with PlantUML
+
+Most of the figures for this proposal are generated with [PlantUML](http://plantuml.com/), an [open-source](https://sourceforge.net/projects/plantuml/) tool that can generate sequence, use case, class, activity, state, object, and other kinds of UML digrams.
+
+PlantUML requires the Java runtime, so we have published a Docker container image that includes all dependencies (to publish your own, use `Dockerfile` in this directory).
+
+## Generating figures
+
+To generate diagrams in this directory, `make figures`.
+
+In general, to generate the figure described in `foo.plantuml`:
+```
+SRC="foo.plantuml"
+docker run \
+	--rm \
+	--volume ${PWD}:/figures \
+	--user $(shell id --user):$(shell id --group) \
+	dpf9/plantuml:1.2019.6 \
+	-v /figures/${SRC}
+```


### PR DESCRIPTION
**What this PR does / why we need it**:
Provides Dockerfile for plantuml image

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
#1070 

This is just the Dockerfile. I can work on the publishing in a separate PR.