### PR TITLE
Remove outdated README content from when CAPBK was own repo

### DIFF
--- a/bootstrap/kubeadm/README.md
+++ b/bootstrap/kubeadm/README.md
@@ -13,52 +13,8 @@ for kubernetes bootstrap.
 * [cluster-api.sigs.k8s.io](https://cluster-api.sigs.k8s.io)
 * [The Kubebuilder Book](https://book.kubebuilder.io)
 
-## How to build, deploy and test CABPK
-CABPK is built using kubebuilder. Please refer to the [The Kubebuilder Book](https://book.kubebuilder.io) for build and deploy in a cluster.
-
-CABPK is only part of a whole and does not function in isolation. It requires coordination
-with the core provider, Cluster API (CAPI), and an infrastructure provider; see the [CAEP](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/20190610-machine-states-preboot-bootstrapping.md)
-document for more information. For the remainder of this document we will be referring to
-[cluster-api-provider-docker](https://github.com/kubernetes-sigs/cluster-api-provider-docker)
-(CAPD) as our infrastructure provider.
-
-A convenient way to set up infrastructure for testing is to use [kind](https://kind.sigs.k8s.io/)
-as the platform cluster to install the controllers and CRDs into. Then use a tool like
-[tilt](https://tilt.dev/) or [skaffold](ttps://skaffold.dev/) to manage your dev environment.
-A minimal example of a Tiltfile looks like this:
-
-```
-allow_k8s_contexts('kubernetes-admin@kubernetes')
-
-controllers = {
-    'capi': {
-        'path': '../cluster-api',
-        'image': 'gcr.io/k8s-staging-cluster-api/cluster-api-controller:dev',
-    },
-    'cabpk': {
-        'path': './',
-        'image': 'gcr.io/k8s-staging-cluster-api/cluster-api-bootstrap-provider-kubeadm:dev',
-    },
-    'capd': {
-        'path': '../cluster-api-provider-docker',
-        'image': 'gcr.io/k8s-staging-cluster-api/cluster-api-provider-docker:dev',
-    },
-}
-
-for name, controller in controllers.items():
-    command = '''sed -i'' -e 's@image: .*@image: '"{}"'@' ./{}/config/default/manager_image_patch.yaml'''.format(controller['image'], controller['path'])
-    local(command)
-
-    k8s_yaml(local('kustomize build ' + controller['path'] + '/config/default'))
-
-    docker_build(controller['image'], controller['path'])
-
-```
-
-See [capi-dev](https://github.com/chuckha/capi-dev) for an example of a more complex developemt environment using [tilt](https://tilt.dev/).
-
 ## How does CABPK work?
-Once your test environment is in place, create a `Cluster` object and its corresponding `DockerCluster`
+CABPK is integrated into `cluster-api-manager`. Assuming you've set of CAPI and the Docker Manager, create a `Cluster` object and its corresponding `DockerCluster`
 infrastructure object.
 
 ```yaml
@@ -224,36 +180,3 @@ The `KubeadmConfig` object supports customizing the content of the config-data:
 - `KubeadmConfig.PostKubeadmCommands` same as above, but after `kubeadm init/join`
 - `KubeadmConfig.Users` specifies a list of users to be created on the machine
 - `KubeadmConfig.NTP` specifies NPT settings for the machine
-
-## Versioning, Maintenance, and Compatibility
-
-- We follow [Semantic Versioning (semver)](https://semver.org/).
-- Cluster API bootstrap provider kubeadm versioning is syncronized with
-  [Cluster API](https://github.com/kubernetes-sigs/cluster-api/blob/master/README.md).
-- The _master_ branch is where development happens, this might include breaking changes.
-- The _release-X_ branches contain stable, backward compatible code. A new _release-X_ branch
-  is created at every major (X) release.
-
-## Get involved!
-
-* Join the [Cluster API discuss forum](https://discuss.kubernetes.io/c/contributors/cluster-api).
-
-* Join the [sig-cluster-lifecycle](https://groups.google.com/forum/#!forum/kubernetes-sig-cluster-lifecycle)
-Google Group for access to documents and calendars.
-
-* Join our Cluster API working group sessions
-  * Weekly on Wednesdays @ 10:00 PT on [Zoom][zoomMeeting]
-  * Previous meetings: \[ [notes][notes] | [recordings][recordings] \]
-
-* Provider implementer office hours
-  * Weekly on Tuesdays @ 12:00 PT ([Zoom][providerZoomMeetingTues]) and Wednesdays @ 15:00 CET ([Zoom][providerZoomMeetingWed])
-  * Previous meetings: \[ [notes][implementerNotes] \]
-
-* Chat with us on [Slack](http://slack.k8s.io/): #cluster-api
-
-[notes]: https://docs.google.com/document/d/1Ys-DOR5UsgbMEeciuG0HOgDQc8kZsaWIWJeKJ1-UfbY/edit
-[recordings]: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
-[zoomMeeting]: https://zoom.us/j/861487554
-[implementerNotes]: https://docs.google.com/document/d/1IZ2-AZhe4r3CYiJuttyciS7bGZTTx4iMppcA8_Pr3xE/edit
-[providerZoomMeetingTues]: https://zoom.us/j/140808484
-[providerZoomMeetingWed]: https://zoom.us/j/424743530


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Since we merged CAPBK into the main capi repo, A lot of the info in the readme is either redundant or just completely wrong. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
I'm working on #778, and this is part of that.
