### PR TITLE
✨clusterctl: add test framework for move

### DIFF
--- a/cmd/clusterctl/pkg/internal/scheme/scheme.go
+++ b/cmd/clusterctl/pkg/internal/scheme/scheme.go
@@ -19,7 +19,7 @@ package scheme
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of the initial work for support for clusterctl move.
It introduces a test framework that allows creating fake v1alpha3 cluster API objects: cluster, control plane, machine deployments, machines etc. with all the ancillary objects (secrets, infrastructureRef or bootstrap.configRef objects etc.)

**Which issue(s) this PR fixes**
Rif #1729

/assign @vincepri 

/cc @detiber (if you can take a look at the fake controlplane implementation 🙏 )