### PR TITLE
Release v0.1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?=60s
 export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?=60s
 
 # Image URL to use all building/pushing image targets
-export CONTROLLER_IMG ?= gcr.io/k8s-staging-cluster-api/cluster-api-controller:v0.1.5
+export CONTROLLER_IMG ?= gcr.io/k8s-staging-cluster-api/cluster-api-controller:v0.1.6
 export EXAMPLE_PROVIDER_IMG ?= gcr.io/k8s-cluster-api/example-provider-controller:latest
 
 all: test manager clusterctl

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: k8s.gcr.io/cluster-api/cluster-api-controller:v0.1.5
+      - image: us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.1.6
         name: manager

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -9,10 +9,10 @@
 
 ### Artifact locations
 
-1. The container image is found in the registry `k8s.gcr.io/cluster-api/` with an image
+1. The container image is found in the registry `us.gcr.io/k8s-artifacts-prod/cluster-api/` with an image
    name of `cluster-api-controller` and a tag that matches the release version. For
    example, in the `v0.1.5` release, the container image location is
-   `k8s.gcr.io/cluster-api/cluster-api-controller:v0.1.5`
+   `us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.1.5`
 
 2. Prior to the `v0.1.5` release, the container image is found in the registry
    `gcr.io/k8s-cluster-api` with an image name of `cluster-api-controller` and a tag


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates for Release v0.1.6

**Release note**:
```release-note
NONE
```
