### PR TITLE
✨ Add Phase to MachineDeploymentStatus

### DIFF
--- a/api/v1alpha3/machinedeployment_types.go
+++ b/api/v1alpha3/machinedeployment_types.go
@@ -178,15 +178,60 @@ type MachineDeploymentStatus struct {
 	// that still have not been created.
 	// +optional
 	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,5,opt,name=unavailableReplicas"`
+
+	// Phase represents the current phase of a MachineDeployment (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+	// +optional
+	Phase string `json:"phase,omitempty"`
 }
 
 // ANCHOR_END: MachineDeploymentStatus
+
+// MachineDeploymentPhase indicates the progress of the machine deployment
+type MachineDeploymentPhase string
+
+const (
+	// MachineDeploymentPhaseScalingUp indicates the MachineDeployment is scaling up.
+	MachineDeploymentPhaseScalingUp = MachineDeploymentPhase("ScalingUp")
+
+	// MachineDeploymentPhaseScalingDown indicates the MachineDeployment is scaling down.
+	MachineDeploymentPhaseScalingDown = MachineDeploymentPhase("ScalingDown")
+
+	// MachineDeploymentPhaseRunning indicates scaling has completed and all Machines are running.
+	MachineDeploymentPhaseRunning = MachineDeploymentPhase("Running")
+
+	// MachineDeploymentPhaseFailed indicates there was a problem scaling and user intervention might be required.
+	MachineDeploymentPhaseFailed = MachineDeploymentPhase("Failed")
+
+	// MachineDeploymentPhaseUnknown indicates the state of the MachineDeployment cannot be determined.
+	MachineDeploymentPhaseUnknown = MachineDeploymentPhase("Unknown")
+)
+
+// SetTypedPhase sets the Phase field to the string representation of MachineDeploymentPhase.
+func (md *MachineDeploymentStatus) SetTypedPhase(p MachineDeploymentPhase) {
+	md.Phase = string(p)
+}
+
+// GetTypedPhase attempts to parse the Phase field and return
+// the typed MachineDeploymentPhase representation.
+func (md *MachineDeploymentStatus) GetTypedPhase() MachineDeploymentPhase {
+	switch phase := MachineDeploymentPhase(md.Phase); phase {
+	case
+		MachineDeploymentPhaseScalingDown,
+		MachineDeploymentPhaseScalingUp,
+		MachineDeploymentPhaseRunning,
+		MachineDeploymentPhaseFailed:
+		return phase
+	default:
+		return MachineDeploymentPhaseUnknown
+	}
+}
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=machinedeployments,shortName=md,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown"
 
 // MachineDeployment is the Schema for the machinedeployments API
 type MachineDeployment struct {

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -539,7 +539,12 @@ spec:
         type: object
     served: true
     storage: false
-  - name: v1alpha3
+  - additionalPrinterColumns:
+    - JSONPath: .status.phase
+      description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      name: Phase
+      type: string
+    name: v1alpha3
     schema:
       openAPIV3Schema:
         description: MachineDeployment is the Schema for the machinedeployments API
@@ -932,6 +937,10 @@ spec:
                 description: The generation observed by the deployment controller.
                 format: int64
                 type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
               readyReplicas:
                 description: Total number of ready machines targeted by this deployment.
                 format: int32

--- a/controllers/machinedeployment_sync_test.go
+++ b/controllers/machinedeployment_sync_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+)
+
+func TestMachineDeploymentSyncStatus(t *testing.T) {
+	msStatusError := capierrors.MachineSetStatusError("some failure")
+
+	var tests = map[string]struct {
+		machineSets    []*clusterv1.MachineSet
+		newMachineSet  *clusterv1.MachineSet
+		deployment     *clusterv1.MachineDeployment
+		expectedStatus clusterv1.MachineDeploymentStatus
+	}{
+		"all machines are running": {
+			machineSets: []*clusterv1.MachineSet{{
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+				Status: clusterv1.MachineSetStatus{
+					Selector:           "",
+					AvailableReplicas:  2,
+					ReadyReplicas:      2,
+					Replicas:           2,
+					ObservedGeneration: 1,
+				},
+			}},
+			newMachineSet: &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+				Status: clusterv1.MachineSetStatus{
+					Selector:           "",
+					AvailableReplicas:  2,
+					ReadyReplicas:      2,
+					Replicas:           2,
+					ObservedGeneration: 1,
+				},
+			},
+			deployment: &clusterv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 2,
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+			},
+			expectedStatus: clusterv1.MachineDeploymentStatus{
+				ObservedGeneration:  2,
+				Replicas:            2,
+				UpdatedReplicas:     2,
+				ReadyReplicas:       2,
+				AvailableReplicas:   2,
+				UnavailableReplicas: 0,
+				Phase:               "Running",
+			},
+		},
+		"scaling up": {
+			machineSets: []*clusterv1.MachineSet{{
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+				Status: clusterv1.MachineSetStatus{
+					Selector:           "",
+					AvailableReplicas:  1,
+					ReadyReplicas:      1,
+					Replicas:           2,
+					ObservedGeneration: 1,
+				},
+			}},
+			newMachineSet: &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+				Status: clusterv1.MachineSetStatus{
+					Selector:           "",
+					AvailableReplicas:  1,
+					ReadyReplicas:      1,
+					Replicas:           2,
+					ObservedGeneration: 1,
+				},
+			},
+			deployment: &clusterv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 2,
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+			},
+			expectedStatus: clusterv1.MachineDeploymentStatus{
+				ObservedGeneration:  2,
+				Replicas:            2,
+				UpdatedReplicas:     2,
+				ReadyReplicas:       1,
+				AvailableReplicas:   1,
+				UnavailableReplicas: 1,
+				Phase:               "ScalingUp",
+			},
+		},
+		"scaling down": {
+			machineSets: []*clusterv1.MachineSet{{
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+				Status: clusterv1.MachineSetStatus{
+					Selector:           "",
+					AvailableReplicas:  3,
+					ReadyReplicas:      2,
+					Replicas:           2,
+					ObservedGeneration: 1,
+				},
+			}},
+			newMachineSet: &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+				Status: clusterv1.MachineSetStatus{
+					Selector:           "",
+					AvailableReplicas:  3,
+					ReadyReplicas:      2,
+					Replicas:           2,
+					ObservedGeneration: 1,
+				},
+			},
+			deployment: &clusterv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 2,
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+			},
+			expectedStatus: clusterv1.MachineDeploymentStatus{
+				ObservedGeneration:  2,
+				Replicas:            2,
+				UpdatedReplicas:     2,
+				ReadyReplicas:       2,
+				AvailableReplicas:   3,
+				UnavailableReplicas: 0,
+				Phase:               "ScalingDown",
+			},
+		},
+		"machine set failed": {
+			machineSets: []*clusterv1.MachineSet{{
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+				Status: clusterv1.MachineSetStatus{
+					Selector:           "",
+					AvailableReplicas:  0,
+					ReadyReplicas:      0,
+					Replicas:           2,
+					ObservedGeneration: 1,
+					ErrorReason:        &msStatusError,
+				},
+			}},
+			newMachineSet: &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+				Status: clusterv1.MachineSetStatus{
+					Selector:           "",
+					AvailableReplicas:  0,
+					ReadyReplicas:      0,
+					Replicas:           2,
+					ObservedGeneration: 1,
+				},
+			},
+			deployment: &clusterv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 2,
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+			},
+			expectedStatus: clusterv1.MachineDeploymentStatus{
+				ObservedGeneration:  2,
+				Replicas:            2,
+				UpdatedReplicas:     2,
+				ReadyReplicas:       0,
+				AvailableReplicas:   0,
+				UnavailableReplicas: 2,
+				Phase:               "Failed",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualStatus := calculateStatus(test.machineSets, test.newMachineSet, test.deployment)
+			if actualStatus != test.expectedStatus {
+				t.Errorf("Expected %+v but got %+v", test.expectedStatus, actualStatus)
+			}
+		})
+
+	}
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
 - phase will be updated as part of status sync based on status of machine sets
 - `phase` values are ScalingUp/ScalingDown/Running/Failed  
 - added unit tests for machine deployment status sync

Fixes #969 
