### PR TITLE
re-apply secret OwnerRef on pivot with correct UID

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/clusterdeployer/clusterclient"
@@ -557,6 +558,10 @@ func (c *testClusterClient) GetMachinesForMachineSet(ms *clusterv1.MachineSet) (
 }
 
 func (c *testClusterClient) WaitForResourceStatuses() error {
+	return nil
+}
+
+func (c *testClusterClient) SetClusterOwnerRef(obj runtime.Object, cluster *clusterv1.Cluster) error {
 	return nil
 }
 

--- a/cmd/clusterctl/phases/pivot_test.go
+++ b/cmd/clusterctl/phases/pivot_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
 )
 
@@ -556,6 +557,10 @@ func (t *target) EnsureNamespace(string) error {
 	return nil
 }
 
+func (t *target) GetCluster(name, ns string) (*clusterv1.Cluster, error) {
+	return nil, nil
+}
+
 func (t *target) GetMachineDeployment(ns, name string) (*clusterv1.MachineDeployment, error) {
 	for _, deployment := range t.machineDeployments[ns] {
 		if deployment.Name == name {
@@ -575,6 +580,10 @@ func (t *target) GetMachineSet(ns, name string) (*clusterv1.MachineSet, error) {
 }
 
 func (t *target) WaitForClusterV1alpha2Ready() error {
+	return nil
+}
+
+func (t *target) SetClusterOwnerRef(obj runtime.Object, cluster *clusterv1.Cluster) error {
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
In https://github.com/kubernetes-sigs/cluster-api/pull/1411, we started to only reset the secret owner ref's UID for clusters, which fails API validation (see [here](https://github.com/kubernetes/apimachinery/blob/master/pkg/api/validation/objectmeta.go#L74-L76)). In order to pass validation, we should create the secret without the owner ref and re-apply it afterwards using the target cluster's UID. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/1428 
