### PR TITLE
📖Add documentation for metrics

### DIFF
--- a/docs/book/src/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/providers/v1alpha2-to-v1alpha3.md
@@ -60,7 +60,21 @@
 
 - Previously examples and tests were setting/checking for the label to be set to `true`.
 - The function `util.IsControlPlaneMachine` was previously checking for any value other than empty string, while now we only check if the associated label exists.
-    
+
 ## Machine `Status.Phase` field set to `Provisioned` if a NodeRef is set but infrastructure is not ready
 
  - The machine Status.Phase is set back to `Provisioned` if the infrastructure is not ready. This is only applicable if the infrastructure node status does not have any errors set.
+
+## Metrics
+
+- The cluster and machine controllers expose the following prometheus metrics.
+  - `capi_cluster_control_plane_ready`: Cluster control plane is ready if set to 1 and not if 0.
+  - `capi_cluster_infrastructure_ready`: Cluster infrastructure is ready if set to 1 and not if 0.
+  - `capi_cluster_kubeconfig_ready`: Cluster kubeconfig is ready if set to 1 and not if 0.
+  - `capi_cluster_error_set`: Cluster ErrorMesssage or ErrorReason is set if metric is 1.
+  - `capi_machine_bootstrap_ready`: Machine Boostrap is ready if set to 1 and not if 0.
+  - `capi_machine_infrastructure_ready`: Machine InfrastructureRef is ready if set to 1 and not if 0.
+  - `capi_machine_node_ready`: Machine NodeRef is ready if set to 1 and not if 0.
+
+  They can be accessed by default via the `8080` metrics port on the cluster
+  api controller manager.


### PR DESCRIPTION
Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR documents the metrics exposed in the cluster api controller manager.
https://github.com/kubernetes-sigs/cluster-api/pull/1736#issuecomment-553474259

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1477