### PR TITLE
:warning: Sync InfraCluster.Status.Ready to Cluster object

### DIFF
--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -157,15 +157,14 @@ func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster
 	}
 
 	// Determine if the infrastructure provider is ready.
-	if !cluster.Status.InfrastructureReady {
-		ready, err := external.IsReady(infraConfig)
-		if err != nil {
-			return err
-		} else if !ready {
-			logger.V(3).Info("Infrastructure provider is not ready yet")
-			return nil
-		}
-		cluster.Status.InfrastructureReady = true
+	ready, err := external.IsReady(infraConfig)
+	if err != nil {
+		return err
+	}
+	cluster.Status.InfrastructureReady = ready
+	if !ready {
+		logger.V(3).Info("Infrastructure provider is not ready yet")
+		return nil
 	}
 
 	// Get and parse Status.APIEndpoint field from the infrastructure provider.


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR pretty much allows to flip the Ready field. There is no changes required for infrastructure providers. It's consistent how the machine controller operates today.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1657 
