### PR TITLE
✨clusterctl: log propagation

### DIFF
--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -17,6 +17,8 @@ limitations under the License.
 package client
 
 import (
+	"github.com/go-logr/logr"
+	"k8s.io/klog/klogr"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
@@ -77,6 +79,7 @@ type clusterctlClient struct {
 	configClient            config.Client
 	repositoryClientFactory RepositoryClientFactory
 	clusterClientFactory    ClusterClientFactory
+	log                     logr.Logger
 }
 
 type RepositoryClientFactory func(config.Provider) (repository.Client, error)
@@ -90,6 +93,7 @@ type NewOptions struct {
 	injectConfig            config.Client
 	injectRepositoryFactory RepositoryClientFactory
 	injectClusterFactory    ClusterClientFactory
+	injectLogger            logr.Logger
 }
 
 // Option is a configuration option supplied to New
@@ -118,6 +122,13 @@ func InjectClusterClientFactory(factory ClusterClientFactory) Option {
 	}
 }
 
+// InjectLogger implements a New Option that allows to override the default logger.
+func InjectLogger(logger logr.Logger) Option {
+	return func(c *NewOptions) {
+		c.injectLogger = logger
+	}
+}
+
 // New returns a configClient.
 func New(path string, options ...Option) (Client, error) {
 	return newClusterctlClient(path, options...)
@@ -129,11 +140,17 @@ func newClusterctlClient(path string, options ...Option) (*clusterctlClient, err
 		o(cfg)
 	}
 
+	// if there is an injected logger, use it, otherwise use a default one
+	logger := cfg.injectLogger
+	if logger == nil {
+		logger = klogr.New() //TODO: replace with a logger with a better output
+	}
+
 	// if there is an injected config, use it, otherwise use the default one
 	// provided by the config low level library
 	configClient := cfg.injectConfig
 	if configClient == nil {
-		c, err := config.New(path)
+		c, err := config.New(path, config.InjectLogger(logger))
 		if err != nil {
 			return nil, err
 		}
@@ -143,32 +160,33 @@ func newClusterctlClient(path string, options ...Option) (*clusterctlClient, err
 	// if there is an injected RepositoryFactory, use it, otherwise use a default one
 	repositoryClientFactory := cfg.injectRepositoryFactory
 	if repositoryClientFactory == nil {
-		repositoryClientFactory = defaultRepositoryFactory(configClient)
+		repositoryClientFactory = defaultRepositoryFactory(configClient, logger)
 	}
 
 	// if there is an injected ClusterFactory, use it, otherwise use a default one
 	clusterClientFactory := cfg.injectClusterFactory
 	if clusterClientFactory == nil {
-		clusterClientFactory = defaultClusterFactory()
+		clusterClientFactory = defaultClusterFactory(logger)
 	}
 
 	return &clusterctlClient{
 		configClient:            configClient,
 		repositoryClientFactory: repositoryClientFactory,
 		clusterClientFactory:    clusterClientFactory,
+		log:                     logger,
 	}, nil
 }
 
 // defaultClusterFactory is a ClusterClientFactory func the uses the default client provided by the cluster low level library
-func defaultClusterFactory() func(kubeconfig string) (cluster.Client, error) {
+func defaultClusterFactory(log logr.Logger) func(kubeconfig string) (cluster.Client, error) {
 	return func(kubeconfig string) (cluster.Client, error) {
-		return cluster.New(kubeconfig, cluster.Options{}), nil
+		return cluster.New(kubeconfig, cluster.InjectLogger(log)), nil
 	}
 }
 
 // defaultRepositoryFactory is a RepositoryClientFactory func the uses the default client provided by the repository low level library
-func defaultRepositoryFactory(configClient config.Client) func(providerConfig config.Provider) (repository.Client, error) {
+func defaultRepositoryFactory(configClient config.Client, log logr.Logger) func(providerConfig config.Provider) (repository.Client, error) {
 	return func(providerConfig config.Provider) (repository.Client, error) {
-		return repository.New(providerConfig, configClient.Variables(), repository.Options{})
+		return repository.New(providerConfig, configClient.Variables(), repository.InjectLogger(log))
 	}
 }

--- a/cmd/clusterctl/pkg/client/client_test.go
+++ b/cmd/clusterctl/pkg/client/client_test.go
@@ -112,6 +112,7 @@ func newFakeClient(configClient config.Client) *fakeClient {
 			}
 			return fake.repositories[provider.Name()], nil
 		}),
+		InjectLogger(test.NewFakeLogger()),
 	)
 
 	return fake
@@ -136,11 +137,7 @@ func (f *fakeClient) WithRepository(repositoryClient repository.Client) *fakeCli
 func newFakeCluster(kubeconfig string) *fakeClusterClient {
 	fakeProxy := test.NewFakeProxy()
 
-	options := cluster.Options{
-		InjectProxy: fakeProxy,
-	}
-
-	client := cluster.New("", options)
+	client := cluster.New("", cluster.InjectProxy(fakeProxy))
 
 	return &fakeClusterClient{
 		kubeconfig:     kubeconfig,
@@ -253,15 +250,12 @@ func (f *fakeConfigClient) WithProvider(provider config.Provider) *fakeConfigCli
 // the WithPaths or WithDefaultVersion methods to configure the repository and WithFile to set the map values.
 func newFakeRepository(provider config.Provider, configVariablesClient config.VariablesClient) *fakeRepositoryClient {
 	fakeRepository := test.NewFakeRepository()
-	options := repository.Options{
-		InjectRepository: fakeRepository,
-	}
 
 	if configVariablesClient == nil {
 		configVariablesClient = newFakeConfig().Variables()
 	}
 
-	client, _ := repository.New(provider, configVariablesClient, options)
+	client, _ := repository.New(provider, configVariablesClient, repository.InjectRepository(fakeRepository))
 
 	return &fakeRepositoryClient{
 		Provider:       provider,

--- a/cmd/clusterctl/pkg/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/pkg/client/cluster/cert_manager.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -47,15 +48,17 @@ type CertMangerClient interface {
 // certMangerClient implements CertMangerClient .
 type certMangerClient struct {
 	proxy Proxy
+	log   logr.Logger
 }
 
 // Ensure certMangerClient implements the CertMangerClient interface.
 var _ CertMangerClient = &certMangerClient{}
 
 // newCertMangerClient returns a certMangerClient.
-func newCertMangerClient(proxy Proxy) *certMangerClient {
+func newCertMangerClient(proxy Proxy, log logr.Logger) *certMangerClient {
 	return &certMangerClient{
 		proxy: proxy,
+		log:   log,
 	}
 }
 

--- a/cmd/clusterctl/pkg/client/cluster/components.go
+++ b/cmd/clusterctl/pkg/client/cluster/components.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -50,6 +51,7 @@ type ComponentsClient interface {
 // providerComponents implements ComponentsClient.
 type providerComponents struct {
 	proxy Proxy
+	log   logr.Logger
 }
 
 // Create provider components defined in the yaml file.
@@ -166,9 +168,10 @@ func (p *providerComponents) Delete(options DeleteOptions) error {
 }
 
 // newComponentsClient returns a providerComponents.
-func newComponentsClient(proxy Proxy) *providerComponents {
+func newComponentsClient(proxy Proxy, log logr.Logger) *providerComponents {
 	return &providerComponents{
 		proxy: proxy,
+		log:   log,
 	}
 }
 

--- a/cmd/clusterctl/pkg/client/cluster/components_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/components_test.go
@@ -174,7 +174,7 @@ func Test_providerComponents_Delete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			proxy := test.NewFakeProxy().WithObjs(initObjs...)
-			c := newComponentsClient(proxy)
+			c := newComponentsClient(proxy, test.NewFakeLogger())
 			err := c.Delete(DeleteOptions{
 				Provider:             tt.args.provider,
 				ForceDeleteNamespace: tt.args.forceDeleteNamespace,

--- a/cmd/clusterctl/pkg/client/cluster/installer.go
+++ b/cmd/clusterctl/pkg/client/cluster/installer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
@@ -39,6 +40,7 @@ type providerInstaller struct {
 	providerComponents ComponentsClient
 	providerInventory  InventoryClient
 	installQueue       []repository.Components
+	log                logr.Logger
 }
 
 var _ ProviderInstaller = &providerInstaller{}
@@ -71,10 +73,11 @@ func (i *providerInstaller) Install() ([]repository.Components, error) {
 	return ret, nil
 }
 
-func newProviderInstaller(proxy Proxy, providerMetadata InventoryClient, providerComponents ComponentsClient) *providerInstaller {
+func newProviderInstaller(proxy Proxy, providerMetadata InventoryClient, providerComponents ComponentsClient, log logr.Logger) *providerInstaller {
 	return &providerInstaller{
 		proxy:              proxy,
 		providerInventory:  providerMetadata,
 		providerComponents: providerComponents,
+		log:                log,
 	}
 }

--- a/cmd/clusterctl/pkg/client/cluster/inventory.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -66,15 +67,17 @@ type InventoryClient interface {
 // inventoryClient implements InventoryClient.
 type inventoryClient struct {
 	proxy Proxy
+	log   logr.Logger
 }
 
 // ensure inventoryClient implements InventoryClient.
 var _ InventoryClient = &inventoryClient{}
 
 // newInventoryClient returns a inventoryClient.
-func newInventoryClient(proxy Proxy) *inventoryClient {
+func newInventoryClient(proxy Proxy, log logr.Logger) *inventoryClient {
 	return &inventoryClient{
 		proxy: proxy,
+		log:   log,
 	}
 }
 

--- a/cmd/clusterctl/pkg/client/cluster/inventory_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory_test.go
@@ -52,7 +52,7 @@ func Test_inventoryClient_EnsureCustomResourceDefinitions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newInventoryClient(test.NewFakeProxy())
+			p := newInventoryClient(test.NewFakeProxy(), test.NewFakeLogger())
 			if tt.fields.alreadyHasCRD {
 				//forcing creation of metadata before test
 				if err := p.EnsureCustomResourceDefinitions(); err != nil {
@@ -97,7 +97,7 @@ func Test_inventoryClient_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newInventoryClient(test.NewFakeProxy().WithObjs(tt.fields.initObjs...))
+			p := newInventoryClient(test.NewFakeProxy().WithObjs(tt.fields.initObjs...), test.NewFakeLogger())
 			got, err := p.List()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("List() error = %v, wantErr %v", err, tt.wantErr)

--- a/cmd/clusterctl/pkg/client/cluster/objects.go
+++ b/cmd/clusterctl/pkg/client/cluster/objects.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package cluster
 
+import "github.com/go-logr/logr"
+
 // ObjectsClient has methods to work with provider objects in the cluster.
 type ObjectsClient interface {
 	//TODO: add move
@@ -24,14 +26,16 @@ type ObjectsClient interface {
 // objectsClient implements ObjectsClient.
 type objectsClient struct {
 	proxy Proxy
+	log   logr.Logger
 }
 
 // ensure objectsClient implements ObjectsClient.
 var _ ObjectsClient = &objectsClient{}
 
 // newProviderObjects returns a objectsClient.
-func newObjectsClient(proxy Proxy) *objectsClient {
+func newObjectsClient(proxy Proxy, log logr.Logger) *objectsClient {
 	return &objectsClient{
 		proxy: proxy,
+		log:   log,
 	}
 }

--- a/cmd/clusterctl/pkg/client/cluster/proxy.go
+++ b/cmd/clusterctl/pkg/client/cluster/proxy.go
@@ -161,6 +161,10 @@ func (k *proxy) getConfig() (*rest.Config, error) {
 	}
 	restConfig.UserAgent = fmt.Sprintf("clusterctl/%s (%s)", version.Get().GitVersion, version.Get().Platform)
 
+	// Set QPS an Burst to a threshold that ensures the controller runtime client don't generates throttling log messages
+	restConfig.QPS = 20
+	restConfig.Burst = 100
+
 	return restConfig, nil
 }
 

--- a/cmd/clusterctl/pkg/client/config/providers_client.go
+++ b/cmd/clusterctl/pkg/client/config/providers_client.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog"
@@ -48,14 +49,16 @@ type ProvidersClient interface {
 // providersClient implements ProvidersClient.
 type providersClient struct {
 	reader Reader
+	log    logr.Logger
 }
 
 // ensure providersClient implements ProvidersClient.
 var _ ProvidersClient = &providersClient{}
 
-func newProvidersClient(reader Reader) *providersClient {
+func newProvidersClient(reader Reader, log logr.Logger) *providersClient {
 	return &providersClient{
 		reader: reader,
+		log:    log,
 	}
 }
 

--- a/cmd/clusterctl/pkg/client/config/reader_viper.go
+++ b/cmd/clusterctl/pkg/client/config/reader_viper.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/util/homedir"
@@ -32,11 +33,14 @@ const ConfigFolder = ".cluster-api"
 // viperReader implements Reader using viper as backend for reading from environment variables
 // and from a clusterctl config file.
 type viperReader struct {
+	log logr.Logger
 }
 
 // newViperReader returns a viperReader.
-func newViperReader() Reader {
-	return &viperReader{}
+func newViperReader(log logr.Logger) Reader {
+	return &viperReader{
+		log: log,
+	}
 }
 
 // Init initialize the viperReader.

--- a/cmd/clusterctl/pkg/client/config/reader_viper_test.go
+++ b/cmd/clusterctl/pkg/client/config/reader_viper_test.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
 )
 
 func Test_viperReader_Get(t *testing.T) {
@@ -74,7 +76,7 @@ func Test_viperReader_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v := &viperReader{}
+			v := newViperReader(test.NewFakeLogger())
 
 			err := v.Init(configFile)
 			if err != nil {
@@ -128,7 +130,7 @@ func Test_viperReader_Set(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v := &viperReader{}
+			v := newViperReader(test.NewFakeLogger())
 
 			err := v.Init(configFile)
 			if err != nil {

--- a/cmd/clusterctl/pkg/client/config/variables_client.go
+++ b/cmd/clusterctl/pkg/client/config/variables_client.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package config
 
-import "sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
+import (
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
+)
 
 // VariablesClient has methods to work with environment variables and with variables defined in the clusterctl configuration file.
 type VariablesClient interface {
@@ -36,14 +39,16 @@ var _ VariablesClient = &test.FakeVariableClient{}
 // variablesClient implements VariablesClient.
 type variablesClient struct {
 	reader Reader
+	log    logr.Logger
 }
 
 // ensure variablesClient implements VariablesClient.
 var _ VariablesClient = &variablesClient{}
 
-func newVariablesClient(reader Reader) *variablesClient {
+func newVariablesClient(reader Reader, log logr.Logger) *variablesClient {
 	return &variablesClient{
 		reader: reader,
+		log:    log,
 	}
 }
 

--- a/cmd/clusterctl/pkg/client/repository/components_client.go
+++ b/cmd/clusterctl/pkg/client/repository/components_client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package repository
 
 import (
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 )
@@ -32,17 +33,19 @@ type componentsClient struct {
 	provider              config.Provider
 	repository            Repository
 	configVariablesClient config.VariablesClient
+	log                   logr.Logger
 }
 
 // ensure componentsClient implements ComponentsClient.
 var _ ComponentsClient = &componentsClient{}
 
 // newComponentsClient returns a componentsClient.
-func newComponentsClient(provider config.Provider, repository Repository, configVariablesClient config.VariablesClient) *componentsClient {
+func newComponentsClient(provider config.Provider, repository Repository, configVariablesClient config.VariablesClient, log logr.Logger) *componentsClient {
 	return &componentsClient{
 		provider:              provider,
 		repository:            repository,
 		configVariablesClient: configVariablesClient,
+		log:                   log,
 	}
 }
 

--- a/cmd/clusterctl/pkg/client/repository/components_client_test.go
+++ b/cmd/clusterctl/pkg/client/repository/components_client_test.go
@@ -234,7 +234,7 @@ func Test_componentsClient_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := newComponentsClient(tt.fields.provider, tt.fields.repository, tt.fields.configVariablesClient)
+			f := newComponentsClient(tt.fields.provider, tt.fields.repository, tt.fields.configVariablesClient, test.NewFakeLogger())
 			got, err := f.Get(tt.args.version, tt.args.targetNamespace, tt.args.watchingNamespace)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)

--- a/cmd/clusterctl/pkg/client/repository/metadata_client.go
+++ b/cmd/clusterctl/pkg/client/repository/metadata_client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package repository
 
 import (
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,17 +39,19 @@ type metadataClient struct {
 	provider   config.Provider
 	version    string
 	repository Repository
+	log        logr.Logger
 }
 
 // ensure metadataClient implements MetadataClient.
 var _ MetadataClient = &metadataClient{}
 
 // newMetadataClient returns a metadataClient.
-func newMetadataClient(provider config.Provider, version string, repository Repository) *metadataClient {
+func newMetadataClient(provider config.Provider, version string, repository Repository, log logr.Logger) *metadataClient {
 	return &metadataClient{
 		provider:   provider,
 		version:    version,
 		repository: repository,
+		log:        log,
 	}
 }
 

--- a/cmd/clusterctl/pkg/client/repository/repository_github.go
+++ b/cmd/clusterctl/pkg/client/repository/repository_github.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
@@ -55,6 +56,7 @@ type gitHubRepository struct {
 	rootPath                 string
 	componentsPath           string
 	injectClient             *github.Client
+	log                      logr.Logger
 }
 
 var _ Repository = &gitHubRepository{}
@@ -100,7 +102,7 @@ func (g *gitHubRepository) GetFile(version, path string) ([]byte, error) {
 }
 
 // newGitHubRepository returns a gitHubRepository implementation
-func newGitHubRepository(providerConfig config.Provider, configVariablesClient config.VariablesClient) (*gitHubRepository, error) {
+func newGitHubRepository(providerConfig config.Provider, configVariablesClient config.VariablesClient, log logr.Logger) (*gitHubRepository, error) {
 	if configVariablesClient == nil {
 		return nil, errors.New("invalid arguments: configVariablesClient can't be nil")
 	}
@@ -144,6 +146,7 @@ func newGitHubRepository(providerConfig config.Provider, configVariablesClient c
 		defaultVersion:        defaultVersion,
 		rootPath:              rootPath,
 		componentsPath:        componentsPath,
+		log:                   log,
 	}
 
 	token, err := configVariablesClient.Get(githubTokeVariable)

--- a/cmd/clusterctl/pkg/client/repository/repository_github_test.go
+++ b/cmd/clusterctl/pkg/client/repository/repository_github_test.go
@@ -74,7 +74,7 @@ func Test_gitHubRepository_getVersions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g, err := newGitHubRepository(tt.field.providerConfig, configVariablesClient)
+			g, err := newGitHubRepository(tt.field.providerConfig, configVariablesClient, test.NewFakeLogger())
 			if err != nil {
 				t.Fatalf("newGitHubRepository() error = %v", err)
 			}
@@ -144,7 +144,7 @@ func Test_gitHubRepository_getLatestRelease(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g, err := newGitHubRepository(tt.field.providerConfig, configVariablesClient)
+			g, err := newGitHubRepository(tt.field.providerConfig, configVariablesClient, test.NewFakeLogger())
 			if err != nil {
 				t.Fatalf("newGitHubRepository() error = %v", err)
 			}
@@ -204,7 +204,7 @@ func Test_gitHubRepository_getReleaseByTag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g, err := newGitHubRepository(providerConfig, configVariablesClient)
+			g, err := newGitHubRepository(providerConfig, configVariablesClient, test.NewFakeLogger())
 			if err != nil {
 				t.Fatalf("newGitHubRepository() error = %v", err)
 			}
@@ -315,7 +315,7 @@ func Test_gitHubRepository_downloadFilesFromRelease(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g, err := newGitHubRepository(providerConfig, configVariablesClient)
+			g, err := newGitHubRepository(providerConfig, configVariablesClient, test.NewFakeLogger())
 			if err != nil {
 				t.Fatalf("newGitHubRepository() error = %v", err)
 			}

--- a/cmd/clusterctl/pkg/client/repository/template_client.go
+++ b/cmd/clusterctl/pkg/client/repository/template_client.go
@@ -19,6 +19,7 @@ package repository
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 )
@@ -47,18 +48,20 @@ type templateClient struct {
 	version               string
 	repository            Repository
 	configVariablesClient config.VariablesClient
+	log                   logr.Logger
 }
 
 // Ensure templateClient implements the TemplateClient interface.
 var _ TemplateClient = &templateClient{}
 
 // newTemplateClient returns a templateClient.
-func newTemplateClient(provider config.Provider, version string, repository Repository, configVariablesClient config.VariablesClient) *templateClient {
+func newTemplateClient(provider config.Provider, version string, repository Repository, configVariablesClient config.VariablesClient, log logr.Logger) *templateClient {
 	return &templateClient{
 		provider:              provider,
 		version:               version,
 		repository:            repository,
 		configVariablesClient: configVariablesClient,
+		log:                   log,
 	}
 }
 

--- a/cmd/clusterctl/pkg/client/repository/template_client_test.go
+++ b/cmd/clusterctl/pkg/client/repository/template_client_test.go
@@ -128,7 +128,7 @@ func Test_templates_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := newTemplateClient(tt.fields.provider, tt.fields.version, tt.fields.repository, tt.fields.configVariablesClient)
+			f := newTemplateClient(tt.fields.provider, tt.fields.version, tt.fields.repository, tt.fields.configVariablesClient, test.NewFakeLogger())
 			got, err := f.Get(tt.args.flavor, tt.args.bootstrap, tt.args.targetNamespace)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)

--- a/cmd/clusterctl/pkg/internal/test/fake_logger.go
+++ b/cmd/clusterctl/pkg/internal/test/fake_logger.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testing"
+)
+
+func NewFakeLogger() logr.Logger {
+	return &testing.NullLogger{}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR:
- ensures that a logger object is propagated through the chain.
- harmonized how the injection of the logger/other objects is managed in the public types.

The PR uses kog.Logger as default logger, but this is designed for machines and it provides an ugly UX for a CLI app, so a better solution should be defined here

**Which issue(s) this PR fixes**:
rif #1729

/area clusterctl
/assign @ncdc
/assign @vincepri