### PR TITLE
📖 Renaming ErrorMessage and ErrorReason to FailureMessage and FailureReason in docs

### DIFF
--- a/docs/book/src/architecture/controllers/cluster.md
+++ b/docs/book/src/architecture/controllers/cluster.md
@@ -35,13 +35,13 @@ The `status` object **must** have the following fields defined:
 
 The `status` object **may** define several fields that do not affect functionality if missing:
 
-* `errorReason` - is a string that explains why an error has occurred, if possible.
-* `errorMessage` - is a string that holds the message contained by the error.
+* `failureReason` - is a string that explains why a fatal error has occurred, if possible.
+* `failureMessage` - is a string that holds the message contained by the error.
 
 Example:
 ```yaml
 kind: MyProviderCluster
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 spec:
   controlPlaneEndpoint:
     host: example.com

--- a/docs/book/src/architecture/controllers/machine.md
+++ b/docs/book/src/architecture/controllers/machine.md
@@ -48,14 +48,14 @@ The `status` object **must** have several fields defined:
 
 The `status` object **may** define several fields that do not affect functionality if missing:
 
-* `errorReason` - is a string that explains why an error has occurred, if possible.
-* `errorMessage` - is a string that holds the message contained by the error.
+* `failureReason` - is a string that explains why a fatal error has occurred, if possible.
+* `failureMessage` - is a string that holds the message contained by the error.
 
 Example:
 
 ```yaml
 kind: MyBootstrapProviderConfig
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 status:
     ready: true
     bootstrapData: "kubeadm init"
@@ -79,13 +79,13 @@ The `status` object **must** have several fields defined:
 
 The `status` object **may** define several fields that do not affect functionality if missing:
 
-* `errorReason` - is a string that explains why an error has occurred, if possible.
-* `errorMessage` - is a string that holds the message contained by the error.
+* `failureReason` - is a string that explains why a fatal error has occurred, if possible.
+* `failureMessage` - is a string that holds the message contained by the error.
 
 Example:
 ```yaml
 kind: MyMachine
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 status:
     ready: true
     providerID: cloud:////my-cloud-provider-id


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Changing ErrorMessage and ErrorReason to FailureMessage and FailureReason in docs.

