### PR TITLE
:bug: Fix validation on machine's bootstrap dataSecretName

### DIFF
--- a/api/v1alpha3/machine_webhook.go
+++ b/api/v1alpha3/machine_webhook.go
@@ -64,12 +64,12 @@ func (m *Machine) ValidateDelete() error {
 
 func (m *Machine) validate() error {
 	var allErrs field.ErrorList
-	if m.Spec.Bootstrap.ConfigRef == nil && m.Spec.Bootstrap.Data == nil {
+	if m.Spec.Bootstrap.ConfigRef == nil && m.Spec.Bootstrap.DataSecretName == nil {
 		allErrs = append(
 			allErrs,
 			field.Required(
 				field.NewPath("spec", "bootstrap", "data"),
-				"expected spec.bootstrap.data or spec.bootstrap.configRef to be populated",
+				"expected either spec.bootstrap.dataSecretName or spec.bootstrap.configRef to be populated",
 			),
 		)
 	}

--- a/api/v1alpha3/machine_webhook_test.go
+++ b/api/v1alpha3/machine_webhook_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestMachineDefault(t *testing.T) {
@@ -43,7 +44,6 @@ func TestMachineDefault(t *testing.T) {
 }
 
 func TestMachineBootstrapValidation(t *testing.T) {
-	data := "some bootstrap data"
 	tests := []struct {
 		name      string
 		bootstrap Bootstrap
@@ -51,12 +51,12 @@ func TestMachineBootstrapValidation(t *testing.T) {
 	}{
 		{
 			name:      "should return error if configref and data are nil",
-			bootstrap: Bootstrap{ConfigRef: nil, Data: nil},
+			bootstrap: Bootstrap{ConfigRef: nil, DataSecretName: nil},
 			expectErr: true,
 		},
 		{
-			name:      "should not return error if data is set",
-			bootstrap: Bootstrap{ConfigRef: nil, Data: &data},
+			name:      "should not return error if dataSecretName is set",
+			bootstrap: Bootstrap{ConfigRef: nil, DataSecretName: pointer.StringPtr("test")},
 			expectErr: false,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Fixes an issue where the validation webhook would reject validation if spec.bootstrap.dataSecretName was set, but configRef wasn't.
