### PR TITLE
🏃 Improve release notes utility / add -from flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -440,7 +440,7 @@ release-alias-tag: ## Adds the tag to the last build tag.
 	gcloud container images add-tag $(KUBEADM_CONTROL_PLANE_CONTROLLER_IMG):$(TAG) $(KUBEADM_CONTROL_PLANE_CONTROLLER_IMG):$(RELEASE_ALIAS_TAG)
 
 .PHONY: release-notes
-release-notes:  ## Generates a release notes template to be used with a release.
+release-notes: $(RELEASE_NOTES)  ## Generates a release notes template to be used with a release.
 	$(RELEASE_NOTES)
 
 ## --------------------------------------


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR improves the release-notes utility to fix the following:
- Missing the first commit from the tag (which ended up empty)
- Add a `-from` flag to tell the application where to start
- Add the image repository line
- Fixes an issue where trimming the prefix would cause it to remove the first word of the commit message as well
