### PR TITLE
Add full vendor utilities for gomod

### DIFF
--- a/hack/update-vendor.sh
+++ b/hack/update-vendor.sh
@@ -23,4 +23,13 @@ source "${KUBE_ROOT}/hack/ensure-go.sh"
 
 go mod tidy
 go mod vendor
+
+# Copy full dependencies if needed.
+for dep in $(cat ${KUBE_ROOT}/go.vendor); do
+    src=$(go mod download -json ${dep} | jq -r .Dir)
+    dst="${KUBE_ROOT}/vendor/${dep}"
+    cp -af "${src}/" "${dst}"
+    chmod -R +w ${dst}
+done
+
 go mod verify


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds some utilities to deal with go modules default-on pruning. It adds a new file `go.vendor` that should specify a newline-delimited list of repositories that we'd like to copy from the module cache.

This isn't currently used in Cluster API, but it's going to be useful in the future for providers using go modules.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
