### PR TITLE
Fix Netlify redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,20 +5,20 @@
 
 # Standard Netlify redirects
 [[redirects]]
-    from = "https://release-0.1--kubernetes-sigs-cluster-api.netlify.com/*"
-    to = "https://v1alpha1.cluster-api.sigs.k8s.io/:splat"
+    from = "https://release-0-1--kubernetes-sigs-cluster-api.netlify.com/*"
+    to = "https://release-0-1.cluster-api.sigs.k8s.io/:splat"
     status = 301
     force = true
 
 # HTTP-to-HTTPS rules
 [[redirects]]
-    from = "http://v1alpha1.cluster-api.sigs.k8s.io/*"
-    to = "https://v1alpha1.cluster-api.sigs.k8s.io/:splat"
+    from = "http://release-0-1.cluster-api.sigs.k8s.io/*"
+    to = "https://release-0-1.cluster-api.sigs.k8s.io/:splat"
     status = 301
     force = true
 
 [[redirects]]
-    from = "http://release-0.1--kubernetes-sigs-cluster-api.netlify.com/*"
-    to = "http://v1alpha1.cluster-api.sigs.k8s.io/:splat"
+    from = "http://release-0-1--kubernetes-sigs-cluster-api.netlify.com/*"
+    to = "http://release-0-1.cluster-api.sigs.k8s.io/:splat"
     status = 301
     force = true


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the Netlify redirects for the `release-0.1` branch

**Release note**:
```release-note
NONE
```
