### PR TITLE
🐛 Update and fix kustomize files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ generate-manifests: ## Generate manifests e.g. CRD, RBAC etc.
 		rbac:roleName=manager-role \
 		output:crd:dir=./config/crd/bases
 	## Copy files in CI folders.
-	cp -f ./config/rbac/role*.yaml ./config/ci/rbac/
+	cp -f ./config/rbac/*.yaml ./config/ci/rbac/
 	cp -f ./config/manager/manager*.yaml ./config/ci/manager/
 
 .PHONY: gazelle

--- a/cmd/example-provider/BUILD.bazel
+++ b/cmd/example-provider/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//api/v1alpha2:go_default_library",
         "//controllers:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime:go_default_library",
     ],

--- a/cmd/example-provider/Dockerfile
+++ b/cmd/example-provider/Dockerfile
@@ -24,10 +24,10 @@ COPY ./ ./
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     go build -a -ldflags '-extldflags "-static"' \
-    -o ./cmd/example-provider/manager sigs.k8s.io/cluster-api/cmd/example-provider
+    -o manager sigs.k8s.io/cluster-api/cmd/example-provider
 
 # Copy the controller-manager into a thin image
 FROM gcr.io/distroless/static:latest
 WORKDIR /
-COPY --from=builder /go/src/sigs.k8s.io/cluster-api/cmd/example-provider/manager .
+COPY --from=builder /go/src/sigs.k8s.io/cluster-api/manager .
 ENTRYPOINT ["/manager"]

--- a/cmd/example-provider/main.go
+++ b/cmd/example-provider/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"os"
 
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/controllers"
@@ -28,12 +29,18 @@ import (
 
 func main() {
 	klog.InitFlags(nil)
+	var enableLeaderElection bool
+	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
 	cfg := ctrl.GetConfigOrDie()
 
 	// Setup a Manager
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:         scheme.Scheme,
+		LeaderElection: enableLeaderElection,
+	})
 	if err != nil {
 		klog.Fatalf("Failed to set up controller manager: %v", err)
 	}

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,24 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
+  commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- certificate.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,16 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution
+nameReference:
+- kind: Issuer
+  group: certmanager.k8s.io
+  fieldSpecs:
+  - kind: Certificate
+    group: certmanager.k8s.io
+    path: spec/issuerRef/name
+
+varReference:
+- kind: Certificate
+  group: certmanager.k8s.io
+  path: spec/commonName
+- kind: Certificate
+  group: certmanager.k8s.io
+  path: spec/dnsNames

--- a/config/ci/kustomization.yaml
+++ b/config/ci/kustomization.yaml
@@ -14,3 +14,4 @@ bases:
 
 patchesStrategicMerge:
 - manager_image_patch.yaml
+- manager_label_patch.yaml

--- a/config/ci/manager_image_patch.yaml
+++ b/config/ci/manager_image_patch.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: controller-manager
   namespace: system

--- a/config/ci/manager_label_patch.yaml
+++ b/config/ci/manager_label_patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: cluster-api-controller-manager
+  name: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: cluster-api-controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: cluster-api-controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: cluster-api-controller-manager

--- a/config/ci/rbac/kustomization.yaml
+++ b/config/ci/rbac/kustomization.yaml
@@ -6,3 +6,5 @@
 resources:
 - role_binding.yaml
 - role.yaml
+- leader_election_role.yaml
+- leader_election_role_binding.yaml

--- a/config/ci/rbac/leader_election_role.yaml
+++ b/config/ci/rbac/leader_election_role.yaml
@@ -1,0 +1,33 @@
+
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/config/ci/rbac/leader_election_role_binding.yaml
+++ b/config/ci/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - bases/cluster.x-k8s.io_machinedeployments.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patches:
+# patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_clusters.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -19,6 +19,7 @@ bases:
 
 patchesStrategicMerge:
 - manager_image_patch.yaml
+- manager_label_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
 #- manager_webhook_patch.yaml
@@ -29,7 +30,7 @@ patchesStrategicMerge:
 #- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
+# vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 #- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
 #  objref:

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: controller-manager
   namespace: system

--- a/config/default/manager_label_patch.yaml
+++ b/config/default/manager_label_patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: cluster-api-controller-manager
+  name: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: cluster-api-controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: cluster-api-controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: cluster-api-controller-manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,65 +2,36 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    controller-tools.k8s.io: "1.0"
+    control-plane: controller-manager
   name: system
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: controller-manager-service
-  namespace: system
-  labels:
-    control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-spec:
-  selector:
-    control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-  ports:
-  - port: 443
----
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
   labels:
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
 spec:
   selector:
     matchLabels:
       control-plane: controller-manager
-      controller-tools.k8s.io: "1.0"
-  serviceName: controller-manager-service
+  replicas: 1
   template:
     metadata:
       labels:
         control-plane: controller-manager
-        controller-tools.k8s.io: "1.0"
     spec:
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        key: node.alpha.kubernetes.io/notReady
-        operator: Exists
-      - effect: NoExecute
-        key: node.alpha.kubernetes.io/unreachable
-        operator: Exists
       containers:
       - command:
         - /manager
+        args:
+        - --enable-leader-election
         image: controller:latest
         name: manager
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            memory: 100Mi
       terminationGracePeriodSeconds: 10

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -6,4 +6,5 @@
 resources:
 - role_binding.yaml
 - role.yaml
-
+- leader_election_role.yaml
+- leader_election_role_binding.yaml

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -1,0 +1,33 @@
+
+# permissions to do leader election.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR updates the `config/` directory with more files needed by kustomize v2.

It also fixes a bug in our crd kustomization script which returns `2019/08/16 11:02:33 invalid patches from <nil>`. 

In addition, it changes the base image to `:master` tag (which still needs to be pushed), removes the CPU limits and increases the memory ones

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
