### PR TITLE
✨ Add util/record package from CAPA

### DIFF
--- a/util/record/recorder.go
+++ b/util/record/recorder.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package record
+
+import (
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+var (
+	initOnce        sync.Once
+	defaultRecorder record.EventRecorder
+)
+
+func init() {
+	defaultRecorder = new(record.FakeRecorder)
+}
+
+// InitFromRecorder initializes the global default recorder. It can only be called once.
+// Subsequent calls are considered noops.
+func InitFromRecorder(recorder record.EventRecorder) {
+	initOnce.Do(func() {
+		defaultRecorder = recorder
+	})
+}
+
+// Event constructs an event from the given information and puts it in the queue for sending.
+func Event(object runtime.Object, reason, message string) {
+	defaultRecorder.Event(object, corev1.EventTypeNormal, strings.Title(reason), message)
+}
+
+// Eventf is just like Event, but with Sprintf for the message field.
+func Eventf(object runtime.Object, reason, message string, args ...interface{}) {
+	defaultRecorder.Eventf(object, corev1.EventTypeNormal, strings.Title(reason), message, args...)
+}
+
+// Event constructs a warning event from the given information and puts it in the queue for sending.
+func Warn(object runtime.Object, reason, message string) {
+	defaultRecorder.Event(object, corev1.EventTypeWarning, strings.Title(reason), message)
+}
+
+// Eventf is just like Event, but with Sprintf for the message field.
+func Warnf(object runtime.Object, reason, message string, args ...interface{}) {
+	defaultRecorder.Eventf(object, corev1.EventTypeWarning, strings.Title(reason), message, args...)
+}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds `util/record` package used in CAPA. It might be useful to keep it here given that it's a nicer interface to recorders and can be used in other providers as well.

(I just copied the package to the gcp provider and I thought I'd put it here instead and remove it from both CAPA and CAPG)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
