### PR TITLE
📖 Add MacOS instructions for the CAPD quickstart

### DIFF
--- a/docs/book/src/tasks/installation.md
+++ b/docs/book/src/tasks/installation.md
@@ -18,7 +18,7 @@ Cluster API requires an existing kubernetes cluster accessible via kubectl, choo
 
 <h1>Warning</h1>
 
-[kind] is not designed for production use, and is intended for development environments only.
+[kind] is not designed for production use; it is intended for development and testing environments.
 
 </aside>
 
@@ -33,7 +33,7 @@ Cluster API requires an existing kubernetes cluster accessible via kubectl, choo
 
 <h1>Warning</h1>
 
-[kind] is not designed for production use, and is intended for development environments only.
+[kind] is not designed for production use; it is intended for development and testing environments.
 
 </aside>
 

--- a/docs/book/src/tasks/installation.md
+++ b/docs/book/src/tasks/installation.md
@@ -45,14 +45,6 @@ The Docker provider is not designed for production use and is intended for devel
 
 </aside>
 
-<aside class="note warning">
-
-<h1>Docker Provider on MacOS</h1>
-
-Instructions for using the Docker provider on MacOS will be added soon.
-
-</aside>
-
   Because the Docker provider needs to access Docker on the host, a custom kind cluster configuration is required:
 
   ```bash
@@ -75,7 +67,7 @@ EOF
 
 <h1>Warning</h1>
 
-[kind] is not designed for production use, and is intended for development environments only.
+[kind] is not designed for production use; it is intended for development and testing environments.
 
 </aside>
 
@@ -89,7 +81,7 @@ EOF
 
 2. **Existing Management Cluster**
 
-For production use-cases a "real" kubernetes cluster should be used with apropriate backup and DR policies and procedures in place.
+For production use-cases a "real" kubernetes cluster should be used with appropriate backup and DR policies and procedures in place.
 
 ```bash
 export KUBECONFIG=<...>

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -318,12 +318,43 @@ spec:
 
 After the controlplane is up and running, let's retrieve the [target cluster] Kubeconfig:
 
+{{#tabs name:"tab-getting-kubeconfig" tabs:"AWS,Docker,vSphere"}}
+{{#tab AWS}}
 ```bash
 kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o json \
   | jq -r .data.value \
   | base64 --decode \
   > ./capi-quickstart.kubeconfig
 ```
+{{#/tab }}
+{{#tab Docker}}
+```bash
+kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o json \
+  | jq -r .data.value \
+  | base64 --decode \
+  > ./capi-quickstart.kubeconfig
+```
+
+When using docker-for-mac MacOS, you will need to do a couple of additional
+steps to get the correct kubeconfig:
+
+```bash
+# Point the kubeconfig to the exposed port of the load balancer, rather than the inaccessible container IP.
+sed -i -e "s/server:.*/server: https:\/\/$(docker port capi-quickstart-lb 6443/tcp | sed "s/0.0.0.0/127.0.0.1/")/g" ./capi-quickstart.kubeconfig
+
+# Ignore the CA, because it is not signed for 127.0.0.1
+sed -i -e "s/certificate-authority-data:.*/insecure-skip-tls-verify: true/g" ./capi-quickstart.kubeconfig
+```  
+{{#/tab }}
+{{#tab vSphere}}
+```bash
+kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o json \
+  | jq -r .data.value \
+  | base64 --decode \
+  > ./capi-quickstart.kubeconfig
+```
+{{#/tab }}
+{{#/tabs }}
 
 Deploy a CNI solution, Calico is used here as an example.
 

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -320,6 +320,7 @@ After the controlplane is up and running, let's retrieve the [target cluster] Ku
 
 {{#tabs name:"tab-getting-kubeconfig" tabs:"AWS,Docker,vSphere"}}
 {{#tab AWS}}
+
 ```bash
 kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o json \
   | jq -r .data.value \
@@ -328,6 +329,7 @@ kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o json \
 ```
 {{#/tab }}
 {{#tab Docker}}
+
 ```bash
 kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o json \
   | jq -r .data.value \
@@ -347,6 +349,7 @@ sed -i -e "s/certificate-authority-data:.*/insecure-skip-tls-verify: true/g" ./c
 ```  
 {{#/tab }}
 {{#tab vSphere}}
+
 ```bash
 kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o json \
   | jq -r .data.value \


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now, without any modifications, the CAPD instructions do not work on MacOS. This PR adds additional instructions to the quickstart guide on how to get it working.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1534
