### PR TITLE
🐛 Set the correct OwnerRef Kind in MD controller

### DIFF
--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -38,6 +38,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+var (
+	// machineDeploymentKind contains the schema.GroupVersionKind for the MachineDeployment type.
+	machineDeploymentKind = clusterv1.GroupVersion.WithKind("MachineDeployment")
+)
+
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;create;update;patch;delete
@@ -221,7 +226,7 @@ func (r *MachineDeploymentReconciler) getMachineSetsForDeployment(d *clusterv1.M
 // adoptOrphan sets the MachineDeployment as a controller OwnerReference to the MachineSet.
 func (r *MachineDeploymentReconciler) adoptOrphan(deployment *clusterv1.MachineDeployment, machineSet *clusterv1.MachineSet) error {
 	patch := client.MergeFrom(machineSet.DeepCopy())
-	newRef := *metav1.NewControllerRef(deployment, controllerKind)
+	newRef := *metav1.NewControllerRef(deployment, machineDeploymentKind)
 	machineSet.OwnerReferences = append(machineSet.OwnerReferences, newRef)
 	return r.Client.Patch(context.Background(), machineSet, patch)
 }

--- a/controllers/machinedeployment_sync.go
+++ b/controllers/machinedeployment_sync.go
@@ -146,7 +146,7 @@ func (r *MachineDeploymentReconciler) getNewMachineSet(d *clusterv1.MachineDeplo
 			Name:            d.Name + "-" + apirand.SafeEncodeString(machineTemplateSpecHash),
 			Namespace:       d.Namespace,
 			Labels:          newMSTemplate.Labels,
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(d, controllerKind)},
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(d, machineDeploymentKind)},
 		},
 		Spec: clusterv1.MachineSetSpec{
 			Replicas:        new(int32),

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -43,8 +43,8 @@ import (
 )
 
 var (
-	// controllerKind contains the schema.GroupVersionKind for this controller type.
-	controllerKind = clusterv1.GroupVersion.WithKind("MachineSet")
+	// machineSetKind contains the schema.GroupVersionKind for the MachineSet type.
+	machineSetKind = clusterv1.GroupVersion.WithKind("MachineSet")
 
 	// stateConfirmationTimeout is the amount of time allowed to wait for desired state.
 	stateConfirmationTimeout = 10 * time.Second
@@ -243,7 +243,7 @@ func (r *MachineSetReconciler) syncReplicas(ms *clusterv1.MachineSet, machines [
 	if diff < 0 {
 		diff *= -1
 		klog.Infof("Too few replicas for %v %s/%s, need %d, creating %d",
-			controllerKind, ms.Namespace, ms.Name, *(ms.Spec.Replicas), diff)
+			machineSetKind, ms.Namespace, ms.Name, *(ms.Spec.Replicas), diff)
 
 		var machineList []*clusterv1.Machine
 		var errstrings []string
@@ -310,7 +310,7 @@ func (r *MachineSetReconciler) syncReplicas(ms *clusterv1.MachineSet, machines [
 		return r.waitForMachineCreation(machineList)
 	} else if diff > 0 {
 		klog.Infof("Too many replicas for %v %s/%s, need %d, deleting %d",
-			controllerKind, ms.Namespace, ms.Name, *(ms.Spec.Replicas), diff)
+			machineSetKind, ms.Namespace, ms.Name, *(ms.Spec.Replicas), diff)
 
 		deletePriorityFunc, err := getDeletePriorityFunc(ms)
 		if err != nil {
@@ -370,7 +370,7 @@ func (r *MachineSetReconciler) getNewMachine(machineSet *clusterv1.MachineSet) *
 		Spec: machineSet.Spec.Template.Spec,
 	}
 	machine.ObjectMeta.GenerateName = fmt.Sprintf("%s-", machineSet.Name)
-	machine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(machineSet, controllerKind)}
+	machine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(machineSet, machineSetKind)}
 	machine.Namespace = machineSet.Namespace
 	return machine
 }
@@ -386,7 +386,7 @@ func shouldExcludeMachine(machineSet *clusterv1.MachineSet, machine *clusterv1.M
 
 // adoptOrphan sets the MachineSet as a controller OwnerReference to the Machine.
 func (r *MachineSetReconciler) adoptOrphan(machineSet *clusterv1.MachineSet, machine *clusterv1.Machine) error {
-	newRef := *metav1.NewControllerRef(machineSet, controllerKind)
+	newRef := *metav1.NewControllerRef(machineSet, machineSetKind)
 	machine.OwnerReferences = append(machine.OwnerReferences, newRef)
 	return r.Client.Update(context.Background(), machine)
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes an issue where the MachineDeployment controller code was referencing the MachineSet controller Kind when creating OwnerRefs. This PR also adds a test that checks that the MachineDeployment is in fact the controller and its Kind matches what we expect.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1366 
