### PR TITLE
✨Add metrics to machine and cluster controller

### DIFF
--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package metrics defines the metrics available for the cluster api
+// controllers.
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// ClusterControlPlaneReady is a metric that is set to 1 if the cluster
+	// control plane is ready and 0 if it is not.
+	ClusterControlPlaneReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "capi_cluster_control_plane_ready",
+			Help: "Cluster control plane is ready if set to 1 and not if 0.",
+		},
+		[]string{"cluster", "namespace"},
+	)
+
+	// ClusterInfrastructureReady is a metric that is set to 1 if the cluster
+	// infrastructure is ready and 0 if it is not.
+	ClusterInfrastructureReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "capi_cluster_infrastructure_ready",
+			Help: "Cluster infrastructure is ready if set to 1 and not if 0.",
+		},
+		[]string{"cluster", "namespace"},
+	)
+
+	// ClusterKubeconfigReady  is a metric that is set to 1 if the cluster
+	// kubeconfig secret has been created and 0 if it is not.
+	ClusterKubeconfigReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "capi_cluster_kubeconfig_ready",
+			Help: "Cluster kubeconfig is ready if set to 1 and not if 0.",
+		},
+		[]string{"cluster", "namespace"},
+	)
+
+	// ClusterErrorSet is a metric that is set to 1 if the cluster ErrorReason
+	// or ErrorMessage is set and 0 if it is not.
+	ClusterErrorSet = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "capi_cluster_error_set",
+			Help: "Cluster error messsage or reason is set if metric is 1.",
+		},
+		[]string{"cluster", "namespace"},
+	)
+
+	// MachineBootstrapReady is a metric that is set to 1 if machine bootstrap
+	// is ready and 0 if it is not.
+	MachineBootstrapReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "capi_machine_bootstrap_ready",
+			Help: "Machine Boostrap is ready if set to 1 and not if 0.",
+		},
+		[]string{"machine", "namespace", "cluster"},
+	)
+
+	// MachineInfrastructureReady  is a metric that is set to 1 if machine
+	// infrastructure is ready and 0 if it is not.
+	MachineInfrastructureReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "capi_machine_infrastructure_ready",
+			Help: "Machine InfrastructureRef is ready if set to 1 and not if 0.",
+		},
+		[]string{"machine", "namespace", "cluster"},
+	)
+
+	// MachineNodeReady  is a metric that is set to 1 if machine node is ready
+	// and 0 if it is not.
+	MachineNodeReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "capi_machine_node_ready",
+			Help: "Machine NodeRef is ready if set to 1 and not if 0.",
+		},
+		[]string{"machine", "namespace", "cluster"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		ClusterControlPlaneReady,
+		ClusterInfrastructureReady,
+		ClusterKubeconfigReady,
+		ClusterErrorSet,
+		MachineBootstrapReady,
+		MachineInfrastructureReady,
+		MachineNodeReady,
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-logr/logr v0.1.0
-	github.com/gogo/protobuf v1.2.1 // indirect
+	github.com/gogo/protobuf v1.2.1
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/gophercloud/gophercloud v0.3.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
@@ -15,6 +15,8 @@ require (
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang v1.0.0
+	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
 	github.com/prometheus/procfs v0.0.5 // indirect
 	github.com/sergi/go-diff v1.0.0
 	github.com/spf13/cobra v0.0.5


### PR DESCRIPTION
Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds prometheus metrics to the machine and cluster controller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1477 
