### PR TITLE
🏃Update e2e test framework

### DIFF
--- a/test/framework/convenience.go
+++ b/test/framework/convenience.go
@@ -39,6 +39,16 @@ func InstallComponents(ctx context.Context, mgmt Applier, components ...Componen
 // WaitForAPIServiceAvailable will wait for an an APIService to be available.
 // For example, kubectl wait --for=condition=Available --timeout=300s apiservice v1beta1.webhook.cert-manager.io
 func WaitForAPIServiceAvailable(ctx context.Context, mgmt Waiter, serviceName string) {
+	By(fmt.Sprintf("waiting for api service %q to be available", serviceName))
 	err := mgmt.Wait(ctx, "--for", "condition=Available", "--timeout", "300s", "apiservice", serviceName)
+	Expect(err).NotTo(HaveOccurred(), "stack: %+v", err)
+}
+
+// WaitForPodsReadyInNamespace will wait for all pods to be Ready in the
+// specified namespace.
+// For example, kubectl wait --for=condition=Ready --timeout=300s --namespace capi-system pods --all
+func WaitForPodsReadyInNamespace(ctx context.Context, cluster Waiter, namespace string) {
+	By(fmt.Sprintf("waiting for pods to be ready in namespace %q", namespace))
+	err := cluster.Wait(ctx, "--for", "condition=Ready", "--timeout", "300s", "--namespace", namespace, "pods", "--all")
 	Expect(err).NotTo(HaveOccurred(), "stack: %+v", err)
 }


### PR DESCRIPTION
Add convenience function WaitForPodsReadyInNamespace.
Use dynamic mapper in client to auto-discover schemes.

Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Creating this PR to specifically include these changes so that others may use them sooner. See https://github.com/kubernetes-sigs/cluster-api/pull/1859#issuecomment-565030325

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Reference #1859 
