### PR TITLE
✨ Implement delete for KubeadmControlPlane

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -69,6 +69,22 @@ func RandomString(n int) string {
 	return string(result)
 }
 
+// GetMachinesForCluster returns a list of machines associated with the cluster.
+func GetMachinesForCluster(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (*clusterv1.MachineList, error) {
+	var machines clusterv1.MachineList
+	if err := c.List(
+		ctx,
+		&machines,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels{
+			clusterv1.ClusterLabelName: cluster.Name,
+		},
+	); err != nil {
+		return nil, err
+	}
+	return &machines, nil
+}
+
 // GetControlPlaneMachines returns a slice containing control plane machines.
 func GetControlPlaneMachines(machines []*clusterv1.Machine) (res []*clusterv1.Machine) {
 	for _, machine := range machines {


### PR DESCRIPTION
**What this PR does / why we need it**: Implement delete for KubeadmControlPlane. Part of #1756.

**Special notes for reviewers**:
- I know that #1539 introduced `Machine.Spec.ClusterName`, but the code base still uses the cluster label to filter, which is why I also did this in `GetMachinesForCluster`.
- The two cases for the delete unit test share some code, but could probably share more. If you feel that's important to address here, let me know.

/cc @chuckha  @detiber @randomvariable 