### PR TITLE
✨ Support multi-node control planes, MachineDeployments, and additional resources in the e2e framework

### DIFF
--- a/test/framework/control_plane.go
+++ b/test/framework/control_plane.go
@@ -23,42 +23,50 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	cabpkv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	// eventuallyInterval is the polling interval used by gomega.Eventually
+	eventuallyInterval = 10 * time.Second
+)
+
 // ControlplaneClusterInput defines the necessary dependencies to run a multi-node control plane cluster.
 type ControlplaneClusterInput struct {
-	Management    ManagementCluster
-	Cluster       *clusterv1.Cluster
-	InfraCluster  runtime.Object
-	Nodes         []Node
-	CreateTimeout time.Duration
-	DeleteTimeout time.Duration
+	Management        ManagementCluster
+	Cluster           *clusterv1.Cluster
+	InfraCluster      runtime.Object
+	Nodes             []Node
+	MachineDeployment MachineDeployment
+	RelatedResources  []runtime.Object
+	CreateTimeout     time.Duration
+	DeleteTimeout     time.Duration
 }
 
 // SetDefaults defaults the struct fields if necessary.
-func (m *ControlplaneClusterInput) SetDefaults() {
-	if m.CreateTimeout == 0 {
-		m.CreateTimeout = 10 * time.Minute
+func (input *ControlplaneClusterInput) SetDefaults() {
+	if input.CreateTimeout == 0 {
+		input.CreateTimeout = 10 * time.Minute
 	}
 
-	if m.DeleteTimeout == 0 {
-		m.DeleteTimeout = 5 * time.Minute
+	if input.DeleteTimeout == 0 {
+		input.DeleteTimeout = 5 * time.Minute
 	}
 }
 
 // ControlPlaneCluster creates an n node control plane cluster.
 // Assertions:
-//  * The number of nodes in the created cluster will equal the number of nodes in the input data.
+//  * The number of nodes in the created cluster will equal the number
+//    of control plane nodes plus the number of replicas in the machine
+//    deployment.
 func (input *ControlplaneClusterInput) ControlPlaneCluster() {
 	ctx := context.Background()
 	Expect(input.Management).ToNot(BeNil())
@@ -69,81 +77,109 @@ func (input *ControlplaneClusterInput) ControlPlaneCluster() {
 	By("creating an InfrastructureCluster resource")
 	Expect(mgmtClient.Create(ctx, input.InfraCluster)).To(Succeed())
 
+	// This call happens in an eventually because of a race condition with the
+	// webhook server. If the latter isn't fully online then this call will
+	// fail.
 	By("creating a Cluster resource linked to the InfrastructureCluster resource")
 	Eventually(func() error {
-		err := mgmtClient.Create(ctx, input.Cluster)
-		if err != nil {
-			fmt.Println(err)
+		if err := mgmtClient.Create(ctx, input.Cluster); err != nil {
+			fmt.Printf("%+v\n", err)
+			return err
 		}
-		return err
-	}, input.CreateTimeout, 10*time.Second).Should(BeNil())
+		return nil
+	}, input.CreateTimeout, eventuallyInterval).Should(BeNil())
 
-	// create all the machines at once
-	for _, node := range input.Nodes {
-		By("creating an InfrastructureMachine resource")
+	By("creating related resources")
+	for _, obj := range input.RelatedResources {
+		By(fmt.Sprintf("creating a/an %s resource", obj.GetObjectKind().GroupVersionKind()))
+		Eventually(func() error {
+			return mgmtClient.Create(ctx, obj)
+		}, input.CreateTimeout, eventuallyInterval).Should(BeNil())
+	}
+
+	// expectedNumberOfNodes is the number of nodes that should be deployed to
+	// the cluster. This is the control plane nodes plus the number of replicas
+	// defined for a possible MachineDeployment.
+	expectedNumberOfNodes := len(input.Nodes)
+
+	// Create the additional control plane nodes.
+	for i, node := range input.Nodes {
+		expectedNumberOfNodes++
+
+		By(fmt.Sprintf("creating %d control plane node's InfrastructureMachine resource", i+1))
 		Expect(mgmtClient.Create(ctx, node.InfraMachine)).To(Succeed())
 
-		By("creating a bootstrap config")
+		By(fmt.Sprintf("creating %d control plane node's BootstrapConfig resource", i+1))
 		Expect(mgmtClient.Create(ctx, node.BootstrapConfig)).To(Succeed())
 
-		By("creating a core Machine resource with a linked InfrastructureMachine and BootstrapConfig")
+		By(fmt.Sprintf("creating %d control plane node's Machine resource with a linked InfrastructureMachine and BootstrapConfig", i+1))
 		Expect(mgmtClient.Create(ctx, node.Machine)).To(Succeed())
 	}
 
-	// Wait for the cluster infrastructure
-	Eventually(func() string {
+	By("waiting for cluster to enter the provisioned phase")
+	Eventually(func() (string, error) {
 		cluster := &clusterv1.Cluster{}
 		key := client.ObjectKey{
 			Namespace: input.Cluster.GetNamespace(),
 			Name:      input.Cluster.GetName(),
 		}
 		if err := mgmtClient.Get(ctx, key, cluster); err != nil {
-			return err.Error()
+			return "", err
 		}
-		return cluster.Status.Phase
-	}, input.CreateTimeout, 10*time.Second).Should(Equal(string(clusterv1.ClusterPhaseProvisioned)))
+		return cluster.Status.Phase, nil
+	}, input.CreateTimeout, eventuallyInterval).Should(Equal(string(clusterv1.ClusterPhaseProvisioned)))
 
-	// wait for all the machines to be running
-	By("waiting for all machines to be running")
-	for _, node := range input.Nodes {
-		Eventually(func() string {
-			machine := &clusterv1.Machine{}
-			key := client.ObjectKey{
-				Namespace: node.Machine.GetNamespace(),
-				Name:      node.Machine.GetName(),
-			}
-			if err := mgmtClient.Get(ctx, key, machine); err != nil {
-				return err.Error()
-			}
-			return machine.Status.Phase
-		}, input.CreateTimeout, 10*time.Second).Should(Equal(string(clusterv1.MachinePhaseRunning)))
+	// Create the machine deployment if the replica count >0.
+	if machineDeployment := input.MachineDeployment.MachineDeployment; machineDeployment != nil {
+		if replicas := machineDeployment.Spec.Replicas; replicas != nil && *replicas > 0 {
+			expectedNumberOfNodes += int(*replicas)
+
+			By("creating a core MachineDeployment resource")
+			Expect(mgmtClient.Create(ctx, machineDeployment)).To(Succeed())
+
+			By("creating a BootstrapConfigTemplate resource")
+			Expect(mgmtClient.Create(ctx, input.MachineDeployment.BootstrapConfigTemplate)).To(Succeed())
+
+			By("creating an InfrastructureMachineTemplate resource")
+			Expect(mgmtClient.Create(ctx, input.MachineDeployment.InfraMachineTemplate)).To(Succeed())
+		}
 	}
 
 	By("waiting for the workload nodes to exist")
-	Eventually(func() []v1.Node {
-		nodes := v1.NodeList{}
-		By("ensuring the workload client can be generated")
-		err := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
-			_, err := input.Management.GetWorkloadClient(ctx, input.Cluster.Namespace, input.Cluster.Name)
-			switch {
-			case apierrors.IsNotFound(err):
-				return false, nil
-			case err != nil:
-				return true, err
-			default:
-				return true, nil
-			}
-		})
-		Expect(err).NotTo(HaveOccurred())
-		By("getting the workload client and listing the nodes")
+	Eventually(func() ([]v1.Node, error) {
 		workloadClient, err := input.Management.GetWorkloadClient(ctx, input.Cluster.Namespace, input.Cluster.Name)
-		Expect(err).NotTo(HaveOccurred(), "Stack:\n%+v\n", err)
-		Expect(workloadClient.List(ctx, &nodes)).To(Succeed())
-		return nodes.Items
-	}, input.CreateTimeout, 10*time.Second).Should(HaveLen(len(input.Nodes)))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get workload client")
+		}
+		nodeList := v1.NodeList{}
+		if err := workloadClient.List(ctx, &nodeList); err != nil {
+			return nil, err
+		}
+		return nodeList.Items, nil
+	}, input.CreateTimeout, 10*time.Second).Should(HaveLen(expectedNumberOfNodes))
+
+	By("waiting for all machines to be running")
+	inClustersNamespaceListOption := client.InNamespace(input.Cluster.Namespace)
+	matchClusterListOption := client.MatchingLabels{clusterv1.ClusterLabelName: input.Cluster.Name}
+	Eventually(func() (bool, error) {
+		// Get a list of all the Machine resources that belong to the Cluster.
+		machineList := &clusterv1.MachineList{}
+		if err := mgmtClient.List(ctx, machineList, inClustersNamespaceListOption, matchClusterListOption); err != nil {
+			return false, err
+		}
+		if len(machineList.Items) != expectedNumberOfNodes {
+			return false, errors.Errorf("number of Machines %d != expected number of nodes %d", len(machineList.Items), expectedNumberOfNodes)
+		}
+		for _, machine := range machineList.Items {
+			if machine.Status.Phase != string(clusterv1.MachinePhaseRunning) {
+				return false, errors.Errorf("machine %s is not running, it's %s", machine.Name, machine.Status.Phase)
+			}
+		}
+		return true, nil
+	}, input.CreateTimeout, eventuallyInterval).Should(BeTrue())
 }
 
-// CleanUp deletes the cluster and waits for everything to be gone.
+// CleanUpCoreArtifacts deletes the cluster and waits for everything to be gone.
 // Assertions:
 //   * Deletes Machines
 //   * Deletes MachineSets
@@ -163,7 +199,7 @@ func (input *ControlplaneClusterInput) CleanUpCoreArtifacts() {
 		clusters := clusterv1.ClusterList{}
 		Expect(mgmtClient.List(ctx, &clusters)).To(Succeed())
 		return clusters.Items
-	}, input.DeleteTimeout, 10*time.Second).Should(HaveLen(0))
+	}, input.DeleteTimeout, eventuallyInterval).Should(HaveLen(0))
 
 	lbl, err := labels.Parse(fmt.Sprintf("%s=%s", clusterv1.ClusterLabelName, input.Cluster.GetClusterName()))
 	Expect(err).ToNot(HaveOccurred())

--- a/test/framework/types.go
+++ b/test/framework/types.go
@@ -35,3 +35,13 @@ type Node struct {
 func TypeToKind(i interface{}) string {
 	return reflect.ValueOf(i).Elem().Type().Name()
 }
+
+// MachineDeployment contains the objects needed to create a
+// CAPI MachineDeployment resource and its associated template
+// resources.
+type MachineDeployment struct {
+	MachineDeployment       *clusterv1.MachineDeployment
+	BootstrapConfigTemplate runtime.Object
+	InfraMachineTemplate    runtime.Object
+}
+


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This patch enhances the e2e test framework's `ControlplaneClusterInput` with support for:

* Multi-node control planes that allow the initial control plane node to come online before additional control plane nodes
* An optional `MachineDepoyment`
* Optional `AdditionalResources` (which is a slice of `runtime.Objects`)

cc @chuckha 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
