### PR TITLE
Update documentation due to `kind get kubeconfig-path` deprecation

### DIFF
--- a/docs/book/src/tasks/installation.md
+++ b/docs/book/src/tasks/installation.md
@@ -18,7 +18,7 @@ Cluster API requires an existing kubernetes cluster accessible via kubectl, choo
 
 <h1>Warning</h1>
 
-**Minimum supported version**: v0.6.x
+**Minimum [kind] supported version**: v0.6.x
 
 [kind] is not designed for production use, and is intended for development environments only.
 
@@ -26,6 +26,7 @@ Cluster API requires an existing kubernetes cluster accessible via kubectl, choo
 
   ```bash
   kind create cluster --name=clusterapi
+  kubectl cluster-info --context kind-clusterapi
   ```
 {{#/tab }}
 {{#tab Docker}}
@@ -34,8 +35,9 @@ Cluster API requires an existing kubernetes cluster accessible via kubectl, choo
 
 <h1>Warning</h1>
 
-[kind] is not designed for production use, and is intended for development environments only.
+**Minimum [kind] supported version**: v0.6.x
 
+[kind] is not designed for production use, and is intended for development environments only.
 </aside>
 
 <aside class="note warning">
@@ -59,7 +61,7 @@ nodes:
         containerPath: /var/run/docker.sock
 EOF
   kind create cluster --config ./kind-cluster-with-extramounts.yaml --name clusterapi
-  export KUBECONFIG="$(kind get kubeconfig-path --name="clusterapi")"
+  kubectl cluster-info --context kind-clusterapi
   ```
 {{#/tab }}
 {{#/tabs }}


### PR DESCRIPTION
As of kind v0.6.0, kind now exports/merges kubeconfig much like
minikube. As a result, one need only change context rather than pointing
at a separate kubeconfig.

:book:

**What this PR does / why we need it**:
Fixes installation documentation flow due to change in `kind` behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1796 
