### PR TITLE
📖Fix broken links to api-conventions doc

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,4 @@
-# See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 aliases:
   sig-cluster-lifecycle-leads:

--- a/api/v1alpha2/common_types.go
+++ b/api/v1alpha2/common_types.go
@@ -88,7 +88,7 @@ type ObjectMeta struct {
 	// should retry (optionally after the time indicated in the Retry-After header).
 	//
 	// Applied only if Name is not specified.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
 	// +optional
 	GenerateName string `json:"generateName,omitempty" protobuf:"bytes,2,opt,name=generateName"`
 

--- a/api/v1alpha2/machineset_types.go
+++ b/api/v1alpha2/machineset_types.go
@@ -66,12 +66,12 @@ type MachineSetSpec struct {
 // MachineTemplateSpec describes the data needed to create a Machine from a template
 type MachineTemplateSpec struct {
 	// Standard object's metadata.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Specification of the desired behavior of the machine.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
 	Spec MachineSpec `json:"spec,omitempty"`
 }

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -165,7 +165,7 @@ spec:
               description: Template describes the machines that will be created.
               properties:
                 metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                   properties:
                     annotations:
                       additionalProperties:
@@ -189,7 +189,7 @@ spec:
                         with Reason ServerTimeout indicating a unique name could not
                         be found in the time allotted, and the client should retry
                         (optionally after the time indicated in the Retry-After header).
-                        \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                        \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                       type: string
                     labels:
                       additionalProperties:
@@ -262,7 +262,7 @@ spec:
                   type: object
                 spec:
                   description: 'Specification of the desired behavior of the machine.
-                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                   properties:
                     bootstrap:
                       description: Bootstrap is a reference to a local struct which
@@ -382,7 +382,7 @@ spec:
                             indicating a unique name could not be found in the time
                             allotted, and the client should retry (optionally after
                             the time indicated in the Retry-After header). \n Applied
-                            only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                            only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                           type: string
                         labels:
                           additionalProperties:

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -164,7 +164,7 @@ spec:
                     name could not be found in the time allotted, and the client should
                     retry (optionally after the time indicated in the Retry-After
                     header). \n Applied only if Name is not specified. More info:
-                    https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                   type: string
                 labels:
                   additionalProperties:

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -115,7 +115,7 @@ spec:
                 to custom resources resources are treated as templates.
               properties:
                 metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                   properties:
                     annotations:
                       additionalProperties:
@@ -139,7 +139,7 @@ spec:
                         with Reason ServerTimeout indicating a unique name could not
                         be found in the time allotted, and the client should retry
                         (optionally after the time indicated in the Retry-After header).
-                        \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                        \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                       type: string
                     labels:
                       additionalProperties:
@@ -212,7 +212,7 @@ spec:
                   type: object
                 spec:
                   description: 'Specification of the desired behavior of the machine.
-                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                   properties:
                     bootstrap:
                       description: Bootstrap is a reference to a local struct which
@@ -332,7 +332,7 @@ spec:
                             indicating a unique name could not be found in the time
                             allotted, and the client should retry (optionally after
                             the time indicated in the Retry-After header). \n Applied
-                            only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                            only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                           type: string
                         labels:
                           additionalProperties:

--- a/config/crds/cluster.k8s.io_clusters.yaml
+++ b/config/crds/cluster.k8s.io_clusters.yaml
@@ -20,12 +20,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -101,7 +101,7 @@ spec:
                             future.'
                           type: string
                         kind:
-                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                           type: string
                         name:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
@@ -115,7 +115,7 @@ spec:
                           type: string
                         resourceVersion:
                           description: 'Specific resourceVersion to which this reference
-                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                           type: string
                         uid:
                           description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'

--- a/config/crds/cluster.k8s.io_machineclasses.yaml
+++ b/config/crds/cluster.k8s.io_machineclasses.yaml
@@ -21,12 +21,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/config/crds/cluster.k8s.io_machinedeployments.yaml
+++ b/config/crds/cluster.k8s.io_machinedeployments.yaml
@@ -26,12 +26,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -162,7 +162,7 @@ spec:
               description: Template describes the machines that will be created.
               properties:
                 metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                   properties:
                     annotations:
                       additionalProperties:
@@ -186,7 +186,7 @@ spec:
                         with Reason ServerTimeout indicating a unique name could not
                         be found in the time allotted, and the client should retry
                         (optionally after the time indicated in the Retry-After header).
-                        \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                        \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                       type: string
                     labels:
                       additionalProperties:
@@ -241,7 +241,7 @@ spec:
                               controller.
                             type: boolean
                           kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                             type: string
                           name:
                             description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -259,7 +259,7 @@ spec:
                   type: object
                 spec:
                   description: 'Specification of the desired behavior of the machine.
-                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                   properties:
                     configSource:
                       description: ConfigSource is used to populate in the associated
@@ -331,7 +331,7 @@ spec:
                             indicating a unique name could not be found in the time
                             allotted, and the client should retry (optionally after
                             the time indicated in the Retry-After header). \n Applied
-                            only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                            only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                           type: string
                         labels:
                           additionalProperties:
@@ -387,7 +387,7 @@ spec:
                                   managing controller.
                                 type: boolean
                               kind:
-                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               name:
                                 description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -460,7 +460,7 @@ spec:
                                     in the future.'
                                   type: string
                                 kind:
-                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                   type: string
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
@@ -475,7 +475,7 @@ spec:
                                   type: string
                                 resourceVersion:
                                   description: 'Specific resourceVersion to which
-                                    this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                    this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                   type: string
                                 uid:
                                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'

--- a/config/crds/cluster.k8s.io_machines.yaml
+++ b/config/crds/cluster.k8s.io_machines.yaml
@@ -20,12 +20,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -97,7 +97,7 @@ spec:
                     name could not be found in the time allotted, and the client should
                     retry (optionally after the time indicated in the Retry-After
                     header). \n Applied only if Name is not specified. More info:
-                    https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                    https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                   type: string
                 labels:
                   additionalProperties:
@@ -149,7 +149,7 @@ spec:
                           controller.
                         type: boolean
                       kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                         type: string
                       name:
                         description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -217,7 +217,7 @@ spec:
                             future.'
                           type: string
                         kind:
-                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                           type: string
                         name:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
@@ -231,7 +231,7 @@ spec:
                           type: string
                         resourceVersion:
                           description: 'Specific resourceVersion to which this reference
-                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                           type: string
                         uid:
                           description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -429,7 +429,7 @@ spec:
                     in the future.'
                   type: string
                 kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                   type: string
                 name:
                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
@@ -439,7 +439,7 @@ spec:
                   type: string
                 resourceVersion:
                   description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                   type: string
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'

--- a/config/crds/cluster.k8s.io_machinesets.yaml
+++ b/config/crds/cluster.k8s.io_machinesets.yaml
@@ -26,12 +26,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -111,7 +111,7 @@ spec:
                 will be created if insufficient replicas are detected.
               properties:
                 metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                   properties:
                     annotations:
                       additionalProperties:
@@ -135,7 +135,7 @@ spec:
                         with Reason ServerTimeout indicating a unique name could not
                         be found in the time allotted, and the client should retry
                         (optionally after the time indicated in the Retry-After header).
-                        \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                        \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                       type: string
                     labels:
                       additionalProperties:
@@ -190,7 +190,7 @@ spec:
                               controller.
                             type: boolean
                           kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                             type: string
                           name:
                             description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -208,7 +208,7 @@ spec:
                   type: object
                 spec:
                   description: 'Specification of the desired behavior of the machine.
-                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                   properties:
                     configSource:
                       description: ConfigSource is used to populate in the associated
@@ -280,7 +280,7 @@ spec:
                             indicating a unique name could not be found in the time
                             allotted, and the client should retry (optionally after
                             the time indicated in the Retry-After header). \n Applied
-                            only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency"
+                            only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
                           type: string
                         labels:
                           additionalProperties:
@@ -336,7 +336,7 @@ spec:
                                   managing controller.
                                 type: boolean
                               kind:
-                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               name:
                                 description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -409,7 +409,7 @@ spec:
                                     in the future.'
                                   type: string
                                 kind:
-                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                   type: string
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
@@ -424,7 +424,7 @@ spec:
                                   type: string
                                 resourceVersion:
                                   description: 'Specific resourceVersion to which
-                                    this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                    this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                   type: string
                                 uid:
                                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'

--- a/pkg/apis/deprecated/v1alpha1/common_types.go
+++ b/pkg/apis/deprecated/v1alpha1/common_types.go
@@ -103,7 +103,7 @@ type ObjectMeta struct {
 	// should retry (optionally after the time indicated in the Retry-After header).
 	//
 	// Applied only if Name is not specified.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
 	// +optional
 	GenerateName string `json:"generateName,omitempty" protobuf:"bytes,2,opt,name=generateName"`
 

--- a/pkg/apis/deprecated/v1alpha1/machineset_types.go
+++ b/pkg/apis/deprecated/v1alpha1/machineset_types.go
@@ -105,12 +105,12 @@ const (
 // MachineTemplateSpec describes the data needed to create a Machine from a template
 type MachineTemplateSpec struct {
 	// Standard object's metadata.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Specification of the desired behavior of the machine.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
 	Spec MachineSpec `json:"spec,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes the broken links in the CRDs and also a link in the OWNER_ALIASES file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1461 
