### PR TITLE
:warning: Set InfrastructureReady before APIEndpoint

### DIFF
--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -149,6 +149,7 @@ func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster
 		klog.V(3).Infof("Infrastructure provider for Cluster %q in namespace %q is not ready yet", cluster.Name, cluster.Namespace)
 		return nil
 	}
+	cluster.Status.InfrastructureReady = true
 
 	// Get and parse Status.APIEndpoint field from the infrastructure provider.
 	if err := util.UnstructuredUnmarshalField(infraConfig, &cluster.Status.APIEndpoints, "status", "apiEndpoints"); err != nil {
@@ -159,6 +160,5 @@ func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster
 			cluster.Name, cluster.Namespace)
 	}
 
-	cluster.Status.InfrastructureReady = true
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
