### PR TITLE
✨clusterctl: rename config file

### DIFF
--- a/cmd/clusterctl/cmd/config_cluster.go
+++ b/cmd/clusterctl/cmd/config_cluster.go
@@ -39,7 +39,7 @@ var configClusterClusterCmd = &cobra.Command{
 	Short: "Generate templates for creating a Cluster API workload clusters",
 	Long: LongDesc(`
 		clusterctl ships with a list of well know providers; if necessary, edit
-		the $HOME/cluster-api/.clusterctl.yaml file to add new provider configurations or to customize existing ones.
+		the $HOME/.cluster-api/clusterctl.yaml file to add new provider configurations or to customize existing ones.
 		
 		Each provider configuration links to a repository, and clusterctl will fetch the template
 		from creating a new cluster from there.`),

--- a/cmd/clusterctl/cmd/config_providers.go
+++ b/cmd/clusterctl/cmd/config_providers.go
@@ -41,7 +41,7 @@ var configProvidersCmd = &cobra.Command{
 	Short:   "Display Cluster API provider configuration",
 	Long: LongDesc(`
 		clusterctl ships with a list of well-known providers; if necessary, edit
-		the $HOME/cluster-api/.clusterctl.yaml file to add new provider configurations or to customize existing ones.
+		the $HOME/.cluster-api/clusterctl.yaml file to add new provider configurations or to customize existing ones.
 		
 		Each provider configuration links to a repository, and clusterctl will fetch the provider
 		components yaml from there; required variables and the default namespace where the

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -46,7 +46,7 @@ var initCmd = &cobra.Command{
 		for accessing the cluster must have enough privileges for installing Cluster API providers.
 
 		Use 'clusterctl config providers' to get the list of available providers; if necessary, edit
-		the $HOME/cluster-api/.clusterctl.yaml file to add new provider configurations or to customize existing ones.
+		the $HOME/.cluster-api/clusterctl.yaml file to add new provider configurations or to customize existing ones.
 		
 		Some providers require environment variables to be set before running clusterctl init; please
 		refer to the provider documentation or use 'clusterctl config provider [name]' to get the

--- a/cmd/clusterctl/hack/local-overrides.py
+++ b/cmd/clusterctl/hack/local-overrides.py
@@ -102,7 +102,7 @@ def get_home():
 def write_local_override(provider, version, components_file, components_yaml):
     try:
         home = get_home()
-        overrides_folder = os.path.join(home, 'cluster-api', 'overrides')
+        overrides_folder = os.path.join(home, '.cluster-api', 'overrides')
         provider_overrides_folder = os.path.join(overrides_folder, provider, version)
         try:
             os.makedirs(provider_overrides_folder)

--- a/cmd/clusterctl/pkg/client/config/reader_viper.go
+++ b/cmd/clusterctl/pkg/client/config/reader_viper.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ConfigFolder defines the name of the config folder under $home
-const ConfigFolder = "cluster-api"
+const ConfigFolder = ".cluster-api"
 
 // viperReader implements Reader using viper as backend for reading from environment variables
 // and from a clusterctl config file.
@@ -45,8 +45,8 @@ func (v *viperReader) Init(path string) error {
 		// Use path file from the flag.
 		viper.SetConfigFile(path)
 	} else {
-		// Configure for searching cluster-api/.clusterctl{.extension} in home directory
-		viper.SetConfigName(".clusterctl")
+		// Configure for searching .cluster-api/clusterctl{.extension} in home directory
+		viper.SetConfigName("clusterctl")
 		viper.AddConfigPath(filepath.Join(homedir.HomeDir(), ConfigFolder))
 	}
 

--- a/cmd/clusterctl/pkg/client/repository/client.go
+++ b/cmd/clusterctl/pkg/client/repository/client.go
@@ -168,7 +168,7 @@ const overrideFolder = "overrides"
 // This is required for development purposes, but it can be used also in production as a workaround for problems on the official repositories
 func getLocalOverride(provider config.Provider, version, path string) ([]byte, error) {
 
-	// local override files are searched at $home/cluster-api/overrides/<provider-name>/<version>/<path>
+	// local override files are searched at $home/.cluster-api/overrides/<provider-name>/<version>/<path>
 	homeFolder := filepath.Join(homedir.HomeDir(), config.ConfigFolder)
 	overridePath := filepath.Join(homeFolder, overrideFolder, provider.Name(), version, path)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As per comment https://github.com/kubernetes-sigs/cluster-api/pull/2027#discussion_r364803275, renaming the clusterctl config folder

**Which issue(s) this PR fixes**:
Rif #1729 

/assign @vincepri 
/cc @ncdc 