### PR TITLE
:sparkles: Add ability to configure Tilt mode

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -14,6 +14,9 @@ settings.update(read_json(
     default = {},
 ))
 
+if settings.get("trigger_mode") == "manual":
+    trigger_mode(TRIGGER_MODE_MANUAL)
+
 allow_k8s_contexts(settings.get("allowed_contexts"))
 
 default_registry(settings.get("default_registry"))

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -88,6 +88,9 @@ base64 -i ~/path/to/gcp/credentials.json
 
 **preload_images_for_kind** (Boolean, default=`true`): Uses `kind load docker-image` to preload images into a kind cluster.
 
+**trigger_mode** (String, default=`auto`): Optional setting to configure if tilt should automatically rebuild on changes. 
+Set to `manual` to disable auto-rebuilding and require users to trigger rebuilds of individual changed components through the UI.
+
 ### Run Tilt!
 
 To launch your development environment, run


### PR DESCRIPTION
Signed-off-by: John Harris <joharris@vmware.com>

**What this PR does / why we need it**:
This adds the ability to specify whether you want to Tilt to rebuild automatically on every file change or operate in manual mode (user needs to trigger rebuilds). It preserves the existing / default behavior (auto-rebuild).

A user can now specify `"trigger_mode": "manual"` in their `tilt-settings.json` to enable manual mode.
