### PR TITLE
Tiltfile: Support appended commands in Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,11 +352,16 @@ clean-book: ## Remove all generated GitBook files
 clean-bindata: ## Remove bindata generated folder
 	rm -rf $(GOBINDATA_CLUSTERCTL_DIR)/manifest
 
+.PHONY: format-tiltfile
+format-tiltfile: ## Format Tiltfile
+	./hack/verify-starlark.sh fix
+
 .PHONY: verify
 verify:
 	./hack/verify-boilerplate.sh
 	./hack/verify-doctoc.sh
 	./hack/verify-shellcheck.sh
+	./hack/verify-starlark.sh
 	$(MAKE) verify-modules
 	$(MAKE) verify-gen
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -71,13 +71,13 @@ COPY --from=tilt-helper /go/kubernetes/client/bin/kubectl /usr/bin/kubectl
 #     }
 # }
 def load_provider_tiltfiles():
-    provider_repos = settings.get('provider_repos', [])
+    provider_repos = settings.get("provider_repos", [])
     for repo in provider_repos:
-        file = repo + '/tilt-provider.json'
-        provider_details = read_json(file, default={})
-        provider_name = provider_details['name']
-        provider_config = provider_details['config']
-        provider_config['context'] = repo
+        file = repo + "/tilt-provider.json"
+        provider_details = read_json(file, default = {})
+        provider_name = provider_details["name"]
+        provider_config = provider_details["config"]
+        provider_config["context"] = repo
         providers[provider_name] = provider_config
 
 tilt_helper_dockerfile_header = """
@@ -109,51 +109,52 @@ ENTRYPOINT [ "/start.sh", "/manager" ]
 def enable_provider(name):
     p = providers.get(name)
 
-    context = p.get('context')
+    context = p.get("context")
 
     # Prefix each live reload dependency with context. For example, for if the context is
     # test/infra/docker and main.go is listed as a dep, the result is test/infra/docker/main.go. This adjustment is
     # needed so Tilt can watch the correct paths for changes.
-    live_reload_deps=[]
-    for d in p.get('live_reload_deps', []):
-        live_reload_deps += [context + '/' + d]
+    live_reload_deps = []
+    for d in p.get("live_reload_deps", []):
+        live_reload_deps += [context + "/" + d]
 
     # Set up a local_resource build of the provider's manager binary. The provider is expected to have a main.go in
     # manager_build_path. The binary is written to .tiltbuild/manager.
-    local_resource(name + "_manager",
-                   cmd='cd ' + context + ';mkdir -p .tiltbuild;CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \'-extldflags "-static"\' -o .tiltbuild/manager',
-                   deps=live_reload_deps)
+    local_resource(
+        name + "_manager",
+        cmd = "cd " + context + ';mkdir -p .tiltbuild;CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags \'-extldflags "-static"\' -o .tiltbuild/manager',
+        deps = live_reload_deps,
+    )
 
     additional_docker_helper_commands = p.get("additional_docker_helper_commands", "")
     additional_docker_build_commands = p.get("additional_docker_build_commands", "")
 
     dockerfile_contents = "\n".join([
-      tilt_helper_dockerfile_header,
-      additional_docker_helper_commands,
-      tilt_dockerfile_header,
-      additional_docker_build_commands,
-     tilt_dockerfile_footer
+        tilt_helper_dockerfile_header,
+        additional_docker_helper_commands,
+        tilt_dockerfile_header,
+        additional_docker_build_commands,
+        tilt_dockerfile_footer,
     ])
-
 
     # Set up an image build for the provider. The live update configuration syncs the output from the local_resource
     # build into the container.
     docker_build(
-        ref=p.get('image'),
-        context=p.get('context'),
-        dockerfile_contents=dockerfile_contents,
-        target='tilt',
-        entrypoint='/start.sh /manager',
-        only='.tiltbuild/manager',
-        live_update=[
-            sync(context + '/.tiltbuild/manager', '/manager'),
-            run('/restart.sh')
-        ]
+        ref = p.get("image"),
+        context = p.get("context"),
+        dockerfile_contents = dockerfile_contents,
+        target = "tilt",
+        entrypoint = "/start.sh /manager",
+        only = ".tiltbuild/manager",
+        live_update = [
+            sync(context + "/.tiltbuild/manager", "/manager"),
+            run("/restart.sh"),
+        ],
     )
 
     # Apply the kustomized yaml for this provider
-    yaml = str(kustomize(context + '/config/default'))
-    substitutions = settings.get('kustomize_substitutions', {})
+    yaml = str(kustomize(context + "/config/default"))
+    substitutions = settings.get("kustomize_substitutions", {})
     for substitution in substitutions:
         value = substitutions[substitution]
         yaml = yaml.replace("${" + substitution + "}", value)
@@ -163,30 +164,30 @@ def enable_provider(name):
 # setup if you're repeatedly destroying and recreating your kind cluster, as it doesn't have to pull the images over
 # the network each time.
 def deploy_cert_manager():
-    registry = 'quay.io/jetstack'
-    version = 'v0.11.0'
-    images = ['cert-manager-controller', 'cert-manager-cainjector', 'cert-manager-webhook']
+    registry = "quay.io/jetstack"
+    version = "v0.11.0"
+    images = ["cert-manager-controller", "cert-manager-cainjector", "cert-manager-webhook"]
 
     if settings.get("preload_images_for_kind"):
-      for image in images:
-          local('docker pull {}/{}:{}'.format(registry, image, version))
-          local('kind load docker-image {}/{}:{}'.format(registry, image, version))
+        for image in images:
+            local("docker pull {}/{}:{}".format(registry, image, version))
+            local("kind load docker-image {}/{}:{}".format(registry, image, version))
 
-    local('kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml')
+    local("kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml")
 
     # wait for the service to become available
-    local('kubectl wait --for=condition=Available --timeout=300s apiservice v1beta1.webhook.cert-manager.io')
+    local("kubectl wait --for=condition=Available --timeout=300s apiservice v1beta1.webhook.cert-manager.io")
 
 # Users may define their own Tilt customizations in tilt.d. This directory is excluded from git and these files will
 # not be checked in to version control.
 def include_user_tilt_files():
-    user_tiltfiles = listdir('tilt.d')
+    user_tiltfiles = listdir("tilt.d")
     for f in user_tiltfiles:
         include(f)
 
 # Enable core cluster-api plus everything listed in 'enable_providers' in tilt-settings.json
 def enable_providers():
-    for name in ['core'] + settings.get('enable_providers', []):
+    for name in ["core"] + settings.get("enable_providers", []):
         enable_provider(name)
 
 ##############################
@@ -197,6 +198,6 @@ include_user_tilt_files()
 load_provider_tiltfiles()
 
 if settings.get("deploy_cert_manager"):
-  deploy_cert_manager()
+    deploy_cert_manager()
 
 enable_providers()

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -108,6 +108,23 @@ build it.
 **live_reload_deps**: a list of files/directories to watch. If any of them changes, Tilt rebuilds the manager binary
 for the provider and performs a live update of the running container.
 
+**additional_docker_helper_commands** (String, default=""): Additional commands to be run in the helper image
+docker build. e.g.
+
+``` Dockerfile
+RUN wget -qO- https://dl.k8s.io/v1.14.4/kubernetes-client-linux-amd64.tar.gz | tar xvz
+RUN wget -qO- https://get.docker.com | sh
+```
+
+**additional_docker_build_commands** (String, default=""): Additional commands to be appended to
+the dockerfile.
+The manager image will use docker-slim, so to download files, use `additional_helper_image_commands`. e.g.
+
+``` Dockerfile
+COPY --from=tilt-helper /usr/bin/docker /usr/bin/docker
+COPY --from=tilt-helper /go/kubernetes/client/bin/kubectl /usr/bin/kubectl
+```
+
 ## Customizing Tilt
 
 If you need to customize Tilt's behavior, you can create files in cluster-api's `tilt.d` directory. This file is ignored


### PR DESCRIPTION
The Docker provider image requires extra binaries in order to work, so add
provider fields to support appending commands to the Dockerfile contents.

Also adds buildifier as the Starlark formatter.