### PR TITLE
:bug: Fix output of event when scaling a MachineDeployment

### DIFF
--- a/controllers/machinedeployment_sync.go
+++ b/controllers/machinedeployment_sync.go
@@ -418,7 +418,7 @@ func (r *MachineDeploymentReconciler) scaleMachineSetOperation(ms *clusterv1.Mac
 			r.recorder.Eventf(deployment, corev1.EventTypeWarning, "FailedScale", "Failed to scale MachineSet %q: %v", ms.Name, err)
 		} else if sizeNeedsUpdate {
 			scaled = true
-			r.recorder.Eventf(deployment, corev1.EventTypeNormal, "SuccessfulScale", "Scaled %d MachineSet %q to %d", scaleOperation, ms.Name, newScale)
+			r.recorder.Eventf(deployment, corev1.EventTypeNormal, "SuccessfulScale", "Scaled %s MachineSet %q to %d", scaleOperation, ms.Name, newScale)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The output of the event when scaling a MachineDeployment is currently wrong:

```
0s    Normal   SuccessfulScale   MachineDeployment   Scaled %!d(string=down) MachineSet "machinedeployment-a-md-0-669486cffb" to 1
```

When it should be:

```
0s    Normal   SuccessfulScale   MachineDeployment   Scaled down MachineSet "machinedeployment-a-md-0-669486cffb" to 1
```

