### PR TITLE
Don't swallow errors when reconciling noderef

### DIFF
--- a/pkg/controller/noderef/noderef_controller.go
+++ b/pkg/controller/noderef/noderef_controller.go
@@ -135,9 +135,14 @@ func (r *ReconcileNodeRef) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	result, err := r.reconcile(ctx, cluster, machine)
 	if err != nil {
+		if err == ErrNodeNotFound {
+			klog.Warningf("Failed to assign NodeRef to Machine %q: cannot find a matching Node in namespace %q, retrying later", machine.Name, machine.Namespace)
+			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+
 		klog.Errorf("Failed to assign NodeRef to Machine %q: %v", request.NamespacedName, err)
 		r.recorder.Event(machine, apicorev1.EventTypeWarning, "FailedSetNodeRef", err.Error())
-		return result, err
+		return reconcile.Result{}, err
 	}
 
 	klog.Infof("Set Machine's (%q in namespace %q) NodeRef to %q", machine.Name, machine.Namespace, machine.Status.NodeRef.Name)
@@ -164,10 +169,6 @@ func (r *ReconcileNodeRef) reconcile(ctx context.Context, cluster *v1alpha2.Clus
 	// Get the Node reference.
 	nodeRef, err := r.getNodeReference(corev1Client, providerID)
 	if err != nil {
-		if err == ErrNodeNotFound {
-			klog.Warningf("Cannot find a matching Node for Machine %q in namespace %q, retrying later", machine.Name, machine.Namespace)
-			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
-		}
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue where an error was being mistakenly swallowed which would result in a panic. It also enforces logging the targeted error as a warning.

**Which issue(s) this PR fixes**:

Fixes #1104

**Special notes for your reviewer**:

I took some time because I wanted to add some test(s) but I can see the growing interest in having this fixed ASAP, and I don't feel prepared to work on a test that proves the fix. I hope it's enough.

**Release note**:

```release-note
NONE
```

cc @chuckha @ykakarap @akutz @vincepri @ncdc