### PR TITLE
release-0.1: kustomization.yaml: Use patchesStrategicMerge (#1184)

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -13,5 +13,5 @@ bases:
 - ../rbac/
 - ../manager/
 
-patches:
+patchesStrategicMerge:
 - manager_image_patch.yaml


### PR DESCRIPTION
A previous release of kustomize deprecated "patches:" and the latest
version (v3.0.3) will fail on it.  Replacing this with
"patchesStrategicMerge:" should make this kustomization.yaml continue
to work across kustomize versions.

(cherry picked from commit 8d4cb92c5c7ffce28750f74a47bbddc10efa8688)