### PR TITLE
:sparkles: Remove unnecessary requeues

### DIFF
--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -180,8 +180,8 @@ func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster
 	if err != nil {
 		return err
 	} else if !ready {
-		klog.V(3).Infof("Infrastructure provider for Cluster %q in namespace %q is not ready, requeuing", cluster.Name, cluster.Namespace)
-		return &capierrors.RequeueAfterError{RequeueAfter: 30 * time.Second}
+		klog.V(3).Infof("Infrastructure provider for Cluster %q in namespace %q is not ready yet", cluster.Name, cluster.Namespace)
+		return nil
 	}
 
 	// Get and parse Status.APIEndpoint field from the infrastructure provider.

--- a/controllers/machine_controller_noderef.go
+++ b/controllers/machine_controller_noderef.go
@@ -54,8 +54,8 @@ func (r *MachineReconciler) reconcileNodeRef(ctx context.Context, cluster *v1alp
 
 	// Check that the Machine has a valid ProviderID.
 	if machine.Spec.ProviderID == nil || *machine.Spec.ProviderID == "" {
-		klog.Warningf("Machine %q in namespace %q doesn't have a valid ProviderID, retrying later", machine.Name, machine.Namespace)
-		return &capierrors.RequeueAfterError{RequeueAfter: 30 * time.Second}
+		klog.Warningf("Machine %q in namespace %q doesn't have a valid ProviderID yet", machine.Name, machine.Namespace)
+		return nil
 	}
 
 	providerID, err := noderefutil.NewProviderID(*machine.Spec.ProviderID)


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove unnecessary requeues, since we are watching the objects being requeued.

**Release note**:
```release-note
NONE
```
