### PR TITLE
[0.1] Rereconcile machineset if not all replicas are ready (#1133)

### DIFF
--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -256,6 +256,12 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 		return reconcile.Result{RequeueAfter: time.Duration(updatedMS.Spec.MinReadySeconds) * time.Second}, nil
 	}
 
+	// Quickly rereconcile until the nodes become Ready.
+	if updatedMS.Status.ReadyReplicas != replicas {
+		klog.V(4).Info("Some nodes are not ready yet, requeuing until they are ready")
+		return reconcile.Result{RequeueAfter: 15 * time.Second}, nil
+	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/machineset/status.go
+++ b/pkg/controller/machineset/status.go
@@ -87,7 +87,7 @@ func (c *ReconcileMachineSet) calculateStatus(ms *v1alpha1.MachineSet, filteredM
 // updateMachineSetStatus attempts to update the Status.Replicas of the given MachineSet, with a single GET/PUT retry.
 func updateMachineSetStatus(c client.Client, ms *v1alpha1.MachineSet, newStatus v1alpha1.MachineSetStatus) (*v1alpha1.MachineSet, error) {
 	// This is the steady state. It happens when the MachineSet doesn't have any expectations, since
-	// we do a periodic relist every 30s. If the generations differ but the replicas are
+	// we do a periodic relist every 10 minutes. If the generations differ but the replicas are
 	// the same, a caller might've resized to the same replica count.
 	if ms.Status.Replicas == newStatus.Replicas &&
 		ms.Status.FullyLabeledReplicas == newStatus.FullyLabeledReplicas &&


### PR DESCRIPTION
This prevents us waiting the full re-list while updating a MachineDeployment

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
A backport to release-0.1 for #1127 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
```release-note
NONE
```

/assign @vincepri @ncdc 
