### PR TITLE
🐛 Fix verify-shellcheck to report errors

### DIFF
--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -33,8 +33,15 @@ TMP_DIR=$(mktemp -d)
 
 # cleanup on exit
 cleanup() {
+  ret=0
+  if [[ -s "${OUT}" ]]; then
+    echo "Found errors:"
+    cat "${OUT}"
+    ret=1
+  fi
   echo "Cleaning up..."
   rm -rf "${TMP_DIR}"
+  exit ${ret}
 }
 trap cleanup EXIT
 
@@ -55,9 +62,3 @@ FILES=$(find . -name "*.sh" | grep -v third_party)
 while read -r file; do
     "${TMP_DIR}/${VERSION}/shellcheck" -x "$file" >> "${OUT}" 2>&1
 done <<< "$FILES"
-
-if [[ -s "${OUT}" ]]; then
-  echo "Found errors:"
-  cat "${OUT}"
-  exit 1
-fi


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashish.amarnath@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
`hack/verify-shellcheck.sh` fails to report errors/ violations.
```
"${TMP_DIR}/${VERSION}/shellcheck" -x "$file" >> "${OUT}" 2>&1
```
when it encounters a violation, causes script to exit triggering the `cleanup` and the
```
  if [[ -s "${OUT}" ]]; then
    echo "Found errors:"
    cat "${OUT}"
    exit 1
  fi
```
above block wouldn't get executed.

e.g. of this failure
- https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/1715/pull-cluster-api-verify/1190490191438024704/build-log.txt
- https://github.com/kubernetes-sigs/cluster-api/pull/1715#issuecomment-549010465

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
