### PR TITLE
🏃 Fix Kubeadm Control Plane controller's concept of Ready

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
@@ -44,7 +44,6 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -294,7 +293,7 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 		if node == nil {
 			continue
 		}
-		if noderefutil.IsNodeReady(node) {
+		if node.Spec.ProviderID != "" {
 			readyMachines++
 		}
 	}

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -850,8 +850,8 @@ func TestKubeadmControlPlaneReconciler_updateStatusNoMachines(t *testing.T) {
 func createMachineNodePair(name string, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, ready bool) (*clusterv1.Machine, *corev1.Node) {
 	machine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
 			Namespace: cluster.Namespace,
+			Name:      name,
 			Labels:    generateKubeadmControlPlaneLabels(cluster.Name),
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane")),
@@ -873,6 +873,7 @@ func createMachineNodePair(name string, cluster *clusterv1.Cluster, kcp *control
 	}
 
 	if ready {
+		node.Spec.ProviderID = fmt.Sprintf("test://%s", machine.GetName())
 		node.Status.Conditions = []corev1.NodeCondition{
 			{
 				Type:   corev1.NodeReady,
@@ -938,8 +939,8 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
 			Namespace: "test",
+			Name:      "foo",
 		},
 	}
 

--- a/test/infrastructure/docker/e2e/docker_suite_test.go
+++ b/test/infrastructure/docker/e2e/docker_suite_test.go
@@ -117,6 +117,7 @@ var _ = BeforeSuite(func() {
 	mgmt, err = NewClusterForCAPD(ctx, kindClusterName, scheme, managerImage, capiImage, capiKubeadmBootstrapImage, capiKubeadmControlPlaneImage)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(mgmt).NotTo(BeNil())
+	fmt.Printf("export KUBECONFIG=%q\n", mgmt.KubeconfigPath)
 
 	// Install the cert-manager components first as some CRDs there will be part of the other providers
 	framework.InstallComponents(ctx, mgmt, cm)


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

This also uses KubeadmControlPlane and Machine Deployment in the e2e.

**What this PR does / why we need it**:
The bulk of this change is implementing the kubeadm control plane + machine deployments in the e2e test.

I've removed the single node control plane test because I've never seen the single node control plane test fail while the multi node control plane test passes. This means that, at least for now, all bugs are being caught with the multi-node control plane. 

If it turns out we need a single node control plane test then we can add it back, but this will save ~ 1 minute of run time.

Fixes #2082 

