### PR TITLE
🏃 [CABPK] Add test for KubeadmConfigReconciler_ReturnEarlyIfClusterInfraNotReady

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func setupScheme() *runtime.Scheme {
@@ -190,6 +191,47 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfMachineHasBootstrapData(
 	}
 	if result.RequeueAfter != time.Duration(0) {
 		t.Fatal("did not expect to requeue after")
+	}
+}
+
+func TestKubeadmConfigReconciler_ReturnEarlyIfClusterInfraNotReady(t *testing.T) {
+	cluster := newCluster("cluster")
+	machine := newMachine(cluster, "machine")
+	config := newKubeadmConfig(machine, "cfg")
+
+	//cluster infra not ready
+	cluster.Status = clusterv1.ClusterStatus{
+		InfrastructureReady: false,
+	}
+
+	objects := []runtime.Object{
+		cluster,
+		machine,
+		config,
+	}
+	myclient := fake.NewFakeClientWithScheme(setupScheme(), objects...)
+
+	k := &KubeadmConfigReconciler{
+		Log:    log.Log,
+		Client: myclient,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "default",
+			Name:      "cfg",
+		},
+	}
+
+	expectedResult := reconcile.Result{}
+	actualResult, actualError := k.Reconcile(request)
+
+	if actualResult != expectedResult {
+		t.Errorf("reconcile result doesn't match, Want %v, Got %v", expectedResult, actualResult)
+	}
+
+	if actualError != nil {
+		t.Errorf("error doesn't match expected value, Want nil, Got %v", actualError)
 	}
 }
 


### PR DESCRIPTION

From https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/pull/277

Signed-off-by: Ashish Amarnath <ashish.amarnath@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
