### PR TITLE
🏃Add remote fake client

### DIFF
--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -27,9 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
+// ClusterClientGetter returns a new remote client.
+type ClusterClientGetter func(c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error)
+
 // NewClusterClient returns a Client for interacting with a remote Cluster using the given scheme for encoding and decoding objects.
 func NewClusterClient(c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error) {
-
 	restConfig, err := RESTConfig(c, cluster)
 	if err != nil {
 		return nil, err

--- a/controllers/remote/fake/cluster.go
+++ b/controllers/remote/fake/cluster.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewClusterClient returns the same client passed as input, as output. It is assumed that the client is a
+// fake controller-runtime client
+func NewClusterClient(c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error) {
+	return c, nil
+}

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -40,6 +40,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
+	fakeremote "sigs.k8s.io/cluster-api/controllers/remote/fake"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/secret"
@@ -501,11 +502,9 @@ func TestReconcileClusterNoEndpoints(t *testing.T) {
 	log.SetLogger(klogr.New())
 
 	r := &KubeadmControlPlaneReconciler{
-		Client: fakeClient,
-		Log:    log.Log,
-		remoteClient: func(c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
-			return c, nil
-		},
+		Client:             fakeClient,
+		Log:                log.Log,
+		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
@@ -601,11 +600,9 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 	expectedLabels := map[string]string{clusterv1.ClusterLabelName: "foo"}
 
 	r := &KubeadmControlPlaneReconciler{
-		Client: fakeClient,
-		Log:    log.Log,
-		remoteClient: func(c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
-			return c, nil
-		},
+		Client:             fakeClient,
+		Log:                log.Log,
+		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
@@ -834,11 +831,9 @@ func TestKubeadmControlPlaneReconciler_updateStatusNoMachines(t *testing.T) {
 	log.SetLogger(klogr.New())
 
 	r := &KubeadmControlPlaneReconciler{
-		Client: fakeClient,
-		Log:    log.Log,
-		remoteClient: func(c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
-			return c, nil
-		},
+		Client:             fakeClient,
+		Log:                log.Log,
+		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(gomega.Succeed())
@@ -922,11 +917,9 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesNotReady(t *testin
 	log.SetLogger(klogr.New())
 
 	r := &KubeadmControlPlaneReconciler{
-		Client: fakeClient,
-		Log:    log.Log,
-		remoteClient: func(c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
-			return c, nil
-		},
+		Client:             fakeClient,
+		Log:                log.Log,
+		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(gomega.Succeed())
@@ -973,11 +966,9 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T
 	log.SetLogger(klogr.New())
 
 	r := &KubeadmControlPlaneReconciler{
-		Client: fakeClient,
-		Log:    log.Log,
-		remoteClient: func(c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
-			return c, nil
-		},
+		Client:             fakeClient,
+		Log:                log.Log,
+		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(gomega.Succeed())
@@ -1028,11 +1019,9 @@ func TestKubeadmControlPlaneReconciler_updateStatusMachinesReadyMixed(t *testing
 	log.SetLogger(klogr.New())
 
 	r := &KubeadmControlPlaneReconciler{
-		Client: fakeClient,
-		Log:    log.Log,
-		remoteClient: func(c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
-			return c, nil
-		},
+		Client:             fakeClient,
+		Log:                log.Log,
+		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(gomega.Succeed())
@@ -1143,12 +1132,10 @@ func TestReconcileControlPlaneScaleUp(t *testing.T) {
 	log.SetLogger(klogr.New())
 
 	r := &KubeadmControlPlaneReconciler{
-		Client: fakeClient,
-		Log:    log.Log,
-		remoteClient: func(c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
-			return c, nil
-		},
-		recorder: record.NewFakeRecorder(32),
+		Client:             fakeClient,
+		Log:                log.Log,
+		remoteClientGetter: fakeremote.NewClusterClient,
+		recorder:           record.NewFakeRecorder(32),
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
@@ -1422,12 +1409,10 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 		log.SetLogger(klogr.New())
 
 		r := &KubeadmControlPlaneReconciler{
-			Client: fakeClient,
-			Log:    log.Log,
-			remoteClient: func(c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
-				return c, nil
-			},
-			recorder: record.NewFakeRecorder(32),
+			Client:             fakeClient,
+			Log:                log.Log,
+			remoteClientGetter: fakeremote.NewClusterClient,
+			recorder:           record.NewFakeRecorder(32),
 		}
 
 		// Create control plane machines
@@ -1525,12 +1510,10 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 		log.SetLogger(klogr.New())
 
 		r := &KubeadmControlPlaneReconciler{
-			Client: fakeClient,
-			Log:    log.Log,
-			remoteClient: func(c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
-				return c, nil
-			},
-			recorder: record.NewFakeRecorder(32),
+			Client:             fakeClient,
+			Log:                log.Log,
+			remoteClientGetter: fakeremote.NewClusterClient,
+			recorder:           record.NewFakeRecorder(32),
 		}
 
 		result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR cleans up the controlplane controller with a new fake client package under `remote/`.
