### PR TITLE
Release v0.1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?=60s
 export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?=60s
 
 # Image URL to use all building/pushing image targets
-export CONTROLLER_IMG ?= gcr.io/k8s-cluster-api/cluster-api-controller:v0.1.4
+export CONTROLLER_IMG ?= gcr.io/k8s-staging-cluster-api/cluster-api-controller:v0.1.5
 export EXAMPLE_PROVIDER_IMG ?= gcr.io/k8s-cluster-api/example-provider-controller:latest
 
 all: test manager clusterctl

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/k8s-cluster-api/cluster-api-controller:v0.1.4
+      - image: k8s.gcr.io/cluster-api/cluster-api-controller:v0.1.5
         name: manager

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -9,12 +9,17 @@
 
 ### Artifact locations
 
-1. The container image is found in the registry `gcr.io/k8s-cluster-api` with an
-   image name of `cluster-api-controller` and a tag that matches the release
-   version. For example, in the `v0.1.4` release, the container image
-   location is `gcr.io/k8s-cluster-api/cluster-api-controller:v0.1.4`
+1. The container image is found in the registry `k8s.gcr.io/cluster-api/` with an image
+   name of `cluster-api-controller` and a tag that matches the release version. For
+   example, in the `v0.1.5` release, the container image location is
+   `k8s.gcr.io/cluster-api/cluster-api-controller:v0.1.5`
 
-1. Prior to the `v0.1.4` release, the container image is found in the
+2. Prior to the `v0.1.5` release, the container image is found in the registry
+   `gcr.io/k8s-cluster-api` with an image name of `cluster-api-controller` and a tag
+   that matches the release version. For example, in the `v0.1.4` release, the container
+   image location is `gcr.io/k8s-cluster-api/cluster-api-controller:v0.1.4`
+
+3. Prior to the `v0.1.4` release, the container image is found in the
    registry `gcr.io/k8s-cluster-api` with an image name of `cluster-api-controller`
    and a tag that matches the release version. For example, in the `0.1.3` release,
    the container image location is `gcr.io/k8s-cluster-api/cluster-api-controller:0.1.3`
@@ -23,26 +28,19 @@
 
 For version v0.x.y:
 
-1. We will target a branch called `release-0.x`.  If this is `v0.x.0` then we'll
-   create a branch from master using `git push origin master:release-0.x`, otherwise
-   simply checkout the existing branch `git checkout release-0.x`
+1. We will target a branch called `release-0.x`.  If this is `v0.x.0` then we'll create a branch from master using `git push origin master:release-0.x`, otherwise simply checkout the existing branch `git checkout release-0.x`
 2. Make two changes:
-   1. Change [the cluster api controller manager image
-   tag][managerimg] from `:latest` to whatever version is being released
-   1. Change the `CONTROLLER_IMG` variable in the [Makefile][makefile] to the
-      version being released
-   (Note that we do not release the example-provider image, so we don't tag that)
+   1. Change [the cluster api controller manager image tag][managerimg] from `:latest` to whatever version is being released
+   1. Change the `CONTROLLER_IMG` variable in the [Makefile][makefile] to the version being released (Note that we do not release the example-provider image, so we don't tag that)
 3. Commit it using `git commit -m "Release v0.x.y"`
 4. Submit a PR to the `release-0.x` branch, e.g. `git push $USER; hub pull-request -b release-0.x`
 5. Get the pull request merged
-6. Switch to the release branch and update to pick up the commit.  (e.g. `git
-   checkout release 0.x && git pull`).  From there build and push the container
-   images and fat manifest with `REGISTRY="gcr.io/k8s-cluster-api" make all-push` (on the 0.1 release branch, we
-   do `make docker-push`)
+6. Switch to the release branch and update to pick up the commit.  (e.g. `git checkout release 0.x && git pull`).  
 7. Create an annotated tag from this same commit `git tag -a v0.x.y -m v0.x.y` and push the tag to the github repository `git push origin v0.x.y`
-8. Create a release in github based on the tag created above
-9. Manually create the release notes by going through the merged PRs since the
-   last release
+8. Build and push the container images and fat manifest with `REGISTRY="gcr.io/k8s-staging-cluster-api" make all-push` (on the 0.1 release branch, we do `make docker-push`)
+9. Follow the [Image Promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter) to promote the image from the staging repo to `k8s.gcr.io/cluster-api`
+10. Create a release in github based on the tag created above
+11. Manually create the release notes by going through the merged PRs since the last release
 
 [managerimg]: https://github.com/kubernetes-sigs/cluster-api/blob/fab4c07ea9fb0f124a5abe3dd7fcfffc23f2a1b3/config/default/manager_image_patch.yaml
 [makefile]: https://github.com/kubernetes-sigs/cluster-api/blob/fab4c07ea9fb0f124a5abe3dd7fcfffc23f2a1b3/Makefile


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the release-0.1 branch for the v0.1.5 release

**Release note**:
```release-note
NONE
```
