### PR TITLE
adding note about envsubst application

### DIFF
--- a/docs/book/src/tasks/installation.md
+++ b/docs/book/src/tasks/installation.md
@@ -129,6 +129,8 @@ Check the [AWS provider releases] for an up-to-date components file.
 # them in a value to be stored in a Kubernetes Secret.
 export AWS_B64ENCODED_CREDENTIALS=$(clusterawsadm alpha bootstrap encode-aws-credentials)
 
+The `envsubst` application is provided by the `gettext` package on Linux and via Brew on MacOS.
+
 # Create the components.
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"infrastructure-components.yaml" version:"0.4.x"}} \
   | envsubst \


### PR DESCRIPTION
:book:

**What this PR does / why we need it**:

Small add-in to the quickstart guide to help lower the barrier for novice users. At least on Mac OS, `envsubst` isn't installed by default, and is provided using Brew with `gettext`. That relationship isn't obvious (at least not to me). An additional note to handle the dependency will help prevent a new user from tripping up during the quickstart guide.
