### PR TITLE
✨ Add defaulting webhook for KubeadmConfig

### DIFF
--- a/bootstrap/kubeadm/types/v1beta1/types.go
+++ b/bootstrap/kubeadm/types/v1beta1/types.go
@@ -277,7 +277,8 @@ type LocalEtcd struct {
 
 	// DataDir is the directory etcd will place its data.
 	// Defaults to "/var/lib/etcd".
-	DataDir string `json:"dataDir"`
+	// +optional
+	DataDir string `json:"dataDir,omitempty"`
 
 	// ExtraArgs are extra arguments provided to the etcd binary
 	// when run inside a static pod.

--- a/bootstrap/kubeadm/types/v1beta2/types.go
+++ b/bootstrap/kubeadm/types/v1beta2/types.go
@@ -265,7 +265,8 @@ type LocalEtcd struct {
 
 	// DataDir is the directory etcd will place its data.
 	// Defaults to "/var/lib/etcd".
-	DataDir string `json:"dataDir"`
+	// +optional
+	DataDir string `json:"dataDir,omitempty"`
 
 	// ExtraArgs are extra arguments provided to the etcd binary
 	// when run inside a static pod.

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -262,8 +262,6 @@ spec:
                             items:
                               type: string
                             type: array
-                        required:
-                        - dataDir
                         type: object
                     type: object
                   featureGates:
@@ -1067,8 +1065,6 @@ spec:
                             items:
                               type: string
                             type: array
-                        required:
-                        - dataDir
                         type: object
                     type: object
                   featureGates:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -274,8 +274,6 @@ spec:
                                   items:
                                     type: string
                                   type: array
-                              required:
-                              - dataDir
                               type: object
                           type: object
                         featureGates:

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -307,8 +307,6 @@ spec:
                               items:
                                 type: string
                               type: array
-                          required:
-                          - dataDir
                           type: object
                       type: object
                     featureGates:


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR adds a defaulting web hook for the KubeadmConfig. It also sets a default that Kubeadm would expect.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1770

/cc @akutz 
