### PR TITLE
📖 Backport: document how to verify control-plane is running

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -640,6 +640,12 @@ spec:
 {{#/tab }}
 {{#/tabs }}
 
+To verify the control plane is up and running ensure the control plane machine
+`PHASE` is `running`.
+```
+kubectl get machines --selector cluster.x-k8s.io/control-plane=true
+```
+
 After the controlplane is up and running, let's retrieve the [target cluster] Kubeconfig:
 
 {{#tabs name:"tab-getting-kubeconfig" tabs:"AWS,Azure,Docker,vSphere"}}

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -640,13 +640,13 @@ spec:
 {{#/tab }}
 {{#/tabs }}
 
-To verify the control plane is up and running ensure the control plane machine
-`PHASE` is `running`.
+To verify the control plane is up, check if the control plane machine
+has a ProviderID.
 ```
-kubectl get machines --selector cluster.x-k8s.io/control-plane=true
+kubectl get machines --selector cluster.x-k8s.io/control-plane
 ```
 
-After the controlplane is up and running, let's retrieve the [target cluster] Kubeconfig:
+After the controlplane is up, we can retrieve the workload cluster Kubeconfig:
 
 {{#tabs name:"tab-getting-kubeconfig" tabs:"AWS,Azure,Docker,vSphere"}}
 {{#tab AWS}}
@@ -731,7 +731,7 @@ spec:
 {{#/tab }}
 {{#/tabs }}
 
-After a short while, our control plane should be up and in `Ready` state,
+After a short while, our control plane should be running and in `Ready` state,
 let's check the status using `kubectl get nodes`:
 
 ```bash
@@ -1185,6 +1185,3 @@ spec:
 
 {{#/tab }}
 {{#/tabs }}
-
-<!-- links -->
-[target cluster]: ../reference/glossary.md#target-cluster


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds a line of documentation that provides a way for users to verify if their control-plane machines are up and running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref #2074 
