### PR TITLE
🐛 Ensure status updates succeed

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -51,12 +51,13 @@ const (
 )
 
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	mgr       manager.Manager
-	doneMgr   = make(chan struct{})
-	ctx       = context.Background()
+	cfg               *rest.Config
+	k8sClient         client.Client
+	testEnv           *envtest.Environment
+	mgr               manager.Manager
+	clusterReconciler *ClusterReconciler
+	doneMgr           = make(chan struct{})
+	ctx               = context.Background()
 )
 
 func TestAPIs(t *testing.T) {
@@ -90,14 +91,11 @@ var _ = BeforeSuite(func(done Done) {
 	By("setting up a new manager")
 	mgr, err = manager.New(cfg, manager.Options{Scheme: scheme.Scheme, MetricsBindAddress: "0"})
 	Expect(err).NotTo(HaveOccurred())
-	Expect((&ClusterReconciler{
+	clusterReconciler = &ClusterReconciler{
 		Client: mgr.GetClient(),
 		Log:    log.Log,
-	}).SetupWithManager(mgr)).NotTo(HaveOccurred())
-	Expect((&MachineReconciler{
-		Client: mgr.GetClient(),
-		Log:    log.Log,
-	}).SetupWithManager(mgr)).NotTo(HaveOccurred())
+	}
+	Expect(clusterReconciler.SetupWithManager(mgr)).NotTo(HaveOccurred())
 
 	By("starting the manager")
 	go func() {


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>
**What this PR does / why we need it**:
This PR is a work around for #1259.

It also removes an outdated hack in the machine-update code that is no longer needed as of controller-runtime beta.5

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This can be fixed in controller-runtime but until that fix is in this hack will be in place.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

/assign @detiber @vincepri 
