### PR TITLE
✨ Set cluster status phase to Provisioned after APIEndpoints are set

### DIFF
--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -49,8 +49,8 @@ func (r *ClusterReconciler) reconcilePhase(_ context.Context, cluster *clusterv1
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhaseProvisioning)
 	}
 
-	// Set the phase to "provisioned" if the infrastructure is ready.
-	if cluster.Status.InfrastructureReady {
+	// Set the phase to "provisioned" if the infrastructure is ready and APIEndpoints exists
+	if cluster.Status.InfrastructureReady && len(cluster.Status.APIEndpoints) > 0 {
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhaseProvisioned)
 	}
 

--- a/docs/book/src/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/providers/v1alpha2-to-v1alpha3.md
@@ -78,3 +78,8 @@
 
   They can be accessed by default via the `8080` metrics port on the cluster
   api controller manager.
+
+## Cluster `Status.Phase` transition to `Provisioned` after at least one APIEndpoint is available.
+
+- Cosmetic change to set Cluster `Status.Phase` to `Provisioned` after at least one APIEndpoint is available. Previously only InfrastructureReady was being used to transition to `Provisioned`, this change now requires at least one APIEndpoint as well.
+- See https://github.com/kubernetes-sigs/cluster-api/pull/1721/files.


### PR DESCRIPTION
**What this PR does / why we need it**:

Update cluster status phase to Provisioned after InfrastructureReady is true
and APIEndpoints are available. InfrastructureReady is set by provider
implementations to indicate that the provider is ready to be used and setting
cluster status to Provisioned just based on infrastructureReady can be a confusing
user experience. Additionally, add unit tests for reconcilePhase.

Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/1722
