### PR TITLE
Document procedure for creating per release books.

### DIFF
--- a/docs/book/RELEASE
+++ b/docs/book/RELEASE
@@ -45,13 +45,14 @@ make serve-book
 
 Each major and minor release should get a new version of the book. Netlify is
 already configured to deploy each branch to a Netlify site at
-`https://<branch-name>--kubernetes-sigs-cluster-api.netlify.com`. Note that 
-dots in the branch name will be replaced by dashes in the domain name. It 
-remains to:
+`https://<branch-name-with-dashes>--kubernetes-sigs-cluster-api.netlify.com`.
+Note that dots in the branch name will be replaced by dashes in the domain
+name. For example, `release-0-1--kubernetes-sigs-cluster-api.netlify.com` is
+the domain name for the branch named `release-0.1`. It remains to:
 
 1) Create a subdomain for the branch. Subdomains are of the form
-`<branch-name>.cluster-api.sigs.k8s.io`. To create one sdubmit a PR to the
-kubernetes/k8s.io repository similar to this one:
+`<branch-name-with-dashes>.cluster-api.sigs.k8s.io`. To create one submit a PR
+to the  kubernetes/k8s.io repository similar to this one:
 https://github.com/kubernetes/k8s.io/pull/324
 
 2) Request for the Netlify SSL cert to be extended to the new subdomain. For 
@@ -67,7 +68,7 @@ How can we help you?:
 
 >I am at step 4) "Contact Netlify Technical Support to get the SSL certificate extended to the new sub-domain." of [how to use Netlify’s branch deploy feature without Netlify DNS](https://community.netlify.com/t/common-issue-how-to-use-netlify-s-branch-deploy-feature-without-netlify-dns/128).
 >
->Can you please extend the SSL cert for the kubernetes-sigs-cluster-api site to the subdomain: release-0-1.cluster-api.sigs.k8s.io?
+>Can you please extend the SSL cert for the kubernetes-sigs-cluster-api site to the subdomain: <branch-name-with-dashes>.cluster-api.sigs.k8s.io?
 >
 >Thank you!
 

--- a/docs/book/RELEASE
+++ b/docs/book/RELEASE
@@ -39,6 +39,38 @@ should include new or changed content and:
 make serve-book
 ```
 
+## Finally submit a PR
+
+# Creating a new book
+
+Each major and minor release should get a new version of the book. Netlify is
+already configured to deploy each branch to a Netlify site at
+`https://<branch-name>--kubernetes-sigs-cluster-api.netlify.com`. Note that 
+dots in the branch name will be replaced by dashes in the domain name. It 
+remains to:
+
+1) Create a subdomain for the branch. Subdomains are of the form
+`<branch-name>.cluster-api.sigs.k8s.io`. To create one sdubmit a PR to the
+kubernetes/k8s.io repository similar to this one:
+https://github.com/kubernetes/k8s.io/pull/324
+
+2) Request for the Netlify SSL cert to be extended to the new subdomain. For 
+example:
+
+Submit a request [here](https://www.netlify.com/support/) with the following
+information:
+
+Topic: SSL ISSUE
+Site Name: kubernetes-sigs-cluster-api
+Subject: Extend SSL certificate to new subdomain
+How can we help you?:
+
+>I am at step 4) "Contact Netlify Technical Support to get the SSL certificate extended to the new sub-domain." of [how to use Netlify’s branch deploy feature without Netlify DNS](https://community.netlify.com/t/common-issue-how-to-use-netlify-s-branch-deploy-feature-without-netlify-dns/128).
+>
+>Can you please extend the SSL cert for the kubernetes-sigs-cluster-api site to the subdomain: release-0-1.cluster-api.sigs.k8s.io?
+>
+>Thank you!
+
 [markdown]: https://toolchain.gitbook.com/syntax/markdown.html
 [gitbook]: https://toolchain.gitbook.com/
 [plugins]: https://toolchain.gitbook.com/plugins/


### PR DESCRIPTION
**What this PR does / why we need it**:
CAPI documentation needs to be versioned so that we can support more than one release at a time. This PR documents that process.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubernetes-sigs/cluster-api/issues/1119

**Special notes for your reviewer**:
None.

**Release note**:
```release-note

```
