### PR TITLE
📖 fix typo in '$ kind create cluster' 

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -23,7 +23,7 @@ workflow that offers easy deployments and rapid iterative builds.
 First, make sure you have a kind cluster and that your `KUBECONFIG` is set up correctly:
 
 ``` bash
-$ kind create cluster
+kind create cluster
 ```
 
 ### Create a tilt-settings.json file


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Removes a redundant _$_. 

