### PR TITLE
reset cluster.status.ControlPlaneInitialized when all control planes are removed

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -341,10 +341,6 @@ func splitMachineList(list *clusterv1.MachineList) (*clusterv1.MachineList, *clu
 func (r *ClusterReconciler) reconcileControlPlaneInitialized(ctx context.Context, cluster *clusterv1.Cluster) error {
 	logger := r.Log.WithValues("cluster", cluster.Name, "namespace", cluster.Namespace)
 
-	if cluster.Status.ControlPlaneInitialized {
-		return nil
-	}
-
 	machines, err := getActiveMachinesInCluster(ctx, r.Client, cluster.Namespace, cluster.Name)
 	if err != nil {
 		logger.Error(err, "Error getting machines in cluster")
@@ -358,6 +354,7 @@ func (r *ClusterReconciler) reconcileControlPlaneInitialized(ctx context.Context
 		}
 	}
 
+	cluster.Status.ControlPlaneInitialized = false
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: JunLi <lijun.git@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Reset cluster.status.ControlPlaneInitialized to false when all control plane machines are removed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/1746
