### PR TITLE
Configure manage with sync-period flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 		machineConcurrency           int
 		machineSetConcurrency        int
 		machineDeploymentConcurrency int
+		syncPeriod                   time.Duration
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080",
@@ -81,6 +82,9 @@ func main() {
 	flag.IntVar(&machineDeploymentConcurrency, "machinedeployment-concurrency", 1,
 		"Number of machine deployments to process simultaneously")
 
+	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
+		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
+
 	flag.Parse()
 
 	ctrl.SetLogger(klogr.New())
@@ -91,8 +95,6 @@ func main() {
 			klog.Info(http.ListenAndServe(profilerAddress, nil))
 		}()
 	}
-
-	syncPeriod := 10 * time.Minute
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
- sync-period flag can be passed as an argument
- If not provided, then value is defaulted to 10m

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1322