### PR TITLE
🐛 Improve clusterctl error message

### DIFF
--- a/cmd/clusterctl/pkg/client/common.go
+++ b/cmd/clusterctl/pkg/client/common.go
@@ -69,7 +69,7 @@ func parseProviderName(provider string) (name string, version string, err error)
 	name = t[0]
 	errs := validation.IsDNS1123Label(name)
 	if len(errs) != 0 {
-		return "", "", errors.Errorf("invalid name value: %s", strings.Join(errs, "; "))
+		return "", "", errors.Errorf("%s is an invalid provider name value: %s", name, strings.Join(errs, "; "))
 	}
 
 	version = ""

--- a/cmd/clusterctl/pkg/client/common_test.go
+++ b/cmd/clusterctl/pkg/client/common_test.go
@@ -47,7 +47,17 @@ func Test_parseProviderName(t *testing.T) {
 			wantVersion: "version",
 			wantErr:     false,
 		},
+		{
+			name: "invalid name",
+			args: args{
+				provider: "out/core-components.yaml",
+			},
+			wantName:    "",
+			wantVersion: "",
+			wantErr:     true,
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotName, gotVersion, err := parseProviderName(tt.args.provider)


### PR DESCRIPTION
Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR improves the error output when using `clusterctl`. For example, if the provider name that is passed in `--core` or `--bootstrap` is invalid, this will provide some more clarity on that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2055 
