### PR TITLE
kustomization.yaml: Use patchesStrategicMerge

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -13,5 +13,5 @@ bases:
 - ../rbac/
 - ../manager/
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml


### PR DESCRIPTION
A previous release of kustomize deprecated "patches:" and the latest
version (v3.0.3) will fail on it.  Replacing this with
"patchesStrategicMerge:" should make this kustomization.yaml continue
to work across kustomize versions.