### PR TITLE
:bug: Add cluster label when creating kubeconfig secret

### DIFF
--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -162,6 +162,9 @@ func GenerateSecretWithOwner(clusterName types.NamespacedName, data []byte, owne
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
 			Namespace: clusterName.Namespace,
+			Labels: map[string]string{
+				clusterv1.ClusterLabelName: clusterName.Name,
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				owner,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds the cluster label when creating the kubeconfig secret
- Adds additional tests for util/kubeconfig/kubeconfig.go
