### PR TITLE
🐛 Fix concatenation of cluster-api-components.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,9 @@ release-manifests: $(RELEASE_DIR) ## Builds the manifests to publish with a rele
 	$(KUSTOMIZE) build config/core > $(RELEASE_DIR)/core-components.yaml
 	$(KUSTOMIZE) build bootstrap/kubeadm/config/default > $(RELEASE_DIR)/bootstrap-components.yaml
 	$(KUSTOMIZE) build controlplane/kubeadm/config/default > $(RELEASE_DIR)/control-plane-components.yaml
-	cat $(RELEASE_DIR)/core-components.yaml $(RELEASE_DIR)/bootstrap-components.yaml $(RELEASE_DIR)/control-plane-components.yaml > $(RELEASE_DIR)/cluster-api-components.yaml
+	@for f in $(RELEASE_DIR)/core-components.yaml $(RELEASE_DIR)/bootstrap-components.yaml $(RELEASE_DIR)/control-plane-components.yaml;\
+		do echo "---" | cat $$f - >> $(RELEASE_DIR)/cluster-api-components.yaml;\
+		done
 
 release-binaries: ## Builds the binaries to publish with a release
 	RELEASE_BINARY=./cmd/clusterctl GOOS=linux GOARCH=amd64 $(MAKE) release-binary


### PR DESCRIPTION
Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes the concatenation of out/cluster-api-components.yaml when running `make release-manifests`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2068 

