### PR TITLE
⚠️ clusterctl: allow config variable override

### DIFF
--- a/cmd/clusterctl/pkg/client/config/client.go
+++ b/cmd/clusterctl/pkg/client/config/client.go
@@ -94,9 +94,13 @@ type Reader interface {
 	// Init allows to initialize the configuration reader.
 	Init(path string) error
 
-	// GetString returns a configuration value of type string.
+	// Get returns a configuration value of type string.
 	// In case the configuration value does not exists, it returns an error.
-	GetString(key string) (string, error)
+	Get(key string) (string, error)
+
+	// Set allows to set an explicit override for a config value.
+	// e.g. It is used to set an override from a flag value over environment/config file variables.
+	Set(key, value string)
 
 	// UnmarshalKey reads a configuration value and unmarshals it into the provided value object.
 	UnmarshalKey(key string, value interface{}) error

--- a/cmd/clusterctl/pkg/client/config/reader_viper.go
+++ b/cmd/clusterctl/pkg/client/config/reader_viper.go
@@ -64,11 +64,15 @@ func (v *viperReader) Init(path string) error {
 	return nil
 }
 
-func (v *viperReader) GetString(key string) (string, error) {
+func (v *viperReader) Get(key string) (string, error) {
 	if viper.Get(key) == nil {
 		return "", errors.Errorf("Failed to get value for variable %q. Please set the variable value using os env variables or using the .clusterctl config file", key)
 	}
 	return viper.GetString(key), nil
+}
+
+func (v *viperReader) Set(key, value string) {
+	viper.Set(key, value)
 }
 
 func (v *viperReader) UnmarshalKey(key string, rawval interface{}) error {

--- a/cmd/clusterctl/pkg/client/config/variables_client.go
+++ b/cmd/clusterctl/pkg/client/config/variables_client.go
@@ -24,6 +24,10 @@ type VariablesClient interface {
 	// In case the same variable is defined both within the environment variables and clusterctl configuration file,
 	// the environment variables value takes precedence.
 	Get(key string) (string, error)
+
+	// Set allows to set an explicit override for a config value.
+	// e.g. It is used to set an override from a flag value over environment/config file variables.
+	Set(key, values string)
 }
 
 // Ensures the FakeVariableClient implements VariablesClient
@@ -44,5 +48,9 @@ func newVariablesClient(reader Reader) *variablesClient {
 }
 
 func (p *variablesClient) Get(key string) (string, error) {
-	return p.reader.GetString(key)
+	return p.reader.Get(key)
+}
+
+func (p *variablesClient) Set(key, value string) {
+	p.reader.Set(key, value)
 }

--- a/cmd/clusterctl/pkg/internal/test/fake_reader.go
+++ b/cmd/clusterctl/pkg/internal/test/fake_reader.go
@@ -42,15 +42,19 @@ func (f *FakeReader) Init(config string) error {
 	return nil
 }
 
-func (f *FakeReader) GetString(key string) (string, error) {
+func (f *FakeReader) Get(key string) (string, error) {
 	if val, ok := f.variables[key]; ok {
 		return val, nil
 	}
 	return "", errors.Errorf("value for variable %q is not set", key)
 }
 
+func (f *FakeReader) Set(key, value string) {
+	f.variables[key] = value
+}
+
 func (f *FakeReader) UnmarshalKey(key string, rawval interface{}) error {
-	data, err := f.GetString(key)
+	data, err := f.Get(key)
 	if err != nil {
 		return nil
 	}

--- a/cmd/clusterctl/pkg/internal/test/fake_variable_client.go
+++ b/cmd/clusterctl/pkg/internal/test/fake_variable_client.go
@@ -32,6 +32,10 @@ func (f FakeVariableClient) Get(key string) (string, error) {
 	return "", errors.Errorf("value for variable %q is not set", key)
 }
 
+func (f FakeVariableClient) Set(key, value string) {
+	f.variables[key] = value
+}
+
 func (f *FakeVariableClient) WithVar(key, value string) *FakeVariableClient {
 	f.variables[key] = value
 	return f


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of the initial work for support for cluster templates in clusterctl.
It introduces the possibility to do override config variables values e.g. with values received from flag

**Which issue(s) this PR fixes**
Rif #1729

/assign @vincepri