### PR TITLE
📖 enable kubeadm providers in example tilt-settings.json

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -35,7 +35,7 @@ Next, create a `tilt-settings.json` file and place it in your local copy of `clu
   "allowed_contexts": ["kind-kind"],
   "default_registry": "gcr.io/your-project-name-here",
   "provider_repos": ["../cluster-api-provider-aws"],
-  "enable_providers": ["aws", "docker"]
+  "enable_providers": ["aws", "docker", "kubeadm-bootstrap", "kubeadm-control-plane"]
 }
 ```
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Now that kubeadm providers are separated, the providers need to be enabled in the tilt configuration

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
