### PR TITLE
🐛 Actually import (and enable) pprof

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ issues:
   # List of regexps of issue texts to exclude, empty list by default.
   exclude:
     - Using the variable on range scope `(tc)|(rt)|(tt)|(test)|(testcase)|(testCase)` in function literal
+    - "G108: Profiling endpoint is automatically exposed on /debug/pprof"
 run:
   deadline: 4m
   skip-files:

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"flag"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"time"
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Import and enable pprof, the profiler flag wasn't working before.
