### PR TITLE
🐛 Align metrics service to use same selector as webhook service

### DIFF
--- a/bootstrap/kubeadm/config/rbac/auth_proxy_service.yaml
+++ b/bootstrap/kubeadm/config/rbac/auth_proxy_service.yaml
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: cluster-api-kubeadm-bootstrap-controller-manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: cluster-api-controller-manager

--- a/controlplane/kubeadm/config/rbac/auth_proxy_service.yaml
+++ b/controlplane/kubeadm/config/rbac/auth_proxy_service.yaml
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: cluster-api-kubeadm-control-plane-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
This aligns the selector of the `metrics` service with the selector used by the `webhook` service. 

The `webhook` service seems to be correct here, as the generated output (`make generate-manifests` -> `make release-manifests`) does not contain any pods or deployments with a label matching `control-plane: controller-manager`.

