### PR TITLE
✨ Use cluster name for admin user in kubeconfig

### DIFF
--- a/docs/book/src/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/providers/v1alpha2-to-v1alpha3.md
@@ -10,7 +10,7 @@
 - The field has been unused for quite some time and didn't have any function.
 - If you have been using this field to setup MachineSet or MachineDeployment, switch to MachineTemplate's metadata instead.
 
-## Set `spec.clusterName` on Machine, MachineSet, MachineDeployments.
+## Set `spec.clusterName` on Machine, MachineSet, MachineDeployments
 
 - The field is now required on all Cluster dependant objects.
 - The `cluster.x-k8s.io/cluster-name` label is created automatically by each respective controller.
@@ -23,7 +23,7 @@
 
 - Pass a context as the first argument to calls to `external.Get`.
 
-## Cluster and Machine `Status.Phase` field values now start with an uppercase letter.
+## Cluster and Machine `Status.Phase` field values now start with an uppercase letter
 
 - To be consistent with Pod phases in k/k.
 - More details in https://github.com/kubernetes-sigs/cluster-api/pull/1532/files.
@@ -40,3 +40,7 @@
 ## The `util/restmapper` package has been removed
 
 - Controller runtime has native support for a [DynamicRESTMapper](https://github.com/kubernetes-sigs/controller-runtime/pull/554/files), which is used by default when creating a new Manager.
+
+## Generated kubeconfig admin username changed from `kubernetes-admin` to `<cluster-name>-admin`
+
+- The kubeconfig secret shipped with Cluster API now uses the cluster name as prefix to the `username` field.

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -69,7 +69,7 @@ func New(clusterName, endpoint string, caCert *x509.Certificate, caKey *rsa.Priv
 		return nil, errors.Wrap(err, "unable to sign certificate")
 	}
 
-	userName := "kubernetes-admin"
+	userName := fmt.Sprintf("%s-admin", clusterName)
 	contextName := fmt.Sprintf("%s@%s", userName, clusterName)
 
 	return &api.Config{


### PR DESCRIPTION
✨ Use cluster name for admin user in kubeconfig

Signed-off-by: Ashish Amarnath <ashish.amarnath@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1651 
