### PR TITLE
:bug: manager: use our RESTMapper

### DIFF
--- a/cmd/clusterctl/clientcmd/configutil.go
+++ b/cmd/clusterctl/clientcmd/configutil.go
@@ -56,8 +56,13 @@ func NewControllerRuntimeClient(kubeconfigPath string, overrides clientcmd.Confi
 		return nil, err
 	}
 
+	mapper, err := restmapper.NewCached(config)
+	if err != nil {
+		return nil, err
+	}
+
 	return client.New(config, client.Options{
-		Mapper: restmapper.NewCached(config),
+		Mapper: mapper,
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/klog/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/controllers"
+	"sigs.k8s.io/cluster-api/util/restmapper"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	// +kubebuilder:scaffold:imports
@@ -99,6 +100,7 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
+		MapperProvider:     restmapper.NewCached,
 		LeaderElection:     enableLeaderElection,
 		Namespace:          watchNamespace,
 		SyncPeriod:         &syncPeriod,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Switch to using our caching RESTMapper in the manager. If one of our
controllers encounters a Kind that was added to the apiserver after the
manager retrieved and cached the API discovery document, it won't be
able to work with it because this new Kind is not in the cache. We need
to invalidate and flush the cache in this scenario.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1402 