### PR TITLE
:sparkles: Feature/move kubeconfig functionality to util

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -172,16 +172,7 @@ func (c *client) EnsureNamespace(namespaceName string) error {
 }
 
 func (c *client) GetKubeconfigFromSecret(namespace, clusterName string) (string, error) {
-	secret, err := kcfg.GetSecret(c.clientSet, clusterName, namespace)
-	if err != nil {
-		return "", err
-	}
-
-	data, err := kcfg.Extract(secret)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
+	return kcfg.FetchKubeconfigFromSecret(c.clientSet, namespace, clusterName)
 }
 
 func (c *client) ScaleDeployment(ns string, name string, scale int32) error {

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -70,3 +70,17 @@ func Extract(secret *corev1.Secret) ([]byte, error) {
 	}
 	return data, nil
 }
+
+// Fetching Kubeconfig
+func FetchKubeconfigFromSecret(c client.Client, namespace, clusterName string) (string, error) {
+	secret, err := GetSecret(c, clusterName, namespace)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := Extract(secret)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes available the functionality which was previously in clusterclient for getting and extracting a kubeconfig for given cluster, also in util/kubeconfig/kubeconfig.go.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1306 
