### PR TITLE
🏃‍♂️ Remove unused test functions

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -1495,13 +1495,6 @@ func newMachineDeploymentsFixture(ns string) []*clusterv1.MachineDeployment {
 	}
 }
 
-func newClustersFixture(ns string) []*clusterv1.Cluster {
-	return []*clusterv1.Cluster{
-		{ObjectMeta: metav1.ObjectMeta{Name: "cluster-name-1", Namespace: ns}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "cluster-name-2", Namespace: ns}},
-	}
-}
-
 func newTempFile(t *testing.T) string {
 	kubeconfigOutFile, err := ioutil.TempFile("", "")
 	if err != nil {

--- a/controllers/mdutil/util_test.go
+++ b/controllers/mdutil/util_test.go
@@ -32,25 +32,6 @@ import (
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
 )
 
-func generateMSWithLabel(labels map[string]string, image string) v1alpha2.MachineSet {
-	return v1alpha2.MachineSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   names.SimpleNameGenerator.GenerateName("machineset"),
-			Labels: labels,
-		},
-		Spec: v1alpha2.MachineSetSpec{
-			Replicas: func(i int32) *int32 { return &i }(1),
-			Selector: metav1.LabelSelector{MatchLabels: labels},
-			Template: v1alpha2.MachineTemplateSpec{
-				ObjectMeta: v1alpha2.ObjectMeta{
-					Labels: labels,
-				},
-				Spec: v1alpha2.MachineSpec{},
-			},
-		},
-	}
-}
-
 func newDControllerRef(d *v1alpha2.MachineDeployment) *metav1.OwnerReference {
 	isController := true
 	return &metav1.OwnerReference{
@@ -335,26 +316,6 @@ func TestFindOldMachineSets(t *testing.T) {
 			}
 		})
 	}
-}
-
-// equal compares the equality of two MachineSet slices regardless of their ordering
-func equal(mss1, mss2 []*v1alpha2.MachineSet) bool {
-	if reflect.DeepEqual(mss1, mss2) {
-		return true
-	}
-	if mss1 == nil || mss2 == nil || len(mss1) != len(mss2) {
-		return false
-	}
-	count := 0
-	for _, ms1 := range mss1 {
-		for _, ms2 := range mss2 {
-			if reflect.DeepEqual(ms1, ms2) {
-				count++
-				break
-			}
-		}
-	}
-	return count == len(mss1)
 }
 
 func TestGetReplicaCountForMachineSets(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

`newClustersFixture` function was made obsolete by the changes in 3b6365b480ef09006adea2c4f3131b824acff706, and the functions in `controllers/mdutil/util_test.go` were unused since their introduction in 7b1f2917c6a51a95caafcbe013d97c474ff2986d.

These were pointed out by the `deadcode` linter run via golangci-lint:
```
controllers/mdutil/util_test.go:35:6: `generateMSWithLabel` is unused (deadcode)
func generateMSWithLabel(labels map[string]string, image string) v1alpha2.MachineSet {
     ^
controllers/mdutil/util_test.go:341:6: `equal` is unused (deadcode)
func equal(mss1, mss2 []*v1alpha2.MachineSet) bool {
     ^
cmd/clusterctl/clusterdeployer/clusterdeployer_test.go:1498:6: `newClustersFixture` is unused (deadcode)
func newClustersFixture(ns string) []*clusterv1.Cluster {
     ^
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
