### PR TITLE
✨The label cluster-name is now applied to external objects

### DIFF
--- a/api/v1alpha3/common_types.go
+++ b/api/v1alpha3/common_types.go
@@ -20,6 +20,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// ClusterLabelName is the label set on machines linked to a cluster and
+	// external objects(bootstrap and infrastructure providers)
+	ClusterLabelName = "cluster.x-k8s.io/cluster-name"
+)
+
 // MachineAddressType describes a valid MachineAddress type.
 type MachineAddressType string
 

--- a/api/v1alpha3/machine_types.go
+++ b/api/v1alpha3/machine_types.go
@@ -26,10 +26,6 @@ const (
 	// MachineFinalizer is set on PrepareForCreate callback.
 	MachineFinalizer = "machine.cluster.x-k8s.io"
 
-	// ClusterLabelName is the label set on machines linked to a cluster and
-	// external objects(bootstrap and infrastructure providers)
-	ClusterLabelName = "cluster.x-k8s.io/cluster-name"
-
 	// MachineControlPlaneLabelName is the label set on machines part of a control plane.
 	MachineControlPlaneLabelName = "cluster.x-k8s.io/control-plane"
 

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -96,6 +96,14 @@ func (r *ClusterReconciler) reconcileExternal(ctx context.Context, cluster *clus
 	// Add ownerRef to object.
 	obj.SetOwnerReferences(util.EnsureOwnerRef(obj.GetOwnerReferences(), ownerRef))
 
+	// Set the Cluster label.
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[clusterv1.ClusterLabelName] = cluster.Name
+	obj.SetLabels(labels)
+
 	// Always attempt to Patch the external object.
 	if err := patchHelper.Patch(ctx, obj); err != nil {
 		return nil, err

--- a/controllers/mdutil/util.go
+++ b/controllers/mdutil/util.go
@@ -160,7 +160,7 @@ var annotationsToSkip = map[string]bool{
 }
 
 // skipCopyAnnotation returns true if we should skip copying the annotation with the given annotation key
-// TODO: How to decide which annotations should / should not be copied?
+// TODO(tbd): How to decide which annotations should / should not be copied?
 //       See https://github.com/kubernetes/kubernetes/pull/20035#issuecomment-179558615
 func skipCopyAnnotation(key string) bool {
 	return annotationsToSkip[key]

--- a/docs/book/src/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/providers/v1alpha2-to-v1alpha3.md
@@ -32,3 +32,7 @@
 
 - The variable name is renamed as this label isn't applied only to machines anymore.
 - This label is also applied to external objects(bootstrap provider, infrastructure provider)
+
+## Cluster and Machine controllers now set `cluster.x-k8s.io/cluster-name` to external objects.
+
+- In addition to the OwnerReference back to the Cluster, a label is now added as well to any external objects, for example objects such as KubeadmConfig (bootstrap provider), AWSCluster (infrastructure provider), AWSMachine (infrastructure provider), etc.


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1567 
