### PR TITLE
🏃 ClusterReconciler: make Client a proper field

### DIFF
--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -90,7 +90,7 @@ func (r *ClusterReconciler) reconcileExternal(ctx context.Context, cluster *clus
 
 	if !util.HasOwnerRef(obj.GetOwnerReferences(), ownerRef) {
 		obj.SetOwnerReferences(util.EnsureOwnerRef(obj.GetOwnerReferences(), ownerRef))
-		if err := r.Patch(ctx, obj, objPatch); err != nil {
+		if err := r.Client.Patch(ctx, obj, objPatch); err != nil {
 			return nil, errors.Wrapf(err,
 				"failed to set OwnerReference on %v %q for Cluster %q in namespace %q",
 				obj.GroupVersionKind(), ref.Name, cluster.Name, cluster.Namespace)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1381
