### PR TITLE
🏃 remove nolint:gocyclo

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,6 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-// nolint:gocyclo
 func main() {
 	var (
 		metricsAddr                  string


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR removes the noting:gocyclo on main.go. The linter no longer fails after the kubeadm bootstrap and kubeadm control plane manager split.

/cc @juan-lee 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1946 
