### PR TITLE
Use context.Context as first parameter for external.Get

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -203,7 +203,7 @@ func (r *ClusterReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 	}
 
 	if cluster.Spec.InfrastructureRef != nil {
-		obj, err := external.Get(r.Client, cluster.Spec.InfrastructureRef, cluster.Namespace)
+		obj, err := external.Get(ctx, r.Client, cluster.Spec.InfrastructureRef, cluster.Namespace)
 		switch {
 		case apierrors.IsNotFound(err):
 			// All good - the infra resource has been deleted

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -68,7 +68,7 @@ func (r *ClusterReconciler) reconcilePhase(ctx context.Context, cluster *cluster
 
 // reconcileExternal handles generic unstructured objects referenced by a Cluster.
 func (r *ClusterReconciler) reconcileExternal(ctx context.Context, cluster *clusterv1.Cluster, ref *corev1.ObjectReference) (*unstructured.Unstructured, error) {
-	obj, err := external.Get(r.Client, ref, cluster.Namespace)
+	obj, err := external.Get(ctx, r.Client, ref, cluster.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: 30 * time.Second},

--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -28,13 +28,13 @@ import (
 )
 
 // Get uses the client and reference to get an external, unstructured object.
-func Get(c client.Client, ref *corev1.ObjectReference, namespace string) (*unstructured.Unstructured, error) {
+func Get(ctx context.Context, c client.Client, ref *corev1.ObjectReference, namespace string) (*unstructured.Unstructured, error) {
 	obj := new(unstructured.Unstructured)
 	obj.SetAPIVersion(ref.APIVersion)
 	obj.SetKind(ref.Kind)
 	obj.SetName(ref.Name)
 	key := client.ObjectKey{Name: obj.GetName(), Namespace: namespace}
-	if err := c.Get(context.Background(), key, obj); err != nil {
+	if err := c.Get(ctx, key, obj); err != nil {
 		return nil, err
 	}
 	return obj, nil
@@ -42,7 +42,7 @@ func Get(c client.Client, ref *corev1.ObjectReference, namespace string) (*unstr
 
 // CloneTemplate uses the client and the reference to create a new object from the template.
 func CloneTemplate(c client.Client, ref *corev1.ObjectReference, namespace string) (*unstructured.Unstructured, error) {
-	from, err := Get(c, ref, namespace)
+	from, err := Get(context.TODO(), c, ref, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -370,7 +370,7 @@ func (r *MachineReconciler) reconcileDeleteExternal(ctx context.Context, m *clus
 			continue
 		}
 
-		obj, err := external.Get(r.Client, ref, m.Namespace)
+		obj, err := external.Get(ctx, r.Client, ref, m.Namespace)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return false, errors.Wrapf(err, "failed to get %s %q for Machine %q in namespace %q",
 				ref.GroupVersionKind(), ref.Name, m.Name, m.Namespace)

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -76,7 +76,7 @@ func (r *MachineReconciler) reconcilePhase(ctx context.Context, m *clusterv1.Mac
 
 // reconcileExternal handles generic unstructured objects referenced by a Machine.
 func (r *MachineReconciler) reconcileExternal(ctx context.Context, m *clusterv1.Machine, ref *corev1.ObjectReference) (*unstructured.Unstructured, error) {
-	obj, err := external.Get(r.Client, ref, m.Namespace)
+	obj, err := external.Get(ctx, r.Client, ref, m.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: externalReadyWait},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1546
