### PR TITLE
🐛 clusterctl: remove duplicate errors, and silence usage on error

### DIFF
--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"strings"
 
@@ -30,8 +29,9 @@ import (
 var cfgFile string
 
 var RootCmd = &cobra.Command{
-	Use:   "clusterctl",
-	Short: "clusterctl controls a management cluster for Cluster API",
+	Use:          "clusterctl",
+	SilenceUsage: true,
+	Short:        "clusterctl controls a management cluster for Cluster API",
 	Long: LongDesc(`
 		Get started with Cluster API using clusterctl for initializing a management cluster by installing
 		Cluster API providers, and then use clusterctl for creating yaml templates for your workload clusters.`),
@@ -41,7 +41,6 @@ func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		//TODO: print error stack if log v>0
 		//TODO: print cmd help if validation error
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
When `clusterctl` has an error, the error is printed twice. I believe RunE prints the error so the `fmt.Fprintln` is not needed.

Also it's hard to find the error as `clusterctl` prints a huge block of usage right after the error message. This hides the usage on error, just as `kubectl` and `kubeadm` do as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
