### PR TITLE
:bug: [0.2] Wait for all descendants when deleting a cluster

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -412,5 +413,166 @@ func TestClusterReconciler_machineToCluster(t *testing.T) {
 				t.Errorf("controlPlaneMachineToCluster() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+type machineDeploymentBuilder struct {
+	md clusterv1.MachineDeployment
+}
+
+func newMachineDeploymentBuilder() *machineDeploymentBuilder {
+	return &machineDeploymentBuilder{}
+}
+
+func (b *machineDeploymentBuilder) named(name string) *machineDeploymentBuilder {
+	b.md.Name = name
+	return b
+}
+
+func (b *machineDeploymentBuilder) ownedBy(c *clusterv1.Cluster) *machineDeploymentBuilder {
+	b.md.OwnerReferences = append(b.md.OwnerReferences, metav1.OwnerReference{
+		APIVersion: clusterv1.GroupVersion.String(),
+		Kind:       "Cluster",
+		Name:       c.Name,
+	})
+	return b
+}
+
+func (b *machineDeploymentBuilder) build() clusterv1.MachineDeployment {
+	return b.md
+}
+
+type machineSetBuilder struct {
+	ms clusterv1.MachineSet
+}
+
+func newMachineSetBuilder() *machineSetBuilder {
+	return &machineSetBuilder{}
+}
+
+func (b *machineSetBuilder) named(name string) *machineSetBuilder {
+	b.ms.Name = name
+	return b
+}
+
+func (b *machineSetBuilder) ownedBy(c *clusterv1.Cluster) *machineSetBuilder {
+	b.ms.OwnerReferences = append(b.ms.OwnerReferences, metav1.OwnerReference{
+		APIVersion: clusterv1.GroupVersion.String(),
+		Kind:       "Cluster",
+		Name:       c.Name,
+	})
+	return b
+}
+
+func (b *machineSetBuilder) build() clusterv1.MachineSet {
+	return b.ms
+}
+
+type machineBuilder struct {
+	m clusterv1.Machine
+}
+
+func newMachineBuilder() *machineBuilder {
+	return &machineBuilder{}
+}
+
+func (b *machineBuilder) named(name string) *machineBuilder {
+	b.m.Name = name
+	return b
+}
+
+func (b *machineBuilder) ownedBy(c *clusterv1.Cluster) *machineBuilder {
+	b.m.OwnerReferences = append(b.m.OwnerReferences, metav1.OwnerReference{
+		APIVersion: clusterv1.GroupVersion.String(),
+		Kind:       "Cluster",
+		Name:       c.Name,
+	})
+	return b
+}
+
+func (b *machineBuilder) controlPlane() *machineBuilder {
+	b.m.Labels = map[string]string{clusterv1.MachineControlPlaneLabelName: "true"}
+	return b
+}
+
+func (b *machineBuilder) build() clusterv1.Machine {
+	return b.m
+}
+
+func TestFilterOwnedDescendants(t *testing.T) {
+	c := clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "c",
+		},
+	}
+
+	md1NotOwnedByCluster := newMachineDeploymentBuilder().named("md1").build()
+	md2OwnedByCluster := newMachineDeploymentBuilder().named("md2").ownedBy(&c).build()
+	md3NotOwnedByCluster := newMachineDeploymentBuilder().named("md3").build()
+	md4OwnedByCluster := newMachineDeploymentBuilder().named("md4").ownedBy(&c).build()
+
+	ms1NotOwnedByCluster := newMachineSetBuilder().named("ms1").build()
+	ms2OwnedByCluster := newMachineSetBuilder().named("ms2").ownedBy(&c).build()
+	ms3NotOwnedByCluster := newMachineSetBuilder().named("ms3").build()
+	ms4OwnedByCluster := newMachineSetBuilder().named("ms4").ownedBy(&c).build()
+
+	m1NotOwnedByCluster := newMachineBuilder().named("m1").build()
+	m2OwnedByCluster := newMachineBuilder().named("m2").ownedBy(&c).build()
+	m3ControlPlaneOwnedByCluster := newMachineBuilder().named("m3").ownedBy(&c).controlPlane().build()
+	m4NotOwnedByCluster := newMachineBuilder().named("m4").build()
+	m5OwnedByCluster := newMachineBuilder().named("m5").ownedBy(&c).build()
+	m6ControlPlaneOwnedByCluster := newMachineBuilder().named("m6").ownedBy(&c).controlPlane().build()
+
+	d := clusterDescendants{
+		machineDeployments: clusterv1.MachineDeploymentList{
+			Items: []clusterv1.MachineDeployment{
+				md1NotOwnedByCluster,
+				md2OwnedByCluster,
+				md3NotOwnedByCluster,
+				md4OwnedByCluster,
+			},
+		},
+		machineSets: clusterv1.MachineSetList{
+			Items: []clusterv1.MachineSet{
+				ms1NotOwnedByCluster,
+				ms2OwnedByCluster,
+				ms3NotOwnedByCluster,
+				ms4OwnedByCluster,
+			},
+		},
+		controlPlaneMachines: clusterv1.MachineList{
+			Items: []clusterv1.Machine{
+				m3ControlPlaneOwnedByCluster,
+				m6ControlPlaneOwnedByCluster,
+			},
+		},
+		workerMachines: clusterv1.MachineList{
+			Items: []clusterv1.Machine{
+				m1NotOwnedByCluster,
+				m2OwnedByCluster,
+				m4NotOwnedByCluster,
+				m5OwnedByCluster,
+			},
+		},
+	}
+
+	actual, err := d.filterOwnedDescendants(&c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := []runtime.Object{
+		&md2OwnedByCluster,
+		&md4OwnedByCluster,
+		&ms2OwnedByCluster,
+		&ms4OwnedByCluster,
+		&m2OwnedByCluster,
+		&m5OwnedByCluster,
+		&m3ControlPlaneOwnedByCluster,
+		&m6ControlPlaneOwnedByCluster,
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %v, got %v", expected, actual)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of waiting for all direct descendants to be deleted and then
allowing cluster deletion to proceed (by removing the finalizer), wait
for all descendants (both direct and indirect) to be removed before
allowing cluster deletion to proceed. There can be race conditions where
there are indirect descendants (machines belonging to a machine set)
that still exist, and they need the cluster to remain so they can be
deleted properly.

Signed-off-by: Andy Goldstein <goldsteina@vmware.com>
(cherry picked from commit a193a179a38dc32e2c01e2722560131c65497ff6)

Backport of #1650

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
