### PR TITLE
controller/machineset: prevent replica updates when it is being deleted

### DIFF
--- a/pkg/controller/machineset/machineset_controller.go
+++ b/pkg/controller/machineset/machineset_controller.go
@@ -217,7 +217,10 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 		filteredMachines = append(filteredMachines, machine)
 	}
 
-	syncErr := r.syncReplicas(machineSet, filteredMachines)
+	var syncErr error
+	if machineSet.DeletionTimestamp == nil {
+		syncErr = r.syncReplicas(machineSet, filteredMachines)
+	}
 
 	ms := machineSet.DeepCopy()
 	newStatus := r.calculateStatus(ms, filteredMachines)


### PR DESCRIPTION
When a machineset is being deleted it is possible to get into an
endless loop where new machine's are constantly recreated as the
reconciliation logic doesn't take into account the machine set's
deletion timestamp.