### PR TITLE
🏃 hack/verify-starlark: better dir handling

### DIFF
--- a/hack/verify-starlark.sh
+++ b/hack/verify-starlark.sh
@@ -17,6 +17,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+ROOT_PATH="$(cd "${SCRIPT_DIR}"/.. && pwd)"
+
 VERSION="0.29.0"
 
 MODE="check"
@@ -30,10 +33,6 @@ if [[ "${OSTYPE}" == "linux"* ]]; then
 elif [[ "${OSTYPE}" == "darwin"* ]]; then
   BINARY="buildifier.mac"
 fi
-
-# shellcheck source=./hack/utils.sh
-source "$(dirname "$0")/utils.sh"
-ROOT_PATH=$(get_root_path)
 
 # create a temporary directory
 TMP_DIR=$(mktemp -d)
@@ -55,7 +54,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-BUILDIFIER="./$(dirname "$0")/tools/bin/buildifier/${VERSION}"
+BUILDIFIER="${SCRIPT_DIR}/tools/bin/buildifier/${VERSION}/buildifier"
 
 if [ ! -f "$BUILDIFIER" ]; then
   # install buildifier
@@ -63,7 +62,7 @@ if [ ! -f "$BUILDIFIER" ]; then
   curl -L "https://github.com/bazelbuild/buildtools/releases/download/${VERSION}/${BINARY}" -o "${TMP_DIR}/buildifier"
   chmod +x "${TMP_DIR}/buildifier"
   cd "${ROOT_PATH}"
-  mkdir -p "$(dirname "$0")/tools/bin/buildifier"
+  mkdir -p "$(dirname "$0")/tools/bin/buildifier/${VERSION}"
   mv "${TMP_DIR}/buildifier" "$BUILDIFIER"
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update hack/verify-starlark to find the hack dir and root dir based on
BASH_SOURCE. This allows it to be invoked by specifying the full path to
the script, which is something that some IDEs do when running commands
on save (i.e. to auto-format).

This forward-ports the changes I made in #1954 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
