### PR TITLE
Release v0.1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT ?=60s
 export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?=60s
 
 # Image URL to use all building/pushing image targets
-export CONTROLLER_IMG ?= gcr.io/k8s-staging-cluster-api/cluster-api-controller:v0.1.7
+export CONTROLLER_IMG ?= gcr.io/k8s-staging-cluster-api/cluster-api-controller:v0.1.8
 export EXAMPLE_PROVIDER_IMG ?= gcr.io/k8s-cluster-api/example-provider-controller:latest
 
 all: test manager clusterctl

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.1.7
+      - image: us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.1.8
         name: manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates image versions for the v0.1.8 release

**Release note**:
```release-note
NONE
```
