### PR TITLE
📖 Fix components file link for docker provider

### DIFF
--- a/docs/book/src/tasks/installation.md
+++ b/docs/book/src/tasks/installation.md
@@ -168,7 +168,7 @@ curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-azure" asset:"
 Check the [Docker provider releases](https://github.com/kubernetes-sigs/cluster-api-provider-docker/releases) for an up-to-date components file.
 
 ```bash
-kubectl create -f {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-docker" asset:"provider_components.yaml" version:"0.2.x"}}
+kubectl create -f {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-docker" asset:"provider-components.yaml" version:"0.2.x"}}
 ```
 
 {{#/tab }}


### PR DESCRIPTION
**What this PR does / why we need it**:

There's a docs bug in "QuickStart > Install Infrastructure Provider > Docker"

The code snippet is:

`kubectl create -f https://github.com/kubernetes-sigs/cluster-api-provider docker/releases/download/v0.2.1/provider_components.yaml`

I updated `provider_components` with `provider-components`, and tested locally with mdbook.

**Which issue(s) this PR fixes** :
Fixes #1750
