### PR TITLE
Rereconcile machineset if not all replicas are ready

### DIFF
--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -271,6 +271,12 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 		return reconcile.Result{RequeueAfter: time.Duration(updatedMS.Spec.MinReadySeconds) * time.Second}, nil
 	}
 
+	// Quickly rereconcile until the nodes become Ready.
+	if updatedMS.Status.ReadyReplicas != replicas {
+		klog.V(4).Info("Some nodes are not ready yet, requeuing until they are ready")
+		return reconcile.Result{RequeueAfter: 15 * time.Second}, nil
+	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/machineset/status.go
+++ b/pkg/controller/machineset/status.go
@@ -87,7 +87,7 @@ func (c *ReconcileMachineSet) calculateStatus(ms *v1alpha2.MachineSet, filteredM
 // updateMachineSetStatus attempts to update the Status.Replicas of the given MachineSet, with a single GET/PUT retry.
 func updateMachineSetStatus(c client.Client, ms *v1alpha2.MachineSet, newStatus v1alpha2.MachineSetStatus) (*v1alpha2.MachineSet, error) {
 	// This is the steady state. It happens when the MachineSet doesn't have any expectations, since
-	// we do a periodic relist every 30s. If the generations differ but the replicas are
+	// we do a periodic relist every 10 minutes. If the generations differ but the replicas are
 	// the same, a caller might've resized to the same replica count.
 	if ms.Status.Replicas == newStatus.Replicas &&
 		ms.Status.FullyLabeledReplicas == newStatus.FullyLabeledReplicas &&


### PR DESCRIPTION
This prevents us waiting the full re-list while updating a MachineDeployment

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR will rereconcile a MachineSet if the number of ready replicas and the number of expected replicas are not equal. This can also be read as rereconcile the machine set quickly until all replicas are ready, do not wait the standard amount of time between a full re-list.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1127 

**Special notes for your reviewer**:
shoutout to @ncdc for helping me track down this bug and to the docker-provider for making this more or less not a pain to test.

This should be back ported to release-0.1.

**Release note**:
```release-note
NONE
```

/assign @vincepri @ncdc 