### PR TITLE
Return correct Machine Name in util.GetOwnerMachine

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -226,7 +226,7 @@ func ClusterToInfrastructureMapFunc(gvk schema.GroupVersionKind) handler.ToReque
 func GetOwnerMachine(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*clusterv1.Machine, error) {
 	for _, ref := range obj.OwnerReferences {
 		if ref.Kind == "Machine" && ref.APIVersion == clusterv1.SchemeGroupVersion.String() {
-			return GetMachineByName(ctx, c, obj.Namespace, obj.Name)
+			return GetMachineByName(ctx, c, obj.Namespace, ref.Name)
 		}
 	}
 	return nil, nil

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -651,3 +651,37 @@ func TestGetOwnerClusterSuccessByName(t *testing.T) {
 		t.Fatal("expected a cluster but got nil")
 	}
 }
+
+func TestGetOwnerMachineSuccessByName(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clusterv1.AddToScheme(scheme); err != nil {
+		t.Fatal("failed to register cluster api objects to scheme")
+	}
+
+	myMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-machine",
+			Namespace: "my-ns",
+		},
+	}
+
+	c := fake.NewFakeClientWithScheme(scheme, myMachine)
+	objm := metav1.ObjectMeta{
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:       "Machine",
+				APIVersion: clusterv1.SchemeGroupVersion.String(),
+				Name:       "my-machine",
+			},
+		},
+		Namespace: "my-ns",
+		Name:      "my-resource-owned-by-machine",
+	}
+	machine, err := GetOwnerMachine(context.TODO(), c, objm)
+	if err != nil {
+		t.Fatalf("did not expect an error but found one: %v", err)
+	}
+	if machine == nil {
+		t.Fatal("expected a machine but got nil")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Return correct Machine Name in util.GetOwnerMachine

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1234 

**Release note**:
```release-note
- util.GetOwnerMachine now returns the proper Machine Name
```
