### PR TITLE
[WIP] :running: Refactor MachineGenerator to take a struct

### DIFF
--- a/controlplane/kubeadm/controllers/generator/machinegenerator_test.go
+++ b/controlplane/kubeadm/controllers/generator/machinegenerator_test.go
@@ -39,8 +39,8 @@ func TestGenerateMachineWithOwner(t *testing.T) {
 	namespace := "test"
 	namePrefix := "generate2"
 	clusterName := "testCluster"
-	version := "my-version"
-	infraRef := &corev1.ObjectReference{
+	version := utilpointer.StringPtr("my-version")
+	infraRef := corev1.ObjectReference{
 		Kind:       "InfraKind",
 		APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 		Name:       "infra",
@@ -68,7 +68,7 @@ func TestGenerateMachineWithOwner(t *testing.T) {
 		},
 		Spec: clusterv1.MachineSpec{
 			ClusterName: clusterName,
-			Version:     utilpointer.StringPtr(version),
+			Version:     version,
 			Bootstrap: clusterv1.Bootstrap{
 				ConfigRef: bootstrapRef.DeepCopy(),
 			},
@@ -76,20 +76,18 @@ func TestGenerateMachineWithOwner(t *testing.T) {
 		},
 	}
 
-	mgg := &MachineGenerator{}
-	err := mgg.GenerateMachine(
-		context.Background(),
-		fakeClient,
-		namespace,
-		namePrefix,
-		clusterName,
-		version,
-		infraRef,
-		bootstrapRef,
-		labels,
-		owner,
-	)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	mgg := NewMachineGenerator(fakeClient)
+	input := MachineGeneratorInput{
+		Namespace:    namespace,
+		NamePrefix:   namePrefix,
+		ClusterName:  clusterName,
+		Version:      version,
+		InfraRef:     infraRef,
+		BootstrapRef: bootstrapRef,
+		Labels:       labels,
+		Owner:        owner,
+	}
+	g.Expect(mgg.GenerateMachine(context.Background(), input)).To(gomega.Succeed())
 
 	machineList := &clusterv1.MachineList{}
 	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(namespace))).To(gomega.Succeed())
@@ -106,8 +104,8 @@ func TestGenerateMachineWithoutOwner(t *testing.T) {
 	namespace := "test"
 	namePrefix := "generate1"
 	clusterName := "testCluster"
-	version := "my-version"
-	infraRef := &corev1.ObjectReference{
+	version := utilpointer.StringPtr("my-version")
+	infraRef := corev1.ObjectReference{
 		Kind:       "InfraKind",
 		APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
 		Name:       "infra",
@@ -129,7 +127,7 @@ func TestGenerateMachineWithoutOwner(t *testing.T) {
 		},
 		Spec: clusterv1.MachineSpec{
 			ClusterName: clusterName,
-			Version:     utilpointer.StringPtr(version),
+			Version:     version,
 			Bootstrap: clusterv1.Bootstrap{
 				ConfigRef: bootstrapRef.DeepCopy(),
 			},
@@ -137,20 +135,17 @@ func TestGenerateMachineWithoutOwner(t *testing.T) {
 		},
 	}
 
-	mgg := &MachineGenerator{}
-	err := mgg.GenerateMachine(
-		context.Background(),
-		fakeClient,
-		namespace,
-		namePrefix,
-		clusterName,
-		version,
-		infraRef,
-		bootstrapRef,
-		labels,
-		nil,
-	)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	mgg := NewMachineGenerator(fakeClient)
+	input := MachineGeneratorInput{
+		Namespace:    namespace,
+		NamePrefix:   namePrefix,
+		ClusterName:  clusterName,
+		Version:      version,
+		InfraRef:     infraRef,
+		BootstrapRef: bootstrapRef,
+		Labels:       labels,
+	}
+	g.Expect(mgg.GenerateMachine(context.Background(), input)).To(gomega.Succeed())
 
 	machineList := &clusterv1.MachineList{}
 	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(namespace))).To(gomega.Succeed())

--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ func main() {
 			Log:                    ctrl.Log.WithName("controllers").WithName("KubeadmControlPlane"),
 			TemplateCloner:         &external.TemplateCloner{},
 			KubeadmConfigGenerator: &generator.KubeadmConfigGenerator{},
-			MachineGenerator:       &generator.MachineGenerator{},
+			MachineGenerator:       generator.NewMachineGenerator(mgr.GetClient()),
 		}).SetupWithManager(mgr, concurrency(kubeadmControlPlaneConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "KubeadmControlPlane")
 			os.Exit(1)


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactors MachineGenerator to take a struct rather than lotsa arguments.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
