### PR TITLE
⚠️ Status.Phase values in Cluster and Machine should be consistent with k/k 

### DIFF
--- a/api/v1alpha3/cluster_phase_types.go
+++ b/api/v1alpha3/cluster_phase_types.go
@@ -31,25 +31,25 @@ type ClusterPhase string
 const (
 	// ClusterPhasePending is the first state a Cluster is assigned by
 	// Cluster API Cluster controller after being created.
-	ClusterPhasePending = ClusterPhase("pending")
+	ClusterPhasePending = ClusterPhase("Pending")
 
 	// ClusterPhaseProvisioning is the state when the Cluster has a provider infrastructure
 	// object associated and can start provisioning.
-	ClusterPhaseProvisioning = ClusterPhase("provisioning")
+	ClusterPhaseProvisioning = ClusterPhase("Provisioning")
 
 	// ClusterPhaseProvisioned is the state when its
 	// infrastructure has been created and configured.
-	ClusterPhaseProvisioned = ClusterPhase("provisioned")
+	ClusterPhaseProvisioned = ClusterPhase("Provisioned")
 
 	// ClusterPhaseDeleting is the Cluster state when a delete
 	// request has been sent to the API Server,
 	// but its infrastructure has not yet been fully deleted.
-	ClusterPhaseDeleting = ClusterPhase("deleting")
+	ClusterPhaseDeleting = ClusterPhase("Deleting")
 
 	// ClusterPhaseFailed is the Cluster state when the system
 	// might require user intervention.
-	ClusterPhaseFailed = ClusterPhase("failed")
+	ClusterPhaseFailed = ClusterPhase("Failed")
 
 	// ClusterPhaseUnknown is returned if the Cluster state cannot be determined.
-	ClusterPhaseUnknown = ClusterPhase("")
+	ClusterPhaseUnknown = ClusterPhase("Unknown")
 )

--- a/api/v1alpha3/machine_phase_types.go
+++ b/api/v1alpha3/machine_phase_types.go
@@ -31,34 +31,34 @@ type MachinePhase string
 const (
 	// MachinePhasePending is the first state a Machine is assigned by
 	// Cluster API Machine controller after being created.
-	MachinePhasePending = MachinePhase("pending")
+	MachinePhasePending = MachinePhase("Pending")
 
 	// MachinePhaseProvisioning is the state when the
 	// Machine infrastructure is being created.
-	MachinePhaseProvisioning = MachinePhase("provisioning")
+	MachinePhaseProvisioning = MachinePhase("Provisioning")
 
 	// MachinePhaseProvisioned is the state when its
 	// infrastructure has been created and configured.
-	MachinePhaseProvisioned = MachinePhase("provisioned")
+	MachinePhaseProvisioned = MachinePhase("Provisioned")
 
 	// MachinePhaseRunning is the Machine state when it has
 	// become a Kubernetes Node in a Ready state.
-	MachinePhaseRunning = MachinePhase("running")
+	MachinePhaseRunning = MachinePhase("Running")
 
 	// MachinePhaseDeleting is the Machine state when a delete
 	// request has been sent to the API Server,
 	// but its infrastructure has not yet been fully deleted.
-	MachinePhaseDeleting = MachinePhase("deleting")
+	MachinePhaseDeleting = MachinePhase("Deleting")
 
 	// MachinePhaseDeleted is the Machine state when the object
 	// and the related infrastructure is deleted and
 	// ready to be garbage collected by the API Server.
-	MachinePhaseDeleted = MachinePhase("deleted")
+	MachinePhaseDeleted = MachinePhase("Deleted")
 
 	// MachinePhaseFailed is the Machine state when the system
 	// might require user intervention.
-	MachinePhaseFailed = MachinePhase("failed")
+	MachinePhaseFailed = MachinePhase("Failed")
 
 	// MachinePhaseUnknown is returned if the Machine state cannot be determined.
-	MachinePhaseUnknown = MachinePhase("")
+	MachinePhaseUnknown = MachinePhase("Unknown")
 )

--- a/test/integration/cluster/cluster_test.go
+++ b/test/integration/cluster/cluster_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Cluster-Controller", func() {
 				if err := apiclient.Get(ctx, client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}, cluster); err != nil {
 					return false
 				}
-				return cluster.Status.Phase == "pending"
+				return cluster.Status.Phase == string(clusterv1.ClusterPhasePending)
 			}).Should(BeTrue())
 
 			close(done)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1522
