### PR TITLE
🏃 kustomize: include KubeadmControlPlane

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - bases/cluster.x-k8s.io_machinedeployments.yaml
 - bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
 - bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+- bases/cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 # patches:


### PR DESCRIPTION
**What this PR does / why we need it**:
Include KubeadmControlPlane in the kustomize config so it gets
installed.