### PR TITLE
Allow optional addresses

### DIFF
--- a/pkg/controller/machine/machine_controller_phases.go
+++ b/pkg/controller/machine/machine_controller_phases.go
@@ -248,8 +248,12 @@ func (r *ReconcileMachine) reconcileInfrastructure(ctx context.Context, m *v1alp
 	}
 
 	// Get and set Status.Addresses from the infrastructure provider.
-	if err := util.UnstructuredUnmarshalField(infraConfig, &m.Status.Addresses, "status", "addresses"); err != nil {
-		return errors.Wrapf(err, "failed to retrieve addresses from infrastructure provider for Machine %q in namespace %q", m.Name, m.Namespace)
+	err = util.UnstructuredUnmarshalField(infraConfig, &m.Status.Addresses, "status", "addresses")
+
+	if err != nil {
+		if err != util.ErrUnstructuredFieldNotFound {
+			return errors.Wrapf(err, "failed to retrieve addresses from infrastructure provider for Machine %q in namespace %q", m.Name, m.Namespace)
+		}
 	}
 
 	m.Spec.ProviderID = pointer.StringPtr(providerID)

--- a/pkg/controller/machine/machine_controller_phases_test.go
+++ b/pkg/controller/machine/machine_controller_phases_test.go
@@ -171,7 +171,7 @@ func TestReconcilePhase(t *testing.T) {
 			},
 		},
 		{
-			name: "ready bootstrap and infra, expect error with nil addresses",
+			name: "ready bootstrap and infra, allow nil addresses as they are optional",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       "BootstrapConfig",
 				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
@@ -199,10 +199,10 @@ func TestReconcilePhase(t *testing.T) {
 					"ready": true,
 				},
 			},
-			expectError:        true,
+			expectError:        false,
 			expectRequeueAfter: false,
 			expected: func(g *gomega.WithT, m *v1alpha2.Machine) {
-				g.Expect(m.Status.GetTypedPhase()).To(gomega.Equal(v1alpha2.MachinePhaseProvisioning))
+				g.Expect(m.Status.GetTypedPhase()).To(gomega.Equal(v1alpha2.MachinePhaseProvisioned))
 				g.Expect(m.Status.Addresses).To(gomega.HaveLen(0))
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
We need this PR to keep cluster-api in line with the spec that says Addresses from the infrastructure provider are optional

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1221 

**Special notes for your reviewer**:

```release-note
Infrastructure addresses are no longer required
```
