### PR TITLE
Update plantuml generation to use CAPI-managed image

### DIFF
--- a/docs/proposals/images/Makefile
+++ b/docs/proposals/images/Makefile
@@ -26,7 +26,7 @@ diagrams: $(DIAGRAMS)
 		--rm \
 		--volume ${ROOT_DIR}:/diagrams \
 		--user $(shell id -u):$(shell id -g) \
-		dpf9/plantuml:1.2019.6 \
+		us.gcr.io/k8s-artifacts-prod/cluster-api/plantuml:1.2019.6 \
 		-v /diagrams/$(shell basename $(shell dirname $^))/$(notdir $^)
 
 .PHONY: diagrams


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates plantuml generation to use CAPI-managed image

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1070

**Release note**:
```release-note
NONE
```
