### PR TITLE
📖 Adds a library API change to v2->v3 document

### DIFF
--- a/docs/book/src/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/providers/v1alpha2-to-v1alpha3.md
@@ -17,7 +17,11 @@
 
 ## Context is now required for `external.CloneTemplate` function.
 
-- Pass a context as first argument to calls to `external.CloneTemplate`.
+- Pass a context as the first argument to calls to `external.CloneTemplate`.
+
+## Context is now required for `external.Get` function.
+
+- Pass a context as the first argument to calls to `external.Get`.
 
 ## Cluster and Machine `Status.Phase` field values now start with an uppercase letter.
 


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR adds an API change to provider document helping devs move from v1a2 to v1a3.



Note:

I think once we have 3 Context-as-first-parameter changes we could consider collapsing that into one section.