### PR TITLE
Fix cloud-init jinja templates 📖

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -292,7 +292,7 @@ spec:
   # refer to the Kubeadm Bootstrap Provider documentation.
   initConfiguration:
     nodeRegistration:
-      name: '{{ ds.meta_data.hostname }}'
+      name: '{{ ds.meta_data.local_hostname }}'
       kubeletExtraArgs:
         cloud-provider: aws
   clusterConfiguration:
@@ -427,7 +427,7 @@ spec:
       kubeletExtraArgs:
         cloud-config: /etc/kubernetes/azure.json
         cloud-provider: azure
-      name: '{{ ds.meta_data["local_hostname"] }}'
+      name: '{{ ds.meta_data.local_hostname }}'
 ```
 {{#/tab }}
 {{#tab Docker}}
@@ -524,7 +524,7 @@ spec:
   # refer to the Kubeadm Bootstrap Provider documentation.
   initConfiguration:
     nodeRegistration:
-      name: '{{ ds.meta_data.hostname }}'
+      name: '{{ ds.meta_data.local_hostname }}'
       kubeletExtraArgs:
         cloud-provider: gce
   clusterConfiguration:
@@ -615,12 +615,12 @@ spec:
       criSocket: /var/run/containerd/containerd.sock
       kubeletExtraArgs:
         cloud-provider: external
-      name: '{{ ds.meta_data.hostname }}'
+      name: '{{ ds.meta_data.local_hostname }}'
   preKubeadmCommands:
-  - hostname "{{ ds.meta_data.hostname }}"
+  - hostname "{{ ds.meta_data.local_hostname }}"
   - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-  - echo "127.0.0.1   localhost {{ ds.meta_data.hostname }}" >>/etc/hosts
-  - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+  - echo "127.0.0.1   localhost {{ ds.meta_data.local_hostname }}" >>/etc/hosts
+  - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
 ```
 {{#/tab }}
 {{#tab OpenStack}}
@@ -678,7 +678,7 @@ spec:
       advertiseAddress: '{{ ds.ec2_metadata.local_ipv4 }}'
       bindPort: 6443
     nodeRegistration:
-      name: '{{ local_hostname }}'
+      name: '{{ ds.meta_data.local_hostname }}'
       criSocket: "/var/run/containerd/containerd.sock"
       kubeletExtraArgs:
         cloud-provider: openstack
@@ -870,7 +870,7 @@ spec:
       # refer to the Kubeadm Bootstrap Provider documentation.
       joinConfiguration:
         nodeRegistration:
-          name: '{{ ds.meta_data.hostname }}'
+          name: '{{ ds.meta_data.local_hostname }}'
           kubeletExtraArgs:
             cloud-provider: aws
 ```
@@ -967,7 +967,7 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
-          name: '{{ ds.meta_data["local_hostname"] }}'
+          name: '{{ ds.meta_data.local_hostname }}'
           kubeletExtraArgs:
             cloud-provider: azure
             cloud-config: /etc/kubernetes/azure.json
@@ -1127,7 +1127,7 @@ spec:
       # refer to the Kubeadm Bootstrap Provider documentation.
       joinConfiguration:
         nodeRegistration:
-          name: '{{ ds.meta_data.hostname }}'
+          name: '{{ ds.meta_data.local_hostname }}'
           kubeletExtraArgs:
             cloud-provider: gce
 ```
@@ -1219,12 +1219,12 @@ spec:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
-          name: '{{ ds.meta_data.hostname }}'
+          name: '{{ ds.meta_data.local_hostname }}'
       preKubeadmCommands:
-      - hostname "{{ ds.meta_data.hostname }}"
+      - hostname "{{ ds.meta_data.local_hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
-      - echo "127.0.0.1   localhost {{ ds.meta_data.hostname }}" >>/etc/hosts
-      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
+      - echo "127.0.0.1   localhost {{ ds.meta_data.local_hostname }}" >>/etc/hosts
+      - echo "{{ ds.meta_data.local_hostname }}" >/etc/hostname
 ```
 
 {{#/tab }}

--- a/docs/proposals/20191017-kubeadm-based-control-plane.md
+++ b/docs/proposals/20191017-kubeadm-based-control-plane.md
@@ -405,7 +405,7 @@ spec:
   kubeadmConfigSpec:
     initConfiguration:
       nodeRegistration:
-        name: '{{ ds.meta_data.hostname }}'
+        name: '{{ ds.meta_data.local_hostname }}'
         kubeletExtraArgs:
           cloud-provider: acme
     clusterConfiguration:
@@ -418,7 +418,7 @@ spec:
     joinConfiguration:
       controlPlane: {}
       nodeRegistration:
-        name: '{{ ds.meta_data.hostname }}'
+        name: '{{ ds.meta_data.local_hostname }}'
         kubeletExtraArgs:
           cloud-provider: acme
 ---
@@ -579,4 +579,4 @@ For the purposes of designing upgrades, two existing lifecycle managers were exa
 - [x] 10/17/2019: Initial Creation
 - [x] 11/19/2019: Initial KubeadmControlPlane types added [#1765](https://github.com/kubernetes-sigs/cluster-api/pull/1765)
 - [x] 12/04/2019: Updated References to ErrorMessage/ErrorReason to FailureMessage/FailureReason
-- [] 12/04/2019: Initial stubbed KubeadmControlPlane controller added [#1826](https://github.com/kubernetes-sigs/cluster-api/pull/1826) 
+- [] 12/04/2019: Initial stubbed KubeadmControlPlane controller added [#1826](https://github.com/kubernetes-sigs/cluster-api/pull/1826)


### PR DESCRIPTION
Cloud-Init does not support the ds.meta_data.hostname key for
user-data replacement.
Instead, it supports the local_hostname key.

These are the supported keys for Jinja templating used by
cloud-init to change userdata.
https://github.com/canonical/cloud-init/blob/34ec440c1ad61c23c34b46f1798813d0f3ada952/cloudinit/sources/__init__.py#L232
