### PR TITLE
🐛Fix e2e framework resource apply order

### DIFF
--- a/test/framework/one_node_cluster.go
+++ b/test/framework/one_node_cluster.go
@@ -70,6 +70,15 @@ func OneNodeCluster(input *OneNodeClusterInput) {
 		return err
 	}, input.CreateTimeout, 10*time.Second).Should(BeNil())
 
+	By("creating an InfrastructureMachine resource")
+	Expect(mgmtClient.Create(ctx, input.Node.InfraMachine)).NotTo(HaveOccurred())
+
+	By("creating a bootstrap config")
+	Expect(mgmtClient.Create(ctx, input.Node.BootstrapConfig)).NotTo(HaveOccurred())
+
+	By("creating a core Machine resource with a linked InfrastructureMachine and BootstrapConfig")
+	Expect(mgmtClient.Create(ctx, input.Node.Machine)).NotTo(HaveOccurred())
+
 	// Wait for the cluster infrastructure
 	Eventually(func() string {
 		cluster := &clusterv1.Cluster{}
@@ -82,15 +91,6 @@ func OneNodeCluster(input *OneNodeClusterInput) {
 		}
 		return cluster.Status.Phase
 	}, input.CreateTimeout, 10*time.Second).Should(Equal(string(clusterv1.ClusterPhaseProvisioned)))
-
-	By("creating an InfrastructureMachine resource")
-	Expect(mgmtClient.Create(ctx, input.Node.InfraMachine)).NotTo(HaveOccurred())
-
-	By("creating a bootstrap config")
-	Expect(mgmtClient.Create(ctx, input.Node.BootstrapConfig)).NotTo(HaveOccurred())
-
-	By("creating a core Machine resource with a linked InfrastructureMachine and BootstrapConfig")
-	Expect(mgmtClient.Create(ctx, input.Node.Machine)).NotTo(HaveOccurred())
 
 	Eventually(func() string {
 		machine := &clusterv1.Machine{}


### PR DESCRIPTION
/kind bug
/assign @chuckha 



<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This patch fixes the order in which resources are applied in the e2e framework. Prior to this patch the cluster and infra cluster resources were applied, and then the framework waited for the cluster to be provisioned. The `Provisioned` phase is not set by the cluster controller [until there is a non-zero control plane endpoint](https://github.com/kubernetes-sigs/cluster-api/blob/1bb8132e8c034d0d24346e3138747e94a90f6d18/controllers/cluster_controller_phases.go#L50-L52). For providers that get the control plane endpoint from a machine, this meant that the cluster would never be provisioned until machine resources existed.

This change is also consistent with how CAPI v1alpha2 works -- all resources are applied in sequence before any action is taken to determine the status of the deployed resources.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

