### PR TITLE
:bug: Fixes an issue when using an empty namespace with `clusterctl create`

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -519,6 +519,7 @@ func (c *client) CreateMachines(machines []*clusterv1.Machine, namespace string)
 		go func(machine *clusterv1.Machine) {
 			defer wg.Done()
 
+			machine.Namespace = namespace
 			if err := c.clientSet.Create(ctx, machine); err != nil {
 				errOnce.Do(func() {
 					gerr = errors.Wrapf(err, "error creating a machine object in namespace %v", namespace)

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -93,10 +93,6 @@ func (d *ClusterDeployer) Create(resources *yaml.ParseOutput, kubeconfigOutput s
 		return errors.Wrapf(err, "unable to create cluster %q in bootstrap cluster", cluster.Name)
 	}
 
-	if cluster.Namespace == "" {
-		cluster.Namespace = bootstrapClient.GetContextNamespace()
-	}
-
 	firstControlPlane := controlPlaneMachines[0]
 	klog.Infof("Creating control plane machine %q in namespace %q", firstControlPlane.Name, cluster.Namespace)
 	if err := phases.ApplyMachines(

--- a/cmd/clusterctl/phases/applycluster.go
+++ b/cmd/clusterctl/phases/applycluster.go
@@ -35,6 +35,10 @@ func ApplyCluster(client clusterclient.Client, cluster *clusterv1.Cluster, extra
 	}
 
 	for _, e := range extra {
+		if e.GetNamespace() == "" {
+			e.SetNamespace(client.GetContextNamespace())
+		}
+
 		klog.Infof("Creating Cluster referenced object %q with name %q in namespace %q", e.GroupVersionKind(), e.GetName(), e.GetNamespace())
 		if err := client.CreateUnstructuredObject(e); err != nil {
 			return err

--- a/cmd/clusterctl/phases/applymachines.go
+++ b/cmd/clusterctl/phases/applymachines.go
@@ -35,6 +35,8 @@ func ApplyMachines(client clusterclient.Client, namespace string, machines []*cl
 	}
 
 	for _, e := range extra {
+		e.SetNamespace(namespace)
+
 		klog.Infof("Creating Machine referenced object %q with name %q in namespace %q", e.GroupVersionKind(), e.GetName(), e.GetNamespace())
 		if err := client.CreateUnstructuredObject(e); err != nil {
 			return err


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
`clusterctl` fails to create a cluster if the Cluster API resources don't have a namespace defined.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1536 
