### PR TITLE
Adopt conditionally based on owner

### DIFF
--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -146,7 +146,7 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (_ reconcile.Res
 			m.Labels[clusterv1.MachineClusterLabelName], m.Name, m.Namespace)
 	}
 
-	if cluster != nil {
+	if cluster != nil && shouldAdopt(m) {
 		m.OwnerReferences = util.EnsureOwnerRef(m.OwnerReferences, metav1.OwnerReference{
 			APIVersion: cluster.APIVersion,
 			Kind:       cluster.Kind,
@@ -316,4 +316,8 @@ func (r *ReconcileMachine) isDeleteReady(ctx context.Context, m *v1alpha2.Machin
 	}
 
 	return nil
+}
+
+func shouldAdopt(m *v1alpha2.Machine) bool {
+	return !util.HasOwner(m.OwnerReferences, v1alpha2.SchemeGroupVersion.String(), []string{"MachineSet", "Cluster"})
 }

--- a/pkg/controller/machinedeployment/machinedeployment_controller.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller.go
@@ -176,7 +176,7 @@ func (r *ReconcileMachineDeployment) reconcile(ctx context.Context, d *v1alpha2.
 		return reconcile.Result{}, err
 	}
 
-	if cluster != nil {
+	if cluster != nil && shouldAdopt(d) {
 		d.OwnerReferences = util.EnsureOwnerRef(d.OwnerReferences, metav1.OwnerReference{
 			APIVersion: cluster.APIVersion,
 			Kind:       cluster.Kind,
@@ -393,4 +393,8 @@ func (r *ReconcileMachineDeployment) MachineSetToDeployments(o handler.MapObject
 	}
 
 	return result
+}
+
+func shouldAdopt(md *v1alpha2.MachineDeployment) bool {
+	return !util.HasOwner(md.OwnerReferences, v1alpha2.SchemeGroupVersion.String(), []string{"Cluster"})
 }

--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -186,7 +186,7 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 		return reconcile.Result{}, err
 	}
 
-	if cluster != nil {
+	if cluster != nil && shouldAdopt(machineSet) {
 		machineSet.OwnerReferences = util.EnsureOwnerRef(machineSet.OwnerReferences, metav1.OwnerReference{
 			APIVersion: cluster.APIVersion,
 			Kind:       cluster.Kind,
@@ -523,4 +523,8 @@ func (r *ReconcileMachineSet) MachineToMachineSets(o handler.MapObject) []reconc
 	}
 
 	return result
+}
+
+func shouldAdopt(ms *clusterv1.MachineSet) bool {
+	return !util.HasOwner(ms.OwnerReferences, clusterv1.SchemeGroupVersion.String(), []string{"MachineDeployment", "Cluster"})
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -486,3 +486,19 @@ func NewYAMLDecoder(r io.ReadCloser) streaming.Decoder {
 		close:   r.Close,
 	}
 }
+
+// HasOwner checks if any of the references in the passed list match the given apiVersion and one of the given kinds
+func HasOwner(refList []metav1.OwnerReference, apiVersion string, kinds []string) bool {
+	kMap := make(map[string]bool)
+	for _, kind := range kinds {
+		kMap[kind] = true
+	}
+
+	for _, mr := range refList {
+		if mr.APIVersion == apiVersion && kMap[mr.Kind] {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
This ports #1207 to master.

Only add a Cluster ownerReference to MachineDeployment if it doesn't
already have one.

Only add a Cluster ownerReference to MachineSet if it doesn't already
have one to a MachineDeployment or Cluster.

Only add a Cluster ownerReference to Machine if it doesn't already have
one to a MachineSet or Cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1210

**Special notes for your reviewer**:
I made a slight change from #1207 - Machines would never belong to a MachineDeployment, so I removed that condition.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Clusters will set OwnerReferences on Machines, MachineSet, and MachineDeployment if they are not already owned by another MachineSet or MachineDeployment
```
