### PR TITLE
🏃 Update kubebuilder / k8s testing version to 1.15.5 & fix tests

### DIFF
--- a/cmd/clusterctl/validation/validate_cluster_api_objects_test.go
+++ b/cmd/clusterctl/validation/validate_cluster_api_objects_test.go
@@ -59,6 +59,7 @@ func getMachineWithError(machineName, namespace string, nodeRef *v1.ObjectRefere
 			Namespace: namespace,
 		},
 		Spec: clusterv1.MachineSpec{
+			ClusterName: "test-cluster",
 			InfrastructureRef: corev1.ObjectReference{
 				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
 				Kind:       "InfrastructureRef",

--- a/controllers/machinedeployment_controller_test.go
+++ b/controllers/machinedeployment_controller_test.go
@@ -85,7 +85,8 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 						Labels: labels,
 					},
 					Spec: clusterv1.MachineSpec{
-						Version: &version,
+						ClusterName: testCluster.Name,
+						Version:     &version,
 						InfrastructureRef: corev1.ObjectReference{
 							APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
 							Kind:       "InfrastructureMachineTemplate",

--- a/controllers/machineset_controller_test.go
+++ b/controllers/machineset_controller_test.go
@@ -86,7 +86,8 @@ var _ = Describe("MachineSet Reconciler", func() {
 						},
 					},
 					Spec: clusterv1.MachineSpec{
-						Version: &version,
+						ClusterName: testCluster.Name,
+						Version:     &version,
 						Bootstrap: clusterv1.Bootstrap{
 							Data: pointer.StringPtr("x"),
 						},

--- a/scripts/fetch_ext_bins.sh
+++ b/scripts/fetch_ext_bins.sh
@@ -26,7 +26,7 @@ if [[ -n "${TRACE}" ]]; then
   set -x
 fi
 
-k8s_version=1.14.1
+k8s_version=1.15.5
 goarch=amd64
 goos="unknown"
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This was caught by updating to Kubebuilder v2.1.0, which also updated the Kubernetes version to 1.15.5. Some tests are now failing (as one would expect) openapi validation, which are fixed in this PR.
