### PR TITLE
✨Add clusterctl labels to labels provider components

### DIFF
--- a/bootstrap/kubeadm/config/default/kustomization.yaml
+++ b/bootstrap/kubeadm/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: capi-kubeadm-bootstrap-system
 namePrefix: capi-kubeadm-bootstrap-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  cluster.x-k8s.io/provider: "bootstrap-kubeadm"
 
 bases:
 - ../crd

--- a/config/core/kustomization.yaml
+++ b/config/core/kustomization.yaml
@@ -1,5 +1,5 @@
-# The core kustomization bundles up all the bits that are capi-specific. 
-# Note that doesn't include bootstrap/controlplane components. 
+# The core kustomization bundles up all the bits that are capi-specific.
+# Note that doesn't include bootstrap/controlplane components.
 # This is just pure, vanilla capi
 
 # Adds namespace to all resources.
@@ -13,8 +13,8 @@ namespace: capi-system
 namePrefix: capi-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  cluster.x-k8s.io/provider: "cluster-api"
 
 bases:
 - ../crd

--- a/controlplane/kubeadm/config/default/kustomization.yaml
+++ b/controlplane/kubeadm/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: capi-kubeadm-control-plane-system
 namePrefix: capi-kubeadm-control-plane-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  cluster.x-k8s.io/provider: "controlplane-kubeadm"
 
 bases:
 - ../crd

--- a/docs/book/src/clusterctl/commands/adopt.md
+++ b/docs/book/src/clusterctl/commands/adopt.md
@@ -1,1 +1,11 @@
 # clusterctl adopt
+
+## Pre-requisites
+
+### Labels
+
+In order for `clusterctl adopt` to work, ensure the components are correctly
+labeled. Please see the [provider contract labels][provider-contract-labels] for reference.
+
+<!-- links -->
+[provider-contract-labels]: ../provider-contract.md#labels

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -7,11 +7,13 @@ The `clusterctl` config file is located at `$HOME/.cluster-api/clusterctl.yaml` 
 
 ## Provider repositories
 
-The `clusterctl` CLI is designed to work with providers implementing the [clusterct Provider Contract](contract.md).
+The `clusterctl` CLI is designed to work with providers implementing the [clusterctl Provider Contract](provider-contract.md).
 
 Each provider is expected to define a provider repository, a well-known place where release assets are published. 
 
-By default, `clusterctl` ships with providers sponsored by SIG Cluster Lifecycle. 
+By default, `clusterctl` ships with providers sponsored by SIG Cluster
+Lifecycle. Use `clusterctl config providers` to get a list of supported
+providers.
 
 Users can customize the list of available providers using the `clusterctl` configuration file, as shown in the following example:
 

--- a/docs/book/src/clusterctl/provider-contract.md
+++ b/docs/book/src/clusterctl/provider-contract.md
@@ -4,7 +4,7 @@ The `clusterctl` command is designed to work with all the providers compliant wi
 
 ## Provider Repositories
 
-Each provider MUST define a **provider repository**, that is a well-known place where the release assets for 
+Each provider MUST define a **provider repository**, that is a well-known place where the release assets for
 a provider are published.
 
 The provider repository MUST contain the following files:
@@ -22,7 +22,7 @@ Additionally, the provider repository SHOULD contain the following files:
 <h1> Pre-defined list of providers </h1>
 
 The `clusterctl` command ships with a pre-defined list of provider repositories that allows a simpler "out-of-the-box" user experience.
-If, as a provider implementer, you are interested to be added to this list, please send a PR to the Cluster API repository.
+As a provider implementer, if you are interested to be added to this list, please create an issue to the [Cluster API repository](https://sigs.k8s.io/cluster-api).
 
 </aside>
 
@@ -103,7 +103,7 @@ the provider installation.
 Each provider is expected to deploy controllers using a Deployment.
 
 While defining the Deployment Spec, the container that executes the controller binary MUST be called `manager`.
- 
+
 The manager MUST support a `--namespace` flag for specifying the namespace where the controller
 will look for objects to reconcile.
 
@@ -114,11 +114,28 @@ recommended to prefix the variable name with the provider name e.g. `${ AWS_CRED
 
 Additionally, each provider should create user facing documentation with the list of required variables and with all the additional
 notes that are required to assist the user in defining the value for each variable.
- 
+
+#### Labels
+The components YAML components should be labeled with
+`cluster.x-k8s.io/provider` and the name of the provider. This will enable an
+easier transition from `kubectl apply` to `clusterctl`.
+
+As a reference you can consider the labels applied to the following
+providers.
+
+| Provider Name| Label                                            |
+|--------------|--------------------------------------------------|
+|CAPI          | cluster.x-k8s.io/provider=cluster-api            |
+|CABPK         | cluster.x-k8s.io/provider=bootstrap-kubeadm      |
+|CACPK         | cluster.x-k8s.io/provider=controlplane-kubeadm   |
+|CAPA          | cluster.x-k8s.io/provider=infrastructure-aws     |
+|CAPV          | cluster.x-k8s.io/provider=infrastructure-vsphere |
+|CAPD          | cluster.x-k8s.io/provider=infrastructure-docker  |
+
 ### Workload cluster templates
 
-An infrastructure provider could publish a **cluster templates** file to be used by `clusterctl config cluster`. 
-This is single YAML with _all_ the objects required to create a new workload cluster. 
+An infrastructure provider could publish a **cluster templates** file to be used by `clusterctl config cluster`.
+This is single YAML with _all_ the objects required to create a new workload cluster.
 
 The following rules apply:
 

--- a/test/infrastructure/docker/config/default/kustomization.yaml
+++ b/test/infrastructure/docker/config/default/kustomization.yaml
@@ -11,8 +11,8 @@ namespace: capd-system
 namePrefix: capd-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  cluster.x-k8s.io/provider: "docker"
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
 #- ../webhook


### PR DESCRIPTION
Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds clusterctl labels to provider components but intentionally not in the selectors for services and controller deployments.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1989 
