### PR TITLE
✨ Adding an auth-proxy sidecar container to CAPI core controller manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ docs/book/book/
 config/ci/rbac/role_binding.yaml
 config/ci/rbac/role.yaml
 config/ci/rbac/aggregated_role.yaml
+config/ci/rbac/auth_proxy_role.yaml
+config/ci/rbac/auth_proxy_role_binding.yaml
+config/ci/rbac/auth_proxy_service.yaml
 config/ci/manager/manager.yaml
 manager_image_patch.yaml-e
 manager_pull_policy.yaml-e

--- a/cmd/example-provider/main.go
+++ b/cmd/example-provider/main.go
@@ -33,14 +33,18 @@ func main() {
 	var enableLeaderElection bool
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	var metricsAddr string
+	flag.StringVar(&metricsAddr, "metrics-addr", ":8080",
+		"The address the metric endpoint binds to.")
 	flag.Parse()
 
 	cfg := ctrl.GetConfigOrDie()
 
 	// Setup a Manager
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:         scheme.Scheme,
-		LeaderElection: enableLeaderElection,
+		Scheme:             scheme.Scheme,
+		LeaderElection:     enableLeaderElection,
+		MetricsBindAddress: metricsAddr,
 	})
 	if err != nil {
 		klog.Fatalf("Failed to set up controller manager: %v", err)

--- a/config/ci/kustomization.yaml
+++ b/config/ci/kustomization.yaml
@@ -15,6 +15,7 @@ patchesStrategicMerge:
 - manager_image_patch.yaml
 - manager_label_patch.yaml
 - manager_role_aggregation_patch.yaml
+- manager_auth_proxy_patch.yaml
 resources:
 - ./rbac/
 - ./manager/

--- a/config/ci/manager_auth_proxy_patch.yaml
+++ b/config/ci/manager_auth_proxy_patch.yaml
@@ -1,0 +1,25 @@
+# This patch inject a sidecar container which is a HTTP proxy for the controller manager,
+# it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+      - name: manager
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"

--- a/config/ci/rbac/kustomization.yaml
+++ b/config/ci/rbac/kustomization.yaml
@@ -11,3 +11,9 @@ resources:
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 - aggregated_role.yaml
+  # Comment the following 3 lines if you want to disable
+  # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+  # which protects your /metrics endpoint.
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml

--- a/config/core/kustomization.yaml
+++ b/config/core/kustomization.yaml
@@ -34,7 +34,7 @@ patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
-# - manager_auth_proxy_patch.yaml
+- manager_auth_proxy_patch.yaml
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, uncomment the following line and
   # comment manager_auth_proxy_patch.yaml.
@@ -51,15 +51,6 @@ patchesStrategicMerge:
   # non SIG Cluster Lifecycle-sponsored provider subprojects by using an
   # aggregated role
 - manager_role_aggregation_patch.yaml
-
-patchesJson6902:
-- target:
-    group: apps
-    version: v1
-    kind: Deployment
-    name: controller-manager
-    namespace: system
-  path: manager_arguments.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/config/core/manager_arguments.yaml
+++ b/config/core/manager_arguments.yaml
@@ -1,4 +1,0 @@
-- op: replace
-  path: "/spec/template/spec/containers/0/args"
-  value:
-    - "--enable-leader-election"

--- a/config/core/manager_auth_proxy_patch.yaml
+++ b/config/core/manager_auth_proxy_patch.yaml
@@ -1,0 +1,25 @@
+# This patch inject a sidecar container which is a HTTP proxy for the controller manager,
+# it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: kube-rbac-proxy
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8080/"
+            - "--logtostderr=true"
+            - "--v=10"
+          ports:
+            - containerPort: 8443
+              name: https
+        - name: manager
+          args:
+            - "--metrics-addr=127.0.0.1:8080"
+            - "--enable-leader-election"

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -7,14 +7,3 @@ namespace: capi-system
 bases:
 ## Vanilla capi components
 - ../core
-
-patchesJson6902:
-## Unfortunately, you can't just delete from the args list with patches
-## so we have to override the whole args key
-- target:
-    group: apps
-    version: v1
-    kind: Deployment
-    name: controller-manager
-    namespace: system
-  path: manager_arguments.yaml

--- a/config/default/manager_arguments.yaml
+++ b/config/default/manager_arguments.yaml
@@ -1,4 +1,0 @@
-- op: replace
-  path: "/spec/template/spec/containers/0/args"
-  value:
-    - "--enable-leader-election"

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: proxy-role
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-service
+  namespace: system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -11,3 +11,9 @@ resources:
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 - aggregated_role.yaml
+  # Comment the following 3 lines if you want to disable
+  # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
+  # which protects your /metrics endpoint.
+- auth_proxy_service.yaml
+- auth_proxy_role.yaml
+- auth_proxy_role_binding.yaml


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Adds an auth proxy which is deployed as sidecar container in the CAPI manager pod.

**Which issue(s) this PR fixes** :
Addresses #1960 