### PR TITLE
✨Stop the reconciliation when the external ref object is paused

### DIFF
--- a/controllers/cluster_controller_phases_test.go
+++ b/controllers/cluster_controller_phases_test.go
@@ -26,12 +26,11 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
-	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 
 func TestClusterReconcilePhases(t *testing.T) {
@@ -97,6 +96,22 @@ func TestClusterReconcilePhases(t *testing.T) {
 						"name":              "test",
 						"namespace":         "test-namespace",
 						"deletionTimestamp": "sometime",
+					},
+				},
+				expectErr: false,
+			},
+			{
+				name:    "returns error if infrastructure has the paused annotation",
+				cluster: cluster,
+				infraRef: map[string]interface{}{
+					"kind":       "InfrastructureConfig",
+					"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test-namespace",
+						"annotations": map[string]interface{}{
+							"cluster.x-k8s.io/paused": "true",
+						},
 					},
 				},
 				expectErr: false,

--- a/controllers/external/types.go
+++ b/controllers/external/types.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ReconcileOutput is a return type of the external reconciliation
+// of referenced objects
+type ReconcileOutput struct {
+	// Details of the referenced external object.
+	// +optional
+	Result *unstructured.Unstructured
+	// Indicates if the external object is paused.
+	// +optional
+	Paused bool
+}

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -170,8 +170,8 @@ func (r *MachineReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cl
 
 	// Call the inner reconciliation methods.
 	reconciliationErrors := []error{
-		r.reconcileBootstrap(ctx, m),
-		r.reconcileInfrastructure(ctx, m),
+		r.reconcileBootstrap(ctx, cluster, m),
+		r.reconcileInfrastructure(ctx, cluster, m),
 		r.reconcileNodeRef(ctx, cluster, m),
 	}
 


### PR DESCRIPTION


**What this PR does / why we need it**:
- Add a check in cluster and machine controllers to stop the reconciliation when the external ref object has the paused annotations

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2006
