### PR TITLE
🏃 Let GCB build release images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,9 +268,6 @@ release: clean-release ## Builds and push container images using the latest git 
 	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
 	@if ! [ -z "$$(git status --porcelain)" ]; then echo "Your local git repository contains uncommitted changes, use git clean before proceeding."; exit 1; fi
 	git checkout "${RELEASE_TAG}"
-	# Push the release image to the staging bucket first.
-	REGISTRY=$(STAGING_REGISTRY) TAG=$(RELEASE_TAG) \
-		$(MAKE) docker-build-all docker-push-all
 	# Set the manifest image to the production bucket.
 	MANIFEST_IMG=$(PROD_REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(RELEASE_TAG) \
 		$(MAKE) set-manifest-image

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -60,7 +60,7 @@ For version v0.x.y:
     1. To use your GPG signature when pushing the tag, use `git tag -s [...]` instead
 1. Push the tag to the GitHub repository `git push origin v0.x.y`
     1. NB: `origin` should be the name of the remote pointing to `github.com/kubernetes-sigs/cluster-api`
-1. Run `make release` to build artifacts and push the images to the staging bucket
+1. Run `make release` to build artifacts (the image is automatically built by CI)
 1. Follow the [Image Promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter) to promote the image from the staging repo to `us.gcr.io/k8s-artifacts-prod/cluster-api`
 1. Create a release in GitHub based on the tag created above
 1. Release notes can be created by running `make release-notes`, which will generate an output that can be copied to the drafted release in GitHub.


### PR DESCRIPTION
**What this PR does / why we need it**:
test-infra has been updated to use GCB to build release version images,
so we no longer need to do it here in the repo.

Requires https://github.com/kubernetes/test-infra/pull/15624

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
