### PR TITLE
🐛 Do not make a secret if a secret already exists

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -199,6 +199,8 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 		return ctrl.Result{
 			RequeueAfter: DefaultTokenTTL / 2,
 		}, nil
+	case config.Status.DataSecretName != nil:
+		return ctrl.Result{}, nil
 	}
 
 	// Attempt to Patch the KubeadmConfig object and status after each reconciliation if no error occurs.

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Docker", func() {
 					Cluster:           cluster,
 					InfraCluster:      infraCluster,
 					ControlplaneNodes: nodes,
-					CreateTimeout:     2 * time.Minute,
+					CreateTimeout:     3 * time.Minute,
 				}
 				framework.MultiNodeControlPlaneCluster(input)
 


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**: 
This prevents an endless error loop for the CABPK controller which caused multiple InitConfigurations to be created. This happened because the init function would return an error which would set the return error which would cause the defer Unlock to happen which would allow another control plane to grab the lock and create an Init configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1880 

