### PR TITLE
:running: Make gomega tests more readable

### DIFF
--- a/api/v1alpha3/cluster_webhook_test.go
+++ b/api/v1alpha3/cluster_webhook_test.go
@@ -19,13 +19,13 @@ package v1alpha3
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestClusterDefault(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	c := &Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -38,8 +38,8 @@ func TestClusterDefault(t *testing.T) {
 	}
 	c.Default()
 
-	g.Expect(c.Spec.InfrastructureRef.Namespace).To(gomega.Equal(c.Namespace))
-	g.Expect(c.Spec.ControlPlaneRef.Namespace).To(gomega.Equal(c.Namespace))
+	g.Expect(c.Spec.InfrastructureRef.Namespace).To(Equal(c.Namespace))
+	g.Expect(c.Spec.ControlPlaneRef.Namespace).To(Equal(c.Namespace))
 }
 
 func TestClusterValidation(t *testing.T) {
@@ -86,18 +86,14 @@ func TestClusterValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			if tt.expectErr {
-				err := tt.c.ValidateCreate()
-				g.Expect(err).To(gomega.HaveOccurred())
-				err = tt.c.ValidateUpdate(nil)
-				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(tt.c.ValidateCreate()).NotTo(Succeed())
+				g.Expect(tt.c.ValidateUpdate(nil)).NotTo(Succeed())
 			} else {
-				err := tt.c.ValidateCreate()
-				g.Expect(err).To(gomega.Succeed())
-				err = tt.c.ValidateUpdate(nil)
-				g.Expect(err).To(gomega.Succeed())
+				g.Expect(tt.c.ValidateCreate()).To(Succeed())
+				g.Expect(tt.c.ValidateUpdate(nil)).To(Succeed())
 			}
 		})
 	}

--- a/api/v1alpha3/machine_webhook_test.go
+++ b/api/v1alpha3/machine_webhook_test.go
@@ -19,14 +19,14 @@ package v1alpha3
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
 func TestMachineDefault(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	m := &Machine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -39,8 +39,8 @@ func TestMachineDefault(t *testing.T) {
 
 	m.Default()
 
-	g.Expect(m.Spec.Bootstrap.ConfigRef.Namespace).To(gomega.Equal(m.Namespace))
-	g.Expect(m.Spec.InfrastructureRef.Namespace).To(gomega.Equal(m.Namespace))
+	g.Expect(m.Spec.Bootstrap.ConfigRef.Namespace).To(Equal(m.Namespace))
+	g.Expect(m.Spec.InfrastructureRef.Namespace).To(Equal(m.Namespace))
 }
 
 func TestMachineBootstrapValidation(t *testing.T) {
@@ -68,18 +68,16 @@ func TestMachineBootstrapValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			m := &Machine{
 				Spec: MachineSpec{Bootstrap: tt.bootstrap},
 			}
 			if tt.expectErr {
-				err := m.ValidateCreate()
-				g.Expect(err).To(gomega.HaveOccurred())
-				err = m.ValidateUpdate(nil)
-				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(m.ValidateCreate()).NotTo(Succeed())
+				g.Expect(m.ValidateUpdate(nil)).NotTo(Succeed())
 			} else {
-				g.Expect(m.ValidateCreate()).To(gomega.Succeed())
-				g.Expect(m.ValidateUpdate(nil)).To(gomega.Succeed())
+				g.Expect(m.ValidateCreate()).To(Succeed())
+				g.Expect(m.ValidateUpdate(nil)).To(Succeed())
 			}
 		})
 	}
@@ -125,7 +123,7 @@ func TestMachineNamespaceValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			m := &Machine{
 				ObjectMeta: metav1.ObjectMeta{Namespace: tt.namespace},
@@ -133,15 +131,11 @@ func TestMachineNamespaceValidation(t *testing.T) {
 			}
 
 			if tt.expectErr {
-				err := m.ValidateCreate()
-				g.Expect(err).To(gomega.HaveOccurred())
-				err = m.ValidateUpdate(nil)
-				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(m.ValidateCreate()).NotTo(Succeed())
+				g.Expect(m.ValidateUpdate(nil)).NotTo(Succeed())
 			} else {
-				err := m.ValidateCreate()
-				g.Expect(err).To(gomega.Succeed())
-				err = m.ValidateUpdate(nil)
-				g.Expect(err).To(gomega.Succeed())
+				g.Expect(m.ValidateCreate()).To(Succeed())
+				g.Expect(m.ValidateUpdate(nil)).To(Succeed())
 			}
 		})
 	}

--- a/api/v1alpha3/machinedeployment_webhook_test.go
+++ b/api/v1alpha3/machinedeployment_webhook_test.go
@@ -19,26 +19,26 @@ package v1alpha3
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
 func TestMachineDeploymentDefault(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	md := &MachineDeployment{}
 
 	md.Default()
 
-	g.Expect(md.Spec.Replicas).To(gomega.Equal(pointer.Int32Ptr(1)))
-	g.Expect(md.Spec.MinReadySeconds).To(gomega.Equal(pointer.Int32Ptr(0)))
-	g.Expect(md.Spec.RevisionHistoryLimit).To(gomega.Equal(pointer.Int32Ptr(1)))
-	g.Expect(md.Spec.ProgressDeadlineSeconds).To(gomega.Equal(pointer.Int32Ptr(600)))
-	g.Expect(md.Spec.Strategy).ToNot(gomega.BeNil())
-	g.Expect(md.Spec.Strategy.Type).To(gomega.Equal(RollingUpdateMachineDeploymentStrategyType))
-	g.Expect(md.Spec.Strategy.RollingUpdate).ToNot(gomega.BeNil())
-	g.Expect(md.Spec.Strategy.RollingUpdate.MaxSurge.IntValue()).To(gomega.Equal(1))
-	g.Expect(md.Spec.Strategy.RollingUpdate.MaxUnavailable.IntValue()).To(gomega.Equal(0))
+	g.Expect(md.Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
+	g.Expect(md.Spec.MinReadySeconds).To(Equal(pointer.Int32Ptr(0)))
+	g.Expect(md.Spec.RevisionHistoryLimit).To(Equal(pointer.Int32Ptr(1)))
+	g.Expect(md.Spec.ProgressDeadlineSeconds).To(Equal(pointer.Int32Ptr(600)))
+	g.Expect(md.Spec.Strategy).ToNot(BeNil())
+	g.Expect(md.Spec.Strategy.Type).To(Equal(RollingUpdateMachineDeploymentStrategyType))
+	g.Expect(md.Spec.Strategy.RollingUpdate).ToNot(BeNil())
+	g.Expect(md.Spec.Strategy.RollingUpdate.MaxSurge.IntValue()).To(Equal(1))
+	g.Expect(md.Spec.Strategy.RollingUpdate.MaxUnavailable.IntValue()).To(Equal(0))
 }
 
 func TestMachineDeploymentValidation(t *testing.T) {
@@ -82,7 +82,7 @@ func TestMachineDeploymentValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			md := &MachineDeployment{
 				Spec: MachineDeploymentSpec{
 					Selector: v1.LabelSelector{
@@ -96,13 +96,11 @@ func TestMachineDeploymentValidation(t *testing.T) {
 				},
 			}
 			if tt.expectErr {
-				err := md.ValidateCreate()
-				g.Expect(err).To(gomega.HaveOccurred())
-				err = md.ValidateUpdate(nil)
-				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(md.ValidateCreate()).NotTo(Succeed())
+				g.Expect(md.ValidateUpdate(nil)).NotTo(Succeed())
 			} else {
-				g.Expect(md.ValidateCreate()).To(gomega.Succeed())
-				g.Expect(md.ValidateUpdate(nil)).To(gomega.Succeed())
+				g.Expect(md.ValidateCreate()).To(Succeed())
+				g.Expect(md.ValidateUpdate(nil)).To(Succeed())
 			}
 		})
 	}

--- a/api/v1alpha3/machineset_webhook_test.go
+++ b/api/v1alpha3/machineset_webhook_test.go
@@ -19,7 +19,7 @@ package v1alpha3
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -64,7 +64,7 @@ func TestMachineSetLabelSelectorMatchValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			ms := &MachineSet{
 				Spec: MachineSetSpec{
 					Selector: v1.LabelSelector{
@@ -78,13 +78,11 @@ func TestMachineSetLabelSelectorMatchValidation(t *testing.T) {
 				},
 			}
 			if tt.expectErr {
-				err := ms.ValidateCreate()
-				g.Expect(err).To(gomega.HaveOccurred())
-				err = ms.ValidateUpdate(nil)
-				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(ms.ValidateCreate()).NotTo(Succeed())
+				g.Expect(ms.ValidateUpdate(nil)).NotTo(Succeed())
 			} else {
-				g.Expect(ms.ValidateCreate()).To(gomega.Succeed())
-				g.Expect(ms.ValidateUpdate(nil)).To(gomega.Succeed())
+				g.Expect(ms.ValidateCreate()).To(Succeed())
+				g.Expect(ms.ValidateUpdate(nil)).To(Succeed())
 			}
 		})
 	}

--- a/controllers/external/util_test.go
+++ b/controllers/external/util_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,7 +34,7 @@ import (
 )
 
 func TestGetResourceFound(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	namespace := "test"
 	testResourceName := "greenTemplate"
@@ -56,12 +56,12 @@ func TestGetResourceFound(t *testing.T) {
 
 	fakeClient := fake.NewFakeClientWithScheme(runtime.NewScheme(), testResource.DeepCopy())
 	got, err := Get(context.Background(), fakeClient, testResourceReference, namespace)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(got).To(gomega.Equal(testResource))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(got).To(Equal(testResource))
 }
 
 func TestGetResourceNotFound(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	namespace := "test"
 
@@ -74,12 +74,12 @@ func TestGetResourceNotFound(t *testing.T) {
 
 	fakeClient := fake.NewFakeClientWithScheme(runtime.NewScheme())
 	_, err := Get(context.Background(), fakeClient, testResourceReference, namespace)
-	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(apierrors.IsNotFound(errors.Cause(err))).To(gomega.BeTrue())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsNotFound(errors.Cause(err))).To(BeTrue())
 }
 
 func TestCloneTemplateResourceNotFound(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	namespace := "test"
 	testClusterName := "bar"
@@ -98,12 +98,12 @@ func TestCloneTemplateResourceNotFound(t *testing.T) {
 		Namespace:   namespace,
 		ClusterName: testClusterName,
 	})
-	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(apierrors.IsNotFound(errors.Cause(err))).To(gomega.BeTrue())
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(apierrors.IsNotFound(errors.Cause(err))).To(BeTrue())
 }
 
 func TestCloneTemplateResourceFound(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	namespace := "test"
 	testClusterName := "test-cluster"
@@ -147,9 +147,9 @@ func TestCloneTemplateResourceFound(t *testing.T) {
 	expectedAPIVersion := templateAPIVersion
 
 	expectedSpec, ok, err := unstructured.NestedMap(template.UnstructuredContent(), "spec", "template", "spec")
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(ok).To(gomega.BeTrue())
-	g.Expect(expectedSpec).NotTo(gomega.BeEmpty())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(BeTrue())
+	g.Expect(expectedSpec).NotTo(BeEmpty())
 
 	fakeClient := fake.NewFakeClientWithScheme(runtime.NewScheme(), template.DeepCopy())
 
@@ -163,34 +163,34 @@ func TestCloneTemplateResourceFound(t *testing.T) {
 			"test-label-1": "value-1",
 		},
 	})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(ref).NotTo(gomega.BeNil())
-	g.Expect(ref.Kind).To(gomega.Equal(expectedKind))
-	g.Expect(ref.APIVersion).To(gomega.Equal(expectedAPIVersion))
-	g.Expect(ref.Namespace).To(gomega.Equal(namespace))
-	g.Expect(ref.Name).To(gomega.HavePrefix(templateRef.Name))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ref).NotTo(BeNil())
+	g.Expect(ref.Kind).To(Equal(expectedKind))
+	g.Expect(ref.APIVersion).To(Equal(expectedAPIVersion))
+	g.Expect(ref.Namespace).To(Equal(namespace))
+	g.Expect(ref.Name).To(HavePrefix(templateRef.Name))
 
 	clone := &unstructured.Unstructured{}
 	clone.SetKind(expectedKind)
 	clone.SetAPIVersion(expectedAPIVersion)
 
 	key := client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}
-	g.Expect(fakeClient.Get(context.Background(), key, clone)).To(gomega.Succeed())
-	g.Expect(clone.GetOwnerReferences()).To(gomega.HaveLen(1))
-	g.Expect(clone.GetOwnerReferences()).To(gomega.ContainElement(owner))
+	g.Expect(fakeClient.Get(context.Background(), key, clone)).To(Succeed())
+	g.Expect(clone.GetOwnerReferences()).To(HaveLen(1))
+	g.Expect(clone.GetOwnerReferences()).To(ContainElement(owner))
 
 	cloneSpec, ok, err := unstructured.NestedMap(clone.UnstructuredContent(), "spec")
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(ok).To(gomega.BeTrue())
-	g.Expect(cloneSpec).To(gomega.Equal(expectedSpec))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(BeTrue())
+	g.Expect(cloneSpec).To(Equal(expectedSpec))
 
 	cloneLabels := clone.GetLabels()
-	g.Expect(cloneLabels).To(gomega.HaveKeyWithValue(clusterv1.ClusterLabelName, testClusterName))
-	g.Expect(cloneLabels).To(gomega.HaveKeyWithValue("test-label-1", "value-1"))
+	g.Expect(cloneLabels).To(HaveKeyWithValue(clusterv1.ClusterLabelName, testClusterName))
+	g.Expect(cloneLabels).To(HaveKeyWithValue("test-label-1", "value-1"))
 }
 
 func TestCloneTemplateResourceFoundNoOwner(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	namespace := "test"
 	testClusterName := "test-cluster"
@@ -229,9 +229,9 @@ func TestCloneTemplateResourceFoundNoOwner(t *testing.T) {
 	expectedLabels := (map[string]string{clusterv1.ClusterLabelName: testClusterName})
 
 	expectedSpec, ok, err := unstructured.NestedMap(template.UnstructuredContent(), "spec", "template", "spec")
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(ok).To(gomega.BeTrue())
-	g.Expect(expectedSpec).NotTo(gomega.BeEmpty())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(BeTrue())
+	g.Expect(expectedSpec).NotTo(BeEmpty())
 
 	fakeClient := fake.NewFakeClientWithScheme(runtime.NewScheme(), template.DeepCopy())
 
@@ -241,28 +241,28 @@ func TestCloneTemplateResourceFoundNoOwner(t *testing.T) {
 		Namespace:   namespace,
 		ClusterName: testClusterName,
 	})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(ref).NotTo(gomega.BeNil())
-	g.Expect(ref.Kind).To(gomega.Equal(expectedKind))
-	g.Expect(ref.APIVersion).To(gomega.Equal(expectedAPIVersion))
-	g.Expect(ref.Namespace).To(gomega.Equal(namespace))
-	g.Expect(ref.Name).To(gomega.HavePrefix(templateRef.Name))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ref).NotTo(BeNil())
+	g.Expect(ref.Kind).To(Equal(expectedKind))
+	g.Expect(ref.APIVersion).To(Equal(expectedAPIVersion))
+	g.Expect(ref.Namespace).To(Equal(namespace))
+	g.Expect(ref.Name).To(HavePrefix(templateRef.Name))
 
 	clone := &unstructured.Unstructured{}
 	clone.SetKind(expectedKind)
 	clone.SetAPIVersion(expectedAPIVersion)
 	key := client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}
-	g.Expect(fakeClient.Get(context.Background(), key, clone)).To(gomega.Succeed())
-	g.Expect(clone.GetLabels()).To(gomega.Equal(expectedLabels))
-	g.Expect(clone.GetOwnerReferences()).To(gomega.BeEmpty())
+	g.Expect(fakeClient.Get(context.Background(), key, clone)).To(Succeed())
+	g.Expect(clone.GetLabels()).To(Equal(expectedLabels))
+	g.Expect(clone.GetOwnerReferences()).To(BeEmpty())
 	cloneSpec, ok, err := unstructured.NestedMap(clone.UnstructuredContent(), "spec")
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(ok).To(gomega.BeTrue())
-	g.Expect(cloneSpec).To(gomega.Equal(expectedSpec))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(BeTrue())
+	g.Expect(cloneSpec).To(Equal(expectedSpec))
 }
 
 func TestCloneTemplateMissingSpecTemplate(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	namespace := "test"
 	testClusterName := "test-cluster"
@@ -298,5 +298,5 @@ func TestCloneTemplateMissingSpecTemplate(t *testing.T) {
 		Namespace:   namespace,
 		ClusterName: testClusterName,
 	})
-	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(HaveOccurred())
 }

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
@@ -19,7 +19,7 @@ package v1alpha3
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -29,7 +29,7 @@ import (
 )
 
 func TestKubeadmControlPlaneDefault(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	kcp := &KubeadmControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -41,7 +41,7 @@ func TestKubeadmControlPlaneDefault(t *testing.T) {
 	}
 	kcp.Default()
 
-	g.Expect(kcp.Spec.InfrastructureTemplate.Namespace).To(gomega.Equal(kcp.Namespace))
+	g.Expect(kcp.Spec.InfrastructureTemplate.Namespace).To(Equal(kcp.Namespace))
 }
 
 func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
@@ -120,14 +120,12 @@ func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			if tt.expectErr {
-				err := tt.kcp.ValidateCreate()
-				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(tt.kcp.ValidateCreate()).NotTo(Succeed())
 			} else {
-				err := tt.kcp.ValidateCreate()
-				g.Expect(err).To(gomega.Succeed())
+				g.Expect(tt.kcp.ValidateCreate()).To(Succeed())
 			}
 		})
 	}
@@ -176,14 +174,13 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
+			err := tt.kcp.ValidateUpdate(before.DeepCopy())
 			if tt.expectErr {
-				err := tt.kcp.ValidateUpdate(before.DeepCopy())
-				g.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(err).To(HaveOccurred())
 			} else {
-				err := tt.kcp.ValidateUpdate(before.DeepCopy())
-				g.Expect(err).To(gomega.Succeed())
+				g.Expect(err).To(Succeed())
 			}
 		})
 	}

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -47,10 +47,10 @@ import (
 )
 
 func TestClusterToKubeadmControlPlane(t *testing.T) {
-	g := gomega.NewWithT(t)
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g := NewWithT(t)
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 
 	cluster := &clusterv1.Cluster{
@@ -87,14 +87,14 @@ func TestClusterToKubeadmControlPlane(t *testing.T) {
 			Object: cluster,
 		},
 	)
-	g.Expect(got).To(gomega.Equal(expectedResult))
+	g.Expect(got).To(Equal(expectedResult))
 }
 
 func TestClusterToKubeadmControlPlaneNoControlPlane(t *testing.T) {
-	g := gomega.NewWithT(t)
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g := NewWithT(t)
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 
 	cluster := &clusterv1.Cluster{
@@ -116,14 +116,14 @@ func TestClusterToKubeadmControlPlaneNoControlPlane(t *testing.T) {
 			Object: cluster,
 		},
 	)
-	g.Expect(got).To(gomega.BeNil())
+	g.Expect(got).To(BeNil())
 }
 
 func TestClusterToKubeadmControlPlaneOtherControlPlane(t *testing.T) {
-	g := gomega.NewWithT(t)
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g := NewWithT(t)
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 
 	cluster := &clusterv1.Cluster{
@@ -152,11 +152,11 @@ func TestClusterToKubeadmControlPlaneOtherControlPlane(t *testing.T) {
 			Object: cluster,
 		},
 	)
-	g.Expect(got).To(gomega.BeNil())
+	g.Expect(got).To(BeNil())
 }
 
 func TestReconcileKubeconfigEmptyAPIEndpoints(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	kcp := &controlplanev1.KubeadmControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -166,27 +166,27 @@ func TestReconcileKubeconfigEmptyAPIEndpoints(t *testing.T) {
 	}
 	clusterName := types.NamespacedName{Namespace: "test", Name: "foo"}
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, kcp)
 	r := &KubeadmControlPlaneReconciler{
 		Client: fakeClient,
 		Log:    log.Log,
 	}
 
-	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, clusterv1.APIEndpoint{}, kcp)).To(gomega.Succeed())
+	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, clusterv1.APIEndpoint{}, kcp)).To(Succeed())
 
 	kubeconfigSecret := &corev1.Secret{}
 	secretName := types.NamespacedName{
 		Namespace: "test",
 		Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
 	}
-	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(gomega.MatchError(gomega.ContainSubstring("not found")))
+	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(MatchError(ContainSubstring("not found")))
 }
 
 func TestReconcileKubeconfigMissingCACertificate(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	kcp := &controlplanev1.KubeadmControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -197,27 +197,27 @@ func TestReconcileKubeconfigMissingCACertificate(t *testing.T) {
 	clusterName := types.NamespacedName{Namespace: "test", Name: "foo"}
 	endpoint := clusterv1.APIEndpoint{Host: "test.local", Port: 8443}
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, kcp)
 	r := &KubeadmControlPlaneReconciler{
 		Client: fakeClient,
 		Log:    log.Log,
 	}
 
-	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, endpoint, kcp)).NotTo(gomega.Succeed())
+	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, endpoint, kcp)).NotTo(Succeed())
 
 	kubeconfigSecret := &corev1.Secret{}
 	secretName := types.NamespacedName{
 		Namespace: "test",
 		Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
 	}
-	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(gomega.MatchError(gomega.ContainSubstring("not found")))
+	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(MatchError(ContainSubstring("not found")))
 }
 
 func TestReconcileKubeconfigSecretAlreadyExists(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -241,31 +241,31 @@ func TestReconcileKubeconfigSecretAlreadyExists(t *testing.T) {
 		*metav1.NewControllerRef(cluster, clusterv1.GroupVersion.WithKind("Cluster")),
 	)
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, kcp, existingKubeconfigSecret)
 	r := &KubeadmControlPlaneReconciler{
 		Client: fakeClient,
 		Log:    log.Log,
 	}
 
-	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, endpoint, kcp)).To(gomega.Succeed())
+	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, endpoint, kcp)).To(Succeed())
 
 	kubeconfigSecret := &corev1.Secret{}
 	secretName := types.NamespacedName{
 		Namespace: "test",
 		Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
 	}
-	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(gomega.Succeed())
-	g.Expect(kubeconfigSecret.Labels).To(gomega.Equal(existingKubeconfigSecret.Labels))
-	g.Expect(kubeconfigSecret.Data).To(gomega.Equal(existingKubeconfigSecret.Data))
-	g.Expect(kubeconfigSecret.OwnerReferences).NotTo(gomega.ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
+	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(Succeed())
+	g.Expect(kubeconfigSecret.Labels).To(Equal(existingKubeconfigSecret.Labels))
+	g.Expect(kubeconfigSecret.Data).To(Equal(existingKubeconfigSecret.Data))
+	g.Expect(kubeconfigSecret.OwnerReferences).NotTo(ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
 
 }
 
 func TestKubeadmControlPlaneReconciler_reconcileKubeconfig(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -284,36 +284,36 @@ func TestKubeadmControlPlaneReconciler_reconcileKubeconfig(t *testing.T) {
 	endpoint := clusterv1.APIEndpoint{Host: "test.local", Port: 8443}
 
 	clusterCerts := secret.NewCertificatesForInitialControlPlane(&kubeadmv1.ClusterConfiguration{})
-	g.Expect(clusterCerts.Generate()).To(gomega.Succeed())
+	g.Expect(clusterCerts.Generate()).To(Succeed())
 	caCert := clusterCerts.GetByPurpose(secret.ClusterCA)
 	existingCACertSecret := caCert.AsSecret(
 		types.NamespacedName{Namespace: "test", Name: "foo"},
 		*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane")),
 	)
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, kcp, existingCACertSecret)
 	r := &KubeadmControlPlaneReconciler{
 		Client: fakeClient,
 		Log:    log.Log,
 	}
-	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, endpoint, kcp)).To(gomega.Succeed())
+	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, endpoint, kcp)).To(Succeed())
 
 	kubeconfigSecret := &corev1.Secret{}
 	secretName := types.NamespacedName{
 		Namespace: "test",
 		Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
 	}
-	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(gomega.Succeed())
-	g.Expect(kubeconfigSecret.OwnerReferences).NotTo(gomega.BeEmpty())
-	g.Expect(kubeconfigSecret.OwnerReferences).To(gomega.ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
-	g.Expect(kubeconfigSecret.Labels).To(gomega.HaveKeyWithValue(clusterv1.ClusterLabelName, clusterName.Name))
+	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(Succeed())
+	g.Expect(kubeconfigSecret.OwnerReferences).NotTo(BeEmpty())
+	g.Expect(kubeconfigSecret.OwnerReferences).To(ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
+	g.Expect(kubeconfigSecret.Labels).To(HaveKeyWithValue(clusterv1.ClusterLabelName, clusterName.Name))
 }
 
 func TestKubeadmControlPlaneReconciler_initializeControlPlane(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -363,9 +363,9 @@ func TestKubeadmControlPlaneReconciler_initializeControlPlane(t *testing.T) {
 		},
 	}
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(
 		scheme.Scheme,
 		cluster.DeepCopy(),
@@ -378,29 +378,29 @@ func TestKubeadmControlPlaneReconciler_initializeControlPlane(t *testing.T) {
 		Log:    log.Log,
 	}
 
-	g.Expect(r.initializeControlPlane(context.Background(), cluster, kcp)).To(gomega.Succeed())
+	g.Expect(r.initializeControlPlane(context.Background(), cluster, kcp)).To(Succeed())
 
 	machineList := &clusterv1.MachineList{}
-	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(gomega.Succeed())
-	g.Expect(machineList.Items).NotTo(gomega.BeEmpty())
-	g.Expect(machineList.Items).To(gomega.HaveLen(1))
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(machineList.Items).NotTo(BeEmpty())
+	g.Expect(machineList.Items).To(HaveLen(1))
 
-	g.Expect(machineList.Items[0].Namespace).To(gomega.Equal(cluster.Namespace))
-	g.Expect(machineList.Items[0].Name).To(gomega.HavePrefix(kcp.Name))
+	g.Expect(machineList.Items[0].Namespace).To(Equal(cluster.Namespace))
+	g.Expect(machineList.Items[0].Name).To(HavePrefix(kcp.Name))
 
-	g.Expect(machineList.Items[0].Spec.InfrastructureRef.Namespace).To(gomega.Equal(cluster.Namespace))
-	g.Expect(machineList.Items[0].Spec.InfrastructureRef.Name).To(gomega.HavePrefix(genericMachineTemplate.GetName()))
-	g.Expect(machineList.Items[0].Spec.InfrastructureRef.APIVersion).To(gomega.Equal(genericMachineTemplate.GetAPIVersion()))
-	g.Expect(machineList.Items[0].Spec.InfrastructureRef.Kind).To(gomega.Equal("GenericMachine"))
+	g.Expect(machineList.Items[0].Spec.InfrastructureRef.Namespace).To(Equal(cluster.Namespace))
+	g.Expect(machineList.Items[0].Spec.InfrastructureRef.Name).To(HavePrefix(genericMachineTemplate.GetName()))
+	g.Expect(machineList.Items[0].Spec.InfrastructureRef.APIVersion).To(Equal(genericMachineTemplate.GetAPIVersion()))
+	g.Expect(machineList.Items[0].Spec.InfrastructureRef.Kind).To(Equal("GenericMachine"))
 
-	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.Namespace).To(gomega.Equal(cluster.Namespace))
-	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.Name).To(gomega.HavePrefix(kcp.Name))
-	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.APIVersion).To(gomega.Equal(bootstrapv1.GroupVersion.String()))
-	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.Kind).To(gomega.Equal("KubeadmConfig"))
+	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.Namespace).To(Equal(cluster.Namespace))
+	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.Name).To(HavePrefix(kcp.Name))
+	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.APIVersion).To(Equal(bootstrapv1.GroupVersion.String()))
+	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.Kind).To(Equal("KubeadmConfig"))
 }
 
 func TestReconcileNoClusterOwnerRef(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	kcp := &controlplanev1.KubeadmControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -409,11 +409,11 @@ func TestReconcileNoClusterOwnerRef(t *testing.T) {
 		},
 	}
 	kcp.Default()
-	g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, kcp)
 	log.SetLogger(klogr.New())
 
@@ -423,16 +423,16 @@ func TestReconcileNoClusterOwnerRef(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
 
 	machineList := &clusterv1.MachineList{}
-	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace("test"))).To(gomega.Succeed())
-	g.Expect(machineList.Items).To(gomega.BeEmpty())
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace("test"))).To(Succeed())
+	g.Expect(machineList.Items).To(BeEmpty())
 }
 
 func TestReconcileNoCluster(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	kcp := &controlplanev1.KubeadmControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -448,11 +448,11 @@ func TestReconcileNoCluster(t *testing.T) {
 		},
 	}
 	kcp.Default()
-	g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, kcp)
 	log.SetLogger(klogr.New())
 
@@ -462,15 +462,15 @@ func TestReconcileNoCluster(t *testing.T) {
 	}
 
 	_, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
-	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(HaveOccurred())
 
 	machineList := &clusterv1.MachineList{}
-	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace("test"))).To(gomega.Succeed())
-	g.Expect(machineList.Items).To(gomega.BeEmpty())
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace("test"))).To(Succeed())
+	g.Expect(machineList.Items).To(BeEmpty())
 }
 
 func TestReconcileClusterNoEndpoints(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -493,11 +493,11 @@ func TestReconcileClusterNoEndpoints(t *testing.T) {
 		},
 	}
 	kcp.Default()
-	g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, kcp, cluster)
 	log.SetLogger(klogr.New())
 
@@ -508,25 +508,25 @@ func TestReconcileClusterNoEndpoints(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
-	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(gomega.Succeed())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(Succeed())
 
 	// Always expect that the Finalizer is set on the passed in resource
-	g.Expect(kcp.Finalizers).To(gomega.ContainElement(controlplanev1.KubeadmControlPlaneFinalizer))
+	g.Expect(kcp.Finalizers).To(ContainElement(controlplanev1.KubeadmControlPlaneFinalizer))
 
-	g.Expect(kcp.Status.Selector).NotTo(gomega.BeEmpty())
+	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
 
 	_, err = secret.GetFromNamespacedName(fakeClient, client.ObjectKey{Namespace: "test", Name: "foo"}, secret.ClusterCA)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	machineList := &clusterv1.MachineList{}
-	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace("test"))).To(gomega.Succeed())
-	g.Expect(machineList.Items).To(gomega.BeEmpty())
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace("test"))).To(Succeed())
+	g.Expect(machineList.Items).To(BeEmpty())
 }
 
 func TestReconcileInitializeControlPlane(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -584,11 +584,11 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 		},
 	}
 	kcp.Default()
-	g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(
 		scheme.Scheme,
 		kcp.DeepCopy(),
@@ -606,13 +606,13 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
-	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(gomega.Succeed())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(Succeed())
 
 	// Expect the referenced infrastructure template to have a Cluster Owner Reference.
-	g.Expect(fakeClient.Get(context.TODO(), client.ObjectKey{Namespace: genericMachineTemplate.GetNamespace(), Name: genericMachineTemplate.GetName()}, genericMachineTemplate)).To(gomega.Succeed())
-	g.Expect(genericMachineTemplate.GetOwnerReferences()).To(gomega.ContainElement(metav1.OwnerReference{
+	g.Expect(fakeClient.Get(context.TODO(), client.ObjectKey{Namespace: genericMachineTemplate.GetNamespace(), Name: genericMachineTemplate.GetName()}, genericMachineTemplate)).To(Succeed())
+	g.Expect(genericMachineTemplate.GetOwnerReferences()).To(ContainElement(metav1.OwnerReference{
 		APIVersion: clusterv1.GroupVersion.String(),
 		Kind:       "Cluster",
 		Name:       cluster.Name,
@@ -620,32 +620,32 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 	}))
 
 	// Always expect that the Finalizer is set on the passed in resource
-	g.Expect(kcp.Finalizers).To(gomega.ContainElement(controlplanev1.KubeadmControlPlaneFinalizer))
+	g.Expect(kcp.Finalizers).To(ContainElement(controlplanev1.KubeadmControlPlaneFinalizer))
 
-	g.Expect(kcp.Status.Selector).NotTo(gomega.BeEmpty())
-	g.Expect(kcp.Status.Replicas).To(gomega.BeEquivalentTo(1))
+	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
+	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(1))
 
 	s, err := secret.GetFromNamespacedName(fakeClient, client.ObjectKey{Namespace: "test", Name: "foo"}, secret.ClusterCA)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(s).NotTo(gomega.BeNil())
-	g.Expect(s.Data).NotTo(gomega.BeEmpty())
-	g.Expect(s.Labels).To(gomega.Equal(expectedLabels))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(s).NotTo(BeNil())
+	g.Expect(s.Data).NotTo(BeEmpty())
+	g.Expect(s.Labels).To(Equal(expectedLabels))
 
 	k, err := kubeconfig.FromSecret(fakeClient, cluster)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(k).NotTo(gomega.BeEmpty())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(k).NotTo(BeEmpty())
 
 	machineList := &clusterv1.MachineList{}
-	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace("test"))).To(gomega.Succeed())
-	g.Expect(machineList.Items).To(gomega.HaveLen(1))
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace("test"))).To(Succeed())
+	g.Expect(machineList.Items).To(HaveLen(1))
 
 	machine := machineList.Items[0]
-	g.Expect(machine.Name).To(gomega.HavePrefix(kcp.Name))
+	g.Expect(machine.Name).To(HavePrefix(kcp.Name))
 }
 
 func TestKubeadmControlPlaneReconciler_generateMachine(t *testing.T) {
-	g := gomega.NewWithT(t)
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g := NewWithT(t)
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 
 	cluster := &clusterv1.Cluster{
@@ -689,24 +689,24 @@ func TestKubeadmControlPlaneReconciler_generateMachine(t *testing.T) {
 		Client: fakeClient,
 		Log:    log.Log,
 	}
-	g.Expect(r.generateMachine(context.Background(), kcp, cluster, infraRef, bootstrapRef)).To(gomega.Succeed())
+	g.Expect(r.generateMachine(context.Background(), kcp, cluster, infraRef, bootstrapRef)).To(Succeed())
 
 	machineList := &clusterv1.MachineList{}
-	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(gomega.Succeed())
-	g.Expect(machineList.Items).NotTo(gomega.BeEmpty())
-	g.Expect(machineList.Items).To(gomega.HaveLen(1))
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(machineList.Items).NotTo(BeEmpty())
+	g.Expect(machineList.Items).To(HaveLen(1))
 	machine := machineList.Items[0]
-	g.Expect(machine.Name).To(gomega.HavePrefix(kcp.Name))
-	g.Expect(machine.Namespace).To(gomega.Equal(kcp.Namespace))
-	g.Expect(machine.Labels).To(gomega.Equal(generateKubeadmControlPlaneLabels(cluster.Name)))
-	g.Expect(machine.OwnerReferences).To(gomega.HaveLen(1))
-	g.Expect(machine.OwnerReferences).To(gomega.ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
-	g.Expect(machine.Spec).To(gomega.Equal(expectedMachineSpec))
+	g.Expect(machine.Name).To(HavePrefix(kcp.Name))
+	g.Expect(machine.Namespace).To(Equal(kcp.Namespace))
+	g.Expect(machine.Labels).To(Equal(generateKubeadmControlPlaneLabels(cluster.Name)))
+	g.Expect(machine.OwnerReferences).To(HaveLen(1))
+	g.Expect(machine.OwnerReferences).To(ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
+	g.Expect(machine.Spec).To(Equal(expectedMachineSpec))
 }
 
 func TestKubeadmControlPlaneReconciler_generateKubeadmConfig(t *testing.T) {
-	g := gomega.NewWithT(t)
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g := NewWithT(t)
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 
 	cluster := &clusterv1.Cluster{
@@ -735,35 +735,35 @@ func TestKubeadmControlPlaneReconciler_generateKubeadmConfig(t *testing.T) {
 	}
 
 	got, err := r.generateKubeadmConfig(context.Background(), kcp, cluster, spec.DeepCopy())
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(got).NotTo(gomega.BeNil())
-	g.Expect(got.Name).To(gomega.HavePrefix(kcp.Name))
-	g.Expect(got.Namespace).To(gomega.Equal(kcp.Namespace))
-	g.Expect(got.Kind).To(gomega.Equal(expectedReferenceKind))
-	g.Expect(got.APIVersion).To(gomega.Equal(expectedReferenceAPIVersion))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Name).To(HavePrefix(kcp.Name))
+	g.Expect(got.Namespace).To(Equal(kcp.Namespace))
+	g.Expect(got.Kind).To(Equal(expectedReferenceKind))
+	g.Expect(got.APIVersion).To(Equal(expectedReferenceAPIVersion))
 
 	bootstrapConfig := &bootstrapv1.KubeadmConfig{}
 	key := client.ObjectKey{Name: got.Name, Namespace: got.Namespace}
-	g.Expect(fakeClient.Get(context.Background(), key, bootstrapConfig)).To(gomega.Succeed())
-	g.Expect(bootstrapConfig.Labels).To(gomega.Equal(expectedLabels))
-	g.Expect(bootstrapConfig.OwnerReferences).To(gomega.HaveLen(1))
-	g.Expect(bootstrapConfig.OwnerReferences).To(gomega.ContainElement(expectedOwner))
-	g.Expect(bootstrapConfig.Spec).To(gomega.Equal(spec))
+	g.Expect(fakeClient.Get(context.Background(), key, bootstrapConfig)).To(Succeed())
+	g.Expect(bootstrapConfig.Labels).To(Equal(expectedLabels))
+	g.Expect(bootstrapConfig.OwnerReferences).To(HaveLen(1))
+	g.Expect(bootstrapConfig.OwnerReferences).To(ContainElement(expectedOwner))
+	g.Expect(bootstrapConfig.Spec).To(Equal(spec))
 }
 
 func Test_getMachineNodeNoNodeRef(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 
 	m := &clusterv1.Machine{}
 	node, err := getMachineNode(context.Background(), fakeClient, m)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(node).To(gomega.BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(node).To(BeNil())
 }
 
 func Test_getMachineNodeNotFound(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme)
 
@@ -777,12 +777,12 @@ func Test_getMachineNodeNotFound(t *testing.T) {
 		},
 	}
 	node, err := getMachineNode(context.Background(), fakeClient, m)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(node).To(gomega.BeNil())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(node).To(BeNil())
 }
 
 func Test_getMachineNodeFound(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -801,12 +801,12 @@ func Test_getMachineNodeFound(t *testing.T) {
 		},
 	}
 	node, err := getMachineNode(context.Background(), fakeClient, m)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(node).To(gomega.Equal(node))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(node).To(Equal(node))
 }
 
 func TestKubeadmControlPlaneReconciler_updateStatusNoMachines(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -822,11 +822,11 @@ func TestKubeadmControlPlaneReconciler_updateStatusNoMachines(t *testing.T) {
 		},
 	}
 	kcp.Default()
-	g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, kcp, cluster)
 	log.SetLogger(klogr.New())
 
@@ -836,15 +836,15 @@ func TestKubeadmControlPlaneReconciler_updateStatusNoMachines(t *testing.T) {
 		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 
-	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(gomega.Succeed())
-	g.Expect(kcp.Status.Replicas).To(gomega.BeEquivalentTo(0))
-	g.Expect(kcp.Status.ReadyReplicas).To(gomega.BeEquivalentTo(0))
-	g.Expect(kcp.Status.UnavailableReplicas).To(gomega.BeEquivalentTo(0))
-	g.Expect(kcp.Status.Initialized).To(gomega.BeFalse())
-	g.Expect(kcp.Status.Ready).To(gomega.BeFalse())
-	g.Expect(kcp.Status.Selector).NotTo(gomega.BeEmpty())
-	g.Expect(kcp.Status.FailureMessage).To(gomega.BeNil())
-	g.Expect(kcp.Status.FailureReason).To(gomega.BeEquivalentTo(""))
+	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
+	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(0))
+	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(0))
+	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(0))
+	g.Expect(kcp.Status.Initialized).To(BeFalse())
+	g.Expect(kcp.Status.Ready).To(BeFalse())
+	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
+	g.Expect(kcp.Status.FailureMessage).To(BeNil())
+	g.Expect(kcp.Status.FailureReason).To(BeEquivalentTo(""))
 }
 
 func createMachineNodePair(name string, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, ready bool) (*clusterv1.Machine, *corev1.Node) {
@@ -886,7 +886,7 @@ func createMachineNodePair(name string, cluster *clusterv1.Cluster, kcp *control
 }
 
 func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesNotReady(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -902,7 +902,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesNotReady(t *testin
 		},
 	}
 	kcp.Default()
-	g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
 
 	objs := []runtime.Object{cluster.DeepCopy(), kcp.DeepCopy()}
 	for i := 0; i < 3; i++ {
@@ -911,9 +911,9 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesNotReady(t *testin
 		objs = append(objs, m, n)
 	}
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, objs...)
 	log.SetLogger(klogr.New())
 
@@ -923,19 +923,19 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesNotReady(t *testin
 		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 
-	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(gomega.Succeed())
-	g.Expect(kcp.Status.Replicas).To(gomega.BeEquivalentTo(3))
-	g.Expect(kcp.Status.ReadyReplicas).To(gomega.BeEquivalentTo(0))
-	g.Expect(kcp.Status.UnavailableReplicas).To(gomega.BeEquivalentTo(3))
-	g.Expect(kcp.Status.Selector).NotTo(gomega.BeEmpty())
-	g.Expect(kcp.Status.FailureMessage).To(gomega.BeNil())
-	g.Expect(kcp.Status.FailureReason).To(gomega.BeEquivalentTo(""))
-	g.Expect(kcp.Status.Initialized).To(gomega.BeFalse())
-	g.Expect(kcp.Status.Ready).To(gomega.BeFalse())
+	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
+	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(3))
+	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(0))
+	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(3))
+	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
+	g.Expect(kcp.Status.FailureMessage).To(BeNil())
+	g.Expect(kcp.Status.FailureReason).To(BeEquivalentTo(""))
+	g.Expect(kcp.Status.Initialized).To(BeFalse())
+	g.Expect(kcp.Status.Ready).To(BeFalse())
 }
 
 func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -951,7 +951,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T
 		},
 	}
 	kcp.Default()
-	g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
 
 	objs := []runtime.Object{cluster.DeepCopy(), kcp.DeepCopy()}
 	for i := 0; i < 3; i++ {
@@ -960,9 +960,9 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T
 		objs = append(objs, m, n)
 	}
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, objs...)
 	log.SetLogger(klogr.New())
 
@@ -972,21 +972,21 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T
 		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 
-	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(gomega.Succeed())
-	g.Expect(kcp.Status.Replicas).To(gomega.BeEquivalentTo(3))
-	g.Expect(kcp.Status.ReadyReplicas).To(gomega.BeEquivalentTo(3))
-	g.Expect(kcp.Status.UnavailableReplicas).To(gomega.BeEquivalentTo(0))
-	g.Expect(kcp.Status.Selector).NotTo(gomega.BeEmpty())
-	g.Expect(kcp.Status.FailureMessage).To(gomega.BeNil())
-	g.Expect(kcp.Status.FailureReason).To(gomega.BeEquivalentTo(""))
-	g.Expect(kcp.Status.Initialized).To(gomega.BeTrue())
+	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
+	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(3))
+	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(3))
+	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(0))
+	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
+	g.Expect(kcp.Status.FailureMessage).To(BeNil())
+	g.Expect(kcp.Status.FailureReason).To(BeEquivalentTo(""))
+	g.Expect(kcp.Status.Initialized).To(BeTrue())
 
 	// TODO: will need to be updated once we start handling Ready
-	g.Expect(kcp.Status.Ready).To(gomega.BeFalse())
+	g.Expect(kcp.Status.Ready).To(BeFalse())
 }
 
 func TestKubeadmControlPlaneReconciler_updateStatusMachinesReadyMixed(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1002,7 +1002,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusMachinesReadyMixed(t *testing
 		},
 	}
 	kcp.Default()
-	g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
 
 	objs := []runtime.Object{cluster.DeepCopy(), kcp.DeepCopy()}
 	for i := 0; i < 4; i++ {
@@ -1013,9 +1013,9 @@ func TestKubeadmControlPlaneReconciler_updateStatusMachinesReadyMixed(t *testing
 	m, n := createMachineNodePair("testReady", cluster, kcp, true)
 	objs = append(objs, m, n)
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, objs...)
 	log.SetLogger(klogr.New())
 
@@ -1025,21 +1025,21 @@ func TestKubeadmControlPlaneReconciler_updateStatusMachinesReadyMixed(t *testing
 		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 
-	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(gomega.Succeed())
-	g.Expect(kcp.Status.Replicas).To(gomega.BeEquivalentTo(5))
-	g.Expect(kcp.Status.ReadyReplicas).To(gomega.BeEquivalentTo(1))
-	g.Expect(kcp.Status.UnavailableReplicas).To(gomega.BeEquivalentTo(4))
-	g.Expect(kcp.Status.Selector).NotTo(gomega.BeEmpty())
-	g.Expect(kcp.Status.FailureMessage).To(gomega.BeNil())
-	g.Expect(kcp.Status.FailureReason).To(gomega.BeEquivalentTo(""))
-	g.Expect(kcp.Status.Initialized).To(gomega.BeTrue())
+	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
+	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(5))
+	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(1))
+	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(4))
+	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
+	g.Expect(kcp.Status.FailureMessage).To(BeNil())
+	g.Expect(kcp.Status.FailureReason).To(BeEquivalentTo(""))
+	g.Expect(kcp.Status.Initialized).To(BeTrue())
 
 	// TODO: will need to be updated once we start handling Ready
-	g.Expect(kcp.Status.Ready).To(gomega.BeFalse())
+	g.Expect(kcp.Status.Ready).To(BeFalse())
 }
 
 func TestReconcileControlPlaneScaleUp(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1118,11 +1118,11 @@ func TestReconcileControlPlaneScaleUp(t *testing.T) {
 	}
 
 	kcp.Default()
-	g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(
 		scheme.Scheme,
 		kcp.DeepCopy(),
@@ -1140,22 +1140,22 @@ func TestReconcileControlPlaneScaleUp(t *testing.T) {
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(result).To(gomega.Equal(ctrl.Result{}))
-	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(gomega.Succeed())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(Succeed())
 
-	g.Expect(kcp.Status.Replicas).To(gomega.BeEquivalentTo(3))
+	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(3))
 
 	machineList := &clusterv1.MachineList{}
-	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace("test"))).To(gomega.Succeed())
-	g.Expect(machineList.Items).To(gomega.HaveLen(3))
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace("test"))).To(Succeed())
+	g.Expect(machineList.Items).To(HaveLen(3))
 	for _, m := range machineList.Items {
-		g.Expect(m.Name).To(gomega.HavePrefix(kcp.Name))
+		g.Expect(m.Name).To(HavePrefix(kcp.Name))
 	}
 }
 
 func TestScaleUpControlPlaneAddsANewMachine(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1202,9 +1202,9 @@ func TestScaleUpControlPlaneAddsANewMachine(t *testing.T) {
 		},
 	}
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(
 		scheme.Scheme,
 		cluster.DeepCopy(),
@@ -1218,19 +1218,19 @@ func TestScaleUpControlPlaneAddsANewMachine(t *testing.T) {
 		recorder: record.NewFakeRecorder(32),
 	}
 
-	g.Expect(r.scaleUpControlPlane(context.Background(), cluster, kcp, 2)).To(gomega.Succeed())
+	g.Expect(r.scaleUpControlPlane(context.Background(), cluster, kcp, 2)).To(Succeed())
 
 	machineList := &clusterv1.MachineList{}
-	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(gomega.Succeed())
-	g.Expect(machineList.Items).To(gomega.HaveLen(2))
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(machineList.Items).To(HaveLen(2))
 
 	for _, m := range machineList.Items {
-		g.Expect(m.Spec.Bootstrap.ConfigRef.Name).To(gomega.HavePrefix(kcp.Name))
+		g.Expect(m.Spec.Bootstrap.ConfigRef.Name).To(HavePrefix(kcp.Name))
 	}
 }
 
 func TestCloneConfigsAndGenerateMachine(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1272,9 +1272,9 @@ func TestCloneConfigsAndGenerateMachine(t *testing.T) {
 		},
 	}
 
-	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 	fakeClient := fake.NewFakeClientWithScheme(
 		scheme.Scheme,
 		cluster.DeepCopy(),
@@ -1291,26 +1291,26 @@ func TestCloneConfigsAndGenerateMachine(t *testing.T) {
 	bootstrapSpec := &bootstrapv1.KubeadmConfigSpec{
 		JoinConfiguration: &kubeadmv1.JoinConfiguration{},
 	}
-	g.Expect(r.cloneConfigsAndGenerateMachine(context.Background(), cluster, kcp, bootstrapSpec)).To(gomega.Succeed())
+	g.Expect(r.cloneConfigsAndGenerateMachine(context.Background(), cluster, kcp, bootstrapSpec)).To(Succeed())
 
 	machineList := &clusterv1.MachineList{}
-	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(gomega.Succeed())
-	g.Expect(machineList.Items).To(gomega.HaveLen(1))
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(machineList.Items).To(HaveLen(1))
 
 	for _, m := range machineList.Items {
-		g.Expect(m.Namespace).To(gomega.Equal(cluster.Namespace))
-		g.Expect(m.Name).NotTo(gomega.BeEmpty())
-		g.Expect(m.Name).To(gomega.HavePrefix(kcp.Name))
+		g.Expect(m.Namespace).To(Equal(cluster.Namespace))
+		g.Expect(m.Name).NotTo(BeEmpty())
+		g.Expect(m.Name).To(HavePrefix(kcp.Name))
 
-		g.Expect(m.Spec.InfrastructureRef.Namespace).To(gomega.Equal(cluster.Namespace))
-		g.Expect(m.Spec.InfrastructureRef.Name).To(gomega.HavePrefix(genericMachineTemplate.GetName()))
-		g.Expect(m.Spec.InfrastructureRef.APIVersion).To(gomega.Equal(genericMachineTemplate.GetAPIVersion()))
-		g.Expect(m.Spec.InfrastructureRef.Kind).To(gomega.Equal("GenericMachine"))
+		g.Expect(m.Spec.InfrastructureRef.Namespace).To(Equal(cluster.Namespace))
+		g.Expect(m.Spec.InfrastructureRef.Name).To(HavePrefix(genericMachineTemplate.GetName()))
+		g.Expect(m.Spec.InfrastructureRef.APIVersion).To(Equal(genericMachineTemplate.GetAPIVersion()))
+		g.Expect(m.Spec.InfrastructureRef.Kind).To(Equal("GenericMachine"))
 
-		g.Expect(m.Spec.Bootstrap.ConfigRef.Namespace).To(gomega.Equal(cluster.Namespace))
-		g.Expect(m.Spec.Bootstrap.ConfigRef.Name).To(gomega.HavePrefix(kcp.Name))
-		g.Expect(m.Spec.Bootstrap.ConfigRef.APIVersion).To(gomega.Equal(bootstrapv1.GroupVersion.String()))
-		g.Expect(m.Spec.Bootstrap.ConfigRef.Kind).To(gomega.Equal("KubeadmConfig"))
+		g.Expect(m.Spec.Bootstrap.ConfigRef.Namespace).To(Equal(cluster.Namespace))
+		g.Expect(m.Spec.Bootstrap.ConfigRef.Name).To(HavePrefix(kcp.Name))
+		g.Expect(m.Spec.Bootstrap.ConfigRef.APIVersion).To(Equal(bootstrapv1.GroupVersion.String()))
+		g.Expect(m.Spec.Bootstrap.ConfigRef.Kind).To(Equal("KubeadmConfig"))
 	}
 }
 
@@ -1353,7 +1353,7 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 	}
 
 	t.Run("delete control plane machines", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 
 		kcp := &controlplanev1.KubeadmControlPlane{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1395,11 +1395,11 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 		}
 
 		kcp.Default()
-		g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+		g.Expect(kcp.ValidateCreate()).To(Succeed())
 
-		g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-		g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-		g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+		g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+		g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+		g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 		fakeClient := fake.NewFakeClientWithScheme(
 			scheme.Scheme,
 			kcp.DeepCopy(),
@@ -1418,32 +1418,32 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 
 		// Create control plane machines
 		result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(result).To(gomega.Equal(ctrl.Result{}))
-		g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(gomega.Succeed())
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+		g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(Succeed())
 
-		g.Expect(kcp.Status.Replicas).To(gomega.BeEquivalentTo(3))
+		g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(3))
 
 		// Delete control plane machines and requeue, but do not remove finalizer
 		result, err = r.reconcileDelete(context.Background(), cluster, kcp, r.Log)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(result).To(gomega.Equal(ctrl.Result{RequeueAfter: DeleteRequeueAfter}))
-		g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(gomega.Succeed())
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{RequeueAfter: DeleteRequeueAfter}))
+		g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
 
-		g.Expect(kcp.Status.Replicas).To(gomega.BeEquivalentTo(0))
-		g.Expect(kcp.Finalizers).To(gomega.Equal([]string{controlplanev1.KubeadmControlPlaneFinalizer}))
+		g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(0))
+		g.Expect(kcp.Finalizers).To(Equal([]string{controlplanev1.KubeadmControlPlaneFinalizer}))
 
 		// Remove finalizer
 		result, err = r.reconcileDelete(context.Background(), cluster, kcp, r.Log)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
 
-		g.Expect(kcp.Status.Replicas).To(gomega.BeEquivalentTo(0))
-		g.Expect(kcp.Finalizers).To(gomega.Equal([]string{}))
+		g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(0))
+		g.Expect(kcp.Finalizers).To(Equal([]string{}))
 	})
 
 	t.Run("fail to delete control plane machines because at least one machine is not owned by the control plane", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 
 		kcp := &controlplanev1.KubeadmControlPlane{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1495,11 +1495,11 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 		}
 
 		kcp.Default()
-		g.Expect(kcp.ValidateCreate()).To(gomega.Succeed())
+		g.Expect(kcp.ValidateCreate()).To(Succeed())
 
-		g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-		g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
-		g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(gomega.Succeed())
+		g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+		g.Expect(bootstrapv1.AddToScheme(scheme.Scheme)).To(Succeed())
+		g.Expect(controlplanev1.AddToScheme(scheme.Scheme)).To(Succeed())
 		fakeClient := fake.NewFakeClientWithScheme(
 			scheme.Scheme,
 			kcp.DeepCopy(),
@@ -1518,14 +1518,14 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 		}
 
 		result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
-		g.Expect(err).NotTo(gomega.HaveOccurred())
-		g.Expect(result).To(gomega.Equal(ctrl.Result{}))
-		g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(gomega.Succeed())
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(Equal(ctrl.Result{}))
+		g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, kcp)).To(Succeed())
 
-		g.Expect(kcp.Status.Replicas).To(gomega.BeEquivalentTo(3))
+		g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(3))
 
 		result, err = r.reconcileDelete(context.Background(), cluster, kcp, r.Log)
-		g.Expect(err).Should(gomega.MatchError(gomega.ContainSubstring("at least one machine is not owned by the control plane")))
-		g.Expect(result).To(gomega.Equal(ctrl.Result{}))
+		g.Expect(err).Should(MatchError(ContainSubstring("at least one machine is not owned by the control plane")))
+		g.Expect(result).To(Equal(ctrl.Result{}))
 	})
 }

--- a/test/framework/control_plane.go
+++ b/test/framework/control_plane.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	// eventuallyInterval is the polling interval used by gomega.Eventually
+	// eventuallyInterval is the polling interval used by gomega's Eventually
 	eventuallyInterval = 10 * time.Second
 )
 

--- a/test/helpers/components/common.go
+++ b/test/helpers/components/common.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/cluster-api/test/helpers/flag"
 	"sigs.k8s.io/cluster-api/test/helpers/kind"
@@ -38,15 +38,15 @@ var (
 )
 
 func DeployCAPIComponents(kindCluster kind.Cluster) {
-	gomega.Expect(capiComponents).ToNot(gomega.BeNil())
+	Expect(capiComponents).ToNot(BeNil())
 	fmt.Fprintf(ginkgo.GinkgoWriter, "Applying cluster-api components\n")
-	gomega.Expect(*capiComponents).ToNot(gomega.BeEmpty())
+	Expect(*capiComponents).ToNot(BeEmpty())
 	kindCluster.ApplyYAML(*capiComponents)
 }
 
 func WaitDeployment(c client.Client, namespace, name string) {
 	fmt.Fprintf(ginkgo.GinkgoWriter, "Ensuring %s/%s is deployed\n", namespace, name)
-	gomega.Eventually(
+	Eventually(
 		func() (int32, error) {
 			deployment := &appsv1.Deployment{}
 			if err := c.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, deployment); err != nil {
@@ -54,5 +54,5 @@ func WaitDeployment(c client.Client, namespace, name string) {
 			}
 			return deployment.Status.ReadyReplicas, nil
 		}, 5*time.Minute, 15*time.Second,
-	).ShouldNot(gomega.BeZero())
+	).ShouldNot(BeZero())
 }

--- a/test/helpers/kind/setup.go
+++ b/test/helpers/kind/setup.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -53,7 +53,7 @@ type Cluster struct {
 func (c *Cluster) Setup() {
 	var err error
 	c.tmpDir, err = ioutil.TempDir("", "kind-home")
-	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	fmt.Fprintf(ginkgo.GinkgoWriter, "creating Kind cluster named %q\n", c.Name)
 	c.run(exec.Command(*kindBinary, "create", "cluster", "--name", c.Name))
 	path := c.runWithOutput(exec.Command(*kindBinary, "get", "kubeconfig-path", "--name", c.Name))
@@ -90,7 +90,7 @@ func (c *Cluster) ApplyYAML(manifestPath string) {
 // RestConfig returns a rest configuration pointed at the provisioned cluster
 func (c *Cluster) RestConfig() *restclient.Config {
 	cfg, err := clientcmd.BuildConfigFromFlags("", c.kubepath)
-	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return cfg
 }
 
@@ -98,7 +98,7 @@ func (c *Cluster) RestConfig() *restclient.Config {
 func (c *Cluster) KubeClient() kubernetes.Interface {
 	cfg := c.RestConfig()
 	client, err := kubernetes.NewForConfig(cfg)
-	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return client
 }
 
@@ -112,7 +112,7 @@ func (c *Cluster) runWithOutput(cmd *exec.Cmd) []byte {
 func (c *Cluster) run(cmd *exec.Cmd) {
 	var wg sync.WaitGroup
 	errPipe, err := cmd.StderrPipe()
-	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	cmd.Env = append(
 		cmd.Env,
@@ -129,14 +129,14 @@ func (c *Cluster) run(cmd *exec.Cmd) {
 	go captureOutput(&wg, errPipe, "stderr")
 	if cmd.Stdout == nil {
 		outPipe, err := cmd.StdoutPipe()
-		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		wg.Add(1)
 		go captureOutput(&wg, outPipe, "stdout")
 	}
 
-	gomega.Expect(cmd.Start()).To(gomega.Succeed())
+	Expect(cmd.Start()).To(Succeed())
 	wg.Wait()
-	gomega.Expect(cmd.Wait()).To(gomega.Succeed())
+	Expect(cmd.Wait()).To(Succeed())
 }
 
 func captureOutput(wg *sync.WaitGroup, r io.Reader, label string) {

--- a/test/helpers/scheme/scheme.go
+++ b/test/helpers/scheme/scheme.go
@@ -17,7 +17,7 @@ limitations under the License.
 package scheme
 
 import (
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -25,7 +25,7 @@ import (
 
 func SetupScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	gomega.Expect(clientgoscheme.AddToScheme(scheme)).To(gomega.Succeed())
-	gomega.Expect(clusterv1.AddToScheme(scheme)).To(gomega.Succeed())
+	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+	Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
 	return scheme
 }

--- a/util/conversion/conversion_test.go
+++ b/util/conversion/conversion_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1a2 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterv1a3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
 func TestMarshalData(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	t.Run("should write source object to destination", func(t *testing.T) {
 		src := &clusterv1a3.Machine{
@@ -44,9 +44,9 @@ func TestMarshalData(t *testing.T) {
 			},
 		}
 
-		g.Expect(MarshalData(src, dst)).To(gomega.Succeed())
-		g.Expect(dst.Annotations[DataAnnotation]).ToNot(gomega.BeEmpty())
-		g.Expect(dst.Annotations[DataAnnotation]).To(gomega.ContainSubstring("label1"))
+		g.Expect(MarshalData(src, dst)).To(Succeed())
+		g.Expect(dst.Annotations[DataAnnotation]).ToNot(BeEmpty())
+		g.Expect(dst.Annotations[DataAnnotation]).To(ContainSubstring("label1"))
 	})
 
 	t.Run("should append the annotation", func(t *testing.T) {
@@ -64,15 +64,15 @@ func TestMarshalData(t *testing.T) {
 			},
 		}
 
-		g.Expect(MarshalData(src, dst)).To(gomega.Succeed())
-		g.Expect(len(dst.Annotations)).To(gomega.Equal(2))
+		g.Expect(MarshalData(src, dst)).To(Succeed())
+		g.Expect(len(dst.Annotations)).To(Equal(2))
 
 		spew.Dump(dst.Annotations)
 	})
 }
 
 func TestUnmarshalData(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	t.Run("should return false without errors if annotation doesn't exist", func(t *testing.T) {
 		src := &clusterv1a3.Machine{
@@ -87,8 +87,8 @@ func TestUnmarshalData(t *testing.T) {
 		}
 
 		ok, err := UnmarshalData(src, dst)
-		g.Expect(ok).To(gomega.BeFalse())
-		g.Expect(err).To(gomega.BeNil())
+		g.Expect(ok).To(BeFalse())
+		g.Expect(err).To(BeNil())
 	})
 
 	t.Run("should return true when a valid annotation with data exists", func(t *testing.T) {
@@ -103,13 +103,13 @@ func TestUnmarshalData(t *testing.T) {
 		dst := &clusterv1a2.Machine{}
 
 		ok, err := UnmarshalData(src, dst)
-		g.Expect(ok).To(gomega.BeTrue())
-		g.Expect(err).To(gomega.BeNil())
+		g.Expect(ok).To(BeTrue())
+		g.Expect(err).To(BeNil())
 
-		g.Expect(len(dst.Labels)).To(gomega.Equal(1))
-		g.Expect(dst.Name).To(gomega.Equal("test-1"))
-		g.Expect(dst.Labels).To(gomega.HaveKeyWithValue("label1", ""))
-		g.Expect(dst.Annotations).To(gomega.BeEmpty())
+		g.Expect(len(dst.Labels)).To(Equal(1))
+		g.Expect(dst.Name).To(Equal("test-1"))
+		g.Expect(dst.Labels).To(HaveKeyWithValue("label1", ""))
+		g.Expect(dst.Annotations).To(BeEmpty())
 	})
 
 	t.Run("should clean the annotation on successful unmarshal", func(t *testing.T) {
@@ -125,10 +125,10 @@ func TestUnmarshalData(t *testing.T) {
 		dst := &clusterv1a2.Machine{}
 
 		ok, err := UnmarshalData(src, dst)
-		g.Expect(ok).To(gomega.BeTrue())
-		g.Expect(err).To(gomega.BeNil())
+		g.Expect(ok).To(BeTrue())
+		g.Expect(err).To(BeNil())
 
-		g.Expect(src.Annotations).ToNot(gomega.HaveKey(DataAnnotation))
-		g.Expect(len(src.Annotations)).To(gomega.Equal(1))
+		g.Expect(src.Annotations).ToNot(HaveKey(DataAnnotation))
+		g.Expect(len(src.Annotations)).To(Equal(1))
 	})
 }

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -203,7 +203,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestGenerateSecretWithOwner(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	owner := metav1.OwnerReference{
 		Name:       "test1",
@@ -223,12 +223,12 @@ func TestGenerateSecretWithOwner(t *testing.T) {
 		owner,
 	)
 
-	g.Expect(kubeconfigSecret).NotTo(gomega.BeNil())
-	g.Expect(kubeconfigSecret).To(gomega.Equal(expectedSecret))
+	g.Expect(kubeconfigSecret).NotTo(BeNil())
+	g.Expect(kubeconfigSecret).To(Equal(expectedSecret))
 }
 
 func TestGenerateSecret(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	expectedSecret := validSecret.DeepCopy()
 	expectedSecret.SetOwnerReferences(
@@ -250,18 +250,18 @@ func TestGenerateSecret(t *testing.T) {
 		[]byte(validKubeConfig),
 	)
 
-	g.Expect(kubeconfigSecret).NotTo(gomega.BeNil())
-	g.Expect(kubeconfigSecret).To(gomega.Equal(expectedSecret))
+	g.Expect(kubeconfigSecret).NotTo(BeNil())
+	g.Expect(kubeconfigSecret).To(Equal(expectedSecret))
 }
 
 func TestCreateSecretWithOwner(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	caKey, err := certs.NewPrivateKey()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	caCert, err := getTestCACert(caKey)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	caSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -293,29 +293,29 @@ func TestCreateSecretWithOwner(t *testing.T) {
 		owner,
 	)
 
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	s := &corev1.Secret{}
 	key := client.ObjectKey{Name: "test1-kubeconfig", Namespace: "test"}
-	g.Expect(c.Get(context.Background(), key, s)).To(gomega.Succeed())
-	g.Expect(s.OwnerReferences).To(gomega.ContainElement(owner))
+	g.Expect(c.Get(context.Background(), key, s)).To(Succeed())
+	g.Expect(s.OwnerReferences).To(ContainElement(owner))
 
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(s.Data[secret.KubeconfigDataName])
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 	restClient, err := clientConfig.ClientConfig()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(restClient.CAData).To(gomega.Equal(certs.EncodeCertPEM(caCert)))
-	g.Expect(restClient.Host).To(gomega.Equal("https://localhost:6443"))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(restClient.CAData).To(Equal(certs.EncodeCertPEM(caCert)))
+	g.Expect(restClient.Host).To(Equal("https://localhost:6443"))
 }
 
 func TestCreateSecret(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 
 	caKey, err := certs.NewPrivateKey()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	caCert, err := getTestCACert(caKey)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	caSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -349,12 +349,12 @@ func TestCreateSecret(t *testing.T) {
 		cluster,
 	)
 
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 
 	s := &corev1.Secret{}
 	key := client.ObjectKey{Name: "test1-kubeconfig", Namespace: "test"}
-	g.Expect(c.Get(context.Background(), key, s)).To(gomega.Succeed())
-	g.Expect(s.OwnerReferences).To(gomega.ContainElement(
+	g.Expect(c.Get(context.Background(), key, s)).To(Succeed())
+	g.Expect(s.OwnerReferences).To(ContainElement(
 		metav1.OwnerReference{
 			Name:       cluster.Name,
 			Kind:       "Cluster",
@@ -363,9 +363,9 @@ func TestCreateSecret(t *testing.T) {
 	))
 
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(s.Data[secret.KubeconfigDataName])
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(HaveOccurred())
 	restClient, err := clientConfig.ClientConfig()
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(restClient.CAData).To(gomega.Equal(certs.EncodeCertPEM(caCert)))
-	g.Expect(restClient.Host).To(gomega.Equal("https://localhost:8443"))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(restClient.CAData).To(Equal(certs.EncodeCertPEM(caCert)))
+	g.Expect(restClient.Host).To(Equal("https://localhost:8443"))
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR makes the test files using `gomega` directly more readable and consistent.