### PR TITLE
Makefiles: Support docker run on SELinux enabled systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,13 @@ ALL_ARCH = amd64 arm arm64 ppc64le s390x
 # Allow overriding the imagePullPolicy
 PULL_POLICY ?= Always
 
+# Hosts running SELinux need :z added to volume mounts
+SELINUX_ENABLED := $(shell cat /sys/fs/selinux/enforce 2> /dev/null || echo 0)
+
+ifeq ($(SELINUX_ENABLED),1)
+  DOCKER_VOL_OPTS?=:z
+endif
+
 all: test manager clusterctl
 
 help:  ## Display this help
@@ -286,7 +293,7 @@ release-binary: $(RELEASE_DIR)
 		-e CGO_ENABLED=0 \
 		-e GOOS=$(GOOS) \
 		-e GOARCH=$(GOARCH) \
-		-v "$$(pwd):/workspace" \
+		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
 		golang:1.12.10 \
 		go build -a -ldflags '-extldflags "-static"' \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,13 +17,20 @@ ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 SOURCES := $(shell find ${ROOT_DIR} -name \*.plantuml)
 DIAGRAMS := $(SOURCES:%.plantuml=%.png)
 
+# Hosts running SELinux need :z added to volume mounts
+SELINUX_ENABLED := $(shell cat /sys/fs/selinux/enforce 2> /dev/null || echo 0)
+
+ifeq ($(SELINUX_ENABLED),1)
+  DOCKER_VOL_OPTS?=:z
+endif
+
 .PHONY: diagrams
 diagrams: $(DIAGRAMS)
 
 %.png: %.plantuml
 	docker run \
 		--rm \
-		--volume ${ROOT_DIR}:/workdir \
+		--volume ${ROOT_DIR}:/workdir$(DOCKER_VOL_OPTS) \
 		--user $(shell id -u):$(shell id -g) \
 		us.gcr.io/k8s-artifacts-prod/cluster-api/plantuml:1.2019.6 \
 		-v /workdir/$(shell echo '$^' | sed -e 's,.*docs/,,g' )


### PR DESCRIPTION
Porting SELinux fixups from https://github.com/kubernetes/kubernetes/pull/79722 here so that commands that use `docker run` work across Linux distributions.
