### PR TITLE
⚠️ clusterctlv2: add interfaces for the management cluster low level library

### DIFF
--- a/cmd/clusterctl/pkg/client/cluster/client.go
+++ b/cmd/clusterctl/pkg/client/cluster/client.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ctx = context.Background()
+)
+
+// Client is used to interact with a management cluster.
+// A management cluster contains following categories of objects:
+// - provider components (e.g. the CRDs, controllers, RBAC)
+// - provider inventory items (e.g. the list of installed providers/versions)
+// - provider objects (e.g. clusters, AWS clusters, machines etc.)
+type Client interface {
+	// Kubeconfig return the path to kubeconfig used to access to a management cluster.
+	Kubeconfig() string
+
+	// Proxy return the Proxy used for operating objects in the management cluster.
+	Proxy() Proxy
+
+	// ProviderComponents returns a ComponentsClient object that can be user for
+	// operating provider components objects in the management cluster (e.g. the CRDs, controllers, RBAC).
+	ProviderComponents() ComponentsClient
+
+	// ProviderInventory returns a InventoryClient object that can be user for
+	// operating provider inventory stored in the management cluster (e.g. the list of installed providers/versions).
+	ProviderInventory() InventoryClient
+
+	// ProviderObjects returns a ObjectsClient object that can be user for
+	// operating cluster API objects stored in the management cluster (e.g. clusters, AWS clusters, machines etc.).
+	ProviderObjects() ObjectsClient
+}
+
+// clusterClient implements Client.
+type clusterClient struct {
+	kubeconfig string
+	proxy      Proxy
+}
+
+// ensure clusterClient implements Client.
+var _ Client = &clusterClient{}
+
+func (c *clusterClient) Kubeconfig() string {
+	return c.kubeconfig
+}
+
+func (c *clusterClient) Proxy() Proxy {
+	return c.proxy
+}
+
+func (c *clusterClient) ProviderComponents() ComponentsClient {
+	return newComponentsClient(c.proxy)
+}
+
+func (c *clusterClient) ProviderInventory() InventoryClient {
+	return newInventoryClient(c.proxy)
+}
+
+func (c *clusterClient) ProviderObjects() ObjectsClient {
+	return newObjectsClient(c.proxy)
+}
+
+// New returns a cluster.Client.
+func New(kubeconfig string, options Options) Client {
+	return newClusterClient(kubeconfig, options)
+}
+
+func newClusterClient(kubeconfig string, options Options) *clusterClient {
+	proxy := options.InjectProxy
+	if proxy == nil {
+		proxy = newK8SProxy(kubeconfig)
+	}
+	return &clusterClient{
+		kubeconfig: kubeconfig,
+		proxy:      proxy,
+	}
+}
+
+// Options allow to set ConfigClient options
+type Options struct {
+	InjectProxy Proxy
+}
+
+type Proxy interface {
+	// CurrentNamespace returns the namespace from the current context in the kubeconfig file
+	CurrentNamespace() (string, error)
+
+	// NewClient returns a new controller runtime Client object for working on the management cluster
+	NewClient() (client.Client, error)
+}
+
+var _ Proxy = &test.FakeProxy{}

--- a/cmd/clusterctl/pkg/client/cluster/components.go
+++ b/cmd/clusterctl/pkg/client/cluster/components.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ComponentsClient has methods to work with provider components in the cluster.
+type ComponentsClient interface {
+	Create(components repository.Components) error
+
+	//TODO: add more in a follow up PR
+}
+
+// providerComponents implements ComponentsClient.
+type providerComponents struct {
+	proxy Proxy
+}
+
+// Create provider components defined in the yaml file.
+func (p *providerComponents) Create(components repository.Components) error {
+
+	c, err := p.proxy.NewClient()
+	if err != nil {
+		return err
+	}
+
+	// sort provider components for creation according to relation across objects (e.g. Namespace before everything namespaced)
+	resources := sortResourcesForCreate(components.Objs())
+
+	// creates (or updates) provider components
+	for _, r := range resources {
+
+		// check if the component already exists, and eventually update it
+		currentR := &unstructured.Unstructured{}
+		currentR.SetGroupVersionKind(r.GroupVersionKind())
+
+		key := client.ObjectKey{
+			Namespace: r.GetNamespace(),
+			Name:      r.GetName(),
+		}
+		if err = c.Get(ctx, key, currentR); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return errors.Wrapf(err, "failed to get current provider object")
+			}
+
+			//if it does not exists, create the component
+			klog.V(3).Infof("Creating: %s, %s/%s", r.GroupVersionKind(), r.GetNamespace(), r.GetName())
+			if err = c.Create(ctx, &r); err != nil { //nolint
+				return errors.Wrapf(err, "failed to create provider object")
+			}
+
+			continue
+		}
+
+		// otherwise update the component
+		klog.V(3).Infof("Updating: %s, %s/%s", r.GroupVersionKind(), r.GetNamespace(), r.GetName())
+
+		// if upgrading an existing component, then use the current resourceVersion for the optimistic lock
+		r.SetResourceVersion(currentR.GetResourceVersion())
+		if err = c.Update(ctx, &r); err != nil { //nolint
+			return errors.Wrapf(err, "failed to update provider object")
+		}
+	}
+
+	return nil
+}
+
+// newComponentsClient returns a providerComponents.
+func newComponentsClient(proxy Proxy) *providerComponents {
+	return &providerComponents{
+		proxy: proxy,
+	}
+}
+
+// - Namespaces go first because all namespaced resources depend on them.
+// - Custom Resource Definitions come before Custom Resource so that they can be
+//   restored with their corresponding CRD.
+// - Storage Classes are needed to create PVs and PVCs correctly.
+// - PVs go before PVCs because PVCs depend on them.
+// - PVCs go before pods or controllers so they can be mounted as volumes.
+// - Secrets and config maps go before pods or controllers so they can be mounted as volumes.
+// - Service accounts go before pods or controllers so pods can use them.
+// - Limit ranges go before pods or controllers so pods can use them.
+// - Pods go before ReplicaSets
+// - ReplicaSets go before Deployments
+// - Endpoints go before Services
+var defaultCreatePriorities = []string{
+	"Namespace",
+	"CustomResourceDefinition",
+	"StorageClass",
+	"PersistentVolume",
+	"PersistentVolumeClaim",
+	"Secret",
+	"ConfigMap",
+	"ServiceAccount",
+	"LimitRange",
+	"Pods",
+	"ReplicaSet",
+	"Endpoints",
+}
+
+func sortResourcesForCreate(resources []unstructured.Unstructured) []unstructured.Unstructured {
+	var ret []unstructured.Unstructured
+
+	// First get resources by priority
+	for _, p := range defaultCreatePriorities {
+		for _, o := range resources {
+			if o.GetKind() == p {
+				ret = append(ret, o)
+			}
+		}
+	}
+
+	// Then get all the other resources
+	for _, o := range resources {
+		found := false
+		for _, r := range ret {
+			if o.GroupVersionKind() == r.GroupVersionKind() && o.GetNamespace() == r.GetNamespace() && o.GetName() == r.GetName() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			ret = append(ret, o)
+		}
+	}
+
+	return ret
+}

--- a/cmd/clusterctl/pkg/client/cluster/inventory.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const embeddedCustomResourceDefinitionPath = "cmd/clusterctl/config/manifest/clusterctl-api.yaml"
+
+// InventoryClient exposes methods to interface with a cluster's provider inventory.
+type InventoryClient interface {
+	// EnsureCustomResourceDefinitions installs the CRD required for creating inventory items, if necessary.
+	// Nb. In order to provide a simpler out-of-the box experience, the inventory CRD
+	// is embedded in the clusterctl binary.
+	EnsureCustomResourceDefinitions() error
+
+	// Validate checks the inventory in order to determine if adding a new provider instance to the cluster.
+	// can lead to an non functional cluster.
+	Validate(clusterctlv1.Provider) error
+
+	// Create an inventory item for a provider instance installed in the cluster.
+	Create(clusterctlv1.Provider) error
+
+	// Return inventory items for all the provider instances installed in the cluster.
+	List() ([]clusterctlv1.Provider, error)
+}
+
+// inventoryClient implements InventoryClient.
+type inventoryClient struct {
+	proxy Proxy
+}
+
+// ensure inventoryClient implements InventoryClient.
+var _ InventoryClient = &inventoryClient{}
+
+// newInventoryClient returns a inventoryClient.
+func newInventoryClient(proxy Proxy) *inventoryClient {
+	return &inventoryClient{
+		proxy: proxy,
+	}
+}
+
+func (p *inventoryClient) EnsureCustomResourceDefinitions() error {
+	// get the CRD manifest from the embedded assets
+	yaml, err := config.Asset(embeddedCustomResourceDefinitionPath)
+	if err != nil {
+		return err
+	}
+
+	// transform the yaml in a list of objects
+	objs, err := util.ToUnstructured(yaml)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse yaml for clusterctl inventory CRD")
+	}
+
+	c, err := p.proxy.NewClient()
+	if err != nil {
+		return err
+	}
+
+	for _, o := range objs {
+		klog.V(3).Infof("Creating: %s, %s/%s", o.GroupVersionKind(), o.GetNamespace(), o.GetName())
+		if err = c.Create(ctx, &o); err != nil { //nolint
+			if apierrors.IsAlreadyExists(err) {
+				return nil
+			}
+			return errors.Wrapf(err, "failed to create clusterctl inventory CRD")
+		}
+	}
+
+	return errors.Wrapf(err, "invalid yaml for clusterctl inventory CRD")
+}
+
+func (p *inventoryClient) Validate(m clusterctlv1.Provider) error {
+	instances, err := p.list(listOptions{
+		Name: m.Name,
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(instances) == 0 {
+		return nil
+	}
+
+	// Target Namespace check
+	// Installing two instances of the same provider in the same namespace won't be supported
+	for _, i := range instances {
+		if i.Namespace == m.Namespace {
+			return errors.Errorf("There is already an instance of the %q provider installed in the %q namespace", m.Name, m.Namespace)
+		}
+	}
+
+	// Version check:
+	// If we are going to install an instance of a provider with version X, and there are already other instances of the same provider with
+	// different versions there is the risk of creating problems to all the version different than X because we are going to override
+	// all the existing non-namespaced objects (e.g. CRDs) with the ones from version X
+	sameVersion := false
+	for _, i := range instances {
+		if i.Version == m.Version {
+			sameVersion = true
+		}
+	}
+	if !sameVersion {
+		return errors.Errorf("The new instance of the %q provider has a version different than other instances of the same provider", m.Name)
+	}
+
+	// Watching Namespace check:
+	// If we are going to install an instance of a provider watching objects in namespaces already controlled by other providers
+	// then there will be providers fighting for objects...
+	if m.WatchedNamespace == "" {
+		return errors.Errorf("The new instance of the %q provider is going to watch for objects in namespaces already controlled by other providers", m.Name)
+	}
+
+	sameNamespace := false
+	for _, i := range instances {
+		if i.WatchedNamespace == "" || m.WatchedNamespace == i.WatchedNamespace {
+			sameNamespace = true
+		}
+	}
+	if sameNamespace {
+		return errors.Errorf("The new instance of the %q provider is going to watch for objects in the namespace %q that is already controlled by other providers", m.Name, m.WatchedNamespace)
+	}
+
+	return nil
+}
+
+func (p *inventoryClient) Create(m clusterctlv1.Provider) error {
+	cl, err := p.proxy.NewClient()
+	if err != nil {
+		return err
+	}
+
+	currentProvider := &clusterctlv1.Provider{}
+	key := client.ObjectKey{
+		Namespace: m.Namespace,
+		Name:      m.Name,
+	}
+	if err = cl.Get(ctx, key, currentProvider); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to get current provider object")
+		}
+		currentProvider = nil
+	}
+
+	c := m.DeepCopyObject()
+	if currentProvider == nil {
+		if err = cl.Create(ctx, c); err != nil {
+			return errors.Wrapf(err, "failed to create provider object")
+		}
+	} else {
+		m.ResourceVersion = currentProvider.ResourceVersion
+		if err = cl.Update(ctx, c); err != nil {
+			return errors.Wrapf(err, "failed to update provider object")
+		}
+	}
+
+	return nil
+}
+
+func (p *inventoryClient) List() ([]clusterctlv1.Provider, error) {
+	return p.list(listOptions{})
+}
+
+type listOptions struct {
+	Namespace string
+	Name      string
+	Type      clusterctlv1.ProviderType
+}
+
+func (p *inventoryClient) list(options listOptions) ([]clusterctlv1.Provider, error) {
+	cl, err := p.proxy.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	l := &clusterctlv1.ProviderList{}
+	if err := cl.List(ctx, l); err != nil {
+		return nil, errors.Wrap(err, "failed get providers")
+	}
+
+	var ret []clusterctlv1.Provider //nolint
+	for _, i := range l.Items {
+		if options.Name != "" && i.Name != options.Name {
+			continue
+		}
+		if options.Namespace != "" && i.Namespace != options.Namespace {
+			continue
+		}
+		if options.Type != "" && i.Type != string(options.Type) {
+			continue
+		}
+		ret = append(ret, i)
+	}
+	return ret, nil
+}

--- a/cmd/clusterctl/pkg/client/cluster/inventory_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
+)
+
+func Test_inventoryClient_EnsureCustomResourceDefinitions(t *testing.T) {
+	type fields struct {
+		alreadyHasCRD bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "Has not CRD",
+			fields: fields{
+				alreadyHasCRD: false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Already has CRD",
+			fields: fields{
+				alreadyHasCRD: true,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newInventoryClient(test.NewFakeK8SProxy())
+			if tt.fields.alreadyHasCRD {
+				//forcing creation of metadata before test
+				if err := p.EnsureCustomResourceDefinitions(); err != nil {
+					t.Errorf("EnsureCustomResourceDefinitions() error = %v", err)
+					return
+				}
+			}
+
+			err := p.EnsureCustomResourceDefinitions()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EnsureCustomResourceDefinitions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+var fooProvider = clusterctlv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns1"}}
+
+func Test_inventoryClient_List(t *testing.T) {
+	type fields struct {
+		initObjs []runtime.Object
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []clusterctlv1.Provider
+		wantErr bool
+	}{
+		{
+			name: "Get list",
+			fields: fields{
+				initObjs: []runtime.Object{
+					&fooProvider,
+				},
+			},
+			want: []clusterctlv1.Provider{
+				fooProvider,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newInventoryClient(test.NewFakeK8SProxy().WithObjs(tt.fields.initObjs...))
+			got, err := p.List()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("List() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("List() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/clusterctl/pkg/client/cluster/objects.go
+++ b/cmd/clusterctl/pkg/client/cluster/objects.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+// ObjectsClient has methods to work with provider objects in the cluster.
+type ObjectsClient interface {
+	//TODO: add move
+}
+
+// objectsClient implements ObjectsClient.
+type objectsClient struct {
+	proxy Proxy
+}
+
+// ensure objectsClient implements ObjectsClient.
+var _ ObjectsClient = &objectsClient{}
+
+// newProviderObjects returns a objectsClient.
+func newObjectsClient(proxy Proxy) *objectsClient {
+	return &objectsClient{
+		proxy: proxy,
+	}
+}

--- a/cmd/clusterctl/pkg/client/cluster/proxy.go
+++ b/cmd/clusterctl/pkg/client/cluster/proxy.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	Scheme = scheme.Scheme
+)
+
+type proxy struct {
+	kubeconfig string
+}
+
+var _ Proxy = &proxy{}
+
+func (k *proxy) CurrentNamespace() (string, error) {
+	config, err := clientcmd.LoadFromFile(k.kubeconfig)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to load Kubeconfig file from %q", k.kubeconfig)
+	}
+
+	if config.CurrentContext == "" {
+		return "", errors.Wrapf(err, "failed to get current-context from %q", k.kubeconfig)
+	}
+
+	v, ok := config.Contexts[config.CurrentContext]
+	if !ok {
+		return "", errors.Wrapf(err, "failed to get context %q from %q", config.CurrentContext, k.kubeconfig)
+	}
+
+	if v.Namespace != "" {
+		return v.Namespace, nil
+	}
+
+	return "default", nil
+}
+
+func (k *proxy) NewClient() (client.Client, error) {
+	config, err := k.getConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create controller-runtime client")
+	}
+
+	c, err := client.New(config, client.Options{Scheme: Scheme})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create controller-runtime client")
+	}
+
+	return c, nil
+}
+
+func newK8SProxy(kubeconfig string) Proxy {
+	// If a kubeconfig file is provided use it, otherwise find a config file in the standard locations
+	if kubeconfig == "" {
+		kubeconfig = clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
+	}
+
+	return &proxy{
+		kubeconfig: kubeconfig,
+	}
+}
+
+func (k *proxy) getConfig() (*rest.Config, error) {
+	config, err := clientcmd.LoadFromFile(k.kubeconfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load Kubeconfig file from %q", k.kubeconfig)
+	}
+
+	restConfig, err := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to rest client")
+	}
+
+	return restConfig, nil
+}

--- a/cmd/clusterctl/pkg/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/pkg/internal/test/fake_proxy.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type FakeProxy struct {
+	cs   client.Client
+	objs []runtime.Object
+}
+
+func (f *FakeProxy) CurrentNamespace() (string, error) {
+	return "default", nil
+}
+
+func (f *FakeProxy) NewClient() (client.Client, error) {
+	if f.cs != nil {
+		return f.cs, nil
+	}
+	f.cs = fake.NewFakeClientWithScheme(scheme.Scheme, f.objs...)
+
+	return f.cs, nil
+}
+
+func NewFakeK8SProxy() *FakeProxy {
+	return &FakeProxy{}
+}
+
+func (f *FakeProxy) WithObjs(objs ...runtime.Object) *FakeProxy {
+	f.objs = objs
+	return f
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the interfaces for the last (YAY!) low-level library of clusterctl, that is responsible for managing the management cluster.

The PR includes also the minimal set of the concrete implementation of those interfaces required to get `clusterctl init` in place ASAP

**Which issue(s) this PR fixes:**
Rif #1729 

/assign @vincepri
/cc @detiber @ncdc
