### PR TITLE
 📖 Automate the release links in mdbook

### DIFF
--- a/docs/book/Makefile
+++ b/docs/book/Makefile
@@ -27,6 +27,10 @@ EMBED := $(TOOLS_BIN_DIR)/mdbook-embed
 $(EMBED): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/mdbook-embed ./mdbook/embed
 
+RELEASELINK := $(TOOLS_BIN_DIR)/mdbook-releaselink
+$(RELEASELINK): $(TOOLS_DIR)/go.mod
+	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/mdbook-releaselink ./mdbook/releaselink
+
 .PHONY: serve
 serve:
 	mdbook serve

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -14,3 +14,6 @@ command = "./util-tabulate.sh"
 
 [preprocessor.embed]
 command = "./util-embed.sh"
+
+[preprocessor.releaselink]
+command = "./util-releaselink.sh"

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -18,10 +18,8 @@ Using [kubectl], let's create the components on the [management cluster]:
 
 #### Install Cluster API Components
 
-Check the [releases](https://github.com/kubernetes-sigs/cluster-api/releases) for an up-to-date components file.
-
 ```bash
-kubectl create -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.2.1/cluster-api-components.yaml
+kubectl create -f {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"cluster-api-components.yaml" version:"0.2.x"}}
 ```
 
 #### Install the Bootstrap Provider Components
@@ -32,7 +30,7 @@ kubectl create -f https://github.com/kubernetes-sigs/cluster-api/releases/downlo
 Check the [Kubeadm provider releases](https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/releases) for an up-to-date components file.
 
 ```bash
-kubectl create -f https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/releases/download/v0.1.0/bootstrap-components.yaml
+kubectl create -f {{#releaselink gomodule:"sigs.k8s.io/cluster-api-bootstrap-provider-kubeadm" asset:"bootstrap-components.yaml" version:"0.1.x"}}
 ```
 
 {{#/tab }}
@@ -67,7 +65,7 @@ Check the [AWS provider releases] for an up-to-date components file.
 export AWS_B64ENCODED_CREDENTIALS=$(clusterawsadm alpha bootstrap encode-aws-credentials)
 
 # Create the components.
-curl -L https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v0.4.0/infrastructure-components.yaml \
+curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"infrastructure-components.yaml" version:"0.4.x"}} \
   | envsubst \
   | kubectl create -f -
 ```
@@ -80,7 +78,7 @@ Check the [vSphere provider releases](https://github.com/kubernetes-sigs/cluster
 For more information about prerequisites, credentials management, or permissions for vSphere, visit the [getting started guide](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/master/docs/getting_started.md).
 
 ```bash
-kubectl create -f https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/download/v0.5.0/infrastructure-components.yaml
+kubectl create -f {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-vsphere" asset:"infrastructure-components.yaml" version:"0.5.x"}}
 ```
 
 {{#/tab }}

--- a/docs/book/util-releaselink.sh
+++ b/docs/book/util-releaselink.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+RELEASELINK="../../hack/tools/bin/mdbook-releaselink"
+make ${RELEASELINK} &>/dev/null
+${RELEASELINK} "$@"

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,7 @@ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 h1:+DCIGbF/swA92ohVg0//6X2I
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/tools v0.0.0-20180221164845-07fd8470d635 h1:2eB4G6bDQDeP69ZXbOKC00S2Kf6TIiRS+DzfKsKeQU0=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -3,7 +3,9 @@ module sigs.k8s.io/cluster-api/hack/tools
 go 1.12
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/golangci/golangci-lint v1.18.0
+	golang.org/x/tools v0.0.0-20190909030654-5b82db07426d
 	k8s.io/code-generator v0.0.0-20190831074504-732c9ca86353
 	sigs.k8s.io/controller-tools v0.2.0
 	sigs.k8s.io/kubebuilder/docs/book/utils v0.0.0-20190903174343-de03361a00cb

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -9,6 +9,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/hack/tools/mdbook/releaselink/releaselink.go
+++ b/hack/tools/mdbook/releaselink/releaselink.go
@@ -1,0 +1,100 @@
+// +build tools
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/blang/semver"
+	"golang.org/x/tools/go/vcs"
+	"sigs.k8s.io/kubebuilder/docs/book/utils/plugin"
+)
+
+// ReleaseLink responds to {{#releaselink <args>}} input. It asks for a `gomodule` parameter
+// pointing to a published modules at index.golang.org, it then lists all the versions available
+// and resolves it back to the GitHub repository link using the `asset` specified.
+// It's possible to add a `version` parameter, which accepts ranges (e.g. >=1.0.0) or wildcards (e.g. >=1.x, v0.1.x)
+// to filter the retrieved versions.
+type ReleaseLink struct{}
+
+func (_ ReleaseLink) SupportsOutput(_ string) bool { return true }
+func (l ReleaseLink) Process(input *plugin.Input) error {
+	return plugin.EachCommand(&input.Book, "releaselink", func(chapter *plugin.BookChapter, args string) (string, error) {
+		tags := reflect.StructTag(strings.TrimSpace(args))
+
+		gomodule := tags.Get("gomodule")
+		asset := tags.Get("asset")
+		versionRange := semver.MustParseRange(tags.Get("version"))
+
+		repo, err := vcs.RepoRootForImportPath(gomodule, false)
+		if err != nil {
+			return "", err
+		}
+
+		rawURL := url.URL{
+			Scheme: "https",
+			Host:   "proxy.golang.org",
+			Path:   path.Join(gomodule, "@v", "/list"),
+		}
+
+		resp, err := http.Get(rawURL.String())
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+
+		out, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+
+		parsedTags := semver.Versions{}
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.HasPrefix(line, "v") {
+				parsedTags = append(parsedTags, semver.MustParse(strings.TrimPrefix(line, "v")))
+			}
+		}
+		sort.Sort(parsedTags)
+
+		var picked semver.Version
+		for i, tag := range parsedTags {
+			if versionRange(tag) {
+				picked = parsedTags[i]
+			}
+		}
+
+		return fmt.Sprintf("%s/releases/download/v%s/%s", repo.Repo, picked, asset), nil
+	})
+}
+
+func main() {
+	cfg := ReleaseLink{}
+	if err := plugin.Run(cfg, os.Stdin, os.Stdout, os.Args[1:]...); err != nil {
+		log.Fatal(err.Error())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR automates the release notes links in the mdbook so that they get regenerated using the latest version in the range specified when building it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
