### PR TITLE
✨clusterctl: inspect images in provider components

### DIFF
--- a/cmd/clusterctl/cmd/config_providers.go
+++ b/cmd/clusterctl/cmd/config_providers.go
@@ -147,6 +147,14 @@ func componentsDefaultOutput(c client.Components) error {
 			fmt.Printf("  %s\n", v)
 		}
 	}
+	if len(c.Images()) > 0 {
+		fmt.Println("Images:")
+		fmt.Println("  Name")
+		fmt.Println("  ----")
+		for _, v := range c.Images() {
+			fmt.Printf("  %s\n", v)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implement code for detecting images that are required in order to install a provider; this is the initial part of the effort for implementing clusterctl pre-pull images/support for air-gapped environments.

**Which issue(s) this PR fixes**:
rif https://github.com/kubernetes-sigs/cluster-api/issues/1829
rif #1729 

/assign @ncdc
/assign @vincepri