### PR TITLE
:book: Add automatic redirects for the development docs book to Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,20 +5,20 @@
 
 # Standard Netlify redirects
 [[redirects]]
-    from = "https://kubernetes-sigs-cluster-api.netlify.com/*"
-    to = "https://cluster-api.sigs.k8s.io/:splat"
+    from = "https://master--kubernetes-sigs-cluster-api.netlify.com/*"
+    to = "https://dev.cluster-api.sigs.k8s.io/:splat"
     status = 301
     force = true
 
 # HTTP-to-HTTPS rules
 [[redirects]]
-    from = "http://go.cluster-api.sigs.k8s.io/*"
-    to = "https://go.cluster-api.sigs.k8s.io/:splat"
+    from = "http://dev.cluster-api.sigs.k8s.io/*"
+    to = "https://dev.cluster-api.sigs.k8s.io/:splat"
     status = 301
     force = true
 
 [[redirects]]
-    from = "http://kubernetes-sigs-cluster-api.netlify.com/*"
-    to = "http://cluster-api.sigs.k8s.io/:splat"
+    from = "http://master--kubernetes-sigs-cluster-api.netlify.com/*"
+    to = "http://dev.cluster-api.sigs.k8s.io/:splat"
     status = 301
     force = true


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds automated redirects for the master/development version of the Cluster API book

/hold
Depends on: https://github.com/kubernetes/k8s.io/pull/486

/assign @ncdc 
/kind documentation