### PR TITLE
⚠️ ClusterConfigration.Networking.* fields are now optional

### DIFF
--- a/bootstrap/kubeadm/types/v1beta1/types.go
+++ b/bootstrap/kubeadm/types/v1beta1/types.go
@@ -227,11 +227,13 @@ type NodeRegistrationOptions struct {
 // Networking contains elements describing cluster's networking configuration
 type Networking struct {
 	// ServiceSubnet is the subnet used by k8s services. Defaults to "10.96.0.0/12".
-	ServiceSubnet string `json:"serviceSubnet"`
+	// +optional
+	ServiceSubnet string `json:"serviceSubnet,omitempty"`
 	// PodSubnet is the subnet used by pods.
 	PodSubnet string `json:"podSubnet"`
 	// DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
-	DNSDomain string `json:"dnsDomain"`
+	// +optional
+	DNSDomain string `json:"dnsDomain,omitempty"`
 }
 
 // BootstrapToken describes one bootstrap token, stored as a Secret in the cluster

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -307,9 +307,7 @@ spec:
                           Defaults to "10.96.0.0/12".
                         type: string
                     required:
-                    - dnsDomain
                     - podSubnet
-                    - serviceSubnet
                     type: object
                   scheduler:
                     description: Scheduler contains extra settings for the scheduler
@@ -1114,9 +1112,7 @@ spec:
                           Defaults to "10.96.0.0/12".
                         type: string
                     required:
-                    - dnsDomain
                     - podSubnet
-                    - serviceSubnet
                     type: object
                   scheduler:
                     description: Scheduler contains extra settings for the scheduler

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -320,9 +320,7 @@ spec:
                                 services. Defaults to "10.96.0.0/12".
                               type: string
                           required:
-                          - dnsDomain
                           - podSubnet
-                          - serviceSubnet
                           type: object
                         scheduler:
                           description: Scheduler contains extra settings for the scheduler

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -353,9 +353,7 @@ spec:
                             Defaults to "10.96.0.0/12".
                           type: string
                       required:
-                      - dnsDomain
                       - podSubnet
-                      - serviceSubnet
                       type: object
                     scheduler:
                       description: Scheduler contains extra settings for the scheduler


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Same as https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/pull/287, but for CAPI types.

This fixes the long-standing issue of seeing patches failing for the first control plane instance. After a little investigation, it seems that the issue was primarily "fixed" because after the first try, there are no more patches to the KubeadmConfig for a control plane.

While the Spec fails to patch, the Status doesn't and it gets updated with the generated bootstrap data. Things flow as you'd expect, but any configuration in ClusterConfiguration.Networking is lost. In v1alpha2, you can see that there is a discrepancy between what's generated and stored under `KubeadmConfig.Status.BootstrapData` and what's in the Spec.

While the generated bootstrap data has Networking fields set (which is the most important bit), the Spec doesn't.

Fixes #1769 
