### PR TITLE
:running: Update cloudbuild.yaml for PULL_BASE_REF substitution

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,14 +1,18 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - TAG=$_GIT_TAG
+    - ADDITIONAL_TAG=$_PULL_BASE_REF
     args:
     - release-staging
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution
   _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'dev'


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates cloudbuild.yaml to unblock https://github.com/kubernetes/test-infra/pull/14228

