### PR TITLE
🐛clusterctl: fix-init

### DIFF
--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -86,7 +86,7 @@ func init() {
 	initCmd.Flags().StringVarP(&io.kubeconfig, "kubeconfig", "", "", "Path to the kubeconfig file to use for accessing the management cluster. If empty, default rules for kubeconfig discovery will be used")
 	initCmd.Flags().StringVarP(&io.coreProvider, "core", "", "", "Infrastructure providers to add to the management cluster. If empty, cluster-api providers will be added automatically only during the first call to init for each cluster")
 	initCmd.Flags().StringSliceVarP(&io.infrastructureProviders, "infrastructure", "i", nil, "Infrastructure providers to add to the management cluster")
-	initCmd.Flags().StringSliceVarP(&io.bootstrapProviders, "bootstrap", "b", nil, "Bootstrap providers to add to the management cluster")
+	initCmd.Flags().StringSliceVarP(&io.bootstrapProviders, "bootstrap", "b", nil, "Bootstrap providers to add to the management cluster. If empty, the kubeadm bootstrap providers will be added automatically only during the first call to init for each cluster")
 	initCmd.Flags().StringVarP(&io.targetNamespace, "target-namespace", "", "", "The target namespace where the providers should be deployed. If not specified, each provider will be installed in a provider's default namespace")
 	initCmd.Flags().StringVarP(&io.watchingNamespace, "watching-namespace", "", "", "Namespace that the providers should watch to reconcile Cluster API objects. If unspecified, the providers watches for Cluster API objects across all namespaces")
 	initCmd.Flags().BoolVarP(&io.force, "force", "f", false, "Force clusterctl to skip preflight checks about supported configurations for a management cluster")

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -84,9 +84,9 @@ var initCmd = &cobra.Command{
 
 func init() {
 	initCmd.Flags().StringVarP(&io.kubeconfig, "kubeconfig", "", "", "Path to the kubeconfig file to use for accessing the management cluster. If empty, default rules for kubeconfig discovery will be used")
-	initCmd.Flags().StringVarP(&io.coreProvider, "core", "", "", "Infrastructure providers to add to the management cluster. If empty, cluster-api providers will be added automatically only during the first call to init for each cluster")
+	initCmd.Flags().StringVarP(&io.coreProvider, "core", "", "", "Infrastructure providers to add to the management cluster. By default (empty), the cluster-api core provider is installed on the first init")
 	initCmd.Flags().StringSliceVarP(&io.infrastructureProviders, "infrastructure", "i", nil, "Infrastructure providers to add to the management cluster")
-	initCmd.Flags().StringSliceVarP(&io.bootstrapProviders, "bootstrap", "b", nil, "Bootstrap providers to add to the management cluster. If empty, the kubeadm bootstrap providers will be added automatically only during the first call to init for each cluster")
+	initCmd.Flags().StringSliceVarP(&io.bootstrapProviders, "bootstrap", "b", nil, "Bootstrap providers to add to the management cluster. By default (empty), the kubeadm bootstrap provider is installed on the first init")
 	initCmd.Flags().StringVarP(&io.targetNamespace, "target-namespace", "", "", "The target namespace where the providers should be deployed. If not specified, each provider will be installed in a provider's default namespace")
 	initCmd.Flags().StringVarP(&io.watchingNamespace, "watching-namespace", "", "", "Namespace that the providers should watch to reconcile Cluster API objects. If unspecified, the providers watches for Cluster API objects across all namespaces")
 	initCmd.Flags().BoolVarP(&io.force, "force", "f", false, "Force clusterctl to skip preflight checks about supported configurations for a management cluster")

--- a/cmd/clusterctl/pkg/client/cluster/client.go
+++ b/cmd/clusterctl/pkg/client/cluster/client.go
@@ -97,7 +97,7 @@ func New(kubeconfig string, options Options) Client {
 func newClusterClient(kubeconfig string, options Options) *clusterClient {
 	proxy := options.InjectProxy
 	if proxy == nil {
-		proxy = newK8SProxy(kubeconfig)
+		proxy = newProxy(kubeconfig)
 	}
 	return &clusterClient{
 		kubeconfig: kubeconfig,

--- a/cmd/clusterctl/pkg/client/cluster/proxy.go
+++ b/cmd/clusterctl/pkg/client/cluster/proxy.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 var (
@@ -62,7 +63,12 @@ func (k *proxy) NewClient() (client.Client, error) {
 		return nil, errors.Wrap(err, "failed to create controller-runtime client")
 	}
 
-	c, err := client.New(config, client.Options{Scheme: Scheme})
+	mapper, err := apiutil.NewDynamicRESTMapper(config, apiutil.WithLazyDiscovery)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create the controller-runtime DynamicRESTMapper")
+	}
+
+	c, err := client.New(config, client.Options{Scheme: Scheme, Mapper: mapper})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create controller-runtime client")
 	}

--- a/cmd/clusterctl/pkg/client/cluster/proxy.go
+++ b/cmd/clusterctl/pkg/client/cluster/proxy.go
@@ -76,7 +76,7 @@ func (k *proxy) NewClient() (client.Client, error) {
 	return c, nil
 }
 
-func newK8SProxy(kubeconfig string) Proxy {
+func newProxy(kubeconfig string) Proxy {
 	// If a kubeconfig file is provided use it, otherwise find a config file in the standard locations
 	if kubeconfig == "" {
 		kubeconfig = clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()

--- a/cmd/clusterctl/pkg/client/config/providers_client.go
+++ b/cmd/clusterctl/pkg/client/config/providers_client.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	ClusterAPIName     = "cluster-api"
-	ProvidersConfigKey = "providers"
+	ClusterAPIName               = "cluster-api"
+	KubeadmBootstrapProviderName = "kubeadm"
+	ProvidersConfigKey           = "providers"
 )
 
 // ProvidersClient has methods to work with provider configurations.
@@ -93,7 +94,7 @@ func (p *providersClient) defaults() []Provider {
 		// Bootstrap providersClient
 		// TODO: CABPK in v1alpha3 will be included into CAPI, so this entry can be removed as soon as v1alpha3 is ready for test
 		&provider{
-			name:         "kubeadm",
+			name:         KubeadmBootstrapProviderName,
 			url:          "https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/releases/latest/bootstrap-components.yaml",
 			providerType: clusterctlv1.BootstrapProviderType,
 		},

--- a/cmd/clusterctl/pkg/client/config_test.go
+++ b/cmd/clusterctl/pkg/client/config_test.go
@@ -19,10 +19,13 @@ package client
 import (
 	"testing"
 
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 )
 
 func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
+	customProviderConfig := config.NewProvider("custom", "url", clusterctlv1.BootstrapProviderType)
+
 	type field struct {
 		client Client
 	}
@@ -41,7 +44,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 				"aws",
 				config.ClusterAPIName,
 				"docker",
-				"kubeadm",
+				config.KubeadmBootstrapProviderName,
 				"vsphere",
 			},
 			wantErr: false,
@@ -49,14 +52,14 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 		{
 			name: "Returns default providers and custom providers if defined",
 			field: field{
-				client: newFakeClient(newFakeConfig().WithProvider(bootstrapProviderConfig)),
+				client: newFakeClient(newFakeConfig().WithProvider(customProviderConfig)),
 			},
 			wantProviders: []string{
 				"aws",
-				bootstrapProviderConfig.Name(),
 				config.ClusterAPIName,
+				customProviderConfig.Name(),
 				"docker",
-				"kubeadm",
+				config.KubeadmBootstrapProviderName,
 				"vsphere",
 			},
 			wantErr: false,

--- a/cmd/clusterctl/pkg/client/init.go
+++ b/cmd/clusterctl/pkg/client/init.go
@@ -48,6 +48,9 @@ func (c *clusterctlClient) Init(options InitOptions) ([]Components, bool, error)
 		if options.CoreProvider == "" {
 			options.CoreProvider = config.ClusterAPIName
 		}
+		if len(options.BootstrapProviders) == 0 {
+			options.BootstrapProviders = append(options.BootstrapProviders, config.KubeadmBootstrapProviderName)
+		}
 	}
 
 	// create an installer service, add the requested providers to the install queue (thus performing validation of the target state of the management cluster

--- a/cmd/clusterctl/pkg/client/init_test.go
+++ b/cmd/clusterctl/pkg/client/init_test.go
@@ -61,8 +61,8 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				hasCRD: false,
 			},
 			args: args{
-				coreProvider:           "", // with an empty cluster, a core provider should be added automatically
-				bootstrapProvider:      []string{"bootstrap"},
+				coreProvider:           "",  // with an empty cluster, a core provider should be added automatically
+				bootstrapProvider:      nil, // with an empty cluster, a bootstrap provider should be added automatically
 				infrastructureProvider: []string{"infra"},
 				targetNameSpace:        "",
 				watchingNamespace:      "",
@@ -98,7 +98,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			},
 			args: args{
 				coreProvider:           fmt.Sprintf("%s:v1.1.0", config.ClusterAPIName),
-				bootstrapProvider:      []string{"bootstrap:v2.1.0"},
+				bootstrapProvider:      []string{fmt.Sprintf("%s:v2.1.0", config.KubeadmBootstrapProviderName)},
 				infrastructureProvider: []string{"infra:v3.1.0"},
 				targetNameSpace:        "",
 				watchingNamespace:      "",
@@ -134,7 +134,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			},
 			args: args{
 				coreProvider:           "", // with an empty cluster, a core provider should be added automatically
-				bootstrapProvider:      []string{"bootstrap"},
+				bootstrapProvider:      []string{config.KubeadmBootstrapProviderName},
 				infrastructureProvider: []string{"infra"},
 				targetNameSpace:        "nsx",
 				watchingNamespace:      "",
@@ -170,7 +170,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			},
 			args: args{
 				coreProvider:           "", // with a NOT empty cluster, a core provider should NOT be added automatically
-				bootstrapProvider:      []string{"bootstrap"},
+				bootstrapProvider:      []string{config.KubeadmBootstrapProviderName},
 				infrastructureProvider: []string{"infra"},
 				targetNameSpace:        "",
 				watchingNamespace:      "",
@@ -231,8 +231,8 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			},
 			args: args{
 				coreProvider:           "",
-				bootstrapProvider:      []string{"bootstrap"},
-				infrastructureProvider: []string{"bootstrap"},
+				bootstrapProvider:      []string{config.KubeadmBootstrapProviderName},
+				infrastructureProvider: []string{config.KubeadmBootstrapProviderName},
 				targetNameSpace:        "",
 				watchingNamespace:      "",
 				force:                  false,
@@ -298,7 +298,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 
 var (
 	capiProviderConfig      = config.NewProvider(config.ClusterAPIName, "url", clusterctlv1.CoreProviderType)
-	bootstrapProviderConfig = config.NewProvider("bootstrap", "url", clusterctlv1.BootstrapProviderType)
+	bootstrapProviderConfig = config.NewProvider(config.KubeadmBootstrapProviderName, "url", clusterctlv1.BootstrapProviderType)
 	infraProviderConfig     = config.NewProvider("infra", "url", clusterctlv1.InfrastructureProviderType)
 )
 

--- a/cmd/clusterctl/pkg/client/repository/client.go
+++ b/cmd/clusterctl/pkg/client/repository/client.go
@@ -148,7 +148,13 @@ func repositoryFactory(providerConfig config.Provider, configVariablesClient con
 	}
 
 	// if the url is a github repository
-	//TODO: implement in a follow up PR
+	if rURL.Scheme == httpsScheme && rURL.Host == githubDomain {
+		repo, err := newGitHubRepository(providerConfig, configVariablesClient)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating the GitHub repository client")
+		}
+		return repo, err
+	}
 
 	// if the url is a local repository
 	//TODO: implement in a follow up PR


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implement fixes to clusterctl init after the first integration test with all the correlated code merged
Most notable changes are
- the kubeadm bootstrap provider gets installed automatically during first init
- the code for installing clusterctl CRD is smarter (it installs only if missing)
- the controller client uses the DynamicRESTMapper (thanks @vincepri)
- the github repository implemented by https://github.com/kubernetes-sigs/cluster-api/pull/1909 is now linked to the rest of the code

**Which issue(s) this PR fixes**
Rif: https://github.com/kubernetes-sigs/cluster-api/issues/1729

/assign @vincepri 