### PR TITLE
✨clusterctl: add the delete command

### DIFF
--- a/cmd/clusterctl/cmd/delete.go
+++ b/cmd/clusterctl/cmd/delete.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client"
 )
 
 type deleteOptions struct {
@@ -96,5 +97,20 @@ func init() {
 }
 
 func runDelete(args []string) error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Delete(client.DeleteOptions{
+		Kubeconfig:           dd.kubeconfig,
+		ForceDeleteNamespace: dd.forceDeleteNamespace,
+		ForceDeleteCRD:       dd.forceDeleteCRD,
+		Namespace:            dd.targetNamespace,
+		Providers:            args,
+	}); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
 )
 
-// InitOptions carries the options supported by Init
+// InitOptions carries the options supported by Init.
 type InitOptions struct {
 	Kubeconfig              string
 	CoreProvider            string
@@ -32,7 +32,7 @@ type InitOptions struct {
 	WatchingNamespace       string
 }
 
-// GetClusterTemplateOptions carries the options supported by GetClusterTemplate
+// GetClusterTemplateOptions carries the options supported by GetClusterTemplate.
 type GetClusterTemplateOptions struct {
 	Kubeconfig               string
 	InfrastructureProvider   string
@@ -43,6 +43,15 @@ type GetClusterTemplateOptions struct {
 	KubernetesVersion        string
 	ControlPlaneMachineCount int
 	WorkerMachineCount       int
+}
+
+// DeleteOptions carries the options supported by Delete.
+type DeleteOptions struct {
+	Kubeconfig           string
+	ForceDeleteNamespace bool
+	ForceDeleteCRD       bool
+	Namespace            string
+	Providers            []string
 }
 
 // Client is exposes the clusterctl high-level client library
@@ -58,6 +67,9 @@ type Client interface {
 
 	// GetClusterTemplate returns a workload cluster template.
 	GetClusterTemplate(options GetClusterTemplateOptions) (Template, error)
+
+	// Delete deletes providers from a management cluster.
+	Delete(options DeleteOptions) error
 }
 
 // clusterctlClient implements Client.

--- a/cmd/clusterctl/pkg/client/client_test.go
+++ b/cmd/clusterctl/pkg/client/client_test.go
@@ -44,7 +44,7 @@ func TestNewFakeClient(t *testing.T) {
 		WithFile("v1.0", "components.yaml", []byte("content"))
 
 	// create a fake cluster, eventually adding some existing runtime objects to it
-	cluster1 := newFakeCluster("kubeconfig").
+	cluster1 := newFakeCluster("cluster1").
 		WithObjs()
 
 	// create a new fakeClient that allows to execute tests on the fake config, the fake repositories and the fake cluster.
@@ -76,6 +76,10 @@ func (f fakeClient) GetClusterTemplate(options GetClusterTemplateOptions) (Templ
 
 func (f fakeClient) Init(options InitOptions) ([]Components, bool, error) {
 	return f.internalClient.Init(options)
+}
+
+func (f fakeClient) Delete(options DeleteOptions) error {
+	return f.internalClient.Delete(options)
 }
 
 // newFakeClient returns a clusterctl client that allows to execute tests on a set of fake config, fake repositories and fake clusters.

--- a/cmd/clusterctl/pkg/client/cluster/client.go
+++ b/cmd/clusterctl/pkg/client/cluster/client.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -124,6 +125,10 @@ type Proxy interface {
 
 	// NewClient returns a new controller runtime Client object for working on the management cluster
 	NewClient() (client.Client, error)
+
+	// ListResources returns all the Kubernetes objects existing in a namespace (or in all namespaces if empty)
+	// with the given labels.
+	ListResources(namespace string, labels map[string]string) ([]unstructured.Unstructured, error)
 }
 
 var _ Proxy = &test.FakeProxy{}

--- a/cmd/clusterctl/pkg/client/cluster/components.go
+++ b/cmd/clusterctl/pkg/client/cluster/components.go
@@ -20,16 +20,30 @@ import (
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type DeleteOptions struct {
+	Provider             clusterctlv1.Provider
+	ForceDeleteNamespace bool
+	ForceDeleteCRD       bool
+}
+
 // ComponentsClient has methods to work with provider components in the cluster.
 type ComponentsClient interface {
+	// Create creates the provider components in the management cluster.
 	Create(components repository.Components) error
 
-	//TODO: add more in a follow up PR
+	// Delete deletes the provider components from the management cluster.
+	// The operation is designed to prevent accidental deletion of user created objects, so
+	// it is required to explicitly opt-in for the deletion of the namespace where the provider components are hosted
+	// and for the deletion of the provider's CRDs.
+	Delete(options DeleteOptions) error
 }
 
 // providerComponents implements ComponentsClient.
@@ -49,41 +63,104 @@ func (p *providerComponents) Create(components repository.Components) error {
 	resources := sortResourcesForCreate(components.Objs())
 
 	// creates (or updates) provider components
-	for _, r := range resources {
+	for i := range resources {
+		obj := resources[i]
 
 		// check if the component already exists, and eventually update it
 		currentR := &unstructured.Unstructured{}
-		currentR.SetGroupVersionKind(r.GroupVersionKind())
+		currentR.SetGroupVersionKind(obj.GroupVersionKind())
 
 		key := client.ObjectKey{
-			Namespace: r.GetNamespace(),
-			Name:      r.GetName(),
+			Namespace: obj.GetNamespace(),
+			Name:      obj.GetName(),
 		}
-		if err = c.Get(ctx, key, currentR); err != nil {
+		if err := c.Get(ctx, key, currentR); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return errors.Wrapf(err, "failed to get current provider object")
 			}
 
 			//if it does not exists, create the component
-			klog.V(3).Infof("Creating: %s, %s/%s", r.GroupVersionKind(), r.GetNamespace(), r.GetName())
-			if err = c.Create(ctx, &r); err != nil { //nolint
-				return errors.Wrapf(err, "failed to create provider object %s, %s/%s", r.GroupVersionKind(), r.GetNamespace(), r.GetName())
+			klog.V(3).Infof("Creating: %s, %s/%s", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
+			if err := c.Create(ctx, &obj); err != nil {
+				return errors.Wrapf(err, "failed to create provider object %s, %s/%s", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
 			}
 
 			continue
 		}
 
 		// otherwise update the component
-		klog.V(3).Infof("Updating: %s, %s/%s", r.GroupVersionKind(), r.GetNamespace(), r.GetName())
+		klog.V(3).Infof("Updating: %s, %s/%s", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
 
 		// if upgrading an existing component, then use the current resourceVersion for the optimistic lock
-		r.SetResourceVersion(currentR.GetResourceVersion())
-		if err = c.Update(ctx, &r); err != nil { //nolint
-			return errors.Wrapf(err, "failed to update provider object %s, %s/%s", r.GroupVersionKind(), r.GetNamespace(), r.GetName())
+		obj.SetResourceVersion(currentR.GetResourceVersion())
+		if err := c.Update(ctx, &obj); err != nil {
+			return errors.Wrapf(err, "failed to update provider object %s, %s/%s", obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
 		}
 	}
 
 	return nil
+}
+
+func (p *providerComponents) Delete(options DeleteOptions) error {
+	// Fetch all the components belonging to a provider.
+	labels := map[string]string{
+		clusterctlv1.ClusterctlProviderLabelName: options.Provider.Name,
+	}
+	resources, err := p.proxy.ListResources(options.Provider.Namespace, labels)
+	if err != nil {
+		return err
+	}
+
+	resourcesToDelete := []unstructured.Unstructured{}
+	namespacesToDelete := sets.NewString()
+	for _, obj := range resources {
+		// If the CRDs should NOT be deleted, skip it;
+		// NB. Skipping CRDs deletion ensures that also the objects of Kind defined in the CRDs Kind are not deleted.
+		if obj.GroupVersionKind().Kind == "CustomResourceDefinition" && !options.ForceDeleteCRD {
+			continue
+		}
+
+		// If the Namespace should NOT be deleted, skip it, otherwise keep track of the namespaces we are deleting;
+		// NB. Skipping Namespaces deletion ensures that also the objects hosted in the namespace but without the "clusterctl.cluster.x-k8s.io/provider" label are not deleted.
+		if obj.GroupVersionKind().Kind == "Namespace" {
+			if !options.ForceDeleteNamespace {
+				continue
+			}
+			namespacesToDelete.Insert(obj.GetName())
+		}
+
+		resourcesToDelete = append(resourcesToDelete, obj)
+	}
+
+	// Delete all the provider components.
+	cs, err := p.proxy.NewClient()
+	if err != nil {
+		return err
+	}
+
+	errList := []error{}
+	for i := range resourcesToDelete {
+		obj := resourcesToDelete[i]
+
+		// if the objects is in a namespace that is going to be deleted, skip deletion
+		// because everything that is contained in the namespace will be deleted by the Namespace controller
+		if namespacesToDelete.Has(obj.GetNamespace()) {
+			continue
+		}
+
+		// Otherwise delete the object
+		if err := cs.Delete(ctx, &obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Tolerate IsNotFound error that might happen because we are not enforcing a deletion order
+				// that considers relation across objects (e.g. Deployments -> ReplicaSets -> Pods)
+				continue
+			}
+			errList = append(errList, errors.Wrapf(err, "Error deleting object %s, %s/%s",
+				obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName()))
+		}
+	}
+
+	return kerrors.NewAggregate(errList)
 }
 
 // newComponentsClient returns a providerComponents.

--- a/cmd/clusterctl/pkg/client/cluster/components_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/components_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func Test_providerComponents_Delete(t *testing.T) {
+	labels := map[string]string{
+		clusterctlv1.ClusterctlProviderLabelName: "aws",
+	}
+
+	crd := unstructured.Unstructured{}
+	crd.SetAPIVersion("apiextensions.k8s.io/v1beta1")
+	crd.SetKind("CustomResourceDefinition")
+	crd.SetName("crd1")
+	crd.SetLabels(labels)
+
+	initObjs := []runtime.Object{
+		// Namespace (should be deleted only if forceDeleteNamespace)
+		&corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Namespace",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "ns1",
+				Labels: labels,
+			},
+		},
+		// A provider component (should always be deleted)
+		&corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Pod",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns1",
+				Name:      "pod1",
+				Labels:    labels,
+			},
+		},
+		// Another object in the namespace but not belonging to the provider (should go away only when deleting the namespace)
+		&corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Pod",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns1",
+				Name:      "pod2",
+			},
+		},
+		// CRDs (should be deleted only if forceDeleteCRD)
+		&crd,
+		// Another object out of the provider namespace (should never be deleted)
+		&corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Pod",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns2",
+				Name:      "pod3",
+				Labels:    labels,
+			},
+		},
+	}
+
+	type args struct {
+		provider             clusterctlv1.Provider
+		forceDeleteNamespace bool
+		forceDeleteCRD       bool
+	}
+	type wantDiff struct {
+		object  corev1.ObjectReference
+		deleted bool
+	}
+
+	tests := []struct {
+		name     string
+		args     args
+		wantDiff []wantDiff
+		wantErr  bool
+	}{
+		{
+			name: "Delete provider while preserving Namespace and CRDs",
+			args: args{
+				provider:             clusterctlv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "aws", Namespace: "ns1"}},
+				forceDeleteNamespace: false,
+				forceDeleteCRD:       false,
+			},
+			wantDiff: []wantDiff{
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: false},                                           //namespace should be preserved
+				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: false}, //crd should be preserved
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                               // provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: false},                              // other objects in the namespace should not be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                              // this object is in another namespace, and should never be touched by delete
+			},
+			wantErr: false,
+		},
+		{
+			name: "Delete provider and provider namespace, while preserving CRDs",
+			args: args{
+				provider:             clusterctlv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "aws", Namespace: "ns1"}},
+				forceDeleteNamespace: true,
+				forceDeleteCRD:       false,
+			},
+			wantDiff: []wantDiff{
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: true},                                            //namespace should be deleted
+				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: false}, //crd should be preserved
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                               // provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: true},                               // other objects in the namespace goes away when deleting the namespace
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                              // this object is in another namespace, and should never be touched by delete
+			},
+			wantErr: false,
+		},
+
+		{
+			name: "Delete provider and provider CRDs, while preserving the provider namespace",
+			args: args{
+				provider:             clusterctlv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "aws", Namespace: "ns1"}},
+				forceDeleteNamespace: false,
+				forceDeleteCRD:       true,
+			},
+			wantDiff: []wantDiff{
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: false},                                          //namespace should be preserved
+				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: true}, //crd should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                              // provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: false},                             // other objects in the namespace should not be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                             // this object is in another namespace, and should never be touched by delete
+			},
+			wantErr: false,
+		},
+
+		{
+			name: "Delete provider, provider namespace and provider CRDs",
+			args: args{
+				provider:             clusterctlv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "aws", Namespace: "ns1"}},
+				forceDeleteNamespace: true,
+				forceDeleteCRD:       true,
+			},
+			wantDiff: []wantDiff{
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: true},                                           //namespace should be deleted
+				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: true}, //crd should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                              // provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: true},                              // other objects in the namespace goes away when deleting the namespace
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                             // this object is in another namespace, and should never be touched by delete
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := test.NewFakeProxy().WithObjs(initObjs...)
+			c := newComponentsClient(proxy)
+			err := c.Delete(DeleteOptions{
+				Provider:             tt.args.provider,
+				ForceDeleteNamespace: tt.args.forceDeleteNamespace,
+				ForceDeleteCRD:       tt.args.forceDeleteCRD,
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			cs, err := proxy.NewClient()
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+			for _, want := range tt.wantDiff {
+				obj := &unstructured.Unstructured{}
+				obj.SetAPIVersion(want.object.APIVersion)
+				obj.SetKind(want.object.Kind)
+
+				key := client.ObjectKey{
+					Namespace: want.object.Namespace,
+					Name:      want.object.Name,
+				}
+
+				err := cs.Get(ctx, key, obj)
+				if err != nil && !apierrors.IsNotFound(err) {
+					t.Fatalf("Failed to get %v from the cluster: %v", key, err)
+				}
+
+				if !want.deleted && apierrors.IsNotFound(err) {
+					t.Errorf("%v deleted, expect NOT deleted", key)
+				}
+
+				if want.deleted && !apierrors.IsNotFound(err) {
+					if want.object.Namespace == tt.args.provider.Namespace && tt.args.forceDeleteNamespace { // Ignoring namespaced object that should be deleted by the namespace controller.
+						continue
+					}
+					t.Errorf("%v not deleted, expect deleted", key)
+				}
+			}
+		})
+	}
+}

--- a/cmd/clusterctl/pkg/client/cluster/proxy.go
+++ b/cmd/clusterctl/pkg/client/cluster/proxy.go
@@ -18,6 +18,10 @@ package cluster
 
 import (
 	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/scheme"
@@ -76,6 +80,62 @@ func (k *proxy) NewClient() (client.Client, error) {
 	return c, nil
 }
 
+func (k *proxy) ListResources(namespace string, labels map[string]string) ([]unstructured.Unstructured, error) {
+	cs, err := k.newClientSet()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := k.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get all the API resources in the cluster.
+	resourceList, err := cs.Discovery().ServerPreferredResources()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list api resources")
+	}
+
+	// Select resources with list and delete methods (list is required by this method, delete by the callers of this method)
+	resourceList = discovery.FilteredBy(discovery.SupportsAllVerbs{Verbs: []string{"list", "delete"}}, resourceList)
+
+	var ret []unstructured.Unstructured
+	for _, resourceGroup := range resourceList {
+		for _, resourceKind := range resourceGroup.APIResources {
+			// Discard the resourceKind that exists in two api groups (we are excluding one of the two groups arbitrarily).
+			if resourceGroup.GroupVersion == "extensions/v1beta1" &&
+				(resourceKind.Name == "daemonsets" || resourceKind.Name == "deployments" || resourceKind.Name == "replicasets" || resourceKind.Name == "networkpolicies" || resourceKind.Name == "ingresses") {
+				continue
+			}
+
+			// List all the object instances of this resourceKind with the given labels
+			selectors := []client.ListOption{
+				client.MatchingLabels(labels),
+			}
+
+			if namespace != "" && resourceKind.Namespaced {
+				selectors = append(selectors, client.InNamespace(namespace))
+			}
+
+			objList := new(unstructured.UnstructuredList)
+			objList.SetAPIVersion(resourceGroup.GroupVersion)
+			objList.SetKind(resourceKind.Kind)
+
+			if err := c.List(ctx, objList, selectors...); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return nil, errors.Wrapf(err, "failed to list objects for the %q GroupVersionKind", objList.GroupVersionKind())
+			}
+
+			// Add obj to the result.
+			ret = append(ret, objList.Items...)
+		}
+	}
+	return ret, nil
+}
+
 func newProxy(kubeconfig string) Proxy {
 	// If a kubeconfig file isn't provided, find one in the standard locations.
 	if kubeconfig == "" {
@@ -98,4 +158,18 @@ func (k *proxy) getConfig() (*rest.Config, error) {
 	}
 
 	return restConfig, nil
+}
+
+func (k *proxy) newClientSet() (*kubernetes.Clientset, error) {
+	config, err := k.getConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create the client-go client")
+	}
+
+	cs, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create the client-go client")
+	}
+
+	return cs, nil
 }

--- a/cmd/clusterctl/pkg/client/delete.go
+++ b/cmd/clusterctl/pkg/client/delete.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/cluster"
+)
+
+func (c *clusterctlClient) Delete(options DeleteOptions) error {
+	clusterClient, err := c.clusterClientFactory(options.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	if err := clusterClient.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
+		return err
+	}
+
+	// Get the list of installed providers.
+	installedProviders, err := clusterClient.ProviderInventory().List()
+	if err != nil {
+		return err
+	}
+
+	// If the list of providers to delete is empty, delete all the providers.
+	// Prepare the list of providers to delete.
+	var providers []clusterctlv1.Provider
+
+	if len(options.Providers) == 0 {
+		providers = installedProviders
+	} else {
+		// Otherwise we are deleting only a subset of providers.
+		for _, provider := range options.Providers {
+			// Parse the abbreviated syntax for name[:version]
+			name, _, err := parseProviderName(provider)
+			if err != nil {
+				return err
+			}
+
+			// If the namespace where the provider is installed is not provided, try to detect it
+			namespace := options.Namespace
+			if namespace == "" {
+				namespace, err = clusterClient.ProviderInventory().GetDefaultProviderNamespace(name)
+				if err != nil {
+					return err
+				}
+
+				// if there are more instance of a providers, it is not possible to get a default namespace for the provider,
+				// so we should return and ask for it.
+				if namespace == "" {
+					return errors.Errorf("Unable to find default namespace for the %q provider. Please specify the provider's namespace", name)
+				}
+			}
+
+			// Check the provider/namespace tuple actually matches one of the installed providers.
+			for _, ip := range installedProviders {
+				if ip.Name == name && ip.Namespace == namespace {
+					providers = append(providers, ip)
+					break
+				}
+			}
+
+			// In case the provider does not match any installed providers, we still force deletion
+			// so the user can do 'delete' without removing CRD and after some time 'delete --delete-crd' (same for the namespace).
+			providers = append(providers, clusterctlv1.Provider{ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			}})
+		}
+	}
+
+	// Delete the selected providers
+	for _, provider := range providers {
+		if err := clusterClient.ProviderComponents().Delete(cluster.DeleteOptions{Provider: provider, ForceDeleteNamespace: options.ForceDeleteNamespace, ForceDeleteCRD: options.ForceDeleteCRD}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/clusterctl/pkg/client/delete_test.go
+++ b/cmd/clusterctl/pkg/client/delete_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+)
+
+func Test_clusterctlClient_Delete(t *testing.T) {
+	type fields struct {
+		client *fakeClient
+	}
+	type args struct {
+		options DeleteOptions
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		wantProviders sets.String
+		wantErr       bool
+	}{
+		{
+			name: "Delete all the providers",
+			fields: fields{
+				client: fakeClusterForDelete(),
+			},
+			args: args{
+				options: DeleteOptions{
+					Kubeconfig:           "kubeconfig",
+					ForceDeleteNamespace: false,
+					ForceDeleteCRD:       false,
+					Namespace:            "",
+					Providers:            nil, // nil means all the providers
+				},
+			},
+			wantProviders: sets.NewString(),
+			wantErr:       false,
+		},
+		{
+			name: "Delete single provider",
+			fields: fields{
+				client: fakeClusterForDelete(),
+			},
+			args: args{
+				options: DeleteOptions{
+					Kubeconfig:           "kubeconfig",
+					ForceDeleteNamespace: false,
+					ForceDeleteCRD:       false,
+					Namespace:            "capbpk-system",
+					Providers:            []string{bootstrapProviderConfig.Name()},
+				},
+			},
+			wantProviders: sets.NewString(capiProviderConfig.Name()),
+			wantErr:       false,
+		},
+		{
+			name: "Delete single provider auto-detect namespace",
+			fields: fields{
+				client: fakeClusterForDelete(),
+			},
+			args: args{
+				options: DeleteOptions{
+					Kubeconfig:           "kubeconfig",
+					ForceDeleteNamespace: false,
+					ForceDeleteCRD:       false,
+					Namespace:            "", // empty namespace triggers namespace auto detection
+					Providers:            []string{bootstrapProviderConfig.Name()},
+				},
+			},
+			wantProviders: sets.NewString(capiProviderConfig.Name()),
+			wantErr:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fields.client.Delete(tt.args.options); (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			proxy := tt.fields.client.clusters["kubeconfig"].Proxy()
+			gotProviders := &clusterctlv1.ProviderList{}
+
+			c, err := proxy.NewClient()
+			if err != nil {
+				t.Fatalf("failed to create client %v", err)
+			}
+
+			if err := c.List(context.TODO(), gotProviders); err != nil {
+				t.Fatalf("failed to read providers %v", err)
+			}
+
+			gotProvidersSet := sets.NewString()
+			for _, gotProvider := range gotProviders.Items {
+				gotProvidersSet.Insert(gotProvider.Name)
+			}
+
+			if !reflect.DeepEqual(gotProvidersSet, tt.wantProviders) {
+				t.Errorf("got = %v providers, want %v", len(gotProviders.Items), len(tt.wantProviders))
+			}
+		})
+	}
+}
+
+// clusterctl client for a management cluster with capi and bootstrap provider
+func fakeClusterForDelete() *fakeClient {
+	config1 := newFakeConfig().
+		WithVar("var", "value").
+		WithProvider(capiProviderConfig).
+		WithProvider(bootstrapProviderConfig)
+
+	repository1 := newFakeRepository(capiProviderConfig, config1.Variables()).
+		WithPaths("root", "components.yaml").
+		WithDefaultVersion("v1.0.0").
+		WithFile("v1.0.0", "components.yaml", componentsYAML("ns1")).
+		WithFile("v1.1.0", "components.yaml", componentsYAML("ns1"))
+	repository2 := newFakeRepository(bootstrapProviderConfig, config1.Variables()).
+		WithPaths("root", "components.yaml").
+		WithDefaultVersion("v2.0.0").
+		WithFile("v2.0.0", "components.yaml", componentsYAML("ns2")).
+		WithFile("v2.1.0", "components.yaml", componentsYAML("ns2"))
+
+	cluster1 := newFakeCluster("kubeconfig")
+	cluster1.fakeProxy.WithProviderInventory(capiProviderConfig.Name(), capiProviderConfig.Type(), "v1.0.0", "capi-system", "")
+	cluster1.fakeProxy.WithProviderInventory(bootstrapProviderConfig.Name(), bootstrapProviderConfig.Type(), "v1.0.0", "capbpk-system", "")
+
+	client := newFakeClient(config1).
+		// fake repository for capi, bootstrap and infra provider (matching provider's config)
+		WithRepository(repository1).
+		WithRepository(repository2).
+		// fake empty cluster
+		WithCluster(cluster1)
+
+	return client
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements the `clusterctl delete` command.

TODO: refactor the list of parameters for delete into a struct
TODO: add more tests

**Which issue(s) this PR fixes** :
rif #1729 
