### PR TITLE
Fix: update cluster annotations when control plane is ready

### DIFF
--- a/pkg/controller/machine/machine_controller_phases.go
+++ b/pkg/controller/machine/machine_controller_phases.go
@@ -275,7 +275,7 @@ func (r *ReconcileMachine) reconcileClusterAnnotations(ctx context.Context, clus
 		}
 
 		if _, ok := cluster.Annotations[v1alpha2.ClusterAnnotationControlPlaneReady]; !ok {
-			clusterPatch := client.MergeFrom(cluster)
+			clusterPatch := client.MergeFrom(cluster.DeepCopy())
 			cluster.Annotations[v1alpha2.ClusterAnnotationControlPlaneReady] = "true"
 			if err := r.Client.Patch(ctx, cluster, clusterPatch); err != nil {
 				return errors.Wrapf(err, "failed to set control-plane-ready annotation on Cluster %q in namespace %q",


### PR DESCRIPTION
Signed-off-by: JunLi <lijun.git@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Fix the failure of updating cluster annotation when control plane is ready.


