### PR TITLE
🐛 Updates release notes generator

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -99,13 +99,13 @@ func run() int {
 	for i := 0; i < len(outLines); i++ {
 		line := strings.TrimSpace(outLines[i])
 		switch {
-		case line == "":
+		case strings.HasPrefix(line, "commit"):
 			commits = append(commits, c)
 			c = commit{}
 		case strings.HasPrefix(line, "Merge"):
 			c.merge = line
-		case strings.HasPrefix(line, "commit"):
 			continue
+		case line == "":
 		default:
 			c.body = line
 		}
@@ -131,7 +131,10 @@ func run() int {
 		if key != unknown {
 			c.body = c.body[len(firstWord):]
 		}
-		c.body = fmt.Sprintf("    - %s", strings.TrimSpace(c.body))
+		if strings.TrimSpace(c.body) == "" {
+			continue
+		}
+		c.body = fmt.Sprintf("- %s", strings.TrimSpace(c.body))
 		fmt.Sscanf(c.merge, "Merge pull request %s from %s", &prNumber, &fork)
 		merges[key] = append(merges[key], formatMerge(c.body, prNumber))
 	}


### PR DESCRIPTION
The git log is actually

```
commit <hash>
Merge Pull Request ...

<body>
```

Which is now parsed correctly

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR fixes a bug in the release notes generator. Originally the output of rev-list was parsed incorrectly. The assumption was that it was formatted like this:

```
<newline>
Body
commit
Merge
```

When it is actually
```
commit
Merge
<newline>
body
```

This commit parses the git output correctly and also ignores commits with no body for easier formatting.

/assign @vincepri 