### PR TITLE
✨ Update status fields to explicit phase types

### DIFF
--- a/api/v1alpha2/cluster_types.go
+++ b/api/v1alpha2/cluster_types.go
@@ -95,7 +95,7 @@ type ClusterStatus struct {
 	// Phase represents the current phase of cluster actuation.
 	// E.g. Pending, Running, Terminating, Failed etc.
 	// +optional
-	Phase string `json:"phase,omitempty"`
+	Phase ClusterPhase `json:"phase,omitempty"`
 
 	// InfrastructureReady is the state of the infrastructure provider.
 	// +optional
@@ -104,20 +104,20 @@ type ClusterStatus struct {
 
 // SetTypedPhase sets the Phase field to the string representation of ClusterPhase.
 func (c *ClusterStatus) SetTypedPhase(p ClusterPhase) {
-	c.Phase = string(p)
+	c.Phase = p
 }
 
 // GetTypedPhase attempts to parse the Phase field and return
 // the typed ClusterPhase representation as described in `machine_phase_types.go`.
 func (c *ClusterStatus) GetTypedPhase() ClusterPhase {
-	switch phase := ClusterPhase(c.Phase); phase {
+	switch c.Phase {
 	case
 		ClusterPhasePending,
 		ClusterPhaseProvisioning,
 		ClusterPhaseProvisioned,
 		ClusterPhaseDeleting,
 		ClusterPhaseFailed:
-		return phase
+		return c.Phase
 	default:
 		return ClusterPhaseUnknown
 	}

--- a/api/v1alpha2/machine_types.go
+++ b/api/v1alpha2/machine_types.go
@@ -135,7 +135,7 @@ type MachineStatus struct {
 	// Phase represents the current phase of machine actuation.
 	// E.g. Pending, Running, Terminating, Failed etc.
 	// +optional
-	Phase string `json:"phase,omitempty"`
+	Phase MachinePhase `json:"phase,omitempty"`
 
 	// BootstrapReady is the state of the bootstrap provider.
 	// +optional
@@ -148,13 +148,13 @@ type MachineStatus struct {
 
 // SetTypedPhase sets the Phase field to the string representation of MachinePhase.
 func (m *MachineStatus) SetTypedPhase(p MachinePhase) {
-	m.Phase = string(p)
+	m.Phase = p
 }
 
 // GetTypedPhase attempts to parse the Phase field and return
 // the typed MachinePhase representation as described in `machine_phase_types.go`.
 func (m *MachineStatus) GetTypedPhase() MachinePhase {
-	switch phase := MachinePhase(m.Phase); phase {
+	switch m.Phase {
 	case
 		MachinePhasePending,
 		MachinePhaseProvisioning,
@@ -163,7 +163,7 @@ func (m *MachineStatus) GetTypedPhase() MachinePhase {
 		MachinePhaseDeleting,
 		MachinePhaseDeleted,
 		MachinePhaseFailed:
-		return phase
+		return m.Phase
 	default:
 		return MachinePhaseUnknown
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Primarily a minor cosmetic change to document the cluster/machine phase fields appropriately by using the explicitly modeled types.
