### PR TITLE
WIP: ✨ Allow disabling leader election in generators

### DIFF
--- a/test/framework/generators/capi_test.go
+++ b/test/framework/generators/capi_test.go
@@ -1,0 +1,142 @@
+package generators
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	outWithLeaderElectionEnabled = `apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: capi-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: capi-controller-manager
+  namespace: capi-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        command:
+        - /manager
+        image: controller:latest
+        name: manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+`
+	outWithLeaderElectionDisabled = `apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: capi-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: capi-controller-manager
+  namespace: capi-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election=false
+        command:
+        - /manager
+        image: controller:latest
+        name: manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+`
+)
+
+func TestClusterAPI_Manifests(t *testing.T) {
+	tests := []struct {
+		name string
+		capi *ClusterAPI
+		want string
+	}{
+		{
+			name: "leader election enabled",
+			capi: &ClusterAPI{
+				KustomizePath:         "testdata/capi/",
+				Version:               "",
+				DisableLeaderElection: false,
+			},
+			want: outWithLeaderElectionEnabled,
+		},
+		{
+			name: "leader election disabled",
+			capi: &ClusterAPI{
+				KustomizePath:         "testdata/capi/",
+				Version:               "",
+				DisableLeaderElection: true,
+			},
+			want: outWithLeaderElectionDisabled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got, err := tt.capi.Manifests(context.TODO())
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(string(got)).To(Equal(tt.want))
+		})
+	}
+}

--- a/test/framework/generators/testdata/capi/kustomization.yaml
+++ b/test/framework/generators/testdata/capi/kustomization.yaml
@@ -1,0 +1,7 @@
+namespace: capi-system
+namePrefix: capi-
+bases:
+- manager
+
+patchesStrategicMerge:
+- manager_auth_proxy_patch.yaml

--- a/test/framework/generators/testdata/capi/manager/kustomization.yaml
+++ b/test/framework/generators/testdata/capi/manager/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- manager.yaml

--- a/test/framework/generators/testdata/capi/manager/manager.yaml
+++ b/test/framework/generators/testdata/capi/manager/manager.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - command:
+        - /manager
+        args:
+        - --enable-leader-election
+        image: controller:latest
+        name: manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master

--- a/test/framework/generators/testdata/capi/manager_auth_proxy_patch.yaml
+++ b/test/framework/generators/testdata/capi/manager_auth_proxy_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: kube-rbac-proxy
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8080/"
+            - "--logtostderr=true"
+            - "--v=10"
+          ports:
+            - containerPort: 8443
+              name: https
+        - name: manager
+          args:
+            - "--metrics-addr=127.0.0.1:8080"
+            - "--enable-leader-election"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds possibility to disable manager leader election in e2e framework generator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #2041
