### PR TITLE
🐛 add a cluster-api label to the init lock configmap

### DIFF
--- a/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
+++ b/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
@@ -163,6 +163,9 @@ func (s *semaphore) setMetadata(cluster *clusterv1.Cluster) {
 	s.ObjectMeta = metav1.ObjectMeta{
 		Namespace: cluster.Namespace,
 		Name:      configMapName(cluster.Name),
+		Labels: map[string]string{
+			clusterv1.ClusterLabelName: cluster.Name,
+		},
 		OwnerReferences: []metav1.OwnerReference{
 			{
 				APIVersion: cluster.APIVersion,


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>
**What this PR does / why we need it**:
Adds a cluster label to the config map used as the init lock

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2009 
