### PR TITLE
:running: Use 8-core machines for cloud builds instead of 1

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,6 +11,8 @@ steps:
     - PULL_BASE_REF=$_PULL_BASE_REF
     args:
     - release-staging
+options:
+  machineType: 'N1_HIGHCPU_8'
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Cloud Build provides two high-CPU virtual machine types to run your builds: 8 CPUs and 32 CPUs. The default machine type is 1 CPU. This PR changes from 1 -> 8 CPUs.