### PR TITLE
⚠️ ClusterConfigration.Networking.* fields are now optional

### DIFF
--- a/bootstrap/kubeadm/types/v1beta1/types.go
+++ b/bootstrap/kubeadm/types/v1beta1/types.go
@@ -227,11 +227,14 @@ type NodeRegistrationOptions struct {
 // Networking contains elements describing cluster's networking configuration
 type Networking struct {
 	// ServiceSubnet is the subnet used by k8s services. Defaults to "10.96.0.0/12".
-	ServiceSubnet string `json:"serviceSubnet"`
+	// +optional
+	ServiceSubnet string `json:"serviceSubnet,omitempty"`
 	// PodSubnet is the subnet used by pods.
-	PodSubnet string `json:"podSubnet"`
+	// +optional
+	PodSubnet string `json:"podSubnet,omitempty"`
 	// DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
-	DNSDomain string `json:"dnsDomain"`
+	// +optional
+	DNSDomain string `json:"dnsDomain,omitempty"`
 }
 
 // BootstrapToken describes one bootstrap token, stored as a Secret in the cluster

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -306,10 +306,6 @@ spec:
                         description: ServiceSubnet is the subnet used by k8s services.
                           Defaults to "10.96.0.0/12".
                         type: string
-                    required:
-                    - dnsDomain
-                    - podSubnet
-                    - serviceSubnet
                     type: object
                   scheduler:
                     description: Scheduler contains extra settings for the scheduler
@@ -1113,10 +1109,6 @@ spec:
                         description: ServiceSubnet is the subnet used by k8s services.
                           Defaults to "10.96.0.0/12".
                         type: string
-                    required:
-                    - dnsDomain
-                    - podSubnet
-                    - serviceSubnet
                     type: object
                   scheduler:
                     description: Scheduler contains extra settings for the scheduler

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -319,10 +319,6 @@ spec:
                               description: ServiceSubnet is the subnet used by k8s
                                 services. Defaults to "10.96.0.0/12".
                               type: string
-                          required:
-                          - dnsDomain
-                          - podSubnet
-                          - serviceSubnet
                           type: object
                         scheduler:
                           description: Scheduler contains extra settings for the scheduler

--- a/config/crd/bases/cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -352,10 +352,6 @@ spec:
                           description: ServiceSubnet is the subnet used by k8s services.
                             Defaults to "10.96.0.0/12".
                           type: string
-                      required:
-                      - dnsDomain
-                      - podSubnet
-                      - serviceSubnet
                       type: object
                     scheduler:
                       description: Scheduler contains extra settings for the scheduler


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Same as https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/pull/287, but for CAPK-in-CAPI types.
