### PR TITLE
✨clusterctl: small refactor of fixNamespace

### DIFF
--- a/cmd/clusterctl/pkg/internal/util/yaml.go
+++ b/cmd/clusterctl/pkg/internal/util/yaml.go
@@ -67,3 +67,17 @@ func ToUnstructured(rawyaml []byte) ([]unstructured.Unstructured, error) {
 
 	return ret, nil
 }
+
+// FromUnstructured takes a list of Unstructured objects and converts it into a YAML
+func FromUnstructured(objs []unstructured.Unstructured) ([]byte, error) {
+	var ret [][]byte //nolint
+	for _, o := range objs {
+		content, err := yaml.Marshal(o.UnstructuredContent())
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to marshal yaml for %s/%s", o.GetNamespace(), o.GetName())
+		}
+		ret = append(ret, content)
+	}
+
+	return JoinYaml(ret...), nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of the initial work for support for cluster templates in clusterctl.
It implements a small refactor in fixNamespace, so the fixTargetNamespace part can be re-used for templates (without addNamespaceIfMissing).

**Which issue(s) this PR fixes**
Rif #1729

/assign @vincepri