### PR TITLE
🏃Improve conversion webhook: add tests, fix preserve logic, remove inline nolint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,5 +24,6 @@ run:
   skip-files:
     - "zz_generated.*\\.go$"
     - crd_manifests.go
+    - ".*conversion.*\\.go$"
   skip-dirs:
     - third_party

--- a/api/v1alpha2/conversion_test.go
+++ b/api/v1alpha2/conversion_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/cluster-api/api/v1alpha3"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+)
+
+func TestConvertCluster(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("to hub", func(t *testing.T) {
+		t.Run("should convert the first value in Status.APIEndpoints to Spec.ControlPlaneEndpoint", func(t *testing.T) {
+			src := &Cluster{
+				Status: ClusterStatus{
+					APIEndpoints: []APIEndpoint{
+						{
+							Host: "example.com",
+							Port: 6443,
+						},
+					},
+				},
+			}
+			dst := &v1alpha3.Cluster{}
+
+			g.Expect(src.ConvertTo(dst)).To(Succeed())
+			g.Expect(dst.Spec.ControlPlaneEndpoint.Host).To(Equal("example.com"))
+			g.Expect(dst.Spec.ControlPlaneEndpoint.Port).To(BeEquivalentTo(6443))
+		})
+	})
+
+	t.Run("from hub", func(t *testing.T) {
+		t.Run("should convert Spec.ControlPlaneEndpoint to Status.APIEndpoints[0]", func(t *testing.T) {
+			src := &v1alpha3.Cluster{
+				Spec: v1alpha3.ClusterSpec{
+					ControlPlaneEndpoint: v1alpha3.APIEndpoint{
+						Host: "example.com",
+						Port: 6443,
+					},
+				},
+			}
+			dst := &Cluster{}
+
+			g.Expect(dst.ConvertFrom(src)).To(Succeed())
+			g.Expect(dst.Status.APIEndpoints[0].Host).To(Equal("example.com"))
+			g.Expect(dst.Status.APIEndpoints[0].Port).To(BeEquivalentTo(6443))
+		})
+	})
+}
+
+func TestConvertMachine(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("from hub", func(t *testing.T) {
+		t.Run("preserves Spec.Bootstrap.DataSecretName", func(t *testing.T) {
+			src := &v1alpha3.Machine{
+				Spec: v1alpha3.MachineSpec{
+					Bootstrap: v1alpha3.Bootstrap{
+						DataSecretName: pointer.StringPtr("secret-data"),
+					},
+				},
+			}
+			dst := &Machine{}
+
+			g.Expect(dst.ConvertFrom(src)).To(Succeed())
+			g.Expect(dst.GetAnnotations()[utilconversion.DataAnnotation]).To(ContainSubstring("secret-data"))
+		})
+	})
+
+}

--- a/bootstrap/kubeadm/api/v1alpha2/conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha2/conversion.go
@@ -24,72 +24,78 @@ import (
 )
 
 // ConvertTo converts this KubeadmConfig to the Hub version (v1alpha3).
-func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error { // nolint
+func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*kubeadmbootstrapv1alpha3.KubeadmConfig)
+	if err := Convert_v1alpha2_KubeadmConfig_To_v1alpha3_KubeadmConfig(src, dst, nil); err != nil {
+		return err
+	}
 
 	// Manually restore data.
 	restored := &kubeadmbootstrapv1alpha3.KubeadmConfig{}
-	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil {
+	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
 		return err
-	} else if ok {
-		if restored.Status.DataSecretName != nil {
-			dst.Status.DataSecretName = restored.Status.DataSecretName
-		}
 	}
 
-	return Convert_v1alpha2_KubeadmConfig_To_v1alpha3_KubeadmConfig(src, dst, nil)
+	if restored.Status.DataSecretName != nil {
+		dst.Status.DataSecretName = restored.Status.DataSecretName
+	}
+
+	return nil
 }
 
 // ConvertFrom converts from the KubeadmConfig Hub version (v1alpha3) to this version.
-func (dst *KubeadmConfig) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+func (dst *KubeadmConfig) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*kubeadmbootstrapv1alpha3.KubeadmConfig)
+	if err := Convert_v1alpha3_KubeadmConfig_To_v1alpha2_KubeadmConfig(src, dst, nil); err != nil {
+		return nil
+	}
 
 	// Preserve Hub data on down-conversion.
 	if err := utilconversion.MarshalData(src, dst); err != nil {
 		return err
 	}
 
-	return Convert_v1alpha3_KubeadmConfig_To_v1alpha2_KubeadmConfig(src, dst, nil)
+	return nil
 }
 
 // ConvertTo converts this KubeadmConfigList to the Hub version (v1alpha3).
-func (src *KubeadmConfigList) ConvertTo(dstRaw conversion.Hub) error { // nolint
+func (src *KubeadmConfigList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*kubeadmbootstrapv1alpha3.KubeadmConfigList)
 	return Convert_v1alpha2_KubeadmConfigList_To_v1alpha3_KubeadmConfigList(src, dst, nil)
 }
 
 // ConvertFrom converts from the KubeadmConfigList Hub version (v1alpha3) to this version.
-func (dst *KubeadmConfigList) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+func (dst *KubeadmConfigList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*kubeadmbootstrapv1alpha3.KubeadmConfigList)
 	return Convert_v1alpha3_KubeadmConfigList_To_v1alpha2_KubeadmConfigList(src, dst, nil)
 }
 
 // ConvertTo converts this KubeadmConfigTemplate to the Hub version (v1alpha3).
-func (src *KubeadmConfigTemplate) ConvertTo(dstRaw conversion.Hub) error { // nolint
+func (src *KubeadmConfigTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*kubeadmbootstrapv1alpha3.KubeadmConfigTemplate)
 	return Convert_v1alpha2_KubeadmConfigTemplate_To_v1alpha3_KubeadmConfigTemplate(src, dst, nil)
 }
 
 // ConvertFrom converts from the KubeadmConfigTemplate Hub version (v1alpha3) to this version.
-func (dst *KubeadmConfigTemplate) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+func (dst *KubeadmConfigTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*kubeadmbootstrapv1alpha3.KubeadmConfigTemplate)
 	return Convert_v1alpha3_KubeadmConfigTemplate_To_v1alpha2_KubeadmConfigTemplate(src, dst, nil)
 }
 
 // ConvertTo converts this KubeadmConfigTemplateList to the Hub version (v1alpha3).
-func (src *KubeadmConfigTemplateList) ConvertTo(dstRaw conversion.Hub) error { // nolint
+func (src *KubeadmConfigTemplateList) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*kubeadmbootstrapv1alpha3.KubeadmConfigTemplateList)
 	return Convert_v1alpha2_KubeadmConfigTemplateList_To_v1alpha3_KubeadmConfigTemplateList(src, dst, nil)
 }
 
 // ConvertFrom converts from the KubeadmConfigTemplateList Hub version (v1alpha3) to this version.
-func (dst *KubeadmConfigTemplateList) ConvertFrom(srcRaw conversion.Hub) error { // nolint
+func (dst *KubeadmConfigTemplateList) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*kubeadmbootstrapv1alpha3.KubeadmConfigTemplateList)
 	return Convert_v1alpha3_KubeadmConfigTemplateList_To_v1alpha2_KubeadmConfigTemplateList(src, dst, nil)
 }
 
 // Convert_v1alpha2_KubeadmConfigStatus_To_v1alpha3_KubeadmConfigStatus converts this KubeadmConfigStatus to the Hub version (v1alpha3).
-func Convert_v1alpha2_KubeadmConfigStatus_To_v1alpha3_KubeadmConfigStatus(in *KubeadmConfigStatus, out *kubeadmbootstrapv1alpha3.KubeadmConfigStatus, s apiconversion.Scope) error { // nolint
+func Convert_v1alpha2_KubeadmConfigStatus_To_v1alpha3_KubeadmConfigStatus(in *KubeadmConfigStatus, out *kubeadmbootstrapv1alpha3.KubeadmConfigStatus, s apiconversion.Scope) error {
 	if err := autoConvert_v1alpha2_KubeadmConfigStatus_To_v1alpha3_KubeadmConfigStatus(in, out, s); err != nil {
 		return err
 	}
@@ -102,7 +108,7 @@ func Convert_v1alpha2_KubeadmConfigStatus_To_v1alpha3_KubeadmConfigStatus(in *Ku
 }
 
 // Convert_v1alpha3_KubeadmConfigStatus_To_v1alpha2_KubeadmConfigStatus converts from the Hub version (v1alpha3) of the KubeadmConfigStatus to this version.
-func Convert_v1alpha3_KubeadmConfigStatus_To_v1alpha2_KubeadmConfigStatus(in *kubeadmbootstrapv1alpha3.KubeadmConfigStatus, out *KubeadmConfigStatus, s apiconversion.Scope) error { // nolint
+func Convert_v1alpha3_KubeadmConfigStatus_To_v1alpha2_KubeadmConfigStatus(in *kubeadmbootstrapv1alpha3.KubeadmConfigStatus, out *KubeadmConfigStatus, s apiconversion.Scope) error {
 	if err := autoConvert_v1alpha3_KubeadmConfigStatus_To_v1alpha2_KubeadmConfigStatus(in, out, s); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR does a few things to improve conversion webhooks:
- Starts adding tests for Cluster and Machine conversions
- Runs the down-conversion preservation logic after the automatic conversion
- Removes all inlines `// nolint` in favor of skip-files