### PR TITLE
✨Move kubeconfig functions under kubeconfig package

### DIFF
--- a/cmd/clusterctl/clusterdeployer/BUILD.bazel
+++ b/cmd/clusterctl/clusterdeployer/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//api/v1alpha2:go_default_library",
         "//cmd/clusterctl/clusterdeployer/clusterclient:go_default_library",
         "//cmd/clusterctl/clusterdeployer/provider:go_default_library",
+        "//util/kubeconfig:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/clusterctl/clusterdeployer/clusterclient/BUILD.bazel
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//api/v1alpha2:go_default_library",
         "//cmd/clusterctl/clientcmd:go_default_library",
         "//util:go_default_library",
+        "//util/kubeconfig:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -29,6 +29,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/provider"
+	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
 )
 
 type testClusterProvisioner struct {
@@ -314,8 +315,8 @@ func (c *testClusterClient) Close() error {
 
 func (c *testClusterClient) GetKubeconfigFromSecret(namespace, clusterName string) (string, error) {
 	for _, secret := range c.secrets {
-		if secret.Namespace == namespace && secret.Name == fmt.Sprintf("%s-kubeconfig", clusterName) {
-			return string(secret.Data["value"]), nil
+		if secret.Namespace == namespace && secret.Name == kcfg.SecretName(clusterName) {
+			return string(secret.Data[kcfg.SecretKey]), nil
 		}
 	}
 
@@ -820,11 +821,11 @@ func TestClusterCreate(t *testing.T) {
 
 					kubeconfigSecret := &apiv1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("%s-kubeconfig", inputCluster.Name),
+							Name:      kcfg.SecretName(inputCluster.Name),
 							Namespace: ns,
 						},
 						Data: map[string][]byte{
-							"value": []byte(targetKubeconfig),
+							kcfg.SecretKey: []byte(targetKubeconfig),
 						},
 					}
 					testcase.bootstrapClient.secrets = append(testcase.bootstrapClient.secrets, kubeconfigSecret)
@@ -922,7 +923,7 @@ func TestCreateProviderComponentsScenarios(t *testing.T) {
 					Namespace: metav1.NamespaceDefault,
 				},
 				Data: map[string][]byte{
-					"value": []byte(targetKubeconfig),
+					kcfg.SecretKey: []byte(targetKubeconfig),
 				},
 			}
 

--- a/cmd/clusterctl/phases/BUILD.bazel
+++ b/cmd/clusterctl/phases/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//cmd/clusterctl/clusterdeployer/bootstrap:go_default_library",
         "//cmd/clusterctl/clusterdeployer/clusterclient:go_default_library",
         "//util:go_default_library",
+        "//util/kubeconfig:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",

--- a/cmd/clusterctl/phases/getkubeconfig.go
+++ b/cmd/clusterctl/phases/getkubeconfig.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
 	"sigs.k8s.io/cluster-api/util"
+	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
 )
 
 const (
@@ -61,7 +62,7 @@ func waitForKubeconfigReady(bootstrapClient clusterclient.Client, clusterName, n
 
 	kubeconfig := ""
 	err := util.PollImmediate(retryKubeConfigReady, timeout, func() (bool, error) {
-		klog.V(2).Infof("Waiting for kubeconfig from Secret %q-kubeconfig in namespace %q to become available...", clusterName, namespace)
+		klog.V(2).Infof("Waiting for kubeconfig from Secret %q in namespace %q to become available...", kcfg.SecretName(clusterName), namespace)
 		k, err := bootstrapClient.GetKubeconfigFromSecret(namespace, clusterName)
 		if err != nil {
 			klog.V(4).Infof("error getting kubeconfig: %v", err)

--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -22,6 +22,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
+	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -40,13 +41,13 @@ type clusterClient struct {
 
 // NewClusterClient creates a new ClusterClient.
 func NewClusterClient(c client.Client, cluster *v1alpha2.Cluster) (ClusterClient, error) {
-	secret, err := GetKubeConfigSecret(c, cluster.Name, cluster.Namespace)
+	secret, err := kcfg.GetSecret(c, cluster.Name, cluster.Namespace)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve kubeconfig secret for Cluster %q in namespace %q",
 			cluster.Name, cluster.Namespace)
 	}
 
-	kubeconfig, err := KubeConfigFromSecret(secret)
+	kubeconfig, err := kcfg.Extract(secret)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get kubeconfig from secret for Cluster %q in namespace %q",
 			cluster.Name, cluster.Namespace)

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -20,9 +20,11 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
+	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -45,6 +47,43 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test3",
 			Namespace: "test",
+		},
+	}
+
+	validKubeConfig = `
+clusters:
+- cluster:
+    server: https://test-cluster-api:6443
+  name: test-cluster-api
+contexts:
+- context:
+    cluster: test-cluster-api
+    user: kubernetes-admin
+  name: kubernetes-admin@test-cluster-api
+current-context: kubernetes-admin@test-cluster-api
+kind: Config
+preferences: {}
+users:
+- name: kubernetes-admin
+`
+
+	validSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test1-kubeconfig",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			kubeconfig.SecretKey: []byte(validKubeConfig),
+		},
+	}
+
+	invalidSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test2-kubeconfig",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			kubeconfig.SecretKey: []byte("Not valid!!1"),
 		},
 	}
 )

--- a/util/kubeconfig/BUILD.bazel
+++ b/util/kubeconfig/BUILD.bazel
@@ -2,29 +2,23 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["cluster.go"],
-    importpath = "sigs.k8s.io/cluster-api/controllers/remote",
+    srcs = ["kubeconfig.go"],
+    importpath = "sigs.k8s.io/cluster-api/util/kubeconfig",
     visibility = ["//visibility:public"],
     deps = [
-        "//api/v1alpha2:go_default_library",
-        "//util/kubeconfig:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
-        "//vendor/k8s.io/client-go/rest:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["cluster_test.go"],
+    srcs = ["kubeconfig_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//api/v1alpha2:go_default_library",
-        "//util/kubeconfig:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client/fake:go_default_library",
     ],

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package remote
+package kubeconfig
 
 import (
 	"context"
@@ -27,7 +27,9 @@ import (
 )
 
 const (
-	kubeconfigSecretKey = "value"
+	// SecretKey is the key used for accessing contents of the KubeConfig
+	// Secret.
+	SecretKey = "value"
 )
 
 var (
@@ -35,19 +37,19 @@ var (
 	ErrSecretMissingValue = errors.New("missing value in secret")
 )
 
-// KubeConfigSecretName generates the expected name for the Kubeconfig secret
-// to access a remote cluster given the cluster's name.
-func KubeConfigSecretName(cluster string) string {
+// SecretName generates the expected name for the KubeConfig Secret to access
+// a remote cluster given the cluster's name.
+func SecretName(cluster string) string {
 	return fmt.Sprintf("%s-kubeconfig", cluster)
 }
 
-// GetKubeConfigSecret retrieves the KubeConfig Secret (if any)
-// from the given cluster name and namespace.
-func GetKubeConfigSecret(c client.Client, cluster, namespace string) (*corev1.Secret, error) {
+// GetSecret retrieves the KubeConfig Secret (if any) from the given
+// cluster name and namespace.
+func GetSecret(c client.Client, cluster, namespace string) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	secretKey := client.ObjectKey{
 		Namespace: namespace,
-		Name:      KubeConfigSecretName(cluster),
+		Name:      SecretName(cluster),
 	}
 
 	if err := c.Get(context.TODO(), secretKey, secret); err != nil {
@@ -60,9 +62,9 @@ func GetKubeConfigSecret(c client.Client, cluster, namespace string) (*corev1.Se
 	return secret, nil
 }
 
-// KubeConfigFromSecret uses the Secret to retrieve the KubeConfig.
-func KubeConfigFromSecret(secret *corev1.Secret) ([]byte, error) {
-	data, ok := secret.Data[kubeconfigSecretKey]
+// Extract uses the Secret to retrieve the KubeConfig.
+func Extract(secret *corev1.Secret) ([]byte, error) {
+	data, ok := secret.Data[SecretKey]
 	if !ok {
 		return nil, ErrSecretMissingValue
 	}

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package remote
+package kubeconfig
 
 import (
 	"reflect"
@@ -53,24 +53,14 @@ users:
 			Namespace: "test",
 		},
 		Data: map[string][]byte{
-			kubeconfigSecretKey: []byte(validKubeConfig),
-		},
-	}
-
-	invalidSecret = &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test2-kubeconfig",
-			Namespace: "test",
-		},
-		Data: map[string][]byte{
-			kubeconfigSecretKey: []byte("Not valid!!1"),
+			SecretKey: []byte(validKubeConfig),
 		},
 	}
 )
 
 func TestGetKubeConfigSecret(t *testing.T) {
 	client := fake.NewFakeClient(validSecret)
-	found, err := GetKubeConfigSecret(client, "test1", "test")
+	found, err := GetSecret(client, "test1", "test")
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -82,7 +72,7 @@ func TestGetKubeConfigSecret(t *testing.T) {
 
 func TestKubeConfigFromSecret(t *testing.T) {
 	t.Run("with valid secret", func(t *testing.T) {
-		out, err := KubeConfigFromSecret(validSecret)
+		out, err := Extract(validSecret)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Moving the kubeconfig functions to `util` makes them more discoverable to the consumers of Cluster API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1266
