### PR TITLE
🐛 cleanup infrastructure configuration object after bootstrap clone error

### DIFF
--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -286,6 +286,9 @@ func (r *MachineSetReconciler) syncReplicas(ctx context.Context, ms *clusterv1.M
 			if machine.Spec.Bootstrap.ConfigRef != nil {
 				bootstrapConfig, err = external.CloneTemplate(ctx, r.Client, machine.Spec.Bootstrap.ConfigRef, machine.Namespace)
 				if err != nil {
+					if err := r.Client.Delete(context.TODO(), infraConfig); !apierrors.IsNotFound(err) {
+						klog.Errorf("Failed to cleanup infrastructure configuration object after bootstrap clone error: %v", err)
+					}
 					return errors.Wrapf(err, "failed to clone bootstrap configuration for MachineSet %q in namespace %q", ms.Name, ms.Namespace)
 				}
 				machine.Spec.Bootstrap.ConfigRef = &corev1.ObjectReference{


### PR DESCRIPTION
Signed-off-by: Tang Le <at28997146@163.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
We should cleanup infrastructure configuration object after bootstrap clone error, otherwise infrastructure configuration object will leak.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
