### PR TITLE
:bug: Fix RBAC for kubeconfig secret generation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -98,6 +98,8 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
+  - patch
   - watch

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -48,7 +48,7 @@ const (
 )
 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes RBAC to allow creating the kubeconfig secret
