### PR TITLE
✨ CBPK Use Unstructured to access Config Owner

### DIFF
--- a/bootstrap/util/configowner.go
+++ b/bootstrap/util/configowner.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ConfigOwner provides a data interface for different config owner types.
+type ConfigOwner struct {
+	*unstructured.Unstructured
+}
+
+// IsInfrastructureReady extracts infrastructure status from the config owner.
+func (co ConfigOwner) IsInfrastructureReady() bool {
+	infrastructureReady, _, err := unstructured.NestedBool(co.Object, "status", "infrastructureReady")
+	if err != nil {
+		return false
+	}
+	return infrastructureReady
+}
+
+// ClusterName extracts spec.clusterName from the config owner.
+func (co ConfigOwner) ClusterName() string {
+	clusterName, _, err := unstructured.NestedString(co.Object, "spec", "clusterName")
+	if err != nil {
+		return ""
+	}
+	return clusterName
+}
+
+// DataSecretName extracts spec.bootstrap.dataSecretName from the config owner.
+func (co ConfigOwner) DataSecretName() *string {
+	dataSecretName, exist, err := unstructured.NestedString(co.Object, "spec", "bootstrap", "dataSecretName")
+	if err != nil || !exist {
+		return nil
+	}
+	return &dataSecretName
+}
+
+// IsControlPlaneMachine checks if an unstructured object is Machine with the control plane role.
+func (co ConfigOwner) IsControlPlaneMachine() bool {
+	if co.GetKind() != "Machine" {
+		return false
+	}
+	labels := co.GetLabels()
+	if labels == nil {
+		return false
+	}
+	_, ok := labels[clusterv1.MachineControlPlaneLabelName]
+	return ok
+}
+
+// GeConfigOwner returns the Unstructured object owning the current resource.
+func GetConfigOwner(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*ConfigOwner, error) {
+	for _, ref := range obj.OwnerReferences {
+		if ref.Kind == "Machine" && ref.APIVersion == clusterv1.GroupVersion.String() {
+			return GetOwnerByRef(ctx, c, &corev1.ObjectReference{
+				APIVersion: ref.APIVersion,
+				Kind:       ref.Kind,
+				Namespace:  obj.Namespace,
+				Name:       ref.Name,
+			})
+		}
+	}
+	return nil, nil
+}
+
+// GetOwnerByRef finds and returns the owner by looking at the object reference.
+func GetOwnerByRef(ctx context.Context, c client.Client, ref *corev1.ObjectReference) (*ConfigOwner, error) {
+	obj, err := external.Get(ctx, c, ref, ref.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return &ConfigOwner{obj}, nil
+}

--- a/bootstrap/util/configowner_test.go
+++ b/bootstrap/util/configowner_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+func TestGetConfigOwnerSuccess(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clusterv1.AddToScheme(scheme); err != nil {
+		t.Fatal("failed to register Cluster API objects to scheme")
+	}
+
+	myMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-machine",
+			Namespace: "my-ns",
+			Labels: map[string]string{
+				clusterv1.MachineControlPlaneLabelName: "",
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: "my-cluster",
+			Bootstrap: clusterv1.Bootstrap{
+				DataSecretName: pointer.StringPtr("my-data-secret"),
+			},
+		},
+		Status: clusterv1.MachineStatus{
+			InfrastructureReady: true,
+		},
+	}
+
+	c := fake.NewFakeClientWithScheme(scheme, myMachine)
+	objm := metav1.ObjectMeta{
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:       "Machine",
+				APIVersion: clusterv1.GroupVersion.String(),
+				Name:       "my-machine",
+			},
+		},
+		Namespace: "my-ns",
+		Name:      "my-resource-owned-by-machine",
+	}
+	configOwner, err := GetConfigOwner(context.TODO(), c, objm)
+	if err != nil {
+		t.Fatalf("did not expect an error but found one: %v", err)
+	}
+	if configOwner == nil {
+		t.Fatal("expected a configOwner but got nil")
+	}
+	if configOwner.ClusterName() != "my-cluster" {
+		t.Fatalf("did not expect ClusterName: %q", configOwner.ClusterName())
+	}
+	if !configOwner.IsInfrastructureReady() {
+		t.Fatalf("did not expect InfrastructureReady: %v", configOwner.IsInfrastructureReady())
+	}
+	if configOwner.DataSecretName() == nil {
+		t.Fatalf("did not expect DataSecretName: %v", configOwner.DataSecretName())
+	}
+	if !configOwner.IsControlPlaneMachine() {
+		t.Fatalf("did not expect IsControlPlane: %v", configOwner.IsControlPlaneMachine())
+	}
+}
+
+func TestGetConfigOwnerNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clusterv1.AddToScheme(scheme); err != nil {
+		t.Fatal("failed to register cluster api objects to scheme")
+	}
+
+	c := fake.NewFakeClientWithScheme(scheme)
+	objm := metav1.ObjectMeta{
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:       "Machine",
+				APIVersion: clusterv1.GroupVersion.String(),
+				Name:       "my-machine",
+			},
+		},
+		Namespace: "my-ns",
+		Name:      "my-resource-owned-by-machine",
+	}
+	_, err := GetConfigOwner(context.TODO(), c, objm)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestGetConfigOwnerNoOwner(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clusterv1.AddToScheme(scheme); err != nil {
+		t.Fatal("failed to register cluster api objects to scheme")
+	}
+
+	c := fake.NewFakeClientWithScheme(scheme)
+	objm := metav1.ObjectMeta{
+		OwnerReferences: []metav1.OwnerReference{},
+		Namespace:       "my-ns",
+		Name:            "my-resource-owned-by-machine",
+	}
+	configOwner, err := GetConfigOwner(context.TODO(), c, objm)
+	if err != nil {
+		t.Fatalf("did not expect an error but found one: %v", err)
+	}
+	if configOwner != nil {
+		t.Fatalf("expected nil, but got %v", configOwner)
+	}
+}

--- a/docs/book/src/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/providers/v1alpha2-to-v1alpha3.md
@@ -121,3 +121,17 @@
 
 The `cloudinit` module has been moved to an `internal` directory as it is not designed to be a public interface consumed
 outside of the existing module.
+
+## Interface for Bootstrap Provider Consumers
+
+- Consumers of bootstrap configuration, Machine and eventually MachinePool, must adhere to a
+  contract that defines a set of required fields used for coordination with the kubeadm bootstrap
+  provider.
+  - `apiVersion` to check for supported version/kind.
+  - `kind` to check for supported version/kind.
+  - `metadata.labels["cluster.x-k8s.io/control-plane"]` only present in the case of a control plane
+    `Machine`.
+  - `spec.clusterName` to retrieve the owning Cluster status.
+  - `spec.bootstrap.dataSecretName` to know where to put bootstrap data with sensitive information.
+  - `status.infrastuctureReady` to understand the state of the configuration consumer so the
+    bootstrap provider can take appropriate action (e.g. renew bootstrap token).


### PR DESCRIPTION
**What this PR does / why we need it**:
In preparation for adding `MachinePool`, update CBPK to access the configuration owner through `Unstructured` instead of `Machine` directly. `Machine`, `MachinePool`, or other are now required to implement the following fields:
- metadata.labels["cluster.x-k8s.io/control-plane"]
- spec.clusterName
- spec.bootstrap.dataSecretName
- status.infrastructureReady

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1799
