### PR TITLE
Better check to wait for the control-plane to become available

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -234,6 +234,15 @@ func NewFromDefaultSearchPath(kubeconfigFile string, overrides tcmd.ConfigOverri
 	if err := util.PollImmediate(retryAcquireClient, timeoutAcquireClient, func() (_ bool, err error) {
 		c, err = clientcmd.NewControllerRuntimeClient(kubeconfigFile, overrides)
 		if err != nil {
+			if strings.Contains(err.Error(), io.EOF.Error()) || strings.Contains(err.Error(), "refused") || strings.Contains(err.Error(), "no such host") {
+				// Connection was refused, probably because the API server is not ready yet.
+				klog.V(2).Infof("Waiting to acquire client... server not yet available: %v", err)
+				return false, nil
+			}
+			if strings.Contains(err.Error(), "unable to recognize") {
+				klog.V(2).Infof("Waiting to acquire client... api not yet available: %v", err)
+				return false, nil
+			}
 			klog.V(2).Infof("Waiting to acquire client...")
 			return false, err
 		}


### PR DESCRIPTION
Before this change, we just bailed out, let's retry at least for some of the conditions. We use the same technique as used in:
https://github.com/kubernetes-sigs/cluster-api/blob/master/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go#L780-L788

Change-Id: I101fd74794ee7bb1fa1ebd0f13e451f5d015dd78

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/154
