### PR TITLE
🐛  Fix the capd e2e tests after the manager split

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -274,7 +274,9 @@ func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Contex
 
 	defer func() {
 		if rerr != nil {
-			r.KubeadmInitLock.Unlock(ctx, scope.Cluster)
+			if !r.KubeadmInitLock.Unlock(ctx, scope.Cluster) {
+				rerr = errors.Wrap(rerr, "failed to unlock the kubeadm init lock")
+			}
 		}
 	}()
 

--- a/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
+++ b/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
@@ -71,7 +71,7 @@ func (c *ControlPlaneInitMutex) Lock(ctx context.Context, cluster *clusterv1.Clu
 		if info.MachineName == machine.Name {
 			return true
 		}
-		log.Info("Waiting on on another machine to initialize", "init-machine", info.MachineName)
+		log.Info("Waiting on another machine to initialize", "init-machine", info.MachineName)
 		return false
 	}
 

--- a/test/framework/generators/kubeadm-bootstrap.go
+++ b/test/framework/generators/kubeadm-bootstrap.go
@@ -27,33 +27,33 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/exec"
 )
 
-// ClusterAPIGitHubManifestsFormat is a convenience string to get Cluster API manifests at an exact revision.
-// Set ClusterAPI.KustomizePath = fmt.Sprintf(ClusterAPIGitHubManifestsFormat, <some git ref>).
-var ClusterAPIGitHubManifestsFormat = "https://github.com/kubernetes-sigs/cluster-api//config/default?ref=%s"
+// KubeadmBootstrapGitHubManifestsFormat is a convenience string to get Cluster API manifests at an exact revision.
+// Set KubeadmBootstrap.KustomizePath = fmt.Sprintf(KubeadmBootstrapGitHubManifestsFormat, <some git ref>).
+var KubeadmBootstrapGitHubManifestsFormat = "https://github.com/kubernetes-sigs/cluster-api//bootstrap/kubeadm/config/default?ref=%s"
 
-// Generator generates provider components for CAPI
-type ClusterAPI struct {
-	// KustomizePath is a URL, relative or absolute filesystem path to a kustomize file that generates Cluster API manifests.
+// KubeadmBootstrap generates provider components for the Kubeadm bootstrap provider.
+type KubeadmBootstrap struct {
+	// KustomizePath is a URL, relative or absolute filesystem path to a kustomize file that generates the Kubeadm Bootstrap manifests.
 	// KustomizePath takes precedence over Version.
 	KustomizePath string
-	// Version defines the release version. If GitRef is not set Version must be set and will not use kustomize
+	// Version defines the release version. If GitRef is not set Version must be set and will not use kustomize.
 	Version string
 }
 
 // GetName returns the name of the components being generated.
-func (g *ClusterAPI) GetName() string {
+func (g *KubeadmBootstrap) GetName() string {
 	if g.KustomizePath != "" {
-		return fmt.Sprintf("Using Cluster API manifests from: %q", g.KustomizePath)
+		return fmt.Sprintf("Using Kubeadm bootstrap provider manifests from: %q", g.KustomizePath)
 	}
-	return fmt.Sprintf("Cluster API  %s", g.Version)
+	return fmt.Sprintf("Kubeadm bootstrap provider manifests from Cluster API version release %s", g.Version)
 }
 
-func (g *ClusterAPI) releaseYAMLPath() string {
+func (g *KubeadmBootstrap) releaseYAMLPath() string {
 	return fmt.Sprintf("https://github.com/kubernetes-sigs/cluster-api/releases/download/%s/cluster-api-components.yaml", g.Version)
 }
 
 // Manifests return the generated components and any error if there is one.
-func (g *ClusterAPI) Manifests(ctx context.Context) ([]byte, error) {
+func (g *KubeadmBootstrap) Manifests(ctx context.Context) ([]byte, error) {
 	if g.KustomizePath != "" {
 		kustomize := exec.NewCommand(
 			exec.WithCommand("kustomize"),

--- a/test/framework/generators/kubeadm-control-plane.go
+++ b/test/framework/generators/kubeadm-control-plane.go
@@ -27,33 +27,33 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/exec"
 )
 
-// ClusterAPIGitHubManifestsFormat is a convenience string to get Cluster API manifests at an exact revision.
-// Set ClusterAPI.KustomizePath = fmt.Sprintf(ClusterAPIGitHubManifestsFormat, <some git ref>).
-var ClusterAPIGitHubManifestsFormat = "https://github.com/kubernetes-sigs/cluster-api//config/default?ref=%s"
+// KubeadmControlPlaneGitHubManifestsFormat is a convenience string to get Cluster API manifests at an exact revision.
+// Set KubeadmControlPlane.KustomizePath = fmt.Sprintf(KubeadmControlPlaneGitHubManifestsFormat, <some git ref>).
+var KubeadmControlPlaneGitHubManifestsFormat = "https://github.com/kubernetes-sigs/cluster-api//controlplane/kubeadm/config/default?ref=%s"
 
-// Generator generates provider components for CAPI
-type ClusterAPI struct {
-	// KustomizePath is a URL, relative or absolute filesystem path to a kustomize file that generates Cluster API manifests.
+// KubeadmControlPlane generates provider components for the Kubeadm Control Plane provider.
+type KubeadmControlPlane struct {
+	// KustomizePath is a URL, relative or absolute filesystem path to a kustomize file that generates the Kubeadm Control Plane provider manifests.
 	// KustomizePath takes precedence over Version.
 	KustomizePath string
-	// Version defines the release version. If GitRef is not set Version must be set and will not use kustomize
+	// Version defines the release version. If GitRef is not set Version must be set and will not use kustomize.
 	Version string
 }
 
 // GetName returns the name of the components being generated.
-func (g *ClusterAPI) GetName() string {
+func (g *KubeadmControlPlane) GetName() string {
 	if g.KustomizePath != "" {
-		return fmt.Sprintf("Using Cluster API manifests from: %q", g.KustomizePath)
+		return fmt.Sprintf("Using Kubeadm control plane provider manifests from: %q", g.KustomizePath)
 	}
-	return fmt.Sprintf("Cluster API  %s", g.Version)
+	return fmt.Sprintf("Kubeadm control plane provider manifests from Cluster API release version %s", g.Version)
 }
 
-func (g *ClusterAPI) releaseYAMLPath() string {
+func (g *KubeadmControlPlane) releaseYAMLPath() string {
 	return fmt.Sprintf("https://github.com/kubernetes-sigs/cluster-api/releases/download/%s/cluster-api-components.yaml", g.Version)
 }
 
 // Manifests return the generated components and any error if there is one.
-func (g *ClusterAPI) Manifests(ctx context.Context) ([]byte, error) {
+func (g *KubeadmControlPlane) Manifests(ctx context.Context) ([]byte, error) {
 	if g.KustomizePath != "" {
 		kustomize := exec.NewCommand(
 			exec.WithCommand("kustomize"),

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -38,15 +38,13 @@ var _ = Describe("Docker", func() {
 	Describe("Cluster Creation", func() {
 		var (
 			namespace  string
-			clusterGen *ClusterGenerator
-			nodeGen    *NodeGenerator
 			input      *framework.ControlplaneClusterInput
+			clusterGen = &ClusterGenerator{}
+			nodeGen    = &NodeGenerator{}
 		)
 
 		BeforeEach(func() {
 			namespace = "default"
-			clusterGen = &ClusterGenerator{}
-			nodeGen = &NodeGenerator{}
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR adds generators for the bootstrap and control plane and makes them easier to use with fewer hacks.

/cc @akutz 


