### PR TITLE
:sparkles: secret: Add generator for etcd client certs

### DIFF
--- a/util/secret/consts.go
+++ b/util/secret/consts.go
@@ -46,4 +46,7 @@ const (
 
 	// APIServerEtcdClient is the secret name of user-supplied secret containing the apiserver-etcd-client key/cert
 	APIServerEtcdClient Purpose = "apiserver-etcd-client"
+
+	// ClusterAPIEtcdClient is the secret name of the Cluster API etcd client
+	ClusterAPIEtcdClient Purpose = "cluster-api-etcd-client"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a generator for etcd client certificates for use by the control plane controller to connect into the workload cluster's etcd endpoint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #1902 