### PR TITLE
:bug: Fix release-notes bug to correctly match on :running:

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -109,7 +109,7 @@ func run() int {
 			key = bugs
 		case strings.HasPrefix(firstWord, ":book:"), strings.HasPrefix(firstWord, "📖"):
 			key = documentation
-		case strings.HasPrefix(firstWord, ":running:"), strings.HasPrefix(firstWord, "🏃‍️"):
+		case strings.HasPrefix(firstWord, ":running:"), strings.HasPrefix(firstWord, "🏃"):
 			key = other
 		case strings.HasPrefix(firstWord, ":warning:"), strings.HasPrefix(firstWord, "⚠️"):
 			key = warning


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR fixes a bug in the release notes. The emoji bytes used on GitHub and the emoji bytes on os x are somehow different. I think it has to do with the gender of the running guy, but I'm not 100% sure. This does work though.

/assign @vincepri 