### PR TITLE
🐛 Fix webhook for KubeadmControlPlane

### DIFF
--- a/config/controlplane/webhook/kustomization.yaml
+++ b/config/controlplane/webhook/kustomization.yaml
@@ -10,3 +10,6 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+patchesStrategicMerge:
+  - webhookcainjection_patch.yaml

--- a/config/controlplane/webhook/manifests.yaml
+++ b/config/controlplane/webhook/manifests.yaml
@@ -9,7 +9,7 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: webhook-service
+      name: capi-webhook-service
       namespace: system
       path: /mutate-controlplane-cluster-x-k8s-io-v1alpha3-kubeadmcontrolplane
   failurePolicy: Fail
@@ -35,7 +35,7 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: webhook-service
+      name: capi-webhook-service
       namespace: system
       path: /validate-controlplane-cluster-x-k8s-io-v1alpha3-kubeadmcontrolplane
   failurePolicy: Fail

--- a/config/controlplane/webhook/webhookcainjection_patch.yaml
+++ b/config/controlplane/webhook/webhookcainjection_patch.yaml
@@ -1,0 +1,16 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+# uncomment the following lines to enable mutating webhook
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This is one of many solutions to #1966 

This is the simplest path forward however it incurs a bit of technical debt as running `go generate` now makes the configs for the control plane invalid.

There are several other options discussed in #1966 but after futzing with this all day I believe this is the simplest solution until we find a different path forward, such as independent web hook servers.

Fixes #1966 