### PR TITLE
:book: Add contributing and code of conduct markdown to SUMMARY TOC referenc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See also: our own [contributor guide] and the Kubernetes [community page].
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct].
 
 [community page]: https://kubernetes.io/community
-[Kubernetes Code of Conduct]: code-of-conduct.md
+[Kubernetes Code of Conduct]: https://github.com/kubernetes-sigs/cluster-api/blob/master/code-of-conduct.md
 [notes]: https://docs.google.com/document/d/1Ys-DOR5UsgbMEeciuG0HOgDQc8kZsaWIWJeKJ1-UfbY/edit
 [recordings]: https://www.youtube.com/playlist?list=PL69nYSiGNLP29D0nYgAGWt1ZFqS9Z7lw4
 [zoomMeeting]: https://zoom.us/j/861487554
@@ -56,7 +56,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 [providerZoomMeetingTues]: https://zoom.us/j/140808484
 [providerZoomMeetingWed]: https://zoom.us/j/424743530
 [issue tracker]: https://github.com/kubernetes-sigs/cluster-api/issues
-[contributor guide]: CONTRIBUTING.md
+[contributor guide]: https://github.com/kubernetes-sigs/cluster-api/blob/master/CONTRIBUTING.md
 
 
 <!-- ANCHOR_END: Community -->

--- a/docs/book/src/CONTRIBUTING.md
+++ b/docs/book/src/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+{{#include ../../../CONTRIBUTING.md}}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -25,3 +25,5 @@
     - [Glossary](./reference/glossary.md)
     - [Provider List](./reference/providers.md)
     - [clusterctl CLI](./tooling/clusterctl.md)
+    - [Code of Conduct](./code-of-conduct.md)
+    - [Contributing](./CONTRIBUTING.md)

--- a/docs/book/src/code-of-conduct.md
+++ b/docs/book/src/code-of-conduct.md
@@ -1,0 +1,1 @@
+{{#include ../../../code-of-conduct.md}}


### PR DESCRIPTION

**What this PR does / why we need it**:
Backports changes from Master to release-0.20 to fix links from https://github.com/kubernetes-sigs/cluster-api/commit/301fc1f19d3e4f1974d1d9370d4890a5fa81e139


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2046
