### PR TITLE
Convert {Bootstrap,Infrastructure}Ready fields to plain bools

### DIFF
--- a/docs/proposals/20190610-machine-states-preboot-bootstrapping.md
+++ b/docs/proposals/20190610-machine-states-preboot-bootstrapping.md
@@ -161,10 +161,10 @@ type MachineStatus struct
         - Type: `*string`
         - Description: Version specifies the current version of Kubernetes running on the corresponding Node. This is meant to be a means of bubbling up status from the Node to the Machine. It is entirely optional, but useful for end-user UX if it’s present.
     - **BootstrapReady [optional]**
-        - Type: `*string`
+        - Type: `bool`
         - Description: True when the bootstrap provider status is ready.
     - **InfrastructureReady [optional]**
-        - Type: `*bool`
+        - Type: `bool`
         - Description: True when the infrastructure provider status is ready.
 
 ```go

--- a/pkg/apis/cluster/v1alpha2/machine_types.go
+++ b/pkg/apis/cluster/v1alpha2/machine_types.go
@@ -157,11 +157,11 @@ type MachineStatus struct {
 
 	// BootstrapReady is the state of the bootstrap provider.
 	// +optional
-	BootstrapReady *bool `json:"bootstrapReady,omitempty"`
+	BootstrapReady bool `json:"bootstrapReady"`
 
 	// InfrastructureReady is the state of the infrastructure provider.
 	// +optional
-	InfrastructureReady *bool `json:"infrastructureReady,omitempty"`
+	InfrastructureReady bool `json:"infrastructureReady"`
 }
 
 // SetTypedPhase sets the Phase field to the string representation of MachinePhase.

--- a/pkg/apis/cluster/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/cluster/v1alpha2/zz_generated.deepcopy.go
@@ -601,16 +601,6 @@ func (in *MachineStatus) DeepCopyInto(out *MachineStatus) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.BootstrapReady != nil {
-		in, out := &in.BootstrapReady, &out.BootstrapReady
-		*out = new(bool)
-		**out = **in
-	}
-	if in.InfrastructureReady != nil {
-		in, out := &in.InfrastructureReady, &out.InfrastructureReady
-		*out = new(bool)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/controller/machine/machine_controller_phases_test.go
+++ b/pkg/controller/machine/machine_controller_phases_test.go
@@ -181,8 +181,8 @@ func TestReconcilePhase(t *testing.T) {
 					},
 				},
 				Status: v1alpha2.MachineStatus{
-					BootstrapReady:      pointer.BoolPtr(true),
-					InfrastructureReady: pointer.BoolPtr(true),
+					BootstrapReady:      true,
+					InfrastructureReady: true,
 					NodeRef:             &corev1.ObjectReference{Kind: "Node", Name: "machine-test-node"},
 				},
 			},
@@ -248,8 +248,8 @@ func TestReconcilePhase(t *testing.T) {
 					},
 				},
 				Status: v1alpha2.MachineStatus{
-					BootstrapReady:      pointer.BoolPtr(true),
-					InfrastructureReady: pointer.BoolPtr(true),
+					BootstrapReady:      true,
+					InfrastructureReady: true,
 					NodeRef:             &corev1.ObjectReference{Kind: "Node", Name: "machine-test-node"},
 				},
 			},
@@ -379,7 +379,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			},
 			expectError: false,
 			expected: func(g *gomega.WithT, m *v1alpha2.Machine) {
-				g.Expect(*m.Status.BootstrapReady).To(gomega.BeTrue())
+				g.Expect(m.Status.BootstrapReady).To(gomega.BeTrue())
 				g.Expect(m.Spec.Bootstrap.Data).ToNot(gomega.BeNil())
 				g.Expect(*m.Spec.Bootstrap.Data).To(gomega.ContainSubstring("#!/bin/bash"))
 			},
@@ -400,7 +400,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			},
 			expectError: true,
 			expected: func(g *gomega.WithT, m *v1alpha2.Machine) {
-				g.Expect(m.Status.BootstrapReady).To(gomega.BeNil())
+				g.Expect(m.Status.BootstrapReady).To(gomega.BeFalse())
 				g.Expect(m.Spec.Bootstrap.Data).To(gomega.BeNil())
 			},
 		},
@@ -418,7 +418,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			},
 			expectError: true,
 			expected: func(g *gomega.WithT, m *v1alpha2.Machine) {
-				g.Expect(m.Status.BootstrapReady).To(gomega.BeNil())
+				g.Expect(m.Status.BootstrapReady).To(gomega.BeFalse())
 			},
 		},
 		{
@@ -435,7 +435,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			},
 			expectError: true,
 			expected: func(g *gomega.WithT, m *v1alpha2.Machine) {
-				g.Expect(m.Status.BootstrapReady).To(gomega.BeNil())
+				g.Expect(m.Status.BootstrapReady).To(gomega.BeFalse())
 			},
 		},
 		{
@@ -483,12 +483,12 @@ func TestReconcileBootstrap(t *testing.T) {
 					},
 				},
 				Status: v1alpha2.MachineStatus{
-					BootstrapReady: pointer.BoolPtr(true),
+					BootstrapReady: true,
 				},
 			},
 			expectError: false,
 			expected: func(g *gomega.WithT, m *v1alpha2.Machine) {
-				g.Expect(*m.Status.BootstrapReady).To(gomega.BeTrue())
+				g.Expect(m.Status.BootstrapReady).To(gomega.BeTrue())
 				g.Expect(*m.Spec.Bootstrap.Data).To(gomega.Equal("#!/bin/bash ... data"))
 			},
 		},
@@ -523,12 +523,12 @@ func TestReconcileBootstrap(t *testing.T) {
 					},
 				},
 				Status: v1alpha2.MachineStatus{
-					BootstrapReady: pointer.BoolPtr(true),
+					BootstrapReady: true,
 				},
 			},
 			expectError: false,
 			expected: func(g *gomega.WithT, m *v1alpha2.Machine) {
-				g.Expect(*m.Status.BootstrapReady).To(gomega.BeTrue())
+				g.Expect(m.Status.BootstrapReady).To(gomega.BeTrue())
 			},
 		},
 	}
@@ -608,7 +608,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			expectError:   false,
 			expectChanged: true,
 			expected: func(g *gomega.WithT, m *v1alpha2.Machine) {
-				g.Expect(*m.Status.InfrastructureReady).To(gomega.BeTrue())
+				g.Expect(m.Status.InfrastructureReady).To(gomega.BeTrue())
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR changes the type of Status.BootstrapReady and Status.InfrastructureReady fields from `*bool` to `bool`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
