### PR TITLE
🐛 clusterctl only deletes the cluster object

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -18,7 +18,6 @@ package clusterdeployer
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -220,29 +219,9 @@ func (d *ClusterDeployer) saveProviderComponentsToCluster(factory provider.Compo
 }
 
 func deleteClusterAPIObjectsInAllNamespaces(client clusterclient.Client) error {
-	var errorList []string
-	klog.Infof("Deleting MachineDeployments in all namespaces")
-	if err := client.DeleteMachineDeployments(""); err != nil {
-		err = errors.Wrap(err, "error deleting MachineDeployments")
-		errorList = append(errorList, err.Error())
-	}
-	klog.Infof("Deleting MachineSets in all namespaces")
-	if err := client.DeleteMachineSets(""); err != nil {
-		err = errors.Wrap(err, "error deleting MachineSets")
-		errorList = append(errorList, err.Error())
-	}
-	klog.Infof("Deleting Machines in all namespaces")
-	if err := client.DeleteMachines(""); err != nil {
-		err = errors.Wrap(err, "error deleting Machines")
-		errorList = append(errorList, err.Error())
-	}
 	klog.Infof("Deleting Clusters in all namespaces")
 	if err := client.DeleteClusters(""); err != nil {
-		err = errors.Wrap(err, "error deleting Clusters")
-		errorList = append(errorList, err.Error())
-	}
-	if len(errorList) > 0 {
-		return errors.Errorf("error(s) encountered deleting objects from bootstrap cluster: [%v]", strings.Join(errorList, ", "))
+		return errors.Errorf("error encountered deleting objects from bootstrap cluster: [error deleting Clusters: %v]", err)
 	}
 	return nil
 }

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer_test.go
@@ -1387,36 +1387,12 @@ func TestClusterDelete(t *testing.T) {
 			expectedExternalClusterCount: 1,
 		},
 		{
-			name:                 "error deleting machines",
-			provisionExternalErr: nil,
-			NewCoreClientsetErr:  nil,
-			bootstrapClient:      &testClusterClient{DeleteMachinesErr: errors.New("delete machines error")},
-			targetClient:         &testClusterClient{},
-			expectedErrorMessage: "error(s) encountered deleting objects from bootstrap cluster: [error deleting Machines: delete machines error]",
-		},
-		{
-			name:                 "error deleting machine sets",
-			provisionExternalErr: nil,
-			NewCoreClientsetErr:  nil,
-			bootstrapClient:      &testClusterClient{DeleteMachineSetsErr: errors.New("delete machine sets error")},
-			targetClient:         &testClusterClient{},
-			expectedErrorMessage: "error(s) encountered deleting objects from bootstrap cluster: [error deleting MachineSets: delete machine sets error]",
-		},
-		{
-			name:                 "error deleting machine deployments",
-			provisionExternalErr: nil,
-			NewCoreClientsetErr:  nil,
-			bootstrapClient:      &testClusterClient{DeleteMachineDeploymentsErr: errors.New("delete machine deployments error")},
-			targetClient:         &testClusterClient{},
-			expectedErrorMessage: "error(s) encountered deleting objects from bootstrap cluster: [error deleting MachineDeployments: delete machine deployments error]",
-		},
-		{
 			name:                 "error deleting clusters",
 			provisionExternalErr: nil,
 			NewCoreClientsetErr:  nil,
 			bootstrapClient:      &testClusterClient{DeleteClustersErr: errors.New("delete clusters error")},
 			targetClient:         &testClusterClient{},
-			expectedErrorMessage: "error(s) encountered deleting objects from bootstrap cluster: [error deleting Clusters: delete clusters error]",
+			expectedErrorMessage: "error encountered deleting objects from bootstrap cluster: [error deleting Clusters: delete clusters error]",
 		},
 		{
 			name:                 "error deleting machines and clusters",
@@ -1424,7 +1400,7 @@ func TestClusterDelete(t *testing.T) {
 			NewCoreClientsetErr:  nil,
 			bootstrapClient:      &testClusterClient{DeleteMachinesErr: errors.New("delete machines error"), DeleteClustersErr: errors.New("delete clusters error")},
 			targetClient:         &testClusterClient{},
-			expectedErrorMessage: "error(s) encountered deleting objects from bootstrap cluster: [error deleting Machines: delete machines error, error deleting Clusters: delete clusters error]",
+			expectedErrorMessage: "error encountered deleting objects from bootstrap cluster: [error deleting Clusters: delete clusters error]",
 		},
 	}
 
@@ -1452,20 +1428,11 @@ func TestClusterDelete(t *testing.T) {
 
 			if !testCase.expectError {
 				var (
-					bootstrapClusters, bootstrapMachines, bootstrapMachineDeployments, bootstrapMachineSets, bootstrapMachineClasses int
-					targetClusters, targetMachines, targetMachineDeployments, targetMachineSets, targetMachineClasses                int
+					bootstrapClusters, bootstrapMachineClasses                                                        int
+					targetClusters, targetMachines, targetMachineDeployments, targetMachineSets, targetMachineClasses int
 				)
 				for _, clusters := range testCase.bootstrapClient.clusters {
 					bootstrapClusters += len(clusters)
-				}
-				for _, machines := range testCase.bootstrapClient.machines {
-					bootstrapMachines += len(machines)
-				}
-				for _, machineDeployments := range testCase.bootstrapClient.machineDeployments {
-					bootstrapMachineDeployments += len(machineDeployments)
-				}
-				for _, machineSets := range testCase.bootstrapClient.machineSets {
-					bootstrapMachineSets += len(machineSets)
 				}
 				for _, clusters := range testCase.targetClient.clusters {
 					targetClusters += len(clusters)
@@ -1482,15 +1449,6 @@ func TestClusterDelete(t *testing.T) {
 
 				if bootstrapClusters != 0 {
 					t.Fatalf("Unexpected Cluster count in bootstrap cluster. Got: %d, Want: 0", bootstrapClusters)
-				}
-				if bootstrapMachines != 0 {
-					t.Fatalf("Unexpected Machine count in bootstrap cluster. Got: %d, Want: 0", bootstrapMachines)
-				}
-				if bootstrapMachineSets != 0 {
-					t.Fatalf("Unexpected MachineSet count in bootstrap cluster. Got: %d, Want: 0", bootstrapMachineSets)
-				}
-				if bootstrapMachineDeployments != 0 {
-					t.Fatalf("Unexpected MachineDeployment count in bootstrap cluster. Got: %d, Want: 0", bootstrapMachineDeployments)
 				}
 				if bootstrapMachineClasses != 0 {
 					t.Fatalf("Unexpected MachineClass count in bootstrap cluster. Got: %d, Want: 0", bootstrapMachineClasses)


### PR DESCRIPTION
Signed-off-by: Juan-Lee Pang <jpang@microsoft.com>

**What this PR does / why we need it:**
Garbage collection will clean up any referenced MachineDeployment,
MachinMachineSet, and Machine objects.

**Which issue(s) this PR fixes** (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #1444
Fixes #1469


