### PR TITLE
:bug: Improve handling of patching and updates in MachineSet and MachineDeployment controllers

### DIFF
--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -386,9 +386,10 @@ func shouldExcludeMachine(machineSet *clusterv1.MachineSet, machine *clusterv1.M
 
 // adoptOrphan sets the MachineSet as a controller OwnerReference to the Machine.
 func (r *MachineSetReconciler) adoptOrphan(machineSet *clusterv1.MachineSet, machine *clusterv1.Machine) error {
+	patch := client.MergeFrom(machine)
 	newRef := *metav1.NewControllerRef(machineSet, machineSetKind)
 	machine.OwnerReferences = append(machine.OwnerReferences, newRef)
-	return r.Client.Update(context.Background(), machine)
+	return r.Client.Patch(context.Background(), machine, patch)
 }
 
 func (r *MachineSetReconciler) waitForMachineCreation(machineList []*clusterv1.Machine) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves handling of patch and update semantics used by MachineSet and MachineDeployment controllers

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1349 
