### PR TITLE
🐛 Allow clusterctl to create and pivot clusters if metadata.namespace is missing

### DIFF
--- a/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
+++ b/cmd/clusterctl/clusterdeployer/clusterclient/clusterclient.go
@@ -522,6 +522,7 @@ func (c *client) CreateMachines(machines []*clusterv1.Machine, namespace string)
 		go func(machine *clusterv1.Machine) {
 			defer wg.Done()
 
+			machine.Namespace = namespace
 			if err := c.clientSet.Create(ctx, machine); err != nil {
 				errOnce.Do(func() {
 					gerr = errors.Wrapf(err, "error creating a machine object in namespace %v", namespace)

--- a/cmd/clusterctl/clusterdeployer/clusterdeployer.go
+++ b/cmd/clusterctl/clusterdeployer/clusterdeployer.go
@@ -97,10 +97,6 @@ func (d *ClusterDeployer) Create(resources *yaml.ParseOutput, kubeconfigOutput s
 		return errors.Wrapf(err, "unable to create cluster %q in bootstrap cluster", cluster.Name)
 	}
 
-	if cluster.Namespace == "" {
-		cluster.Namespace = bootstrapClient.GetContextNamespace()
-	}
-
 	firstControlPlane := controlPlaneMachines[0]
 	klog.Infof("Creating control plane machine %q in namespace %q", firstControlPlane.Name, cluster.Namespace)
 	if err := phases.ApplyMachines(

--- a/cmd/clusterctl/phases/applycluster.go
+++ b/cmd/clusterctl/phases/applycluster.go
@@ -35,6 +35,10 @@ func ApplyCluster(client clusterclient.Client, cluster *clusterv1.Cluster, extra
 	}
 
 	for _, e := range extra {
+		if e.GetNamespace() == "" {
+			e.SetNamespace(client.GetContextNamespace())
+		}
+
 		klog.Infof("Creating Cluster referenced object %q with name %q in namespace %q", e.GroupVersionKind(), e.GetName(), e.GetNamespace())
 		if err := client.CreateUnstructuredObject(e); err != nil {
 			return err

--- a/cmd/clusterctl/phases/applymachines.go
+++ b/cmd/clusterctl/phases/applymachines.go
@@ -35,6 +35,8 @@ func ApplyMachines(client clusterclient.Client, namespace string, machines []*cl
 	}
 
 	for _, e := range extra {
+		e.SetNamespace(namespace)
+
 		klog.Infof("Creating Machine referenced object %q with name %q in namespace %q", e.GroupVersionKind(), e.GetName(), e.GetNamespace())
 		if err := client.CreateUnstructuredObject(e); err != nil {
 			return err

--- a/cmd/clusterctl/phases/pivot.go
+++ b/cmd/clusterctl/phases/pivot.go
@@ -208,7 +208,7 @@ func moveCluster(from sourceClient, to targetClient, cluster *clusterv1.Cluster)
 
 	// Move infrastructure reference, if any.
 	if cluster.Spec.InfrastructureRef != nil {
-		if err := moveReference(from, to, cluster.Spec.InfrastructureRef); err != nil {
+		if err := moveReference(from, to, cluster.Spec.InfrastructureRef, cluster.Namespace); err != nil {
 			return errors.Wrapf(err, "error copying Cluster %s/%s infrastructure reference to target cluster",
 				cluster.Namespace, cluster.Name)
 		}
@@ -324,7 +324,7 @@ func moveMachineDeployment(from sourceClient, to targetClient, md *clusterv1.Mac
 	}
 
 	// Move infrastructure reference.
-	if err := moveReference(from, to, &md.Spec.Template.Spec.InfrastructureRef); err != nil {
+	if err := moveReference(from, to, &md.Spec.Template.Spec.InfrastructureRef, md.Namespace); err != nil {
 		return errors.Wrapf(err, "error copying MachineSet %s/%s infrastructure reference to target cluster",
 			md.Namespace, md.Name)
 	}
@@ -377,7 +377,7 @@ func moveMachineSet(from sourceClient, to targetClient, ms *clusterv1.MachineSet
 	// When a MachineSet is owned by a MachineDeployment, the referenced template has already been moved
 	// by the time this function is called.
 	if metav1.GetControllerOf(ms) == nil {
-		if err := moveReference(from, to, &ms.Spec.Template.Spec.InfrastructureRef); err != nil {
+		if err := moveReference(from, to, &ms.Spec.Template.Spec.InfrastructureRef, ms.Namespace); err != nil {
 			return errors.Wrapf(err, "error copying MachineSet %s/%s infrastructure reference to target cluster",
 				ms.Namespace, ms.Name)
 		}
@@ -426,14 +426,14 @@ func moveMachine(from sourceClient, to targetClient, m *clusterv1.Machine) error
 
 	// Move bootstrap reference, if any.
 	if m.Spec.Bootstrap.ConfigRef != nil {
-		if err := moveReference(from, to, m.Spec.Bootstrap.ConfigRef); err != nil {
+		if err := moveReference(from, to, m.Spec.Bootstrap.ConfigRef, m.Namespace); err != nil {
 			return errors.Wrapf(err, "error copying Machine %s/%s bootstrap reference to target cluster",
 				m.Namespace, m.Name)
 		}
 	}
 
 	// Move infrastructure reference.
-	if err := moveReference(from, to, &m.Spec.InfrastructureRef); err != nil {
+	if err := moveReference(from, to, &m.Spec.InfrastructureRef, m.Namespace); err != nil {
 		return errors.Wrapf(err, "error copying Machine %s/%s infrastructure reference to target cluster",
 			m.Namespace, m.Name)
 	}
@@ -455,11 +455,11 @@ func moveMachine(from sourceClient, to targetClient, m *clusterv1.Machine) error
 	return nil
 }
 
-func moveReference(from sourceClient, to targetClient, ref *corev1.ObjectReference) error {
+func moveReference(from sourceClient, to targetClient, ref *corev1.ObjectReference, namespace string) error {
 	u := &unstructured.Unstructured{}
 	u.SetAPIVersion(ref.APIVersion)
 	u.SetKind(ref.Kind)
-	u.SetNamespace(ref.Namespace)
+	u.SetNamespace(namespace)
 	u.SetName(ref.Name)
 	if err := from.GetUnstructuredObject(u); err != nil {
 		return errors.Wrapf(err, "error fetching unstructured object %q %s/%s",


### PR DESCRIPTION
**What this PR does / why we need it**:
`clusterctl` had issues creating or pivoting clusters if any of the resources in the yaml was missing `metadata.namespace`. This ports the fixes from `release-0.2` to master.

The original PRs were #1590 and #1616

cc @aaroniscode