### PR TITLE
🏃 Speed up + debug cluster tests

### DIFF
--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -63,7 +63,7 @@ func fakeMachineNodeRef(m *clusterv1.Machine) {
 	// Create a new fake Node.
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "test-",
+			GenerateName: m.Name + "-",
 		},
 	}
 	Expect(k8sClient.Create(ctx, node)).ShouldNot(HaveOccurred())


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Precreate a Node so the machine reconciler doesn't wait 10 seconds to
retry the node.

Make cluster/machine/node names unique to make it easier to debug log
output.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1597 
