### PR TITLE
:running: Update cert manager to v0.11 / v1alpha2

### DIFF
--- a/config/certmanager/cert-manager.yaml
+++ b/config/certmanager/cert-manager.yaml
@@ -4,490 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: certificaterequests.certmanager.k8s.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.issuerRef.name
-    name: Issuer
-    priority: 1
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="Ready")].message
-    name: Status
-    priority: 1
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC.
-    name: Age
-    type: date
-  group: certmanager.k8s.io
-  names:
-    kind: CertificateRequest
-    plural: certificaterequests
-    shortNames:
-    - cr
-    - crs
-  scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: CertificateRequest is a type to represent a Certificate Signing
-        Request
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CertificateRequestSpec defines the desired state of CertificateRequest
-          properties:
-            csr:
-              description: Byte slice containing the PEM encoded CertificateSigningRequest
-              format: byte
-              type: string
-            duration:
-              description: Requested certificate default Duration
-              type: string
-            isCA:
-              description: IsCA will mark the resulting certificate as valid for signing.
-                This implies that the 'cert sign' usage is set
-              type: boolean
-            issuerRef:
-              description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
-                the 'kind' field is not set, or set to 'Issuer', an Issuer resource
-                with the given name in the same namespace as the CertificateRequest
-                will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                with the provided name will be used. The 'name' field in this stanza
-                is required at all times. The group field refers to the API group
-                of the issuer which defaults to 'certmanager.k8s.io' if empty.
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-              required:
-              - name
-              type: object
-            usages:
-              description: Usages is the set of x509 actions that are enabled for
-                a given key. Defaults are ('digital signature', 'key encipherment')
-                if empty
-              items:
-                description: 'KeyUsage specifies valid usage contexts for keys. See:
-                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12'
-                enum:
-                - signing
-                - digital signature
-                - content commitment
-                - key encipherment
-                - key agreement
-                - data encipherment
-                - cert sign
-                - crl sign
-                - encipher only
-                - decipher only
-                - any
-                - server auth
-                - client auth
-                - code signing
-                - email protection
-                - s/mime
-                - ipsec end system
-                - ipsec tunnel
-                - ipsec user
-                - timestamping
-                - ocsp signing
-                - microsoft sgc
-                - netscape sgc
-                type: string
-              type: array
-          required:
-          - issuerRef
-          type: object
-        status:
-          description: CertificateStatus defines the observed state of CertificateRequest
-            and resulting signed certificate.
-          properties:
-            ca:
-              description: Byte slice containing the PEM encoded certificate authority
-                of the signed certificate.
-              format: byte
-              type: string
-            certificate:
-              description: Byte slice containing a PEM encoded signed certificate
-                resulting from the given certificate signing request.
-              format: byte
-              type: string
-            conditions:
-              items:
-                description: CertificateRequestCondition contains condition information
-                  for a CertificateRequest.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: Type of the condition, currently ('Ready').
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            failureTime:
-              description: FailureTime stores the time that this CertificateRequest
-                failed. This is used to influence garbage collection and back-off.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  name: certificates.certmanager.k8s.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.secretName
-    name: Secret
-    type: string
-  - JSONPath: .spec.issuerRef.name
-    name: Issuer
-    priority: 1
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="Ready")].message
-    name: Status
-    priority: 1
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC.
-    name: Age
-    type: date
-  group: certmanager.k8s.io
-  names:
-    kind: Certificate
-    plural: certificates
-    shortNames:
-    - cert
-    - certs
-  scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: Certificate is a type to represent a Certificate from ACME
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CertificateSpec defines the desired state of Certificate
-          properties:
-            acme:
-              description: ACME contains configuration specific to ACME Certificates.
-                Notably, this contains details on how the domain names listed on this
-                Certificate resource should be 'solved', i.e. mapping HTTP01 and DNS01
-                providers to DNS names.
-              properties:
-                config:
-                  items:
-                    description: DomainSolverConfig contains solver configuration
-                      for a set of domains.
-                    properties:
-                      dns01:
-                        description: DNS01 contains DNS01 challenge solving configuration
-                        properties:
-                          provider:
-                            description: Provider is the name of the DNS01 challenge
-                              provider to use, as configure on the referenced Issuer
-                              or ClusterIssuer resource.
-                            type: string
-                        required:
-                        - provider
-                        type: object
-                      domains:
-                        description: Domains is the list of domains that this SolverConfig
-                          applies to.
-                        items:
-                          type: string
-                        type: array
-                      http01:
-                        description: HTTP01 contains HTTP01 challenge solving configuration
-                        properties:
-                          ingress:
-                            description: Ingress is the name of an Ingress resource
-                              that will be edited to include the ACME HTTP01 'well-known'
-                              challenge path in order to solve HTTP01 challenges.
-                              If this field is specified, 'ingressClass' **must not**
-                              be specified.
-                            type: string
-                          ingressClass:
-                            description: IngressClass is the ingress class that should
-                              be set on new ingress resources that are created in
-                              order to solve HTTP01 challenges. This field should
-                              be used when using an ingress controller such as nginx,
-                              which 'flattens' ingress configuration instead of maintaining
-                              a 1:1 mapping between loadbalancer IP:ingress resources.
-                              If this field is not set, and 'ingress' is not set,
-                              then ingresses without an ingress class set will be
-                              created to solve HTTP01 challenges. If this field is
-                              specified, 'ingress' **must not** be specified.
-                            type: string
-                        type: object
-                    required:
-                    - domains
-                    type: object
-                  type: array
-              required:
-              - config
-              type: object
-            commonName:
-              description: CommonName is a common name to be used on the Certificate.
-                If no CommonName is given, then the first entry in DNSNames is used
-                as the CommonName. The CommonName should have a length of 64 characters
-                or fewer to avoid generating invalid CSRs; in order to have longer
-                domain names, set the CommonName (or first DNSNames entry) to have
-                64 characters or fewer, and then add the longer domain name to DNSNames.
-              type: string
-            dnsNames:
-              description: DNSNames is a list of subject alt names to be used on the
-                Certificate. If no CommonName is given, then the first entry in DNSNames
-                is used as the CommonName and must have a length of 64 characters
-                or fewer.
-              items:
-                type: string
-              type: array
-            duration:
-              description: Certificate default Duration
-              type: string
-            ipAddresses:
-              description: IPAddresses is a list of IP addresses to be used on the
-                Certificate
-              items:
-                type: string
-              type: array
-            isCA:
-              description: IsCA will mark this Certificate as valid for signing. This
-                implies that the 'cert sign' usage is set
-              type: boolean
-            issuerRef:
-              description: IssuerRef is a reference to the issuer for this certificate.
-                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
-                with the given name in the same namespace as the Certificate will
-                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                with the provided name will be used. The 'name' field in this stanza
-                is required at all times.
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-              required:
-              - name
-              type: object
-            keyAlgorithm:
-              description: KeyAlgorithm is the private key algorithm of the corresponding
-                private key for this certificate. If provided, allowed values are
-                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
-                not provided, key size of 256 will be used for "ecdsa" key algorithm
-                and key size of 2048 will be used for "rsa" key algorithm.
-              enum:
-              - rsa
-              - ecdsa
-              type: string
-            keyEncoding:
-              description: KeyEncoding is the private key cryptography standards (PKCS)
-                for this certificate's private key to be encoded in. If provided,
-                allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
-                respectively. If KeyEncoding is not specified, then PKCS#1 will be
-                used by default.
-              enum:
-              - pkcs1
-              - pkcs8
-              type: string
-            keySize:
-              description: KeySize is the key bit size of the corresponding private
-                key for this certificate. If provided, value must be between 2048
-                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
-                and value must be one of (256, 384, 521) when KeyAlgorithm is set
-                to "ecdsa".
-              type: integer
-            organization:
-              description: Organization is the organization to be used on the Certificate
-              items:
-                type: string
-              type: array
-            renewBefore:
-              description: Certificate renew before expiration duration
-              type: string
-            secretName:
-              description: SecretName is the name of the secret resource to store
-                this secret in
-              type: string
-            usages:
-              description: Usages is the set of x509 actions that are enabled for
-                a given key. Defaults are ('digital signature', 'key encipherment')
-                if empty
-              items:
-                description: 'KeyUsage specifies valid usage contexts for keys. See:
-                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12'
-                enum:
-                - signing
-                - digital signature
-                - content commitment
-                - key encipherment
-                - key agreement
-                - data encipherment
-                - cert sign
-                - crl sign
-                - encipher only
-                - decipher only
-                - any
-                - server auth
-                - client auth
-                - code signing
-                - email protection
-                - s/mime
-                - ipsec end system
-                - ipsec tunnel
-                - ipsec user
-                - timestamping
-                - ocsp signing
-                - microsoft sgc
-                - netscape sgc
-                type: string
-              type: array
-          required:
-          - issuerRef
-          - secretName
-          type: object
-        status:
-          description: CertificateStatus defines the observed state of Certificate
-          properties:
-            conditions:
-              items:
-                description: CertificateCondition contains condition information for
-                  an Certificate.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: Type of the condition, currently ('Ready').
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            lastFailureTime:
-              format: date-time
-              type: string
-            notAfter:
-              description: The expiration time of the certificate stored in the secret
-                named by this resource in spec.secretName.
-              format: date-time
-              type: string
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  name: challenges.certmanager.k8s.io
+  name: challenges.acme.cert-manager.io
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.state
@@ -507,12 +24,15 @@ spec:
       in RFC3339 form and is in UTC.
     name: Age
     type: date
-  group: certmanager.k8s.io
+  group: acme.cert-manager.io
   names:
     kind: Challenge
+    listKind: ChallengeList
     plural: challenges
+    singular: challenge
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: Challenge is a type to represent a Challenge request with an ACME
@@ -521,12 +41,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -536,45 +56,6 @@ spec:
               description: AuthzURL is the URL to the ACME Authorization resource
                 that this challenge is a part of.
               type: string
-            config:
-              description: 'Config specifies the solver configuration for this challenge.
-                Only **one** of ''config'' or ''solver'' may be specified, and if
-                both are specified then no action will be performed on the Challenge
-                resource. DEPRECATED: the ''solver'' field should be specified instead'
-              properties:
-                dns01:
-                  description: DNS01 contains DNS01 challenge solving configuration
-                  properties:
-                    provider:
-                      description: Provider is the name of the DNS01 challenge provider
-                        to use, as configure on the referenced Issuer or ClusterIssuer
-                        resource.
-                      type: string
-                  required:
-                  - provider
-                  type: object
-                http01:
-                  description: HTTP01 contains HTTP01 challenge solving configuration
-                  properties:
-                    ingress:
-                      description: Ingress is the name of an Ingress resource that
-                        will be edited to include the ACME HTTP01 'well-known' challenge
-                        path in order to solve HTTP01 challenges. If this field is
-                        specified, 'ingressClass' **must not** be specified.
-                      type: string
-                    ingressClass:
-                      description: IngressClass is the ingress class that should be
-                        set on new ingress resources that are created in order to
-                        solve HTTP01 challenges. This field should be used when using
-                        an ingress controller such as nginx, which 'flattens' ingress
-                        configuration instead of maintaining a 1:1 mapping between
-                        loadbalancer IP:ingress resources. If this field is not set,
-                        and 'ingress' is not set, then ingresses without an ingress
-                        class set will be created to solve HTTP01 challenges. If this
-                        field is specified, 'ingress' **must not** be specified.
-                      type: string
-                  type: object
-              type: object
             dnsName:
               description: DNSName is the identifier that this challenge is for, e.g.
                 example.com.
@@ -889,7 +370,7 @@ spec:
                             use a SecretKeySelector to reference a Secret resource.
                             For details on the schema of this field, consult the webhook
                             provider implementation's documentation.
-                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         groupName:
                           description: The API group name that should be used when
                             POSTing ChallengePayload resources to the webhook apiserver.
@@ -1883,8 +1364,9 @@ spec:
       required:
       - metadata
       type: object
+  version: v1alpha2
   versions:
-  - name: v1alpha1
+  - name: v1alpha2
     served: true
     storage: true
 status:
@@ -1900,3957 +1382,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: clusterissuers.certmanager.k8s.io
-spec:
-  group: certmanager.k8s.io
-  names:
-    kind: ClusterIssuer
-    plural: clusterissuers
-  scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IssuerSpec is the specification of an Issuer. This includes
-            any configuration required for the issuer.
-          properties:
-            acme:
-              description: ACMEIssuer contains the specification for an ACME issuer
-              properties:
-                dns01:
-                  description: 'DEPRECATED: DNS-01 config'
-                  properties:
-                    providers:
-                      items:
-                        description: ACMEIssuerDNS01Provider contains configuration
-                          for a DNS provider that can be used to solve ACME DNS01
-                          challenges.
-                        properties:
-                          acmedns:
-                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
-                              containing the configuration for ACME-DNS servers
-                            properties:
-                              accountSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              host:
-                                type: string
-                            required:
-                            - accountSecretRef
-                            - host
-                            type: object
-                          akamai:
-                            description: ACMEIssuerDNS01ProviderAkamai is a structure
-                              containing the DNS configuration for Akamai DNS—Zone
-                              Record Management API
-                            properties:
-                              accessTokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              clientSecretSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              clientTokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceConsumerDomain:
-                                type: string
-                            required:
-                            - accessTokenSecretRef
-                            - clientSecretSecretRef
-                            - clientTokenSecretRef
-                            - serviceConsumerDomain
-                            type: object
-                          azuredns:
-                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                              containing the configuration for Azure DNS
-                            properties:
-                              clientID:
-                                type: string
-                              clientSecretSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              environment:
-                                enum:
-                                - AzurePublicCloud
-                                - AzureChinaCloud
-                                - AzureGermanCloud
-                                - AzureUSGovernmentCloud
-                                type: string
-                              hostedZoneName:
-                                type: string
-                              resourceGroupName:
-                                type: string
-                              subscriptionID:
-                                type: string
-                              tenantID:
-                                type: string
-                            required:
-                            - clientID
-                            - clientSecretSecretRef
-                            - resourceGroupName
-                            - subscriptionID
-                            - tenantID
-                            type: object
-                          clouddns:
-                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                              containing the DNS configuration for Google Cloud DNS
-                            properties:
-                              project:
-                                type: string
-                              serviceAccountSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - project
-                            - serviceAccountSecretRef
-                            type: object
-                          cloudflare:
-                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                              containing the DNS configuration for Cloudflare
-                            properties:
-                              apiKeySecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              email:
-                                type: string
-                            required:
-                            - apiKeySecretRef
-                            - email
-                            type: object
-                          cnameStrategy:
-                            description: CNAMEStrategy configures how the DNS01 provider
-                              should handle CNAME records when found in DNS zones.
-                            enum:
-                            - None
-                            - Follow
-                            type: string
-                          digitalocean:
-                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
-                              structure containing the DNS configuration for DigitalOcean
-                              Domains
-                            properties:
-                              tokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - tokenSecretRef
-                            type: object
-                          name:
-                            description: Name is the name of the DNS provider, which
-                              should be used to reference this DNS provider configuration
-                              on Certificate resources.
-                            type: string
-                          rfc2136:
-                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
-                              containing the configuration for RFC2136 DNS
-                            properties:
-                              nameserver:
-                                description: 'The IP address of the DNS supporting
-                                  RFC2136. Required. Note: FQDN is not a valid value,
-                                  only IP.'
-                                type: string
-                              tsigAlgorithm:
-                                description: 'The TSIG Algorithm configured in the
-                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
-                                  and ``tsigKeyName`` are defined. Supported values
-                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
-                                  ``HMACSHA256`` or ``HMACSHA512``.'
-                                type: string
-                              tsigKeyName:
-                                description: The TSIG Key name configured in the DNS.
-                                  If ``tsigSecretSecretRef`` is defined, this field
-                                  is required.
-                                type: string
-                              tsigSecretSecretRef:
-                                description: The name of the secret containing the
-                                  TSIG value. If ``tsigKeyName`` is defined, this
-                                  field is required.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - nameserver
-                            type: object
-                          route53:
-                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
-                              containing the Route 53 configuration for AWS
-                            properties:
-                              accessKeyID:
-                                description: 'The AccessKeyID is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
-                                type: string
-                              hostedZoneID:
-                                description: If set, the provider will manage only
-                                  this zone in Route53 and will not do an lookup using
-                                  the route53:ListHostedZonesByName api call.
-                                type: string
-                              region:
-                                description: Always set the region when using AccessKeyID
-                                  and SecretAccessKey
-                                type: string
-                              role:
-                                description: Role is a Role ARN which the Route53
-                                  provider will assume using either the explicit credentials
-                                  AccessKeyID/SecretAccessKey or the inferred credentials
-                                  from environment variables, shared credentials file
-                                  or AWS Instance metadata
-                                type: string
-                              secretAccessKeySecretRef:
-                                description: The SecretAccessKey is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - region
-                            type: object
-                          webhook:
-                            description: ACMEIssuerDNS01ProviderWebhook specifies
-                              configuration for a webhook DNS01 provider, including
-                              where to POST ChallengePayload resources.
-                            properties:
-                              config:
-                                description: Additional configuration that should
-                                  be passed to the webhook apiserver when challenges
-                                  are processed. This can contain arbitrary JSON data.
-                                  Secret values should not be specified in this stanza.
-                                  If secret values are needed (e.g. credentials for
-                                  a DNS service), you should use a SecretKeySelector
-                                  to reference a Secret resource. For details on the
-                                  schema of this field, consult the webhook provider
-                                  implementation's documentation.
-                                type: object
-                              groupName:
-                                description: The API group name that should be used
-                                  when POSTing ChallengePayload resources to the webhook
-                                  apiserver. This should be the same as the GroupName
-                                  specified in the webhook provider implementation.
-                                type: string
-                              solverName:
-                                description: The name of the solver to use, as defined
-                                  in the webhook provider implementation. This will
-                                  typically be the name of the provider, e.g. 'cloudflare'.
-                                type: string
-                            required:
-                            - groupName
-                            - solverName
-                            type: object
-                        required:
-                        - name
-                        type: object
-                      type: array
-                  type: object
-                email:
-                  description: Email is the email for this account
-                  type: string
-                http01:
-                  description: 'DEPRECATED: HTTP-01 config'
-                  properties:
-                    serviceType:
-                      description: Optional service type for Kubernetes solver service
-                      type: string
-                  type: object
-                privateKeySecretRef:
-                  description: PrivateKey is the name of a secret containing the private
-                    key for this user account.
-                  properties:
-                    key:
-                      description: The key of the secret to select from. Must be a
-                        valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  required:
-                  - name
-                  type: object
-                server:
-                  description: Server is the ACME server URL
-                  type: string
-                skipTLSVerify:
-                  description: If true, skip verifying the ACME server TLS certificate
-                  type: boolean
-                solvers:
-                  description: Solvers is a list of challenge solvers that will be
-                    used to solve ACME challenges for the matching domains.
-                  items:
-                    properties:
-                      dns01:
-                        properties:
-                          acmedns:
-                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
-                              containing the configuration for ACME-DNS servers
-                            properties:
-                              accountSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              host:
-                                type: string
-                            required:
-                            - accountSecretRef
-                            - host
-                            type: object
-                          akamai:
-                            description: ACMEIssuerDNS01ProviderAkamai is a structure
-                              containing the DNS configuration for Akamai DNS—Zone
-                              Record Management API
-                            properties:
-                              accessTokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              clientSecretSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              clientTokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceConsumerDomain:
-                                type: string
-                            required:
-                            - accessTokenSecretRef
-                            - clientSecretSecretRef
-                            - clientTokenSecretRef
-                            - serviceConsumerDomain
-                            type: object
-                          azuredns:
-                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                              containing the configuration for Azure DNS
-                            properties:
-                              clientID:
-                                type: string
-                              clientSecretSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              environment:
-                                enum:
-                                - AzurePublicCloud
-                                - AzureChinaCloud
-                                - AzureGermanCloud
-                                - AzureUSGovernmentCloud
-                                type: string
-                              hostedZoneName:
-                                type: string
-                              resourceGroupName:
-                                type: string
-                              subscriptionID:
-                                type: string
-                              tenantID:
-                                type: string
-                            required:
-                            - clientID
-                            - clientSecretSecretRef
-                            - resourceGroupName
-                            - subscriptionID
-                            - tenantID
-                            type: object
-                          clouddns:
-                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                              containing the DNS configuration for Google Cloud DNS
-                            properties:
-                              project:
-                                type: string
-                              serviceAccountSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - project
-                            - serviceAccountSecretRef
-                            type: object
-                          cloudflare:
-                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                              containing the DNS configuration for Cloudflare
-                            properties:
-                              apiKeySecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              email:
-                                type: string
-                            required:
-                            - apiKeySecretRef
-                            - email
-                            type: object
-                          cnameStrategy:
-                            description: CNAMEStrategy configures how the DNS01 provider
-                              should handle CNAME records when found in DNS zones.
-                            enum:
-                            - None
-                            - Follow
-                            type: string
-                          digitalocean:
-                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
-                              structure containing the DNS configuration for DigitalOcean
-                              Domains
-                            properties:
-                              tokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - tokenSecretRef
-                            type: object
-                          rfc2136:
-                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
-                              containing the configuration for RFC2136 DNS
-                            properties:
-                              nameserver:
-                                description: 'The IP address of the DNS supporting
-                                  RFC2136. Required. Note: FQDN is not a valid value,
-                                  only IP.'
-                                type: string
-                              tsigAlgorithm:
-                                description: 'The TSIG Algorithm configured in the
-                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
-                                  and ``tsigKeyName`` are defined. Supported values
-                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
-                                  ``HMACSHA256`` or ``HMACSHA512``.'
-                                type: string
-                              tsigKeyName:
-                                description: The TSIG Key name configured in the DNS.
-                                  If ``tsigSecretSecretRef`` is defined, this field
-                                  is required.
-                                type: string
-                              tsigSecretSecretRef:
-                                description: The name of the secret containing the
-                                  TSIG value. If ``tsigKeyName`` is defined, this
-                                  field is required.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - nameserver
-                            type: object
-                          route53:
-                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
-                              containing the Route 53 configuration for AWS
-                            properties:
-                              accessKeyID:
-                                description: 'The AccessKeyID is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
-                                type: string
-                              hostedZoneID:
-                                description: If set, the provider will manage only
-                                  this zone in Route53 and will not do an lookup using
-                                  the route53:ListHostedZonesByName api call.
-                                type: string
-                              region:
-                                description: Always set the region when using AccessKeyID
-                                  and SecretAccessKey
-                                type: string
-                              role:
-                                description: Role is a Role ARN which the Route53
-                                  provider will assume using either the explicit credentials
-                                  AccessKeyID/SecretAccessKey or the inferred credentials
-                                  from environment variables, shared credentials file
-                                  or AWS Instance metadata
-                                type: string
-                              secretAccessKeySecretRef:
-                                description: The SecretAccessKey is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - region
-                            type: object
-                          webhook:
-                            description: ACMEIssuerDNS01ProviderWebhook specifies
-                              configuration for a webhook DNS01 provider, including
-                              where to POST ChallengePayload resources.
-                            properties:
-                              config:
-                                description: Additional configuration that should
-                                  be passed to the webhook apiserver when challenges
-                                  are processed. This can contain arbitrary JSON data.
-                                  Secret values should not be specified in this stanza.
-                                  If secret values are needed (e.g. credentials for
-                                  a DNS service), you should use a SecretKeySelector
-                                  to reference a Secret resource. For details on the
-                                  schema of this field, consult the webhook provider
-                                  implementation's documentation.
-                                type: object
-                              groupName:
-                                description: The API group name that should be used
-                                  when POSTing ChallengePayload resources to the webhook
-                                  apiserver. This should be the same as the GroupName
-                                  specified in the webhook provider implementation.
-                                type: string
-                              solverName:
-                                description: The name of the solver to use, as defined
-                                  in the webhook provider implementation. This will
-                                  typically be the name of the provider, e.g. 'cloudflare'.
-                                type: string
-                            required:
-                            - groupName
-                            - solverName
-                            type: object
-                        type: object
-                      http01:
-                        description: ACMEChallengeSolverHTTP01 contains configuration
-                          detailing how to solve HTTP01 challenges within a Kubernetes
-                          cluster. Typically this is accomplished through creating
-                          'routes' of some description that configure ingress controllers
-                          to direct traffic to 'solver pods', which are responsible
-                          for responding to the ACME server's HTTP requests.
-                        properties:
-                          ingress:
-                            description: The ingress based HTTP01 challenge solver
-                              will solve challenges by creating or modifying Ingress
-                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
-                              to 'challenge solver' pods that are provisioned by cert-manager
-                              for each Challenge to be completed.
-                            properties:
-                              class:
-                                description: The ingress class to use when creating
-                                  Ingress resources to solve ACME challenges that
-                                  use this challenge solver. Only one of 'class' or
-                                  'name' may be specified.
-                                type: string
-                              name:
-                                description: The name of the ingress resource that
-                                  should have ACME challenge solving routes inserted
-                                  into it in order to solve HTTP01 challenges. This
-                                  is typically used in conjunction with ingress controllers
-                                  like ingress-gce, which maintains a 1:1 mapping
-                                  between external IPs and ingress resources.
-                                type: string
-                              podTemplate:
-                                description: Optional pod template used to configure
-                                  the ACME challenge solver pods used for HTTP01 challenges
-                                properties:
-                                  metadata:
-                                    description: ObjectMeta overrides for the pod
-                                      used to solve HTTP01 challenges. Only the 'labels'
-                                      and 'annotations' fields may be set. If labels
-                                      or annotations overlap with in-built values,
-                                      the values here will override the in-built values.
-                                    type: object
-                                  spec:
-                                    description: PodSpec defines overrides for the
-                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                      'affinity' and 'tolerations' fields are supported
-                                      currently. All other fields will be ignored.
-                                    properties:
-                                      affinity:
-                                        description: If specified, the pod's scheduling
-                                          constraints
-                                        properties:
-                                          nodeAffinity:
-                                            description: Describes node affinity scheduling
-                                              rules for the pod.
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node matches the
-                                                  corresponding matchExpressions;
-                                                  the node(s) with the highest sum
-                                                  are the most preferred.
-                                                items:
-                                                  description: An empty preferred
-                                                    scheduling term matches all objects
-                                                    with implicit weight 0 (i.e. it's
-                                                    a no-op). A null preferred scheduling
-                                                    term matches no objects (i.e.
-                                                    is also a no-op).
-                                                  properties:
-                                                    preference:
-                                                      description: A node selector
-                                                        term, associated with the
-                                                        corresponding weight.
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    weight:
-                                                      description: Weight associated
-                                                        with matching the corresponding
-                                                        nodeSelectorTerm, in the range
-                                                        1-100.
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - preference
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to an update), the system
-                                                  may or may not try to eventually
-                                                  evict the pod from its node.
-                                                properties:
-                                                  nodeSelectorTerms:
-                                                    description: Required. A list
-                                                      of node selector terms. The
-                                                      terms are ORed.
-                                                    items:
-                                                      description: A null or empty
-                                                        node selector term matches
-                                                        no objects. The requirements
-                                                        of them are ANDed. The TopologySelectorTerm
-                                                        type implements a subset of
-                                                        the NodeSelectorTerm.
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    type: array
-                                                required:
-                                                - nodeSelectorTerms
-                                                type: object
-                                            type: object
-                                          podAffinity:
-                                            description: Describes pod affinity scheduling
-                                              rules (e.g. co-locate this pod in the
-                                              same node, zone, etc. as some other
-                                              pod(s)).
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node has pods
-                                                  which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
-                                                      properties:
-                                                        labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
-                                                          properties:
-                                                            matchExpressions:
-                                                              description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
-                                                              items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
-                                                                  a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
-                                                                properties:
-                                                                  key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
-                                                                      to.
-                                                                    type: string
-                                                                  operator:
-                                                                    description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
-                                                                      and DoesNotExist.
-                                                                    type: string
-                                                                  values:
-                                                                    description: values
-                                                                      is an array
-                                                                      of string values.
-                                                                      If the operator
-                                                                      is In or NotIn,
-                                                                      the values array
-                                                                      must be non-empty.
-                                                                      If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
-                                                                      the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
-                                                                      merge patch.
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              description: matchLabels
-                                                                is a map of {key,value}
-                                                                pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
-                                                                are ANDed.
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
-                                                            that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
-                                                            is not allowed.
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to a pod label update),
-                                                  the system may or may not try to
-                                                  eventually evict the pod from its
-                                                  node. When there are multiple elements,
-                                                  the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                type: array
-                                            type: object
-                                          podAntiAffinity:
-                                            description: Describes pod anti-affinity
-                                              scheduling rules (e.g. avoid putting
-                                              this pod in the same node, zone, etc.
-                                              as some other pod(s)).
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the anti-affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  anti-affinity expressions, etc.),
-                                                  compute a sum by iterating through
-                                                  the elements of this field and adding
-                                                  "weight" to the sum if the node
-                                                  has pods which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
-                                                      properties:
-                                                        labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
-                                                          properties:
-                                                            matchExpressions:
-                                                              description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
-                                                              items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
-                                                                  a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
-                                                                properties:
-                                                                  key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
-                                                                      to.
-                                                                    type: string
-                                                                  operator:
-                                                                    description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
-                                                                      and DoesNotExist.
-                                                                    type: string
-                                                                  values:
-                                                                    description: values
-                                                                      is an array
-                                                                      of string values.
-                                                                      If the operator
-                                                                      is In or NotIn,
-                                                                      the values array
-                                                                      must be non-empty.
-                                                                      If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
-                                                                      the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
-                                                                      merge patch.
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              description: matchLabels
-                                                                is a map of {key,value}
-                                                                pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
-                                                                are ANDed.
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
-                                                            that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
-                                                            is not allowed.
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the anti-affinity
-                                                  requirements specified by this field
-                                                  are not met at scheduling time,
-                                                  the pod will not be scheduled onto
-                                                  the node. If the anti-affinity requirements
-                                                  specified by this field cease to
-                                                  be met at some point during pod
-                                                  execution (e.g. due to a pod label
-                                                  update), the system may or may not
-                                                  try to eventually evict the pod
-                                                  from its node. When there are multiple
-                                                  elements, the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                type: array
-                                            type: object
-                                        type: object
-                                      nodeSelector:
-                                        additionalProperties:
-                                          type: string
-                                        description: 'NodeSelector is a selector which
-                                          must be true for the pod to fit on a node.
-                                          Selector which must match a node''s labels
-                                          for the pod to be scheduled on that node.
-                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-                                        type: object
-                                      tolerations:
-                                        description: If specified, the pod's tolerations.
-                                        items:
-                                          description: The pod this Toleration is
-                                            attached to tolerates any taint that matches
-                                            the triple <key,value,effect> using the
-                                            matching operator <operator>.
-                                          properties:
-                                            effect:
-                                              description: Effect indicates the taint
-                                                effect to match. Empty means match
-                                                all taint effects. When specified,
-                                                allowed values are NoSchedule, PreferNoSchedule
-                                                and NoExecute.
-                                              type: string
-                                            key:
-                                              description: Key is the taint key that
-                                                the toleration applies to. Empty means
-                                                match all taint keys. If the key is
-                                                empty, operator must be Exists; this
-                                                combination means to match all values
-                                                and all keys.
-                                              type: string
-                                            operator:
-                                              description: Operator represents a key's
-                                                relationship to the value. Valid operators
-                                                are Exists and Equal. Defaults to
-                                                Equal. Exists is equivalent to wildcard
-                                                for value, so that a pod can tolerate
-                                                all taints of a particular category.
-                                              type: string
-                                            tolerationSeconds:
-                                              description: TolerationSeconds represents
-                                                the period of time the toleration
-                                                (which must be of effect NoExecute,
-                                                otherwise this field is ignored) tolerates
-                                                the taint. By default, it is not set,
-                                                which means tolerate the taint forever
-                                                (do not evict). Zero and negative
-                                                values will be treated as 0 (evict
-                                                immediately) by the system.
-                                              format: int64
-                                              type: integer
-                                            value:
-                                              description: Value is the taint value
-                                                the toleration matches to. If the
-                                                operator is Exists, the value should
-                                                be empty, otherwise just a regular
-                                                string.
-                                              type: string
-                                          type: object
-                                        type: array
-                                    type: object
-                                type: object
-                              serviceType:
-                                description: Optional service type for Kubernetes
-                                  solver service
-                                type: string
-                            type: object
-                        type: object
-                      selector:
-                        description: Selector selects a set of DNSNames on the Certificate
-                          resource that should be solved using this challenge solver.
-                        properties:
-                          dnsNames:
-                            description: List of DNSNames that this solver will be
-                              used to solve. If specified and a match is found, a
-                              dnsNames selector will take precedence over a dnsZones
-                              selector. If multiple solvers match with the same dnsNames
-                              value, the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            items:
-                              type: string
-                            type: array
-                          dnsZones:
-                            description: List of DNSZones that this solver will be
-                              used to solve. The most specific DNS zone match specified
-                              here will take precedence over other DNS zone matches,
-                              so a solver specifying sys.example.com will be selected
-                              over one specifying example.com for the domain www.sys.example.com.
-                              If multiple solvers match with the same dnsZones value,
-                              the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            items:
-                              type: string
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: A label selector that is used to refine the
-                              set of certificate's that this challenge solver will
-                              apply to.
-                            type: object
-                        type: object
-                    type: object
-                  type: array
-              required:
-              - privateKeySecretRef
-              - server
-              type: object
-            ca:
-              properties:
-                secretName:
-                  description: SecretName is the name of the secret used to sign Certificates
-                    issued by this Issuer.
-                  type: string
-              required:
-              - secretName
-              type: object
-            selfSigned:
-              type: object
-            vault:
-              properties:
-                auth:
-                  description: Vault authentication
-                  properties:
-                    appRole:
-                      description: This Secret contains a AppRole and Secret
-                      properties:
-                        path:
-                          description: Where the authentication path is mounted in
-                            Vault.
-                          type: string
-                        roleId:
-                          type: string
-                        secretRef:
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          required:
-                          - name
-                          type: object
-                      required:
-                      - path
-                      - roleId
-                      - secretRef
-                      type: object
-                    tokenSecretRef:
-                      description: This Secret contains the Vault token key
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      required:
-                      - name
-                      type: object
-                  type: object
-                caBundle:
-                  description: Base64 encoded CA bundle to validate Vault server certificate.
-                    Only used if the Server URL is using HTTPS protocol. This parameter
-                    is ignored for plain HTTP protocol connection. If not set the
-                    system root certificates are used to validate the TLS connection.
-                  format: byte
-                  type: string
-                path:
-                  description: Vault URL path to the certificate role
-                  type: string
-                server:
-                  description: Server is the vault connection address
-                  type: string
-              required:
-              - auth
-              - path
-              - server
-              type: object
-            venafi:
-              description: VenafiIssuer describes issuer configuration details for
-                Venafi Cloud.
-              properties:
-                cloud:
-                  description: Cloud specifies the Venafi cloud configuration settings.
-                    Only one of TPP or Cloud may be specified.
-                  properties:
-                    apiTokenSecretRef:
-                      description: APITokenSecretRef is a secret key selector for
-                        the Venafi Cloud API token.
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    url:
-                      description: URL is the base URL for Venafi Cloud
-                      type: string
-                  required:
-                  - apiTokenSecretRef
-                  - url
-                  type: object
-                tpp:
-                  description: TPP specifies Trust Protection Platform configuration
-                    settings. Only one of TPP or Cloud may be specified.
-                  properties:
-                    caBundle:
-                      description: CABundle is a PEM encoded TLS certifiate to use
-                        to verify connections to the TPP instance. If specified, system
-                        roots will not be used and the issuing CA for the TPP instance
-                        must be verifiable using the provided root. If not specified,
-                        the connection will be verified using the cert-manager system
-                        root certificates.
-                      format: byte
-                      type: string
-                    credentialsRef:
-                      description: CredentialsRef is a reference to a Secret containing
-                        the username and password for the TPP server. The secret must
-                        contain two keys, 'username' and 'password'.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    url:
-                      description: URL is the base URL for the Venafi TPP instance
-                      type: string
-                  required:
-                  - credentialsRef
-                  - url
-                  type: object
-                zone:
-                  description: Zone is the Venafi Policy Zone to use for this issuer.
-                    All requests made to the Venafi platform will be restricted by
-                    the named zone policy. This field is required.
-                  type: string
-              required:
-              - zone
-              type: object
-          type: object
-        status:
-          description: IssuerStatus contains status information about an Issuer
-          properties:
-            acme:
-              properties:
-                lastRegisteredEmail:
-                  description: LastRegisteredEmail is the email associated with the
-                    latest registered ACME account, in order to track changes made
-                    to registered account associated with the  Issuer
-                  type: string
-                uri:
-                  description: URI is the unique account identifier, which can also
-                    be used to retrieve account details from the CA
-                  type: string
-              type: object
-            conditions:
-              items:
-                description: IssuerCondition contains condition information for an
-                  Issuer.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: Type of the condition, currently ('Ready').
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  name: issuers.certmanager.k8s.io
-spec:
-  group: certmanager.k8s.io
-  names:
-    kind: Issuer
-    plural: issuers
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IssuerSpec is the specification of an Issuer. This includes
-            any configuration required for the issuer.
-          properties:
-            acme:
-              description: ACMEIssuer contains the specification for an ACME issuer
-              properties:
-                dns01:
-                  description: 'DEPRECATED: DNS-01 config'
-                  properties:
-                    providers:
-                      items:
-                        description: ACMEIssuerDNS01Provider contains configuration
-                          for a DNS provider that can be used to solve ACME DNS01
-                          challenges.
-                        properties:
-                          acmedns:
-                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
-                              containing the configuration for ACME-DNS servers
-                            properties:
-                              accountSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              host:
-                                type: string
-                            required:
-                            - accountSecretRef
-                            - host
-                            type: object
-                          akamai:
-                            description: ACMEIssuerDNS01ProviderAkamai is a structure
-                              containing the DNS configuration for Akamai DNS—Zone
-                              Record Management API
-                            properties:
-                              accessTokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              clientSecretSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              clientTokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceConsumerDomain:
-                                type: string
-                            required:
-                            - accessTokenSecretRef
-                            - clientSecretSecretRef
-                            - clientTokenSecretRef
-                            - serviceConsumerDomain
-                            type: object
-                          azuredns:
-                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                              containing the configuration for Azure DNS
-                            properties:
-                              clientID:
-                                type: string
-                              clientSecretSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              environment:
-                                enum:
-                                - AzurePublicCloud
-                                - AzureChinaCloud
-                                - AzureGermanCloud
-                                - AzureUSGovernmentCloud
-                                type: string
-                              hostedZoneName:
-                                type: string
-                              resourceGroupName:
-                                type: string
-                              subscriptionID:
-                                type: string
-                              tenantID:
-                                type: string
-                            required:
-                            - clientID
-                            - clientSecretSecretRef
-                            - resourceGroupName
-                            - subscriptionID
-                            - tenantID
-                            type: object
-                          clouddns:
-                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                              containing the DNS configuration for Google Cloud DNS
-                            properties:
-                              project:
-                                type: string
-                              serviceAccountSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - project
-                            - serviceAccountSecretRef
-                            type: object
-                          cloudflare:
-                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                              containing the DNS configuration for Cloudflare
-                            properties:
-                              apiKeySecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              email:
-                                type: string
-                            required:
-                            - apiKeySecretRef
-                            - email
-                            type: object
-                          cnameStrategy:
-                            description: CNAMEStrategy configures how the DNS01 provider
-                              should handle CNAME records when found in DNS zones.
-                            enum:
-                            - None
-                            - Follow
-                            type: string
-                          digitalocean:
-                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
-                              structure containing the DNS configuration for DigitalOcean
-                              Domains
-                            properties:
-                              tokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - tokenSecretRef
-                            type: object
-                          name:
-                            description: Name is the name of the DNS provider, which
-                              should be used to reference this DNS provider configuration
-                              on Certificate resources.
-                            type: string
-                          rfc2136:
-                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
-                              containing the configuration for RFC2136 DNS
-                            properties:
-                              nameserver:
-                                description: 'The IP address of the DNS supporting
-                                  RFC2136. Required. Note: FQDN is not a valid value,
-                                  only IP.'
-                                type: string
-                              tsigAlgorithm:
-                                description: 'The TSIG Algorithm configured in the
-                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
-                                  and ``tsigKeyName`` are defined. Supported values
-                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
-                                  ``HMACSHA256`` or ``HMACSHA512``.'
-                                type: string
-                              tsigKeyName:
-                                description: The TSIG Key name configured in the DNS.
-                                  If ``tsigSecretSecretRef`` is defined, this field
-                                  is required.
-                                type: string
-                              tsigSecretSecretRef:
-                                description: The name of the secret containing the
-                                  TSIG value. If ``tsigKeyName`` is defined, this
-                                  field is required.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - nameserver
-                            type: object
-                          route53:
-                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
-                              containing the Route 53 configuration for AWS
-                            properties:
-                              accessKeyID:
-                                description: 'The AccessKeyID is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
-                                type: string
-                              hostedZoneID:
-                                description: If set, the provider will manage only
-                                  this zone in Route53 and will not do an lookup using
-                                  the route53:ListHostedZonesByName api call.
-                                type: string
-                              region:
-                                description: Always set the region when using AccessKeyID
-                                  and SecretAccessKey
-                                type: string
-                              role:
-                                description: Role is a Role ARN which the Route53
-                                  provider will assume using either the explicit credentials
-                                  AccessKeyID/SecretAccessKey or the inferred credentials
-                                  from environment variables, shared credentials file
-                                  or AWS Instance metadata
-                                type: string
-                              secretAccessKeySecretRef:
-                                description: The SecretAccessKey is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - region
-                            type: object
-                          webhook:
-                            description: ACMEIssuerDNS01ProviderWebhook specifies
-                              configuration for a webhook DNS01 provider, including
-                              where to POST ChallengePayload resources.
-                            properties:
-                              config:
-                                description: Additional configuration that should
-                                  be passed to the webhook apiserver when challenges
-                                  are processed. This can contain arbitrary JSON data.
-                                  Secret values should not be specified in this stanza.
-                                  If secret values are needed (e.g. credentials for
-                                  a DNS service), you should use a SecretKeySelector
-                                  to reference a Secret resource. For details on the
-                                  schema of this field, consult the webhook provider
-                                  implementation's documentation.
-                                type: object
-                              groupName:
-                                description: The API group name that should be used
-                                  when POSTing ChallengePayload resources to the webhook
-                                  apiserver. This should be the same as the GroupName
-                                  specified in the webhook provider implementation.
-                                type: string
-                              solverName:
-                                description: The name of the solver to use, as defined
-                                  in the webhook provider implementation. This will
-                                  typically be the name of the provider, e.g. 'cloudflare'.
-                                type: string
-                            required:
-                            - groupName
-                            - solverName
-                            type: object
-                        required:
-                        - name
-                        type: object
-                      type: array
-                  type: object
-                email:
-                  description: Email is the email for this account
-                  type: string
-                http01:
-                  description: 'DEPRECATED: HTTP-01 config'
-                  properties:
-                    serviceType:
-                      description: Optional service type for Kubernetes solver service
-                      type: string
-                  type: object
-                privateKeySecretRef:
-                  description: PrivateKey is the name of a secret containing the private
-                    key for this user account.
-                  properties:
-                    key:
-                      description: The key of the secret to select from. Must be a
-                        valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  required:
-                  - name
-                  type: object
-                server:
-                  description: Server is the ACME server URL
-                  type: string
-                skipTLSVerify:
-                  description: If true, skip verifying the ACME server TLS certificate
-                  type: boolean
-                solvers:
-                  description: Solvers is a list of challenge solvers that will be
-                    used to solve ACME challenges for the matching domains.
-                  items:
-                    properties:
-                      dns01:
-                        properties:
-                          acmedns:
-                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
-                              containing the configuration for ACME-DNS servers
-                            properties:
-                              accountSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              host:
-                                type: string
-                            required:
-                            - accountSecretRef
-                            - host
-                            type: object
-                          akamai:
-                            description: ACMEIssuerDNS01ProviderAkamai is a structure
-                              containing the DNS configuration for Akamai DNS—Zone
-                              Record Management API
-                            properties:
-                              accessTokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              clientSecretSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              clientTokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              serviceConsumerDomain:
-                                type: string
-                            required:
-                            - accessTokenSecretRef
-                            - clientSecretSecretRef
-                            - clientTokenSecretRef
-                            - serviceConsumerDomain
-                            type: object
-                          azuredns:
-                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                              containing the configuration for Azure DNS
-                            properties:
-                              clientID:
-                                type: string
-                              clientSecretSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              environment:
-                                enum:
-                                - AzurePublicCloud
-                                - AzureChinaCloud
-                                - AzureGermanCloud
-                                - AzureUSGovernmentCloud
-                                type: string
-                              hostedZoneName:
-                                type: string
-                              resourceGroupName:
-                                type: string
-                              subscriptionID:
-                                type: string
-                              tenantID:
-                                type: string
-                            required:
-                            - clientID
-                            - clientSecretSecretRef
-                            - resourceGroupName
-                            - subscriptionID
-                            - tenantID
-                            type: object
-                          clouddns:
-                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                              containing the DNS configuration for Google Cloud DNS
-                            properties:
-                              project:
-                                type: string
-                              serviceAccountSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - project
-                            - serviceAccountSecretRef
-                            type: object
-                          cloudflare:
-                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                              containing the DNS configuration for Cloudflare
-                            properties:
-                              apiKeySecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              email:
-                                type: string
-                            required:
-                            - apiKeySecretRef
-                            - email
-                            type: object
-                          cnameStrategy:
-                            description: CNAMEStrategy configures how the DNS01 provider
-                              should handle CNAME records when found in DNS zones.
-                            enum:
-                            - None
-                            - Follow
-                            type: string
-                          digitalocean:
-                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
-                              structure containing the DNS configuration for DigitalOcean
-                              Domains
-                            properties:
-                              tokenSecretRef:
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - tokenSecretRef
-                            type: object
-                          rfc2136:
-                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
-                              containing the configuration for RFC2136 DNS
-                            properties:
-                              nameserver:
-                                description: 'The IP address of the DNS supporting
-                                  RFC2136. Required. Note: FQDN is not a valid value,
-                                  only IP.'
-                                type: string
-                              tsigAlgorithm:
-                                description: 'The TSIG Algorithm configured in the
-                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
-                                  and ``tsigKeyName`` are defined. Supported values
-                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
-                                  ``HMACSHA256`` or ``HMACSHA512``.'
-                                type: string
-                              tsigKeyName:
-                                description: The TSIG Key name configured in the DNS.
-                                  If ``tsigSecretSecretRef`` is defined, this field
-                                  is required.
-                                type: string
-                              tsigSecretSecretRef:
-                                description: The name of the secret containing the
-                                  TSIG value. If ``tsigKeyName`` is defined, this
-                                  field is required.
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - nameserver
-                            type: object
-                          route53:
-                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
-                              containing the Route 53 configuration for AWS
-                            properties:
-                              accessKeyID:
-                                description: 'The AccessKeyID is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
-                                type: string
-                              hostedZoneID:
-                                description: If set, the provider will manage only
-                                  this zone in Route53 and will not do an lookup using
-                                  the route53:ListHostedZonesByName api call.
-                                type: string
-                              region:
-                                description: Always set the region when using AccessKeyID
-                                  and SecretAccessKey
-                                type: string
-                              role:
-                                description: Role is a Role ARN which the Route53
-                                  provider will assume using either the explicit credentials
-                                  AccessKeyID/SecretAccessKey or the inferred credentials
-                                  from environment variables, shared credentials file
-                                  or AWS Instance metadata
-                                type: string
-                              secretAccessKeySecretRef:
-                                description: The SecretAccessKey is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                            required:
-                            - region
-                            type: object
-                          webhook:
-                            description: ACMEIssuerDNS01ProviderWebhook specifies
-                              configuration for a webhook DNS01 provider, including
-                              where to POST ChallengePayload resources.
-                            properties:
-                              config:
-                                description: Additional configuration that should
-                                  be passed to the webhook apiserver when challenges
-                                  are processed. This can contain arbitrary JSON data.
-                                  Secret values should not be specified in this stanza.
-                                  If secret values are needed (e.g. credentials for
-                                  a DNS service), you should use a SecretKeySelector
-                                  to reference a Secret resource. For details on the
-                                  schema of this field, consult the webhook provider
-                                  implementation's documentation.
-                                type: object
-                              groupName:
-                                description: The API group name that should be used
-                                  when POSTing ChallengePayload resources to the webhook
-                                  apiserver. This should be the same as the GroupName
-                                  specified in the webhook provider implementation.
-                                type: string
-                              solverName:
-                                description: The name of the solver to use, as defined
-                                  in the webhook provider implementation. This will
-                                  typically be the name of the provider, e.g. 'cloudflare'.
-                                type: string
-                            required:
-                            - groupName
-                            - solverName
-                            type: object
-                        type: object
-                      http01:
-                        description: ACMEChallengeSolverHTTP01 contains configuration
-                          detailing how to solve HTTP01 challenges within a Kubernetes
-                          cluster. Typically this is accomplished through creating
-                          'routes' of some description that configure ingress controllers
-                          to direct traffic to 'solver pods', which are responsible
-                          for responding to the ACME server's HTTP requests.
-                        properties:
-                          ingress:
-                            description: The ingress based HTTP01 challenge solver
-                              will solve challenges by creating or modifying Ingress
-                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
-                              to 'challenge solver' pods that are provisioned by cert-manager
-                              for each Challenge to be completed.
-                            properties:
-                              class:
-                                description: The ingress class to use when creating
-                                  Ingress resources to solve ACME challenges that
-                                  use this challenge solver. Only one of 'class' or
-                                  'name' may be specified.
-                                type: string
-                              name:
-                                description: The name of the ingress resource that
-                                  should have ACME challenge solving routes inserted
-                                  into it in order to solve HTTP01 challenges. This
-                                  is typically used in conjunction with ingress controllers
-                                  like ingress-gce, which maintains a 1:1 mapping
-                                  between external IPs and ingress resources.
-                                type: string
-                              podTemplate:
-                                description: Optional pod template used to configure
-                                  the ACME challenge solver pods used for HTTP01 challenges
-                                properties:
-                                  metadata:
-                                    description: ObjectMeta overrides for the pod
-                                      used to solve HTTP01 challenges. Only the 'labels'
-                                      and 'annotations' fields may be set. If labels
-                                      or annotations overlap with in-built values,
-                                      the values here will override the in-built values.
-                                    type: object
-                                  spec:
-                                    description: PodSpec defines overrides for the
-                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                      'affinity' and 'tolerations' fields are supported
-                                      currently. All other fields will be ignored.
-                                    properties:
-                                      affinity:
-                                        description: If specified, the pod's scheduling
-                                          constraints
-                                        properties:
-                                          nodeAffinity:
-                                            description: Describes node affinity scheduling
-                                              rules for the pod.
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node matches the
-                                                  corresponding matchExpressions;
-                                                  the node(s) with the highest sum
-                                                  are the most preferred.
-                                                items:
-                                                  description: An empty preferred
-                                                    scheduling term matches all objects
-                                                    with implicit weight 0 (i.e. it's
-                                                    a no-op). A null preferred scheduling
-                                                    term matches no objects (i.e.
-                                                    is also a no-op).
-                                                  properties:
-                                                    preference:
-                                                      description: A node selector
-                                                        term, associated with the
-                                                        corresponding weight.
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    weight:
-                                                      description: Weight associated
-                                                        with matching the corresponding
-                                                        nodeSelectorTerm, in the range
-                                                        1-100.
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - preference
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to an update), the system
-                                                  may or may not try to eventually
-                                                  evict the pod from its node.
-                                                properties:
-                                                  nodeSelectorTerms:
-                                                    description: Required. A list
-                                                      of node selector terms. The
-                                                      terms are ORed.
-                                                    items:
-                                                      description: A null or empty
-                                                        node selector term matches
-                                                        no objects. The requirements
-                                                        of them are ANDed. The TopologySelectorTerm
-                                                        type implements a subset of
-                                                        the NodeSelectorTerm.
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    type: array
-                                                required:
-                                                - nodeSelectorTerms
-                                                type: object
-                                            type: object
-                                          podAffinity:
-                                            description: Describes pod affinity scheduling
-                                              rules (e.g. co-locate this pod in the
-                                              same node, zone, etc. as some other
-                                              pod(s)).
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node has pods
-                                                  which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
-                                                      properties:
-                                                        labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
-                                                          properties:
-                                                            matchExpressions:
-                                                              description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
-                                                              items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
-                                                                  a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
-                                                                properties:
-                                                                  key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
-                                                                      to.
-                                                                    type: string
-                                                                  operator:
-                                                                    description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
-                                                                      and DoesNotExist.
-                                                                    type: string
-                                                                  values:
-                                                                    description: values
-                                                                      is an array
-                                                                      of string values.
-                                                                      If the operator
-                                                                      is In or NotIn,
-                                                                      the values array
-                                                                      must be non-empty.
-                                                                      If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
-                                                                      the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
-                                                                      merge patch.
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              description: matchLabels
-                                                                is a map of {key,value}
-                                                                pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
-                                                                are ANDed.
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
-                                                            that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
-                                                            is not allowed.
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to a pod label update),
-                                                  the system may or may not try to
-                                                  eventually evict the pod from its
-                                                  node. When there are multiple elements,
-                                                  the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                type: array
-                                            type: object
-                                          podAntiAffinity:
-                                            description: Describes pod anti-affinity
-                                              scheduling rules (e.g. avoid putting
-                                              this pod in the same node, zone, etc.
-                                              as some other pod(s)).
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the anti-affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  anti-affinity expressions, etc.),
-                                                  compute a sum by iterating through
-                                                  the elements of this field and adding
-                                                  "weight" to the sum if the node
-                                                  has pods which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
-                                                      properties:
-                                                        labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
-                                                          properties:
-                                                            matchExpressions:
-                                                              description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
-                                                              items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
-                                                                  a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
-                                                                properties:
-                                                                  key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
-                                                                      to.
-                                                                    type: string
-                                                                  operator:
-                                                                    description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
-                                                                      and DoesNotExist.
-                                                                    type: string
-                                                                  values:
-                                                                    description: values
-                                                                      is an array
-                                                                      of string values.
-                                                                      If the operator
-                                                                      is In or NotIn,
-                                                                      the values array
-                                                                      must be non-empty.
-                                                                      If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
-                                                                      the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
-                                                                      merge patch.
-                                                                    items:
-                                                                      type: string
-                                                                    type: array
-                                                                required:
-                                                                - key
-                                                                - operator
-                                                                type: object
-                                                              type: array
-                                                            matchLabels:
-                                                              additionalProperties:
-                                                                type: string
-                                                              description: matchLabels
-                                                                is a map of {key,value}
-                                                                pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
-                                                                are ANDed.
-                                                              type: object
-                                                          type: object
-                                                        namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
-                                                          items:
-                                                            type: string
-                                                          type: array
-                                                        topologyKey:
-                                                          description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
-                                                            that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
-                                                            is not allowed.
-                                                          type: string
-                                                      required:
-                                                      - topologyKey
-                                                      type: object
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      format: int32
-                                                      type: integer
-                                                  required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                  type: object
-                                                type: array
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the anti-affinity
-                                                  requirements specified by this field
-                                                  are not met at scheduling time,
-                                                  the pod will not be scheduled onto
-                                                  the node. If the anti-affinity requirements
-                                                  specified by this field cease to
-                                                  be met at some point during pod
-                                                  execution (e.g. due to a pod label
-                                                  update), the system may or may not
-                                                  try to eventually evict the pod
-                                                  from its node. When there are multiple
-                                                  elements, the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                items:
-                                                                  type: string
-                                                                type: array
-                                                            required:
-                                                            - key
-                                                            - operator
-                                                            type: object
-                                                          type: array
-                                                        matchLabels:
-                                                          additionalProperties:
-                                                            type: string
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
-                                                          type: object
-                                                      type: object
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                                  required:
-                                                  - topologyKey
-                                                  type: object
-                                                type: array
-                                            type: object
-                                        type: object
-                                      nodeSelector:
-                                        additionalProperties:
-                                          type: string
-                                        description: 'NodeSelector is a selector which
-                                          must be true for the pod to fit on a node.
-                                          Selector which must match a node''s labels
-                                          for the pod to be scheduled on that node.
-                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-                                        type: object
-                                      tolerations:
-                                        description: If specified, the pod's tolerations.
-                                        items:
-                                          description: The pod this Toleration is
-                                            attached to tolerates any taint that matches
-                                            the triple <key,value,effect> using the
-                                            matching operator <operator>.
-                                          properties:
-                                            effect:
-                                              description: Effect indicates the taint
-                                                effect to match. Empty means match
-                                                all taint effects. When specified,
-                                                allowed values are NoSchedule, PreferNoSchedule
-                                                and NoExecute.
-                                              type: string
-                                            key:
-                                              description: Key is the taint key that
-                                                the toleration applies to. Empty means
-                                                match all taint keys. If the key is
-                                                empty, operator must be Exists; this
-                                                combination means to match all values
-                                                and all keys.
-                                              type: string
-                                            operator:
-                                              description: Operator represents a key's
-                                                relationship to the value. Valid operators
-                                                are Exists and Equal. Defaults to
-                                                Equal. Exists is equivalent to wildcard
-                                                for value, so that a pod can tolerate
-                                                all taints of a particular category.
-                                              type: string
-                                            tolerationSeconds:
-                                              description: TolerationSeconds represents
-                                                the period of time the toleration
-                                                (which must be of effect NoExecute,
-                                                otherwise this field is ignored) tolerates
-                                                the taint. By default, it is not set,
-                                                which means tolerate the taint forever
-                                                (do not evict). Zero and negative
-                                                values will be treated as 0 (evict
-                                                immediately) by the system.
-                                              format: int64
-                                              type: integer
-                                            value:
-                                              description: Value is the taint value
-                                                the toleration matches to. If the
-                                                operator is Exists, the value should
-                                                be empty, otherwise just a regular
-                                                string.
-                                              type: string
-                                          type: object
-                                        type: array
-                                    type: object
-                                type: object
-                              serviceType:
-                                description: Optional service type for Kubernetes
-                                  solver service
-                                type: string
-                            type: object
-                        type: object
-                      selector:
-                        description: Selector selects a set of DNSNames on the Certificate
-                          resource that should be solved using this challenge solver.
-                        properties:
-                          dnsNames:
-                            description: List of DNSNames that this solver will be
-                              used to solve. If specified and a match is found, a
-                              dnsNames selector will take precedence over a dnsZones
-                              selector. If multiple solvers match with the same dnsNames
-                              value, the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            items:
-                              type: string
-                            type: array
-                          dnsZones:
-                            description: List of DNSZones that this solver will be
-                              used to solve. The most specific DNS zone match specified
-                              here will take precedence over other DNS zone matches,
-                              so a solver specifying sys.example.com will be selected
-                              over one specifying example.com for the domain www.sys.example.com.
-                              If multiple solvers match with the same dnsZones value,
-                              the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            items:
-                              type: string
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: A label selector that is used to refine the
-                              set of certificate's that this challenge solver will
-                              apply to.
-                            type: object
-                        type: object
-                    type: object
-                  type: array
-              required:
-              - privateKeySecretRef
-              - server
-              type: object
-            ca:
-              properties:
-                secretName:
-                  description: SecretName is the name of the secret used to sign Certificates
-                    issued by this Issuer.
-                  type: string
-              required:
-              - secretName
-              type: object
-            selfSigned:
-              type: object
-            vault:
-              properties:
-                auth:
-                  description: Vault authentication
-                  properties:
-                    appRole:
-                      description: This Secret contains a AppRole and Secret
-                      properties:
-                        path:
-                          description: Where the authentication path is mounted in
-                            Vault.
-                          type: string
-                        roleId:
-                          type: string
-                        secretRef:
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          required:
-                          - name
-                          type: object
-                      required:
-                      - path
-                      - roleId
-                      - secretRef
-                      type: object
-                    tokenSecretRef:
-                      description: This Secret contains the Vault token key
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      required:
-                      - name
-                      type: object
-                  type: object
-                caBundle:
-                  description: Base64 encoded CA bundle to validate Vault server certificate.
-                    Only used if the Server URL is using HTTPS protocol. This parameter
-                    is ignored for plain HTTP protocol connection. If not set the
-                    system root certificates are used to validate the TLS connection.
-                  format: byte
-                  type: string
-                path:
-                  description: Vault URL path to the certificate role
-                  type: string
-                server:
-                  description: Server is the vault connection address
-                  type: string
-              required:
-              - auth
-              - path
-              - server
-              type: object
-            venafi:
-              description: VenafiIssuer describes issuer configuration details for
-                Venafi Cloud.
-              properties:
-                cloud:
-                  description: Cloud specifies the Venafi cloud configuration settings.
-                    Only one of TPP or Cloud may be specified.
-                  properties:
-                    apiTokenSecretRef:
-                      description: APITokenSecretRef is a secret key selector for
-                        the Venafi Cloud API token.
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    url:
-                      description: URL is the base URL for Venafi Cloud
-                      type: string
-                  required:
-                  - apiTokenSecretRef
-                  - url
-                  type: object
-                tpp:
-                  description: TPP specifies Trust Protection Platform configuration
-                    settings. Only one of TPP or Cloud may be specified.
-                  properties:
-                    caBundle:
-                      description: CABundle is a PEM encoded TLS certifiate to use
-                        to verify connections to the TPP instance. If specified, system
-                        roots will not be used and the issuing CA for the TPP instance
-                        must be verifiable using the provided root. If not specified,
-                        the connection will be verified using the cert-manager system
-                        root certificates.
-                      format: byte
-                      type: string
-                    credentialsRef:
-                      description: CredentialsRef is a reference to a Secret containing
-                        the username and password for the TPP server. The secret must
-                        contain two keys, 'username' and 'password'.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    url:
-                      description: URL is the base URL for the Venafi TPP instance
-                      type: string
-                  required:
-                  - credentialsRef
-                  - url
-                  type: object
-                zone:
-                  description: Zone is the Venafi Policy Zone to use for this issuer.
-                    All requests made to the Venafi platform will be restricted by
-                    the named zone policy. This field is required.
-                  type: string
-              required:
-              - zone
-              type: object
-          type: object
-        status:
-          description: IssuerStatus contains status information about an Issuer
-          properties:
-            acme:
-              properties:
-                lastRegisteredEmail:
-                  description: LastRegisteredEmail is the email associated with the
-                    latest registered ACME account, in order to track changes made
-                    to registered account associated with the  Issuer
-                  type: string
-                uri:
-                  description: URI is the unique account identifier, which can also
-                    be used to retrieve account details from the CA
-                  type: string
-              type: object
-            conditions:
-              items:
-                description: IssuerCondition contains condition information for an
-                  Issuer.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: Type of the condition, currently ('Ready').
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  name: orders.certmanager.k8s.io
+  name: orders.acme.cert-manager.io
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.state
@@ -5871,12 +1403,15 @@ spec:
       in RFC3339 form and is in UTC.
     name: Age
     type: date
-  group: certmanager.k8s.io
+  group: acme.cert-manager.io
   names:
     kind: Order
+    listKind: OrderList
     plural: orders
+    singular: order
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: Order is a type to represent an Order with an ACME server
@@ -5884,12 +1419,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -5902,62 +1437,6 @@ spec:
                 must be set. This field must match the corresponding field on the
                 DER encoded CSR.
               type: string
-            config:
-              description: "Config specifies a mapping from DNS identifiers to how
-                those identifiers should be solved when performing ACME challenges.
-                A config entry must exist for each domain listed in DNSNames and CommonName.
-                Only **one** of 'config' or 'solvers' may be specified, and if both
-                are specified then no action will be performed on the Order resource.
-                \n This field will be removed when support for solver config specified
-                on the Certificate under certificate.spec.acme has been removed. DEPRECATED:
-                this field will be removed in future. Solver configuration must instead
-                be provided on ACME Issuer resources."
-              items:
-                description: DomainSolverConfig contains solver configuration for
-                  a set of domains.
-                properties:
-                  dns01:
-                    description: DNS01 contains DNS01 challenge solving configuration
-                    properties:
-                      provider:
-                        description: Provider is the name of the DNS01 challenge provider
-                          to use, as configure on the referenced Issuer or ClusterIssuer
-                          resource.
-                        type: string
-                    required:
-                    - provider
-                    type: object
-                  domains:
-                    description: Domains is the list of domains that this SolverConfig
-                      applies to.
-                    items:
-                      type: string
-                    type: array
-                  http01:
-                    description: HTTP01 contains HTTP01 challenge solving configuration
-                    properties:
-                      ingress:
-                        description: Ingress is the name of an Ingress resource that
-                          will be edited to include the ACME HTTP01 'well-known' challenge
-                          path in order to solve HTTP01 challenges. If this field
-                          is specified, 'ingressClass' **must not** be specified.
-                        type: string
-                      ingressClass:
-                        description: IngressClass is the ingress class that should
-                          be set on new ingress resources that are created in order
-                          to solve HTTP01 challenges. This field should be used when
-                          using an ingress controller such as nginx, which 'flattens'
-                          ingress configuration instead of maintaining a 1:1 mapping
-                          between loadbalancer IP:ingress resources. If this field
-                          is not set, and 'ingress' is not set, then ingresses without
-                          an ingress class set will be created to solve HTTP01 challenges.
-                          If this field is specified, 'ingress' **must not** be specified.
-                        type: string
-                    type: object
-                required:
-                - domains
-                type: object
-              type: array
             csr:
               description: Certificate signing request bytes in DER encoding. This
                 will be used when finalizing the order. This field must be set on
@@ -5995,6 +1474,64 @@ spec:
           type: object
         status:
           properties:
+            authorizations:
+              description: Authorizations contains data returned from the ACME server
+                on what authoriations must be completed in order to validate the DNS
+                names specified on the Order.
+              items:
+                description: ACMEAuthorization contains data returned from the ACME
+                  server on an authorization that must be completed in order validate
+                  a DNS name on an ACME Order resource.
+                properties:
+                  challenges:
+                    description: Challenges specifies the challenge types offered
+                      by the ACME server. One of these challenge types will be selected
+                      when validating the DNS name and an appropriate Challenge resource
+                      will be created to perform the ACME challenge process.
+                    items:
+                      description: Challenge specifies a challenge offered by the
+                        ACME server for an Order. An appropriate Challenge resource
+                        can be created to perform the ACME challenge process.
+                      properties:
+                        token:
+                          description: Token is the token that must be presented for
+                            this challenge. This is used to compute the 'key' that
+                            must also be presented.
+                          type: string
+                        type:
+                          description: Type is the type of challenge being offered,
+                            e.g. http-01, dns-01
+                          type: string
+                        url:
+                          description: URL is the URL of this challenge. It can be
+                            used to retrieve additional metadata about the Challenge
+                            from the ACME server.
+                          type: string
+                      required:
+                      - token
+                      - type
+                      - url
+                      type: object
+                    type: array
+                  identifier:
+                    description: Identifier is the DNS name to be validated as part
+                      of this authorization
+                    type: string
+                  url:
+                    description: URL is the URL of the Authorization that must be
+                      completed
+                    type: string
+                  wildcard:
+                    description: Wildcard will be true if this authorization is for
+                      a wildcard DNS name. If this is true, the identifier will be
+                      the *non-wildcard* version of the DNS name. For example, if
+                      '*.example.com' is the DNS name being validated, this field
+                      will be 'true' and the 'identifier' field will be 'example.com'.
+                    type: boolean
+                required:
+                - url
+                type: object
+              type: array
             certificate:
               description: Certificate is a copy of the PEM encoded certificate for
                 this Order. This field will be populated after the order has been
@@ -6002,85 +1539,556 @@ spec:
                 to the 'valid' state.
               format: byte
               type: string
-            challenges:
-              description: Challenges is a list of ChallengeSpecs for Challenges that
-                must be created in order to complete this Order.
+            failureTime:
+              description: FailureTime stores the time that this order failed. This
+                is used to influence garbage collection and back-off.
+              format: date-time
+              type: string
+            finalizeURL:
+              description: FinalizeURL of the Order. This is used to obtain certificates
+                for this order once it has been completed.
+              type: string
+            reason:
+              description: Reason optionally provides more information about a why
+                the order is in the current state.
+              type: string
+            state:
+              description: State contains the current state of this Order resource.
+                States 'success' and 'expired' are 'final'
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
+              type: string
+            url:
+              description: URL of the Order. This will initially be empty when the
+                resource is first created. The Order controller will populate this
+                field when the Order is first processed. This field will be immutable
+                after it is initially set.
+              type: string
+          type: object
+      required:
+      - metadata
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: certificaterequests.cert-manager.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: cert-manager.io
+  names:
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    shortNames:
+    - cr
+    - crs
+    singular: certificaterequest
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: CertificateRequest is a type to represent a Certificate Signing
+        Request
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertificateRequestSpec defines the desired state of CertificateRequest
+          properties:
+            csr:
+              description: Byte slice containing the PEM encoded CertificateSigningRequest
+              format: byte
+              type: string
+            duration:
+              description: Requested certificate default Duration
+              type: string
+            isCA:
+              description: IsCA will mark the resulting certificate as valid for signing.
+                This implies that the 'cert sign' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
+                the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the CertificateRequest
+                will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times. The group field refers to the API group
+                of the issuer which defaults to 'cert-manager.io' if empty.
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            usages:
+              description: Usages is the set of x509 actions that are enabled for
+                a given key. Defaults are ('digital signature', 'key encipherment')
+                if empty
               items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12'
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+                type: string
+              type: array
+          required:
+          - issuerRef
+          type: object
+        status:
+          description: CertificateStatus defines the observed state of CertificateRequest
+            and resulting signed certificate.
+          properties:
+            ca:
+              description: Byte slice containing the PEM encoded certificate authority
+                of the signed certificate.
+              format: byte
+              type: string
+            certificate:
+              description: Byte slice containing a PEM encoded signed certificate
+                resulting from the given certificate signing request.
+              format: byte
+              type: string
+            conditions:
+              items:
+                description: CertificateRequestCondition contains condition information
+                  for a CertificateRequest.
                 properties:
-                  authzURL:
-                    description: AuthzURL is the URL to the ACME Authorization resource
-                      that this challenge is a part of.
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
                     type: string
-                  config:
-                    description: 'Config specifies the solver configuration for this
-                      challenge. Only **one** of ''config'' or ''solver'' may be specified,
-                      and if both are specified then no action will be performed on
-                      the Challenge resource. DEPRECATED: the ''solver'' field should
-                      be specified instead'
-                    properties:
-                      dns01:
-                        description: DNS01 contains DNS01 challenge solving configuration
-                        properties:
-                          provider:
-                            description: Provider is the name of the DNS01 challenge
-                              provider to use, as configure on the referenced Issuer
-                              or ClusterIssuer resource.
-                            type: string
-                        required:
-                        - provider
-                        type: object
-                      http01:
-                        description: HTTP01 contains HTTP01 challenge solving configuration
-                        properties:
-                          ingress:
-                            description: Ingress is the name of an Ingress resource
-                              that will be edited to include the ACME HTTP01 'well-known'
-                              challenge path in order to solve HTTP01 challenges.
-                              If this field is specified, 'ingressClass' **must not**
-                              be specified.
-                            type: string
-                          ingressClass:
-                            description: IngressClass is the ingress class that should
-                              be set on new ingress resources that are created in
-                              order to solve HTTP01 challenges. This field should
-                              be used when using an ingress controller such as nginx,
-                              which 'flattens' ingress configuration instead of maintaining
-                              a 1:1 mapping between loadbalancer IP:ingress resources.
-                              If this field is not set, and 'ingress' is not set,
-                              then ingresses without an ingress class set will be
-                              created to solve HTTP01 challenges. If this field is
-                              specified, 'ingress' **must not** be specified.
-                            type: string
-                        type: object
-                    type: object
-                  dnsName:
-                    description: DNSName is the identifier that this challenge is
-                      for, e.g. example.com.
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
                     type: string
-                  issuerRef:
-                    description: IssuerRef references a properly configured ACME-type
-                      Issuer which should be used to create this Challenge. If the
-                      Issuer does not exist, processing will be retried. If the Issuer
-                      is not an 'ACME' Issuer, an error will be returned and the Challenge
-                      will be marked as failed.
-                    properties:
-                      group:
-                        type: string
-                      kind:
-                        type: string
-                      name:
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  key:
-                    description: Key is the ACME challenge key for this challenge
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
                     type: string
-                  solver:
-                    description: Solver contains the domain solving configuration
-                      that should be used to solve this challenge resource. Only **one**
-                      of 'config' or 'solver' may be specified, and if both are specified
-                      then no action will be performed on the Challenge resource.
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            failureTime:
+              description: FailureTime stores the time that this CertificateRequest
+                failed. This is used to influence garbage collection and back-off.
+              format: date-time
+              type: string
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: certificates.cert-manager.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.secretName
+    name: Secret
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+    - cert
+    - certs
+    singular: certificate
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Certificate is a type to represent a Certificate from ACME
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CertificateSpec defines the desired state of Certificate. A
+            valid Certificate requires at least one of a CommonName, DNSName, or URISAN
+            to be valid.
+          properties:
+            commonName:
+              description: CommonName is a common name to be used on the Certificate.
+                The CommonName should have a length of 64 characters or fewer to avoid
+                generating invalid CSRs.
+              type: string
+            dnsNames:
+              description: DNSNames is a list of subject alt names to be used on the
+                Certificate.
+              items:
+                type: string
+              type: array
+            duration:
+              description: Certificate default Duration
+              type: string
+            ipAddresses:
+              description: IPAddresses is a list of IP addresses to be used on the
+                Certificate
+              items:
+                type: string
+              type: array
+            isCA:
+              description: IsCA will mark this Certificate as valid for signing. This
+                implies that the 'cert sign' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this certificate.
+                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the Certificate will
+                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times.
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            keyAlgorithm:
+              description: KeyAlgorithm is the private key algorithm of the corresponding
+                private key for this certificate. If provided, allowed values are
+                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
+                not provided, key size of 256 will be used for "ecdsa" key algorithm
+                and key size of 2048 will be used for "rsa" key algorithm.
+              enum:
+              - rsa
+              - ecdsa
+              type: string
+            keyEncoding:
+              description: KeyEncoding is the private key cryptography standards (PKCS)
+                for this certificate's private key to be encoded in. If provided,
+                allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
+                respectively. If KeyEncoding is not specified, then PKCS#1 will be
+                used by default.
+              enum:
+              - pkcs1
+              - pkcs8
+              type: string
+            keySize:
+              description: KeySize is the key bit size of the corresponding private
+                key for this certificate. If provided, value must be between 2048
+                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                to "ecdsa".
+              type: integer
+            organization:
+              description: Organization is the organization to be used on the Certificate
+              items:
+                type: string
+              type: array
+            renewBefore:
+              description: Certificate renew before expiration duration
+              type: string
+            secretName:
+              description: SecretName is the name of the secret resource to store
+                this secret in
+              type: string
+            uriSANs:
+              description: URISANs is a list of URI Subject Alternative Names to be
+                set on this Certificate.
+              items:
+                type: string
+              type: array
+            usages:
+              description: Usages is the set of x509 actions that are enabled for
+                a given key. Defaults are ('digital signature', 'key encipherment')
+                if empty
+              items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12'
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+                type: string
+              type: array
+          required:
+          - issuerRef
+          - secretName
+          type: object
+        status:
+          description: CertificateStatus defines the observed state of Certificate
+          properties:
+            conditions:
+              items:
+                description: CertificateCondition contains condition information for
+                  an Certificate.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            lastFailureTime:
+              format: date-time
+              type: string
+            notAfter:
+              description: The expiration time of the certificate stored in the secret
+                named by this resource in spec.secretName.
+              format: date-time
+              type: string
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: clusterissuers.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: ClusterIssuer
+    listKind: ClusterIssuerList
+    plural: clusterissuers
+    singular: clusterissuer
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the specification of an Issuer. This includes
+            any configuration required for the issuer.
+          properties:
+            acme:
+              description: ACMEIssuer contains the specification for an ACME issuer
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+                solvers:
+                  description: Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains.
+                  items:
                     properties:
                       dns01:
                         properties:
@@ -6393,7 +2401,7 @@ spec:
                                   to reference a Secret resource. For details on the
                                   schema of this field, consult the webhook provider
                                   implementation's documentation.
-                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               groupName:
                                 description: The API group name that should be used
                                   when POSTing ChallengePayload resources to the webhook
@@ -7428,69 +3436,1913 @@ spec:
                             type: object
                         type: object
                     type: object
-                  token:
-                    description: Token is the ACME challenge token for this challenge.
+                  type: array
+              required:
+              - privateKeySecretRef
+              - server
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    kubernetes:
+                      description: This contains a Role and Secret with a ServiceAccount
+                        token to authenticate with vault.
+                      properties:
+                        mountPath:
+                          description: The value here will be used as part of the
+                            path used when authenticating with vault, for example
+                            if you set a value of "foo", the path used will be `/v1/auth/foo/login`.
+                            If unspecified, the default value "kubernetes" will be
+                            used.
+                          type: string
+                        role:
+                          description: A required field containing the Vault Role
+                            to assume. A Role binds a Kubernetes ServiceAccount with
+                            a set of Vault policies.
+                          type: string
+                        secretRef:
+                          description: The required Secret field containing a Kubernetes
+                            ServiceAccount JWT used for authenticating with Vault.
+                            Use of 'ambient credentials' is not supported.
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - role
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - path
+              - server
+              type: object
+            venafi:
+              description: VenafiIssuer describes issuer configuration details for
+                Venafi Cloud.
+              properties:
+                cloud:
+                  description: Cloud specifies the Venafi cloud configuration settings.
+                    Only one of TPP or Cloud may be specified.
+                  properties:
+                    apiTokenSecretRef:
+                      description: APITokenSecretRef is a secret key selector for
+                        the Venafi Cloud API token.
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for Venafi Cloud
+                      type: string
+                  required:
+                  - apiTokenSecretRef
+                  - url
+                  type: object
+                tpp:
+                  description: TPP specifies Trust Protection Platform configuration
+                    settings. Only one of TPP or Cloud may be specified.
+                  properties:
+                    caBundle:
+                      description: CABundle is a PEM encoded TLS certifiate to use
+                        to verify connections to the TPP instance. If specified, system
+                        roots will not be used and the issuing CA for the TPP instance
+                        must be verifiable using the provided root. If not specified,
+                        the connection will be verified using the cert-manager system
+                        root certificates.
+                      format: byte
+                      type: string
+                    credentialsRef:
+                      description: CredentialsRef is a reference to a Secret containing
+                        the username and password for the TPP server. The secret must
+                        contain two keys, 'username' and 'password'.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for the Venafi TPP instance
+                      type: string
+                  required:
+                  - credentialsRef
+                  - url
+                  type: object
+                zone:
+                  description: Zone is the Venafi Policy Zone to use for this issuer.
+                    All requests made to the Venafi platform will be restricted by
+                    the named zone policy. This field is required.
+                  type: string
+              required:
+              - zone
+              type: object
+          type: object
+        status:
+          description: IssuerStatus contains status information about an Issuer
+          properties:
+            acme:
+              properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              type: object
+            conditions:
+              items:
+                description: IssuerCondition contains condition information for an
+                  Issuer.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
-                    description: Type is the type of ACME challenge this resource
-                      represents, e.g. "dns01" or "http01"
+                    description: Type of the condition, currently ('Ready').
                     type: string
-                  url:
-                    description: URL is the URL of the ACME Challenge resource for
-                      this challenge. This can be used to lookup details about the
-                      status of this challenge.
-                    type: string
-                  wildcard:
-                    description: Wildcard will be true if this challenge is for a
-                      wildcard identifier, for example '*.example.com'
-                    type: boolean
                 required:
-                - authzURL
-                - dnsName
-                - issuerRef
-                - key
-                - token
+                - status
                 - type
-                - url
                 type: object
               type: array
-            failureTime:
-              description: FailureTime stores the time that this order failed. This
-                is used to influence garbage collection and back-off.
-              format: date-time
-              type: string
-            finalizeURL:
-              description: FinalizeURL of the Order. This is used to obtain certificates
-                for this order once it has been completed.
-              type: string
-            reason:
-              description: Reason optionally provides more information about a why
-                the order is in the current state.
-              type: string
-            state:
-              description: State contains the current state of this Order resource.
-                States 'success' and 'expired' are 'final'
-              enum:
-              - valid
-              - ready
-              - pending
-              - processing
-              - invalid
-              - expired
-              - errored
-              type: string
-            url:
-              description: URL of the Order. This will initially be empty when the
-                resource is first created. The Order controller will populate this
-                field when the Order is first processed. This field will be immutable
-                after it is initially set.
-              type: string
           type: object
-      required:
-      - metadata
       type: object
+  version: v1alpha2
   versions:
-  - name: v1alpha1
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: issuers.cert-manager.io
+spec:
+  group: cert-manager.io
+  names:
+    kind: Issuer
+    listKind: IssuerList
+    plural: issuers
+    singular: issuer
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IssuerSpec is the specification of an Issuer. This includes
+            any configuration required for the issuer.
+          properties:
+            acme:
+              description: ACMEIssuer contains the specification for an ACME issuer
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+                solvers:
+                  description: Solvers is a list of challenge solvers that will be
+                    used to solve ACME challenges for the matching domains.
+                  items:
+                    properties:
+                      dns01:
+                        properties:
+                          acmedns:
+                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                              containing the configuration for ACME-DNS servers
+                            properties:
+                              accountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              host:
+                                type: string
+                            required:
+                            - accountSecretRef
+                            - host
+                            type: object
+                          akamai:
+                            description: ACMEIssuerDNS01ProviderAkamai is a structure
+                              containing the DNS configuration for Akamai DNS—Zone
+                              Record Management API
+                            properties:
+                              accessTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              clientTokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              serviceConsumerDomain:
+                                type: string
+                            required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                            type: object
+                          azuredns:
+                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                              containing the configuration for Azure DNS
+                            properties:
+                              clientID:
+                                type: string
+                              clientSecretSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                                type: string
+                              hostedZoneName:
+                                type: string
+                              resourceGroupName:
+                                type: string
+                              subscriptionID:
+                                type: string
+                              tenantID:
+                                type: string
+                            required:
+                            - clientID
+                            - clientSecretSecretRef
+                            - resourceGroupName
+                            - subscriptionID
+                            - tenantID
+                            type: object
+                          clouddns:
+                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                              containing the DNS configuration for Google Cloud DNS
+                            properties:
+                              project:
+                                type: string
+                              serviceAccountSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - project
+                            - serviceAccountSecretRef
+                            type: object
+                          cloudflare:
+                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                              containing the DNS configuration for Cloudflare
+                            properties:
+                              apiKeySecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              email:
+                                type: string
+                            required:
+                            - apiKeySecretRef
+                            - email
+                            type: object
+                          cnameStrategy:
+                            description: CNAMEStrategy configures how the DNS01 provider
+                              should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
+                            type: string
+                          digitalocean:
+                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                              structure containing the DNS configuration for DigitalOcean
+                              Domains
+                            properties:
+                              tokenSecretRef:
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - tokenSecretRef
+                            type: object
+                          rfc2136:
+                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                              containing the configuration for RFC2136 DNS
+                            properties:
+                              nameserver:
+                                description: 'The IP address of the DNS supporting
+                                  RFC2136. Required. Note: FQDN is not a valid value,
+                                  only IP.'
+                                type: string
+                              tsigAlgorithm:
+                                description: 'The TSIG Algorithm configured in the
+                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                  and ``tsigKeyName`` are defined. Supported values
+                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                  ``HMACSHA256`` or ``HMACSHA512``.'
+                                type: string
+                              tsigKeyName:
+                                description: The TSIG Key name configured in the DNS.
+                                  If ``tsigSecretSecretRef`` is defined, this field
+                                  is required.
+                                type: string
+                              tsigSecretSecretRef:
+                                description: The name of the secret containing the
+                                  TSIG value. If ``tsigKeyName`` is defined, this
+                                  field is required.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - nameserver
+                            type: object
+                          route53:
+                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                              containing the Route 53 configuration for AWS
+                            properties:
+                              accessKeyID:
+                                description: 'The AccessKeyID is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                type: string
+                              hostedZoneID:
+                                description: If set, the provider will manage only
+                                  this zone in Route53 and will not do an lookup using
+                                  the route53:ListHostedZonesByName api call.
+                                type: string
+                              region:
+                                description: Always set the region when using AccessKeyID
+                                  and SecretAccessKey
+                                type: string
+                              role:
+                                description: Role is a Role ARN which the Route53
+                                  provider will assume using either the explicit credentials
+                                  AccessKeyID/SecretAccessKey or the inferred credentials
+                                  from environment variables, shared credentials file
+                                  or AWS Instance metadata
+                                type: string
+                              secretAccessKeySecretRef:
+                                description: The SecretAccessKey is used for authentication.
+                                  If not set we fall-back to using env vars, shared
+                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.
+                                      Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                            required:
+                            - region
+                            type: object
+                          webhook:
+                            description: ACMEIssuerDNS01ProviderWebhook specifies
+                              configuration for a webhook DNS01 provider, including
+                              where to POST ChallengePayload resources.
+                            properties:
+                              config:
+                                description: Additional configuration that should
+                                  be passed to the webhook apiserver when challenges
+                                  are processed. This can contain arbitrary JSON data.
+                                  Secret values should not be specified in this stanza.
+                                  If secret values are needed (e.g. credentials for
+                                  a DNS service), you should use a SecretKeySelector
+                                  to reference a Secret resource. For details on the
+                                  schema of this field, consult the webhook provider
+                                  implementation's documentation.
+                                x-kubernetes-preserve-unknown-fields: true
+                              groupName:
+                                description: The API group name that should be used
+                                  when POSTing ChallengePayload resources to the webhook
+                                  apiserver. This should be the same as the GroupName
+                                  specified in the webhook provider implementation.
+                                type: string
+                              solverName:
+                                description: The name of the solver to use, as defined
+                                  in the webhook provider implementation. This will
+                                  typically be the name of the provider, e.g. 'cloudflare'.
+                                type: string
+                            required:
+                            - groupName
+                            - solverName
+                            type: object
+                        type: object
+                      http01:
+                        description: ACMEChallengeSolverHTTP01 contains configuration
+                          detailing how to solve HTTP01 challenges within a Kubernetes
+                          cluster. Typically this is accomplished through creating
+                          'routes' of some description that configure ingress controllers
+                          to direct traffic to 'solver pods', which are responsible
+                          for responding to the ACME server's HTTP requests.
+                        properties:
+                          ingress:
+                            description: The ingress based HTTP01 challenge solver
+                              will solve challenges by creating or modifying Ingress
+                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                              to 'challenge solver' pods that are provisioned by cert-manager
+                              for each Challenge to be completed.
+                            properties:
+                              class:
+                                description: The ingress class to use when creating
+                                  Ingress resources to solve ACME challenges that
+                                  use this challenge solver. Only one of 'class' or
+                                  'name' may be specified.
+                                type: string
+                              name:
+                                description: The name of the ingress resource that
+                                  should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  is typically used in conjunction with ingress controllers
+                                  like ingress-gce, which maintains a 1:1 mapping
+                                  between external IPs and ingress resources.
+                                type: string
+                              podTemplate:
+                                description: Optional pod template used to configure
+                                  the ACME challenge solver pods used for HTTP01 challenges
+                                properties:
+                                  metadata:
+                                    description: ObjectMeta overrides for the pod
+                                      used to solve HTTP01 challenges. Only the 'labels'
+                                      and 'annotations' fields may be set. If labels
+                                      or annotations overlap with in-built values,
+                                      the values here will override the in-built values.
+                                    type: object
+                                  spec:
+                                    description: PodSpec defines overrides for the
+                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                      'affinity' and 'tolerations' fields are supported
+                                      currently. All other fields will be ignored.
+                                    properties:
+                                      affinity:
+                                        description: If specified, the pod's scheduling
+                                          constraints
+                                        properties:
+                                          nodeAffinity:
+                                            description: Describes node affinity scheduling
+                                              rules for the pod.
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node matches the
+                                                  corresponding matchExpressions;
+                                                  the node(s) with the highest sum
+                                                  are the most preferred.
+                                                items:
+                                                  description: An empty preferred
+                                                    scheduling term matches all objects
+                                                    with implicit weight 0 (i.e. it's
+                                                    a no-op). A null preferred scheduling
+                                                    term matches no objects (i.e.
+                                                    is also a no-op).
+                                                  properties:
+                                                    preference:
+                                                      description: A node selector
+                                                        term, associated with the
+                                                        corresponding weight.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    weight:
+                                                      description: Weight associated
+                                                        with matching the corresponding
+                                                        nodeSelectorTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - preference
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to an update), the system
+                                                  may or may not try to eventually
+                                                  evict the pod from its node.
+                                                properties:
+                                                  nodeSelectorTerms:
+                                                    description: Required. A list
+                                                      of node selector terms. The
+                                                      terms are ORed.
+                                                    items:
+                                                      description: A null or empty
+                                                        node selector term matches
+                                                        no objects. The requirements
+                                                        of them are ANDed. The TopologySelectorTerm
+                                                        type implements a subset of
+                                                        the NodeSelectorTerm.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's labels.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchFields:
+                                                          description: A list of node
+                                                            selector requirements
+                                                            by node's fields.
+                                                          items:
+                                                            description: A node selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: The label
+                                                                  key that the selector
+                                                                  applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: Represents
+                                                                  a key's relationship
+                                                                  to a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists,
+                                                                  DoesNotExist. Gt,
+                                                                  and Lt.
+                                                                type: string
+                                                              values:
+                                                                description: An array
+                                                                  of string values.
+                                                                  If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. If
+                                                                  the operator is
+                                                                  Gt or Lt, the values
+                                                                  array must have
+                                                                  a single element,
+                                                                  which will be interpreted
+                                                                  as an integer. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                required:
+                                                - nodeSelectorTerms
+                                                type: object
+                                            type: object
+                                          podAffinity:
+                                            description: Describes pod affinity scheduling
+                                              rules (e.g. co-locate this pod in the
+                                              same node, zone, etc. as some other
+                                              pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  affinity expressions, etc.), compute
+                                                  a sum by iterating through the elements
+                                                  of this field and adding "weight"
+                                                  to the sum if the node has pods
+                                                  which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the affinity requirements
+                                                  specified by this field are not
+                                                  met at scheduling time, the pod
+                                                  will not be scheduled onto the node.
+                                                  If the affinity requirements specified
+                                                  by this field cease to be met at
+                                                  some point during pod execution
+                                                  (e.g. due to a pod label update),
+                                                  the system may or may not try to
+                                                  eventually evict the pod from its
+                                                  node. When there are multiple elements,
+                                                  the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          podAntiAffinity:
+                                            description: Describes pod anti-affinity
+                                              scheduling rules (e.g. avoid putting
+                                              this pod in the same node, zone, etc.
+                                              as some other pod(s)).
+                                            properties:
+                                              preferredDuringSchedulingIgnoredDuringExecution:
+                                                description: The scheduler will prefer
+                                                  to schedule pods to nodes that satisfy
+                                                  the anti-affinity expressions specified
+                                                  by this field, but it may choose
+                                                  a node that violates one or more
+                                                  of the expressions. The node that
+                                                  is most preferred is the one with
+                                                  the greatest sum of weights, i.e.
+                                                  for each node that meets all of
+                                                  the scheduling requirements (resource
+                                                  request, requiredDuringScheduling
+                                                  anti-affinity expressions, etc.),
+                                                  compute a sum by iterating through
+                                                  the elements of this field and adding
+                                                  "weight" to the sum if the node
+                                                  has pods which matches the corresponding
+                                                  podAffinityTerm; the node(s) with
+                                                  the highest sum are the most preferred.
+                                                items:
+                                                  description: The weights of all
+                                                    of the matched WeightedPodAffinityTerm
+                                                    fields are added per-node to find
+                                                    the most preferred node(s)
+                                                  properties:
+                                                    podAffinityTerm:
+                                                      description: Required. A pod
+                                                        affinity term, associated
+                                                        with the corresponding weight.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query
+                                                            over a set of resources,
+                                                            in this case pods.
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label
+                                                                selector requirements.
+                                                                The requirements are
+                                                                ANDed.
+                                                              items:
+                                                                description: A label
+                                                                  selector requirement
+                                                                  is a selector that
+                                                                  contains values,
+                                                                  a key, and an operator
+                                                                  that relates the
+                                                                  key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key
+                                                                      is the label
+                                                                      key that the
+                                                                      selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a
+                                                                      key's relationship
+                                                                      to a set of
+                                                                      values. Valid
+                                                                      operators are
+                                                                      In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or
+                                                                      DoesNotExist,
+                                                                      the values array
+                                                                      must be empty.
+                                                                      This array is
+                                                                      replaced during
+                                                                      a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels
+                                                                map is equivalent
+                                                                to an element of matchExpressions,
+                                                                whose key field is
+                                                                "key", the operator
+                                                                is "In", and the values
+                                                                array contains only
+                                                                "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                          type: object
+                                                        namespaces:
+                                                          description: namespaces
+                                                            specifies which namespaces
+                                                            the labelSelector applies
+                                                            to (matches against);
+                                                            null or empty list means
+                                                            "this pod's namespace"
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity)
+                                                            or not co-located (anti-affinity)
+                                                            with the pods matching
+                                                            the labelSelector in the
+                                                            specified namespaces,
+                                                            where co-located is defined
+                                                            as running on a node whose
+                                                            value of the label with
+                                                            key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods
+                                                            is running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                                      required:
+                                                      - topologyKey
+                                                      type: object
+                                                    weight:
+                                                      description: weight associated
+                                                        with matching the corresponding
+                                                        podAffinityTerm, in the range
+                                                        1-100.
+                                                      format: int32
+                                                      type: integer
+                                                  required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                  type: object
+                                                type: array
+                                              requiredDuringSchedulingIgnoredDuringExecution:
+                                                description: If the anti-affinity
+                                                  requirements specified by this field
+                                                  are not met at scheduling time,
+                                                  the pod will not be scheduled onto
+                                                  the node. If the anti-affinity requirements
+                                                  specified by this field cease to
+                                                  be met at some point during pod
+                                                  execution (e.g. due to a pod label
+                                                  update), the system may or may not
+                                                  try to eventually evict the pod
+                                                  from its node. When there are multiple
+                                                  elements, the lists of nodes corresponding
+                                                  to each podAffinityTerm are intersected,
+                                                  i.e. all terms must be satisfied.
+                                                items:
+                                                  description: Defines a set of pods
+                                                    (namely those matching the labelSelector
+                                                    relative to the given namespace(s))
+                                                    that this pod should be co-located
+                                                    (affinity) or not co-located (anti-affinity)
+                                                    with, where co-located is defined
+                                                    as running on a node whose value
+                                                    of the label with key <topologyKey>
+                                                    matches that of any node on which
+                                                    a pod of the set of pods is running
+                                                  properties:
+                                                    labelSelector:
+                                                      description: A label query over
+                                                        a set of resources, in this
+                                                        case pods.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions
+                                                            is a list of label selector
+                                                            requirements. The requirements
+                                                            are ANDed.
+                                                          items:
+                                                            description: A label selector
+                                                              requirement is a selector
+                                                              that contains values,
+                                                              a key, and an operator
+                                                              that relates the key
+                                                              and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is
+                                                                  the label key that
+                                                                  the selector applies
+                                                                  to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator
+                                                                  represents a key's
+                                                                  relationship to
+                                                                  a set of values.
+                                                                  Valid operators
+                                                                  are In, NotIn, Exists
+                                                                  and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values
+                                                                  is an array of string
+                                                                  values. If the operator
+                                                                  is In or NotIn,
+                                                                  the values array
+                                                                  must be non-empty.
+                                                                  If the operator
+                                                                  is Exists or DoesNotExist,
+                                                                  the values array
+                                                                  must be empty. This
+                                                                  array is replaced
+                                                                  during a strategic
+                                                                  merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels
+                                                            is a map of {key,value}
+                                                            pairs. A single {key,value}
+                                                            in the matchLabels map
+                                                            is equivalent to an element
+                                                            of matchExpressions, whose
+                                                            key field is "key", the
+                                                            operator is "In", and
+                                                            the values array contains
+                                                            only "value". The requirements
+                                                            are ANDed.
+                                                          type: object
+                                                      type: object
+                                                    namespaces:
+                                                      description: namespaces specifies
+                                                        which namespaces the labelSelector
+                                                        applies to (matches against);
+                                                        null or empty list means "this
+                                                        pod's namespace"
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      description: This pod should
+                                                        be co-located (affinity) or
+                                                        not co-located (anti-affinity)
+                                                        with the pods matching the
+                                                        labelSelector in the specified
+                                                        namespaces, where co-located
+                                                        is defined as running on a
+                                                        node whose value of the label
+                                                        with key topologyKey matches
+                                                        that of any node on which
+                                                        any of the selected pods is
+                                                        running. Empty topologyKey
+                                                        is not allowed.
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                type: array
+                                            type: object
+                                        type: object
+                                      nodeSelector:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'NodeSelector is a selector which
+                                          must be true for the pod to fit on a node.
+                                          Selector which must match a node''s labels
+                                          for the pod to be scheduled on that node.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                        type: object
+                                      tolerations:
+                                        description: If specified, the pod's tolerations.
+                                        items:
+                                          description: The pod this Toleration is
+                                            attached to tolerates any taint that matches
+                                            the triple <key,value,effect> using the
+                                            matching operator <operator>.
+                                          properties:
+                                            effect:
+                                              description: Effect indicates the taint
+                                                effect to match. Empty means match
+                                                all taint effects. When specified,
+                                                allowed values are NoSchedule, PreferNoSchedule
+                                                and NoExecute.
+                                              type: string
+                                            key:
+                                              description: Key is the taint key that
+                                                the toleration applies to. Empty means
+                                                match all taint keys. If the key is
+                                                empty, operator must be Exists; this
+                                                combination means to match all values
+                                                and all keys.
+                                              type: string
+                                            operator:
+                                              description: Operator represents a key's
+                                                relationship to the value. Valid operators
+                                                are Exists and Equal. Defaults to
+                                                Equal. Exists is equivalent to wildcard
+                                                for value, so that a pod can tolerate
+                                                all taints of a particular category.
+                                              type: string
+                                            tolerationSeconds:
+                                              description: TolerationSeconds represents
+                                                the period of time the toleration
+                                                (which must be of effect NoExecute,
+                                                otherwise this field is ignored) tolerates
+                                                the taint. By default, it is not set,
+                                                which means tolerate the taint forever
+                                                (do not evict). Zero and negative
+                                                values will be treated as 0 (evict
+                                                immediately) by the system.
+                                              format: int64
+                                              type: integer
+                                            value:
+                                              description: Value is the taint value
+                                                the toleration matches to. If the
+                                                operator is Exists, the value should
+                                                be empty, otherwise just a regular
+                                                string.
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              serviceType:
+                                description: Optional service type for Kubernetes
+                                  solver service
+                                type: string
+                            type: object
+                        type: object
+                      selector:
+                        description: Selector selects a set of DNSNames on the Certificate
+                          resource that should be solved using this challenge solver.
+                        properties:
+                          dnsNames:
+                            description: List of DNSNames that this solver will be
+                              used to solve. If specified and a match is found, a
+                              dnsNames selector will take precedence over a dnsZones
+                              selector. If multiple solvers match with the same dnsNames
+                              value, the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          dnsZones:
+                            description: List of DNSZones that this solver will be
+                              used to solve. The most specific DNS zone match specified
+                              here will take precedence over other DNS zone matches,
+                              so a solver specifying sys.example.com will be selected
+                              over one specifying example.com for the domain www.sys.example.com.
+                              If multiple solvers match with the same dnsZones value,
+                              the solver with the most matching labels in matchLabels
+                              will be selected. If neither has more matches, the solver
+                              defined earlier in the list will be selected.
+                            items:
+                              type: string
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: A label selector that is used to refine the
+                              set of certificate's that this challenge solver will
+                              apply to.
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+              required:
+              - privateKeySecretRef
+              - server
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    kubernetes:
+                      description: This contains a Role and Secret with a ServiceAccount
+                        token to authenticate with vault.
+                      properties:
+                        mountPath:
+                          description: The value here will be used as part of the
+                            path used when authenticating with vault, for example
+                            if you set a value of "foo", the path used will be `/v1/auth/foo/login`.
+                            If unspecified, the default value "kubernetes" will be
+                            used.
+                          type: string
+                        role:
+                          description: A required field containing the Vault Role
+                            to assume. A Role binds a Kubernetes ServiceAccount with
+                            a set of Vault policies.
+                          type: string
+                        secretRef:
+                          description: The required Secret field containing a Kubernetes
+                            ServiceAccount JWT used for authenticating with Vault.
+                            Use of 'ambient credentials' is not supported.
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - role
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - path
+              - server
+              type: object
+            venafi:
+              description: VenafiIssuer describes issuer configuration details for
+                Venafi Cloud.
+              properties:
+                cloud:
+                  description: Cloud specifies the Venafi cloud configuration settings.
+                    Only one of TPP or Cloud may be specified.
+                  properties:
+                    apiTokenSecretRef:
+                      description: APITokenSecretRef is a secret key selector for
+                        the Venafi Cloud API token.
+                      properties:
+                        key:
+                          description: The key of the secret to select from. Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for Venafi Cloud
+                      type: string
+                  required:
+                  - apiTokenSecretRef
+                  - url
+                  type: object
+                tpp:
+                  description: TPP specifies Trust Protection Platform configuration
+                    settings. Only one of TPP or Cloud may be specified.
+                  properties:
+                    caBundle:
+                      description: CABundle is a PEM encoded TLS certifiate to use
+                        to verify connections to the TPP instance. If specified, system
+                        roots will not be used and the issuing CA for the TPP instance
+                        must be verifiable using the provided root. If not specified,
+                        the connection will be verified using the cert-manager system
+                        root certificates.
+                      format: byte
+                      type: string
+                    credentialsRef:
+                      description: CredentialsRef is a reference to a Secret containing
+                        the username and password for the TPP server. The secret must
+                        contain two keys, 'username' and 'password'.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    url:
+                      description: URL is the base URL for the Venafi TPP instance
+                      type: string
+                  required:
+                  - credentialsRef
+                  - url
+                  type: object
+                zone:
+                  description: Zone is the Venafi Policy Zone to use for this issuer.
+                    All requests made to the Venafi platform will be restricted by
+                    the named zone policy. This field is required.
+                  type: string
+              required:
+              - zone
+              type: object
+          type: object
+        status:
+          description: IssuerStatus contains status information about an Issuer
+          properties:
+            acme:
+              properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              type: object
+            conditions:
+              items:
+                description: IssuerCondition contains condition information for an
+                  Issuer.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
     served: true
     storage: true
 status:
@@ -7504,8 +5356,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager
-  labels:
-    certmanager.k8s.io/disable-validation: "true"
 
 ---
 ---
@@ -7520,7 +5370,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cainjector-v0.10.1
+    helm.sh/chart: cainjector-v0.11.0
 
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
@@ -7529,12 +5379,13 @@ kind: ServiceAccount
 metadata:
   name: cert-manager
   namespace: "cert-manager"
+  annotations:
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
 
 ---
 # Source: cert-manager/templates/webhook-serviceaccount.yaml
@@ -7548,7 +5399,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
 ---
 # Source: cert-manager/charts/cainjector/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -7560,16 +5411,16 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cainjector-v0.10.1
+    helm.sh/chart: cainjector-v0.11.0
 rules:
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["configmaps", "events"]
+    resources: ["events"]
     verbs: ["get", "create", "update", "patch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
@@ -7590,7 +5441,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cainjector-v0.10.1
+    helm.sh/chart: cainjector-v0.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -7599,417 +5450,51 @@ subjects:
   - name: cert-manager-cainjector
     namespace: "cert-manager"
     kind: ServiceAccount
+
 ---
-# Source: cert-manager/templates/rbac.yaml
+# leader election rules
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: cert-manager-leaderelection
+  name: cert-manager-cainjector:leaderelection
+  namespace: kube-system
   labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
+    app: cainjector
+    app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cainjector-v0.11.0
 rules:
   # Used for leader election by the controller
+  # TODO: refine the permission to *just* the leader election configmap
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "create", "update", "patch"]
 
 ---
 
-# Issuer controller role
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: RoleBinding
 metadata:
-  name: cert-manager-controller-issuers
+  name: cert-manager-cainjector:leaderelection
+  namespace: kube-system
   labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
+    app: cainjector
+    app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-rules:
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["issuers", "issuers/status"]
-    verbs: ["update"]
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["issuers"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-
----
-
-# ClusterIssuer controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: cert-manager-controller-clusterissuers
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-rules:
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["clusterissuers", "clusterissuers/status"]
-    verbs: ["update"]
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["clusterissuers"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-
----
-
-# Certificates controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: cert-manager-controller-certificates
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-rules:
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
-    verbs: ["update"]
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers", "orders"]
-    verbs: ["get", "list", "watch"]
-  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
-  # admission controller enabled:
-  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates/finalizers"]
-    verbs: ["update"]
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["orders"]
-    verbs: ["create", "delete"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-
----
-
-# Orders controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: cert-manager-controller-orders
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-rules:
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["orders", "orders/status"]
-    verbs: ["update"]
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["orders", "clusterissuers", "issuers", "challenges"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["challenges"]
-    verbs: ["create", "delete"]
-  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
-  # admission controller enabled:
-  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["orders/finalizers"]
-    verbs: ["update"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-
----
-
-# Challenges controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: cert-manager-controller-challenges
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-rules:
-  # Use to update challenge resource status
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["challenges", "challenges/status"]
-    verbs: ["update"]
-  # Used to watch challenges, issuer and clusterissuer resources
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["challenges", "issuers", "clusterissuers"]
-    verbs: ["get", "list", "watch"]
-  # Need to be able to retrieve ACME account private key to complete challenges
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
-  # Used to create events
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-  # HTTP01 rules
-  - apiGroups: [""]
-    resources: ["pods", "services"]
-    verbs: ["get", "list", "watch", "create", "delete"]
-  - apiGroups: ["extensions"]
-    resources: ["ingresses"]
-    verbs: ["get", "list", "watch", "create", "delete", "update"]
-  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
-  # admission controller enabled:
-  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["challenges/finalizers"]
-    verbs: ["update"]
-  # DNS01 rules (duplicated above)
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
-
----
-
-# ingress-shim controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: cert-manager-controller-ingress-shim
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-rules:
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificaterequests"]
-    verbs: ["create", "update", "delete"]
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["ingresses"]
-    verbs: ["get", "list", "watch"]
-  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
-  # admission controller enabled:
-  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-  - apiGroups: ["extensions"]
-    resources: ["ingresses/finalizers"]
-    verbs: ["update"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-leaderelection
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cainjector-v0.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-leaderelection
+  kind: Role
+  name: cert-manager-cainjector:leaderelection
 subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
+  - apiGroup: ""
     kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-issuers
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-issuers
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-clusterissuers
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-clusterissuers
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-certificates
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-certificates
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-orders
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-orders
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-challenges
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-challenges
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: cert-manager-controller-ingress-shim
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cert-manager-controller-ingress-shim
-subjects:
-  - name: cert-manager
-    namespace: "cert-manager"
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cert-manager-view
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-rules:
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificaterequests", "issuers"]
-    verbs: ["get", "list", "watch"]
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: cert-manager-edit
-  labels:
-    app: cert-manager
-    app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/instance:  cert-manager
-    app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-rules:
-  - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificaterequests", "issuers"]
-    verbs: ["create", "delete", "deletecollection", "patch", "update"]
-
+    name: cert-manager-cainjector
+    namespace: cert-manager
 ---
 # Source: cert-manager/templates/webhook-rbac.yaml
 ### Webhook ###
@@ -8025,7 +5510,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8051,7 +5536,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -8073,10 +5558,10 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
 rules:
 - apiGroups:
-  - admission.certmanager.k8s.io
+  - admission.cert-manager.io
   resources:
   - certificates
   - certificaterequests
@@ -8084,6 +5569,451 @@ rules:
   - clusterissuers
   verbs:
   - create
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: cert-manager:leaderelection
+  namespace: kube-system
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+rules:
+  # Used for leader election by the controller
+  # TODO: refine the permission to *just* the leader election configmap
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update", "patch"]
+
+---
+
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: cert-manager:leaderelection
+  namespace: kube-system
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager:leaderelection
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager
+
+---
+
+# Issuer controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "issuers/status"]
+    verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+---
+
+# ClusterIssuer controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers", "clusterissuers/status"]
+    verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+---
+
+# Certificates controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
+    verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+---
+
+# Orders controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+rules:
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "orders/status"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "challenges"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["create", "delete"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+---
+
+# Challenges controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+rules:
+  # Use to update challenge resource status
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges", "challenges/status"]
+    verbs: ["update"]
+  # Used to watch challenge resources
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["get", "list", "watch"]
+  # Used to watch challenges, issuer and clusterissuer resources
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  # Need to be able to retrieve ACME account private key to complete challenges
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  # Used to create events
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  # HTTP01 rules
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges/finalizers"]
+    verbs: ["update"]
+  # DNS01 rules (duplicated above)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+# ingress-shim controller role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-ingress-shim
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests"]
+    verbs: ["create", "update", "delete"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["extensions"]
+    resources: ["ingresses/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-leaderelection
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-leaderelection
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-issuers
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-clusterissuers
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-certificates
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-orders
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-challenges
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-ingress-shim
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-ingress-shim
+subjects:
+  - name: cert-manager
+    namespace: "cert-manager"
+    kind: ServiceAccount
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-view
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-edit
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance:  cert-manager
+    app.kubernetes.io/managed-by: Tiller
+    helm.sh/chart: cert-manager-v0.11.0
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+
 ---
 # Source: cert-manager/templates/service.yaml
 
@@ -8097,7 +6027,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
 spec:
   type: ClusterIP
   ports:
@@ -8120,7 +6050,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
 spec:
   type: ClusterIP
   ports:
@@ -8144,7 +6074,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cainjector-v0.10.1
+    helm.sh/chart: cainjector-v0.11.0
 spec:
   replicas: 1
   selector:
@@ -8160,17 +6090,17 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance:  cert-manager
         app.kubernetes.io/managed-by: Tiller
-        helm.sh/chart: cainjector-v0.10.1
+        helm.sh/chart: cainjector-v0.11.0
       annotations:
     spec:
       serviceAccountName: cert-manager-cainjector
       containers:
         - name: cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v0.10.1"
+          image: "quay.io/jetstack/cert-manager-cainjector:v0.11.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
-          - --leader-election-namespace=$(POD_NAMESPACE)
+          - --leader-election-namespace=kube-system
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -8178,7 +6108,7 @@ spec:
                 fieldPath: metadata.namespace
           resources:
             {}
-            
+
 
 ---
 # Source: cert-manager/templates/deployment.yaml
@@ -8192,7 +6122,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
 spec:
   replicas: 1
   selector:
@@ -8208,7 +6138,7 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance:  cert-manager
         app.kubernetes.io/managed-by: Tiller
-        helm.sh/chart: cert-manager-v0.10.1
+        helm.sh/chart: cert-manager-v0.11.0
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -8217,12 +6147,12 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.10.1"
+          image: "quay.io/jetstack/cert-manager-controller:v0.11.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
-          - --leader-election-namespace=$(POD_NAMESPACE)
+          - --leader-election-namespace=kube-system
           - --webhook-namespace=$(POD_NAMESPACE)
           - --webhook-ca-secret=cert-manager-webhook-ca
           - --webhook-serving-secret=cert-manager-webhook-tls
@@ -8238,7 +6168,7 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
-            
+
 
 ---
 # Source: cert-manager/templates/webhook-deployment.yaml
@@ -8252,7 +6182,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
 spec:
   replicas: 1
   selector:
@@ -8268,13 +6198,13 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance:  cert-manager
         app.kubernetes.io/managed-by: Tiller
-        helm.sh/chart: cert-manager-v0.10.1
+        helm.sh/chart: cert-manager-v0.11.0
       annotations:
     spec:
       serviceAccountName: cert-manager-webhook
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-webhook:v0.10.1"
+          image: "quay.io/jetstack/cert-manager-webhook:v0.11.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -8288,7 +6218,7 @@ spec:
                 fieldPath: metadata.namespace
           resources:
             {}
-            
+
           volumeMounts:
           - name: certs
             mountPath: /certs
@@ -8301,17 +6231,17 @@ spec:
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
-  name: v1beta1.webhook.certmanager.k8s.io
+  name: v1beta1.webhook.cert-manager.io
   labels:
     app: webhook
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
   annotations:
-    certmanager.k8s.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-tls"
+    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-tls"
 spec:
-  group: webhook.certmanager.k8s.io
+  group: webhook.cert-manager.io
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:
@@ -8329,16 +6259,16 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
   annotations:
-    certmanager.k8s.io/inject-apiserver-ca: "true"
+    cert-manager.io/inject-apiserver-ca: "true"
 webhooks:
-  - name: webhook.certmanager.k8s.io
+  - name: webhook.cert-manager.io
     rules:
       - apiGroups:
-          - "certmanager.k8s.io"
+          - "cert-manager.io"
         apiVersions:
-          - v1alpha1
+          - v1alpha2
         operations:
           - CREATE
           - UPDATE
@@ -8354,7 +6284,31 @@ webhooks:
       service:
         name: kubernetes
         namespace: default
-        path: /apis/webhook.certmanager.k8s.io/v1beta1/mutations
+        path: /apis/webhook.cert-manager.io/v1beta1/mutations
+---
+# Source: cert-manager/charts/cainjector/templates/psp-clusterrole.yaml
+
+
+---
+# Source: cert-manager/charts/cainjector/templates/psp-clusterrolebinding.yaml
+
+
+---
+# Source: cert-manager/charts/cainjector/templates/psp.yaml
+
+
+---
+# Source: cert-manager/templates/psp-clusterrole.yaml
+
+
+---
+# Source: cert-manager/templates/psp-clusterrolebinding.yaml
+
+
+---
+# Source: cert-manager/templates/psp.yaml
+
+
 ---
 # Source: cert-manager/templates/servicemonitor.yaml
 
@@ -8370,14 +6324,14 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance:  cert-manager
     app.kubernetes.io/managed-by: Tiller
-    helm.sh/chart: cert-manager-v0.10.1
+    helm.sh/chart: cert-manager-v0.11.0
   annotations:
-    certmanager.k8s.io/inject-apiserver-ca: "true"
+    cert-manager.io/inject-apiserver-ca: "true"
 webhooks:
-  - name: webhook.certmanager.k8s.io
+  - name: webhook.cert-manager.io
     namespaceSelector:
       matchExpressions:
-      - key: "certmanager.k8s.io/disable-validation"
+      - key: "cert-manager.io/disable-validation"
         operator: "NotIn"
         values:
         - "true"
@@ -8387,9 +6341,9 @@ webhooks:
         - cert-manager
     rules:
       - apiGroups:
-          - "certmanager.k8s.io"
+          - "cert-manager.io"
         apiVersions:
-          - v1alpha1
+          - v1alpha2
         operations:
           - CREATE
           - UPDATE
@@ -8404,4 +6358,4 @@ webhooks:
       service:
         name: kubernetes
         namespace: default
-        path: /apis/webhook.certmanager.k8s.io/v1beta1/validations
+        path: /apis/webhook.cert-manager.io/v1beta1/validations

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,15 +8,15 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
   namespace: system
 spec:
   # $(SERVICE_NAME) and $(SERVICE_NAMESPACE) will be substituted by kustomize
-  commonName: $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
   - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
   issuerRef:
     kind: Issuer


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

Kubebuilder moved their generation to v1alpha2 and v0.11 https://github.com/kubernetes-sigs/kubebuilder/blob/master/testdata/project-v2/config/certmanager/certificate.yaml. This PR updates this repository, I'll update CAPA next.
