### PR TITLE
controlplane: Allow nil ClusterConfiguration

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
@@ -38,6 +38,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
+	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -185,6 +186,9 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, kcp *cont
 	// Generate Cluster Certificates if needed
 	config := kcp.Spec.KubeadmConfigSpec.DeepCopy()
 	config.JoinConfiguration = nil
+	if config.ClusterConfiguration == nil {
+		config.ClusterConfiguration = &kubeadmv1.ClusterConfiguration{}
+	}
 	certificates := secret.NewCertificatesForInitialControlPlane(config.ClusterConfiguration)
 	err = certificates.LookupOrGenerate(
 		ctx,


### PR DESCRIPTION
Prevents a nil pointer exception when using the following control plane spec:

```yaml
---
apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
kind: KubeadmControlPlane
metadata:
  name: test
  namespace: docker-test
spec:
  infrastructureTemplate:
    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
    kind: DockerMachineTemplate
    name: test
    namespace: 'docker-test'
  kubeadmConfigSpec: {}
  replicas: 1
  version: 1.16.3
```