### PR TITLE
🏃 integration test: better cert-manager wait

### DIFF
--- a/scripts/ci-integration.sh
+++ b/scripts/ci-integration.sh
@@ -133,9 +133,7 @@ main() {
    create_bootstrap
 
    kubectl create -f "${CERT_MANAGER_URL}"
-   set +e
-   wait_deployment_available "cert-manager-webhook" "cert-manager"
-   set -e
+   kubectl wait --for=condition=Available --timeout=5m apiservice v1beta1.webhook.cert-manager.io
 
    kubectl create -f "${CRD_YAML}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Wait for the apiservice for cert-manager to be available, which means
the aggregated apiserver (pod) is online and functional.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1835
