### PR TITLE
🐛 Remove generic labels for metrics services

### DIFF
--- a/bootstrap/kubeadm/config/rbac/auth_proxy_service.yaml
+++ b/bootstrap/kubeadm/config/rbac/auth_proxy_service.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:

--- a/controlplane/kubeadm/config/rbac/auth_proxy_service.yaml
+++ b/controlplane/kubeadm/config/rbac/auth_proxy_service.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Generic labels are not intended on metrics services and should therefore be removed. Provider labels will be added in https://github.com/kubernetes-sigs/cluster-api/pull/2070

I might have gotten this wrong but this was my understanding of the issue. I did not `kubectl apply` the generated result but checked that there are no more services with that label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2097
