### PR TITLE
⚠️ Clarify Machine.Spec.ObjectMeta use in godoc

### DIFF
--- a/api/v1alpha2/machine_types.go
+++ b/api/v1alpha2/machine_types.go
@@ -37,9 +37,7 @@ const (
 
 // MachineSpec defines the desired state of Machine
 type MachineSpec struct {
-	// ObjectMeta will autopopulate the Node created. Use this to
-	// indicate what labels, annotations, name prefix, etc., should be used
-	// when creating the Node.
+	// DEPRECATED: ObjectMeta has no function and isn't used anywhere.
 	// +optional
 	ObjectMeta `json:"metadata,omitempty"`
 

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -355,9 +355,8 @@ spec:
                           type: string
                       type: object
                     metadata:
-                      description: ObjectMeta will autopopulate the Node created.
-                        Use this to indicate what labels, annotations, name prefix,
-                        etc., should be used when creating the Node.
+                      description: 'DEPRECATED: ObjectMeta has no function and isn''t
+                        used anywhere.'
                       properties:
                         annotations:
                           additionalProperties:

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -139,9 +139,8 @@ spec:
                   type: string
               type: object
             metadata:
-              description: ObjectMeta will autopopulate the Node created. Use this
-                to indicate what labels, annotations, name prefix, etc., should be
-                used when creating the Node.
+              description: 'DEPRECATED: ObjectMeta has no function and isn''t used
+                anywhere.'
               properties:
                 annotations:
                   additionalProperties:

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -305,9 +305,8 @@ spec:
                           type: string
                       type: object
                     metadata:
-                      description: ObjectMeta will autopopulate the Node created.
-                        Use this to indicate what labels, annotations, name prefix,
-                        etc., should be used when creating the Node.
+                      description: 'DEPRECATED: ObjectMeta has no function and isn''t
+                        used anywhere.'
                       properties:
                         annotations:
                           additionalProperties:

--- a/controllers/mdutil/util_test.go
+++ b/controllers/mdutil/util_test.go
@@ -204,7 +204,7 @@ func TestFindNewMachineSet(t *testing.T) {
 	newMSDup.CreationTimestamp = now
 
 	oldDeployment := generateDeployment("nginx")
-	oldDeployment.Spec.Template.Spec.Name = "nginx-old-1"
+	oldDeployment.Spec.Template.Name = "nginx-old-1"
 	oldMS := generateMS(oldDeployment)
 	oldMS.Status.FullyLabeledReplicas = *(oldMS.Spec.Replicas)
 
@@ -259,7 +259,7 @@ func TestFindOldMachineSets(t *testing.T) {
 	newMSDup.CreationTimestamp = now
 
 	oldDeployment := generateDeployment("nginx")
-	oldDeployment.Spec.Template.Spec.Name = "nginx-old-1"
+	oldDeployment.Spec.Template.Name = "nginx-old-1"
 	oldMS := generateMS(oldDeployment)
 	oldMS.Status.FullyLabeledReplicas = *(oldMS.Spec.Replicas)
 	oldMS.CreationTimestamp = before


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Not a breaking change, but wanted to make it clear for users that this didn't do what it said it did.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
