### PR TITLE
:bug: Reduce MS controller test flakiness

### DIFF
--- a/controllers/machineset_controller_test.go
+++ b/controllers/machineset_controller_test.go
@@ -158,6 +158,11 @@ var _ = Describe("MachineSet Reconciler", func() {
 		// Verify that each machine has the desired kubelet version,
 		// create a fake node in Ready state, update NodeRef, and wait for a reconciliation request.
 		for _, m := range machines.Items {
+			if !m.DeletionTimestamp.IsZero() {
+				// Skip deleted Machines
+				continue
+			}
+
 			Expect(m.Spec.Version).ToNot(BeNil())
 			Expect(*m.Spec.Version).To(BeEquivalentTo("1.14.2"))
 			fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource)


### PR DESCRIPTION
**What this PR does / why we need it**:
Skip over deleted Machines in MachineSet controller tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #