### PR TITLE
🏃 Add clusterName to example machine spec

### DIFF
--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -39,6 +39,7 @@ metadata:
   namespace: default
 spec:
   version: "v1.14.2"
+  clusterName: my-cluster
   bootstrap:
     configRef:
       apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
@@ -81,6 +82,7 @@ metadata:
   namespace: default
 spec:
   version: "v1.14.2"
+  clusterName: my-cluster
   bootstrap:
     configRef:
       apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3


### PR DESCRIPTION
Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds `clusterName` property to CAPD `examples/simple-cluster.yaml`

When I tried to `kubectl apply` I got the following error:

> error: error validating "examples/simple-cluster.yaml": error validating data: ValidationError(Machine.spec): missing required field "clusterName" in io.x-k8s.cluster.v1alpha3.Machine.spec; if you choose to ignore these errors, turn validation off with --validate=false

