### PR TITLE
:book: Re-add netlify redirects for development version of the Cluster API book

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,20 +5,20 @@
 
 # Standard Netlify redirects
 [[redirects]]
-    from = "https://kubernetes-sigs-cluster-api.netlify.com/*"
-    to = "https://cluster-api.sigs.k8s.io/:splat"
+    from = "https://master--kubernetes-sigs-cluster-api.netlify.com/*"
+    to = "https://master.cluster-api.sigs.k8s.io/:splat"
     status = 301
     force = true
 
 # HTTP-to-HTTPS rules
 [[redirects]]
-    from = "http://go.cluster-api.sigs.k8s.io/*"
-    to = "https://go.cluster-api.sigs.k8s.io/:splat"
+    from = "http://master.cluster-api.sigs.k8s.io/*"
+    to = "https://master.cluster-api.sigs.k8s.io/:splat"
     status = 301
     force = true
 
 [[redirects]]
-    from = "http://kubernetes-sigs-cluster-api.netlify.com/*"
-    to = "http://cluster-api.sigs.k8s.io/:splat"
+    from = "http://master--kubernetes-sigs-cluster-api.netlify.com/*"
+    to = "http://master.cluster-api.sigs.k8s.io/:splat"
     status = 301
     force = true


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-adds the Netlify redirects for the development version of the book (with a subdomain that Netlify will actually accept this time).
