### PR TITLE
📖 Improve machine controller book

### DIFF
--- a/docs/book/src/architecture/controllers/machine.md
+++ b/docs/book/src/architecture/controllers/machine.md
@@ -18,7 +18,12 @@ The Machine controller's main responsibilities are:
 
 Cluster associations are made via labels.
 
-A machine must have a label with a key of `cluster.x-k8s.io/cluster-name` and a value of the core Cluster's name.
+#### Expected labels
+
+| what | label | value | meaning |
+| --- | --- | --- | --- |
+| Machine | `cluster.x-k8s.io/cluster-name` | `<cluster-name>` | Identify a machine as belonging to a cluster with the name `<cluster-name>`|
+| Machine | `cluster.x-k8s.io/control-plane` | `true` | Identifies a machine as a control-plane node |
 
 ### Bootstrap provider
 


### PR DESCRIPTION
The label needed to identify the control plane nodes was missing.

Signed-off-by: Chuck Ha <chuckh@vmware.com>
