### PR TITLE
⚠️ clusterctlv2: add the clusterctl init command

### DIFF
--- a/cmd/clusterctl/pkg/client/alias.go
+++ b/cmd/clusterctl/pkg/client/alias.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
 )
 
 // Alias creates local alias for types defined in the low-level library.
@@ -25,3 +26,6 @@ import (
 
 // Provider defines a provider configuration.
 type Provider config.Provider
+
+// Components wraps a YAML file that defines the provider's components (CRD, controller, RBAC rules etc.)
+type Components repository.Components

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -38,7 +38,7 @@ type Client interface {
 	// GetProvidersConfig returns the list of providers configured for this instance of clusterctl.
 	GetProvidersConfig() ([]Provider, error)
 
-	// Init a management cluster by adding the requested list of providers.
+	// Init initializes a management cluster by adding the requested list of providers.
 	Init(options InitOptions) ([]Components, bool, error)
 }
 

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -17,25 +17,49 @@ limitations under the License.
 package client
 
 import (
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
 )
+
+// InitOptions carries the options supported by Init
+type InitOptions struct {
+	Kubeconfig              string
+	CoreProvider            string
+	BootstrapProviders      []string
+	InfrastructureProviders []string
+	TargetNameSpace         string
+	WatchingNamespace       string
+	Force                   bool
+}
 
 // Client is exposes the clusterctl high-level client library
 type Client interface {
+	// GetProvidersConfig returns the list of providers configured for this instance of clusterctl.
 	GetProvidersConfig() ([]Provider, error)
+
+	// Init a management cluster by adding the requested list of providers.
+	Init(options InitOptions) ([]Components, bool, error)
 }
 
 // clusterctlClient implements Client.
 type clusterctlClient struct {
-	configClient config.Client
+	configClient            config.Client
+	repositoryClientFactory RepositoryClientFactory
+	clusterClientFactory    ClusterClientFactory
 }
+
+type RepositoryClientFactory func(config.Provider) (repository.Client, error)
+type ClusterClientFactory func(string) (cluster.Client, error)
 
 // ensure clusterctlClient implements Client.
 var _ Client = &clusterctlClient{}
 
 // NewOptions carries the options supported by New
 type NewOptions struct {
-	injectConfig config.Client
+	injectConfig            config.Client
+	injectRepositoryFactory RepositoryClientFactory
+	injectClusterFactory    ClusterClientFactory
 }
 
 // Option is a configuration option supplied to New
@@ -45,6 +69,22 @@ type Option func(*NewOptions)
 func InjectConfig(config config.Client) Option {
 	return func(c *NewOptions) {
 		c.injectConfig = config
+	}
+}
+
+// InjectRepositoryFactory implements a New Option that allows to override the default factory used for creating
+// RepositoryClient objects.
+func InjectRepositoryFactory(factory RepositoryClientFactory) Option {
+	return func(c *NewOptions) {
+		c.injectRepositoryFactory = factory
+	}
+}
+
+// InjectClusterClientFactory implements a New Option that allows to override the default factory used for creating
+// ClusterClient objects.
+func InjectClusterClientFactory(factory ClusterClientFactory) Option {
+	return func(c *NewOptions) {
+		c.injectClusterFactory = factory
 	}
 }
 
@@ -59,6 +99,8 @@ func newClusterctlClient(path string, options ...Option) (*clusterctlClient, err
 		o(cfg)
 	}
 
+	// if there is an injected config, use it, otherwise use the default one
+	// provided by the config low level library
 	configClient := cfg.injectConfig
 	if configClient == nil {
 		c, err := config.New(path)
@@ -68,7 +110,35 @@ func newClusterctlClient(path string, options ...Option) (*clusterctlClient, err
 		configClient = c
 	}
 
+	// if there is an injected RepositoryFactory, use it, otherwise use a default one
+	repositoryClientFactory := cfg.injectRepositoryFactory
+	if repositoryClientFactory == nil {
+		repositoryClientFactory = defaultRepositoryFactory(configClient)
+	}
+
+	// if there is an injected ClusterFactory, use it, otherwise use a default one
+	clusterClientFactory := cfg.injectClusterFactory
+	if clusterClientFactory == nil {
+		clusterClientFactory = defaultClusterFactory()
+	}
+
 	return &clusterctlClient{
-		configClient: configClient,
+		configClient:            configClient,
+		repositoryClientFactory: repositoryClientFactory,
+		clusterClientFactory:    clusterClientFactory,
 	}, nil
+}
+
+// defaultClusterFactory is a ClusterClientFactory func the uses the default client provided by the cluster low level library
+func defaultClusterFactory() func(kubeconfig string) (cluster.Client, error) {
+	return func(kubeconfig string) (cluster.Client, error) {
+		return cluster.New(kubeconfig, cluster.Options{}), nil
+	}
+}
+
+// defaultRepositoryFactory is a RepositoryClientFactory func the uses the default client provided by the repository low level library
+func defaultRepositoryFactory(configClient config.Client) func(providerConfig config.Provider) (repository.Client, error) {
+	return func(providerConfig config.Provider) (repository.Client, error) {
+		return repository.New(providerConfig, configClient.Variables(), repository.Options{})
+	}
 }

--- a/cmd/clusterctl/pkg/client/client_test.go
+++ b/cmd/clusterctl/pkg/client/client_test.go
@@ -118,7 +118,7 @@ func (f *fakeClient) WithRepository(repositoryClient repository.Client) *fakeCli
 	return f
 }
 
-// fakeClusterClient returns a cluster.Client for a fake management cluster that
+// newFakeCluster returns a fakeClusterClient that
 // internally uses a FakeProxy (based on the controller-runtime FakeClient).
 // You can use WithObjs to pre-load a set of runtime objects in the cluster.
 func newFakeCluster(kubeconfig string) *fakeClusterClient {
@@ -165,7 +165,7 @@ func (f fakeClusterClient) ProviderObjects() cluster.ObjectsClient {
 	return f.internalclient.ProviderObjects()
 }
 
-func (f fakeClusterClient) ProviderInstaller() cluster.ProviderInstallerService {
+func (f fakeClusterClient) ProviderInstaller() cluster.ProviderInstaller {
 	return f.internalclient.ProviderInstaller()
 }
 

--- a/cmd/clusterctl/pkg/client/cluster/client.go
+++ b/cmd/clusterctl/pkg/client/cluster/client.go
@@ -51,9 +51,9 @@ type Client interface {
 	// operating cluster API objects stored in the management cluster (e.g. clusters, AWS clusters, machines etc.).
 	ProviderObjects() ObjectsClient
 
-	// ProviderInstaller returns an ProviderInstallerService that enforces consistency rules for provider installation,
+	// ProviderInstaller returns a ProviderInstaller that enforces consistency rules for provider installation,
 	// trying to prevent e.g. controllers fighting for objects, inconsistent versions, etc.
-	ProviderInstaller() ProviderInstallerService
+	ProviderInstaller() ProviderInstaller
 }
 
 // clusterClient implements Client.
@@ -85,7 +85,7 @@ func (c *clusterClient) ProviderObjects() ObjectsClient {
 	return newObjectsClient(c.proxy)
 }
 
-func (c *clusterClient) ProviderInstaller() ProviderInstallerService {
+func (c *clusterClient) ProviderInstaller() ProviderInstaller {
 	return newProviderInstaller(c.proxy, c.ProviderInventory(), c.ProviderComponents())
 }
 

--- a/cmd/clusterctl/pkg/client/cluster/client.go
+++ b/cmd/clusterctl/pkg/client/cluster/client.go
@@ -50,6 +50,10 @@ type Client interface {
 	// ProviderObjects returns a ObjectsClient object that can be user for
 	// operating cluster API objects stored in the management cluster (e.g. clusters, AWS clusters, machines etc.).
 	ProviderObjects() ObjectsClient
+
+	// ProviderInstaller returns an ProviderInstallerService that enforces consistency rules for provider installation,
+	// trying to prevent e.g. controllers fighting for objects, inconsistent versions, etc.
+	ProviderInstaller() ProviderInstallerService
 }
 
 // clusterClient implements Client.
@@ -79,6 +83,10 @@ func (c *clusterClient) ProviderInventory() InventoryClient {
 
 func (c *clusterClient) ProviderObjects() ObjectsClient {
 	return newObjectsClient(c.proxy)
+}
+
+func (c *clusterClient) ProviderInstaller() ProviderInstallerService {
+	return newProviderInstaller(c.proxy, c.ProviderInventory(), c.ProviderComponents())
 }
 
 // New returns a cluster.Client.

--- a/cmd/clusterctl/pkg/client/cluster/components.go
+++ b/cmd/clusterctl/pkg/client/cluster/components.go
@@ -67,7 +67,7 @@ func (p *providerComponents) Create(components repository.Components) error {
 			//if it does not exists, create the component
 			klog.V(3).Infof("Creating: %s, %s/%s", r.GroupVersionKind(), r.GetNamespace(), r.GetName())
 			if err = c.Create(ctx, &r); err != nil { //nolint
-				return errors.Wrapf(err, "failed to create provider object")
+				return errors.Wrapf(err, "failed to create provider object %s, %s/%s", r.GroupVersionKind(), r.GetNamespace(), r.GetName())
 			}
 
 			continue
@@ -79,7 +79,7 @@ func (p *providerComponents) Create(components repository.Components) error {
 		// if upgrading an existing component, then use the current resourceVersion for the optimistic lock
 		r.SetResourceVersion(currentR.GetResourceVersion())
 		if err = c.Update(ctx, &r); err != nil { //nolint
-			return errors.Wrapf(err, "failed to update provider object")
+			return errors.Wrapf(err, "failed to update provider object %s, %s/%s", r.GroupVersionKind(), r.GetNamespace(), r.GetName())
 		}
 	}
 

--- a/cmd/clusterctl/pkg/client/cluster/installer.go
+++ b/cmd/clusterctl/pkg/client/cluster/installer.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/klog"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
+)
+
+// ProviderInstallerService defined methods for enforcing consistency rules for provider installation.
+type ProviderInstallerService interface {
+	// Add a provider to the install queue.
+	// NB. By deferring the installation, the installer service can perform validation of the target state of the management cluster
+	// before actually starting the installation of new providers.
+	Add(repository.Components, bool) error
+
+	// Perform the installation of the providers ready in the install queue.
+	Install() ([]repository.Components, error)
+}
+
+// installerService implements ProviderInstallerService
+type installerService struct {
+	proxy              Proxy
+	providerComponents ComponentsClient
+	providerInventory  InventoryClient
+	installQueue       []repository.Components
+}
+
+var _ ProviderInstallerService = &installerService{}
+
+func (i *installerService) Add(components repository.Components, force bool) error {
+	if err := i.providerInventory.Validate(components.Metadata()); err != nil {
+		if !force {
+			return errors.Wrapf(err, "Installing provider %q can lead to a non functioning management cluster (you can use --force to ignore this error).", components.Name())
+		}
+	}
+
+	i.installQueue = append(i.installQueue, components)
+	return nil
+}
+
+func (i *installerService) Install() ([]repository.Components, error) {
+	ret := make([]repository.Components, len(i.installQueue))
+	for c, components := range i.installQueue {
+		klog.V(3).Infof("Installing provider %s/%s:%s", components.TargetNamespace(), components.Name(), components.Version())
+
+		// create the provider
+		err := i.providerComponents.Create(components)
+		if err != nil {
+			return nil, err
+		}
+
+		// create providers metadata
+		err = i.providerInventory.Create(components.Metadata())
+		if err != nil {
+			return nil, err
+		}
+
+		ret[c] = components
+	}
+
+	return ret, nil
+}
+
+func newProviderInstaller(proxy Proxy, providerMetadata InventoryClient, providerComponents ComponentsClient) *installerService {
+	return &installerService{
+		proxy:              proxy,
+		providerInventory:  providerMetadata,
+		providerComponents: providerComponents,
+	}
+}

--- a/cmd/clusterctl/pkg/client/cluster/inventory_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory_test.go
@@ -52,7 +52,7 @@ func Test_inventoryClient_EnsureCustomResourceDefinitions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newInventoryClient(test.NewFakeK8SProxy())
+			p := newInventoryClient(test.NewFakeProxy())
 			if tt.fields.alreadyHasCRD {
 				//forcing creation of metadata before test
 				if err := p.EnsureCustomResourceDefinitions(); err != nil {
@@ -97,7 +97,7 @@ func Test_inventoryClient_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newInventoryClient(test.NewFakeK8SProxy().WithObjs(tt.fields.initObjs...))
+			p := newInventoryClient(test.NewFakeProxy().WithObjs(tt.fields.initObjs...))
 			got, err := p.List()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("List() error = %v, wantErr %v", err, tt.wantErr)

--- a/cmd/clusterctl/pkg/client/common.go
+++ b/cmd/clusterctl/pkg/client/common.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
+)
+
+// getComponentsByName is a utility methods that returns provider component for a given provider, targetNamespace and WatchingNamespace.
+func (c *clusterctlClient) getComponentsByName(provider string, targetNamespace string, watchingNamespace string) (repository.Components, error) {
+
+	// parse the abbreviated syntax for name[:version]
+	name, version, err := parseProviderName(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	// if a target namespace is defined, use it, otherwise let the namespace empty so the default one defined in the
+	// provider components YAML will be used
+	var namespace string
+	if targetNamespace != "" {
+		namespace = targetNamespace
+	}
+
+	// gets the provider configuration (that includes the location of the provider repository)
+	providerConfig, err := c.configClient.Providers().Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	// get a client for the provider repository and read the provider components;
+	// during the process, provider components will be processed performing variable substitution, customization of target
+	// and watching namespace etc.
+
+	repository, err := c.repositoryClientFactory(*providerConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	components, err := repository.Components().Get(version, namespace, watchingNamespace)
+	if err != nil {
+		return nil, err
+	}
+	return components, nil
+}
+
+// parseProviderName defines a utility function that parses the abbreviated syntax for name[:version]
+func parseProviderName(provider string) (name string, version string, err error) {
+	t := strings.Split(strings.ToLower(provider), ":")
+	if len(t) > 2 {
+		return "", "", errors.Errorf("invalid provider name %q. Provider name should be in the form [namespace/]name[:version]", provider)
+	}
+
+	name = t[0]
+	errs := validation.IsDNS1123Label(name)
+	if len(errs) != 0 {
+		return "", "", errors.Errorf("invalid name value: %s", strings.Join(errs, "; "))
+	}
+
+	version = ""
+	if len(t) > 1 {
+		version = t[1]
+	}
+
+	return name, version, nil
+}

--- a/cmd/clusterctl/pkg/client/common_test.go
+++ b/cmd/clusterctl/pkg/client/common_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import "testing"
+
+func Test_parseProviderName(t *testing.T) {
+	type args struct {
+		provider string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantNamespace string
+		wantName      string
+		wantVersion   string
+		wantErr       bool
+	}{
+		{
+			name: "simple name",
+			args: args{
+				provider: "provider",
+			},
+			wantNamespace: "",
+			wantName:      "provider",
+			wantVersion:   "",
+			wantErr:       false,
+		},
+		{
+			name: "name & version",
+			args: args{
+				provider: "provider:version",
+			},
+			wantNamespace: "",
+			wantName:      "provider",
+			wantVersion:   "version",
+			wantErr:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotVersion, err := parseProviderName(tt.args.provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseProviderName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotName != tt.wantName {
+				t.Errorf("parseProviderName() gotName = %v, want %v", gotName, tt.wantName)
+			}
+			if gotVersion != tt.wantVersion {
+				t.Errorf("parseProviderName() gotVersion = %v, want %v", gotVersion, tt.wantVersion)
+			}
+		})
+	}
+}

--- a/cmd/clusterctl/pkg/client/common_test.go
+++ b/cmd/clusterctl/pkg/client/common_test.go
@@ -23,46 +23,42 @@ func Test_parseProviderName(t *testing.T) {
 		provider string
 	}
 	tests := []struct {
-		name          string
-		args          args
-		wantNamespace string
-		wantName      string
-		wantVersion   string
-		wantErr       bool
+		name        string
+		args        args
+		wantName    string
+		wantVersion string
+		wantErr     bool
 	}{
 		{
 			name: "simple name",
 			args: args{
 				provider: "provider",
 			},
-			wantNamespace: "",
-			wantName:      "provider",
-			wantVersion:   "",
-			wantErr:       false,
+			wantName:    "provider",
+			wantVersion: "",
+			wantErr:     false,
 		},
 		{
 			name: "name & version",
 			args: args{
 				provider: "provider:version",
 			},
-			wantNamespace: "",
-			wantName:      "provider",
-			wantVersion:   "version",
-			wantErr:       false,
+			wantName:    "provider",
+			wantVersion: "version",
+			wantErr:     false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotName, gotVersion, err := parseProviderName(tt.args.provider)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("parseProviderName() error = %v, wantErr %v", err, tt.wantErr)
-				return
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if gotName != tt.wantName {
-				t.Errorf("parseProviderName() gotName = %v, want %v", gotName, tt.wantName)
+				t.Errorf("gotName = %v, want %v", gotName, tt.wantName)
 			}
 			if gotVersion != tt.wantVersion {
-				t.Errorf("parseProviderName() gotVersion = %v, want %v", gotVersion, tt.wantVersion)
+				t.Errorf("gotVersion = %v, want %v", gotVersion, tt.wantVersion)
 			}
 		})
 	}

--- a/cmd/clusterctl/pkg/client/init.go
+++ b/cmd/clusterctl/pkg/client/init.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/pkg/errors"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/cluster"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
+)
+
+// Init a management cluster by adding the requested list of providers.
+func (c *clusterctlClient) Init(options InitOptions) ([]Components, bool, error) {
+	// gets access to the management cluster
+	cluster, err := c.clusterClientFactory(options.Kubeconfig)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// ensure the custom resource definitions required by clusterctl are in place
+	if err := cluster.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
+		return nil, false, err
+	}
+
+	// checks if the cluster already contains a Core provider.
+	// if not we consider this the first time init is executed, and thus we enforce the installation of a core provider (if not already explicitly requested by the user)
+	firstRun := false
+	currentCoreProvider, err := cluster.ProviderInventory().GetDefaultProviderName(clusterctlv1.CoreProviderType)
+	if err != nil {
+		return nil, false, err
+	}
+	if currentCoreProvider == "" && options.CoreProvider == "" {
+		firstRun = true
+		options.CoreProvider = config.ClusterAPIName
+	}
+
+	// create and installer service, add the requested providers to the install queue (thus performing validation of the target state of the management cluster
+	// before starting the installation), and then perform the installation.
+	installer := cluster.ProviderInstaller()
+
+	addOptions := addToInstallerOptions{
+		installer:         installer,
+		targetNameSpace:   options.TargetNameSpace,
+		watchingNamespace: options.WatchingNamespace,
+		force:             options.Force,
+	}
+
+	if options.CoreProvider != "" {
+		if err := c.addToInstaller(addOptions, clusterctlv1.CoreProviderType, options.CoreProvider); err != nil {
+			return nil, false, err
+		}
+	}
+
+	if err := c.addToInstaller(addOptions, clusterctlv1.BootstrapProviderType, options.BootstrapProviders...); err != nil {
+		return nil, false, err
+	}
+
+	if err := c.addToInstaller(addOptions, clusterctlv1.InfrastructureProviderType, options.InfrastructureProviders...); err != nil {
+		return nil, false, err
+	}
+
+	r, err := installer.Install()
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Components is an alias for repository.Components; this makes conversion
+	rr := make([]Components, len(r))
+	for i, components := range r {
+		rr[i] = components
+	}
+	return rr, firstRun, nil
+}
+
+type addToInstallerOptions struct {
+	installer         cluster.ProviderInstallerService
+	targetNameSpace   string
+	watchingNamespace string
+	force             bool
+}
+
+// addToInstaller adds the components to the install queue and checks that the actual provider type match the target group
+func (c *clusterctlClient) addToInstaller(options addToInstallerOptions, targetGroup clusterctlv1.ProviderType, providers ...string) error {
+	for _, provider := range providers {
+		components, err := c.getComponentsByName(provider, options.targetNameSpace, options.watchingNamespace)
+		if err != nil {
+			return err
+		}
+
+		if components.Type() != targetGroup {
+			return errors.Errorf("can't use %q provider as an %q, it is a %q", provider, targetGroup, components.Type())
+		}
+
+		if err := options.installer.Add(components, options.force); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/clusterctl/pkg/client/init_test.go
+++ b/cmd/clusterctl/pkg/client/init_test.go
@@ -1,0 +1,379 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"fmt"
+	"testing"
+
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/util"
+)
+
+func Test_clusterctlClient_Init(t *testing.T) {
+	type field struct {
+		client *fakeClient
+		hasCRD bool
+	}
+
+	type args struct {
+		coreProvider           string
+		bootstrapProvider      []string
+		infrastructureProvider []string
+		targetNameSpace        string
+		watchingNamespace      string
+		force                  bool
+	}
+	type want struct {
+		provider          Provider
+		version           string
+		targetNamespace   string
+		watchingNamespace string
+	}
+
+	tests := []struct {
+		name    string
+		field   field
+		args    args
+		want    []want
+		wantErr bool
+	}{
+		{
+			name: "Init (with an empty cluster) with default provider versions",
+			field: field{
+				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap and infra provider)
+				hasCRD: false,
+			},
+			args: args{
+				coreProvider:           "", // with an empty cluster, a core provider should be added automatically
+				bootstrapProvider:      []string{"bootstrap"},
+				infrastructureProvider: []string{"infra"},
+				targetNameSpace:        "",
+				watchingNamespace:      "",
+				force:                  false,
+			},
+			want: []want{
+				{
+					provider:          capiProviderConfig,
+					version:           "v1.0.0",
+					targetNamespace:   "ns1",
+					watchingNamespace: "",
+				},
+				{
+					provider:          bootstrapProviderConfig,
+					version:           "v2.0.0",
+					targetNamespace:   "ns2",
+					watchingNamespace: "",
+				},
+				{
+					provider:          infraProviderConfig,
+					version:           "v3.0.0",
+					targetNamespace:   "ns3",
+					watchingNamespace: "",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Init (with an empty cluster) with custom provider versions",
+			field: field{
+				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap and infra provider)
+				hasCRD: false,
+			},
+			args: args{
+				coreProvider:           fmt.Sprintf("%s:v1.1.0", config.ClusterAPIName),
+				bootstrapProvider:      []string{"bootstrap:v2.1.0"},
+				infrastructureProvider: []string{"infra:v3.1.0"},
+				targetNameSpace:        "",
+				watchingNamespace:      "",
+				force:                  false,
+			},
+			want: []want{
+				{
+					provider:          capiProviderConfig,
+					version:           "v1.1.0",
+					targetNamespace:   "ns1",
+					watchingNamespace: "",
+				},
+				{
+					provider:          bootstrapProviderConfig,
+					version:           "v2.1.0",
+					targetNamespace:   "ns2",
+					watchingNamespace: "",
+				},
+				{
+					provider:          infraProviderConfig,
+					version:           "v3.1.0",
+					targetNamespace:   "ns3",
+					watchingNamespace: "",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Init (with an empty cluster) with target namespace",
+			field: field{
+				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap and infra provider)
+				hasCRD: false,
+			},
+			args: args{
+				coreProvider:           "", // with an empty cluster, a core provider should be added automatically
+				bootstrapProvider:      []string{"bootstrap"},
+				infrastructureProvider: []string{"infra"},
+				targetNameSpace:        "nsx",
+				watchingNamespace:      "",
+				force:                  false,
+			},
+			want: []want{
+				{
+					provider:          capiProviderConfig,
+					version:           "v1.0.0",
+					targetNamespace:   "nsx",
+					watchingNamespace: "",
+				},
+				{
+					provider:          bootstrapProviderConfig,
+					version:           "v2.0.0",
+					targetNamespace:   "nsx",
+					watchingNamespace: "",
+				},
+				{
+					provider:          infraProviderConfig,
+					version:           "v3.0.0",
+					targetNamespace:   "nsx",
+					watchingNamespace: "",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Init (with a NOT empty cluster) adds a provider",
+			field: field{
+				client: fakeInitializedCluster(), // clusterctl client for an management cluster with capi installed (with repository setup for capi, bootstrap and infra provider)
+				hasCRD: true,
+			},
+			args: args{
+				coreProvider:           "", // with a NOT empty cluster, a core provider should NOT be added automatically
+				bootstrapProvider:      []string{"bootstrap"},
+				infrastructureProvider: []string{"infra"},
+				targetNameSpace:        "",
+				watchingNamespace:      "",
+				force:                  false,
+			},
+			want: []want{
+				{
+					provider:          bootstrapProviderConfig,
+					version:           "v2.0.0",
+					targetNamespace:   "ns2",
+					watchingNamespace: "",
+				},
+				{
+					provider:          infraProviderConfig,
+					version:           "v3.0.0",
+					targetNamespace:   "ns3",
+					watchingNamespace: "",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Fails when coreProvider is a provider with the wrong type",
+			field: field{
+				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap and infra provider)
+			},
+			args: args{
+				coreProvider:           "infra",
+				bootstrapProvider:      []string{"infra"},
+				infrastructureProvider: []string{"infra"},
+				targetNameSpace:        "",
+				watchingNamespace:      "",
+				force:                  false,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Fails when bootstrapProvider list contains providers of the wrong type",
+			field: field{
+				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap and infra provider)
+			},
+			args: args{
+				coreProvider:           "",
+				bootstrapProvider:      []string{"infra"},
+				infrastructureProvider: []string{"infra"},
+				targetNameSpace:        "",
+				watchingNamespace:      "",
+				force:                  false,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Fails when infrastructureProvider  list contains providers of the wrong type",
+			field: field{
+				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap and infra provider)
+			},
+			args: args{
+				coreProvider:           "",
+				bootstrapProvider:      []string{"bootstrap"},
+				infrastructureProvider: []string{"bootstrap"},
+				targetNameSpace:        "",
+				watchingNamespace:      "",
+				force:                  false,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if tt.field.hasCRD {
+				if err := tt.field.client.clusters["kubeconfig"].ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
+					t.Fatalf("EnsureMetadata() error = %v", err)
+					return
+				}
+			}
+
+			got, _, err := tt.field.client.Init(InitOptions{
+				Kubeconfig:              "kubeconfig",
+				CoreProvider:            tt.args.coreProvider,
+				BootstrapProviders:      tt.args.bootstrapProvider,
+				InfrastructureProviders: tt.args.infrastructureProvider,
+				TargetNameSpace:         tt.args.targetNameSpace,
+				WatchingNamespace:       tt.args.watchingNamespace,
+				Force:                   tt.args.force,
+			})
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if len(got) != len(tt.want) {
+				t.Errorf("Init() got = %v items, want %v items", len(got), len(tt.want))
+				return
+			}
+
+			for i, g := range got {
+				w := tt.want[i]
+
+				if g.Name() != w.provider.Name() {
+					t.Errorf("Init(), Item[%d].Name() got = %v, want = %v ", i, g.Name(), w.provider.Name())
+				}
+
+				if g.Type() != w.provider.Type() {
+					t.Errorf("Init(), Item[%d].Type() got = %v, want = %v ", i, g.Type(), w.provider.Type())
+				}
+
+				if g.Version() != w.version {
+					t.Errorf("Init(), Item[%d].Version() got = %v, want = %v ", i, g.Version(), w.version)
+				}
+
+				if g.TargetNamespace() != w.targetNamespace {
+					t.Errorf("Init(), Item[%d].TargetNamespace() got = %v, want = %v ", i, g.TargetNamespace(), w.targetNamespace)
+				}
+
+				if g.WatchingNamespace() != w.watchingNamespace {
+					t.Errorf("Init(), Item[%d].WatchingNamespace() got = %v, want = %v ", i, g.WatchingNamespace(), w.watchingNamespace)
+				}
+			}
+		})
+	}
+}
+
+var (
+	capiProviderConfig      = config.NewProvider(config.ClusterAPIName, "url", clusterctlv1.CoreProviderType)
+	bootstrapProviderConfig = config.NewProvider("bootstrap", "url", clusterctlv1.BootstrapProviderType)
+	infraProviderConfig     = config.NewProvider("infra", "url", clusterctlv1.InfrastructureProviderType)
+)
+
+// clusterctl client for an empty management cluster (with repository setup for capi, bootstrap and infra provider)
+func fakeEmptyCluster() *fakeClient {
+	config1 := newFakeConfig().
+		WithVar("var", "value").
+		WithProvider(capiProviderConfig).
+		WithProvider(bootstrapProviderConfig).
+		WithProvider(infraProviderConfig)
+
+	repository1 := newFakeRepository(capiProviderConfig, config1.Variables()).
+		WithPaths("root", "components.yaml").
+		WithDefaultVersion("v1.0.0").
+		WithFile("v1.0.0", "components.yaml", componentsYAML("ns1")).
+		WithFile("v1.1.0", "components.yaml", componentsYAML("ns1"))
+	repository2 := newFakeRepository(bootstrapProviderConfig, config1.Variables()).
+		WithPaths("root", "components.yaml").
+		WithDefaultVersion("v2.0.0").
+		WithFile("v2.0.0", "components.yaml", componentsYAML("ns2")).
+		WithFile("v2.1.0", "components.yaml", componentsYAML("ns2"))
+	repository3 := newFakeRepository(infraProviderConfig, config1.Variables()).
+		WithPaths("root", "components.yaml").
+		WithDefaultVersion("v3.0.0").
+		WithFile("v3.0.0", "components.yaml", componentsYAML("ns3")).
+		WithFile("v3.1.0", "components.yaml", componentsYAML("ns3")).
+		WithFile("v3.0.0", "config-kubeadm.yaml", templateYAML("ns3"))
+
+	cluster1 := newFakeCluster("kubeconfig")
+
+	client := newFakeClient(config1).
+		// fake repository for capi, bootstrap and infra provider (matching provider's config)
+		WithRepository(repository1).
+		WithRepository(repository2).
+		WithRepository(repository3).
+		// fake empty cluster
+		WithCluster(cluster1)
+
+	return client
+}
+
+// clusterctl client for an management cluster with capi installed (with repository setup for capi, bootstrap and infra provider)
+func fakeInitializedCluster() *fakeClient {
+	client := fakeEmptyCluster()
+
+	p := client.clusters["kubeconfig"].Proxy()
+	fp := p.(*test.FakeProxy)
+
+	fp.WithProviderInventory(capiProviderConfig.Name(), capiProviderConfig.Type(), "v1.0.0", "capi-system", "")
+
+	return client
+}
+
+func componentsYAML(ns string) []byte {
+	var namespaceYaml = []byte("apiVersion: v1\n" +
+		"kind: Namespace\n" +
+		"metadata:\n" +
+		fmt.Sprintf("  name: %s", ns))
+
+	var podYaml = []byte("apiVersion: v1\n" +
+		"kind: Pod\n" +
+		"metadata:\n" +
+		"  name: manager")
+
+	return util.JoinYaml(namespaceYaml, podYaml)
+}
+
+func templateYAML(ns string) []byte {
+	var podYaml = []byte("apiVersion: v1\n" +
+		"kind: Pod\n" +
+		"metadata:\n" +
+		"  name: manager\n" +
+		fmt.Sprintf("  namespace: %s", ns))
+
+	return podYaml
+}

--- a/cmd/clusterctl/pkg/client/init_test.go
+++ b/cmd/clusterctl/pkg/client/init_test.go
@@ -247,7 +247,6 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			if tt.field.hasCRD {
 				if err := tt.field.client.clusters["kubeconfig"].ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
 					t.Fatalf("EnsureMetadata() error = %v", err)
-					return
 				}
 			}
 
@@ -262,12 +261,11 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			})
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
-				return
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if len(got) != len(tt.want) {
-				t.Errorf("Init() got = %v items, want %v items", len(got), len(tt.want))
+				t.Errorf("got = %v items, want %v items", len(got), len(tt.want))
 				return
 			}
 
@@ -275,23 +273,23 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				w := tt.want[i]
 
 				if g.Name() != w.provider.Name() {
-					t.Errorf("Init(), Item[%d].Name() got = %v, want = %v ", i, g.Name(), w.provider.Name())
+					t.Errorf("Item[%d].Name() got = %v, want = %v ", i, g.Name(), w.provider.Name())
 				}
 
 				if g.Type() != w.provider.Type() {
-					t.Errorf("Init(), Item[%d].Type() got = %v, want = %v ", i, g.Type(), w.provider.Type())
+					t.Errorf("Item[%d].Type() got = %v, want = %v ", i, g.Type(), w.provider.Type())
 				}
 
 				if g.Version() != w.version {
-					t.Errorf("Init(), Item[%d].Version() got = %v, want = %v ", i, g.Version(), w.version)
+					t.Errorf("Item[%d].Version() got = %v, want = %v ", i, g.Version(), w.version)
 				}
 
 				if g.TargetNamespace() != w.targetNamespace {
-					t.Errorf("Init(), Item[%d].TargetNamespace() got = %v, want = %v ", i, g.TargetNamespace(), w.targetNamespace)
+					t.Errorf("Item[%d].TargetNamespace() got = %v, want = %v ", i, g.TargetNamespace(), w.targetNamespace)
 				}
 
 				if g.WatchingNamespace() != w.watchingNamespace {
-					t.Errorf("Init(), Item[%d].WatchingNamespace() got = %v, want = %v ", i, g.WatchingNamespace(), w.watchingNamespace)
+					t.Errorf("Item[%d].WatchingNamespace() got = %v, want = %v ", i, g.WatchingNamespace(), w.watchingNamespace)
 				}
 			}
 		})

--- a/test/infrastructure/docker/go.sum
+++ b/test/infrastructure/docker/go.sum
@@ -145,6 +145,8 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `clusterctl init` command and completes the internal test framework that will be used by all the other commands

**Which issue(s) this PR fixes** 
Rif #1729

/assign @vincepri 
/cc @detiber @ncdc