### PR TITLE
:sparkles: Improve ErrorMessage from referenced resources

### DIFF
--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -119,7 +120,10 @@ func (r *ClusterReconciler) reconcileExternal(ctx context.Context, cluster *v1al
 		cluster.Status.ErrorReason = &clusterStatusError
 	}
 	if errorMessage != "" {
-		cluster.Status.ErrorMessage = pointer.StringPtr(errorMessage)
+		cluster.Status.ErrorMessage = pointer.StringPtr(
+			fmt.Sprintf("Failure detected from referenced resource %v with name %q: %s",
+				obj.GroupVersionKind(), obj.GetName(), errorMessage),
+		)
 	}
 
 	return obj, nil

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -128,7 +129,10 @@ func (r *MachineReconciler) reconcileExternal(ctx context.Context, m *v1alpha2.M
 		m.Status.ErrorReason = &machineStatusError
 	}
 	if errorMessage != "" {
-		m.Status.ErrorMessage = pointer.StringPtr(errorMessage)
+		m.Status.ErrorMessage = pointer.StringPtr(
+			fmt.Sprintf("Failure detected from referenced resource %v with name %q: %s",
+				obj.GroupVersionKind(), obj.GetName(), errorMessage),
+		)
 	}
 
 	return obj, nil


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1294
