### PR TITLE
✨ Adds pod logs for capd e2e tests

### DIFF
--- a/scripts/ci-capd-e2e.sh
+++ b/scripts/ci-capd-e2e.sh
@@ -30,5 +30,8 @@ source "${REPO_ROOT}/hack/ensure-kubectl.sh"
 # shellcheck source=./hack/ensure-kustomize.sh
 source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 
+ARTIFACTS="${ARTIFACTS:-${PWD}/_artifacts}"
+mkdir -p "$ARTIFACTS/logs/"
+
 echo "*** Testing Cluster API Provider Docker e2es ***"
-cd "${REPO_ROOT}/test/infrastructure/docker" && make test-e2e
+cd "${REPO_ROOT}/test/infrastructure/docker" && ARTIFACTS="${ARTIFACTS}" make test-e2e

--- a/test/framework/management/kind/mgmt.go
+++ b/test/framework/management/kind/mgmt.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/test/framework/exec"
@@ -218,7 +219,16 @@ func (c *Cluster) ClientFromRestConfig(restConfig *rest.Config) (client.Client, 
 	return c.Client, nil
 }
 
-// GetClient returns a controller-rutnime client for the management cluster.
+// GetClientSet returns a clientset to the management cluster to be used for object interface expansions such as pod logs.
+func (c *Cluster) GetClientSet() (*kubernetes.Clientset, error) {
+	restConfig, err := clientcmd.BuildConfigFromFlags("", c.KubeconfigPath)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return kubernetes.NewForConfig(restConfig)
+}
+
+// GetClient returns a controller-runtime client for the management cluster.
 func (c *Cluster) GetClient() (client.Client, error) {
 	restConfig, err := clientcmd.BuildConfigFromFlags("", c.KubeconfigPath)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR adds a method to return a kubernetes ClientSet that allows us to get things like pod logs and other expansion interfaces.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1921 
