### PR TITLE
:book: Fix bootstrap provider activity diagram url

### DIFF
--- a/docs/book/src/providers/bootstrap.md
+++ b/docs/book/src/providers/bootstrap.md
@@ -45,7 +45,7 @@ accordingly.
 
 The following diagram shows the typical logic for a bootstrap provider:
 
-![Bootstrap provider activity diagram](../images/bootstrap-infra-provider.png)
+![Bootstrap provider activity diagram](../images/bootstrap-provider.png)
 
 1. If the resource does not have a `Machine` owner, exit the reconciliation
     1. The Cluster API `Machine` reconciler populates this based on the value in the `Machine`'s `spec.bootstrap.configRef`


### PR DESCRIPTION
**What this PR does / why we need it**:
The activity diagram for the bootstrap provider had a bad URL. This fixes it.