### PR TITLE
Add MachineAddress type for infrastructure providers

### DIFF
--- a/pkg/apis/cluster/v1alpha2/common_types.go
+++ b/pkg/apis/cluster/v1alpha2/common_types.go
@@ -20,6 +20,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// MachineAddressType describes a valid MachineAddress type.
+type MachineAddressType string
+
+const (
+	MachineHostName    MachineAddressType = "Hostname"
+	MachineExternalIP  MachineAddressType = "ExternalIP"
+	MachineInternalIP  MachineAddressType = "InternalIP"
+	MachineExternalDNS MachineAddressType = "ExternalDNS"
+	MachineInternalDNS MachineAddressType = "InternalDNS"
+)
+
+// MachineAddress contains information for the node's address.
+type MachineAddress struct {
+	// Machine address type, one of Hostname, ExternalIP or InternalIP.
+	Type MachineAddressType `json:"type"`
+
+	// The machine address.
+	Address string `json:"address"`
+}
+
+// MachineAddresses is a slice of MachineAddress items to be used by infrastructure providers.
+type MachineAddresses []MachineAddress
+
 // ObjectMeta is metadata that all persisted resources must have, which includes all objects
 // users must create. This is a copy of customizable fields from metav1.ObjectMeta.
 //


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This PR adds a new type copied from `corev1.NodeAddress`: `MachineAddress`.
Infrastructure Providers should use this type in their Status to store the Machine's addresses.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
