### PR TITLE
✨clusterctl: add the config provider <provider-name> command

### DIFF
--- a/cmd/clusterctl/cmd/config_providers.go
+++ b/cmd/clusterctl/cmd/config_providers.go
@@ -72,7 +72,7 @@ var configProvidersCmd = &cobra.Command{
 		if len(args) == 0 {
 			return runGetRepositories()
 		}
-		return runGetRepository(args[0], cpo.targetNamespace, cpo.watchingNamespace, cpo.output)
+		return runGetComponents(args[0], cpo.targetNamespace, cpo.watchingNamespace, cpo.output)
 	},
 }
 
@@ -105,6 +105,48 @@ func runGetRepositories() error {
 	return nil
 }
 
-func runGetRepository(providerName, targetNamespace, watchingNamespace, output string) error {
+func runGetComponents(providerName, targetNamespace, watchingNamespace, output string) error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	components, err := c.GetProviderComponents(providerName, targetNamespace, watchingNamespace)
+	if err != nil {
+		return err
+	}
+
+	if output == "yaml" {
+		return componentsYAMLOutput(components)
+	}
+	return componentsDefaultOutput(components)
+}
+
+func componentsYAMLOutput(c client.Components) error {
+	yaml, err := c.Yaml()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(yaml))
+	return err
+}
+
+func componentsDefaultOutput(c client.Components) error {
+	fmt.Printf("Name:               %s\n", c.Name())
+	fmt.Printf("Type:               %s\n", c.Type())
+	fmt.Printf("URL:                %s\n", c.URL())
+	fmt.Printf("Version:            %s\n", c.Version())
+	fmt.Printf("TargetNamespace:    %s\n", c.TargetNamespace())
+	fmt.Printf("WatchingNamespace:  %s\n", c.WatchingNamespace())
+	if len(c.Variables()) > 0 {
+		fmt.Println("Variables:")
+		fmt.Println("  Name")
+		fmt.Println("  ----")
+		for _, v := range c.Variables() {
+			fmt.Printf("  %s\n", v)
+		}
+	}
+
 	return nil
 }

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -38,6 +38,9 @@ type Client interface {
 	// GetProvidersConfig returns the list of providers configured for this instance of clusterctl.
 	GetProvidersConfig() ([]Provider, error)
 
+	// GetProviderComponents returns the provider components for a given provider, targetNamespace, watchingNamespace.
+	GetProviderComponents(provider, targetNameSpace, watchingNamespace string) (Components, error)
+
 	// Init initializes a management cluster by adding the requested list of providers.
 	Init(options InitOptions) ([]Components, bool, error)
 }

--- a/cmd/clusterctl/pkg/client/client_test.go
+++ b/cmd/clusterctl/pkg/client/client_test.go
@@ -66,6 +66,10 @@ func (f fakeClient) GetProvidersConfig() ([]Provider, error) {
 	return f.internalClient.GetProvidersConfig()
 }
 
+func (f fakeClient) GetProviderComponents(provider, targetNameSpace, watchingNamespace string) (Components, error) {
+	return f.internalClient.GetProviderComponents(provider, targetNameSpace, watchingNamespace)
+}
+
 func (f fakeClient) Init(options InitOptions) ([]Components, bool, error) {
 	return f.internalClient.Init(options)
 }

--- a/cmd/clusterctl/pkg/client/config.go
+++ b/cmd/clusterctl/pkg/client/config.go
@@ -30,3 +30,12 @@ func (c *clusterctlClient) GetProvidersConfig() ([]Provider, error) {
 
 	return rr, nil
 }
+
+func (c *clusterctlClient) GetProviderComponents(provider, targetNameSpace, watchingNamespace string) (Components, error) {
+	components, err := c.getComponentsByName(provider, targetNameSpace, watchingNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return components, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `clusterctl config provider <povider-name>` command, that allows user to check the provider components YAML before being actually installed

**Which issue(s) this PR fixes** 
Rif #1729

/assign @vincepri 
/cc @ncdc
