### PR TITLE
⚠️ MachinePool API Controller Implementation

### DIFF
--- a/api/v1alpha3/machinepool_types.go
+++ b/api/v1alpha3/machinepool_types.go
@@ -54,10 +54,10 @@ type MachinePoolSpec struct {
 	// +optional
 	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 
-	// ProviderIDs are the identification IDs of machine instances provided by the provider.
+	// ProviderIDList are the identification IDs of machine instances provided by the provider.
 	// This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
 	// +optional
-	ProviderIDs []string `json:"providerIDs,omitempty"`
+	ProviderIDList []string `json:"providerIDList,omitempty"`
 }
 
 // ANCHOR_END: MachinePoolSpec
@@ -93,7 +93,7 @@ type MachinePoolStatus struct {
 	// FailureReason indicates that there is a problem reconciling the state, and
 	// will be set to a token value suitable for programmatic interpretation.
 	// +optional
-	FailureReason *capierrors.MachinePoolStatusError `json:"failureReason,omitempty"`
+	FailureReason *capierrors.MachinePoolStatusFailure `json:"failureReason,omitempty"`
 
 	// FailureMessage indicates that there is a problem reconciling the state,
 	// and will be set to a descriptive error message.
@@ -171,6 +171,7 @@ func (m *MachinePoolStatus) GetTypedPhase() MachinePoolPhase {
 		MachinePoolPhasePending,
 		MachinePoolPhaseProvisioning,
 		MachinePoolPhaseProvisioned,
+		MachinePoolPhaseRunning,
 		MachinePoolPhaseDeleting,
 		MachinePoolPhaseFailed:
 		return phase

--- a/api/v1alpha3/machinepool_webhook_test.go
+++ b/api/v1alpha3/machinepool_webhook_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestMachinePoolDefault(t *testing.T) {
+	g := NewWithT(t)
+
+	m := &MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foobar",
+		},
+		Spec: MachinePoolSpec{
+			Template: MachineTemplateSpec{
+				Spec: MachineSpec{
+					Bootstrap: Bootstrap{ConfigRef: &corev1.ObjectReference{}},
+				},
+			},
+		},
+	}
+
+	m.Default()
+
+	g.Expect(m.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace).To(Equal(m.Namespace))
+	g.Expect(m.Spec.Template.Spec.InfrastructureRef.Namespace).To(Equal(m.Namespace))
+}
+
+func TestMachinePoolBootstrapValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		bootstrap Bootstrap
+		expectErr bool
+	}{
+		{
+			name:      "should return error if configref and data are nil",
+			bootstrap: Bootstrap{ConfigRef: nil, DataSecretName: nil},
+			expectErr: true,
+		},
+		{
+			name:      "should not return error if dataSecretName is set",
+			bootstrap: Bootstrap{ConfigRef: nil, DataSecretName: pointer.StringPtr("test")},
+			expectErr: false,
+		},
+		{
+			name:      "should not return error if config ref is set",
+			bootstrap: Bootstrap{ConfigRef: &corev1.ObjectReference{}, Data: nil},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			m := &MachinePool{
+				Spec: MachinePoolSpec{
+					Template: MachineTemplateSpec{
+						Spec: MachineSpec{
+							Bootstrap: tt.bootstrap,
+						},
+					},
+				},
+			}
+			if tt.expectErr {
+				g.Expect(m.ValidateCreate()).NotTo(Succeed())
+				g.Expect(m.ValidateUpdate(nil)).NotTo(Succeed())
+			} else {
+				g.Expect(m.ValidateCreate()).To(Succeed())
+				g.Expect(m.ValidateUpdate(nil)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestMachinePoolNamespaceValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		expectErr bool
+		bootstrap Bootstrap
+		infraRef  corev1.ObjectReference
+		namespace string
+	}{
+		{
+			name:      "should succeed if all namespaces match",
+			expectErr: false,
+			namespace: "foobar",
+			bootstrap: Bootstrap{ConfigRef: &corev1.ObjectReference{Namespace: "foobar"}},
+			infraRef:  corev1.ObjectReference{Namespace: "foobar"},
+		},
+		{
+			name:      "should return error if namespace and bootstrap namespace don't match",
+			expectErr: true,
+			namespace: "foobar",
+			bootstrap: Bootstrap{ConfigRef: &corev1.ObjectReference{Namespace: "foobar123"}},
+			infraRef:  corev1.ObjectReference{Namespace: "foobar"},
+		},
+		{
+			name:      "should return error if namespace and infrastructure ref namespace don't match",
+			expectErr: true,
+			namespace: "foobar",
+			bootstrap: Bootstrap{ConfigRef: &corev1.ObjectReference{Namespace: "foobar"}},
+			infraRef:  corev1.ObjectReference{Namespace: "foobar123"},
+		},
+		{
+			name:      "should return error if no namespaces match",
+			expectErr: true,
+			namespace: "foobar1",
+			bootstrap: Bootstrap{ConfigRef: &corev1.ObjectReference{Namespace: "foobar2"}},
+			infraRef:  corev1.ObjectReference{Namespace: "foobar3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			m := &MachinePool{
+				ObjectMeta: metav1.ObjectMeta{Namespace: tt.namespace},
+				Spec: MachinePoolSpec{
+					Template: MachineTemplateSpec{
+						Spec: MachineSpec{
+							Bootstrap:         tt.bootstrap,
+							InfrastructureRef: tt.infraRef,
+						},
+					},
+				},
+			}
+
+			if tt.expectErr {
+				g.Expect(m.ValidateCreate()).NotTo(Succeed())
+				g.Expect(m.ValidateUpdate(nil)).NotTo(Succeed())
+			} else {
+				g.Expect(m.ValidateCreate()).To(Succeed())
+				g.Expect(m.ValidateUpdate(nil)).To(Succeed())
+			}
+		})
+	}
+}

--- a/api/v1alpha3/zz_generated.deepcopy.go
+++ b/api/v1alpha3/zz_generated.deepcopy.go
@@ -675,8 +675,8 @@ func (in *MachinePoolSpec) DeepCopyInto(out *MachinePoolSpec) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.ProviderIDs != nil {
-		in, out := &in.ProviderIDs, &out.ProviderIDs
+	if in.ProviderIDList != nil {
+		in, out := &in.ProviderIDList, &out.ProviderIDList
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
@@ -702,7 +702,7 @@ func (in *MachinePoolStatus) DeepCopyInto(out *MachinePoolStatus) {
 	}
 	if in.FailureReason != nil {
 		in, out := &in.FailureReason, &out.FailureReason
-		*out = new(errors.MachinePoolStatusError)
+		*out = new(errors.MachinePoolStatusFailure)
 		**out = **in
 	}
 	if in.FailureMessage != nil {

--- a/bootstrap/kubeadm/config/rbac/role.yaml
+++ b/bootstrap/kubeadm/config/rbac/role.yaml
@@ -38,6 +38,8 @@ rules:
   resources:
   - clusters
   - clusters/status
+  - machinepools
+  - machinepools/status
   - machines
   - machines/status
   verbs:

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -57,11 +57,11 @@ spec:
                   be considered available as soon as it is ready)
                 format: int32
                 type: integer
-              providerIDs:
-                description: ProviderIDs are the identification IDs of machine instances
-                  provided by the provider. This field must match the provider IDs
-                  as seen on the node objects corresponding to a machine pool's machine
-                  instances.
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine
+                  instances provided by the provider. This field must match the provider
+                  IDs as seen on the node objects corresponding to a machine pool's
+                  machine instances.
                 items:
                   type: string
                 type: array

--- a/controllers/machinepool_controller.go
+++ b/controllers/machinepool_controller.go
@@ -17,15 +17,29 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
+	"sync"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
@@ -34,15 +48,16 @@ import (
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinepools;machinepools/status,verbs=get;list;watch;create;update;patch;delete
 
-// MachinePoolReconciler reconciles a MachineSet object
+// MachinePoolReconciler reconciles a MachinePool object
 type MachinePoolReconciler struct {
 	Client client.Client
 	Log    logr.Logger
 
-	config     *rest.Config
-	controller controller.Controller
-	recorder   record.EventRecorder
-	scheme     *runtime.Scheme
+	config           *rest.Config
+	controller       controller.Controller
+	recorder         record.EventRecorder
+	externalWatchers sync.Map
+	scheme           *runtime.Scheme
 }
 
 func (r *MachinePoolReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
@@ -57,13 +72,175 @@ func (r *MachinePoolReconciler) SetupWithManager(mgr ctrl.Manager, options contr
 	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("machinepool-controller")
 	r.config = mgr.GetConfig()
-
 	r.scheme = mgr.GetScheme()
 	return nil
 }
 
-func (r *MachinePoolReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	// TODO(juan-lee): Add machine pool implementation.
-	// TODO(vincepri): Add support for pause annotation and honoring Cluster.Spec.Paused.
+func (r *MachinePoolReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
+	ctx := context.Background()
+	logger := r.Log.WithValues("machinepool", req.NamespacedName)
+
+	mp := &clusterv1.MachinePool{}
+	if err := r.Client.Get(ctx, req.NamespacedName, mp); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Object not found, return. Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "Error reading the object - requeue the request.")
+		return ctrl.Result{}, err
+	}
+
+	cluster, err := util.GetClusterByName(ctx, r.Client, mp.ObjectMeta.Namespace, mp.Spec.ClusterName)
+	if err != nil {
+		logger.Error(err, "Failed to get Cluster %s for MachinePool.", mp.Spec.ClusterName)
+		return ctrl.Result{}, errors.Wrapf(err, "failed to get cluster %q for machinepool %q in namespace %q",
+			mp.Spec.ClusterName, mp.Name, mp.Namespace)
+	}
+
+	// Return early if the object or Cluster is paused.
+	if util.IsPaused(cluster, mp) {
+		logger.V(3).Info("reconciliation is paused for this object")
+		return ctrl.Result{}, nil
+	}
+
+	// Initialize the patch helper.
+	patchHelper, err := patch.NewHelper(mp, r.Client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	defer func() {
+		r.reconcilePhase(mp)
+		// TODO(jpang): add support for metrics.
+
+		// Always attempt to patch the object and status after each reconciliation.
+		if err := patchHelper.Patch(ctx, mp); err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+	}()
+
+	// Reconcile labels.
+	if mp.Labels == nil {
+		mp.Labels = make(map[string]string)
+	}
+	mp.Labels[clusterv1.ClusterLabelName] = mp.Spec.ClusterName
+
+	// Handle deletion reconciliation loop.
+	if !mp.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, cluster, mp)
+	}
+
+	// Handle normal reconciliation loop.
+	return r.reconcile(ctx, cluster, mp)
+}
+
+func (r *MachinePoolReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, mp *clusterv1.MachinePool) (ctrl.Result, error) {
+	logger := r.Log.WithValues("machinepool", mp.Name, "namespace", mp.Namespace)
+	logger = logger.WithValues("cluster", cluster.Name)
+
+	// Ensure the MachinePool is owned by the Cluster it belongs to.
+	mp.OwnerReferences = util.EnsureOwnerRef(mp.OwnerReferences, metav1.OwnerReference{
+		APIVersion: cluster.APIVersion,
+		Kind:       cluster.Kind,
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+	})
+
+	// If the MachinePool doesn't have a finalizer, add one.
+	controllerutil.AddFinalizer(mp, clusterv1.MachinePoolFinalizer)
+
+	// Call the inner reconciliation methods.
+	reconciliationErrors := []error{
+		r.reconcileBootstrap(ctx, cluster, mp),
+		r.reconcileInfrastructure(ctx, cluster, mp),
+		r.reconcileNodeRefs(ctx, cluster, mp),
+	}
+
+	// Parse the errors, making sure we record if there is a RequeueAfterError.
+	res := ctrl.Result{}
+	errs := []error{}
+	for _, err := range reconciliationErrors {
+		if requeueErr, ok := errors.Cause(err).(capierrors.HasRequeueAfterError); ok {
+			// Only record and log the first RequeueAfterError.
+			if !res.Requeue {
+				res.Requeue = true
+				res.RequeueAfter = requeueErr.GetRequeueAfter()
+				logger.Error(err, "Reconciliation for MachinePool asked to requeue")
+			}
+			continue
+		}
+
+		errs = append(errs, err)
+	}
+	return res, kerrors.NewAggregate(errs)
+}
+
+func (r *MachinePoolReconciler) reconcileDelete(ctx context.Context, cluster *clusterv1.Cluster, mp *clusterv1.MachinePool) (ctrl.Result, error) {
+	if ok, err := r.reconcileDeleteExternal(ctx, mp); !ok || err != nil {
+		// Return early and don't remove the finalizer if we got an error or
+		// the external reconciliation deletion isn't ready.
+		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileDeleteNodes(ctx, cluster, mp); err != nil {
+		// Return early and don't remove the finalizer if we got an error.
+		return ctrl.Result{}, err
+	}
+
+	controllerutil.RemoveFinalizer(mp, clusterv1.MachinePoolFinalizer)
 	return ctrl.Result{}, nil
+}
+
+func (r *MachinePoolReconciler) reconcileDeleteNodes(ctx context.Context, cluster *clusterv1.Cluster, machinepool *clusterv1.MachinePool) error {
+	if len(machinepool.Status.NodeRefs) == 0 {
+		return nil
+	}
+
+	clusterClient, err := remote.NewClusterClient(ctx, r.Client, cluster, r.scheme)
+	if err != nil {
+		return err
+	}
+
+	if err := r.deleteRetiredNodes(ctx, clusterClient, machinepool.Status.NodeRefs, machinepool.Spec.ProviderIDList); err != nil {
+		return err
+	}
+	return nil
+}
+
+// reconcileDeleteExternal tries to delete external references, returning true if it cannot find any.
+func (r *MachinePoolReconciler) reconcileDeleteExternal(ctx context.Context, m *clusterv1.MachinePool) (bool, error) {
+	objects := []*unstructured.Unstructured{}
+	references := []*corev1.ObjectReference{
+		m.Spec.Template.Spec.Bootstrap.ConfigRef,
+		&m.Spec.Template.Spec.InfrastructureRef,
+	}
+
+	// Loop over the references and try to retrieve it with the client.
+	for _, ref := range references {
+		if ref == nil {
+			continue
+		}
+
+		obj, err := external.Get(ctx, r.Client, ref, m.Namespace)
+		if err != nil && !apierrors.IsNotFound(errors.Cause(err)) {
+			return false, errors.Wrapf(err, "failed to get %s %q for MachinePool %q in namespace %q",
+				ref.GroupVersionKind(), ref.Name, m.Name, m.Namespace)
+		}
+		if obj != nil {
+			objects = append(objects, obj)
+		}
+	}
+
+	// Issue a delete request for any object that has been found.
+	for _, obj := range objects {
+		if err := r.Client.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
+			return false, errors.Wrapf(err,
+				"failed to delete %v %q for MachinePool %q in namespace %q",
+				obj.GroupVersionKind(), obj.GetName(), m.Name, m.Namespace)
+		}
+	}
+
+	// Return true if there are no more external objects.
+	return len(objects) == 0, nil
 }

--- a/controllers/machinepool_controller_noderef.go
+++ b/controllers/machinepool_controller_noderef.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	apicorev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controllers/noderefutil"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ErrNoAvailableNodes = errors.New("cannot find nodes with matching ProviderIDs in ProviderIDList")
+)
+
+type getNodeReferencesResult struct {
+	references []apicorev1.ObjectReference
+	available  int
+	ready      int
+}
+
+func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, cluster *clusterv1.Cluster, mp *clusterv1.MachinePool) error {
+	logger := r.Log.WithValues("machinepool", mp.Name, "namespace", mp.Namespace)
+	// Check that the MachinePool hasn't been deleted or in the process.
+	if !mp.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	// Check that the Machine doesn't already have a NodeRefs.
+	if mp.Status.Replicas == mp.Status.ReadyReplicas && len(mp.Status.NodeRefs) == int(mp.Status.ReadyReplicas) {
+		return nil
+	}
+
+	// Check that Cluster isn't nil.
+	if cluster == nil {
+		logger.V(2).Info("MachinePool doesn't have a linked cluster, won't assign NodeRef")
+		return nil
+	}
+
+	logger = logger.WithValues("cluster", cluster.Name)
+
+	// Check that the MachinePool has valid ProviderIDList.
+	if len(mp.Spec.ProviderIDList) == 0 {
+		logger.V(2).Info("MachinePool doesn't have any ProviderIDs yet")
+		return nil
+	}
+
+	clusterClient, err := remote.NewClusterClient(ctx, r.Client, cluster, r.scheme)
+	if err != nil {
+		return err
+	}
+
+	if err = r.deleteRetiredNodes(ctx, clusterClient, mp.Status.NodeRefs, mp.Spec.ProviderIDList); err != nil {
+		return err
+	}
+
+	// Get the Node references.
+	nodeRefsResult, err := r.getNodeReferences(ctx, clusterClient, mp.Spec.ProviderIDList)
+	if err != nil {
+		if err == ErrNoAvailableNodes {
+			return errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: 10 * time.Second},
+				"cannot assign NodeRefs to MachinePool, no matching Nodes")
+		}
+		r.recorder.Event(mp, apicorev1.EventTypeWarning, "FailedSetNodeRef", err.Error())
+		return errors.Wrapf(err, "failed to get node references")
+	}
+
+	mp.Status.ReadyReplicas = int32(nodeRefsResult.ready)
+	mp.Status.AvailableReplicas = int32(nodeRefsResult.available)
+	mp.Status.UnavailableReplicas = mp.Status.Replicas - mp.Status.AvailableReplicas
+	mp.Status.NodeRefs = nodeRefsResult.references
+
+	logger.Info("Set MachinePools's NodeRefs", "noderefs", mp.Status.NodeRefs)
+	r.recorder.Event(mp, apicorev1.EventTypeNormal, "SuccessfulSetNodeRefs", fmt.Sprintf("%+v", mp.Status.NodeRefs))
+
+	if mp.Status.Replicas != mp.Status.ReadyReplicas || len(nodeRefsResult.references) != int(mp.Status.ReadyReplicas) {
+		return errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: 30 * time.Second},
+			"NodeRefs != ReadyReplicas [%q != %q] for MachinePool %q in namespace %q", len(nodeRefsResult.references), mp.Status.ReadyReplicas, mp.Name, mp.Namespace)
+	}
+	return nil
+}
+
+// deleteRetiredNodes deletes nodes that don't have a corresponding ProviderID in Spec.ProviderIDList.
+// A MachinePool infrastucture provider indicates an instance in the set has been deleted by
+// removing its ProviderID from the slice.
+func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client.Client, nodeRefs []apicorev1.ObjectReference, providerIDList []string) error {
+	logger := r.Log.WithValues("providerIDList", len(providerIDList))
+	nodeRefsMap := make(map[string]*apicorev1.Node, len(nodeRefs))
+	for _, nodeRef := range nodeRefs {
+		node := &corev1.Node{}
+		if err := c.Get(ctx, types.NamespacedName{Name: nodeRef.Name}, node); err != nil {
+			logger.V(2).Info("Failed to get Node, skipping", "err", err, "nodeRef.Name", nodeRef.Name)
+			continue
+		}
+
+		nodeProviderID, err := noderefutil.NewProviderID(node.Spec.ProviderID)
+		if err != nil {
+			logger.V(2).Info("Failed to parse ProviderID, skipping", "err", err, "providerID", node.Spec.ProviderID)
+			continue
+		}
+
+		nodeRefsMap[nodeProviderID.ID()] = node
+	}
+	for _, providerID := range providerIDList {
+		pid, err := noderefutil.NewProviderID(providerID)
+		if err != nil {
+			logger.V(2).Info("Failed to parse ProviderID, skipping", "err", err, "providerID", providerID)
+			continue
+		}
+		delete(nodeRefsMap, pid.ID())
+	}
+	for _, node := range nodeRefsMap {
+		if err := c.Delete(ctx, node); err != nil {
+			return errors.Wrapf(err, "failed to delete Node")
+		}
+	}
+	return nil
+}
+
+func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, c client.Client, providerIDList []string) (getNodeReferencesResult, error) {
+	logger := r.Log.WithValues("providerIDList", len(providerIDList))
+
+	var ready, available int
+	nodeRefsMap := make(map[string]apicorev1.Node)
+	nodeList := apicorev1.NodeList{}
+	for {
+		if err := c.List(ctx, &nodeList, client.Continue(nodeList.Continue)); err != nil {
+			return getNodeReferencesResult{}, errors.Wrapf(err, "failed to List nodes")
+		}
+
+		for _, node := range nodeList.Items {
+			nodeProviderID, err := noderefutil.NewProviderID(node.Spec.ProviderID)
+			if err != nil {
+				logger.V(2).Info("Failed to parse ProviderID, skipping", "err", err, "providerID", node.Spec.ProviderID)
+				continue
+			}
+
+			nodeRefsMap[nodeProviderID.ID()] = node
+		}
+
+		if nodeList.Continue == "" {
+			break
+		}
+	}
+
+	var nodeRefs []apicorev1.ObjectReference
+	for _, providerID := range providerIDList {
+		pid, err := noderefutil.NewProviderID(providerID)
+		if err != nil {
+			logger.V(2).Info("Failed to parse ProviderID, skipping", "err", err, "providerID", providerID)
+			continue
+		}
+		if node, ok := nodeRefsMap[pid.ID()]; ok {
+			available++
+			if nodeIsReady(&node) {
+				ready++
+			}
+			nodeRefs = append(nodeRefs, apicorev1.ObjectReference{
+				Kind:       node.Kind,
+				APIVersion: node.APIVersion,
+				Name:       node.Name,
+				UID:        node.UID,
+			})
+		}
+	}
+
+	if len(nodeRefs) == 0 {
+		return getNodeReferencesResult{}, ErrNoAvailableNodes
+	}
+	return getNodeReferencesResult{nodeRefs, available, ready}, nil
+}
+
+func nodeIsReady(node *apicorev1.Node) bool {
+	for _, n := range node.Status.Conditions {
+		if n.Type == apicorev1.NodeReady {
+			return n.Status == apicorev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/controllers/machinepool_controller_noderef_test.go
+++ b/controllers/machinepool_controller_noderef_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+func TestMachinePoolGetNodeReference(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	r := &MachinePoolReconciler{
+		Client:   fake.NewFakeClientWithScheme(scheme.Scheme),
+		Log:      log.Log,
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	nodeList := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-1",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "aws://us-east-1/id-node-1",
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-2",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "aws://us-west-2/id-node-2",
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gce-node-2",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "gce://us-central1/gce-id-node-2",
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "azure-node-4",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "azure://westus2/id-node-4",
+			},
+		},
+	}
+
+	client := fake.NewFakeClientWithScheme(scheme.Scheme, nodeList...)
+
+	testCases := []struct {
+		name           string
+		providerIDList []string
+		expected       *getNodeReferencesResult
+		err            error
+	}{
+		{
+			name:           "valid provider id, valid aws node",
+			providerIDList: []string{"aws://us-east-1/id-node-1"},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{
+					{Name: "node-1"},
+				},
+			},
+		},
+		{
+			name:           "valid provider id, valid aws node",
+			providerIDList: []string{"aws://us-west-2/id-node-2"},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{
+					{Name: "node-2"},
+				},
+			},
+		},
+		{
+			name:           "valid provider id, valid gce node",
+			providerIDList: []string{"gce://us-central1/gce-id-node-2"},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{
+					{Name: "gce-node-2"},
+				},
+			},
+		},
+		{
+			name:           "valid provider id, valid azure node",
+			providerIDList: []string{"azure://westus2/id-node-4"},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{
+					{Name: "azure-node-4"},
+				},
+			},
+		},
+		{
+			name:           "valid provider ids, valid azure and aws nodes",
+			providerIDList: []string{"aws://us-east-1/id-node-1", "azure://westus2/id-node-4"},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{
+					{Name: "node-1"},
+					{Name: "azure-node-4"},
+				},
+			},
+		},
+		{
+			name:           "valid provider id, no node found",
+			providerIDList: []string{"aws:///id-node-100"},
+			expected:       nil,
+			err:            ErrNoAvailableNodes,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			gt := NewWithT(t)
+
+			result, err := r.getNodeReferences(context.TODO(), client, test.providerIDList)
+			if test.err == nil {
+				g.Expect(err).To(BeNil())
+			} else {
+				gt.Expect(err).NotTo(BeNil())
+				gt.Expect(err).To(Equal(test.err), "Expected error %v, got %v", test.err, err)
+			}
+
+			if test.expected == nil && len(result.references) == 0 {
+				return
+			}
+
+			gt.Expect(len(result.references)).To(Equal(len(test.expected.references)), "Expected NodeRef count to be %v, got %v", len(result.references), len(test.expected.references))
+
+			for n := range test.expected.references {
+				gt.Expect(result.references[n].Name).To(Equal(test.expected.references[n].Name), "Expected NodeRef's name to be %v, got %v", result.references[n].Name, test.expected.references[n].Name)
+				gt.Expect(result.references[n].Namespace).To(Equal(test.expected.references[n].Namespace), "Expected NodeRef's namespace to be %v, got %v", result.references[n].Namespace, test.expected.references[n].Namespace)
+			}
+		})
+
+	}
+}

--- a/controllers/machinepool_controller_phases.go
+++ b/controllers/machinepool_controller_phases.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+func (r *MachinePoolReconciler) reconcilePhase(mp *clusterv1.MachinePool) {
+	// Set the phase to "pending" if nil.
+	if mp.Status.Phase == "" {
+		mp.Status.SetTypedPhase(clusterv1.MachinePoolPhasePending)
+	}
+
+	// Set the phase to "provisioning" if bootstrap is ready and the infrastructure isn't.
+	if mp.Status.BootstrapReady && !mp.Status.InfrastructureReady {
+		mp.Status.SetTypedPhase(clusterv1.MachinePoolPhaseProvisioning)
+	}
+
+	// Set the phase to "provisioned" if the infrastructure is ready.
+	if len(mp.Status.NodeRefs) != 0 {
+		mp.Status.SetTypedPhase(clusterv1.MachinePoolPhaseProvisioned)
+	}
+
+	// Set the phase to "running" if there is a NodeRef field.
+	if mp.Status.InfrastructureReady && len(mp.Status.NodeRefs) == int(mp.Status.ReadyReplicas) {
+		mp.Status.SetTypedPhase(clusterv1.MachinePoolPhaseRunning)
+	}
+
+	// Set the phase to "failed" if any of Status.FailureReason or Status.FailureMessage is not-nil.
+	if mp.Status.FailureReason != nil || mp.Status.FailureMessage != nil {
+		mp.Status.SetTypedPhase(clusterv1.MachinePoolPhaseFailed)
+	}
+
+	// Set the phase to "deleting" if the deletion timestamp is set.
+	if !mp.DeletionTimestamp.IsZero() {
+		mp.Status.SetTypedPhase(clusterv1.MachinePoolPhaseDeleting)
+	}
+}
+
+// reconcileExternal handles generic unstructured objects referenced by a MachinePool.
+func (r *MachinePoolReconciler) reconcileExternal(ctx context.Context, cluster *clusterv1.Cluster, m *clusterv1.MachinePool, ref *corev1.ObjectReference) (external.ReconcileOutput, error) {
+	logger := r.Log.WithValues("machinepool", m.Name, "namespace", m.Namespace)
+
+	obj, err := external.Get(ctx, r.Client, ref, m.Namespace)
+	if err != nil {
+		if apierrors.IsNotFound(errors.Cause(err)) {
+			return external.ReconcileOutput{}, errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: externalReadyWait},
+				"could not find %v %q for MachinePool %q in namespace %q, requeuing",
+				ref.GroupVersionKind(), ref.Name, m.Name, m.Namespace)
+		}
+		return external.ReconcileOutput{}, err
+	}
+
+	// if external ref is paused, return error.
+	if util.IsPaused(cluster, obj) {
+		logger.V(3).Info("External object referenced is paused")
+		return external.ReconcileOutput{Paused: true}, nil
+	}
+
+	// Initialize the patch helper.
+	patchHelper, err := patch.NewHelper(obj, r.Client)
+	if err != nil {
+		return external.ReconcileOutput{}, err
+	}
+
+	// Set external object ControllerReference to the MachinePool.
+	if err := controllerutil.SetControllerReference(m, obj, r.scheme); err != nil {
+		return external.ReconcileOutput{}, err
+	}
+
+	// Set the Cluster label.
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[clusterv1.ClusterLabelName] = m.Spec.ClusterName
+	obj.SetLabels(labels)
+
+	// Always attempt to Patch the external object.
+	if err := patchHelper.Patch(ctx, obj); err != nil {
+		return external.ReconcileOutput{}, err
+	}
+
+	// Add watcher for external object, if there isn't one already.
+	_, loaded := r.externalWatchers.LoadOrStore(obj.GroupVersionKind().String(), struct{}{})
+	if !loaded && r.controller != nil {
+		logger.Info("Adding watcher on external object", "gvk", obj.GroupVersionKind())
+		err := r.controller.Watch(
+			&source.Kind{Type: obj},
+			&handler.EnqueueRequestForOwner{OwnerType: &clusterv1.MachinePool{}},
+		)
+		if err != nil {
+			r.externalWatchers.Delete(obj.GroupVersionKind().String())
+			return external.ReconcileOutput{}, errors.Wrapf(err, "failed to add watcher on external object %q", obj.GroupVersionKind())
+		}
+	}
+
+	// Set failure reason and message, if any.
+	failureReason, failureMessage, err := external.FailuresFrom(obj)
+	if err != nil {
+		return external.ReconcileOutput{}, err
+	}
+	if failureReason != "" {
+		machineStatusFailure := capierrors.MachinePoolStatusFailure(failureReason)
+		m.Status.FailureReason = &machineStatusFailure
+	}
+	if failureMessage != "" {
+		m.Status.FailureMessage = pointer.StringPtr(
+			fmt.Sprintf("Failure detected from referenced resource %v with name %q: %s",
+				obj.GroupVersionKind(), obj.GetName(), failureMessage),
+		)
+	}
+
+	return external.ReconcileOutput{Result: obj}, nil
+}
+
+// reconcileBootstrap reconciles the Spec.Bootstrap.ConfigRef object on a MachinePool.
+func (r *MachinePoolReconciler) reconcileBootstrap(ctx context.Context, cluster *clusterv1.Cluster, m *clusterv1.MachinePool) error {
+	// Call generic external reconciler if we have an external reference.
+	var bootstrapConfig *unstructured.Unstructured
+	if m.Spec.Template.Spec.Bootstrap.ConfigRef != nil {
+		bootstrapReconcileResult, err := r.reconcileExternal(ctx, cluster, m, m.Spec.Template.Spec.Bootstrap.ConfigRef)
+		if err != nil {
+			return err
+		}
+		// if the external object is paused, return without any further processing
+		if bootstrapReconcileResult.Paused {
+			return nil
+		}
+		bootstrapConfig = bootstrapReconcileResult.Result
+	}
+
+	// If the bootstrap data secret is populated, set ready and return.
+	if m.Spec.Template.Spec.Bootstrap.Data != nil || m.Spec.Template.Spec.Bootstrap.DataSecretName != nil {
+		m.Status.BootstrapReady = true
+		return nil
+	}
+
+	// If the bootstrap config is being deleted, return early.
+	if !bootstrapConfig.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	// Determine if the bootstrap provider is ready.
+	ready, err := external.IsReady(bootstrapConfig)
+	if err != nil {
+		return err
+	} else if !ready {
+		return errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: externalReadyWait},
+			"Bootstrap provider for MachinePool %q in namespace %q is not ready, requeuing", m.Name, m.Namespace)
+	}
+
+	// Get and set the name of the secret containing the bootstrap data.
+	secretName, _, err := unstructured.NestedString(bootstrapConfig.Object, "status", "dataSecretName")
+	if err != nil {
+		return errors.Wrapf(err, "failed to retrieve dataSecretName from bootstrap provider for MachinePool %q in namespace %q", m.Name, m.Namespace)
+	} else if secretName == "" {
+		return errors.Errorf("retrieved empty dataSecretName from bootstrap provider for MachinePool %q in namespace %q", m.Name, m.Namespace)
+	}
+
+	m.Spec.Template.Spec.Bootstrap.DataSecretName = pointer.StringPtr(secretName)
+	m.Status.BootstrapReady = true
+	return nil
+}
+
+// reconcileInfrastructure reconciles the Spec.InfrastructureRef object on a MachinePool.
+func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, cluster *clusterv1.Cluster, mp *clusterv1.MachinePool) error {
+	// Call generic external reconciler.
+	infraReconcileResult, err := r.reconcileExternal(ctx, cluster, mp, &mp.Spec.Template.Spec.InfrastructureRef)
+	if err != nil {
+		if mp.Status.InfrastructureReady && strings.Contains(err.Error(), "could not find") {
+			// Infra object went missing after the machine pool was up and running
+			r.Log.Error(err, "MachinePool infrastructure reference has been deleted after being ready, setting failure state")
+			mp.Status.FailureReason = capierrors.MachinePoolStatusErrorPtr(capierrors.InvalidConfigurationMachinePoolError)
+			mp.Status.FailureMessage = pointer.StringPtr(fmt.Sprintf("MachinePool infrastructure resource %v with name %q has been deleted after being ready",
+				mp.Spec.Template.Spec.InfrastructureRef.GroupVersionKind(), mp.Spec.Template.Spec.InfrastructureRef.Name))
+		}
+		return err
+	}
+	// if the external object is paused, return without any further processing
+	if infraReconcileResult.Paused {
+		return nil
+	}
+	infraConfig := infraReconcileResult.Result
+
+	if !infraConfig.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
+	ready, err := external.IsReady(infraConfig)
+	if err != nil {
+		return err
+	}
+
+	mp.Status.InfrastructureReady = ready
+	if !mp.Status.InfrastructureReady {
+		return errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: externalReadyWait},
+			"Infrastructure provider for MachinePool %q in namespace %q is not ready, requeuing", mp.Name, mp.Namespace,
+		)
+	}
+
+	var providerIDList []string
+	// Get Spec.ProviderIDList from the infrastructure provider.
+	if err := util.UnstructuredUnmarshalField(infraConfig, &providerIDList, "spec", "providerIDList"); err != nil {
+		return errors.Wrapf(err, "failed to retrieve data from infrastructure provider for MachinePool %q in namespace %q", mp.Name, mp.Namespace)
+	} else if len(providerIDList) == 0 {
+		return errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: externalReadyWait},
+			"retrieved empty Spec.ProviderIDList from infrastructure provider for MachinePool %q in namespace %q", mp.Name, mp.Namespace,
+		)
+	}
+
+	// Get and set Status.Replicas from the infrastructure provider.
+	err = util.UnstructuredUnmarshalField(infraConfig, &mp.Status.Replicas, "status", "replicas")
+	if err != nil {
+		if err != util.ErrUnstructuredFieldNotFound {
+			return errors.Wrapf(err, "failed to retrieve replicas from infrastructure provider for MachinePool %q in namespace %q", mp.Name, mp.Namespace)
+		}
+	} else if mp.Status.Replicas == 0 {
+		return errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: externalReadyWait},
+			"retrieved unset Status.Replicas from infrastructure provider for MachinePool %q in namespace %q", mp.Name, mp.Namespace,
+		)
+	}
+
+	if !reflect.DeepEqual(mp.Spec.ProviderIDList, providerIDList) {
+		mp.Spec.ProviderIDList = providerIDList
+		mp.Status.ReadyReplicas = 0
+		mp.Status.AvailableReplicas = 0
+		mp.Status.UnavailableReplicas = mp.Status.Replicas
+	}
+
+	return nil
+}

--- a/controllers/machinepool_controller_phases_test.go
+++ b/controllers/machinepool_controller_phases_test.go
@@ -1,0 +1,821 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func init() {
+	externalReadyWait = 1 * time.Second
+}
+
+var _ = Describe("Reconcile MachinePool Phases", func() {
+	deletionTimestamp := metav1.Now()
+
+	var defaultKubeconfigSecret *corev1.Secret
+	defaultCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+
+	defaultMachinePool := clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machinepool-test",
+			Namespace: "default",
+		},
+		Spec: clusterv1.MachinePoolSpec{
+			ClusterName: defaultCluster.Name,
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+							Kind:       "BootstrapConfig",
+							Name:       "bootstrap-config1",
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+						Kind:       "InfrastructureConfig",
+						Name:       "infra-config1",
+					},
+				},
+			},
+		},
+	}
+
+	defaultBootstrap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "BootstrapConfig",
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+			"metadata": map[string]interface{}{
+				"name":      "bootstrap-config1",
+				"namespace": "default",
+			},
+			"spec":   map[string]interface{}{},
+			"status": map[string]interface{}{},
+		},
+	}
+
+	defaultInfra := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "InfrastructureConfig",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+			"metadata": map[string]interface{}{
+				"name":      "infra-config1",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"providerIDList": []interface{}{
+					"test://id-1",
+				},
+			},
+			"status": map[string]interface{}{},
+		},
+	}
+
+	BeforeEach(func() {
+		defaultKubeconfigSecret = kubeconfig.GenerateSecret(defaultCluster, kubeconfig.FromEnvTestConfig(cfg, defaultCluster))
+	})
+
+	It("Should set OwnerReference and cluster name label on external objects", func() {
+		machinepool := defaultMachinePool.DeepCopy()
+		bootstrapConfig := defaultBootstrap.DeepCopy()
+		infraConfig := defaultInfra.DeepCopy()
+
+		r := &MachinePoolReconciler{
+			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig),
+			Log:    log.Log,
+			scheme: scheme.Scheme,
+		}
+
+		res, err := r.reconcile(context.Background(), defaultCluster, machinepool)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Requeue).To(BeTrue())
+
+		r.reconcilePhase(machinepool)
+
+		Expect(r.Client.Get(ctx, types.NamespacedName{Name: bootstrapConfig.GetName(), Namespace: bootstrapConfig.GetNamespace()}, bootstrapConfig)).To(Succeed())
+
+		Expect(bootstrapConfig.GetOwnerReferences()).To(HaveLen(1))
+		Expect(bootstrapConfig.GetLabels()[clusterv1.ClusterLabelName]).To(BeEquivalentTo("test-cluster"))
+
+		Expect(r.Client.Get(ctx, types.NamespacedName{Name: infraConfig.GetName(), Namespace: infraConfig.GetNamespace()}, infraConfig)).To(Succeed())
+
+		Expect(infraConfig.GetOwnerReferences()).To(HaveLen(1))
+		Expect(infraConfig.GetLabels()[clusterv1.ClusterLabelName]).To(BeEquivalentTo("test-cluster"))
+	})
+
+	It("Should set `Pending` with a new MachinePool", func() {
+		machinepool := defaultMachinePool.DeepCopy()
+		bootstrapConfig := defaultBootstrap.DeepCopy()
+		infraConfig := defaultInfra.DeepCopy()
+
+		r := &MachinePoolReconciler{
+			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig),
+			Log:    log.Log,
+			scheme: scheme.Scheme,
+		}
+
+		res, err := r.reconcile(context.Background(), defaultCluster, machinepool)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Requeue).To(BeTrue())
+
+		r.reconcilePhase(machinepool)
+		Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhasePending))
+	})
+
+	It("Should set `Provisioning` when bootstrap is ready", func() {
+		machinepool := defaultMachinePool.DeepCopy()
+		bootstrapConfig := defaultBootstrap.DeepCopy()
+		infraConfig := defaultInfra.DeepCopy()
+
+		// Set bootstrap ready.
+		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
+		Expect(err).NotTo(HaveOccurred())
+
+		r := &MachinePoolReconciler{
+			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig),
+			Log:    log.Log,
+			scheme: scheme.Scheme,
+		}
+
+		res, err := r.reconcile(context.Background(), defaultCluster, machinepool)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Requeue).To(BeTrue())
+
+		r.reconcilePhase(machinepool)
+		Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseProvisioning))
+	})
+
+	It("Should set `Running` when bootstrap and infra is ready", func() {
+		machinepool := defaultMachinePool.DeepCopy()
+		bootstrapConfig := defaultBootstrap.DeepCopy()
+		infraConfig := defaultInfra.DeepCopy()
+
+		// Set bootstrap ready.
+		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set infra ready.
+		err = unstructured.SetNestedField(infraConfig.Object, true, "status", "ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, int64(1), "status", "replicas")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedStringSlice(infraConfig.Object, []string{"test://machinepool-test-node"}, "spec", "providerIDList")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, "us-east-2a", "spec", "failureDomain")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set NodeRef.
+		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
+
+		r := &MachinePoolReconciler{
+			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig),
+			Log:    log.Log,
+			scheme: scheme.Scheme,
+		}
+
+		res, err := r.reconcile(context.Background(), defaultCluster, machinepool)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Requeue).To(BeTrue())
+
+		// Set ReadyReplicas
+		machinepool.Status.ReadyReplicas = 1
+
+		r.reconcilePhase(machinepool)
+		Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseRunning))
+	})
+
+	It("Should set `Running` when bootstrap, infra, and NodeRef is ready", func() {
+		machinepool := defaultMachinePool.DeepCopy()
+		bootstrapConfig := defaultBootstrap.DeepCopy()
+		infraConfig := defaultInfra.DeepCopy()
+
+		// Set bootstrap ready.
+		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set infra ready.
+		err = unstructured.SetNestedStringSlice(infraConfig.Object, []string{"test://id-1"}, "spec", "providerIDList")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, true, "status", "ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, int64(1), "status", "replicas")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, []interface{}{
+			map[string]interface{}{
+				"type":    "InternalIP",
+				"address": "10.0.0.1",
+			},
+			map[string]interface{}{
+				"type":    "InternalIP",
+				"address": "10.0.0.2",
+			},
+		}, "addresses")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set NodeRef.
+		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
+
+		r := &MachinePoolReconciler{
+			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig),
+			Log:    log.Log,
+			scheme: scheme.Scheme,
+		}
+
+		res, err := r.reconcile(context.Background(), defaultCluster, machinepool)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Requeue).To(BeTrue())
+
+		// Set ReadyReplicas
+		machinepool.Status.ReadyReplicas = 1
+
+		r.reconcilePhase(machinepool)
+		Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseRunning))
+	})
+
+	It("Should set `Provisioned` when there is a NodeRef but infra is not ready ", func() {
+		machinepool := defaultMachinePool.DeepCopy()
+		bootstrapConfig := defaultBootstrap.DeepCopy()
+		infraConfig := defaultInfra.DeepCopy()
+
+		// Set bootstrap ready.
+		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set NodeRef.
+		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
+
+		r := &MachinePoolReconciler{
+			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig),
+			Log:    log.Log,
+			scheme: scheme.Scheme,
+		}
+
+		res, err := r.reconcile(context.Background(), defaultCluster, machinepool)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Requeue).To(BeTrue())
+
+		r.reconcilePhase(machinepool)
+		Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseProvisioned))
+	})
+
+	It("Should set `Deleting` when MachinePool is being deleted", func() {
+		machinepool := defaultMachinePool.DeepCopy()
+		bootstrapConfig := defaultBootstrap.DeepCopy()
+		infraConfig := defaultInfra.DeepCopy()
+
+		// Set bootstrap ready.
+		err := unstructured.SetNestedField(bootstrapConfig.Object, true, "status", "ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set infra ready.
+		err = unstructured.SetNestedStringSlice(infraConfig.Object, []string{"test://id-1"}, "spec", "providerIDList")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, true, "status", "ready")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = unstructured.SetNestedField(infraConfig.Object, []interface{}{
+			map[string]interface{}{
+				"type":    "InternalIP",
+				"address": "10.0.0.1",
+			},
+			map[string]interface{}{
+				"type":    "InternalIP",
+				"address": "10.0.0.2",
+			},
+		}, "addresses")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set NodeRef.
+		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
+
+		// Set Deletion Timestamp.
+		machinepool.SetDeletionTimestamp(&deletionTimestamp)
+
+		r := &MachinePoolReconciler{
+			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig),
+			Log:    log.Log,
+			scheme: scheme.Scheme,
+		}
+
+		res, err := r.reconcile(context.Background(), defaultCluster, machinepool)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.Requeue).To(BeFalse())
+
+		r.reconcilePhase(machinepool)
+		Expect(machinepool.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseDeleting))
+	})
+})
+
+func TestReconcileMachinePoolBootstrap(t *testing.T) {
+	defaultMachinePool := clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machinepool-test",
+			Namespace: "default",
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: "test-cluster",
+			},
+		},
+		Spec: clusterv1.MachinePoolSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+							Kind:       "BootstrapConfig",
+							Name:       "bootstrap-config1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	defaultCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+	}
+
+	testCases := []struct {
+		name            string
+		bootstrapConfig map[string]interface{}
+		machinepool     *clusterv1.MachinePool
+		expectError     bool
+		expected        func(g *WithT, m *clusterv1.MachinePool)
+	}{
+		{
+			name: "new machinepool, bootstrap config ready with data",
+			bootstrapConfig: map[string]interface{}{
+				"kind":       "BootstrapConfig",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{},
+				"status": map[string]interface{}{
+					"ready":          true,
+					"dataSecretName": "secret-data",
+				},
+			},
+			expectError: false,
+			expected: func(g *WithT, m *clusterv1.MachinePool) {
+				g.Expect(m.Status.BootstrapReady).To(BeTrue())
+				g.Expect(m.Spec.Template.Spec.Bootstrap.DataSecretName).ToNot(BeNil())
+				g.Expect(*m.Spec.Template.Spec.Bootstrap.DataSecretName).To(ContainSubstring("secret-data"))
+			},
+		},
+		{
+			name: "new machinepool, bootstrap config ready with no data",
+			bootstrapConfig: map[string]interface{}{
+				"kind":       "BootstrapConfig",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{},
+				"status": map[string]interface{}{
+					"ready": true,
+				},
+			},
+			expectError: true,
+			expected: func(g *WithT, m *clusterv1.MachinePool) {
+				g.Expect(m.Status.BootstrapReady).To(BeFalse())
+				g.Expect(m.Spec.Template.Spec.Bootstrap.Data).To(BeNil())
+			},
+		},
+		{
+			name: "new machinepool, bootstrap config not ready",
+			bootstrapConfig: map[string]interface{}{
+				"kind":       "BootstrapConfig",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": "default",
+				},
+				"spec":   map[string]interface{}{},
+				"status": map[string]interface{}{},
+			},
+			expectError: true,
+			expected: func(g *WithT, m *clusterv1.MachinePool) {
+				g.Expect(m.Status.BootstrapReady).To(BeFalse())
+			},
+		},
+		{
+			name: "new machinepool, bootstrap config is not found",
+			bootstrapConfig: map[string]interface{}{
+				"kind":       "BootstrapConfig",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": "wrong-namespace",
+				},
+				"spec":   map[string]interface{}{},
+				"status": map[string]interface{}{},
+			},
+			expectError: true,
+			expected: func(g *WithT, m *clusterv1.MachinePool) {
+				g.Expect(m.Status.BootstrapReady).To(BeFalse())
+			},
+		},
+		{
+			name: "new machinepool, no bootstrap config or data",
+			bootstrapConfig: map[string]interface{}{
+				"kind":       "BootstrapConfig",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": "wrong-namespace",
+				},
+				"spec":   map[string]interface{}{},
+				"status": map[string]interface{}{},
+			},
+			expectError: true,
+		},
+		{
+			name: "existing machinepool, bootstrap data should not change",
+			bootstrapConfig: map[string]interface{}{
+				"kind":       "BootstrapConfig",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{},
+				"status": map[string]interface{}{
+					"ready":          true,
+					"dataSecretName": "secret-data",
+				},
+			},
+			machinepool: &clusterv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bootstrap-test-existing",
+					Namespace: "default",
+				},
+				Spec: clusterv1.MachinePoolSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Bootstrap: clusterv1.Bootstrap{
+								ConfigRef: &corev1.ObjectReference{
+									APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+									Kind:       "BootstrapConfig",
+									Name:       "bootstrap-config1",
+								},
+								Data: pointer.StringPtr("#!/bin/bash ... data"),
+							},
+						},
+					},
+				},
+				Status: clusterv1.MachinePoolStatus{
+					BootstrapReady: true,
+				},
+			},
+			expectError: false,
+			expected: func(g *WithT, m *clusterv1.MachinePool) {
+				g.Expect(m.Status.BootstrapReady).To(BeTrue())
+				g.Expect(*m.Spec.Template.Spec.Bootstrap.Data).To(Equal("#!/bin/bash ... data"))
+			},
+		},
+		{
+			name: "existing machinepool, bootstrap provider is to not ready",
+			bootstrapConfig: map[string]interface{}{
+				"kind":       "BootstrapConfig",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{},
+				"status": map[string]interface{}{
+					"ready": false,
+					"data":  "#!/bin/bash ... data",
+				},
+			},
+			machinepool: &clusterv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bootstrap-test-existing",
+					Namespace: "default",
+				},
+				Spec: clusterv1.MachinePoolSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Bootstrap: clusterv1.Bootstrap{
+								ConfigRef: &corev1.ObjectReference{
+									APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+									Kind:       "BootstrapConfig",
+									Name:       "bootstrap-config1",
+								},
+								Data: pointer.StringPtr("#!/bin/bash ... data"),
+							},
+						},
+					},
+				},
+				Status: clusterv1.MachinePoolStatus{
+					BootstrapReady: true,
+				},
+			},
+			expectError: false,
+			expected: func(g *WithT, m *clusterv1.MachinePool) {
+				g.Expect(m.Status.BootstrapReady).To(BeTrue())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+			if tc.machinepool == nil {
+				tc.machinepool = defaultMachinePool.DeepCopy()
+			}
+
+			bootstrapConfig := &unstructured.Unstructured{Object: tc.bootstrapConfig}
+			r := &MachinePoolReconciler{
+				Client: fake.NewFakeClientWithScheme(scheme.Scheme, tc.machinepool, bootstrapConfig),
+				Log:    log.Log,
+				scheme: scheme.Scheme,
+			}
+
+			err := r.reconcileBootstrap(context.Background(), defaultCluster, tc.machinepool)
+			if tc.expectError {
+				g.Expect(err).ToNot(BeNil())
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+
+			if tc.expected != nil {
+				tc.expected(g, tc.machinepool)
+			}
+		})
+	}
+}
+
+func TestReconcileMachinePoolInfrastructure(t *testing.T) {
+	defaultMachinePool := clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machinepool-test",
+			Namespace: "default",
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: "test-cluster",
+			},
+		},
+		Spec: clusterv1.MachinePoolSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+							Kind:       "BootstrapConfig",
+							Name:       "bootstrap-config1",
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+						Kind:       "InfrastructureConfig",
+						Name:       "infra-config1",
+					},
+				},
+			},
+		},
+	}
+
+	defaultCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+	}
+
+	testCases := []struct {
+		name               string
+		bootstrapConfig    map[string]interface{}
+		infraConfig        map[string]interface{}
+		machinepool        *clusterv1.MachinePool
+		expectError        bool
+		expectChanged      bool
+		expectRequeueAfter bool
+		expected           func(g *WithT, m *clusterv1.MachinePool)
+	}{
+		{
+			name: "new machinepool, infrastructure config ready",
+			infraConfig: map[string]interface{}{
+				"kind":       "InfrastructureConfig",
+				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "infra-config1",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"providerIDList": []interface{}{
+						"test://id-1",
+					},
+				},
+				"status": map[string]interface{}{
+					"ready": true,
+					"addresses": []interface{}{
+						map[string]interface{}{
+							"type":    "InternalIP",
+							"address": "10.0.0.1",
+						},
+						map[string]interface{}{
+							"type":    "InternalIP",
+							"address": "10.0.0.2",
+						},
+					},
+				},
+			},
+			expectError:   false,
+			expectChanged: true,
+			expected: func(g *WithT, m *clusterv1.MachinePool) {
+				g.Expect(m.Status.InfrastructureReady).To(BeTrue())
+			},
+		},
+		{
+			name: "ready bootstrap, infra, and nodeRef, machinepool is running, infra object is deleted, expect failed",
+			machinepool: &clusterv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machinepool-test",
+					Namespace: "default",
+				},
+				Spec: clusterv1.MachinePoolSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Bootstrap: clusterv1.Bootstrap{
+								ConfigRef: &corev1.ObjectReference{
+									APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+									Kind:       "BootstrapConfig",
+									Name:       "bootstrap-config1",
+								},
+							},
+							InfrastructureRef: corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+								Kind:       "InfrastructureConfig",
+								Name:       "infra-config1",
+							},
+						},
+					},
+				},
+				Status: clusterv1.MachinePoolStatus{
+					BootstrapReady:      true,
+					InfrastructureReady: true,
+					NodeRefs:            []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}},
+				},
+			},
+			bootstrapConfig: map[string]interface{}{
+				"kind":       "BootstrapConfig",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{},
+				"status": map[string]interface{}{
+					"ready":          true,
+					"dataSecretName": "secret-data",
+				},
+			},
+			infraConfig: map[string]interface{}{
+				"kind":       "InfrastructureConfig",
+				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+				"metadata":   map[string]interface{}{},
+			},
+			expectError:        true,
+			expectRequeueAfter: true,
+			expected: func(g *WithT, m *clusterv1.MachinePool) {
+				g.Expect(m.Status.InfrastructureReady).To(BeTrue())
+				g.Expect(m.Status.FailureMessage).ToNot(BeNil())
+				g.Expect(m.Status.FailureReason).ToNot(BeNil())
+				g.Expect(m.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePoolPhaseFailed))
+			},
+		},
+		{
+			name: "infrastructure ref is paused",
+			infraConfig: map[string]interface{}{
+				"kind":       "InfrastructureConfig",
+				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "infra-config1",
+					"namespace": "default",
+					"annotations": map[string]interface{}{
+						"cluster.x-k8s.io/paused": "true",
+					},
+				},
+				"spec": map[string]interface{}{
+					"providerIDList": []interface{}{
+						"test://id-1",
+					},
+				},
+				"status": map[string]interface{}{
+					"ready": true,
+					"addresses": []interface{}{
+						map[string]interface{}{
+							"type":    "InternalIP",
+							"address": "10.0.0.1",
+						},
+						map[string]interface{}{
+							"type":    "InternalIP",
+							"address": "10.0.0.2",
+						},
+					},
+				},
+			},
+			expectError:   false,
+			expectChanged: false,
+			expected: func(g *WithT, m *clusterv1.MachinePool) {
+				g.Expect(m.Status.InfrastructureReady).To(BeFalse())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+			if tc.machinepool == nil {
+				tc.machinepool = defaultMachinePool.DeepCopy()
+			}
+
+			infraConfig := &unstructured.Unstructured{Object: tc.infraConfig}
+			r := &MachinePoolReconciler{
+				Client: fake.NewFakeClientWithScheme(scheme.Scheme, tc.machinepool, infraConfig),
+				Log:    log.Log,
+				scheme: scheme.Scheme,
+			}
+
+			err := r.reconcileInfrastructure(context.Background(), defaultCluster, tc.machinepool)
+			r.reconcilePhase(tc.machinepool)
+			if tc.expectError {
+				g.Expect(err).ToNot(BeNil())
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+
+			if tc.expected != nil {
+				tc.expected(g, tc.machinepool)
+			}
+		})
+	}
+}

--- a/controllers/machinepool_controller_test.go
+++ b/controllers/machinepool_controller_test.go
@@ -1,0 +1,614 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+func TestMachinePoolFinalizer(t *testing.T) {
+	bootstrapData := "some valid machinepool bootstrap data"
+	clusterCorrectMeta := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "valid-cluster",
+		},
+	}
+
+	machinePoolValidCluster := &clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machinePool1",
+			Namespace: "default",
+		},
+		Spec: clusterv1.MachinePoolSpec{
+			Replicas: pointer.Int32Ptr(1),
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						Data: &bootstrapData,
+					},
+				},
+			},
+			ClusterName: "valid-cluster",
+		},
+	}
+
+	machinePoolWithFinalizer := &clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "machinePool2",
+			Namespace:  "default",
+			Finalizers: []string{"some-other-finalizer"},
+		},
+		Spec: clusterv1.MachinePoolSpec{
+			Replicas: pointer.Int32Ptr(1),
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						Data: &bootstrapData,
+					},
+				},
+			},
+			ClusterName: "valid-cluster",
+		},
+	}
+
+	testCases := []struct {
+		name               string
+		request            reconcile.Request
+		m                  *clusterv1.MachinePool
+		expectedFinalizers []string
+	}{
+		{
+			name: "should add a machinePool finalizer to the machinePool if it doesn't have one",
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      machinePoolValidCluster.Name,
+					Namespace: machinePoolValidCluster.Namespace,
+				},
+			},
+			m:                  machinePoolValidCluster,
+			expectedFinalizers: []string{clusterv1.MachinePoolFinalizer},
+		},
+		{
+			name: "should append the machinePool finalizer to the machinePool if it already has a finalizer",
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      machinePoolWithFinalizer.Name,
+					Namespace: machinePoolWithFinalizer.Namespace,
+				},
+			},
+			m:                  machinePoolWithFinalizer,
+			expectedFinalizers: []string{"some-other-finalizer", clusterv1.MachinePoolFinalizer},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+			mr := &MachinePoolReconciler{
+				Client: fake.NewFakeClientWithScheme(
+					scheme.Scheme,
+					clusterCorrectMeta,
+					machinePoolValidCluster,
+					machinePoolWithFinalizer,
+				),
+				Log:    log.Log,
+				scheme: scheme.Scheme,
+			}
+
+			_, _ = mr.Reconcile(tc.request)
+
+			key := client.ObjectKey{Namespace: tc.m.Namespace, Name: tc.m.Name}
+			var actual clusterv1.MachinePool
+			if len(tc.expectedFinalizers) > 0 {
+				g.Expect(mr.Client.Get(ctx, key, &actual)).To(Succeed())
+				g.Expect(actual.Finalizers).ToNot(BeEmpty())
+				g.Expect(actual.Finalizers).To(Equal(tc.expectedFinalizers))
+			} else {
+				g.Expect(actual.Finalizers).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestMachinePoolOwnerReference(t *testing.T) {
+	bootstrapData := "some valid machinepool bootstrap data"
+	testCluster := &clusterv1.Cluster{
+		TypeMeta:   metav1.TypeMeta{Kind: "Cluster", APIVersion: clusterv1.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-cluster"},
+	}
+
+	machinePoolInvalidCluster := &clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machinePool1",
+			Namespace: "default",
+		},
+		Spec: clusterv1.MachinePoolSpec{
+			ClusterName: "invalid",
+		},
+	}
+
+	machinePoolValidCluster := &clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machinePool2",
+			Namespace: "default",
+		},
+		Spec: clusterv1.MachinePoolSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						Data: &bootstrapData,
+					},
+				},
+			},
+			ClusterName: "test-cluster",
+		},
+	}
+
+	machinePoolValidMachinePool := &clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machinePool3",
+			Namespace: "default",
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: "valid-cluster",
+			},
+		},
+		Spec: clusterv1.MachinePoolSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						Data: &bootstrapData,
+					},
+				},
+			},
+			ClusterName: "test-cluster",
+		},
+	}
+
+	testCases := []struct {
+		name       string
+		request    reconcile.Request
+		m          *clusterv1.MachinePool
+		expectedOR []metav1.OwnerReference
+	}{
+		{
+			name: "should add owner reference to machinePool referencing a cluster with correct type meta",
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      machinePoolValidCluster.Name,
+					Namespace: machinePoolValidCluster.Namespace,
+				},
+			},
+			m: machinePoolValidCluster,
+			expectedOR: []metav1.OwnerReference{
+				{
+					APIVersion: testCluster.APIVersion,
+					Kind:       testCluster.Kind,
+					Name:       testCluster.Name,
+					UID:        testCluster.UID,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+			mr := &MachinePoolReconciler{
+				Client: fake.NewFakeClientWithScheme(
+					scheme.Scheme,
+					testCluster,
+					machinePoolInvalidCluster,
+					machinePoolValidCluster,
+					machinePoolValidMachinePool,
+				),
+				Log:    log.Log,
+				scheme: scheme.Scheme,
+			}
+
+			_, _ = mr.Reconcile(tc.request)
+
+			key := client.ObjectKey{Namespace: tc.m.Namespace, Name: tc.m.Name}
+			var actual clusterv1.MachinePool
+			if len(tc.expectedOR) > 0 {
+				g.Expect(mr.Client.Get(ctx, key, &actual)).To(Succeed())
+				g.Expect(actual.OwnerReferences).To(Equal(tc.expectedOR))
+			} else {
+				g.Expect(actual.OwnerReferences).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestReconcileMachinePoolRequest(t *testing.T) {
+	infraConfig := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "InfrastructureConfig",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+			"metadata": map[string]interface{}{
+				"name":      "infra-config1",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"providerIDList": []interface{}{
+					"test://id-1",
+				},
+			},
+			"status": map[string]interface{}{
+				"ready": true,
+				"addresses": []interface{}{
+					map[string]interface{}{
+						"type":    "InternalIP",
+						"address": "10.0.0.1",
+					},
+				},
+			},
+		},
+	}
+
+	time := metav1.Now()
+
+	testCluster := clusterv1.Cluster{
+		TypeMeta:   metav1.TypeMeta{Kind: "Cluster", APIVersion: clusterv1.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-cluster"},
+	}
+
+	bootstrapConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "BootstrapConfig",
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+			"metadata": map[string]interface{}{
+				"name":      "test-bootstrap",
+				"namespace": "default",
+			},
+		},
+	}
+
+	type expected struct {
+		result reconcile.Result
+		err    bool
+	}
+	testCases := []struct {
+		machinePool clusterv1.MachinePool
+		expected    expected
+	}{
+		{
+			machinePool: clusterv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "created",
+					Namespace:  "default",
+					Finalizers: []string{clusterv1.MachinePoolFinalizer, metav1.FinalizerDeleteDependents},
+				},
+				Spec: clusterv1.MachinePoolSpec{
+					ClusterName:    "test-cluster",
+					ProviderIDList: []string{"test://id-1"},
+					Replicas:       pointer.Int32Ptr(1),
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+
+							InfrastructureRef: corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+								Kind:       "InfrastructureConfig",
+								Name:       "infra-config1",
+							},
+							Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+						},
+					},
+				},
+				Status: clusterv1.MachinePoolStatus{
+					Replicas:      1,
+					ReadyReplicas: 1,
+					NodeRefs: []corev1.ObjectReference{
+						{Name: "test"},
+					},
+				},
+			},
+			expected: expected{
+				result: reconcile.Result{},
+				err:    false,
+			},
+		},
+		{
+			machinePool: clusterv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "updated",
+					Namespace:  "default",
+					Finalizers: []string{clusterv1.MachinePoolFinalizer, metav1.FinalizerDeleteDependents},
+				},
+				Spec: clusterv1.MachinePoolSpec{
+					ClusterName:    "test-cluster",
+					ProviderIDList: []string{"test://id-1"},
+					Replicas:       pointer.Int32Ptr(1),
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							InfrastructureRef: corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+								Kind:       "InfrastructureConfig",
+								Name:       "infra-config1",
+							},
+							Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+						},
+					},
+				},
+				Status: clusterv1.MachinePoolStatus{
+					Replicas:      1,
+					ReadyReplicas: 1,
+					NodeRefs: []corev1.ObjectReference{
+						{Name: "test"},
+					},
+				},
+			},
+			expected: expected{
+				result: reconcile.Result{},
+				err:    false,
+			},
+		},
+		{
+			machinePool: clusterv1.MachinePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deleted",
+					Namespace: "default",
+					Labels: map[string]string{
+						clusterv1.MachineControlPlaneLabelName: "",
+					},
+					Finalizers:        []string{clusterv1.MachinePoolFinalizer, metav1.FinalizerDeleteDependents},
+					DeletionTimestamp: &time,
+				},
+				Spec: clusterv1.MachinePoolSpec{
+					ClusterName: "test-cluster",
+					Replicas:    pointer.Int32Ptr(1),
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							InfrastructureRef: corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+								Kind:       "InfrastructureConfig",
+								Name:       "infra-config1",
+							},
+							Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+						},
+					},
+				},
+			},
+			expected: expected{
+				result: reconcile.Result{},
+				err:    false,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("machinePool should be "+tc.machinePool.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+			client := fake.NewFakeClientWithScheme(
+				scheme.Scheme,
+				&testCluster,
+				&tc.machinePool,
+				&infraConfig,
+				bootstrapConfig,
+			)
+
+			r := &MachinePoolReconciler{
+				Client: client,
+				Log:    log.Log,
+				scheme: scheme.Scheme,
+			}
+
+			result, err := r.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tc.machinePool.Namespace, Name: tc.machinePool.Name}})
+			if tc.expected.err {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+
+			g.Expect(result).To(Equal(tc.expected.result))
+		})
+	}
+}
+
+func TestReconcileMachinePoolDeleteExternal(t *testing.T) {
+	testCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-cluster"},
+	}
+
+	bootstrapConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "BootstrapConfig",
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+			"metadata": map[string]interface{}{
+				"name":      "delete-bootstrap",
+				"namespace": "default",
+			},
+		},
+	}
+
+	infraConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "InfrastructureConfig",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+			"metadata": map[string]interface{}{
+				"name":      "delete-infra",
+				"namespace": "default",
+			},
+		},
+	}
+
+	machinePool := &clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "delete",
+			Namespace: "default",
+		},
+		Spec: clusterv1.MachinePoolSpec{
+			ClusterName: "test-cluster",
+			Replicas:    pointer.Int32Ptr(1),
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+						Kind:       "InfrastructureConfig",
+						Name:       "delete-infra",
+					},
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+							Kind:       "BootstrapConfig",
+							Name:       "delete-bootstrap",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name            string
+		bootstrapExists bool
+		infraExists     bool
+		expected        bool
+		expectError     bool
+	}{
+		{
+			name:            "should continue to reconcile delete of external refs since both refs exists",
+			bootstrapExists: true,
+			infraExists:     true,
+			expected:        false,
+			expectError:     false,
+		},
+		{
+			name:            "should continue to reconcile delete of external refs since infra ref exist",
+			bootstrapExists: false,
+			infraExists:     true,
+			expected:        false,
+			expectError:     false,
+		},
+		{
+			name:            "should continue to reconcile delete of external refs since bootstrap ref exist",
+			bootstrapExists: true,
+			infraExists:     false,
+			expected:        false,
+			expectError:     false,
+		},
+		{
+			name:            "should no longer reconcile deletion of external refs since both don't exist",
+			bootstrapExists: false,
+			infraExists:     false,
+			expected:        true,
+			expectError:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+			objs := []runtime.Object{testCluster, machinePool}
+
+			if tc.bootstrapExists {
+				objs = append(objs, bootstrapConfig)
+			}
+
+			if tc.infraExists {
+				objs = append(objs, infraConfig)
+			}
+
+			r := &MachinePoolReconciler{
+				Client: fake.NewFakeClientWithScheme(scheme.Scheme, objs...),
+				Log:    log.Log,
+				scheme: scheme.Scheme,
+			}
+
+			ok, err := r.reconcileDeleteExternal(ctx, machinePool)
+			g.Expect(ok).To(Equal(tc.expected))
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestRemoveMachinePoolFinalizerAfterDeleteReconcile(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	dt := metav1.Now()
+
+	testCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-cluster"},
+	}
+
+	m := &clusterv1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "delete123",
+			Namespace:         "default",
+			Finalizers:        []string{clusterv1.MachinePoolFinalizer, metav1.FinalizerDeleteDependents},
+			DeletionTimestamp: &dt,
+		},
+		Spec: clusterv1.MachinePoolSpec{
+			ClusterName: "test-cluster",
+			Replicas:    pointer.Int32Ptr(1),
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+						Kind:       "InfrastructureConfig",
+						Name:       "infra-config1",
+					},
+					Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+				},
+			},
+		},
+	}
+	key := client.ObjectKey{Namespace: m.Namespace, Name: m.Name}
+	mr := &MachinePoolReconciler{
+		Client: fake.NewFakeClientWithScheme(scheme.Scheme, testCluster, m),
+		Log:    log.Log,
+		scheme: scheme.Scheme,
+	}
+	_, err := mr.Reconcile(reconcile.Request{NamespacedName: key})
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(mr.Client.Get(ctx, key, m)).To(Succeed())
+	g.Expect(m.ObjectMeta.Finalizers).To(Equal([]string{metav1.FinalizerDeleteDependents}))
+}

--- a/docs/proposals/20190919-machinepool-api.md
+++ b/docs/proposals/20190919-machinepool-api.md
@@ -179,9 +179,9 @@ type MachinePoolSpec struct
   - **MinReadySeconds [optional]**
     - Type: `*int32`
     - Description: Minimum number of seconds for which a newly created machine should be ready.
-  - **ProviderIDs [optional]**
+  - **ProviderIDList [optional]**
     - Type: `[]string`
-    - Description: ProviderIDs contain a ProviderID for each machine instance that's currently
+    - Description: ProviderIDList contain a ProviderID for each machine instance that's currently
       managed by the infrastructure provider belonging to the machine pool.
 
 ``` go
@@ -191,7 +191,7 @@ type MachinePoolStatus struct
 - **To add**
   - **NodeRefs [optional]**
     - Type: `[]corev1.ObjectReference`
-    - Description: NodeRefs contain a NodeRef for each ProviderID in MachinePoolSpec.ProviderIDs.
+    - Description: NodeRefs contain a NodeRef for each ProviderID in MachinePoolSpec.ProviderIDList.
   - **Replicas [optional]**
     - Type: `*int32`
     - Description: Replicas is the most recent observed number of replicas.

--- a/errors/consts.go
+++ b/errors/consts.go
@@ -112,7 +112,7 @@ const (
 	InvalidConfigurationMachineSetError MachineSetStatusError = "InvalidConfiguration"
 )
 
-type MachinePoolStatusError string
+type MachinePoolStatusFailure string
 
 const (
 	// Represents that the combination of configuration in the MachineTemplateSpec
@@ -120,7 +120,7 @@ const (
 	// indicates a state that must be fixed before progress can be made.
 	//
 	// Example: the ProviderSpec specifies an instance type that doesn't exist.
-	InvalidConfigurationMachinePoolError MachinePoolStatusError = "InvalidConfiguration"
+	InvalidConfigurationMachinePoolError MachinePoolStatusFailure = "InvalidConfiguration"
 )
 
 type KubeadmControlPlaneStatusError string

--- a/errors/pointer.go
+++ b/errors/pointer.go
@@ -21,6 +21,11 @@ func MachineStatusErrorPtr(v MachineStatusError) *MachineStatusError {
 	return &v
 }
 
+// MachinePoolStatusErrorPtr converts a MachinePoolStatusError to a pointer.
+func MachinePoolStatusErrorPtr(v MachinePoolStatusFailure) *MachinePoolStatusFailure {
+	return &v
+}
+
 // ClusterStatusErrorPtr converts a MachineStatusError to a pointer.
 func ClusterStatusErrorPtr(v ClusterStatusError) *ClusterStatusError {
 	return &v


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `MachinePool` controller implementation described in the [MachinePool API proposal](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/20190919-machinepool-api.md).