### PR TITLE
:sparkles: Add support to pause reconciliation

### DIFF
--- a/api/v1alpha2/conversion.go
+++ b/api/v1alpha2/conversion.go
@@ -147,12 +147,27 @@ func (dst *MachineSetList) ConvertFrom(srcRaw conversion.Hub) error {
 func (src *MachineDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1alpha3.MachineDeployment)
 
+	// Manually restore data.
+	restored := &v1alpha3.MachineDeployment{}
+	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil {
+		return err
+	} else if ok {
+		if restored.Spec.Paused {
+			dst.Spec.Paused = restored.Spec.Paused
+		}
+	}
+
 	return Convert_v1alpha2_MachineDeployment_To_v1alpha3_MachineDeployment(src, dst, nil)
 }
 
 // nolint
 func (dst *MachineDeployment) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha3.MachineDeployment)
+
+	// Preserve Hub data on down-conversion.
+	if err := utilconversion.MarshalData(src, dst); err != nil {
+		return err
+	}
 
 	return Convert_v1alpha3_MachineDeployment_To_v1alpha2_MachineDeployment(src, dst, nil)
 }

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -508,6 +508,7 @@ func autoConvert_v1alpha2_ClusterSpec_To_v1alpha3_ClusterSpec(in *ClusterSpec, o
 }
 
 func autoConvert_v1alpha3_ClusterSpec_To_v1alpha2_ClusterSpec(in *v1alpha3.ClusterSpec, out *ClusterSpec, s conversion.Scope) error {
+	// WARNING: in.Paused requires manual conversion: does not exist in peer-type
 	out.ClusterNetwork = (*ClusterNetwork)(unsafe.Pointer(in.ClusterNetwork))
 	// WARNING: in.ControlPlaneEndpoint requires manual conversion: does not exist in peer-type
 	// WARNING: in.ControlPlaneRef requires manual conversion: does not exist in peer-type

--- a/api/v1alpha3/cluster_types.go
+++ b/api/v1alpha3/cluster_types.go
@@ -32,7 +32,11 @@ const (
 
 // ClusterSpec defines the desired state of Cluster
 type ClusterSpec struct {
-	// Cluster network configuration
+	// Paused can be used to prevent controllers from processing the Cluster and all its associated objects.
+	// +optional
+	Paused bool `json:"paused,omitempty"`
+
+	// Cluster network configuration.
 	// +optional
 	ClusterNetwork *ClusterNetwork `json:"clusterNetwork,omitempty"`
 

--- a/api/v1alpha3/common_types.go
+++ b/api/v1alpha3/common_types.go
@@ -24,6 +24,13 @@ const (
 	// ClusterLabelName is the label set on machines linked to a cluster and
 	// external objects(bootstrap and infrastructure providers)
 	ClusterLabelName = "cluster.x-k8s.io/cluster-name"
+
+	// PausedAnnotation is an annotation that can be applied to any Cluster API
+	// object to prevent a controller from processing a resource.
+	//
+	// Controllers working with Cluster API objects must check the existence of this annotation
+	// on the reconciled object.
+	PausedAnnotation = "cluster.x-k8s.io/paused"
 )
 
 // MachineAddressType describes a valid MachineAddress type.

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -186,7 +186,7 @@ spec:
             description: ClusterSpec defines the desired state of Cluster
             properties:
               clusterNetwork:
-                description: Cluster network configuration
+                description: Cluster network configuration.
                 properties:
                   apiServerPort:
                     description: APIServerPort specifies the port the API Server should
@@ -308,6 +308,10 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+              paused:
+                description: Paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
             type: object
           status:
             description: ClusterStatus defines the observed state of Cluster

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -89,6 +89,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, options controlle
 
 func (r *ClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
 	ctx := context.Background()
+	logger := r.Log.WithValues("cluster", req.Name, "namespace", req.Namespace)
 
 	// Fetch the Cluster instance.
 	cluster := &clusterv1.Cluster{}
@@ -101,6 +102,12 @@ func (r *ClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr e
 
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
+	}
+
+	// Return early if the object or Cluster is paused.
+	if util.IsPaused(cluster, cluster) {
+		logger.V(3).Info("reconciliation is paused for this object")
+		return ctrl.Result{}, nil
 	}
 
 	// Initialize the patch helper.

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -91,6 +91,17 @@ func (r *MachineDeploymentReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 		return ctrl.Result{}, err
 	}
 
+	cluster, err := util.GetClusterByName(ctx, r.Client, deployment.Namespace, deployment.Spec.ClusterName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Return early if the object or Cluster is paused.
+	if util.IsPaused(cluster, deployment) {
+		logger.V(3).Info("reconciliation is paused for this object")
+		return ctrl.Result{}, nil
+	}
+
 	// Initialize the patch helper
 	patchHelper, err := patch.NewHelper(deployment, r.Client)
 	if err != nil {
@@ -112,7 +123,7 @@ func (r *MachineDeploymentReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 		return ctrl.Result{}, nil
 	}
 
-	result, err := r.reconcile(ctx, deployment)
+	result, err := r.reconcile(ctx, cluster, deployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile MachineDeployment")
 		r.recorder.Eventf(deployment, corev1.EventTypeWarning, "ReconcileError", "%v", err)
@@ -121,7 +132,7 @@ func (r *MachineDeploymentReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 	return result, nil
 }
 
-func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, d *clusterv1.MachineDeployment) (ctrl.Result, error) {
+func (r *MachineDeploymentReconciler) reconcile(_ context.Context, cluster *clusterv1.Cluster, d *clusterv1.MachineDeployment) (ctrl.Result, error) {
 	logger := r.Log.WithValues("machinedeployment", d.Name, "namespace", d.Namespace)
 	logger.V(4).Info("Reconcile MachineDeployment")
 
@@ -145,12 +156,6 @@ func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, d *clusterv
 	// Add label and selector based on the MachineDeployment's name.
 	d.Spec.Selector.MatchLabels[clusterv1.MachineDeploymentLabelName] = d.Name
 	d.Spec.Template.Labels[clusterv1.MachineDeploymentLabelName] = d.Name
-
-	// Check for Cluster ownership.
-	cluster, err := util.GetClusterByName(ctx, r.Client, d.ObjectMeta.Namespace, d.Spec.ClusterName)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
 
 	if r.shouldAdopt(d) {
 		d.OwnerReferences = util.EnsureOwnerRef(d.OwnerReferences, metav1.OwnerReference{

--- a/controllers/machinepool_controller.go
+++ b/controllers/machinepool_controller.go
@@ -64,5 +64,6 @@ func (r *MachinePoolReconciler) SetupWithManager(mgr ctrl.Manager, options contr
 
 func (r *MachinePoolReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// TODO(juan-lee): Add machine pool implementation.
+	// TODO(vincepri): Add support for pause annotation and honoring Cluster.Spec.Paused.
 	return ctrl.Result{}, nil
 }

--- a/docs/book/src/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/providers/v1alpha2-to-v1alpha3.md
@@ -135,3 +135,9 @@ outside of the existing module.
   - `spec.bootstrap.dataSecretName` to know where to put bootstrap data with sensitive information.
   - `status.infrastuctureReady` to understand the state of the configuration consumer so the
     bootstrap provider can take appropriate action (e.g. renew bootstrap token).
+
+## Support the `cluster.x-k8s.io/paused` annotation and `Cluster.Spec.Paused` field.
+
+- A new annotation `cluster.x-k8s.io/paused` provides the ability to pause reconciliation on specific objects.
+- A new field `Cluster.Spec.Paused` provides the ability to pause reconciliation on a Cluster and all associated objects.
+- A helper function `util.IsPaused` can be used on any Kubernetes object associated with a Cluster.

--- a/util/util.go
+++ b/util/util.go
@@ -380,3 +380,17 @@ func HasOwner(refList []metav1.OwnerReference, apiVersion string, kinds []string
 
 	return false
 }
+
+// IsPaused returns true if the Cluster is paused or the object has the `paused` annotation.
+func IsPaused(cluster *clusterv1.Cluster, v metav1.Object) bool {
+	if cluster.Spec.Paused {
+		return true
+	}
+
+	annotations := v.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, ok := annotations[clusterv1.PausedAnnotation]
+	return ok
+}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds support for a generic annotation to Cluster API to stop reconciliation on objects.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1780
