### PR TITLE
🏃 Add restart capabilities to the builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,15 @@ RUN go mod download
 # Copy the sources
 COPY ./ ./
 
+RUN wget --output-file /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
+    wget --output-file /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh
+
 # Build
 ARG ARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     go build -a -ldflags '-extldflags "-static"' \
     -o manager .
+ENTRYPOINT [ "/start.sh", "/workspace/manager" ]
 
 # Copy the controller-manager into a thin image
 FROM gcr.io/distroless/static:latest


### PR DESCRIPTION
The builder image can be used as a development image and with this
change supports tilt's live update feature.

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR makes the builder image useful without impacting production images in anyway whatsoever.

