### PR TITLE
🐛clusterctl: remove --force flag from init

### DIFF
--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -30,7 +30,6 @@ type initOptions struct {
 	infrastructureProviders []string
 	targetNamespace         string
 	watchingNamespace       string
-	force                   bool
 }
 
 var io = &initOptions{}
@@ -89,7 +88,6 @@ func init() {
 	initCmd.Flags().StringSliceVarP(&io.bootstrapProviders, "bootstrap", "b", nil, "Bootstrap providers to add to the management cluster. By default (empty), the kubeadm bootstrap provider is installed on the first init")
 	initCmd.Flags().StringVarP(&io.targetNamespace, "target-namespace", "", "", "The target namespace where the providers should be deployed. If not specified, each provider will be installed in a provider's default namespace")
 	initCmd.Flags().StringVarP(&io.watchingNamespace, "watching-namespace", "", "", "Namespace that the providers should watch to reconcile Cluster API objects. If unspecified, the providers watches for Cluster API objects across all namespaces")
-	initCmd.Flags().BoolVarP(&io.force, "force", "f", false, "Force clusterctl to skip preflight checks about supported configurations for a management cluster")
 
 	RootCmd.AddCommand(initCmd)
 }
@@ -109,7 +107,6 @@ func runInit() error {
 		InfrastructureProviders: io.infrastructureProviders,
 		TargetNameSpace:         io.targetNamespace,
 		WatchingNamespace:       io.watchingNamespace,
-		Force:                   io.force,
 	})
 	if err != nil {
 		return err

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -30,7 +30,6 @@ type InitOptions struct {
 	InfrastructureProviders []string
 	TargetNameSpace         string
 	WatchingNamespace       string
-	Force                   bool
 }
 
 // Client is exposes the clusterctl high-level client library

--- a/cmd/clusterctl/pkg/client/cluster/installer.go
+++ b/cmd/clusterctl/pkg/client/cluster/installer.go
@@ -27,7 +27,7 @@ type ProviderInstaller interface {
 	// Add adds a provider to the install queue.
 	// NB. By deferring the installation, the installer service can perform validation of the target state of the management cluster
 	// before actually starting the installation of new providers.
-	Add(repository.Components, bool) error
+	Add(repository.Components) error
 
 	// Install performs the installation of the providers ready in the install queue.
 	Install() ([]repository.Components, error)
@@ -43,11 +43,9 @@ type providerInstaller struct {
 
 var _ ProviderInstaller = &providerInstaller{}
 
-func (i *providerInstaller) Add(components repository.Components, force bool) error {
+func (i *providerInstaller) Add(components repository.Components) error {
 	if err := i.providerInventory.Validate(components.Metadata()); err != nil {
-		if !force {
-			return errors.Wrapf(err, "Installing provider %q can lead to a non functioning management cluster (you can use --force to ignore this error).", components.Name())
-		}
+		return errors.Wrapf(err, "Installing provider %q can lead to a non functioning management cluster.", components.Name())
 	}
 
 	i.installQueue = append(i.installQueue, components)

--- a/cmd/clusterctl/pkg/client/cluster/inventory.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory.go
@@ -128,20 +128,6 @@ func (p *inventoryClient) Validate(m clusterctlv1.Provider) error {
 		}
 	}
 
-	// Version check:
-	// If we are going to install an instance of a provider with version X, and there are already other instances of the same provider with
-	// different versions there is the risk of creating problems to all the version different than X because we are going to override
-	// all the existing non-namespaced objects (e.g. CRDs) with the ones from version X
-	sameVersion := false
-	for _, i := range instances {
-		if i.Version == m.Version {
-			sameVersion = true
-		}
-	}
-	if !sameVersion {
-		return errors.Errorf("The new instance of the %q provider has a version different than other instances of the same provider", m.Name)
-	}
-
 	// Watching Namespace check:
 	// If we are going to install an instance of a provider watching objects in namespaces already controlled by other providers
 	// then there will be providers fighting for objects...

--- a/cmd/clusterctl/pkg/client/init.go
+++ b/cmd/clusterctl/pkg/client/init.go
@@ -66,7 +66,6 @@ func (c *clusterctlClient) Init(options InitOptions) ([]Components, bool, error)
 		installer:         installer,
 		targetNameSpace:   options.TargetNameSpace,
 		watchingNamespace: options.WatchingNamespace,
-		force:             options.Force,
 	}
 
 	if options.CoreProvider != "" {
@@ -100,7 +99,6 @@ type addToInstallerOptions struct {
 	installer         cluster.ProviderInstaller
 	targetNameSpace   string
 	watchingNamespace string
-	force             bool
 }
 
 // addToInstaller adds the components to the install queue and checks that the actual provider type match the target group
@@ -115,7 +113,7 @@ func (c *clusterctlClient) addToInstaller(options addToInstallerOptions, targetG
 			return errors.Errorf("can't use %q provider as an %q, it is a %q", provider, targetGroup, components.Type())
 		}
 
-		if err := options.installer.Add(components, options.force); err != nil {
+		if err := options.installer.Add(components); err != nil {
 			return err
 		}
 	}

--- a/cmd/clusterctl/pkg/client/init_test.go
+++ b/cmd/clusterctl/pkg/client/init_test.go
@@ -38,7 +38,6 @@ func Test_clusterctlClient_Init(t *testing.T) {
 		infrastructureProvider []string
 		targetNameSpace        string
 		watchingNamespace      string
-		force                  bool
 	}
 	type want struct {
 		provider          Provider
@@ -66,7 +65,6 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				infrastructureProvider: []string{"infra"},
 				targetNameSpace:        "",
 				watchingNamespace:      "",
-				force:                  false,
 			},
 			want: []want{
 				{
@@ -102,7 +100,6 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				infrastructureProvider: []string{"infra:v3.1.0"},
 				targetNameSpace:        "",
 				watchingNamespace:      "",
-				force:                  false,
 			},
 			want: []want{
 				{
@@ -138,7 +135,6 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				infrastructureProvider: []string{"infra"},
 				targetNameSpace:        "nsx",
 				watchingNamespace:      "",
-				force:                  false,
 			},
 			want: []want{
 				{
@@ -174,7 +170,6 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				infrastructureProvider: []string{"infra"},
 				targetNameSpace:        "",
 				watchingNamespace:      "",
-				force:                  false,
 			},
 			want: []want{
 				{
@@ -203,7 +198,6 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				infrastructureProvider: []string{"infra"},
 				targetNameSpace:        "",
 				watchingNamespace:      "",
-				force:                  false,
 			},
 			want:    nil,
 			wantErr: true,
@@ -219,7 +213,6 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				infrastructureProvider: []string{"infra"},
 				targetNameSpace:        "",
 				watchingNamespace:      "",
-				force:                  false,
 			},
 			want:    nil,
 			wantErr: true,
@@ -235,7 +228,6 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				infrastructureProvider: []string{config.KubeadmBootstrapProviderName},
 				targetNameSpace:        "",
 				watchingNamespace:      "",
-				force:                  false,
 			},
 			want:    nil,
 			wantErr: true,
@@ -257,7 +249,6 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				InfrastructureProviders: tt.args.infrastructureProvider,
 				TargetNameSpace:         tt.args.targetNameSpace,
 				WatchingNamespace:       tt.args.watchingNamespace,
-				Force:                   tt.args.force,
 			})
 
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
**What this PR does / why we need it**:
As per https://github.com/kubernetes-sigs/cluster-api/issues/2057#issuecomment-574215538 comment, this PR removes the `--force` flag from `clusterctl init`.
Contextually, also an `inventory.Validate `check is removed because not anymore necessary after recent changes.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2057
