### PR TITLE
🏃Aggregate return errors instead of overwriting/ignoring

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -116,9 +116,7 @@ func (r *ClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr e
 
 		// Always attempt to Patch the Cluster object and status after each reconciliation.
 		if err := patchHelper.Patch(ctx, cluster); err != nil {
-			if reterr == nil {
-				reterr = err
-			}
+			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()
 

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -117,9 +117,7 @@ func (r *MachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr e
 
 		// Always attempt to patch the object and status after each reconciliation.
 		if err := patchHelper.Patch(ctx, m); err != nil {
-			if reterr == nil {
-				reterr = err
-			}
+			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()
 

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
@@ -100,9 +101,7 @@ func (r *MachineDeploymentReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 	defer func() {
 		// Always attempt to patch the object and status after each reconciliation.
 		if err := patchHelper.Patch(ctx, deployment); err != nil {
-			if reterr == nil {
-				reterr = err
-			}
+			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()
 

--- a/util/yaml/yaml_test.go
+++ b/util/yaml/yaml_test.go
@@ -18,6 +18,7 @@ package yaml
 
 import (
 	"io/ioutil"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"os"
 	"testing"
 )
@@ -313,8 +314,8 @@ func createTempFile(contents string) (filename string, reterr error) {
 		return "", err
 	}
 	defer func() {
-		if err := f.Close(); err != nil && reterr == nil {
-			reterr = err
+		if err := f.Close(); err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()
 	_, _ = f.WriteString(contents)


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR uses APIMachinery's errors.NewAggregate to always aggregate errors if and whey they happen, instead of overwriting or ignoring them. The NewAggregate function is smart enough to ignore any `nil` error, if any.
