### PR TITLE
🏃 Adds a tool to update certmanager YAML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ BIN_DIR := bin
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 CONVERSION_GEN := $(TOOLS_BIN_DIR)/conversion-gen
+CERTMANAGER_UPDATE := $(TOOLS_BIN_DIR)/certmanager-update
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
@@ -100,6 +101,9 @@ $(GOLANGCI_LINT): $(TOOLS_DIR)/go.mod # Build golangci-lint from tools folder.
 $(CONVERSION_GEN): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/conversion-gen k8s.io/code-generator/cmd/conversion-gen
 
+$(CERTMANAGER_UPDATE): $(TOOLS_DIR)/go.mod
+	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/certmanager-update ./certmanager
+
 ## --------------------------------------
 ## Linting
 ## --------------------------------------
@@ -152,6 +156,10 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 modules: ## Runs go mod to ensure modules are up to date.
 	go mod tidy
 	cd $(TOOLS_DIR); go mod tidy
+
+.PHONY: update-certmanager
+update-certmanager: $(CERTMANAGER_UPDATE)
+	VERSION=$(CERTMANAGER_VERSION) $(CERTMANAGER_UPDATE) > config/certmanager/cert-manager.yaml
 
 ## --------------------------------------
 ## Docker

--- a/docs/book/src/tooling/tooling.md
+++ b/docs/book/src/tooling/tooling.md
@@ -1,3 +1,9 @@
 # Tooling
 
-This page is still being written - stay tuned!
+## update-certmanager
+
+Run this make command substituting the desired version of cert-manager
+
+```
+CERTMANAGER_VERSION=v0.11.0 make update-certmanager
+```

--- a/hack/tools/certmanager/update.go
+++ b/hack/tools/certmanager/update.go
@@ -1,0 +1,45 @@
+// +build tools
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+func main() {
+	version := os.Getenv("VERSION")
+	if version == "" {
+		panic("env var VERSION cannot be empty")
+	}
+
+	resp, err := http.Get(fmt.Sprintf("https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml", version))
+	if err != nil{
+		panic(err)
+	}
+
+	out, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(out))
+}


### PR DESCRIPTION
Automating the pulling in of cert-manager.yaml through the hack/tools pattern.

**What this PR does / why we need it**:
We will likely be updating the cert-manager moving forward as controller-runtime updates
their version of cert-manager. However, they do not expose the version they support in an
obvious or programmatic way, so this is an attempt to make the manual step of updating
cert-manager as easy as possible.

Signed-off-by: Chuck Ha <chuckh@vmware.com>