### PR TITLE
:running: Update kubebuilder tools to 1.16.4

### DIFF
--- a/scripts/fetch_ext_bins.sh
+++ b/scripts/fetch_ext_bins.sh
@@ -26,7 +26,7 @@ if [[ -n "${TRACE}" ]]; then
   set -x
 fi
 
-k8s_version=1.15.5
+k8s_version=1.16.4
 goarch=amd64
 goos="unknown"
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
In preparation for CRDv1 update, set the k8s version for kubebuilder tools to 1.16.4
