### PR TITLE
🐛Add deprecation message to clusterctl commands

### DIFF
--- a/cmd/clusterctl/cmd/alpha_phase_apply_addons.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_addons.go
@@ -39,13 +39,14 @@ var alphaPhaseApplyAddonsCmd = &cobra.Command{
 	Long:  `Apply Addons`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if paao.Addons == "" {
-			exitWithHelp(cmd, "Please provide yaml file for addons definition.")
+			exitWithHelp(cmd, "Please provide yaml file for addons definition.\n")
 		}
 
 		if paao.Kubeconfig == "" {
-			exitWithHelp(cmd, "Please provide a kubeconfig file.")
+			exitWithHelp(cmd, "Please provide a kubeconfig file.\n")
 		}
 
+		fmt.Println(deprecationMsg)
 		if err := RunAlphaPhaseApplyAddons(paao); err != nil {
 			klog.Exit(err)
 		}

--- a/cmd/clusterctl/cmd/alpha_phase_apply_boostrap_components.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_boostrap_components.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/pkg/errors"
@@ -39,13 +40,14 @@ var alphaPhaseApplyBootstrapComponentsCmd = &cobra.Command{
 	Long:  `Apply bootstrap components`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if pabco.BootstrapComponents == "" {
-			exitWithHelp(cmd, "Please provide yaml file for bootstrap component definition.")
+			exitWithHelp(cmd, "Please provide yaml file for bootstrap component definition.\n")
 		}
 
 		if pabco.Kubeconfig == "" {
-			exitWithHelp(cmd, "Please provide a kubeconfig file.")
+			exitWithHelp(cmd, "Please provide a kubeconfig file.\n")
 		}
 
+		fmt.Println(deprecationMsg)
 		if err := RunAlphaPhaseApplyBootstrapComponents(pabco); err != nil {
 			klog.Exit(err)
 		}

--- a/cmd/clusterctl/cmd/alpha_phase_apply_cluster.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/pkg/errors"
@@ -40,13 +41,14 @@ var alphaPhaseApplyClusterCmd = &cobra.Command{
 	Long:  `Apply Cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if paco.Cluster == "" {
-			exitWithHelp(cmd, "Please provide yaml file for cluster definition.")
+			exitWithHelp(cmd, "Please provide yaml file for cluster definition.\n")
 		}
 
 		if paco.Kubeconfig == "" {
-			exitWithHelp(cmd, "Please provide a kubeconfig file.")
+			exitWithHelp(cmd, "Please provide a kubeconfig file.\n")
 		}
 
+		fmt.Println(deprecationMsg)
 		if err := RunAlphaPhaseApplyCluster(paco); err != nil {
 			klog.Exit(err)
 		}

--- a/cmd/clusterctl/cmd/alpha_phase_apply_cluster_api_components.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_cluster_api_components.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/pkg/errors"
@@ -39,13 +40,14 @@ var alphaPhaseApplyClusterAPIComponentsCmd = &cobra.Command{
 	Long:  `Apply Cluster API components`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if pacaso.ProviderComponents == "" {
-			exitWithHelp(cmd, "Please provide yaml file for provider component definition.")
+			exitWithHelp(cmd, "Please provide yaml file for provider component definition.\n")
 		}
 
 		if pacaso.Kubeconfig == "" {
-			exitWithHelp(cmd, "Please provide a kubeconfig file.")
+			exitWithHelp(cmd, "Please provide a kubeconfig file.\n")
 		}
 
+		fmt.Println(deprecationMsg)
 		if err := RunAlphaPhaseApplyClusterAPIComponents(pacaso); err != nil {
 			klog.Exit(err)
 		}

--- a/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
+++ b/cmd/clusterctl/cmd/alpha_phase_apply_machines.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/pkg/errors"
@@ -42,13 +43,14 @@ var alphaPhaseApplyMachinesCmd = &cobra.Command{
 	Long:  `Apply Machines`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if pamo.Machines == "" {
-			exitWithHelp(cmd, "Please provide yaml file for machines definition.")
+			exitWithHelp(cmd, "Please provide yaml file for machines definition.\n")
 		}
 
 		if pamo.Kubeconfig == "" {
-			exitWithHelp(cmd, "Please provide a kubeconfig file.")
+			exitWithHelp(cmd, "Please provide a kubeconfig file.\n")
 		}
 
+		fmt.Println(deprecationMsg)
 		if err := RunAlphaPhaseApplyMachines(pamo); err != nil {
 			klog.Exit(err)
 		}

--- a/cmd/clusterctl/cmd/alpha_phase_create_bootstrap_cluster.go
+++ b/cmd/clusterctl/cmd/alpha_phase_create_bootstrap_cluster.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
@@ -37,6 +39,7 @@ var alphaPhaseCreateBootstrapClusterCmd = &cobra.Command{
 	Short: "Create a bootstrap cluster",
 	Long:  `Create a bootstrap cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(deprecationMsg)
 		if err := RunAlphaPhaseCreateBootstrapCluster(pcbco); err != nil {
 			klog.Exit(err)
 		}

--- a/cmd/clusterctl/cmd/alpha_phase_get_kubeconfig.go
+++ b/cmd/clusterctl/cmd/alpha_phase_get_kubeconfig.go
@@ -41,13 +41,14 @@ var alphaPhaseGetKubeconfigCmd = &cobra.Command{
 	Long:  `Get Kubeconfig`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if pgko.Kubeconfig == "" {
-			exitWithHelp(cmd, "Please provide a kubeconfig file.")
+			exitWithHelp(cmd, "Please provide a kubeconfig file.\n")
 		}
 
 		if pgko.ClusterName == "" {
-			exitWithHelp(cmd, "Please specify a cluster name.")
+			exitWithHelp(cmd, "Please specify a cluster name.\n")
 		}
 
+		fmt.Println(deprecationMsg)
 		if err := RunAlphaPhaseGetKubeconfig(pgko); err != nil {
 			klog.Exit(err)
 		}

--- a/cmd/clusterctl/cmd/alpha_phase_pivot.go
+++ b/cmd/clusterctl/cmd/alpha_phase_pivot.go
@@ -40,17 +40,18 @@ var alphaPhasePivotCmd = &cobra.Command{
 	Long:  `Pivot`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if ppo.ProviderComponents == "" {
-			exitWithHelp(cmd, "Please provide yaml file for provider components definition.")
+			exitWithHelp(cmd, "Please provide yaml file for provider components definition.\n")
 		}
 
 		if ppo.SourceKubeconfig == "" {
-			exitWithHelp(cmd, "Please provide a source kubeconfig file.")
+			exitWithHelp(cmd, "Please provide a source kubeconfig file.\n")
 		}
 
 		if ppo.TargetKubeconfig == "" {
-			exitWithHelp(cmd, "Please provide a target kubeconfig file.")
+			exitWithHelp(cmd, "Please provide a target kubeconfig file.\n")
 		}
 
+		fmt.Println(deprecationMsg)
 		if err := RunAlphaPhasePivot(ppo); err != nil {
 			klog.Exit(err)
 		}

--- a/cmd/clusterctl/cmd/create_cluster.go
+++ b/cmd/clusterctl/cmd/create_cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/pkg/errors"
@@ -47,14 +48,15 @@ var createClusterCmd = &cobra.Command{
 	Long:  `Create a kubernetes cluster with one command`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if co.Cluster == "" {
-			exitWithHelp(cmd, "Please provide yaml file for cluster definition.")
+			exitWithHelp(cmd, "Please provide yaml file for cluster definition.\n")
 		}
 		if co.Machine == "" {
-			exitWithHelp(cmd, "Please provide yaml file for machine definition.")
+			exitWithHelp(cmd, "Please provide yaml file for machine definition.\n")
 		}
 		if co.ProviderComponents == "" {
-			exitWithHelp(cmd, "Please provide yaml file for provider component definition.")
+			exitWithHelp(cmd, "Please provide yaml file for provider component definition.\n")
 		}
+		fmt.Println(deprecationMsg)
 		if err := RunCreate(co); err != nil {
 			klog.Exit(err)
 		}

--- a/cmd/clusterctl/cmd/delete_cluster.go
+++ b/cmd/clusterctl/cmd/delete_cluster.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
@@ -44,14 +46,16 @@ var deleteClusterCmd = &cobra.Command{
 	Long:  `Delete a kubernetes cluster with one command`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if do.KubeconfigPath == "" {
-			exitWithHelp(cmd, "Please provide kubeconfig file for cluster to delete.")
+			exitWithHelp(cmd, "Please provide kubeconfig file for cluster to delete.\n")
 		}
 		if do.ProviderComponents == "" {
-			exitWithHelp(cmd, "Please provide yaml file for provider component definition.")
+			exitWithHelp(cmd, "Please provide yaml file for provider component definition.\n")
 		}
+		fmt.Println(deprecationMsg)
 		if err := RunDelete(); err != nil {
 			klog.Exit(err)
 		}
+
 	},
 }
 

--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -26,12 +26,18 @@ import (
 	"k8s.io/klog"
 )
 
+const deprecationMsg string = "NOTICE: clusterctl has been deprecated in v1alpha2 and will be removed in a future version."
+
+var helpTemplate = fmt.Sprintf(`%s
+{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`, deprecationMsg)
+
 var RootCmd = &cobra.Command{
 	Use:   "clusterctl",
 	Short: "cluster management",
 	Long:  `Simple kubernetes cluster management`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Do Stuff Here
 		cmd.Help()
 	},
 }
@@ -53,5 +59,6 @@ func init() {
 	klog.InitFlags(flag.CommandLine)
 	RootCmd.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
 	RootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	RootCmd.SetHelpTemplate(helpTemplate)
 	InitLogs()
 }

--- a/cmd/clusterctl/cmd/validate_cluster.go
+++ b/cmd/clusterctl/cmd/validate_cluster.go
@@ -43,6 +43,7 @@ var validateClusterCmd = &cobra.Command{
 	Short: "Validate a cluster created by cluster API.",
 	Long:  `Validate a cluster created by cluster API.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(deprecationMsg)
 		if err := RunValidateCluster(); err != nil {
 			os.Stdout.Sync()
 			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)

--- a/cmd/clusterctl/testdata/create-no-args.golden
+++ b/cmd/clusterctl/testdata/create-no-args.golden
@@ -1,3 +1,4 @@
+NOTICE: clusterctl has been deprecated in v1alpha2 and will be removed in a future version.
 Create a cluster API resource with one command
 
 Usage:

--- a/cmd/clusterctl/testdata/delete-cluster-no-args.golden
+++ b/cmd/clusterctl/testdata/delete-cluster-no-args.golden
@@ -1,4 +1,6 @@
 Please provide kubeconfig file for cluster to delete.
+
+NOTICE: clusterctl has been deprecated in v1alpha2 and will be removed in a future version.
 Delete a kubernetes cluster with one command
 
 Usage:

--- a/cmd/clusterctl/testdata/delete-no-args.golden
+++ b/cmd/clusterctl/testdata/delete-no-args.golden
@@ -1,3 +1,4 @@
+NOTICE: clusterctl has been deprecated in v1alpha2 and will be removed in a future version.
 Delete a cluster API resource with one command
 
 Usage:

--- a/cmd/clusterctl/testdata/no-args.golden
+++ b/cmd/clusterctl/testdata/no-args.golden
@@ -1,3 +1,4 @@
+NOTICE: clusterctl has been deprecated in v1alpha2 and will be removed in a future version.
 Simple kubernetes cluster management
 
 Usage:

--- a/cmd/clusterctl/testdata/validate-no-args.golden
+++ b/cmd/clusterctl/testdata/validate-no-args.golden
@@ -1,3 +1,4 @@
+NOTICE: clusterctl has been deprecated in v1alpha2 and will be removed in a future version.
 Validate an API resource created by cluster API. See subcommands for supported API resources.
 
 Usage:


### PR DESCRIPTION

Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Add deprecation message to each clusterctl command

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1423 

**NOTES**
A side effect of setting the `Deprecated` property on `cobra.Command` is that in the `--help` of the commands, it does not list the available sub-commands. The sub-commands will still run and print out the deprecation message at the top. Scripts/automation will not break.