### PR TITLE
:bug: Tiltfile: union providers enabled in tilt-settings.json with those always enabled

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -18,6 +18,8 @@ allow_k8s_contexts(settings.get("allowed_contexts"))
 
 default_registry(settings.get("default_registry"))
 
+always_enable_providers = ["core"]
+
 providers = {
     "core": {
         "context": ".",
@@ -201,7 +203,9 @@ def include_user_tilt_files():
 
 # Enable core cluster-api plus everything listed in 'enable_providers' in tilt-settings.json
 def enable_providers():
-    for name in ["core"] + settings.get("enable_providers", []):
+    user_enable_providers = settings.get("enable_providers", [])
+    union_enable_providers = {k: "" for k in user_enable_providers + always_enable_providers}.keys()
+    for name in union_enable_providers:
         enable_provider(name)
 
 ##############################


### PR DESCRIPTION
**What this PR does / why we need it**: Previously, the providers were appended, so specifying the "core" provider in settings caused it to appear twice in the list of enabled providers, which caused `tilt up` to issue a cryptic error:

```
Successfully loaded Tiltfile (6.720128969s)
Traceback (most recent call last):
  /home/dlipovetsky/projects/cluster-api/Tiltfile:217:17: in <toplevel>
  /home/dlipovetsky/projects/cluster-api/Tiltfile:205:24: in enable_providers
  /home/dlipovetsky/projects/cluster-api/Tiltfile:156:17: in enable_provider
  <builtin>: in docker_build
Error: Image for ref "gcr.io/k8s-staging-cluster-api/cluster-api-controller" has already been defined
```

Thanks to @randomvariable for identifying the root cause :smile: 