### PR TITLE
✨clusterctl: add Repository.GetVersions method

### DIFF
--- a/cmd/clusterctl/pkg/client/repository/client.go
+++ b/cmd/clusterctl/pkg/client/repository/client.go
@@ -31,6 +31,9 @@ import (
 type Client interface {
 	config.Provider
 
+	// GetVersion return the list of versions that are available in a provider repository
+	GetVersions() ([]string, error)
+
 	// Components provide access to YAML file for creating provider components.
 	Components() ComponentsClient
 
@@ -48,6 +51,10 @@ type repositoryClient struct {
 
 // ensure repositoryClient implements Client.
 var _ Client = &repositoryClient{}
+
+func (c *repositoryClient) GetVersions() ([]string, error) {
+	return c.repository.GetVersions()
+}
 
 func (c *repositoryClient) Components() ComponentsClient {
 	return newComponentsClient(c.Provider, c.repository, c.configVariablesClient)
@@ -121,6 +128,9 @@ type Repository interface {
 
 	// GetFile return a file for a given provider version.
 	GetFile(version string, path string) ([]byte, error)
+
+	// GetVersion return the list of versions that are available in a provider repository
+	GetVersions() ([]string, error)
 }
 
 var _ Repository = &test.FakeRepository{}

--- a/cmd/clusterctl/pkg/internal/test/fake_repository.go
+++ b/cmd/clusterctl/pkg/internal/test/fake_repository.go
@@ -55,6 +55,14 @@ func (f FakeRepository) GetFile(version string, path string) ([]byte, error) {
 	return nil, errors.Errorf("unable to get file %s for version %s", path, version)
 }
 
+func (f *FakeRepository) GetVersions() ([]string, error) {
+	v := make([]string, len(f.versions))
+	for k := range f.versions {
+		v = append(v, k)
+	}
+	return v, nil
+}
+
 func NewFakeRepository() *FakeRepository {
 	return &FakeRepository{
 		versions: map[string]bool{},
@@ -76,6 +84,13 @@ func (f *FakeRepository) WithDefaultVersion(version string) *FakeRepository {
 func (f *FakeRepository) WithFile(version, path string, content []byte) *FakeRepository {
 	f.versions[version] = true
 	f.files[vpath(version, path)] = content
+	return f
+}
+
+func (f *FakeRepository) WithVersions(version ...string) *FakeRepository {
+	for _, v := range version {
+		f.versions[v] = true
+	}
 	return f
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of the initial work for support for clusterctl upgrade.
It introduces a new method for getting the list of versions available in a provider repository

**Which issue(s) this PR fixes**
Rif #1729

/assign @vincepri 