### PR TITLE
 ⚠️ Change remote.NewClusterClient to return a controller-runtime client.Client

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
@@ -533,8 +533,8 @@ func TestKubeadmConfigReconciler_Reconcile_RequeueIfControlPlaneIsMissingAPIEndp
 	}
 }
 
-func testRemoteClient(c client.Client) func(client.Client, *clusterv1.Cluster) (client.Client, error) {
-	return func(client.Client, *clusterv1.Cluster) (client.Client, error) {
+func testRemoteClient(c client.Client) func(client.Client, *clusterv1.Cluster, *runtime.Scheme) (client.Client, error) {
+	return func(client.Client, *clusterv1.Cluster, *runtime.Scheme) (client.Client, error) {
 		return c, nil
 	}
 }

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -76,9 +76,14 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, options controlle
 		WithOptions(options).
 		Build(r)
 
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+
 	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("cluster-controller")
-	return err
+
+	return nil
 }
 
 func (r *ClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {

--- a/controllers/machine_controller_noderef_test.go
+++ b/controllers/machine_controller_noderef_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	fakeclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -70,7 +69,7 @@ func TestGetNodeReference(t *testing.T) {
 		},
 	}
 
-	coreV1Client := fakeclient.NewSimpleClientset(nodeList...).CoreV1()
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, nodeList...)
 
 	testCases := []struct {
 		name       string
@@ -108,7 +107,7 @@ func TestGetNodeReference(t *testing.T) {
 				t.Fatalf("Expected no error parsing provider id %q, got %v", test.providerID, err)
 			}
 
-			reference, err := r.getNodeReference(coreV1Client, providerID)
+			reference, err := r.getNodeReference(client, providerID)
 			if err != nil {
 				if (test.err != nil && !strings.Contains(err.Error(), test.err.Error())) || test.err == nil {
 					t.Fatalf("Expected error %v, got %v", test.err, err)

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -67,8 +67,13 @@ func (r *MachineDeploymentReconciler) SetupWithManager(mgr ctrl.Manager, options
 		WithOptions(options).
 		Complete(r)
 
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+
 	r.recorder = mgr.GetEventRecorderFor("machinedeployment-controller")
-	return err
+
+	return nil
 }
 
 func (r *MachineDeploymentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controllers/external"
@@ -65,6 +66,7 @@ type MachineSetReconciler struct {
 	Log    logr.Logger
 
 	recorder record.EventRecorder
+	scheme   *runtime.Scheme
 }
 
 func (r *MachineSetReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
@@ -78,8 +80,14 @@ func (r *MachineSetReconciler) SetupWithManager(mgr ctrl.Manager, options contro
 		WithOptions(options).
 		Complete(r)
 
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+
 	r.recorder = mgr.GetEventRecorderFor("machineset-controller")
-	return err
+
+	r.scheme = mgr.GetScheme()
+	return nil
 }
 
 func (r *MachineSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -18,53 +18,45 @@ package remote
 
 import (
 	"github.com/pkg/errors"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-// ClusterClient is an interface encapsulating methods
-// to access a remote cluster.
-type ClusterClient interface {
-	RESTConfig() *restclient.Config
-	CoreV1() (corev1.CoreV1Interface, error)
-}
+// NewClusterClient returns a Client for interacting with a remote Cluster using the given scheme for encoding and decoding objects.
+func NewClusterClient(c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error) {
 
-// clusterClient is a helper struct to connect to remote workload clusters.
-type clusterClient struct {
-	restConfig *restclient.Config
-	cluster    *clusterv1.Cluster
-}
-
-// NewClusterClient creates a new ClusterClient.
-func NewClusterClient(c client.Client, cluster *clusterv1.Cluster) (ClusterClient, error) {
-	kubeconfig, err := kcfg.FromSecret(c, cluster)
+	restConfig, err := RESTConfig(c, cluster)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve kubeconfig secret for Cluster %q in namespace %q",
-			cluster.Name, cluster.Namespace)
+		return nil, err
+	}
+	mapper, err := apiutil.NewDynamicRESTMapper(restConfig, apiutil.WithLazyDiscovery)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create a DynamicRESTMapper for Cluster %s/%s", cluster.Namespace, cluster.Name)
+	}
+	ret, err := client.New(restConfig, client.Options{Scheme: scheme, Mapper: mapper})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create client for Cluster %s/%s", cluster.Namespace, cluster.Name)
 	}
 
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create client configuration for Cluster %q in namespace %q",
-			cluster.Name, cluster.Namespace)
-	}
-
-	return &clusterClient{
-		restConfig: restConfig,
-		cluster:    cluster,
-	}, nil
+	return ret, nil
 }
 
 // RESTConfig returns a configuration instance to be used with a Kubernetes client.
-func (c *clusterClient) RESTConfig() *restclient.Config {
-	return c.restConfig
-}
+func RESTConfig(c client.Client, cluster *clusterv1.Cluster) (*restclient.Config, error) {
+	kubeConfig, err := kcfg.FromSecret(c, cluster)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve kubeconfig secret for Cluster %s/%s", cluster.Namespace, cluster.Name)
+	}
 
-// CoreV1 returns a new Kubernetes CoreV1 client.
-func (c *clusterClient) CoreV1() (corev1.CoreV1Interface, error) {
-	return corev1.NewForConfig(c.RESTConfig())
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create REST configuration for Cluster %s/%s", cluster.Namespace, cluster.Name)
+	}
+
+	return restConfig, nil
 }

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -23,6 +23,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util/secret"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -89,9 +91,15 @@ users:
 )
 
 func TestNewClusterClient(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	err := scheme.AddToScheme(testScheme)
+	if err != nil {
+		t.Fatalf("Failed to addd types to the scheme: %v", err)
+	}
+
 	t.Run("cluster with valid kubeconfig", func(t *testing.T) {
-		client := fake.NewFakeClient(validSecret)
-		c, err := NewClusterClient(client, clusterWithValidKubeConfig)
+		client := fake.NewFakeClientWithScheme(testScheme, validSecret)
+		c, err := NewClusterClient(client, clusterWithValidKubeConfig, testScheme)
 		if err != nil {
 			t.Fatalf("Expected no errors, got %v", err)
 		}
@@ -100,23 +108,26 @@ func TestNewClusterClient(t *testing.T) {
 			t.Fatal("Expected actual client, got nil")
 		}
 
-		restConfig := c.RESTConfig()
+		restConfig, err := RESTConfig(client, clusterWithValidKubeConfig)
+		if err != nil {
+			t.Fatalf("Expected no errors, got %v", err)
+		}
 		if restConfig.Host != "https://test-cluster-api:6443" {
 			t.Fatalf("Unexpected Host value in RESTConfig: %q", restConfig.Host)
 		}
 	})
 
 	t.Run("cluster with no kubeconfig", func(t *testing.T) {
-		client := fake.NewFakeClient()
-		_, err := NewClusterClient(client, clusterWithNoKubeConfig)
+		client := fake.NewFakeClientWithScheme(testScheme)
+		_, err := NewClusterClient(client, clusterWithNoKubeConfig, testScheme)
 		if !strings.Contains(err.Error(), "not found") {
 			t.Fatalf("Expected not found error, got %v", err)
 		}
 	})
 
 	t.Run("cluster with invalid kubeconfig", func(t *testing.T) {
-		client := fake.NewFakeClient(invalidSecret)
-		_, err := NewClusterClient(client, clusterWithInvalidKubeConfig)
+		client := fake.NewFakeClientWithScheme(testScheme, invalidSecret)
+		_, err := NewClusterClient(client, clusterWithInvalidKubeConfig, testScheme)
 		if err == nil || apierrors.IsNotFound(err) {
 			t.Fatalf("Expected error, got %v", err)
 		}

--- a/docs/book/src/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/providers/v1alpha2-to-v1alpha3.md
@@ -44,3 +44,14 @@
 ## Generated kubeconfig admin username changed from `kubernetes-admin` to `<cluster-name>-admin`
 
 - The kubeconfig secret shipped with Cluster API now uses the cluster name as prefix to the `username` field.
+
+## Changes to `sigs.k8s.io/cluster-api/controllers/remote`
+
+-  The `ClusterClient` interface has been removed.
+- `remote.NewClusterClient` now returns a `sigs.k8s.io/controller-runtime/pkg/client` Client. The signature changed from 
+
+    `func NewClusterClient(c client.Client, cluster *clusterv1.Cluster) (ClusterClient, error)`
+
+    to
+
+    `func NewClusterClient(c client.Client, cluster *clusterv1.Cluster, scheme runtime.Scheme) (client.Client, error)`


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Updating the `remote` package -
-  The `ClusterClient` interface has been removed.
- `remote.NewClusterClient` now returns a `sigs.k8s.io/controller-runtime/pkg/client` Client.

**Which issue(s) this PR fixes** :
Fixes #1606 
