### PR TITLE
🐛 DeepCopy unstructured objects in helper before patching

### DIFF
--- a/util/patch/patch.go
+++ b/util/patch/patch.go
@@ -44,7 +44,14 @@ func NewHelper(resource runtime.Object, crClient client.Client) (*Helper, error)
 		return nil, errors.Errorf("expected non-nil resource")
 	}
 
-	// convert the resource to unstructured for easier comparison later
+	// If the object is already unstructured, we need to perform a deepcopy first
+	// because the `DefaultUnstructuredConverter.ToUnstructured` function returns
+	// the underlying unstructured object map without making a copy.
+	if _, ok := resource.(runtime.Unstructured); ok {
+		resource = resource.DeepCopyObject()
+	}
+
+	// Convert the resource to unstructured for easier comparison later.
 	before, err := runtime.DefaultUnstructuredConverter.ToUnstructured(resource)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1465
