### PR TITLE
✨Auto-select on cluster-name label in MachineDeployment and MachineSet

### DIFF
--- a/controllers/machinedeployment_controller_test.go
+++ b/controllers/machinedeployment_controller_test.go
@@ -327,6 +327,9 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 
 			return len(machineSets.Items)
 		}, timeout*5).Should(BeEquivalentTo(0))
+
+		// Validate that the controller set the cluster name label in selector.
+		Expect(deployment.Status.Selector).To(ContainSubstring(testCluster.Name))
 	})
 })
 

--- a/controllers/machinedeployment_sync.go
+++ b/controllers/machinedeployment_sync.go
@@ -362,9 +362,13 @@ func calculateStatus(allMSs []*clusterv1.MachineSet, newMS *clusterv1.MachineSet
 		unavailableReplicas = 0
 	}
 
+	// Calculate the label selector. We check the error in the MD reconcile function, ignore here.
+	selector, _ := metav1.LabelSelectorAsSelector(&deployment.Spec.Selector) //nolint
+
 	status := clusterv1.MachineDeploymentStatus{
 		// TODO: Ensure that if we start retrying status updates, we won't pick up a new Generation value.
 		ObservedGeneration:  deployment.Generation,
+		Selector:            selector.String(),
 		Replicas:            mdutil.GetActualReplicaCountForMachineSets(allMSs),
 		UpdatedReplicas:     mdutil.GetActualReplicaCountForMachineSets([]*clusterv1.MachineSet{newMS}),
 		ReadyReplicas:       mdutil.GetReadyReplicaCountForMachineSets(allMSs),

--- a/controllers/machineset_controller_test.go
+++ b/controllers/machineset_controller_test.go
@@ -201,6 +201,9 @@ var _ = Describe("MachineSet Reconciler", func() {
 			}
 			return instance.Status.AvailableReplicas
 		}, timeout).Should(BeEquivalentTo(replicas))
+
+		// Validate that the controller set the cluster name label in selector.
+		Expect(instance.Status.Selector).To(ContainSubstring(testCluster.Name))
 	})
 })
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds support to auto-select on cluster-name label in MD/MS controllers. It also fixes a 🐛that prevented the `Status.Selector` to not being populated in MachineDeployments.

/milestone v0.3.0