### PR TITLE
📖 Add CABPK abbreviation and v1alpha2-ize other abbreviations

### DIFF
--- a/docs/book/src/reference/abbreviations.md
+++ b/docs/book/src/reference/abbreviations.md
@@ -3,8 +3,9 @@
 Acronym or Abbreviation  | Full name
 -------------------------|---------------------
 CAPI                     | Cluster API
-CAPA                     | Cluster API Provider AWS
-CAPD                     | Cluster API Provider Docker
-CAPO                     | Cluster API Provider OpenStack
-CAPV                     | Cluster API Provider vSphere
-CAPZ                     | Cluster API Provider Azure
+CAPA                     | Cluster API AWS infrastructure provider
+CAPD                     | Cluster API Docker infrastructure provider
+CAPO                     | Cluster API OpenStack infrastructure provider
+CAPV                     | Cluster API vSphere infrastructure provider
+CAPZ                     | Cluster API Azure infrastructure provider
+CABPK                    | Cluster API Kubeadm bootstrap provider


### PR DESCRIPTION
This PR adds CABPK (kubeadm bootstrap provider) to the abbreviation overview. It further rewords the abbreviations in the book to emphasize the difference between the infrastructure and bootstrap providers introduced in v1alpha2

