### PR TITLE
Fix: set semphore information for control plane init lock

### DIFF
--- a/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
+++ b/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
@@ -149,7 +149,7 @@ func (s semaphore) information() (*information, error) {
 	return li, nil
 }
 
-func (s semaphore) setInformation(information *information) error {
+func (s *semaphore) setInformation(information *information) error {
 	b, err := json.Marshal(information)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal semaphore information")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Currently, the ControlPlaneInitMutex in `bootstrap/kubeadm/controllers/control_plane_init_mutex.go` does not set the `lock-information`. The type of `s` below should be a pointer. 

```golang
func (s semaphore) setInformation(information *information) error {
	b, err := json.Marshal(information)
	if err != nil {
		return errors.Wrap(err, "failed to marshal semaphore information")
	}
	s.Data = map[string]string{}
	s.Data[semaphoreInformationKey] = string(b)
	return nil
}
```

