### PR TITLE
:sparkles: Make sure KCP template resources have a Cluster owner

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -617,6 +617,15 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
 
+	// Expect the referenced infrastructure template to have a Cluster Owner Reference.
+	g.Expect(fakeClient.Get(context.TODO(), client.ObjectKey{Namespace: genericMachineTemplate.GetNamespace(), Name: genericMachineTemplate.GetName()}, genericMachineTemplate)).To(gomega.Succeed())
+	g.Expect(genericMachineTemplate.GetOwnerReferences()).To(gomega.ContainElement(metav1.OwnerReference{
+		APIVersion: clusterv1.GroupVersion.String(),
+		Kind:       "Cluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+	}))
+
 	// Always expect that the Finalizer is set on the passed in resource
 	g.Expect(kcp.Finalizers).To(gomega.ContainElement(controlplanev1.KubeadmControlPlaneFinalizer))
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1756 
