### PR TITLE
🐛 DeepCopy unstructured object in patch helper Patch method

### DIFF
--- a/util/patch/patch.go
+++ b/util/patch/patch.go
@@ -86,7 +86,14 @@ func (h *Helper) Patch(ctx context.Context, resource runtime.Object) error {
 		return errors.Errorf("expected non-nil resource")
 	}
 
-	// convert the resource to unstructured to compare against our before copy
+	// If the object is already unstructured, we need to perform a deepcopy first
+	// because the `DefaultUnstructuredConverter.ToUnstructured` function returns
+	// the underlying unstructured object map without making a copy.
+	if _, ok := resource.(runtime.Unstructured); ok {
+		resource = resource.DeepCopyObject()
+	}
+
+	// Convert the resource to unstructured to compare against our before copy.
 	after, err := runtime.DefaultUnstructuredConverter.ToUnstructured(resource)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR is a follow-up to #1464, the same behavior is shown when we call `Patch` on the helper method, which wipes out the `status` from the original object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
