### PR TITLE
🐛 Be consistent with dataSecretName field

### DIFF
--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -183,11 +183,11 @@ func (r *MachineReconciler) reconcileBootstrap(ctx context.Context, m *clusterv1
 	}
 
 	// Get and set the name of the secret containing the bootstrap data.
-	secretName, _, err := unstructured.NestedString(bootstrapConfig.Object, "status", "secretDataName")
+	secretName, _, err := unstructured.NestedString(bootstrapConfig.Object, "status", "dataSecretName")
 	if err != nil {
-		return errors.Wrapf(err, "failed to retrieve secretDataName from bootstrap provider for Machine %q in namespace %q", m.Name, m.Namespace)
+		return errors.Wrapf(err, "failed to retrieve dataSecretName from bootstrap provider for Machine %q in namespace %q", m.Name, m.Namespace)
 	} else if secretName == "" {
-		return errors.Errorf("retrieved empty secretDataName from bootstrap provider for Machine %q in namespace %q", m.Name, m.Namespace)
+		return errors.Errorf("retrieved empty dataSecretName from bootstrap provider for Machine %q in namespace %q", m.Name, m.Namespace)
 	}
 
 	m.Spec.Bootstrap.DataSecretName = pointer.StringPtr(secretName)

--- a/controllers/machine_controller_phases_test.go
+++ b/controllers/machine_controller_phases_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "secretDataName")
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
 		Expect(err).NotTo(HaveOccurred())
 
 		r := &MachineReconciler{
@@ -185,7 +185,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "secretDataName")
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Set infra ready.
@@ -233,7 +233,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "secretDataName")
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Set infra ready.
@@ -269,7 +269,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "secretDataName")
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Set infra ready.
@@ -316,7 +316,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "secretDataName")
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Set NodeRef.
@@ -344,7 +344,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "secretDataName")
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Set infra ready.
@@ -425,7 +425,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				"spec": map[string]interface{}{},
 				"status": map[string]interface{}{
 					"ready":          true,
-					"secretDataName": "secret-data",
+					"dataSecretName": "secret-data",
 				},
 			},
 			expectError: false,
@@ -515,7 +515,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				"spec": map[string]interface{}{},
 				"status": map[string]interface{}{
 					"ready":          true,
-					"secretDataName": "secret-data",
+					"dataSecretName": "secret-data",
 				},
 			},
 			machine: &clusterv1.Machine{
@@ -720,7 +720,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 				"spec": map[string]interface{}{},
 				"status": map[string]interface{}{
 					"ready":          true,
-					"secretDataName": "secret-data",
+					"dataSecretName": "secret-data",
 				},
 			},
 			infraConfig: map[string]interface{}{


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR changes the controller to look for the field that is defined in both the machine and the bootstrap config types.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1866

/cc @vincepri 
