### PR TITLE
Remove unnecessary get for MachineSet in MachineSetToDeployments

### DIFF
--- a/pkg/controller/machinedeployment/machinedeployment_controller_test.go
+++ b/pkg/controller/machinedeployment/machinedeployment_controller_test.go
@@ -133,7 +133,7 @@ func TestMachineSetToDeployments(t *testing.T) {
 
 	v1alpha2.AddToScheme(scheme.Scheme)
 	r := &ReconcileMachineDeployment{
-		Client:   fake.NewFakeClient(&ms1, &ms2, &ms3, machineDeplopymentList),
+		Client:   fake.NewFakeClient(machineDeplopymentList),
 		scheme:   scheme.Scheme,
 		recorder: record.NewFakeRecorder(32),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove unnecessary get for MachineSet in MachineSetToDeployments

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1237 

**Release note**:
```release-note
The MachineDeployment Controller will no longer call get to retrieve the current MachineSet in MachineSetToDeployments
```
