### PR TITLE
:running: Fix more conversions / add tests

### DIFF
--- a/api/v1alpha2/conversion_test.go
+++ b/api/v1alpha2/conversion_test.go
@@ -20,9 +20,10 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/cluster-api/api/v1alpha3"
-	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
 
 func TestConvertCluster(t *testing.T) {
@@ -49,6 +50,32 @@ func TestConvertCluster(t *testing.T) {
 	})
 
 	t.Run("from hub", func(t *testing.T) {
+		t.Run("preserves fields from hub version", func(t *testing.T) {
+			src := &v1alpha3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hub",
+				},
+				Spec: v1alpha3.ClusterSpec{
+					ControlPlaneRef: &corev1.ObjectReference{
+						Name: "controlplane-1",
+					},
+				},
+				Status: v1alpha3.ClusterStatus{
+					ControlPlaneReady: true,
+				},
+			}
+			dst := &Cluster{}
+
+			g.Expect(dst.ConvertFrom(src)).To(Succeed())
+			restored := &v1alpha3.Cluster{}
+			g.Expect(dst.ConvertTo(restored)).To(Succeed())
+
+			// Test field restored fields.
+			g.Expect(restored.Name).To(Equal(src.Name))
+			g.Expect(restored.Spec.ControlPlaneRef).To(Equal(src.Spec.ControlPlaneRef))
+			g.Expect(restored.Status.ControlPlaneReady).To(Equal(src.Status.ControlPlaneReady))
+		})
+
 		t.Run("should convert Spec.ControlPlaneEndpoint to Status.APIEndpoints[0]", func(t *testing.T) {
 			src := &v1alpha3.Cluster{
 				Spec: v1alpha3.ClusterSpec{
@@ -70,10 +97,30 @@ func TestConvertCluster(t *testing.T) {
 func TestConvertMachine(t *testing.T) {
 	g := NewWithT(t)
 
+	t.Run("to hub", func(t *testing.T) {
+		t.Run("should convert the Spec.ClusterName from label", func(t *testing.T) {
+			src := &Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						MachineClusterLabelName: "test-cluster",
+					},
+				},
+			}
+			dst := &v1alpha3.Machine{}
+
+			g.Expect(src.ConvertTo(dst)).To(Succeed())
+			g.Expect(dst.Spec.ClusterName).To(Equal("test-cluster"))
+		})
+	})
+
 	t.Run("from hub", func(t *testing.T) {
-		t.Run("preserves Spec.Bootstrap.DataSecretName", func(t *testing.T) {
+		t.Run("preserves fields from hub version", func(t *testing.T) {
 			src := &v1alpha3.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hub",
+				},
 				Spec: v1alpha3.MachineSpec{
+					ClusterName: "test-cluster",
 					Bootstrap: v1alpha3.Bootstrap{
 						DataSecretName: pointer.StringPtr("secret-data"),
 					},
@@ -82,8 +129,112 @@ func TestConvertMachine(t *testing.T) {
 			dst := &Machine{}
 
 			g.Expect(dst.ConvertFrom(src)).To(Succeed())
-			g.Expect(dst.GetAnnotations()[utilconversion.DataAnnotation]).To(ContainSubstring("secret-data"))
+			restored := &v1alpha3.Machine{}
+			g.Expect(dst.ConvertTo(restored)).To(Succeed())
+
+			// Test field restored fields.
+			g.Expect(restored.Name).To(Equal(src.Name))
+			g.Expect(restored.Spec.Bootstrap.DataSecretName).To(Equal(src.Spec.Bootstrap.DataSecretName))
+			g.Expect(restored.Spec.ClusterName).To(Equal(src.Spec.ClusterName))
+		})
+	})
+}
+
+func TestConvertMachineSet(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("to hub", func(t *testing.T) {
+		t.Run("should convert the Spec.ClusterName from label", func(t *testing.T) {
+			src := &MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						MachineClusterLabelName: "test-cluster",
+					},
+				},
+			}
+			dst := &v1alpha3.MachineSet{}
+
+			g.Expect(src.ConvertTo(dst)).To(Succeed())
+			g.Expect(dst.Spec.ClusterName).To(Equal("test-cluster"))
 		})
 	})
 
+	t.Run("from hub", func(t *testing.T) {
+		t.Run("preserves field from hub version", func(t *testing.T) {
+			src := &v1alpha3.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hub",
+				},
+				Spec: v1alpha3.MachineSetSpec{
+					ClusterName: "test-cluster",
+					Template: v1alpha3.MachineTemplateSpec{
+						Spec: v1alpha3.MachineSpec{
+							ClusterName: "test-cluster",
+						},
+					},
+				},
+			}
+			dst := &MachineSet{}
+
+			g.Expect(dst.ConvertFrom(src)).To(Succeed())
+			restored := &v1alpha3.MachineSet{}
+			g.Expect(dst.ConvertTo(restored)).To(Succeed())
+
+			// Test field restored fields.
+			g.Expect(restored.Name).To(Equal(src.Name))
+			g.Expect(restored.Spec.ClusterName).To(Equal(src.Spec.ClusterName))
+			g.Expect(restored.Spec.Template.Spec.ClusterName).To(Equal(src.Spec.Template.Spec.ClusterName))
+		})
+	})
+}
+
+func TestConvertMachineDeployment(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("to hub", func(t *testing.T) {
+		t.Run("should convert the Spec.ClusterName from label", func(t *testing.T) {
+			src := &MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						MachineClusterLabelName: "test-cluster",
+					},
+				},
+			}
+			dst := &v1alpha3.MachineDeployment{}
+
+			g.Expect(src.ConvertTo(dst)).To(Succeed())
+			g.Expect(dst.Spec.ClusterName).To(Equal("test-cluster"))
+		})
+	})
+
+	t.Run("from hub", func(t *testing.T) {
+		t.Run("preserves fields from hub version", func(t *testing.T) {
+			src := &v1alpha3.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hub",
+				},
+				Spec: v1alpha3.MachineDeploymentSpec{
+					ClusterName: "test-cluster",
+					Paused:      true,
+					Template: v1alpha3.MachineTemplateSpec{
+						Spec: v1alpha3.MachineSpec{
+							ClusterName: "test-cluster",
+						},
+					},
+				},
+			}
+			src.Status.SetTypedPhase(v1alpha3.MachineDeploymentPhaseRunning)
+			dst := &MachineDeployment{}
+
+			g.Expect(dst.ConvertFrom(src)).To(Succeed())
+			restored := &v1alpha3.MachineDeployment{}
+			g.Expect(dst.ConvertTo(restored)).To(Succeed())
+
+			// Test field restored fields.
+			g.Expect(restored.Name).To(Equal(src.Name))
+			g.Expect(restored.Spec.ClusterName).To(Equal(src.Spec.ClusterName))
+			g.Expect(restored.Spec.Paused).To(Equal(src.Spec.Paused))
+			g.Expect(restored.Spec.Template.Spec.ClusterName).To(Equal(src.Spec.Template.Spec.ClusterName))
+		})
+	})
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
/assign @ncdc 
