### PR TITLE
*: Consitently use DeletionTimestamp.IsZero

### DIFF
--- a/cmd/clusterctl/phases/pivot.go
+++ b/cmd/clusterctl/phases/pivot.go
@@ -402,8 +402,8 @@ func moveMachineSet(from sourceClient, to targetClient, ms *clusterv1.MachineSet
 func moveMachines(from sourceClient, to targetClient, machines []*clusterv1.Machine) error {
 	machineNames := make([]string, 0, len(machines))
 	for _, m := range machines {
-		if m.DeletionTimestamp != nil {
-			klog.V(4).Infof("Skipping to move deleted machine: %q", m.Name)
+		if !m.DeletionTimestamp.IsZero() {
+			klog.V(4).Infof("Do not move machine with deletion timestamp %s: %q", m.DeletionTimestamp, m.Name)
 			continue
 		}
 		machineNames = append(machineNames, m.Name)

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -93,7 +93,7 @@ func (r *MachineDeploymentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, 
 
 	// Ignore deleted MachineDeployments, this can happen when foregroundDeletion
 	// is enabled
-	if d.DeletionTimestamp != nil {
+	if !d.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/machinedeployment_sync.go
+++ b/controllers/machinedeployment_sync.go
@@ -464,7 +464,7 @@ func (r *MachineDeploymentReconciler) cleanupDeployment(oldMSs []*clusterv1.Mach
 
 	// Avoid deleting machine set with deletion timestamp set
 	aliveFilter := func(ms *clusterv1.MachineSet) bool {
-		return ms != nil && ms.ObjectMeta.DeletionTimestamp == nil
+		return ms != nil && ms.ObjectMeta.DeletionTimestamp.IsZero()
 	}
 
 	cleanableMSes := mdutil.FilterMachineSets(oldMSs, aliveFilter)
@@ -484,7 +484,7 @@ func (r *MachineDeploymentReconciler) cleanupDeployment(oldMSs []*clusterv1.Mach
 		}
 
 		// Avoid delete machine set with non-zero replica counts
-		if ms.Status.Replicas != 0 || *(ms.Spec.Replicas) != 0 || ms.Generation > ms.Status.ObservedGeneration || ms.DeletionTimestamp != nil {
+		if ms.Status.Replicas != 0 || *(ms.Spec.Replicas) != 0 || ms.Generation > ms.Status.ObservedGeneration || !ms.DeletionTimestamp.IsZero() {
 			continue
 		}
 

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -411,7 +411,7 @@ func shouldExcludeMachine(machineSet *clusterv1.MachineSet, machine *clusterv1.M
 		logger.V(4).Info("Machine is not controlled by machineset", "machine", machine.Name)
 		return true
 	}
-	return machine.ObjectMeta.DeletionTimestamp != nil
+	return !machine.ObjectMeta.DeletionTimestamp.IsZero()
 }
 
 // adoptOrphan sets the MachineSet as a controller OwnerReference to the Machine.

--- a/controllers/machineset_delete_policy.go
+++ b/controllers/machineset_delete_policy.go
@@ -45,7 +45,7 @@ const (
 
 // maps the creation timestamp onto the 0-100 priority range
 func oldestDeletePriority(machine *clusterv1.Machine) deletePriority {
-	if machine.DeletionTimestamp != nil && !machine.DeletionTimestamp.IsZero() {
+	if !machine.DeletionTimestamp.IsZero() {
 		return mustDelete
 	}
 	if machine.ObjectMeta.Annotations != nil && machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" {
@@ -65,7 +65,7 @@ func oldestDeletePriority(machine *clusterv1.Machine) deletePriority {
 }
 
 func newestDeletePriority(machine *clusterv1.Machine) deletePriority {
-	if machine.DeletionTimestamp != nil && !machine.DeletionTimestamp.IsZero() {
+	if !machine.DeletionTimestamp.IsZero() {
 		return mustDelete
 	}
 	if machine.ObjectMeta.Annotations != nil && machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" {
@@ -78,7 +78,7 @@ func newestDeletePriority(machine *clusterv1.Machine) deletePriority {
 }
 
 func randomDeletePolicy(machine *clusterv1.Machine) deletePriority {
-	if machine.DeletionTimestamp != nil && !machine.DeletionTimestamp.IsZero() {
+	if !machine.DeletionTimestamp.IsZero() {
 		return mustDelete
 	}
 	if machine.ObjectMeta.Annotations != nil && machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" {

--- a/docs/proposals/20190610-machine-states-preboot-bootstrapping.md
+++ b/docs/proposals/20190610-machine-states-preboot-bootstrapping.md
@@ -323,7 +323,7 @@ MachinePhaseDeleting = MachinePhaseType("deleting")
 ```
 
 #### Transition Conditions
-- `Machine.ObjectMeta.DeletionTimestamp` is not `<nil>`
+- `Machine.ObjectMeta.DeletionTimestamp` is not zero.
 
 #### Expectations
 - Node associated should be drained and cordoned.
@@ -339,9 +339,9 @@ MachinePhaseDeleted = MachinePhaseType("deleted")
 ```
 
 #### Transition Conditions
-- `Machine.ObjectMeta.DeletionTimestamp` is not `<nil>`
-- (optional) `Machine.Bootstrap.ConfigRef` -> `ObjectMeta.DeletionTimestamp` is not `<nil>`
-- `Machine.Spec.InfrastructureRef`-> `ObjectMeta.DeletionTimestamp` is not `<nil>`
+- `Machine.ObjectMeta.DeletionTimestamp` is not zero.
+- (optional) `Machine.Bootstrap.ConfigRef` -> `ObjectMeta.DeletionTimestamp` is not zero.
+- `Machine.Spec.InfrastructureRef`-> `ObjectMeta.DeletionTimestamp` is not zero.
 
 #### Expectations
 - Machine controller should remove finalizer.


### PR DESCRIPTION
[`IsZero`][1] includes a `nil` check.

[1]: https://github.com/kubernetes/apimachinery/blob/641a75999153845d3b1dd839555903869beb7fec/pkg/apis/meta/v1/time.go#L60-L66