### PR TITLE
 📖 Fix target management cluster broken link

### DIFF
--- a/docs/book/src/reference/glossary.md
+++ b/docs/book/src/reference/glossary.md
@@ -134,7 +134,7 @@ Perform create, scale, upgrade, or destroy operations on the cluster.
 
 ### Management cluster
 
-The cluster where one or more Infrastructure Providers run, and where resources (e.g. Machines) are stored.  Typically referred to when you are provisioning multiple clusters.
+The cluster where one or more Infrastructure Providers run, and where resources (e.g. Machines) are stored. Typically referred to when you are provisioning multiple workload clusters.
 
 ### Management group
 
@@ -199,7 +199,7 @@ The infrastructure that backs a [Machine Resource](#user-content-machine), typic
 # T
 ---
 
-### Target management cluster
+### Target cluster
 
 The declared cluster we intend to create and manage using cluster-api when running `clusterctl create cluster`.
 
@@ -211,4 +211,3 @@ When running `clusterctl alpha phases pivot` this refers to the cluster that wil
 ### Workload Cluster
 
 A cluster created by a ClusterAPI controller, which is *not* a bootstrap cluster, and is meant to be used by end-users, as opposed to by CAPI tooling.
-

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -747,7 +747,7 @@ ready.
 kubectl get clusters --output jsonpath="{range .items[*]} [{.metadata.name} {.status.ControlPlaneInitialized} {.status.ControlPlaneReady}] {end}"
 ```
 
-After the control plane node is up, we can retrieve the workload cluster Kubeconfig:
+After the control plane node is up, we can retrieve the [workload cluster] Kubeconfig:
 
 {{#tabs name:"tab-getting-kubeconfig" tabs:"AWS|Azure|GCP|vSphere|OpenStack, Docker"}}
 {{#tab AWS|Azure|GCP|vSphere|OpenStack}}
@@ -1347,3 +1347,4 @@ spec:
 
 <!-- links -->
 [control-plane-controller]: ../architecture/controllers/control-plane.md
+[workload cluster]: ../reference/glossary.md#workload-cluster


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Changes target cluster to target management cluster as defined in the glossary. Also, fixes the broken link to redirect to the correct definition in the glossary. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2072
