### PR TITLE
✨ Add Validation webhooks to cluster api manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 		crd \
 		rbac:roleName=manager-role \
 		output:crd:dir=./config/crd/bases \
+		output:webhook:dir=./config/webhook \
 		webhook
 	$(CONTROLLER_GEN) \
 		paths=./bootstrap/kubeadm/api/... \

--- a/api/v1alpha3/machine_webhook.go
+++ b/api/v1alpha3/machine_webhook.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (m *Machine) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(m).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1alpha3-machine,mutating=false,failurePolicy=fail,groups=cluster.x-k8s.io,resources=machines,versions=v1alpha3,name=validation.machine.cluster.x-k8s.io
+
+var _ webhook.Validator = &Machine{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (m *Machine) ValidateCreate() error {
+	return m.validate()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (m *Machine) ValidateUpdate(old runtime.Object) error {
+	return m.validate()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (m *Machine) ValidateDelete() error {
+	return nil
+}
+
+func (m *Machine) validate() error {
+	var allErrs field.ErrorList
+	if m.Spec.Bootstrap.ConfigRef == nil && m.Spec.Bootstrap.Data == nil {
+		allErrs = append(
+			allErrs,
+			field.Required(field.NewPath("spec", "bootstrap", "data"), "expected spec.bootstrap.data or spec.bootstrap.configRef to be populated"),
+		)
+
+	}
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(GroupVersion.WithKind("Machine").GroupKind(), m.Name, allErrs)
+}

--- a/api/v1alpha3/machine_webhook_test.go
+++ b/api/v1alpha3/machine_webhook_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestMachineBootstrapValidation(t *testing.T) {
+	data := "some bootstrap data"
+	tests := []struct {
+		name      string
+		bootstrap Bootstrap
+		expectErr bool
+	}{
+		{
+			name:      "should return error if configref and data are nil",
+			bootstrap: Bootstrap{ConfigRef: nil, Data: nil},
+			expectErr: true,
+		},
+		{
+			name:      "should not return error if data is set",
+			bootstrap: Bootstrap{ConfigRef: nil, Data: &data},
+			expectErr: false,
+		},
+		{
+			name:      "should not return error if config ref is set",
+			bootstrap: Bootstrap{ConfigRef: &corev1.ObjectReference{}, Data: nil},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			m := &Machine{
+				Spec: MachineSpec{Bootstrap: tt.bootstrap},
+			}
+			if tt.expectErr {
+				err := m.ValidateCreate()
+				g.Expect(err).To(gomega.HaveOccurred())
+				err = m.ValidateUpdate(nil)
+				g.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				g.Expect(m.ValidateCreate()).To(gomega.Succeed())
+				g.Expect(m.ValidateUpdate(nil)).To(gomega.Succeed())
+			}
+		})
+	}
+}

--- a/api/v1alpha3/machinedeployment_webhook.go
+++ b/api/v1alpha3/machinedeployment_webhook.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (m *MachineDeployment) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(m).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1alpha3-machinedeployment,mutating=false,failurePolicy=fail,groups=cluster.x-k8s.io,resources=machinedeployments,versions=v1alpha3,name=validation.machinedeployment.cluster.x-k8s.io
+
+var _ webhook.Validator = &MachineDeployment{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (m *MachineDeployment) ValidateCreate() error {
+	return m.validate()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (m *MachineDeployment) ValidateUpdate(old runtime.Object) error {
+	return m.validate()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (m *MachineDeployment) ValidateDelete() error {
+	return nil
+}
+
+func (m *MachineDeployment) validate() error {
+	var allErrs field.ErrorList
+	selector, err := metav1.LabelSelectorAsSelector(&m.Spec.Selector)
+	if err != nil {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec", "selector"), m.Spec.Selector, err.Error()),
+		)
+	} else if !selector.Matches(labels.Set(m.Spec.Template.Labels)) {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				field.NewPath("spec", "template", "labels"),
+				m.Spec.Template.Labels,
+				fmt.Sprintf("must match spec.selector %q", selector.String()),
+			),
+		)
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(GroupVersion.WithKind("MachineDeployment").GroupKind(), m.Name, allErrs)
+}

--- a/api/v1alpha3/machinedeployment_webhook_test.go
+++ b/api/v1alpha3/machinedeployment_webhook_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMachineDeploymentValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectors map[string]string
+		labels    map[string]string
+		expectErr bool
+	}{
+		{
+			name:      "should return error on mismatch",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "baz"},
+			expectErr: true,
+		},
+		{
+			name:      "should return error on missing labels",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"": ""},
+			expectErr: true,
+		},
+		{
+			name:      "should return error if all selectors don't match",
+			selectors: map[string]string{"foo": "bar", "hello": "world"},
+			labels:    map[string]string{"foo": "bar"},
+			expectErr: true,
+		},
+		{
+			name:      "should not return error on match",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "bar"},
+			expectErr: false,
+		},
+		{
+			name:      "should return error for invalid selector",
+			selectors: map[string]string{"-123-foo": "bar"},
+			labels:    map[string]string{"-123-foo": "bar"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			md := &MachineDeployment{
+				Spec: MachineDeploymentSpec{
+					Selector: v1.LabelSelector{
+						MatchLabels: tt.selectors,
+					},
+					Template: MachineTemplateSpec{
+						ObjectMeta: ObjectMeta{
+							Labels: tt.labels,
+						},
+					},
+				},
+			}
+			if tt.expectErr {
+				err := md.ValidateCreate()
+				g.Expect(err).To(gomega.HaveOccurred())
+				err = md.ValidateUpdate(nil)
+				g.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				g.Expect(md.ValidateCreate()).To(gomega.Succeed())
+				g.Expect(md.ValidateUpdate(nil)).To(gomega.Succeed())
+			}
+		})
+	}
+}

--- a/api/v1alpha3/machineset_webhook.go
+++ b/api/v1alpha3/machineset_webhook.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func (m *MachineSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(m).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1alpha3-machineset,mutating=false,failurePolicy=fail,groups=cluster.x-k8s.io,resources=machinesets,versions=v1alpha3,name=validation.machineset.cluster.x-k8s.io
+
+var _ webhook.Validator = &MachineSet{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (m *MachineSet) ValidateCreate() error {
+	return m.validate()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (m *MachineSet) ValidateUpdate(old runtime.Object) error {
+	return m.validate()
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (m *MachineSet) ValidateDelete() error {
+	return nil
+}
+
+func (m *MachineSet) validate() error {
+	var allErrs field.ErrorList
+	selector, err := metav1.LabelSelectorAsSelector(&m.Spec.Selector)
+	if err != nil {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec", "selector"), m.Spec.Selector, err.Error()),
+		)
+	} else if !selector.Matches(labels.Set(m.Spec.Template.Labels)) {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				field.NewPath("spec", "template", "labels"),
+				m.Spec.Template.Labels,
+				fmt.Sprintf("must match spec.selector %q", selector.String()),
+			),
+		)
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(GroupVersion.WithKind("MachineSet").GroupKind(), m.Name, allErrs)
+}

--- a/api/v1alpha3/machineset_webhook_test.go
+++ b/api/v1alpha3/machineset_webhook_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMachineSetLabelSelectorMatchValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectors map[string]string
+		labels    map[string]string
+		expectErr bool
+	}{
+		{
+			name:      "should return error on mismatch",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "baz"},
+			expectErr: true,
+		},
+		{
+			name:      "should return error on missing labels",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"": ""},
+			expectErr: true,
+		},
+		{
+			name:      "should return error if all selectors don't match",
+			selectors: map[string]string{"foo": "bar", "hello": "world"},
+			labels:    map[string]string{"foo": "bar"},
+			expectErr: true,
+		},
+		{
+			name:      "should not return error on match",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "bar"},
+			expectErr: false,
+		},
+		{
+			name:      "should return error for invalid selector",
+			selectors: map[string]string{"-123-foo": "bar"},
+			labels:    map[string]string{"-123-foo": "bar"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			ms := &MachineSet{
+				Spec: MachineSetSpec{
+					Selector: v1.LabelSelector{
+						MatchLabels: tt.selectors,
+					},
+					Template: MachineTemplateSpec{
+						ObjectMeta: ObjectMeta{
+							Labels: tt.labels,
+						},
+					},
+				},
+			}
+			if tt.expectErr {
+				err := ms.ValidateCreate()
+				g.Expect(err).To(gomega.HaveOccurred())
+				err = ms.ValidateUpdate(nil)
+				g.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				g.Expect(ms.ValidateCreate()).To(gomega.Succeed())
+				g.Expect(ms.ValidateUpdate(nil)).To(gomega.Succeed())
+			}
+		})
+	}
+
+}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,5 +1,3 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
@@ -13,7 +11,7 @@ resources:
 - bases/cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-# patches:
+patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_clusters.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,3 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 # Adds namespace to all resources.
 namespace: capi-system
 
@@ -14,7 +12,7 @@ namePrefix: capi-
 #commonLabels:
 #  someName: someValue
 
-resources:
+bases:
 - ../crd
 - ../rbac
 - ../manager
@@ -39,10 +37,8 @@ patchesStrategicMerge:
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
 #- manager_prometheus_metrics_patch.yaml
-
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
 - manager_webhook_patch.yaml
-
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -50,3 +50,57 @@ webhooks:
     - UPDATE
     resources:
     - kubeadmcontrolplanes
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-cluster-x-k8s-io-v1alpha3-machine
+  failurePolicy: Fail
+  name: validation.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-cluster-x-k8s-io-v1alpha3-machinedeployment
+  failurePolicy: Fail
+  name: validation.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-cluster-x-k8s-io-v1alpha3-machineset
+  failurePolicy: Fail
+  name: validation.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -152,14 +152,6 @@ func (r *MachineReconciler) reconcileExternal(ctx context.Context, m *clusterv1.
 
 // reconcileBootstrap reconciles the Spec.Bootstrap.ConfigRef object on a Machine.
 func (r *MachineReconciler) reconcileBootstrap(ctx context.Context, m *clusterv1.Machine) error {
-	// TODO(vincepri): Move this validation in kubebuilder / webhook.
-	if m.Spec.Bootstrap.ConfigRef == nil && m.Spec.Bootstrap.Data == nil {
-		return errors.Errorf(
-			"Expected at least one of `Bootstrap.ConfigRef` or `Bootstrap.Data` to be populated for Machine %q in namespace %q",
-			m.Name, m.Namespace,
-		)
-	}
-
 	// Call generic external reconciler if we have an external reference.
 	var bootstrapConfig *unstructured.Unstructured
 	if m.Spec.Bootstrap.ConfigRef != nil {

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -38,6 +38,7 @@ import (
 
 func TestMachineFinalizer(t *testing.T) {
 	RegisterTestingT(t)
+	bootstrapData := "some valid data"
 	clusterCorrectMeta := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -51,6 +52,9 @@ func TestMachineFinalizer(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: clusterv1.MachineSpec{
+			Bootstrap: clusterv1.Bootstrap{
+				Data: &bootstrapData,
+			},
 			ClusterName: "valid-cluster",
 		},
 	}
@@ -62,6 +66,9 @@ func TestMachineFinalizer(t *testing.T) {
 			Finalizers: []string{"some-other-finalizer"},
 		},
 		Spec: clusterv1.MachineSpec{
+			Bootstrap: clusterv1.Bootstrap{
+				Data: &bootstrapData,
+			},
 			ClusterName: "valid-cluster",
 		},
 	}
@@ -127,6 +134,7 @@ func TestMachineFinalizer(t *testing.T) {
 
 func TestMachineOwnerReference(t *testing.T) {
 	RegisterTestingT(t)
+	bootstrapData := "some valid data"
 	testCluster := &clusterv1.Cluster{
 		TypeMeta:   metav1.TypeMeta{Kind: "Cluster", APIVersion: clusterv1.GroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-cluster"},
@@ -148,6 +156,9 @@ func TestMachineOwnerReference(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: clusterv1.MachineSpec{
+			Bootstrap: clusterv1.Bootstrap{
+				Data: &bootstrapData,
+			},
 			ClusterName: "test-cluster",
 		},
 	}
@@ -168,6 +179,9 @@ func TestMachineOwnerReference(t *testing.T) {
 			},
 		},
 		Spec: clusterv1.MachineSpec{
+			Bootstrap: clusterv1.Bootstrap{
+				Data: &bootstrapData,
+			},
 			ClusterName: "test-cluster",
 		},
 	}

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -148,17 +148,6 @@ func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, d *clusterv
 		}
 	}
 
-	// Make sure that label selector can match the template's labels.
-	// TODO(vincepri): Move to a validation (admission) webhook when supported.
-	selector, err := metav1.LabelSelectorAsSelector(&d.Spec.Selector)
-	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to parse MachineDeployment %q label selector", d.Name)
-	}
-
-	if !selector.Matches(labels.Set(d.Spec.Template.Labels)) {
-		return ctrl.Result{}, errors.Errorf("failed validation on MachineDeployment %q label selector, cannot match Machine template labels", d.Name)
-	}
-
 	msList, err := r.getMachineSetsForDeployment(d)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/main.go
+++ b/main.go
@@ -99,12 +99,10 @@ func main() {
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 
 	flag.DurationVar(&kubeadmcontrollers.DefaultTokenTTL, "bootstrap-token-ttl", 15*time.Minute,
-		"The amount of time the bootstrap token will be valid",
-	)
+		"The amount of time the bootstrap token will be valid")
 
 	flag.IntVar(&webhookPort, "webhook-port", 9443,
-		"Webhook server port (set to 0 to disable)",
-	)
+		"Webhook Server port (set to 0 to disable)")
 
 	flag.Parse()
 
@@ -185,6 +183,10 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Machine")
 			os.Exit(1)
 		}
+		if err = (&clusterv1alpha3.Machine{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "Machine")
+			os.Exit(1)
+		}
 
 		if err = (&clusterv1alpha2.MachineList{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "MachineList")
@@ -195,6 +197,10 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "MachineSet")
 			os.Exit(1)
 		}
+		if err = (&clusterv1alpha3.MachineSet{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "MachineSet")
+			os.Exit(1)
+		}
 
 		if err = (&clusterv1alpha2.MachineSetList{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "MachineSetList")
@@ -202,6 +208,10 @@ func main() {
 		}
 
 		if err = (&clusterv1alpha2.MachineDeployment{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "MachineDeployment")
+			os.Exit(1)
+		}
+		if err = (&clusterv1alpha3.MachineDeployment{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "MachineDeployment")
 			os.Exit(1)
 		}
@@ -216,8 +226,8 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	// +kubebuilder:scaffold:builder
 
+	// +kubebuilder:scaffold:builder
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")


### PR DESCRIPTION
Performs validation for Machines, MachineSets and MachineDeployments.
For Machines it validates that Bootstrap has either ConfigRef or Data
set.
For MachineSets and MachineDeployments it verifies selectors match
template labels.

Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Performs validation for Machines, MachineSets and MachineDeployments.
For Machines it validates that Bootstrap has either ConfigRef or Data set.
For MachineSets and MachineDeployments it verifies selectors match template labels.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1757 
