### PR TITLE
✨ support kustomize v3.1.0

### DIFF
--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - certificate.yaml
 

--- a/config/ci/kustomization.yaml
+++ b/config/ci/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Adds namespace to all resources.
 namespace: provider-system
 
@@ -8,10 +10,10 @@ namespace: provider-system
 # field above.
 namePrefix: provider-
 
-bases:
-- ./rbac/
-- ./manager/
 
 patchesStrategicMerge:
 - manager_image_patch.yaml
 - manager_label_patch.yaml
+resources:
+- ./rbac/
+- ./manager/

--- a/config/ci/manager/kustomization.yaml
+++ b/config/ci/manager/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Each entry in this list must resolve to an existing
 # resource definition in YAML.  These are the resource
 # files that kustomize reads, modifies and emits as a
@@ -5,4 +7,3 @@
 # markers ("---").
 resources:
 - manager.yaml
-

--- a/config/ci/rbac/kustomization.yaml
+++ b/config/ci/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Each entry in this list must resolve to an existing
 # resource definition in YAML.  These are the resource
 # files that kustomize reads, modifies and emits as a

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default

--- a/config/crds/kustomization.yaml
+++ b/config/crds/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Each entry in this list must resolve to an existing
 # resource definition in YAML.  These are the resource
 # files that kustomize reads, modifies and emits as a
@@ -9,4 +11,3 @@ resources:
 - cluster.k8s.io_machinesets.yaml
 - cluster.k8s.io_machineclasses.yaml
 - cluster.k8s.io_machinedeployments.yaml
-

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Adds namespace to all resources.
 namespace: cluster-api-system
 
@@ -8,10 +10,6 @@ namespace: cluster-api-system
 # field above.
 namePrefix: cluster-api-
 
-bases:
-- ../crd
-- ../rbac
-- ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
 #- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
@@ -58,3 +56,7 @@ patchesStrategicMerge:
 #    kind: Service
 #    version: v1
 #    name: webhook-service
+resources:
+- ../crd
+- ../rbac
+- ../manager

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Each entry in this list must resolve to an existing
 # resource definition in YAML.  These are the resource
 # files that kustomize reads, modifies and emits as a
@@ -5,4 +7,3 @@
 # markers ("---").
 resources:
 - manager.yaml
-

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 # Each entry in this list must resolve to an existing
 # resource definition in YAML.  These are the resource
 # files that kustomize reads, modifies and emits as a

--- a/scripts/ci-integration.sh
+++ b/scripts/ci-integration.sh
@@ -21,6 +21,7 @@ set -o pipefail
 MAKE="make"
 KIND_VERSION="v0.5.0"
 KUBECTL_VERSION="v1.15.3"
+KUSTOMIZE_VERSION="3.1.0"
 CRD_YAML="crd.yaml"
 BOOTSTRAP_CLUSTER_NAME="clusterapi-bootstrap"
 CONTROLLER_REPO="controller-ci" # use arbitrary repo name since we don't need to publish it
@@ -42,6 +43,12 @@ install_kubectl() {
    chmod +x /usr/local/bin/kubectl
 }
 
+install_kustomize() {
+  wget https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_${GOOS}_${GOARCH} \
+    --no-verbose -O /usr/local/bin/kustomize
+    chmod +x /usr/local/bin/kustomize
+}
+
 build_containers() {
    VERSION="$(git describe --exact-match 2> /dev/null || git describe --match="$(git rev-parse --short=8 HEAD)" --always --dirty --abbrev=8)"
    export CONTROLLER_IMG="${CONTROLLER_REPO}"
@@ -53,9 +60,9 @@ build_containers() {
 
 prepare_crd_yaml() {
    CLUSTER_API_CONFIG_PATH="./config"
-   kubectl kustomize "${CLUSTER_API_CONFIG_PATH}/default/" > "${CRD_YAML}"
+   kustomize build "${CLUSTER_API_CONFIG_PATH}/default/" > "${CRD_YAML}"
    echo "---" >> "${CRD_YAML}"
-   kubectl kustomize "${CLUSTER_API_CONFIG_PATH}/ci/" >> "${CRD_YAML}"
+   kustomize build "${CLUSTER_API_CONFIG_PATH}/ci/" >> "${CRD_YAML}"
 }
 
 create_bootstrap() {
@@ -117,6 +124,7 @@ main() {
 
    install_kubectl
    install_kind
+   install_kustomize
    prepare_crd_yaml
    create_bootstrap
 


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This supports kustomize v3.1.0 which is the newest release of kustomize. It includes adding the apiversion/group/kind of the Kustomization type.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1295 

**Release note**:
```release-note
Kustomize v3.1.x support
```
