### PR TITLE
✨clusterctl: fix RBAC rules and make multi-tenancy possible

### DIFF
--- a/cmd/clusterctl/pkg/client/repository/components.go
+++ b/cmd/clusterctl/pkg/client/repository/components.go
@@ -341,9 +341,11 @@ func isResourceNamespaced(kind string) bool {
 	}
 }
 
-const clusterRoleKind = "ClusterRole"
-const clusterRoleBindingKind = "ClusterRoleBinding"
-const roleBindingKind = "RoleBinding"
+const (
+	clusterRoleKind        = "ClusterRole"
+	clusterRoleBindingKind = "ClusterRoleBinding"
+	roleBindingKind        = "RoleBinding"
+)
 
 // fixRBAC ensures all the ClusterRole and ClusterRoleBinding have the name prefixed with the namespace name and that
 // all the clusterRole/clusterRoleBinding namespaced subjects refers to targetNamespace
@@ -363,8 +365,8 @@ func fixRBAC(objs []unstructured.Unstructured, targetNamespace string) ([]unstru
 	}
 
 	for i, o := range objs {
-		// if the object has Kind ClusterRoleBinding
-		if o.GetKind() == clusterRoleBindingKind {
+		switch o.GetKind() {
+		case clusterRoleBindingKind: // if the object has Kind ClusterRoleBinding
 			// Convert Unstructured into a typed object
 			b := &rbacv1.ClusterRoleBinding{}
 			if err := scheme.Scheme.Convert(&o, b, nil); err != nil { //nolint
@@ -391,10 +393,8 @@ func fixRBAC(objs []unstructured.Unstructured, targetNamespace string) ([]unstru
 				return nil, err
 			}
 			objs[i] = o
-		}
 
-		// if the object has Kind RoleBinding
-		if o.GetKind() == roleBindingKind {
+		case roleBindingKind: // if the object has Kind RoleBinding
 			// Convert Unstructured into a typed object
 			b := &rbacv1.RoleBinding{}
 			if err := scheme.Scheme.Convert(&o, b, nil); err != nil { //nolint


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a transformation in the RBAC rules read from the components YAML that ensures that also the ClusterRole and the ClusterRoleBindings are duplicated for each instance of a provider.

By having duplicated RBAC each instance of the provider can have separated lifecycles without introducing any backward/forward compatibility rules.

Nb. technically the providers share CRD, but CRD changes are strictly ruled.

**Which issue(s) this PR fixes** 
Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/1631
Rif #1729

@vincepri 
@ncdc 