### PR TITLE
🏃Raise golangci-lint deadline to 2m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,5 +22,6 @@ issue:
   max-same-issues: 0
   max-per-linter: 0
 run:
+  deadline: 2m
   skip-files:
     - ".*\\.deepcopy\\.go$"


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR raises the golangci-lint deadline to 2 minutes instead of the default 1m. See https://github.com/golangci/golangci-lint#config-file

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
