### PR TITLE
:bug: Fix null pointer exceptions in MachineStatus conversion

### DIFF
--- a/api/v1alpha2/conversion.go
+++ b/api/v1alpha2/conversion.go
@@ -118,6 +118,10 @@ func Convert_v1alpha1_MachineStatus_To_v1alpha2_MachineStatus(in *v1alpha1.Machi
 		return err
 	}
 
+	if in.Versions == nil {
+		return nil
+	}
+
 	if in.Versions.ControlPlane != "" {
 		out.Version = &in.Versions.ControlPlane
 	} else if in.Versions.Kubelet != "" {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->

**What this PR does / why we need it**:
A bug in the conversion version logic causes segfaults in some situations. This fixes that. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
