### PR TITLE
:book: Add GCP credentials doc for tilt

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -52,13 +52,35 @@ Next, create a `tilt-settings.json` file and place it in your local copy of `clu
 for more details.
 
 **kustomize_substitutions** (Map{String: String}, default={}): An optional map of substitutions for `${}`-style placeholders in the
-provider's yaml. For example, if the yaml contains `${AWS_B64ENCODED_CREDENTIALS}`, you could do the following:
+provider's yaml.
+
+{{#tabs name:"tab-tilt-kustomize-substitution" tabs:"AWS,GCP"}}
+{{#tab AWS}}
+
+For example, if the yaml contains `${AWS_B64ENCODED_CREDENTIALS}`, you could do the following:
 
 ```json
 "kustomize_substitutions": {
   "AWS_B64ENCODED_CREDENTIALS": "your credentials here"
 }
 ```
+
+{{#/tab }}
+{{#tab GCP}}
+
+You can generate a base64 version of your GCP json credentials file using:
+```bash
+base64 -i ~/path/to/gcp/credentials.json
+```
+
+```json
+"kustomize_substitutions": {
+  "GCP_B64ENCODED_CREDENTIALS": "your credentials here"
+}
+```
+
+{{#/tab }}
+{{#/tabs }}
 
 **deploy_cert_manager** (Boolean, default=`true`): Deploys cert-manager into the cluster for use for webhook registration.
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Adds a tab for GCP in Tilt credentials section
