### PR TITLE
:running: Re-add context to reconcileNodeRef function

### DIFF
--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -161,7 +161,7 @@ func (r *MachineReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cl
 	reconciliationErrors := []error{
 		r.reconcileBootstrap(ctx, m),
 		r.reconcileInfrastructure(ctx, m),
-		r.reconcileNodeRef(cluster, m),
+		r.reconcileNodeRef(ctx, cluster, m),
 	}
 
 	// Parse the errors, making sure we record if there is a RequeueAfterError.

--- a/controllers/machine_controller_noderef.go
+++ b/controllers/machine_controller_noderef.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"time"
 
 	"github.com/pkg/errors"
@@ -33,7 +34,7 @@ var (
 	ErrNodeNotFound = errors.New("cannot find node with matching ProviderID")
 )
 
-func (r *MachineReconciler) reconcileNodeRef(cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+func (r *MachineReconciler) reconcileNodeRef(_ context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	logger := r.Log.WithValues("machine", machine.Name, "namespace", machine.Namespace)
 	// Check that the Machine hasn't been deleted or in the process.
 	if !machine.DeletionTimestamp.IsZero() {

--- a/controllers/machineset_controller_test.go
+++ b/controllers/machineset_controller_test.go
@@ -125,10 +125,10 @@ var _ = Describe("MachineSet Reconciler", func() {
 
 		// Create the MachineSet.
 		Expect(k8sClient.Create(ctx, instance)).To(BeNil())
-		// defer func() {
-		// 	err := k8sClient.Delete(ctx, instance)
-		// 	Expect(err).NotTo(HaveOccurred())
-		// }()
+		defer func() {
+			err := k8sClient.Delete(ctx, instance)
+			Expect(err).NotTo(HaveOccurred())
+		}()
 
 		machines := &clusterv1.MachineList{}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
