### PR TITLE
:running: Add test for KubeadmConfig conversion

### DIFF
--- a/bootstrap/kubeadm/api/v1alpha2/conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha2/conversion.go
@@ -36,9 +36,7 @@ func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 
-	if restored.Status.DataSecretName != nil {
-		dst.Status.DataSecretName = restored.Status.DataSecretName
-	}
+	dst.Status.DataSecretName = restored.Status.DataSecretName
 
 	return nil
 }

--- a/bootstrap/kubeadm/api/v1alpha2/conversion_test.go
+++ b/bootstrap/kubeadm/api/v1alpha2/conversion_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
+)
+
+func TestConvertKubeadmConfig(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Run("from hub", func(t *testing.T) {
+		t.Run("preserves fields from hub version", func(t *testing.T) {
+			src := &v1alpha3.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "hub",
+				},
+				Spec: v1alpha3.KubeadmConfigSpec{},
+				Status: v1alpha3.KubeadmConfigStatus{
+					Ready:          true,
+					DataSecretName: pointer.StringPtr("secret-data"),
+				},
+			}
+			dst := &KubeadmConfig{}
+
+			g.Expect(dst.ConvertFrom(src)).To(Succeed())
+			restored := &v1alpha3.KubeadmConfig{}
+			g.Expect(dst.ConvertTo(restored)).To(Succeed())
+
+			// Test field restored fields.
+			g.Expect(restored.Name).To(Equal(src.Name))
+			g.Expect(restored.Status.Ready).To(Equal(src.Status.Ready))
+			g.Expect(restored.Status.DataSecretName).To(Equal(src.Status.DataSecretName))
+		})
+
+	})
+}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Related to #2108 

/assign @chuckha 