### PR TITLE
:warning: Set Machine phase to provisioned regardless of infrastructure readiness

### DIFF
--- a/controllers/machine_controller_phases_test.go
+++ b/controllers/machine_controller_phases_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioning))
 	})
 
-	It("Should set `Provisioned` when bootstrap and infra is ready", func() {
+	It("Should set `Running` when bootstrap and infra is ready", func() {
 		machine := defaultMachine.DeepCopy()
 		bootstrapConfig := defaultBootstrap.DeepCopy()
 		infraConfig := defaultInfra.DeepCopy()
@@ -206,6 +206,9 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		}, "status", "addresses")
 		Expect(err).NotTo(HaveOccurred())
 
+		// Set NodeRef.
+		machine.Status.NodeRef = &corev1.ObjectReference{Kind: "Node", Name: "machine-test-node"}
+
 		r := &MachineReconciler{
 			Client: fake.NewFakeClient(defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
 			Log:    log.Log,
@@ -213,14 +216,14 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		res, err := r.reconcile(context.Background(), defaultCluster, machine)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res.Requeue).To(BeTrue())
+		Expect(res.Requeue).To(BeFalse())
 		Expect(machine.Status.Addresses).To(HaveLen(2))
 
 		r.reconcilePhase(context.Background(), machine)
-		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioned))
+		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
 	})
 
-	It("Should set `Provisioned` when bootstrap and infra is ready with no Status.Addresses", func() {
+	It("Should set `Running` when bootstrap and infra is ready with no Status.Addresses", func() {
 		machine := defaultMachine.DeepCopy()
 		bootstrapConfig := defaultBootstrap.DeepCopy()
 		infraConfig := defaultInfra.DeepCopy()
@@ -239,6 +242,9 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		err = unstructured.SetNestedField(infraConfig.Object, "test://id-1", "spec", "providerID")
 		Expect(err).NotTo(HaveOccurred())
 
+		// Set NodeRef.
+		machine.Status.NodeRef = &corev1.ObjectReference{Kind: "Node", Name: "machine-test-node"}
+
 		r := &MachineReconciler{
 			Client: fake.NewFakeClient(defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
 			Log:    log.Log,
@@ -246,11 +252,11 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		res, err := r.reconcile(context.Background(), defaultCluster, machine)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res.Requeue).To(BeTrue())
+		Expect(res.Requeue).To(BeFalse())
 		Expect(machine.Status.Addresses).To(HaveLen(0))
 
 		r.reconcilePhase(context.Background(), machine)
-		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioned))
+		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
 	})
 
 	It("Should set `Running` when bootstrap, infra, and NodeRef is ready", func() {
@@ -298,6 +304,34 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		r.reconcilePhase(context.Background(), machine)
 		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
+	})
+
+	It("Should set `Provisioned` when there is a NodeRef but infra is not ready ", func() {
+		machine := defaultMachine.DeepCopy()
+		bootstrapConfig := defaultBootstrap.DeepCopy()
+		infraConfig := defaultInfra.DeepCopy()
+
+		// Set bootstrap ready.
+		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "...", "status", "bootstrapData")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set NodeRef.
+		machine.Status.NodeRef = &corev1.ObjectReference{Kind: "Node", Name: "machine-test-node"}
+
+		r := &MachineReconciler{
+			Client: fake.NewFakeClient(defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
+			Log:    log.Log,
+		}
+
+		res, err := r.reconcile(context.Background(), defaultCluster, machine)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Requeue).To(BeTrue())
+
+		r.reconcilePhase(context.Background(), machine)
+		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioned))
 	})
 
 	It("Should set `Deleting` when Machine is being deleted", func() {

--- a/docs/book/src/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/providers/v1alpha2-to-v1alpha3.md
@@ -60,3 +60,7 @@
 
 - Previously examples and tests were setting/checking for the label to be set to `true`.
 - The function `util.IsControlPlaneMachine` was previously checking for any value other than empty string, while now we only check if the associated label exists.
+    
+## Machine `Status.Phase` field set to `Provisioned` if a NodeRef is set but infrastructure is not ready
+
+ - The machine Status.Phase is set back to `Provisioned` if the infrastructure is not ready. This is only applicable if the infrastructure node status does not have any errors set.


### PR DESCRIPTION

**What this PR does / why we need it**:
If the infra machine turns to `not ready`, the machine controller was not updating the machine phase from `running`. 
Now will flip it back to `provisioned` and If there is an error message, the phase will be set to `failed`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1622 
