### PR TITLE
:running: Cleanup the readability of some gomega error checking

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -134,7 +134,7 @@ func deployCAPIComponents(kindCluster kind.Cluster) {
 
 	// write out the manifests
 	manifestFile := path.Join(suiteTmpDir, "cluster-api-components.yaml")
-	gomega.Expect(ioutil.WriteFile(manifestFile, capiManifests, 0644)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(ioutil.WriteFile(manifestFile, capiManifests, 0644)).To(gomega.Succeed())
 
 	// apply generated manifests
 	applyManifests(kindCluster, &manifestFile)

--- a/test/helpers/kind/setup.go
+++ b/test/helpers/kind/setup.go
@@ -133,9 +133,9 @@ func (c *Cluster) run(cmd *exec.Cmd) {
 		go captureOutput(&wg, outPipe, "stdout")
 	}
 
-	gomega.Expect(cmd.Start()).NotTo(gomega.HaveOccurred())
+	gomega.Expect(cmd.Start()).To(gomega.Succeed())
 	wg.Wait()
-	gomega.Expect(cmd.Wait()).NotTo(gomega.HaveOccurred())
+	gomega.Expect(cmd.Wait()).To(gomega.Succeed())
 }
 
 func captureOutput(wg *sync.WaitGroup, r io.Reader, label string) {

--- a/test/helpers/scheme/scheme.go
+++ b/test/helpers/scheme/scheme.go
@@ -25,7 +25,7 @@ import (
 
 func SetupScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	gomega.Expect(clientgoscheme.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
-	gomega.Expect(clusterv1.AddToScheme(scheme)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(clientgoscheme.AddToScheme(scheme)).To(gomega.Succeed())
+	gomega.Expect(clusterv1.AddToScheme(scheme)).To(gomega.Succeed())
 	return scheme
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleans up the readability of some of the gomega error checking in the test helpers.

