### PR TITLE
:bug: Kubeadm-based Control Plane: Fix error handling during cleanup

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
@@ -394,7 +394,7 @@ func (r *KubeadmControlPlaneReconciler) cleanupFromGeneration(ctx context.Contex
 			config.SetNamespace(ref.Namespace)
 			config.SetName(ref.Name)
 
-			if err := r.Client.Delete(ctx, config); !apierrors.IsNotFound(err) {
+			if err := r.Client.Delete(ctx, config); err != nil && !apierrors.IsNotFound(err) {
 				errs = append(errs, errors.Wrap(err, "failed to cleanup generated resources after error"))
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a minor bug in the error handling. If err is nil, the condition evaluates to true. The condition should evaluate to true only if there is an actual error.

I discovered this issue when I was working on #2037. Other code that evaluates `!apierrors.IsNotFound` already checks that the error is not nil.