### PR TITLE
:sparkles: Add optional pprof http server

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -39,12 +39,12 @@ func main() {
 	watchNamespace := flag.String("namespace", "",
 		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
 	profilerAddress := flag.String("profiler-address", "", "Bind address to expose the pprof profiler (e.g. localhost:6060)")
-	
+
 	flag.Parse()
 	if *watchNamespace != "" {
 		klog.Infof("Watching cluster-api objects only in namespace %q for reconciliation", *watchNamespace)
 	}
-	
+
 	if *profilerAddress != "" {
 		klog.Infof("Profiler listening for requests at %s", *profilerAddress)
 		go func() {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"flag"
+	"net/http"
+	_ "net/http/pprof"
 	"time"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -36,10 +38,18 @@ func main() {
 	klog.InitFlags(nil)
 	watchNamespace := flag.String("namespace", "",
 		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
-
+	profilerAddress := flag.String("profiler-address", "", "Bind address to expose the pprof profiler (e.g. localhost:6060)")
+	
 	flag.Parse()
 	if *watchNamespace != "" {
 		klog.Infof("Watching cluster-api objects only in namespace %q for reconciliation", *watchNamespace)
+	}
+	
+	if *profilerAddress != "" {
+		klog.Infof("Profiler listening for requests at %s", *profilerAddress)
+		go func() {
+			klog.Info(http.ListenAndServe(*profilerAddress, nil))
+		}()
 	}
 
 	// Setup controller-runtime logger.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

The CAPI equivalent of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/900 , to offer an avenue for debugging this problem:

```$ k get po -n cluster-api-system
NAME                               READY   STATUS             RESTARTS   AGE
cluster-api-controller-manager-0   0/1     CrashLoopBackOff   362        7d23h
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added --profiler-address flag to the manager, allowing you to enable the pprof http server.
```
