### PR TITLE
🐛 [capd] Remove dockerlib volume mount from CAPD manager

### DIFF
--- a/test/infrastructure/docker/config/manager/manager.yaml
+++ b/test/infrastructure/docker/config/manager/manager.yaml
@@ -30,8 +30,6 @@ spec:
         volumeMounts:
           - mountPath: /var/run/docker.sock
             name: dockersock
-          - mountPath: /var/lib/docker
-            name: dockerlib
         securityContext:
           privileged: true
       terminationGracePeriodSeconds: 10
@@ -39,7 +37,3 @@ spec:
         - name: dockersock
           hostPath:
             path: /var/run/docker.sock
-            type: Socket
-        - name: dockerlib
-          hostPath:
-            path: /var/lib/docker


### PR DESCRIPTION
**What this PR does / why we need it**:

This is not actually necessary for CAPD

Signed-off-by: Chuck Ha <chuckh@vmware.com>

I tested this locally and the change is fine. I believe @detiber also runs without /var/lib/docker.