### PR TITLE
:bug: Fix package for test/helpers/components/common.go

### DIFF
--- a/test/helpers/components/common.go
+++ b/test/helpers/components/common.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+package components
 
 import (
 	"context"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the package name for test/helpers/components/common.go

On trying to update CAPA to consume the test helpers I discovered that this file was using the wrong package name.

