### PR TITLE
:running: Mass update of test cases, docs, and other outdated references to v1alpha2

### DIFF
--- a/bootstrap/kubeadm/README.md
+++ b/bootstrap/kubeadm/README.md
@@ -19,18 +19,18 @@ infrastructure object.
 
 ```yaml
 kind: DockerCluster
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 metadata:
   name: my-cluster-docker
 ---
 kind: Cluster
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 metadata:
   name: my-cluster
 spec:
   infrastructureRef:
     kind: DockerCluster
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     name: my-cluster-docker
 ```
 
@@ -39,7 +39,7 @@ the `KubeadmConfig` bootstrap object.
 
 ```yaml
 kind: KubeadmConfig
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 metadata:
   name: my-control-plane1-config
 spec:
@@ -53,12 +53,12 @@ spec:
         enable-hostpath-provisioner: "true"
 ---
 kind: DockerMachine
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 metadata:
   name: my-control-plane1-docker
 ---
 kind: Machine
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 metadata:
   name: my-control-plane1
   labels:
@@ -69,11 +69,11 @@ spec:
   bootstrap:
     configRef:
       kind: KubeadmConfig
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       name: my-control-plane1-config
   infrastructureRef:
     kind: DockerMachine
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     name: my-control-plane1-docker
   version: "v1.14.2"
 ```
@@ -113,7 +113,7 @@ Valid combinations of configuration objects are:
 Bootstrap control plane node:
 ```yaml
 kind: KubeadmConfig
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 metadata:
   name: my-control-plane1-config
 spec:
@@ -130,7 +130,7 @@ spec:
 Additional control plane nodes:
 ```yaml
 kind: KubeadmConfig
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 metadata:
   name: my-control-plane2-config
 spec:
@@ -144,7 +144,7 @@ spec:
 worker nodes:
 ```yaml
 kind: KubeadmConfig
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 metadata:
   name: my-worker1-config
 spec:

--- a/bootstrap/kubeadm/docs/external-etcd.md
+++ b/bootstrap/kubeadm/docs/external-etcd.md
@@ -56,7 +56,7 @@ data:
 After that the rest is standard Kubeadm. Config your ClusterConfiguration as follows:
 
 ```yaml
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: CLUSTER_NAME-controlplane-0

--- a/controllers/cluster_controller_phases_test.go
+++ b/controllers/cluster_controller_phases_test.go
@@ -50,7 +50,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 					Port: 8443,
 				},
 				InfrastructureRef: &corev1.ObjectReference{
-					APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 					Kind:       "InfrastructureConfig",
 					Name:       "test",
 				},
@@ -78,7 +78,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 				cluster: cluster,
 				infraRef: map[string]interface{}{
 					"kind":       "InfrastructureConfig",
-					"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha2",
+					"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
 					"metadata": map[string]interface{}{
 						"name":              "test",
 						"namespace":         "test-namespace",
@@ -92,7 +92,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 				cluster: cluster,
 				infraRef: map[string]interface{}{
 					"kind":       "InfrastructureConfig",
-					"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha2",
+					"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
 					"metadata": map[string]interface{}{
 						"name":              "test",
 						"namespace":         "test-namespace",

--- a/controllers/external/testing.go
+++ b/controllers/external/testing.go
@@ -39,7 +39,7 @@ var (
 			Validation: &apiextensionsv1beta1.CustomResourceValidation{},
 			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
 				{
-					Name:    "v1alpha2",
+					Name:    "v1alpha3",
 					Served:  true,
 					Storage: true,
 				},
@@ -64,7 +64,7 @@ var (
 			Validation: &apiextensionsv1beta1.CustomResourceValidation{},
 			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
 				{
-					Name:    "v1alpha2",
+					Name:    "v1alpha3",
 					Served:  true,
 					Storage: true,
 				},

--- a/controllers/machine_controller_phases_test.go
+++ b/controllers/machine_controller_phases_test.go
@@ -63,13 +63,13 @@ var _ = Describe("Reconcile Machine Phases", func() {
 			ClusterName: defaultCluster.Name,
 			Bootstrap: clusterv1.Bootstrap{
 				ConfigRef: &corev1.ObjectReference{
-					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
 					Kind:       "BootstrapConfig",
 					Name:       "bootstrap-config1",
 				},
 			},
 			InfrastructureRef: corev1.ObjectReference{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 				Kind:       "InfrastructureConfig",
 				Name:       "infra-config1",
 			},
@@ -79,7 +79,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 	defaultBootstrap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "BootstrapConfig",
-			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 			"metadata": map[string]interface{}{
 				"name":      "bootstrap-config1",
 				"namespace": "default",
@@ -92,7 +92,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 	defaultInfra := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "InfrastructureConfig",
-			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha2",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
 			"metadata": map[string]interface{}{
 				"name":      "infra-config1",
 				"namespace": "default",
@@ -398,7 +398,7 @@ func TestReconcileBootstrap(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			Bootstrap: clusterv1.Bootstrap{
 				ConfigRef: &corev1.ObjectReference{
-					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
 					Kind:       "BootstrapConfig",
 					Name:       "bootstrap-config1",
 				},
@@ -417,7 +417,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			name: "new machine, bootstrap config ready with data",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": "default",
@@ -439,7 +439,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			name: "new machine, bootstrap config ready with no data",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": "default",
@@ -459,7 +459,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			name: "new machine, bootstrap config not ready",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": "default",
@@ -476,7 +476,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			name: "new machine, bootstrap config is not found",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": "wrong-namespace",
@@ -493,7 +493,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			name: "new machine, no bootstrap config or data",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": "wrong-namespace",
@@ -507,7 +507,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			name: "existing machine, bootstrap data should not change",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": "default",
@@ -526,7 +526,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
 						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
 							Kind:       "BootstrapConfig",
 							Name:       "bootstrap-config1",
 						},
@@ -547,7 +547,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			name: "existing machine, bootstrap provider is to not ready",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": "default",
@@ -566,7 +566,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
 						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
 							Kind:       "BootstrapConfig",
 							Name:       "bootstrap-config1",
 						},
@@ -628,13 +628,13 @@ func TestReconcileInfrastructure(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			Bootstrap: clusterv1.Bootstrap{
 				ConfigRef: &corev1.ObjectReference{
-					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
 					Kind:       "BootstrapConfig",
 					Name:       "bootstrap-config1",
 				},
 			},
 			InfrastructureRef: corev1.ObjectReference{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 				Kind:       "InfrastructureConfig",
 				Name:       "infra-config1",
 			},
@@ -655,7 +655,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			name: "new machine, infrastructure config ready",
 			infraConfig: map[string]interface{}{
 				"kind":       "InfrastructureConfig",
-				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha2",
+				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
 				"metadata": map[string]interface{}{
 					"name":      "infra-config1",
 					"namespace": "default",
@@ -693,13 +693,13 @@ func TestReconcileInfrastructure(t *testing.T) {
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
 						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
 							Kind:       "BootstrapConfig",
 							Name:       "bootstrap-config1",
 						},
 					},
 					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 						Kind:       "InfrastructureConfig",
 						Name:       "infra-config1",
 					},
@@ -712,7 +712,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			},
 			bootstrapConfig: map[string]interface{}{
 				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": "default",
@@ -725,7 +725,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			},
 			infraConfig: map[string]interface{}{
 				"kind":       "InfrastructureConfig",
-				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha2",
+				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
 				"metadata":   map[string]interface{}{},
 			},
 			expectError:        true,

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -266,7 +266,7 @@ func TestReconcileRequest(t *testing.T) {
 	infraConfig := unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "InfrastructureConfig",
-			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha2",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
 			"metadata": map[string]interface{}{
 				"name":      "infra-config1",
 				"namespace": "default",
@@ -313,7 +313,7 @@ func TestReconcileRequest(t *testing.T) {
 				Spec: clusterv1.MachineSpec{
 					ClusterName: "test-cluster",
 					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 						Kind:       "InfrastructureConfig",
 						Name:       "infra-config1",
 					},
@@ -340,7 +340,7 @@ func TestReconcileRequest(t *testing.T) {
 				Spec: clusterv1.MachineSpec{
 					ClusterName: "test-cluster",
 					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 						Kind:       "InfrastructureConfig",
 						Name:       "infra-config1",
 					},
@@ -371,7 +371,7 @@ func TestReconcileRequest(t *testing.T) {
 				Spec: clusterv1.MachineSpec{
 					ClusterName: "test-cluster",
 					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 						Kind:       "InfrastructureConfig",
 						Name:       "infra-config1",
 					},
@@ -420,7 +420,7 @@ func TestReconcileDeleteExternal(t *testing.T) {
 	bootstrapConfig := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "BootstrapConfig",
-			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 			"metadata": map[string]interface{}{
 				"name":      "delete-bootstrap",
 				"namespace": "default",
@@ -431,7 +431,7 @@ func TestReconcileDeleteExternal(t *testing.T) {
 	infraConfig := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "InfrastructureConfig",
-			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha2",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
 			"metadata": map[string]interface{}{
 				"name":      "delete-infra",
 				"namespace": "default",
@@ -447,13 +447,13 @@ func TestReconcileDeleteExternal(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			ClusterName: "test-cluster",
 			InfrastructureRef: corev1.ObjectReference{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 				Kind:       "InfrastructureConfig",
 				Name:       "delete-infra",
 			},
 			Bootstrap: clusterv1.Bootstrap{
 				ConfigRef: &corev1.ObjectReference{
-					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
 					Kind:       "BootstrapConfig",
 					Name:       "delete-bootstrap",
 				},
@@ -551,7 +551,7 @@ func TestRemoveMachineFinalizerAfterDeleteReconcile(t *testing.T) {
 		Spec: clusterv1.MachineSpec{
 			ClusterName: "test-cluster",
 			InfrastructureRef: corev1.ObjectReference{
-				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 				Kind:       "InfrastructureConfig",
 				Name:       "infra-config1",
 			},

--- a/controllers/machinedeployment_controller_test.go
+++ b/controllers/machinedeployment_controller_test.go
@@ -88,7 +88,7 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 						ClusterName: testCluster.Name,
 						Version:     &version,
 						InfrastructureRef: corev1.ObjectReference{
-							APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 							Kind:       "InfrastructureMachineTemplate",
 							Name:       "md-template",
 						},
@@ -107,7 +107,7 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		// Create infrastructure template resource.
 		infraResource := map[string]interface{}{
 			"kind":       "InfrastructureMachine",
-			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha2",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
 			"metadata":   map[string]interface{}{},
 			"spec": map[string]interface{}{
 				"size":       "3xlarge",
@@ -122,7 +122,7 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 			},
 		}
 		infraTmpl.SetKind("InfrastructureMachineTemplate")
-		infraTmpl.SetAPIVersion("infrastructure.cluster.x-k8s.io/v1alpha2")
+		infraTmpl.SetAPIVersion("infrastructure.cluster.x-k8s.io/v1alpha3")
 		infraTmpl.SetName("md-template")
 		infraTmpl.SetNamespace(namespace.Name)
 		By("Creating the infrastructure template")

--- a/controllers/machineset_controller_test.go
+++ b/controllers/machineset_controller_test.go
@@ -92,7 +92,7 @@ var _ = Describe("MachineSet Reconciler", func() {
 							Data: pointer.StringPtr("x"),
 						},
 						InfrastructureRef: corev1.ObjectReference{
-							APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 							Kind:       "InfrastructureMachineTemplate",
 							Name:       "ms-template",
 						},
@@ -104,7 +104,7 @@ var _ = Describe("MachineSet Reconciler", func() {
 		// Create infrastructure template resource.
 		infraResource := map[string]interface{}{
 			"kind":       "InfrastructureMachine",
-			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha2",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
 			"metadata":   map[string]interface{}{},
 			"spec": map[string]interface{}{
 				"size":       "3xlarge",
@@ -119,7 +119,7 @@ var _ = Describe("MachineSet Reconciler", func() {
 			},
 		}
 		infraTmpl.SetKind("InfrastructureMachineTemplate")
-		infraTmpl.SetAPIVersion("infrastructure.cluster.x-k8s.io/v1alpha2")
+		infraTmpl.SetAPIVersion("infrastructure.cluster.x-k8s.io/v1alpha3")
 		infraTmpl.SetName("ms-template")
 		infraTmpl.SetNamespace(namespace.Name)
 		Expect(k8sClient.Create(ctx, infraTmpl)).To(BeNil())

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -15,7 +15,7 @@ For the purpose of this tutorial, we'll name our cluster `capi-quickstart`.
 {{#tab AWS}}
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: capi-quickstart
@@ -24,11 +24,11 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: AWSCluster
     name: capi-quickstart
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSCluster
 metadata:
   name: capi-quickstart
@@ -42,7 +42,7 @@ spec:
 {{#tab Azure}}
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: capi-quickstart
@@ -52,11 +52,11 @@ spec:
       cidrBlocks:
       - 192.168.0.0/16
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: AzureCluster
     name: capi-quickstart
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureCluster
 metadata:
   name: capi-quickstart
@@ -73,7 +73,7 @@ spec:
 {{#tab Docker}}
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: capi-quickstart
@@ -82,11 +82,11 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerCluster
     name: capi-quickstart
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerCluster
 metadata:
   name: capi-quickstart
@@ -102,7 +102,7 @@ Replace the project below with your unique value and update region if desired.
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: capi-quickstart
@@ -112,11 +112,11 @@ spec:
       cidrBlocks:
       - 192.168.0.0/16
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: GCPCluster
     name: capi-quickstart
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: GCPCluster
 metadata:
   name: capi-quickstart
@@ -146,7 +146,7 @@ This quick start assumes the following vSphere environment which you should repl
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: capi-quickstart
@@ -155,11 +155,11 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"] # CIDR block used by Calico.
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereCluster
     name: capi-quickstart
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereCluster
 metadata:
   name: capi-quickstart
@@ -205,7 +205,7 @@ These examples include environment variables that you should substitute before c
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: capi-quickstart
@@ -217,11 +217,11 @@ spec:
       cidrBlocks: ["192.168.0.0/16"] # CIDR block used by Calico.
     serviceDomain: "cluster.local"
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: OpenStackCluster
     name: capi-quickstart
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: OpenStackCluster
 metadata:
   name: capi-quickstart
@@ -253,7 +253,7 @@ Now that we've created the cluster object, we can create a control plane Machine
 {{#tab AWS}}
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Machine
 metadata:
   name: capi-quickstart-controlplane-0
@@ -264,15 +264,15 @@ spec:
   version: v1.15.3
   bootstrap:
     configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: KubeadmConfig
       name: capi-quickstart-controlplane-0
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: AWSMachine
     name: capi-quickstart-controlplane-0
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachine
 metadata:
   name: capi-quickstart-controlplane-0
@@ -283,7 +283,7 @@ spec:
   # Change this value to a valid SSH Key Pair present in your AWS Account.
   sshKeyName: default
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: capi-quickstart-controlplane-0
@@ -331,7 +331,7 @@ cat controlplane.yaml \
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Machine
 metadata:
   name: capi-quickstart-controlplane-0
@@ -342,15 +342,15 @@ spec:
   version: v1.16.1
   bootstrap:
     configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: KubeadmConfig
       name: capi-quickstart-controlplane-0
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: AzureMachine
     name: capi-quickstart-controlplane-0
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachine
 metadata:
   name: capi-quickstart-controlplane-0
@@ -369,7 +369,7 @@ spec:
   sshPublicKey: ${SSH_PUBLIC_KEY}
   vmSize: Standard_B2ms
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: capi-quickstart-controlplane-0
@@ -433,7 +433,7 @@ spec:
 {{#tab Docker}}
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Machine
 metadata:
   name: capi-quickstart-controlplane-0
@@ -444,20 +444,20 @@ spec:
   version: v1.15.3
   bootstrap:
     configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: KubeadmConfig
       name: capi-quickstart-controlplane-0
   infrastructureRef:
     kind: DockerMachine
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     name: capi-quickstart-controlplane-0
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachine
 metadata:
   name: capi-quickstart-controlplane-0
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: capi-quickstart-controlplane-0
@@ -488,7 +488,7 @@ Feel free to update instance types and zones below.
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Machine
 metadata:
   name: capi-quickstart-controlplane-0
@@ -499,15 +499,15 @@ spec:
   version: v1.15.3
   bootstrap:
     configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: KubeadmConfig
       name: capi-quickstart-controlplane-0
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: GCPMachine
     name: capi-quickstart-controlplane-0
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: GCPMachine
 metadata:
   name: capi-quickstart-controlplane-0
@@ -515,7 +515,7 @@ spec:
   instanceType: n1-standard-2
   zone: us-central1-a
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: capi-quickstart-controlplane-0
@@ -557,7 +557,7 @@ This quick start assumes the following vSphere environment which you should repl
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Machine
 metadata:
   name: capi-quickstart-controlplane-0
@@ -568,15 +568,15 @@ spec:
   version: v1.16.2
   bootstrap:
     configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: KubeadmConfig
       name: capi-quickstart-controlplane-0
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: VSphereMachine
     name: capi-quickstart-controlplane-0
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachine
 metadata:
   labels:
@@ -596,7 +596,7 @@ spec:
   numCPUs: 2
   template: ubuntu-1804-kube-v1.16.2
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: capi-quickstart-controlplane-0
@@ -634,7 +634,7 @@ These examples include environment variables that you should substitute before c
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Machine
 metadata:
   name: capi-quickstart-controlplane-0
@@ -645,15 +645,15 @@ spec:
   version: v1.15.3
   bootstrap:
     configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: KubeadmConfig
       name: capi-quickstart-controlplane-0
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: OpenStackMachine
     name: capi-quickstart-controlplane-0
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: OpenStackMachine
 metadata:
   name: capi-quickstart-controlplane-0
@@ -666,7 +666,7 @@ spec:
   cloudsSecret:
     name: cloud-config
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: capi-quickstart-controlplane-0
@@ -813,7 +813,7 @@ Finishing up, we'll create a single node _MachineDeployment_.
 {{#tab AWS}}
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: capi-quickstart-worker
@@ -839,14 +839,14 @@ spec:
       bootstrap:
         configRef:
           name: capi-quickstart-worker
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: capi-quickstart-worker
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AWSMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate
 metadata:
   name: capi-quickstart-worker
@@ -859,7 +859,7 @@ spec:
       # Change this value to a valid SSH Key Pair present in your AWS Account.
       sshKeyName: default
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: capi-quickstart-worker
@@ -904,7 +904,7 @@ cat machinedeployment.yaml \
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: capi-quickstart-node
@@ -930,14 +930,14 @@ spec:
       bootstrap:
         configRef:
           name: capi-quickstart-node
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: capi-quickstart-node
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AzureMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureMachineTemplate
 metadata:
   name: capi-quickstart-node
@@ -958,7 +958,7 @@ spec:
           storageAccountType: "Premium_LRS"
       sshPublicKey: ${SSH_PUBLIC_KEY}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: capi-quickstart-node
@@ -1002,7 +1002,7 @@ spec:
 {{#tab Docker}}
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: capi-quickstart-worker
@@ -1028,14 +1028,14 @@ spec:
       bootstrap:
         configRef:
           name: capi-quickstart-worker
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: capi-quickstart-worker
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: DockerMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachineTemplate
 metadata:
   name: capi-quickstart-worker
@@ -1043,7 +1043,7 @@ spec:
   template:
     spec: {}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: capi-quickstart-worker
@@ -1073,7 +1073,7 @@ Feel free to update instance types and zones below.
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: capi-quickstart-worker
@@ -1099,14 +1099,14 @@ spec:
       bootstrap:
         configRef:
           name: capi-quickstart-worker
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: capi-quickstart-worker
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: GCPMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: GCPMachineTemplate
 metadata:
   name: capi-quickstart-worker
@@ -1116,7 +1116,7 @@ spec:
       instanceType: n1-standard-2
       zone: us-central1-a
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: capi-quickstart-worker
@@ -1154,7 +1154,7 @@ This quick start assumes the following vSphere environment which you should repl
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: capi-quickstart-worker
@@ -1179,15 +1179,15 @@ spec:
       version: v1.16.2
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: capi-quickstart-worker
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: VSphereMachineTemplate
         name: capi-quickstart-worker
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: VSphereMachineTemplate
 metadata:
   name: capi-quickstart-md-0
@@ -1206,7 +1206,7 @@ spec:
       numCPUs: 2
       template: ubuntu-1804-kube-v1.16.2
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: capi-quickstart-md-0
@@ -1239,7 +1239,7 @@ These examples include environment variables that you should substitute before c
 </aside>
 
 ```yaml
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: capi-quickstart-worker
@@ -1264,15 +1264,15 @@ spec:
       version: v1.15.3
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: KubeadmConfigTemplate
           name: capi-quickstart-worker
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: OpenStackMachineTemplate
         name: capi-quickstart-worker
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: OpenStackMachineTemplate
 metadata:
   name: capi-quickstart-worker
@@ -1286,7 +1286,7 @@ spec:
       flavor: m1.medium
       image: ${IMAGE_NAME}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate
 metadata:
   name: capi-quickstart-worker

--- a/test/infrastructure/docker/api/v1alpha3/groupversion_info.go
+++ b/test/infrastructure/docker/api/v1alpha3/groupversion_info.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha2 contains API Schema definitions for the infrastructure v1alpha2 API group
+// Package v1alpha3 contains API Schema definitions for the infrastructure v1alpha3 API group
 // +kubebuilder:object:generate=true
 // +groupName=infrastructure.cluster.x-k8s.io
 package v1alpha3

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -1,11 +1,11 @@
 # Creates a cluster with one control-plane node and one worker node
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerCluster
 metadata:
   name: my-cluster
   namespace: default
 ---
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: my-cluster
@@ -18,18 +18,18 @@ spec:
       cidrBlocks: ["192.168.0.0/16"]
     serviceDomain: "cluster.local"
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerCluster
     name: my-cluster
     namespace: default
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachine
 metadata:
   name: controlplane-0
   namespace: default
 ---
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Machine
 metadata:
   labels:
@@ -41,17 +41,17 @@ spec:
   version: "v1.14.2"
   bootstrap:
     configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: KubeadmConfig
       name: controlplane-0-config
       namespace: default
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachine
     name: controlplane-0
     namespace: default
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: controlplane-0-config
@@ -66,13 +66,13 @@ spec:
       kubeletExtraArgs:
         eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: DockerMachine
 metadata:
   name: worker-0
   namespace: default
 ---
-apiVersion: cluster.x-k8s.io/v1alpha2
+apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Machine
 metadata:
   labels:
@@ -83,17 +83,17 @@ spec:
   version: "v1.14.2"
   bootstrap:
     configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
       kind: KubeadmConfig
       name: worker-0-config
       namespace: default
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachine
     name: worker-0
     namespace: default
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfig
 metadata:
   name: worker-0-config

--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -41,7 +41,7 @@ func TestHelperUnstructuredPatch(t *testing.T) {
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "BootstrapConfig",
-			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 			"metadata": map[string]interface{}{
 				"name":      "test-bootstrap",
 				"namespace": "default",
@@ -62,7 +62,7 @@ func TestHelperUnstructuredPatch(t *testing.T) {
 
 	refs := []metav1.OwnerReference{
 		{
-			APIVersion: "cluster.x-k8s.io/v1alpha2",
+			APIVersion: "cluster.x-k8s.io/v1alpha3",
 			Kind:       "Cluster",
 			Name:       "test",
 		},
@@ -198,7 +198,7 @@ func TestHelperPatch(t *testing.T) {
 			before: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "BootstrapConfig",
-					"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+					"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 					"metadata": map[string]interface{}{
 						"name":      "test-bootstrap",
 						"namespace": "default",
@@ -208,14 +208,14 @@ func TestHelperPatch(t *testing.T) {
 			after: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "BootstrapConfig",
-					"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha2",
+					"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
 					"metadata": map[string]interface{}{
 						"name":      "test-bootstrap",
 						"namespace": "default",
 						"ownerReferences": []interface{}{
 							map[string]interface{}{
 								"kind":       "TestOwner",
-								"apiVersion": "test.cluster.x-k8s.io/v1alpha2",
+								"apiVersion": "test.cluster.x-k8s.io/v1alpha3",
 								"name":       "test",
 							},
 						},

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -45,7 +45,7 @@ func TestMachineToInfrastructureMapFunc(t *testing.T) {
 			name: "should reconcile infra-1",
 			input: schema.GroupVersionKind{
 				Group:   "foo.cluster.x-k8s.io",
-				Version: "v1alpha2",
+				Version: "v1alpha3",
 				Kind:    "TestMachine",
 			},
 			request: handler.MapObject{
@@ -56,7 +56,7 @@ func TestMachineToInfrastructureMapFunc(t *testing.T) {
 					},
 					Spec: clusterv1.MachineSpec{
 						InfrastructureRef: corev1.ObjectReference{
-							APIVersion: "foo.cluster.x-k8s.io/v1alpha2",
+							APIVersion: "foo.cluster.x-k8s.io/v1alpha3",
 							Kind:       "TestMachine",
 							Name:       "infra-1",
 						},
@@ -76,7 +76,7 @@ func TestMachineToInfrastructureMapFunc(t *testing.T) {
 			name: "should return no matching reconcile requests",
 			input: schema.GroupVersionKind{
 				Group:   "foo.cluster.x-k8s.io",
-				Version: "v1alpha2",
+				Version: "v1alpha3",
 				Kind:    "TestMachine",
 			},
 			request: handler.MapObject{
@@ -87,7 +87,7 @@ func TestMachineToInfrastructureMapFunc(t *testing.T) {
 					},
 					Spec: clusterv1.MachineSpec{
 						InfrastructureRef: corev1.ObjectReference{
-							APIVersion: "bar.cluster.x-k8s.io/v1alpha2",
+							APIVersion: "bar.cluster.x-k8s.io/v1alpha3",
 							Kind:       "TestMachine",
 							Name:       "bar-1",
 						},
@@ -120,7 +120,7 @@ func TestClusterToInfrastructureMapFunc(t *testing.T) {
 			name: "should reconcile infra-1",
 			input: schema.GroupVersionKind{
 				Group:   "foo.cluster.x-k8s.io",
-				Version: "v1alpha2",
+				Version: "v1alpha3",
 				Kind:    "TestCluster",
 			},
 			request: handler.MapObject{
@@ -131,7 +131,7 @@ func TestClusterToInfrastructureMapFunc(t *testing.T) {
 					},
 					Spec: clusterv1.ClusterSpec{
 						InfrastructureRef: &corev1.ObjectReference{
-							APIVersion: "foo.cluster.x-k8s.io/v1alpha2",
+							APIVersion: "foo.cluster.x-k8s.io/v1alpha3",
 							Kind:       "TestCluster",
 							Name:       "infra-1",
 						},
@@ -151,7 +151,7 @@ func TestClusterToInfrastructureMapFunc(t *testing.T) {
 			name: "should return no matching reconcile requests",
 			input: schema.GroupVersionKind{
 				Group:   "foo.cluster.x-k8s.io",
-				Version: "v1alpha2",
+				Version: "v1alpha3",
 				Kind:    "TestCluster",
 			},
 			request: handler.MapObject{
@@ -162,7 +162,7 @@ func TestClusterToInfrastructureMapFunc(t *testing.T) {
 					},
 					Spec: clusterv1.ClusterSpec{
 						InfrastructureRef: &corev1.ObjectReference{
-							APIVersion: "bar.cluster.x-k8s.io/v1alpha2",
+							APIVersion: "bar.cluster.x-k8s.io/v1alpha3",
 							Kind:       "TestCluster",
 							Name:       "bar-1",
 						},

--- a/util/yaml/yaml_test.go
+++ b/util/yaml/yaml_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const validCluster = `
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster
 metadata:
   name: cluster1
@@ -31,39 +31,39 @@ spec:`
 
 const validMachines1 = `
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Machine
 metadata:
   name: machine1
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Machine
 metadata:
   name: machine2`
 
 const validUnified1 = `
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster
 metadata:
   name: cluster1
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Machine
 metadata:
   name: machine1`
 
 const validUnified2 = `
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster
 metadata:
   name: cluster1
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Machine
 metadata:
   name: machine1
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Machine
 metadata:
   name: machine2`
@@ -80,24 +80,24 @@ metadata:
   name: cluster-api-shared-configuration
   namespace: cluster-api-test
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster
 metadata:
   name: cluster1
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Machine
 metadata:
   name: machine1
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Machine
 metadata:
   name: machine2`
 
 const invalidMachines1 = `
 items:
-- apiVersion: "cluster.x-k8s.io/v1alpha2"
+- apiVersion: "cluster.x-k8s.io/v1alpha3"
   kind: Machine
   metadata:
     name: machine1
@@ -124,12 +124,12 @@ metadata:
   name: cluster-api-shared-configuration
   namespace: cluster-api-test
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster
 metadata:
   name: cluster1
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Machine
 - metadata:
     name: machine1
@@ -150,7 +150,7 @@ metadata:
   name: cluster-api-shared-configuration
   namespace: cluster-api-test
 ---
-apiVersion: "cluster.x-k8s.io/v1alpha2"
+apiVersion: "cluster.x-k8s.io/v1alpha3"
 kind: Cluster
 metadata:
   name: cluster1


### PR DESCRIPTION
**What this PR does / why we need it**:

Most of this is to avoid confusion, and cleanup examples or docs that have previously been missed with the move to v1alpha3
