### PR TITLE
✨ Add more print columns to machinedeployments

### DIFF
--- a/api/v1alpha3/machinedeployment_types.go
+++ b/api/v1alpha3/machinedeployment_types.go
@@ -232,6 +232,9 @@ func (md *MachineDeploymentStatus) GetTypedPhase() MachineDeploymentPhase {
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown"
+// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="Total number of non-terminated machines targeted by this deployment"
+// +kubebuilder:printcolumn:name="Available",type="integer",JSONPath=".status.availableReplicas",description="Total number of available machines (ready for at least minReadySeconds)"
+// +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Total number of ready machines targeted by this deployment."
 
 // MachineDeployment is the Schema for the machinedeployments API
 type MachineDeployment struct {

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -549,6 +549,18 @@ spec:
       description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
       name: Phase
       type: string
+    - JSONPath: .status.replicas
+      description: Total number of non-terminated machines targeted by this deployment
+      name: Replicas
+      type: integer
+    - JSONPath: .status.availableReplicas
+      description: Total number of available machines (ready for at least minReadySeconds)
+      name: Available
+      type: integer
+    - JSONPath: .status.readyReplicas
+      description: Total number of ready machines targeted by this deployment.
+      name: Ready
+      type: integer
     name: v1alpha3
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This adds "Replicas", "Available", and "Ready" columns to command `kubectl get machinedeployments`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2067 
