### PR TITLE
Do not delete NodeRef for last control plane node

### DIFF
--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -349,17 +349,17 @@ func (r *ReconcileMachine) getMachines(ctx context.Context, machine *clusterv1.M
 		return nil, nil
 	}
 
-	mlist := &clusterv1.MachineList{}
-	lbls := map[string]string{clusterv1.MachineClusterLabelName: clusterName}
-	listOptions := client.InNamespace(machine.Namespace).MatchingLabels(lbls)
+	machineList := &clusterv1.MachineList{}
+	labels := map[string]string{clusterv1.MachineClusterLabelName: clusterName}
+	listOptions := client.InNamespace(machine.Namespace).MatchingLabels(labels)
 
-	if err := r.Client.List(ctx, listOptions, mlist); err != nil {
-		return nil, errors.Wrapf(err, "Failed to list machines")
+	if err := r.Client.List(ctx, listOptions, machineList); err != nil {
+		return nil, errors.Wrap(err, "failed to list machines")
 	}
 
-	machines := make([]*clusterv1.Machine, len(mlist.Items))
-	for i := range mlist.Items {
-		machines[i] = &mlist.Items[i]
+	machines := make([]*clusterv1.Machine, len(machineList.Items))
+	for i := range machineList.Items {
+		machines[i] = &machineList.Items[i]
 	}
 
 	return machines, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This patch fixes a bug that occurs when the NodeRef is deleted for the last control plane node in a cluster. A timeout error would occur because the last machine would have already been deleted, and the cluster would no longer be active to receive the delete node request.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1105 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Fixes bug when deleting NodeRef for last control plane member in a cluster
```
