### PR TITLE
🐛 Install the dependencies for capd e2es

### DIFF
--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+set -x
+
+GOPATH_BIN="$(go env GOPATH)/bin/"
+MINIMUM_KIND_VERSION=v0.6.1
+
+# Ensure the kind tool exists and is a viable version, or installs it
+verify_kind_version() {
+
+  # If kind is not available on the path, get it
+  if ! [ -x "$(command -v kind)" ]; then
+    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+      echo 'kind not found, installing'
+      if ! [ -d "${GOPATH_BIN}" ]; then
+        mkdir -p "${GOPATH_BIN}"
+      fi
+      curl -sLo "${GOPATH_BIN}/kind" https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-linux-amd64
+      chmod +x "${GOPATH_BIN}/kind"
+    else
+      echo "Missing required binary in path: kind"
+      return 2
+    fi
+  fi
+
+  local kind_version
+  kind_version=$(kind version)
+  if ! [[ "${kind_version}" =~ ${MINIMUM_KIND_VERSION} ]]; then
+    cat <<EOF
+Detected kind version: ${kind_version}.
+Requires ${MINIMUM_KIND_VERSION} or greater.
+Please install ${MINIMUM_KIND_VERSION} or later.
+EOF
+    return 2
+  fi
+}
+
+verify_kind_version

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOPATH_BIN="$(go env GOPATH)/bin/"
+MINIMUM_KUBECTL_VERSION=v1.15.0
+
+# Ensure the kubectl tool exists and is a viable version, or installs it
+verify_kubectl_version() {
+
+  # If kubectl is not available on the path, get it
+  if ! [ -x "$(command -v kubectl)" ]; then
+    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+      if ! [ -d "${GOPATH_BIN}" ]; then
+        mkdir -p "${GOPATH_BIN}"
+      fi
+      echo 'kubectl not found, installing'
+      curl -sLo "${GOPATH_BIN}/kubectl" https://storage.googleapis.com/kubernetes-release/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
+      chmod +x "${GOPATH_BIN}/kubectl"
+    else
+      echo "Missing required binary in path: kubectl"
+      return 2
+    fi
+  fi
+
+  local kubectl_version
+  IFS=" " read -ra kubectl_version <<< "$(kubectl version --client --short)"
+  if [[ "${MINIMUM_KUBECTL_VERSION}" != $(echo -e "${MINIMUM_KUBECTL_VERSION}\n${kubectl_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
+    cat <<EOF
+Detected kubectl version: ${kubectl_version[2]}.
+Requires ${MINIMUM_KUBECTL_VERSION} or greater.
+Please install ${MINIMUM_KUBECTL_VERSION} or later.
+EOF
+    return 2
+  fi
+}
+
+verify_kubectl_version

--- a/hack/ensure-kustomize.sh
+++ b/hack/ensure-kustomize.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GOPATH_BIN="$(go env GOPATH)/bin/"
+MINIMUM_KUSTOMIZE_VERSION=3.1.0
+
+# Ensure the kustomize tool exists and is a viable version, or installs it
+verify_kustomize_version() {
+
+  # If kustomize is not available on the path, get it
+  if ! [ -x "$(command -v kustomize)" ]; then
+    if [[ "${OSTYPE}" == "linux-gnu" ]]; then
+      echo 'kustomize not found, installing'
+      if ! [ -d "${GOPATH_BIN}" ]; then
+        mkdir -p "${GOPATH_BIN}"
+      fi
+      curl -sLo "${GOPATH_BIN}/kustomize" https://github.com/kubernetes-sigs/kustomize/releases/download/v${MINIMUM_KUSTOMIZE_VERSION}/kustomize_${MINIMUM_KUSTOMIZE_VERSION}_linux_amd64
+      chmod +x "${GOPATH_BIN}/kustomize"
+    else
+      echo "Missing required binary in path: kustomize"
+      return 2
+    fi
+  fi
+
+  local kustomize_version
+  kustomize_version=$(kustomize version)
+  if [[ "${MINIMUM_KUSTOMIZE_VERSION}" != $(echo -e "${MINIMUM_KUSTOMIZE_VERSION}\n${kustomize_version}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) ]]; then
+    cat <<EOF
+Detected kustomize version: ${kustomize_version}.
+Requires ${MINIMUM_KUSTOMIZE_VERSION} or greater.
+Please install ${MINIMUM_KUSTOMIZE_VERSION} or later.
+EOF
+    return 2
+  fi
+}
+
+verify_kustomize_version

--- a/scripts/ci-capd-e2e.sh
+++ b/scripts/ci-capd-e2e.sh
@@ -23,6 +23,12 @@ cd "${REPO_ROOT}" || exit 1
 
 # shellcheck source=./hack/ensure-go.sh
 source "${REPO_ROOT}/hack/ensure-go.sh"
+# shellcheck source=./hack/ensure-kind.sh
+source "${REPO_ROOT}/hack/ensure-kind.sh"
+# shellcheck source=./hack/ensure-kubectl.sh
+source "${REPO_ROOT}/hack/ensure-kubectl.sh"
+# shellcheck source=./hack/ensure-kustomize.sh
+source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 
 echo "*** Testing Cluster API Provider Docker e2es ***"
 cd "${REPO_ROOT}/test/infrastructure/docker" && make test-e2e


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This installs the necessary dependencies for the capd e2es.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1921 

the three hack scripts are copied verbatim from CAPA.
