### PR TITLE
:bug: Fix MachineDeployment test flake

### DIFF
--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -38,6 +38,12 @@ func fakeInfrastructureRefReady(ref corev1.ObjectReference, base map[string]inte
 		return k8sClient.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, iref)
 	}, timeout).ShouldNot(HaveOccurred())
 
+	ready, found, err := unstructured.NestedBool(iref.Object, "status", "ready")
+	Expect(err).To(BeNil())
+	if found && ready {
+		return
+	}
+
 	irefPatch := client.MergeFrom(iref.DeepCopy())
 	unstructured.SetNestedField(iref.Object, true, "status", "ready")
 	Expect(k8sClient.Status().Patch(ctx, iref, irefPatch)).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a race condition where a Machine was deleted from the
apiserver but the manager's shared informer cache hadn't caught up yet.
We were trying to update all the infra resources for all Machines,
including the Machines that had been deleted (but as far as the cache
was concerned, they hadn't been deleted yet).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1377 

@vincepri @detiber @rudoi hopefully this will do it. The key bit in the PR is `thirdMachineSet` and its associated logic. PTAL!