### PR TITLE
⚠️ Add certificate and secret utils

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -172,7 +172,9 @@ func (c *client) EnsureNamespace(namespaceName string) error {
 }
 
 func (c *client) GetKubeconfigFromSecret(namespace, clusterName string) (string, error) {
-	return kcfg.FetchKubeconfigFromSecret(c.clientSet, namespace, clusterName)
+	cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: clusterName}}
+	out, err := kcfg.FetchKubeconfigFromSecret(c.clientSet, cluster)
+	return string(out), err
 }
 
 func (c *client) ScaleDeployment(ns string, name string, scale int32) error {

--- a/cmd/clusterctl/phases/getkubeconfig.go
+++ b/cmd/clusterctl/phases/getkubeconfig.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
 	"sigs.k8s.io/cluster-api/util"
-	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/cluster-api/util/secret"
 )
 
 const (
@@ -62,7 +62,8 @@ func waitForKubeconfigReady(bootstrapClient clusterclient.Client, clusterName, n
 
 	kubeconfig := ""
 	err := util.PollImmediate(retryKubeConfigReady, timeout, func() (bool, error) {
-		klog.V(2).Infof("Waiting for kubeconfig from Secret %q in namespace %q to become available...", kcfg.SecretName(clusterName), namespace)
+		klog.V(2).Infof("Waiting for kubeconfig from Secret %q in namespace %q to become available...",
+			secret.Name(clusterName, secret.Kubeconfig), namespace)
 		k, err := bootstrapClient.GetKubeconfigFromSecret(namespace, clusterName)
 		if err != nil {
 			klog.V(4).Infof("error getting kubeconfig: %v", err)

--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -41,15 +41,9 @@ type clusterClient struct {
 
 // NewClusterClient creates a new ClusterClient.
 func NewClusterClient(c client.Client, cluster *v1alpha2.Cluster) (ClusterClient, error) {
-	secret, err := kcfg.GetSecret(c, cluster.Name, cluster.Namespace)
+	kubeconfig, err := kcfg.FetchKubeconfigFromSecret(c, cluster)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve kubeconfig secret for Cluster %q in namespace %q",
-			cluster.Name, cluster.Namespace)
-	}
-
-	kubeconfig, err := kcfg.Extract(secret)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get kubeconfig from secret for Cluster %q in namespace %q",
 			cluster.Name, cluster.Namespace)
 	}
 

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -24,7 +24,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
-	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -73,7 +73,7 @@ users:
 			Namespace: "test",
 		},
 		Data: map[string][]byte{
-			kubeconfig.SecretKey: []byte(validKubeConfig),
+			secret.KubeconfigDataName: []byte(validKubeConfig),
 		},
 	}
 
@@ -83,7 +83,7 @@ users:
 			Namespace: "test",
 		},
 		Data: map[string][]byte{
-			kubeconfig.SecretKey: []byte("Not valid!!1"),
+			secret.KubeconfigDataName: []byte("Not valid!!1"),
 		},
 	}
 )
@@ -109,7 +109,7 @@ func TestNewClusterClient(t *testing.T) {
 	t.Run("cluster with no kubeconfig", func(t *testing.T) {
 		client := fake.NewFakeClient()
 		_, err := NewClusterClient(client, clusterWithNoKubeConfig)
-		if !strings.Contains(err.Error(), "secret not found") {
+		if !strings.Contains(err.Error(), "not found") {
 			t.Fatalf("Expected not found error, got %v", err)
 		}
 	})

--- a/util/certs/certs.go
+++ b/util/certs/certs.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certs
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+
+	"github.com/pkg/errors"
+)
+
+// NewPrivateKey creates an RSA private key
+func NewPrivateKey() (*rsa.PrivateKey, error) {
+	pk, err := rsa.GenerateKey(rand.Reader, DefaultRSAKeySize)
+	return pk, errors.WithStack(err)
+}
+
+// EncodeCertPEM returns PEM-endcoded certificate data.
+func EncodeCertPEM(cert *x509.Certificate) []byte {
+	block := pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	}
+	return pem.EncodeToMemory(&block)
+}
+
+// EncodePrivateKeyPEM returns PEM-encoded private key data.
+func EncodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
+	block := pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+
+	return pem.EncodeToMemory(&block)
+}
+
+// EncodePublicKeyPEM returns PEM-encoded public key data.
+func EncodePublicKeyPEM(key *rsa.PublicKey) ([]byte, error) {
+	der, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return []byte{}, errors.WithStack(err)
+	}
+	block := pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: der,
+	}
+	return pem.EncodeToMemory(&block), nil
+}
+
+// DecodeCertPEM attempts to return a decoded certificate or nil
+// if the encoded input does not contain a certificate.
+func DecodeCertPEM(encoded []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(encoded)
+	if block == nil {
+		return nil, nil
+	}
+
+	return x509.ParseCertificate(block.Bytes)
+}
+
+// DecodePrivateKeyPEM attempts to return a decoded key or nil
+// if the encoded input does not contain a private key.
+func DecodePrivateKeyPEM(encoded []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(encoded)
+	if block == nil {
+		return nil, nil
+	}
+
+	return x509.ParsePKCS1PrivateKey(block.Bytes)
+}

--- a/util/certs/consts.go
+++ b/util/certs/consts.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certs
+
+import "time"
+
+const (
+	// DefaultRSAKeySize is the default key size used when created RSA keys.
+	DefaultRSAKeySize = 2048
+
+	// DefaultCertDuration is the default lifespan used when creating certificates.
+	DefaultCertDuration = time.Hour * 24 * 365
+)

--- a/util/certs/types.go
+++ b/util/certs/types.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certs
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// KeyPair holds the raw bytes for a certificate and key.
+type KeyPair struct {
+	Cert, Key []byte
+}
+
+// IsValid returns true if both the certificate and key are non-nil.
+func (k *KeyPair) IsValid() bool {
+	return k.Cert != nil && k.Key != nil
+}
+
+// Config contains the basic fields required for creating a certificate.
+type Config struct {
+	CommonName   string
+	Organization []string
+	AltNames     AltNames
+	Usages       []x509.ExtKeyUsage
+}
+
+// NewSignedCert creates a signed certificate using the given CA certificate and key.
+func (cfg *Config) NewSignedCert(key *rsa.PrivateKey, caCert *x509.Certificate, caKey *rsa.PrivateKey) (*x509.Certificate, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate random integer for signed cerficate")
+	}
+
+	if len(cfg.CommonName) == 0 {
+		return nil, errors.New("must specify a CommonName")
+	}
+
+	if len(cfg.Usages) == 0 {
+		return nil, errors.New("must specify at least one ExtKeyUsage")
+	}
+
+	tmpl := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:   cfg.CommonName,
+			Organization: cfg.Organization,
+		},
+		DNSNames:     cfg.AltNames.DNSNames,
+		IPAddresses:  cfg.AltNames.IPs,
+		SerialNumber: serial,
+		NotBefore:    caCert.NotBefore,
+		NotAfter:     time.Now().Add(DefaultCertDuration).UTC(),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  cfg.Usages,
+	}
+
+	b, err := x509.CreateCertificate(rand.Reader, &tmpl, caCert, key.Public(), caKey)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create signed certificate: %+v", tmpl)
+	}
+
+	return x509.ParseCertificate(b)
+}
+
+// AltNames contains the domain names and IP addresses that will be added
+// to the API Server's x509 certificate SubAltNames field. The values will
+// be passed directly to the x509.Certificate object.
+type AltNames struct {
+	DNSNames []string
+	IPs      []net.IP
+}

--- a/util/secret/consts.go
+++ b/util/secret/consts.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+// Purpose is the name to append to the secret generated for a cluster.
+type Purpose string
+
+const (
+	// KubeconfigDataName is the key used to store a Kubeconfig in the secret's data field.
+	KubeconfigDataName = "value"
+
+	// TLSKeyDataName is the key used to store a TLS private key in the secret's data field.
+	TLSKeyDataName = "tls.key"
+
+	// TLSCrtDataName is the key used to store a TLS certificate in the secret's data field.
+	TLSCrtDataName = "tls.crt"
+
+	// Kubeconfig is the secret name suffix storing the Cluster Kubeconfig.
+	Kubeconfig = Purpose("kubeconfig")
+
+	// ClusterCA is the secret name suffix for APIServer CA.
+	ClusterCA = Purpose("ca")
+)

--- a/util/secret/secret.go
+++ b/util/secret/secret.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Get retrieves the specified Secret (if any) from the given
+// cluster name and namespace.
+func Get(c client.Client, cluster *clusterv1.Cluster, purpose Purpose) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	secretKey := client.ObjectKey{
+		Namespace: cluster.Namespace,
+		Name:      Name(cluster.Name, purpose),
+	}
+
+	if err := c.Get(context.TODO(), secretKey, secret); err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+// Name returns the name of the secret for a cluster.
+func Name(cluster string, suffix Purpose) string {
+	return fmt.Sprintf("%s-%s", cluster, suffix)
+}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR moves some utilities functions from the kubeadm bootstrap provider to this repository. It introduces a `util/secret` package to deal with Cluster API related secrets.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
