### PR TITLE
controlplane: Update finalizer and PROJECT domains to controlplane.cluster.x-k8s.io

### DIFF
--- a/controlplane/kubeadm/PROJECT
+++ b/controlplane/kubeadm/PROJECT
@@ -1,5 +1,5 @@
 version: "2"
-domain: cluster.x-k8s.io
+domain: controlplane.cluster.x-k8s.io
 repo: sigs.k8s.io/cluster-api/controlplane/kubeadm
 resources:
 - group: controlplane

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	KubeadmControlPlaneFinalizer = "kubeadmcontrolplane.cluster.x-k8s.io"
+	KubeadmControlPlaneFinalizer = "kubeadm.controlplane.cluster.x-k8s.io"
 )
 
 // KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.


### PR DESCRIPTION
Cleaning up post move of control plane to its own subdomain.