### PR TITLE
 🏃Bump controllers concurrency to 10

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,16 +78,16 @@ func main() {
 	flag.StringVar(&profilerAddress, "profiler-address", "",
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)")
 
-	flag.IntVar(&clusterConcurrency, "cluster-concurrency", 1,
+	flag.IntVar(&clusterConcurrency, "cluster-concurrency", 10,
 		"Number of clusters to process simultaneously")
 
-	flag.IntVar(&machineConcurrency, "machine-concurrency", 1,
+	flag.IntVar(&machineConcurrency, "machine-concurrency", 10,
 		"Number of machines to process simultaneously")
 
-	flag.IntVar(&machineSetConcurrency, "machineset-concurrency", 1,
+	flag.IntVar(&machineSetConcurrency, "machineset-concurrency", 10,
 		"Number of machine sets to process simultaneously")
 
-	flag.IntVar(&machineDeploymentConcurrency, "machinedeployment-concurrency", 1,
+	flag.IntVar(&machineDeploymentConcurrency, "machinedeployment-concurrency", 10,
 		"Number of machine deployments to process simultaneously")
 
 	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

