### PR TITLE
:sparkles: Make all ClusterNetwork fields optional

### DIFF
--- a/api/v1alpha2/cluster_types.go
+++ b/api/v1alpha2/cluster_types.go
@@ -47,13 +47,16 @@ type ClusterSpec struct {
 // parameters for a cluster.
 type ClusterNetworkingConfig struct {
 	// The network ranges from which service VIPs are allocated.
-	Services NetworkRanges `json:"services"`
+	// +optional
+	Services NetworkRanges `json:"services,omitempty"`
 
 	// The network ranges from which Pod networks are allocated.
-	Pods NetworkRanges `json:"pods"`
+	// +optional
+	Pods NetworkRanges `json:"pods,omitempty"`
 
 	// Domain name for services.
-	ServiceDomain string `json:"serviceDomain"`
+	// +optional
+	ServiceDomain string `json:"serviceDomain,omitempty"`
 }
 
 /// [ClusterNetworkingConfig]

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -67,10 +67,6 @@ spec:
                   required:
                   - cidrBlocks
                   type: object
-              required:
-              - pods
-              - serviceDomain
-              - services
               type: object
             infrastructureRef:
               description: InfrastructureRef is a reference to a provider-specific


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of just making ClusterNetwork itself optional, also make it's fields optional as well.

/assign @vincepri 