### PR TITLE
update doc quick start for openstack

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -733,8 +733,8 @@ spec:
 
 After the controlplane is up and running, let's retrieve the [target cluster] Kubeconfig:
 
-{{#tabs name:"tab-getting-kubeconfig" tabs:"AWS|Azure|GCP|vSphere|OpenStack, Docker"}}
-{{#tab AWS|Azure|GCP|vSphere|OpenStack}}
+{{#tabs name:"tab-getting-kubeconfig" tabs:"AWS|Azure|GCP|vSphere|OpenStack|Docker"}}
+{{#tab AWS|Azure|GCP|vSphere|OpenStack|Docker}}
 
 ```bash
 kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o json \


### PR DESCRIPTION
Now the doc site https://cluster-api.sigs.k8s.io/user/quick-start.html
get kubeconfig section doesn't have openstack but actually openstack
has same requirements to other platform.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
