### PR TITLE
🏃 Fix validation e2e test

### DIFF
--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Cluster API Validation", func() {
 				Spec: capiv1.MachineSpec{
 					ClusterName: name,
 					Bootstrap: capiv1.Bootstrap{
-						Data: &bootstrapData,
+						DataSecretName: &bootstrapData,
 					},
 					InfrastructureRef: corev1.ObjectReference{
 						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
@@ -105,7 +105,7 @@ var _ = Describe("Cluster API Validation", func() {
 			err := kindClient.Create(ctx, machine)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal(
-				fmt.Sprintf(`admission webhook "validation.machine.cluster.x-k8s.io" denied the request: Machine.cluster.x-k8s.io "%s" is invalid: spec.bootstrap.data: Required value: expected spec.bootstrap.data or spec.bootstrap.configRef to be populated`, name),
+				fmt.Sprintf(`admission webhook "validation.machine.cluster.x-k8s.io" denied the request: Machine.cluster.x-k8s.io "%s" is invalid: spec.bootstrap.data: Required value: expected either spec.bootstrap.dataSecretName or spec.bootstrap.configRef to be populated`, name),
 			))
 		})
 	})


### PR DESCRIPTION
Use DataSecretName vs. Data for test and update error assertion

Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes the validation e2e test as I noticed that it was failing when running locally.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Referencing this issue https://github.com/kubernetes-sigs/cluster-api/issues/1884 so that future changes can be caught in CI.

