### PR TITLE
:sparkles: Add cluster owner references to external MS/MD objects

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -254,7 +254,7 @@ func (r *ClusterReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 	if cluster.Spec.InfrastructureRef != nil {
 		obj, err := external.Get(ctx, r.Client, cluster.Spec.InfrastructureRef, cluster.Namespace)
 		switch {
-		case apierrors.IsNotFound(err):
+		case apierrors.IsNotFound(errors.Cause(err)):
 			// All good - the infra resource has been deleted
 		case err != nil:
 			return ctrl.Result{}, errors.Wrapf(err, "failed to get %s %q for Cluster %s/%s",

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -66,7 +66,7 @@ func (r *ClusterReconciler) reconcileExternal(ctx context.Context, cluster *clus
 
 	obj, err := external.Get(ctx, r.Client, ref, cluster.Namespace)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(errors.Cause(err)) {
 			return nil, errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: 30 * time.Second},
 				"could not find %v %q for Cluster %q in namespace %q, requeuing",
 				ref.GroupVersionKind(), ref.Name, cluster.Name, cluster.Namespace)

--- a/controllers/external/testing.go
+++ b/controllers/external/testing.go
@@ -22,6 +22,56 @@ import (
 )
 
 var (
+	TestGenericBootstrapCRD = &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "genericmachines.bootstrap.cluster.x-k8s.io",
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group: "bootstrap.cluster.x-k8s.io",
+			Scope: apiextensionsv1beta1.NamespaceScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Kind:   "BootstrapMachine",
+				Plural: "genericmachines",
+			},
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{},
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha3",
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+	}
+
+	TestGenericBootstrapTemplateCRD = &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "genericmachinetemplates.bootstrap.cluster.x-k8s.io",
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group: "bootstrap.cluster.x-k8s.io",
+			Scope: apiextensionsv1beta1.NamespaceScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Kind:   "BootstrapMachineTemplate",
+				Plural: "genericmachinetemplates",
+			},
+			Subresources: &apiextensionsv1beta1.CustomResourceSubresources{
+				Status: &apiextensionsv1beta1.CustomResourceSubresourceStatus{},
+			},
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{},
+			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha3",
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+	}
+
 	TestGenericInfrastructureCRD = &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "genericmachines.infrastructure.cluster.x-k8s.io",

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -396,7 +396,7 @@ func (r *MachineReconciler) reconcileDeleteExternal(ctx context.Context, m *clus
 		}
 
 		obj, err := external.Get(ctx, r.Client, ref, m.Namespace)
-		if err != nil && !apierrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(errors.Cause(err)) {
 			return false, errors.Wrapf(err, "failed to get %s %q for Machine %q in namespace %q",
 				ref.GroupVersionKind(), ref.Name, m.Name, m.Namespace)
 		}

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -79,7 +79,7 @@ func (r *MachineReconciler) reconcileExternal(ctx context.Context, m *clusterv1.
 
 	obj, err := external.Get(ctx, r.Client, ref, m.Namespace)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(errors.Cause(err)) {
 			return nil, errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: externalReadyWait},
 				"could not find %v %q for Machine %q in namespace %q, requeuing",
 				ref.GroupVersionKind(), ref.Name, m.Name, m.Namespace)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -75,6 +75,8 @@ var _ = BeforeSuite(func(done Done) {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDs: []*apiextensionsv1beta1.CustomResourceDefinition{
+			external.TestGenericBootstrapCRD,
+			external.TestGenericBootstrapTemplateCRD,
 			external.TestGenericInfrastructureCRD,
 			external.TestGenericInfrastructureTemplateCRD,
 		},


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1775
ref #1718