### PR TITLE
:running: Update use of deprecated helpers

### DIFF
--- a/controllers/external/util_test.go
+++ b/controllers/external/util_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestGetResourceFound(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	namespace := "test"
 	testResourceName := "greenTemplate"
@@ -62,7 +62,7 @@ func TestGetResourceFound(t *testing.T) {
 }
 
 func TestGetResourceNotFound(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	namespace := "test"
 
@@ -80,7 +80,7 @@ func TestGetResourceNotFound(t *testing.T) {
 }
 
 func TestCloneTemplateResourceNotFound(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	namespace := "test"
 	testClusterName := "bar"
@@ -107,7 +107,7 @@ func TestCloneTemplateResourceNotFound(t *testing.T) {
 }
 
 func TestCloneTemplateResourceFound(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	namespace := "test"
 	testClusterName := "test-cluster"
@@ -195,7 +195,7 @@ func TestCloneTemplateResourceFound(t *testing.T) {
 }
 
 func TestCloneTemplateResourceFoundNoOwner(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	namespace := "test"
 	testClusterName := "test-cluster"
@@ -276,7 +276,7 @@ func TestCloneTemplateResourceFoundNoOwner(t *testing.T) {
 }
 
 func TestCloneTemplateMissingSpecTemplate(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	namespace := "test"
 	testClusterName := "test-cluster"

--- a/controllers/machineset_delete_policy_test.go
+++ b/controllers/machineset_delete_policy_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package controllers
 
 import (
-	"reflect"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
@@ -151,10 +152,10 @@ func TestMachineToDelete(t *testing.T) {
 		}}
 
 	for _, test := range tests {
+		g := NewWithT(t)
+
 		result := getMachinesToDeletePrioritized(test.machines, test.diff, randomDeletePolicy)
-		if !reflect.DeepEqual(result, test.expect) {
-			t.Errorf("[case %s]", test.desc)
-		}
+		g.Expect(result).To(Equal(test.expect))
 	}
 }
 
@@ -219,10 +220,10 @@ func TestMachineNewestDelete(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		g := NewWithT(t)
+
 		result := getMachinesToDeletePrioritized(test.machines, test.diff, newestDeletePriority)
-		if !reflect.DeepEqual(result, test.expect) {
-			t.Errorf("[case %s]", test.desc)
-		}
+		g.Expect(result).To(Equal(test.expect))
 	}
 }
 
@@ -295,9 +296,9 @@ func TestMachineOldestDelete(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		g := NewWithT(t)
+
 		result := getMachinesToDeletePrioritized(test.machines, test.diff, oldestDeletePriority)
-		if !reflect.DeepEqual(result, test.expect) {
-			t.Errorf("[case %s]", test.desc)
-		}
+		g.Expect(result).To(Equal(test.expect))
 	}
 }

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -17,17 +17,18 @@ limitations under the License.
 package remote
 
 import (
-	"strings"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util/secret"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var (
@@ -91,46 +92,33 @@ users:
 )
 
 func TestNewClusterClient(t *testing.T) {
+	g := NewWithT(t)
+
 	testScheme := runtime.NewScheme()
-	err := scheme.AddToScheme(testScheme)
-	if err != nil {
-		t.Fatalf("Failed to addd types to the scheme: %v", err)
-	}
+	g.Expect(scheme.AddToScheme(testScheme)).To(Succeed())
 
 	t.Run("cluster with valid kubeconfig", func(t *testing.T) {
 		client := fake.NewFakeClientWithScheme(testScheme, validSecret)
 		c, err := NewClusterClient(client, clusterWithValidKubeConfig, testScheme)
-		if err != nil {
-			t.Fatalf("Expected no errors, got %v", err)
-		}
-
-		if c == nil {
-			t.Fatal("Expected actual client, got nil")
-		}
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(c).NotTo(BeNil())
 
 		restConfig, err := RESTConfig(client, clusterWithValidKubeConfig)
-		if err != nil {
-			t.Fatalf("Expected no errors, got %v", err)
-		}
-		if restConfig.Host != "https://test-cluster-api:6443" {
-			t.Fatalf("Unexpected Host value in RESTConfig: %q", restConfig.Host)
-		}
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(restConfig.Host).To(Equal("https://test-cluster-api:6443"))
 	})
 
 	t.Run("cluster with no kubeconfig", func(t *testing.T) {
 		client := fake.NewFakeClientWithScheme(testScheme)
 		_, err := NewClusterClient(client, clusterWithNoKubeConfig, testScheme)
-		if !strings.Contains(err.Error(), "not found") {
-			t.Fatalf("Expected not found error, got %v", err)
-		}
+		g.Expect(err).To(MatchError(ContainSubstring("not found")))
 	})
 
 	t.Run("cluster with invalid kubeconfig", func(t *testing.T) {
 		client := fake.NewFakeClientWithScheme(testScheme, invalidSecret)
 		_, err := NewClusterClient(client, clusterWithInvalidKubeConfig, testScheme)
-		if err == nil || apierrors.IsNotFound(err) {
-			t.Fatalf("Expected error, got %v", err)
-		}
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(apierrors.IsNotFound(err)).To(BeFalse())
 	})
 
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,8 +29,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	"k8s.io/klog/klogr"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
-	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -38,6 +36,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controllers/external"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -88,8 +89,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = clusterv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// +kubebuilder:scaffold:scheme
 
@@ -110,27 +110,27 @@ var _ = BeforeSuite(func(done Done) {
 		Log:      log.Log,
 		recorder: mgr.GetEventRecorderFor("cluster-controller"),
 	}
-	Expect(clusterReconciler.SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: 1})).NotTo(HaveOccurred())
+	Expect(clusterReconciler.SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 	Expect((&MachineReconciler{
 		Client:   k8sClient,
 		Log:      log.Log,
 		recorder: mgr.GetEventRecorderFor("machine-controller"),
-	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: 1})).NotTo(HaveOccurred())
+	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 	Expect((&MachineSetReconciler{
 		Client:         k8sClient,
 		Log:            log.Log,
 		TemplateCloner: &external.TemplateCloner{},
 		recorder:       mgr.GetEventRecorderFor("machineset-controller"),
-	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: 1})).NotTo(HaveOccurred())
+	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 	Expect((&MachineDeploymentReconciler{
 		Client:   k8sClient,
 		Log:      log.Log,
 		recorder: mgr.GetEventRecorderFor("machinedeployment-controller"),
-	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: 1})).NotTo(HaveOccurred())
+	}).SetupWithManager(mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 
 	By("starting the manager")
 	go func() {
-		Expect(mgr.Start(doneMgr)).ToNot(HaveOccurred())
+		Expect(mgr.Start(doneMgr)).To(Succeed())
 	}()
 
 	close(done)
@@ -140,6 +140,5 @@ var _ = AfterSuite(func() {
 	By("closing the manager")
 	close(doneMgr)
 	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	Expect(testEnv.Stop()).To(Succeed())
 })

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -203,7 +203,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestGenerateSecretWithOwner(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	owner := metav1.OwnerReference{
 		Name:       "test1",
@@ -228,7 +228,7 @@ func TestGenerateSecretWithOwner(t *testing.T) {
 }
 
 func TestGenerateSecret(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	expectedSecret := validSecret.DeepCopy()
 	expectedSecret.SetOwnerReferences(
@@ -255,7 +255,7 @@ func TestGenerateSecret(t *testing.T) {
 }
 
 func TestCreateSecretWithOwner(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	caKey, err := certs.NewPrivateKey()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
@@ -309,7 +309,7 @@ func TestCreateSecretWithOwner(t *testing.T) {
 }
 
 func TestCreateSecret(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
+	g := gomega.NewWithT(t)
 
 	caKey, err := certs.NewPrivateKey()
 	g.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update calls to controller-runtime NewFakeClient to NewFakeClientWithScheme
- Update calls to gomega NewGomegaWithT to NewWithT
- Update usage of gomega RegisterTestingT to use NewWithT and returned it's struct
- Fix up some consistency with the use of gomega Matchers

