### PR TITLE
📖 fix spelling mistake in readme

### DIFF
--- a/bootstrap/kubeadm/README.md
+++ b/bootstrap/kubeadm/README.md
@@ -179,4 +179,4 @@ The `KubeadmConfig` object supports customizing the content of the config-data:
 - `KubeadmConfig.PreKubeadmCommands` specifies a list of commands to be executed before `kubeadm init/join`
 - `KubeadmConfig.PostKubeadmCommands` same as above, but after `kubeadm init/join`
 - `KubeadmConfig.Users` specifies a list of users to be created on the machine
-- `KubeadmConfig.NTP` specifies NPT settings for the machine
+- `KubeadmConfig.NTP` specifies NTP settings for the machine


### PR DESCRIPTION
*What this PR does / why we need it**:

Fixes a simple spelling mistake in the bootstrap/kubeadm readme about NTP