### PR TITLE
🐛 Restore 10 minute default for Manager SyncPeriod

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"net/http"
 	"os"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -91,11 +92,14 @@ func main() {
 		}()
 	}
 
+	syncPeriod := 10 * time.Minute
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
 		Namespace:          watchNamespace,
+		SyncPeriod:         &syncPeriod,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
**What this PR does / why we need it**:

@detiber pointed out in https://github.com/kubernetes-sigs/cluster-api/issues/1322#issuecomment-525471811 that the intended Manager SyncPeriod for CAPI is 10 minutes. It looks like this was lost in the kubebuilder v2 migration, as the previous [`cmd/manager/main.go`](https://github.com/kubernetes-sigs/cluster-api/blob/2ea2000a619bcd1b805beb049ea3bb0cd0c3aa2f/cmd/manager/main.go#L64-L69) had this set to 10 minutes as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
