### PR TITLE
Allow empty bootstrap data

### DIFF
--- a/pkg/controller/machine/machine_controller_phases.go
+++ b/pkg/controller/machine/machine_controller_phases.go
@@ -207,8 +207,6 @@ func (r *ReconcileMachine) reconcileBootstrap(ctx context.Context, m *v1alpha2.M
 	data, _, err := unstructured.NestedString(bootstrapConfig.Object, "status", "bootstrapData")
 	if err != nil {
 		return errors.Wrapf(err, "failed to retrieve data from bootstrap provider for Machine %q in namespace %q", m.Name, m.Namespace)
-	} else if data == "" {
-		return errors.Errorf("retrieved empty data from bootstrap provider for Machine %q in namespace %q", m.Name, m.Namespace)
 	}
 
 	m.Spec.Bootstrap.Data = pointer.StringPtr(data)

--- a/pkg/controller/machine/machine_controller_phases_test.go
+++ b/pkg/controller/machine/machine_controller_phases_test.go
@@ -442,13 +442,14 @@ func TestReconcileBootstrap(t *testing.T) {
 				},
 				"spec": map[string]interface{}{},
 				"status": map[string]interface{}{
-					"ready": true,
+					"ready":         true,
+					"bootstrapData": "",
 				},
 			},
-			expectError: true,
+			expectError: false,
 			expected: func(g *gomega.WithT, m *v1alpha2.Machine) {
-				g.Expect(m.Status.BootstrapReady).To(gomega.BeFalse())
-				g.Expect(m.Spec.Bootstrap.Data).To(gomega.BeNil())
+				g.Expect(m.Status.BootstrapReady).To(gomega.BeTrue())
+				g.Expect(*m.Spec.Bootstrap.Data).To(gomega.BeEmpty())
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR aligns cluster api with the proposal expectations of allowing an empty bootstrap data field.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1219 

**Special notes for your reviewer**:

**Release note**:
```release-note
Bootstrap.Status.Data is now allowed to be the empty string for providers that do not need bootstrap data.
```

/assign @ncdc @detiber 