### PR TITLE
🏃 Increase timeout for capd e2es

### DIFF
--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Docker", func() {
 					Cluster:           cluster,
 					InfraCluster:      infraCluster,
 					ControlplaneNodes: nodes,
-					CreateTimeout:     3 * time.Minute,
+					CreateTimeout:     4 * time.Minute,
 				}
 				framework.MultiNodeControlPlaneCluster(input)
 


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
The tests *usually* pass. They fail to timeouts though: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#e2e%20tests

This is an effort to twiddle the timeout so the tests pass reliably.

this may require further modification if 4 minutes is not sufficient. Deeper debugging may be required if that