### PR TITLE
Fixes a bug in GetClusterByName

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -170,7 +170,7 @@ func GetClusterFromMetadata(ctx context.Context, c client.Client, obj metav1.Obj
 func GetOwnerCluster(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*clusterv1.Cluster, error) {
 	for _, ref := range obj.OwnerReferences {
 		if ref.Kind == "Cluster" && ref.APIVersion == clusterv1.SchemeGroupVersion.String() {
-			return GetClusterByName(ctx, c, obj.Namespace, obj.Name)
+			return GetClusterByName(ctx, c, obj.Namespace, ref.Name)
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This fixes a but in GetOwnerCluster and scopes down the client to exactly what this function needs. This improves testability and scope of the function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1229 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

/assign @ncdc @detiber 