### PR TITLE
🐛 Set clusterctl user-agent

### DIFF
--- a/cmd/clusterctl/pkg/client/cluster/proxy.go
+++ b/cmd/clusterctl/pkg/client/cluster/proxy.go
@@ -17,10 +17,13 @@ limitations under the License.
 package cluster
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/scheme"
+	"sigs.k8s.io/cluster-api/cmd/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
@@ -96,6 +99,7 @@ func (k *proxy) getConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to rest client")
 	}
+	restConfig.UserAgent = fmt.Sprintf("clusterctl/%s (%s)", version.Get().GitVersion, version.Get().Platform)
 
 	return restConfig, nil
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Currently clusterctl uses client-go's REST client and it calls DefaultKubernetesUserAgent which populates incorrect info, like: `User-Agent: clusterctl/v0.0.0 (darwin/amd64) kubernetes/$Format`

This populates the user-agent with output like: `User-Agent: clusterctl/v0.2.5 (darwin/amd64)`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
