### PR TITLE
🏃 Add i/o timeout to retry errors to acquire kube client

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -237,7 +237,7 @@ func NewFromDefaultSearchPath(kubeconfigFile string, overrides tcmd.ConfigOverri
 	if err := util.PollImmediate(retryAcquireClient, timeoutAcquireClient, func() (_ bool, err error) {
 		c, err = clientcmd.NewControllerRuntimeClient(kubeconfigFile, overrides)
 		if err != nil {
-			if strings.Contains(err.Error(), io.EOF.Error()) || strings.Contains(err.Error(), "refused") || strings.Contains(err.Error(), "no such host") {
+			if strings.Contains(err.Error(), io.EOF.Error()) || strings.Contains(err.Error(), "refused") || strings.Contains(err.Error(), "no such host") || strings.Contains(err.Error(), "i/o timeout") {
 				// Connection was refused, probably because the API server is not ready yet.
 				klog.V(2).Infof("Waiting to acquire client... server not yet available: %v", err)
 				return false, nil


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
The clusterctl apply-addons command sometimes fails to get kube client because Get is failing with `i/o timeout`:
```
alpha_phase_apply_addons.go:51] unable to create cluster client: failed to acquire new client: Get https://aug-img-5-8c4287d8.eastus.cloudapp.azure.com:6443/api?timeout=32s: dial tcp 52.224.206.236:6443: i/o timeout
Makefile:295: recipe for target 'create-cluster-management' failed
```

This PR ensures that we retry if this error occurs (until timeout) instead of returning the error right away.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
