### PR TITLE
📖 dead contributor and conduct links on cluster-api.sigs.k8s.io website

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,13 @@ API design. Because of this, all of the codebase is rapidly changing.
 Pull Requests are very welcome!
 See the [issue tracker] if you're unsure where to start, or feel free to reach out to discuss.
 
-See also: our own [contributor guide] and the Kubernetes [community page].
+See also: our own [contributor guide](CONTRIBUTING.md) and the Kubernetes [community page].
 
 ### Code of conduct
 
-Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct].
+Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).
 
 [community page]: https://kubernetes.io/community
-[Kubernetes Code of Conduct]: https://github.com/kubernetes-sigs/cluster-api/blob/master/code-of-conduct.md
 [notes]: https://docs.google.com/document/d/1Ys-DOR5UsgbMEeciuG0HOgDQc8kZsaWIWJeKJ1-UfbY/edit
 [recordings]: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
 [zoomMeeting]: https://zoom.us/j/861487554
@@ -56,7 +55,6 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [providerZoomMeetingTues]: https://zoom.us/j/140808484
 [providerZoomMeetingWed]: https://zoom.us/j/424743530
 [issue tracker]: https://github.com/kubernetes-sigs/cluster-api/issues
-[contributor guide]: https://github.com/kubernetes-sigs/cluster-api/blob/master/CONTRIBUTING.md
 
 
 <!-- ANCHOR_END: Community -->

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See also: our own [contributor guide] and the Kubernetes [community page].
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct].
 
 [community page]: https://kubernetes.io/community
-[Kubernetes Code of Conduct]: code-of-conduct.md
+[Kubernetes Code of Conduct]: https://github.com/kubernetes-sigs/cluster-api/blob/master/code-of-conduct.md
 [notes]: https://docs.google.com/document/d/1Ys-DOR5UsgbMEeciuG0HOgDQc8kZsaWIWJeKJ1-UfbY/edit
 [recordings]: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
 [zoomMeeting]: https://zoom.us/j/861487554
@@ -56,7 +56,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [providerZoomMeetingTues]: https://zoom.us/j/140808484
 [providerZoomMeetingWed]: https://zoom.us/j/424743530
 [issue tracker]: https://github.com/kubernetes-sigs/cluster-api/issues
-[contributor guide]: CONTRIBUTING.md
+[contributor guide]: https://github.com/kubernetes-sigs/cluster-api/blob/master/CONTRIBUTING.md
 
 
 <!-- ANCHOR_END: Community -->

--- a/docs/book/src/CONTRIBUTING.md
+++ b/docs/book/src/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+{{#include ../../../CONTRIBUTING.md}}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -23,3 +23,5 @@
     - [Glossary](./reference/glossary.md)
     - [Provider List](./reference/providers.md)
     - [clusterctl CLI](./tooling/clusterctl.md)
+    - [Code of Conduct](./code-of-conduct.md)
+    - [Contributing](./CONTRIBUTING.md)

--- a/docs/book/src/code-of-conduct.md
+++ b/docs/book/src/code-of-conduct.md
@@ -1,0 +1,1 @@
+{{#include ../../../code-of-conduct.md}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses two dead links on the README.md doc. Fixes #1816

Learning how to first time contribute code to this SIG by reading https://cluster-api.sigs.k8s.io/ and found a couple dead links in the documentation. Killing two birds with one stone by confirming my understanding of how to first time contribute by contributing a patch to those same docs! 🐦 🐦

There were a lot of docs about how to contribute so please let me know if I missed any steps!