### PR TITLE
:bug: Ensure MachineSet controller won't orphan resources

### DIFF
--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -259,7 +259,7 @@ func (r *MachineSetReconciler) syncReplicas(ms *clusterv1.MachineSet, machines [
 				err                          error
 			)
 
-			infraConfig, err = external.CloneTemplate(r.Client, &machine.Spec.InfrastructureRef, machine.Namespace)
+			infraConfig, err = external.CloneTemplateWithOwner(r.Client, &machine.Spec.InfrastructureRef, machine.Namespace, metav1.NewControllerRef(ms, machineSetKind))
 			if err != nil {
 				return errors.Wrapf(err, "failed to clone infrastructure configuration for MachineSet %q in namespace %q", ms.Name, ms.Namespace)
 			}
@@ -271,7 +271,7 @@ func (r *MachineSetReconciler) syncReplicas(ms *clusterv1.MachineSet, machines [
 			}
 
 			if machine.Spec.Bootstrap.ConfigRef != nil {
-				bootstrapConfig, err = external.CloneTemplate(r.Client, machine.Spec.Bootstrap.ConfigRef, machine.Namespace)
+				bootstrapConfig, err = external.CloneTemplateWithOwner(r.Client, machine.Spec.Bootstrap.ConfigRef, machine.Namespace, metav1.NewControllerRef(ms, machineSetKind))
 				if err != nil {
 					return errors.Wrapf(err, "failed to clone bootstrap configuration for MachineSet %q in namespace %q", ms.Name, ms.Namespace)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

To ensure that the `MachineSet` controller won't orphan infrastructure config or bootstrap config resources as the result of an incomplete reconcile followed by cluster deletion, add an `OwnerReference` during creation of these resources by the `MachineSet` controller.

This case may be uncommon when Cluster API is used directly by a user (as the window where deletion of the `Cluster` will lead to an orphaned resource is short), but may be more common when an automation layer sits above Cluster API (as its "reaction time" may be fast).

**Which issue(s) this PR fixes**:

I didn't file a separate issue for this, but would be happy to do so.

**Additional details**:

I borrowed pieces of this change from #1959 on `master`, introducing a new method that supports passing `owners` to avoid backwards-compatibility issues (because `CloneTemplate` is a public function and I'm proposing submission to a release branch).