### PR TITLE
✨ Delete the ControlPlaneRef object if it exists

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -98,6 +98,7 @@ var _ = Describe("Cluster Reconciler", func() {
 			ph, err := patch.NewHelper(cluster, k8sClient)
 			Expect(err).ShouldNot(HaveOccurred())
 			cluster.Spec.InfrastructureRef = &v1.ObjectReference{Name: "test"}
+			cluster.Spec.ControlPlaneRef = &v1.ObjectReference{Name: "test-too"}
 			Expect(ph.Patch(ctx, cluster)).ShouldNot(HaveOccurred())
 			return true
 		}, timeout).Should(BeTrue())


### PR DESCRIPTION
* This is the same logic as the InfrastructureRef so I factored the code there

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
The one line test addition ensures the code is exercised during the test. It's not super thorough testing though.

Note: I am mostly relying on the control plane e2e test for this functionality which is in an upcoming PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2092 
related to #1756 

/assign @ncdc @vincepri 