### PR TITLE
🏃Use const instead of var for string constants

### DIFF
--- a/api/v1alpha2/cluster_phase_types.go
+++ b/api/v1alpha2/cluster_phase_types.go
@@ -28,7 +28,7 @@ package v1alpha2
 // Controllers should always look at the actual state of the Cluster’s fields to make those decisions.
 type ClusterPhase string
 
-var (
+const (
 	// ClusterPhasePending is the first state a Cluster is assigned by
 	// Cluster API Cluster controller after being created.
 	ClusterPhasePending = ClusterPhase("pending")

--- a/api/v1alpha2/machine_phase_types.go
+++ b/api/v1alpha2/machine_phase_types.go
@@ -28,7 +28,7 @@ package v1alpha2
 // Controllers should always look at the actual state of the Machine’s fields to make those decisions.
 type MachinePhase string
 
-var (
+const (
 	// MachinePhasePending is the first state a Machine is assigned by
 	// Cluster API Machine controller after being created.
 	MachinePhasePending = MachinePhase("pending")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Robustness: constants should be, well, constant. It's good if the compiler can enforce that for us, right?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
