### PR TITLE
NodeOutOfDisk condition obsolete in Kubernetes 1.16

### DIFF
--- a/controllers/noderefutil/util_test.go
+++ b/controllers/noderefutil/util_test.go
@@ -51,7 +51,7 @@ func TestIsNodeAvaialble(t *testing.T) {
 			node: &corev1.Node{Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
 					{
-						Type:   corev1.NodeOutOfDisk,
+						Type:   corev1.NodeDiskPressure,
 						Status: corev1.ConditionTrue,
 					},
 				}},
@@ -166,7 +166,7 @@ func TestGetReadyCondition(t *testing.T) {
 			nodeStatus: &corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
 					{
-						Type:   corev1.NodeOutOfDisk,
+						Type:   corev1.NodeDiskPressure,
 						Status: corev1.ConditionTrue,
 					},
 				},
@@ -254,7 +254,7 @@ func TestIsNodeReady(t *testing.T) {
 			node: &corev1.Node{Status: corev1.NodeStatus{
 				Conditions: []corev1.NodeCondition{
 					{
-						Type:   corev1.NodeOutOfDisk,
+						Type:   corev1.NodeDiskPressure,
 						Status: corev1.ConditionTrue,
 					},
 				}},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Kubernetes 1.16 removed NodeOutOfDisk to only keep NodeDiskPressure. This PR simply replace the condition NodeOutOfDisk by NodeDiskPressure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
