### PR TITLE
🐛 Use go1.12 instead of go1.13 for the e2e framework

### DIFF
--- a/test/framework/go.mod
+++ b/test/framework/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api/test/framework
 
-go 1.13
+go 1.12
 
 require (
 	github.com/onsi/ginkgo v1.10.3


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR uses go 1.12 instead of go 1.13 for the e2e framework

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1773 

/assign @ncdc 
