### PR TITLE
Fixing quick-start.md

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -480,6 +480,7 @@ spec:
       apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
       kind: KubeadmConfig
       name: capi-quickstart-controlplane-0
+      namespace: default
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
     kind: VSphereMachine


### PR DESCRIPTION
Fix for the error related to the missing 'bootstrap.configRef.namespace'. The actual error message is this  - controller.go:218] controller-runtime/controller "msg"="Reconciler error" "error"="failed to reconcile cloud config secret for VSphereCluster default/capi-quickstart: failed to get client for Cluster default/capi-quickstart: failed to retrieve kubeconfig secret for Cluster \"capi-quickstart\" in namespace \"default\": Secret \"capi-quickstart-kubeconfig\" not found"  "controller"="vspherecluster" "request"={"Namespace":"default","Name":"capi-quickstart"}

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
