### PR TITLE
🐛Remove provider from get-kubeconfig alpha phase

### DIFF
--- a/cmd/clusterctl/cmd/alpha_phase_get_kubeconfig.go
+++ b/cmd/clusterctl/cmd/alpha_phase_get_kubeconfig.go
@@ -31,7 +31,6 @@ type AlphaPhaseGetKubeconfigOptions struct {
 	Kubeconfig       string
 	KubeconfigOutput string
 	Namespace        string
-	Provider         string
 }
 
 var pgko = &AlphaPhaseGetKubeconfigOptions{}
@@ -43,10 +42,6 @@ var alphaPhaseGetKubeconfigCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if pgko.Kubeconfig == "" {
 			exitWithHelp(cmd, "Please provide a kubeconfig file.")
-		}
-
-		if pgko.Provider == "" {
-			exitWithHelp(cmd, "Please specify a provider.")
 		}
 
 		if pgko.ClusterName == "" {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes a bug where the get-kubeconfig alpha phase would check for a Provider flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

/assign @detiber