### PR TITLE
🐛 Bump cloud build timeout

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-timeout: 1200s
+timeout: 1800s
 options:
   substitution_option: ALLOW_LOOSE
 steps:


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>
**What this PR does / why we need it**:
This PR bumps the cloud build timeout to 30 minutes. It's almost done after 20 so 30 should be sufficient.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1998 

/assign @ncdc 
