### PR TITLE
:warning: [0.1] Cluster, machine controller: support concurrency

### DIFF
--- a/cmd/example-provider/main.go
+++ b/cmd/example-provider/main.go
@@ -33,8 +33,15 @@ import (
 )
 
 func main() {
+	var (
+		clusterConcurrency int
+		machineConcurrency int
+	)
+
 	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
+	flag.IntVar(&clusterConcurrency, "cluster-concurrency", 1, "Number of clusters to process simultaneously")
+	flag.IntVar(&machineConcurrency, "machine-concurrency", 1, "Number of machines to process simultaneously")
 	flag.Parse()
 
 	cfg := config.GetConfigOrDie()
@@ -65,8 +72,8 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	capimachine.AddWithActuator(mgr, machineActuator)
-	capicluster.AddWithActuator(mgr, clusterActuator)
+	capimachine.AddWithActuator(mgr, machineActuator, machineConcurrency)
+	capicluster.AddWithActuator(mgr, clusterActuator, clusterConcurrency)
 
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		klog.Fatalf("Failed to run manager: %v", err)

--- a/pkg/controller/cluster/cluster_controller.go
+++ b/pkg/controller/cluster/cluster_controller.go
@@ -47,13 +47,13 @@ const deleteRequeueAfter = 5 * time.Second
 
 var DefaultActuator Actuator
 
-func AddWithActuator(mgr manager.Manager, actuator Actuator) error {
+func AddWithActuator(mgr manager.Manager, actuator Actuator, concurrency int) error {
 	reconciler, err := newReconciler(mgr, actuator)
 	if err != nil {
 		return err
 	}
 
-	return add(mgr, reconciler)
+	return add(mgr, reconciler, concurrency)
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -70,9 +70,9 @@ func newReconciler(mgr manager.Manager, actuator Actuator) (reconcile.Reconciler
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(mgr manager.Manager, r reconcile.Reconciler, concurrency int) error {
 	// Create a new controller
-	c, err := controller.New("cluster-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("cluster-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: concurrency})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/cluster/cluster_reconciler_test.go
+++ b/pkg/controller/cluster/cluster_reconciler_test.go
@@ -60,7 +60,7 @@ func TestReconcile(t *testing.T) {
 		t.Fatalf("Couldn't create controller: %v", err)
 	}
 	recFn, requests := SetupTestReconcile(r)
-	if err := add(mgr, recFn); err != nil {
+	if err := add(mgr, recFn, 1); err != nil {
 		t.Fatalf("error adding controller to manager: %v", err)
 	}
 	defer close(StartTestManager(mgr, t))

--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -45,8 +45,8 @@ const (
 
 var DefaultActuator Actuator
 
-func AddWithActuator(mgr manager.Manager, actuator Actuator) error {
-	return add(mgr, newReconciler(mgr, actuator))
+func AddWithActuator(mgr manager.Manager, actuator Actuator, concurrency int) error {
+	return add(mgr, newReconciler(mgr, actuator), concurrency)
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -66,9 +66,9 @@ func newReconciler(mgr manager.Manager, actuator Actuator) reconcile.Reconciler 
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(mgr manager.Manager, r reconcile.Reconciler, concurrency int) error {
 	// Create a new controller
-	c, err := controller.New("machine-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("machine-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: concurrency})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/machine/machine_reconciler_test.go
+++ b/pkg/controller/machine/machine_reconciler_test.go
@@ -53,7 +53,7 @@ func TestReconcile(t *testing.T) {
 
 	a := newTestActuator()
 	recFn, requests := SetupTestReconcile(newReconciler(mgr, a))
-	if err := add(mgr, recFn); err != nil {
+	if err := add(mgr, recFn, 1); err != nil {
 		t.Fatalf("error adding controller to manager: %v", err)
 	}
 	defer close(StartTestManager(mgr, t))


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow the concurrency to be configurable for the cluster and machine controllers. This is a breaking change to the `AddWithActuator` functions, but it's minor (the addition of a new `concurrency` parameter). Providers will need to adjust their manager `main.go` files accordingly (ideally by adding flags to control the concurrency).

I have not dealt with the MachineSet and MachineDeployment controllers in this PR because that requires some more surgery - we'd essentially need to remove the `init()`-based `AddToManagerFuncs` approach to make that happen. If there is interest, I can do it, but I think reconciling MachineSets and MachineDeployments one by one is probably ok for now, given that each iteration should be fast compared to single-threading cluster & machine.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
