### PR TITLE
✨ Use Spec.ClusterName to get the linked cluster

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -118,7 +118,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	log = log.WithValues("machine-name", machine.Name)
 
 	// Lookup the cluster the machine is associated with
-	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machine.ObjectMeta)
+	cluster, err := util.GetClusterByName(ctx, r.Client, machine.ObjectMeta.Namespace, machine.Spec.ClusterName)
 	if err != nil {
 		if errors.Cause(err) == util.ErrNoCluster {
 			log.Info("Machine does not belong to a cluster yet, waiting until its part of a cluster")

--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
@@ -1421,6 +1421,7 @@ func newMachine(cluster *clusterv1.Cluster, name string) *clusterv1.Machine {
 		},
 	}
 	if cluster != nil {
+		machine.Spec.ClusterName = cluster.Name
 		machine.ObjectMeta.Labels = map[string]string{
 			clusterv1.ClusterLabelName: cluster.Name,
 		}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -339,7 +339,7 @@ func (r *ClusterReconciler) controlPlaneMachineToCluster(o handler.MapObject) []
 		return nil
 	}
 
-	cluster, err := util.GetClusterFromMetadata(context.TODO(), r.Client, m.ObjectMeta)
+	cluster, err := util.GetClusterByName(context.TODO(), r.Client, m.ObjectMeta.Namespace, m.Spec.ClusterName)
 	if err != nil {
 		r.Log.Error(err, "Failed to get cluster", "machine", m.Name, "cluster", m.ClusterName, "namespace", m.Namespace)
 		return nil

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -121,7 +121,7 @@ func (r *MachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr e
 	}
 	m.Labels[clusterv1.ClusterLabelName] = m.Spec.ClusterName
 
-	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, m.ObjectMeta)
+	cluster, err := util.GetClusterByName(ctx, r.Client, m.ObjectMeta.Namespace, m.Spec.ClusterName)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to get cluster %q for machine %q in namespace %q",
 			m.Labels[clusterv1.ClusterLabelName], m.Name, m.Namespace)

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -143,7 +143,7 @@ func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, d *clusterv
 	}
 	d.Labels[clusterv1.ClusterLabelName] = d.Spec.ClusterName
 
-	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, d.ObjectMeta)
+	cluster, err := util.GetClusterByName(ctx, r.Client, d.ObjectMeta.Namespace, d.Spec.ClusterName)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -153,7 +153,7 @@ func (r *MachineSetReconciler) reconcile(ctx context.Context, machineSet *cluste
 	}
 	machineSet.Labels[clusterv1.ClusterLabelName] = machineSet.Spec.ClusterName
 
-	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machineSet.ObjectMeta)
+	cluster, err := util.GetClusterByName(ctx, r.Client, machineSet.ObjectMeta.Namespace, machineSet.Spec.ClusterName)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/machineset_status.go
+++ b/controllers/machineset_status.go
@@ -52,7 +52,7 @@ func (r *MachineSetReconciler) calculateStatus(ms *clusterv1.MachineSet, filtere
 	templateLabel := labels.Set(ms.Spec.Template.Labels).AsSelectorPreValidated()
 
 	// Retrieve Cluster, if any.
-	cluster, _ := util.GetClusterFromMetadata(context.Background(), r.Client, ms.ObjectMeta)
+	cluster, _ := util.GetClusterByName(context.Background(), r.Client, ms.ObjectMeta.Namespace, ms.Spec.ClusterName)
 
 	for _, machine := range filteredMachines {
 		if templateLabel.Matches(labels.Set(machine.Labels)) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Using the `GetClusterByName` method instead of `GetClusterFromMetadata`.

**Which issue(s) this PR fixes** :
Fixes #1547 
