### PR TITLE
🐛 Fix wrong selectorpath for scale subresources

### DIFF
--- a/api/v1alpha2/machinedeployment_types.go
+++ b/api/v1alpha2/machinedeployment_types.go
@@ -138,6 +138,12 @@ type MachineDeploymentStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,1,opt,name=observedGeneration"`
 
+	// Selector is the same as the label selector but in the string format to avoid introspection
+	// by clients. The string will be in the same format as the query-param syntax.
+	// More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+	// +optional
+	Selector string `json:"selector,omitempty"`
+
 	// Total number of non-terminated machines targeted by this deployment
 	// (their labels match the selector).
 	// +optional
@@ -172,7 +178,7 @@ type MachineDeploymentStatus struct {
 // +kubebuilder:resource:path=machinedeployments,shortName=md,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 
 /// [MachineDeployment]
 // MachineDeployment is the Schema for the machinedeployments API

--- a/api/v1alpha2/machineset_types.go
+++ b/api/v1alpha2/machineset_types.go
@@ -103,6 +103,12 @@ const (
 /// [MachineSetStatus]
 // MachineSetStatus defines the observed state of MachineSet
 type MachineSetStatus struct {
+	// Selector is the same as the label selector but in the string format to avoid introspection
+	// by clients. The string will be in the same format as the query-param syntax.
+	// More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+	// +optional
+	Selector string `json:"selector,omitempty"`
+
 	// Replicas is the most recently observed number of replicas.
 	Replicas int32 `json:"replicas"`
 
@@ -195,7 +201,7 @@ func (m *MachineSet) Default() {
 // +kubebuilder:resource:path=machinesets,shortName=ms,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 
 /// [MachineSet]
 // MachineSet is the Schema for the machinesets API

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -17,7 +17,7 @@ spec:
   scope: Namespaced
   subresources:
     scale:
-      labelSelectorPath: .status.labelSelector
+      labelSelectorPath: .status.selector
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
     status: {}
@@ -508,6 +508,12 @@ spec:
                 deployment (their labels match the selector).
               format: int32
               type: integer
+            selector:
+              description: 'Selector is the same as the label selector but in the
+                string format to avoid introspection by clients. The string will be
+                in the same format as the query-param syntax. More info about label
+                selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+              type: string
             unavailableReplicas:
               description: Total number of unavailable machines targeted by this deployment.
                 This is the total number of machines that are still required for the

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -17,7 +17,7 @@ spec:
   scope: Namespaced
   subresources:
     scale:
-      labelSelectorPath: .status.labelSelector
+      labelSelectorPath: .status.selector
       specReplicasPath: .spec.replicas
       statusReplicasPath: .status.replicas
     status: {}
@@ -481,6 +481,12 @@ spec:
               description: Replicas is the most recently observed number of replicas.
               format: int32
               type: integer
+            selector:
+              description: 'Selector is the same as the label selector but in the
+                string format to avoid introspection by clients. The string will be
+                in the same format as the query-param syntax. More info about label
+                selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+              type: string
           required:
           - replicas
           type: object

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -117,6 +117,10 @@ func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, d *clusterv
 		return ctrl.Result{}, errors.Errorf("failed validation on MachineDeployment %q label selector, cannot match Machine template labels", d.Name)
 	}
 
+	// Copy label selector to its status counterpart in string format.
+	// This is necessary for CRDs including scale subresources.
+	d.Status.Selector = selector.String()
+
 	// Cluster might be nil as some providers might not require a cluster object
 	// for machine management.
 	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, d.ObjectMeta)

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -123,6 +123,11 @@ func (r *MachineSetReconciler) reconcile(ctx context.Context, machineSet *cluste
 		return ctrl.Result{}, errors.Wrapf(err, "failed to convert MachineSet %q label selector to a map", machineSet.Name)
 	}
 
+	// Copy label selector to its status counterpart in string format.
+	// This is necessary for CRDs including scale subresources.
+	machineSet.Status.Selector = selector.String()
+
+	// Get all Machines linked to this MachineSet.
 	allMachines := &clusterv1.MachineList{}
 	err = r.Client.List(
 		context.Background(), allMachines,


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes the `selectorpath` specified in the `kubebuilder:subresource:scale` kubebuilder marker.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
