### PR TITLE
🐛 Support running alongside other Cluster API pods in the same namespace with leader election enabled 

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func main() {
 		MetricsBindAddress: metricsAddr,
 		MapperProvider:     restmapper.NewCached,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   "controller-leader-election-capi",
 		Namespace:          watchNamespace,
 		SyncPeriod:         &syncPeriod,
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently `LeaderElectionID`  is set to the default `controller-leader-election-helper`. This causes an issue when several Cluster API pods are deployed in the same namespace. Adding a unique ID per service should resolve this.

**Which issue(s) this PR fixes**:
Fixes #1488 
