### PR TITLE
✨ proxy: add proxy package for connecting to pods

### DIFF
--- a/controlplane/kubeadm/internal/proxy/addr.go
+++ b/controlplane/kubeadm/internal/proxy/addr.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"fmt"
+	"net"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/portforward"
+)
+
+const scheme string = "proxy"
+
+// Addr defines a proxy net/addr format
+type Addr struct {
+	net.Addr
+	port       string
+	identifier uint32
+}
+
+// Network returns a fake network
+func (a Addr) Network() string {
+	return portforward.PortForwardProtocolV1Name
+}
+
+// String returns encoded information about the connection
+func (a Addr) String() string {
+	return fmt.Sprintf(
+		"%s://%d.%s.local:%s",
+		scheme,
+		a.identifier,
+		portforward.PortForwardProtocolV1Name,
+		a.port,
+	)
+}
+
+// NewAddrFromConn creates an Addr from the given connection
+func NewAddrFromConn(c Conn) Addr {
+	return Addr{
+		port:       c.stream.Headers().Get(corev1.PortHeader),
+		identifier: c.stream.Identifier(),
+	}
+}

--- a/controlplane/kubeadm/internal/proxy/conn.go
+++ b/controlplane/kubeadm/internal/proxy/conn.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"net"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+// Conn is a Kubernetes API server proxied type of net/conn
+type Conn struct {
+	stream        httpstream.Stream
+	readDeadline  time.Time
+	writeDeadline time.Time
+}
+
+// Read from the connection
+func (c Conn) Read(b []byte) (n int, err error) {
+	return c.stream.Read(b)
+}
+
+// Close the underlying proxied connection
+func (c Conn) Close() error {
+	return c.stream.Close()
+}
+
+// Write to the connection
+func (c Conn) Write(b []byte) (n int, err error) {
+	return c.stream.Write(b)
+}
+
+// Return a fake address representing the proxied connection
+func (c Conn) LocalAddr() net.Addr {
+	return NewAddrFromConn(c)
+}
+
+// Return a fake address representing the proxied connection
+func (c Conn) RemoteAddr() net.Addr {
+	return NewAddrFromConn(c)
+}
+
+// SetDeadline sets the read and write deadlines to the specified interval
+func (c Conn) SetDeadline(t time.Time) error {
+	// TODO: Handle deadlines
+	c.readDeadline = t
+	c.writeDeadline = t
+	return nil
+}
+
+// SetWriteDeadline sets the read and write deadlines to the specified interval
+func (c Conn) SetWriteDeadline(t time.Time) error {
+	c.writeDeadline = t
+	return nil
+}
+
+// SetReadDeadline sets the read and write deadlines to the specified interval
+func (c Conn) SetReadDeadline(t time.Time) error {
+	c.readDeadline = t
+	return nil
+}
+
+// NewConn creates a new net/conn interface based on an underlying Kubernetes
+// API server proxy connection
+func NewConn(stream httpstream.Stream) Conn {
+	return Conn{
+		stream: stream,
+	}
+}

--- a/controlplane/kubeadm/internal/proxy/dial.go
+++ b/controlplane/kubeadm/internal/proxy/dial.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+const defaultTimeout = 10 * time.Second
+
+// Dialer creates connections using Kubernetes API Server port-forwarding
+type Dialer struct {
+	proxy          Proxy
+	clientset      *kubernetes.Clientset
+	proxyTransport http.RoundTripper
+	upgrader       spdy.Upgrader
+	timeout        time.Duration
+}
+
+// NewDialer creates a new dialer for a given API server scope
+func NewDialer(p Proxy, options ...func(*Dialer) error) (*Dialer, error) {
+	if p.Port == 0 {
+		return nil, errors.New("port required")
+	}
+
+	dialer := &Dialer{
+		proxy: p,
+	}
+
+	for _, option := range options {
+		err := option(dialer)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if dialer.timeout == 0 {
+		dialer.timeout = defaultTimeout
+	}
+	p.KubeConfig.Timeout = dialer.timeout
+	clientset, err := kubernetes.NewForConfig(p.KubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	proxyTransport, upgrader, err := spdy.RoundTripperFor(p.KubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	dialer.proxyTransport = proxyTransport
+	dialer.upgrader = upgrader
+	dialer.clientset = clientset
+	return dialer, nil
+}
+
+// DialContextWithAddr is a GO grpc compliant dialer construct
+func (d *Dialer) DialContextWithAddr(ctx context.Context, addr string) (net.Conn, error) {
+	return d.DialContext(ctx, scheme, addr)
+}
+
+// DialContext creates proxied port-forwarded connections.
+// ctx is currently unused, but fulfils the type signature used by GRPC.
+func (d *Dialer) DialContext(_ context.Context, network string, addr string) (net.Conn, error) {
+	req := d.clientset.CoreV1().RESTClient().
+		Post().
+		Resource(d.proxy.Kind).
+		Namespace(d.proxy.Namespace).
+		Name(d.proxy.ResourceName).
+		SubResource("portforward")
+
+	dialer := spdy.NewDialer(d.upgrader, &http.Client{Transport: d.proxyTransport}, "POST", req.URL())
+
+	p, _, err := dialer.Dial(portforward.PortForwardProtocolV1Name)
+	if err != nil {
+		return nil, errors.Wrap(err, "error upgrading connection")
+	}
+	headers := http.Header{}
+	headers.Set(corev1.StreamType, corev1.StreamTypeError)
+	headers.Set(corev1.PortHeader, fmt.Sprintf("%d", d.proxy.Port))
+	// We only create a single stream over the connection
+	headers.Set(corev1.PortForwardRequestIDHeader, "0")
+	errorStream, err := p.CreateStream(headers)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := errorStream.Close(); err != nil {
+		return nil, err
+	}
+
+	headers.Set(corev1.StreamType, corev1.StreamTypeData)
+	dataStream, err := p.CreateStream(headers)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating forwarding stream")
+	}
+
+	c := NewConn(dataStream)
+
+	return c, nil
+}
+
+// DialTimeout sets the timeout
+func DialTimeout(duration time.Duration) func(*Dialer) error {
+	return func(d *Dialer) error {
+		return d.setTimeout(duration)
+	}
+}
+
+func (d *Dialer) setTimeout(duration time.Duration) error {
+	d.timeout = duration
+	return nil
+}

--- a/controlplane/kubeadm/internal/proxy/proxy.go
+++ b/controlplane/kubeadm/internal/proxy/proxy.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"crypto/tls"
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+// Proxy defines the API server port-forwarded proxy
+type Proxy struct {
+
+	// Kind is the kind of Kubernetes resource
+	Kind string
+
+	// Namespace is the namespace in which the Kubernetes resource exists
+	Namespace string
+
+	// ResourceName is the name of the Kubernetes resource
+	ResourceName string
+
+	// KubeConfig is the config to connect to the API server
+	KubeConfig *rest.Config
+
+	// TLSConfig is for connecting to TLS servers listening on a proxied port
+	TLSConfig *tls.Config
+
+	// KeepAlive specifies how often a keep alive message is sent to hold
+	// the connection open
+	KeepAlive *time.Duration
+
+	// Port is the port to be forwarded from the relevant resource
+	Port int
+}

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,10 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e h1:p1yVGRW3nmb85p1Sh1ZJSDm4A4iKLS5QNbvUHMgGu/M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=


### PR DESCRIPTION
with http/transport and net/dialer compliant
interfaces

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
adds a port-forwarding proxy package with http/transport and net/dialer compliant
interfaces. Is based on a mixture of the kubectl & client-go port-forward packages, but they are only able to open listening ports rather than pass a proxied connection to another reader/writer.

The proxy has been tested successfully with the etcd3 client. Long-term, this may be PR'd back into relevant parts of client-go and api-machinery.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #1902 

/assign @dlipovetsky 
