### PR TITLE
⚠️ clusterctl: add the clusterctl config cluster command

### DIFF
--- a/cmd/clusterctl/pkg/client/alias.go
+++ b/cmd/clusterctl/pkg/client/alias.go
@@ -27,5 +27,8 @@ import (
 // Provider defines a provider configuration.
 type Provider config.Provider
 
-// Components wraps a YAML file that defines the provider's components (CRD, controller, RBAC rules etc.)
+// Components wraps a YAML file that defines the provider's components (CRDs, controller, RBAC rules etc.).
 type Components repository.Components
+
+// Template wraps a YAML file that defines the cluster objects (Cluster, Machines etc.).
+type Template repository.Template

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -33,6 +33,19 @@ type InitOptions struct {
 	Force                   bool
 }
 
+// GetClusterTemplateOptions carries the options supported by GetClusterTemplate
+type GetClusterTemplateOptions struct {
+	Kubeconfig               string
+	InfrastructureProvider   string
+	Flavor                   string
+	BootstrapProvider        string
+	ClusterName              string
+	TargetNamespace          string
+	KubernetesVersion        string
+	ControlPlaneMachineCount int
+	WorkerMachineCount       int
+}
+
 // Client is exposes the clusterctl high-level client library
 type Client interface {
 	// GetProvidersConfig returns the list of providers configured for this instance of clusterctl.
@@ -43,6 +56,9 @@ type Client interface {
 
 	// Init initializes a management cluster by adding the requested list of providers.
 	Init(options InitOptions) ([]Components, bool, error)
+
+	// GetClusterTemplate returns a workload cluster template.
+	GetClusterTemplate(options GetClusterTemplateOptions) (Template, error)
 }
 
 // clusterctlClient implements Client.

--- a/cmd/clusterctl/pkg/client/client_test.go
+++ b/cmd/clusterctl/pkg/client/client_test.go
@@ -70,6 +70,10 @@ func (f fakeClient) GetProviderComponents(provider, targetNameSpace, watchingNam
 	return f.internalClient.GetProviderComponents(provider, targetNameSpace, watchingNamespace)
 }
 
+func (f fakeClient) GetClusterTemplate(options GetClusterTemplateOptions) (Template, error) {
+	return f.internalClient.GetClusterTemplate(options)
+}
+
 func (f fakeClient) Init(options InitOptions) ([]Components, bool, error) {
 	return f.internalClient.Init(options)
 }
@@ -189,6 +193,11 @@ func (f fakeClusterClient) ProviderInstaller() cluster.ProviderInstaller {
 
 func (f *fakeClusterClient) WithObjs(objs ...runtime.Object) *fakeClusterClient {
 	f.fakeProxy.WithObjs(objs...)
+	return f
+}
+
+func (f *fakeClusterClient) WithProviderInventory(name string, providerType clusterctlv1.ProviderType, version, targetNamespace, watchingNamespace string) *fakeClusterClient {
+	f.fakeProxy.WithProviderInventory(name, providerType, version, targetNamespace, watchingNamespace)
 	return f
 }
 

--- a/cmd/clusterctl/pkg/client/common.go
+++ b/cmd/clusterctl/pkg/client/common.go
@@ -67,9 +67,8 @@ func parseProviderName(provider string) (name string, version string, err error)
 	}
 
 	name = t[0]
-	errs := validation.IsDNS1123Label(name)
-	if len(errs) != 0 {
-		return "", "", errors.Errorf("invalid name value: %s", strings.Join(errs, "; "))
+	if err := validateDNS1123Label(name); err != nil {
+		return "", "", errors.Wrapf(err, "invalid provider name %q. Provider name should be in the form name[:version] and the name should be valid", provider)
 	}
 
 	version = ""
@@ -81,4 +80,12 @@ func parseProviderName(provider string) (name string, version string, err error)
 	}
 
 	return name, version, nil
+}
+
+func validateDNS1123Label(label string) error {
+	errs := validation.IsDNS1123Label(label)
+	if len(errs) != 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
 }

--- a/cmd/clusterctl/pkg/client/config.go
+++ b/cmd/clusterctl/pkg/client/config.go
@@ -16,6 +16,14 @@ limitations under the License.
 
 package client
 
+import (
+	"strconv"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/version"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+)
+
 func (c *clusterctlClient) GetProvidersConfig() ([]Provider, error) {
 	r, err := c.configClient.Providers().List()
 	if err != nil {
@@ -36,6 +44,121 @@ func (c *clusterctlClient) GetProviderComponents(provider, targetNameSpace, watc
 	if err != nil {
 		return nil, err
 	}
-
 	return components, nil
+}
+
+func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions) (Template, error) {
+
+	cluster, err := c.clusterClientFactory(options.Kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cluster.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
+		return nil, err
+	}
+
+	// If the option specifying the name of the infrastructure provider to get templates from is empty, try to detect it.
+	provider := options.InfrastructureProvider
+	if provider == "" {
+		defaultProviderName, err := cluster.ProviderInventory().GetDefaultProviderName(clusterctlv1.InfrastructureProviderType)
+		if err != nil {
+			return nil, err
+		}
+
+		if defaultProviderName == "" {
+			return nil, errors.New("failed to identify the default infrastructure provider. Please specify an infrastructure provider")
+		}
+		provider = defaultProviderName
+	}
+
+	// parse the abbreviated syntax for name[:version]
+	name, version, err := parseProviderName(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the version of the infrastructure provider to get templates from is empty, try to detect it.
+	if version == "" {
+		defaultProviderVersion, err := cluster.ProviderInventory().GetDefaultProviderVersion(name)
+		if err != nil {
+			return nil, err
+		}
+
+		if defaultProviderVersion == "" {
+			return nil, errors.Errorf("failed to identify the default version for the provider %q. Please specify a version", name)
+		}
+		version = defaultProviderVersion
+	}
+
+	// If the option specifyng the targetNamespace is empty, try to detect it.
+	if options.TargetNamespace == "" {
+		currentNamespace, err := cluster.Proxy().CurrentNamespace()
+		if err != nil {
+			return nil, err
+		}
+		options.TargetNamespace = currentNamespace
+	}
+
+	// Inject some of the templateOptions into the configClient so they can be consumed as a variables from the template.
+	if err := c.templateOptionsToVariables(options); err != nil {
+		return nil, err
+	}
+
+	// Get the template from the template repository.
+	providerConfig, err := c.configClient.Providers().Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := c.repositoryClientFactory(*providerConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	template, err := repo.Templates(version).Get(options.Flavor, options.BootstrapProvider, options.TargetNamespace)
+	if err != nil {
+		return nil, err
+	}
+	return template, nil
+}
+
+// templateOptionsToVariables injects some of the templateOptions to the configClient so they can be consumed as a variables from the template.
+func (c *clusterctlClient) templateOptionsToVariables(options GetClusterTemplateOptions) error {
+
+	// the TargetNamespace, if valid, can be used in templates using the ${ NAMESPACE } variable.
+	if err := validateDNS1123Label(options.TargetNamespace); err != nil {
+		return errors.Wrapf(err, "invalid target-namespace")
+	}
+	c.configClient.Variables().Set("NAMESPACE", options.TargetNamespace)
+
+	// the ClusterName, if valid, can be used in templates using the ${ CLUSTER_NAME } variable.
+	if err := validateDNS1123Label(options.ClusterName); err != nil {
+		return errors.Wrapf(err, "invalid cluster name")
+	}
+	c.configClient.Variables().Set("CLUSTER_NAME", options.ClusterName)
+
+	// the KubernetesVersion, if valid, can be used in templates using the ${ KUBERNETES_VERSION } variable.
+	// NB. in case the KubernetesVersion from the templateOptions is empty, we are not setting any values so the
+	// configClient is going to search into os env variables/the clusterctl config file as a fallback options.
+	if options.KubernetesVersion != "" {
+		if _, err := version.ParseSemantic(options.KubernetesVersion); err != nil {
+			return errors.Errorf("invalid KubernetesVersion. Please use a semantic version number")
+		}
+		c.configClient.Variables().Set("KUBERNETES_VERSION", options.KubernetesVersion)
+	}
+
+	// the ControlPlaneMachineCount, if valid, can be used in templates using the ${ CONTROLPLANE_MACHINE_COUNT } variable.
+	if options.ControlPlaneMachineCount < 1 {
+		return errors.Errorf("invalid ControlPlaneMachineCount. Please use a number greater or equal than 1")
+	}
+	c.configClient.Variables().Set("CONTROLPLANE_MACHINE_COUNT", strconv.Itoa(options.ControlPlaneMachineCount))
+
+	// the WorkerMachineCount, if valid, can be used in templates using the ${ WORKER_MACHINE_COUNT } variable.
+	if options.WorkerMachineCount < 0 {
+		return errors.Errorf("invalid WorkerMachineCount. Please use a number greater or equal than 0")
+	}
+	c.configClient.Variables().Set("WORKER_MACHINE_COUNT", strconv.Itoa(options.WorkerMachineCount))
+
+	return nil
 }

--- a/cmd/clusterctl/pkg/client/config_test.go
+++ b/cmd/clusterctl/pkg/client/config_test.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
@@ -69,10 +70,10 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.field.client.GetProvidersConfig()
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("error = %v, wantErr = %v", err, tt.wantErr)
 			}
-			if err != nil {
+			if tt.wantErr {
 				return
 			}
 
@@ -158,6 +159,305 @@ func Test_clusterctlClient_GetProviderComponents(t *testing.T) {
 
 			if got.Version() != tt.want.version {
 				t.Errorf("got.Version() = %v, want = %v ", got.Version(), tt.want.version)
+			}
+		})
+	}
+}
+
+func Test_clusterctlClient_templateOptionsToVariables(t *testing.T) {
+	type args struct {
+		options GetClusterTemplateOptions
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantVars map[string]string
+		wantErr  bool
+	}{
+		{
+			name: "pass (using KubernetesVersion from template options)",
+			args: args{
+				options: GetClusterTemplateOptions{
+					ClusterName:              "foo",
+					TargetNamespace:          "bar",
+					KubernetesVersion:        "v1.2.3",
+					ControlPlaneMachineCount: 1,
+					WorkerMachineCount:       2,
+				},
+			},
+			wantVars: map[string]string{
+				"CLUSTER_NAME":               "foo",
+				"NAMESPACE":                  "bar",
+				"KUBERNETES_VERSION":         "v1.2.3",
+				"CONTROLPLANE_MACHINE_COUNT": "1",
+				"WORKER_MACHINE_COUNT":       "2",
+			},
+			wantErr: false,
+		},
+		{
+			name: "pass (using KubernetesVersion from env variables)",
+			args: args{
+				options: GetClusterTemplateOptions{
+					ClusterName:              "foo",
+					TargetNamespace:          "bar",
+					KubernetesVersion:        "", // empty means to use value from env variables/config file
+					ControlPlaneMachineCount: 1,
+					WorkerMachineCount:       2,
+				},
+			},
+			wantVars: map[string]string{
+				"CLUSTER_NAME":               "foo",
+				"NAMESPACE":                  "bar",
+				"KUBERNETES_VERSION":         "v3.4.5",
+				"CONTROLPLANE_MACHINE_COUNT": "1",
+				"WORKER_MACHINE_COUNT":       "2",
+			},
+			wantErr: false,
+		},
+		{
+			name: "fails for invalid cluster Name",
+			args: args{
+				options: GetClusterTemplateOptions{
+					ClusterName: "A!££%",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "fails for invalid namespace Name",
+			args: args{
+				options: GetClusterTemplateOptions{
+					ClusterName:     "foo",
+					TargetNamespace: "A!££%",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "fails for invalid version",
+			args: args{
+				options: GetClusterTemplateOptions{
+					ClusterName:       "foo",
+					TargetNamespace:   "bar",
+					KubernetesVersion: "A!££%",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "fails for invalid control plane machine count",
+			args: args{
+				options: GetClusterTemplateOptions{
+					ClusterName:              "foo",
+					TargetNamespace:          "bar",
+					KubernetesVersion:        "v1.2.3",
+					ControlPlaneMachineCount: -1,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "fails for invalid worker machine count",
+			args: args{
+				options: GetClusterTemplateOptions{
+					ClusterName:              "foo",
+					TargetNamespace:          "bar",
+					KubernetesVersion:        "v1.2.3",
+					ControlPlaneMachineCount: 1,
+					WorkerMachineCount:       -1,
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := newFakeConfig().
+				WithVar("KUBERNETES_VERSION", "v3.4.5") // with this line we are simulating an env var
+
+			c := &clusterctlClient{
+				configClient: config,
+			}
+			err := c.templateOptionsToVariables(tt.args.options)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			for name, wantValue := range tt.wantVars {
+				gotValue, err := config.Variables().Get(name)
+				if err != nil {
+					t.Fatalf("variable %s is not definied in config variables", name)
+				}
+				if gotValue != wantValue {
+					t.Errorf("variable %s, got = %v, want %v", name, gotValue, wantValue)
+				}
+			}
+		})
+	}
+}
+
+func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
+	config1 := newFakeConfig().
+		WithProvider(infraProviderConfig)
+
+	repository1 := newFakeRepository(infraProviderConfig, config1.Variables()).
+		WithPaths("root", "components").
+		WithDefaultVersion("v3.0.0").
+		WithFile("v3.0.0", "config-kubeadm.yaml", templateYAML("ns3", "${ CLUSTER_NAME }"))
+
+	cluster1 := newFakeCluster("kubeconfig").
+		WithProviderInventory(infraProviderConfig.Name(), infraProviderConfig.Type(), "v3.0.0", "foo", "bar")
+
+	client := newFakeClient(config1).
+		WithCluster(cluster1).
+		WithRepository(repository1)
+
+	type args struct {
+		options GetClusterTemplateOptions
+	}
+
+	type templateValues struct {
+		name            string
+		url             string
+		providerType    clusterctlv1.ProviderType
+		version         string
+		flavor          string
+		bootstrap       string
+		path            string
+		variables       []string
+		targetNamespace string
+		yaml            []byte
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    templateValues
+		wantErr bool
+	}{
+		{
+			name: "pass",
+			args: args{
+				options: GetClusterTemplateOptions{
+					Kubeconfig:               "kubeconfig",
+					InfrastructureProvider:   "infra:v3.0.0",
+					Flavor:                   "",
+					BootstrapProvider:        "kubeadm",
+					ClusterName:              "test",
+					TargetNamespace:          "ns1",
+					ControlPlaneMachineCount: 1,
+				},
+			},
+			want: templateValues{
+				name:            "infra",
+				url:             "url",
+				providerType:    clusterctlv1.InfrastructureProviderType,
+				version:         "v3.0.0",
+				flavor:          "",
+				bootstrap:       "kubeadm",
+				path:            "config-kubeadm.yaml",
+				variables:       []string{"CLUSTER_NAME"}, // variable detected
+				targetNamespace: "ns1",
+				yaml:            templateYAML("ns1", "test"), // original template modified with target namespace and variable replacement
+			},
+		},
+		{
+			name: "detects provider name/version if missing",
+			args: args{
+				options: GetClusterTemplateOptions{
+					Kubeconfig:               "kubeconfig",
+					InfrastructureProvider:   "", // empty triggers auto-detection of the provider name/version
+					Flavor:                   "",
+					BootstrapProvider:        "kubeadm",
+					ClusterName:              "test",
+					TargetNamespace:          "ns1",
+					ControlPlaneMachineCount: 1,
+				},
+			},
+			want: templateValues{
+				name:            "infra",
+				url:             "url",
+				providerType:    clusterctlv1.InfrastructureProviderType,
+				version:         "v3.0.0",
+				flavor:          "",
+				bootstrap:       "kubeadm",
+				path:            "config-kubeadm.yaml",
+				variables:       []string{"CLUSTER_NAME"}, // variable detected
+				targetNamespace: "ns1",
+				yaml:            templateYAML("ns1", "test"), // original template modified with target namespace and variable replacement
+			},
+		},
+		{
+			name: "use current namespace if targetNamespace is missing",
+			args: args{
+				options: GetClusterTemplateOptions{
+					Kubeconfig:               "kubeconfig",
+					InfrastructureProvider:   "infra:v3.0.0",
+					Flavor:                   "",
+					BootstrapProvider:        "kubeadm",
+					ClusterName:              "test",
+					TargetNamespace:          "", // empty triggers usage of the current namespace
+					ControlPlaneMachineCount: 1,
+				},
+			},
+			want: templateValues{
+				name:            "infra",
+				url:             "url",
+				providerType:    clusterctlv1.InfrastructureProviderType,
+				version:         "v3.0.0",
+				flavor:          "",
+				bootstrap:       "kubeadm",
+				path:            "config-kubeadm.yaml",
+				variables:       []string{"CLUSTER_NAME"}, // variable detected
+				targetNamespace: "default",
+				yaml:            templateYAML("default", "test"), // original template modified with target namespace and variable replacement
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := client.GetClusterTemplate(tt.args.options)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if got.Name() != tt.want.name {
+				t.Errorf("Name() got = %v, want %v", got.Name(), tt.want.name)
+			}
+			if got.URL() != tt.want.url {
+				t.Errorf("URL() got = %v, want %v", got.URL(), tt.want.url)
+			}
+			if got.Type() != tt.want.providerType {
+				t.Errorf("Type() got = %v, want %v", got.Type(), tt.want.providerType)
+			}
+			if got.Version() != tt.want.version {
+				t.Errorf("Version() got = %v, want %v", got.Version(), tt.want.version)
+			}
+			if got.Flavor() != tt.want.flavor {
+				t.Errorf("Flavor() got = %v, want %v", got.Flavor(), tt.want.flavor)
+			}
+			if got.Bootstrap() != tt.want.bootstrap {
+				t.Errorf("Bootstrap() got = %v, want %v", got.Bootstrap(), tt.want.bootstrap)
+			}
+			if !reflect.DeepEqual(got.Variables(), tt.want.variables) {
+				t.Errorf("Variables() got = %v, want %v", got.Variables(), tt.want.variables)
+			}
+			if got.TargetNamespace() != tt.want.targetNamespace {
+				t.Errorf("TargetNamespace() got = %v, want %v", got.TargetNamespace(), tt.want.targetNamespace)
+			}
+
+			gotYaml, err := got.Yaml()
+			if err != nil {
+				t.Fatalf("Yaml() error = %v, wantErr nil", err)
+			}
+			if !reflect.DeepEqual(gotYaml, tt.want.yaml) {
+				t.Errorf("Yaml() got = %v, want %v", gotYaml, tt.want.yaml)
 			}
 		})
 	}

--- a/cmd/clusterctl/pkg/client/init_test.go
+++ b/cmd/clusterctl/pkg/client/init_test.go
@@ -325,7 +325,7 @@ func fakeEmptyCluster() *fakeClient {
 		WithDefaultVersion("v3.0.0").
 		WithFile("v3.0.0", "components.yaml", componentsYAML("ns3")).
 		WithFile("v3.1.0", "components.yaml", componentsYAML("ns3")).
-		WithFile("v3.0.0", "config-kubeadm.yaml", templateYAML("ns3"))
+		WithFile("v3.0.0", "config-kubeadm.yaml", templateYAML("ns3", "test"))
 
 	cluster1 := newFakeCluster("kubeconfig")
 
@@ -366,11 +366,11 @@ func componentsYAML(ns string) []byte {
 	return util.JoinYaml(namespaceYaml, podYaml)
 }
 
-func templateYAML(ns string) []byte {
+func templateYAML(ns string, clusterName string) []byte {
 	var podYaml = []byte("apiVersion: v1\n" +
-		"kind: Pod\n" +
+		"kind: Cluster\n" +
 		"metadata:\n" +
-		"  name: manager\n" +
+		fmt.Sprintf("  name: %s\n", clusterName) +
 		fmt.Sprintf("  namespace: %s", ns))
 
 	return podYaml


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `clusterctl config cluster` command, thus completing the day 1 journey

**Which issue(s) this PR fixes** 
Rif #1729

/assign @vincepri 
/cc @detiber @ncdc
