### PR TITLE
🐛 Better use of docker cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /workspace
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
 # Run this with docker build --build_arg package=./controlplane/kubeadm or --build_arg package=./bootstrap/kubeadm
-ARG package=.
 ENV GOPROXY=$goproxy
 
 # Copy the Go Modules manifests
@@ -34,6 +33,7 @@ RUN go mod download
 COPY ./ ./
 
 # Build
+ARG package=.
 ARG ARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     go build -a -ldflags '-extldflags "-static"' \


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

/assign @ncdc 

**What this PR does / why we need it**:
This PR will reuse the docker cache on *all* builds not just builds that share the `package` argument.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1998 
