### PR TITLE
🐛 fix the e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,9 +412,11 @@ release-manifests: $(RELEASE_DIR) $(KUSTOMIZE) ## Builds the manifests to publis
 	$(KUSTOMIZE) build config/core > $(RELEASE_DIR)/core-components.yaml
 	$(KUSTOMIZE) build bootstrap/kubeadm/config/default > $(RELEASE_DIR)/bootstrap-components.yaml
 	$(KUSTOMIZE) build controlplane/kubeadm/config/default > $(RELEASE_DIR)/control-plane-components.yaml
-	@for f in $(RELEASE_DIR)/core-components.yaml $(RELEASE_DIR)/bootstrap-components.yaml $(RELEASE_DIR)/control-plane-components.yaml;\
-		do echo "---" | cat $$f - >> $(RELEASE_DIR)/cluster-api-components.yaml;\
-		done
+	cat $(RELEASE_DIR)/core-components.yaml > $(RELEASE_DIR)/cluster-api-components.yaml
+	echo "---" >> $(RELEASE_DIR)/cluster-api-components.yaml
+	cat $(RELEASE_DIR)/bootstrap-components.yaml >> $(RELEASE_DIR)/cluster-api-components.yaml
+	echo "---" >> $(RELEASE_DIR)/cluster-api-components.yaml
+	cat $(RELEASE_DIR)/control-plane-components.yaml >> $(RELEASE_DIR)/cluster-api-components.yaml
 
 release-binaries: ## Builds the binaries to publish with a release
 	RELEASE_BINARY=./cmd/clusterctl GOOS=linux GOARCH=amd64 $(MAKE) release-binary

--- a/scripts/ci-capi-e2e.sh
+++ b/scripts/ci-capi-e2e.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+echo "*** Running Cluster API e2e tests ***"
+
+cd "${REPO_ROOT}" && make test-e2e


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR fixes the e2e tests.

The makefile syntax wasn't right for generating the YAML correctly so I've replaced it with something a little more direct. This allows the e2es to pass.

I'll be adding these to the presubmits. They don't take very long to run.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1884

/assign @wfernandes 

This also adds a ci script to call from test-infra.
