### PR TITLE
[0.1] set OwnerRef in more cases

### DIFF
--- a/pkg/controller/machinedeployment/machinedeployment_controller.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller.go
@@ -173,7 +173,8 @@ func (r *ReconcileMachineDeployment) reconcile(ctx context.Context, d *v1alpha1.
 	}
 
 	// Set the ownerRef with foreground deletion if there is a linked cluster.
-	if cluster != nil && len(d.OwnerReferences) == 0 {
+	if cluster != nil && shouldAdopt(d) {
+		klog.Infof("Cluster %s/%s is adopting MachineDeployment %s", cluster.Namespace, cluster.Name, d.Name)
 		blockOwnerDeletion := true
 		d.OwnerReferences = append(d.OwnerReferences, metav1.OwnerReference{
 			APIVersion:         cluster.APIVersion,
@@ -411,4 +412,8 @@ func (r *ReconcileMachineDeployment) MachineSetToDeployments(o handler.MapObject
 	}
 
 	return result
+}
+
+func shouldAdopt(md *v1alpha1.MachineDeployment) bool {
+	return !util.HasOwner(md.OwnerReferences, v1alpha1.SchemeGroupVersion.String(), []string{"Cluster"})
 }

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 	"sigs.k8s.io/cluster-api/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -170,7 +171,8 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 	}
 
 	// Set the ownerRef with foreground deletion if there is a linked cluster.
-	if cluster != nil && len(machineSet.OwnerReferences) == 0 {
+	if cluster != nil && shouldAdopt(machineSet) {
+		klog.Infof("Cluster %s/%s is adopting MachineSet %s", cluster.Namespace, cluster.Name, machineSet.Name)
 		blockOwnerDeletion := true
 		machineSet.OwnerReferences = append(machineSet.OwnerReferences, metav1.OwnerReference{
 			APIVersion:         cluster.APIVersion,
@@ -493,4 +495,8 @@ func (r *ReconcileMachineSet) MachineToMachineSets(o handler.MapObject) []reconc
 	}
 
 	return result
+}
+
+func shouldAdopt(ms *v1alpha1.MachineSet) bool {
+	return !util.HasOwner(ms.OwnerReferences, v1alpha1.SchemeGroupVersion.String(), []string{"MachineDeployment", "Cluster"})
 }

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     srcs = ["util_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apis/cluster/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -326,3 +326,19 @@ func PointsTo(refs []metav1.OwnerReference, target *metav1.ObjectMeta) bool {
 
 	return false
 }
+
+// HasOwner checks if any of the references in the past list match the given apiVersion and one of the given kinds
+func HasOwner(refList []metav1.OwnerReference, apiVersion string, kinds []string) bool {
+	kMap := make(map[string]bool)
+	for _, kind := range kinds {
+		kMap[kind] = true
+	}
+
+	for _, mr := range refList {
+		if mr.APIVersion == apiVersion && kMap[mr.Kind] {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
Right now the cluster manager will only set an ownerreference if no owner exists at creation time. This could potentially cause issues if an object is owned by a not-Cluster API object. Instead, we will check all references to see if they point to a cluster-api object, and "adopt" them if they do not.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1190 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Clusters will set OwnerReferences on Machines, MachineSet, and MachineDeployment if they are not already owned by another MachineSet or MachineDeployment
```
