### PR TITLE
✨clusterctl: fix labels

### DIFF
--- a/api/v1alpha3/common_types.go
+++ b/api/v1alpha3/common_types.go
@@ -25,6 +25,11 @@ const (
 	// external objects(bootstrap and infrastructure providers)
 	ClusterLabelName = "cluster.x-k8s.io/cluster-name"
 
+	// ProviderLabelName is the label set on components in the provider manifest.
+	// This label allows to easily identify all the components belonging to a provider; the clusterctl
+	// tool uses this label for implementing provider's lifecycle operations.
+	ProviderLabelName = "cluster.x-k8s.io/provider"
+
 	// PausedAnnotation is an annotation that can be applied to any Cluster API
 	// object to prevent a controller from processing a resource.
 	//

--- a/cmd/clusterctl/api/v1alpha3/labels.go
+++ b/cmd/clusterctl/api/v1alpha3/labels.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1alpha3
 
 const (
-	ClusterctlLabelName         = "clusterctl.cluster.x-k8s.io"
-	ClusterctlProviderLabelName = "clusterctl.cluster.x-k8s.io/provider"
+	// ClusterctlLabelName defines the label that is applied to all the components managed by clusterctl.
+	ClusterctlLabelName = "clusterctl.cluster.x-k8s.io"
+
+	// ClusterctlCoreLabelName defines the label that is applied to all the core objects managed by clusterctl.
+	ClusterctlCoreLabelName = "clusterctl.cluster.x-k8s.io/core"
 )

--- a/cmd/clusterctl/pkg/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/pkg/client/cluster/cert_manager.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,6 +92,14 @@ func (cm *certMangerClient) EnsureWebHook() error {
 	objs = sortResourcesForCreate(objs)
 	for _, o := range objs {
 		klog.V(3).Infof("Creating: %s, %s/%s", o.GroupVersionKind(), o.GetNamespace(), o.GetName())
+
+		labels := o.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[clusterctlv1.ClusterctlCoreLabelName] = "cert-manager"
+		o.SetLabels(labels)
+
 		if err = c.Create(ctx, &o); err != nil { //nolint
 			if apierrors.IsAlreadyExists(err) {
 				continue

--- a/cmd/clusterctl/pkg/client/cluster/components.go
+++ b/cmd/clusterctl/pkg/client/cluster/components.go
@@ -23,6 +23,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -104,7 +105,8 @@ func (p *providerComponents) Create(components repository.Components) error {
 func (p *providerComponents) Delete(options DeleteOptions) error {
 	// Fetch all the components belonging to a provider.
 	labels := map[string]string{
-		clusterctlv1.ClusterctlProviderLabelName: options.Provider.Name,
+		clusterctlv1.ClusterctlLabelName: "",
+		clusterv1.ProviderLabelName:      options.Provider.Name,
 	}
 	resources, err := p.proxy.ListResources(options.Provider.Namespace, labels)
 	if err != nil {
@@ -121,7 +123,7 @@ func (p *providerComponents) Delete(options DeleteOptions) error {
 		}
 
 		// If the Namespace should NOT be deleted, skip it, otherwise keep track of the namespaces we are deleting;
-		// NB. Skipping Namespaces deletion ensures that also the objects hosted in the namespace but without the "clusterctl.cluster.x-k8s.io/provider" label are not deleted.
+		// NB. Skipping Namespaces deletion ensures that also the objects hosted in the namespace but without the "clusterctl.cluster.x-k8s.io" and the "cluster.x-k8s.io/provider" label are not deleted.
 		if obj.GroupVersionKind().Kind == "Namespace" {
 			if !options.ForceDeleteNamespace {
 				continue

--- a/cmd/clusterctl/pkg/client/cluster/components_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/components_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,7 +32,7 @@ import (
 
 func Test_providerComponents_Delete(t *testing.T) {
 	labels := map[string]string{
-		clusterctlv1.ClusterctlProviderLabelName: "aws",
+		clusterv1.ProviderLabelName: "aws",
 	}
 
 	crd := unstructured.Unstructured{}

--- a/cmd/clusterctl/pkg/client/cluster/inventory.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory.go
@@ -107,6 +107,14 @@ func (p *inventoryClient) EnsureCustomResourceDefinitions() error {
 	// Install the CRDs.
 	for _, o := range objs {
 		klog.V(3).Infof("Creating: %s, %s/%s", o.GroupVersionKind(), o.GetNamespace(), o.GetName())
+
+		labels := o.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[clusterctlv1.ClusterctlCoreLabelName] = "inventory"
+		o.SetLabels(labels)
+
 		if err := c.Create(ctx, o.DeepCopy()); err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				continue

--- a/cmd/clusterctl/pkg/client/repository/components.go
+++ b/cmd/clusterctl/pkg/client/repository/components.go
@@ -27,6 +27,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/scheme"
@@ -107,6 +108,9 @@ func (c *components) WatchingNamespace() string {
 }
 
 func (c *components) Metadata() clusterctlv1.Provider {
+	labels := getLabels(c.Name())
+	labels[clusterctlv1.ClusterctlCoreLabelName] = "inventory"
+
 	return clusterctlv1.Provider{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: clusterctlv1.GroupVersion.String(),
@@ -115,7 +119,7 @@ func (c *components) Metadata() clusterctlv1.Provider {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: c.targetNamespace,
 			Name:      c.Name(),
-			Labels:    getLabels(c.Name()),
+			Labels:    labels,
 		},
 		Type:             string(c.Type()),
 		Version:          c.version,
@@ -536,7 +540,7 @@ func addLabels(objs []unstructured.Unstructured, name string) []unstructured.Uns
 
 func getLabels(name string) map[string]string {
 	return map[string]string{
-		clusterctlv1.ClusterctlLabelName:         "",
-		clusterctlv1.ClusterctlProviderLabelName: name,
+		clusterctlv1.ClusterctlLabelName: "",
+		clusterv1.ProviderLabelName:      name,
 	}
 }

--- a/cmd/clusterctl/pkg/client/repository/components_client_test.go
+++ b/cmd/clusterctl/pkg/client/repository/components_client_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
@@ -283,7 +284,7 @@ func Test_componentsClient_Get(t *testing.T) {
 			}
 
 			for _, o := range got.Objs() {
-				for _, v := range []string{clusterctlv1.ClusterctlLabelName, clusterctlv1.ClusterctlProviderLabelName} {
+				for _, v := range []string{clusterctlv1.ClusterctlLabelName, clusterv1.ProviderLabelName} {
 					if _, ok := o.GetLabels()[v]; !ok {
 						t.Errorf("Get().Objs() object %s does not contains %s label", o.GetName(), v)
 					}

--- a/cmd/clusterctl/pkg/client/repository/components_test.go
+++ b/cmd/clusterctl/pkg/client/repository/components_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
@@ -764,8 +765,8 @@ func Test_addLabels(t *testing.T) {
 						"kind": "ClusterRole",
 						"metadata": map[string]interface{}{
 							"labels": map[string]interface{}{
-								clusterctlv1.ClusterctlLabelName:         "",
-								clusterctlv1.ClusterctlProviderLabelName: "provider",
+								clusterctlv1.ClusterctlLabelName: "",
+								clusterv1.ProviderLabelName:      "provider",
 							},
 						},
 					},

--- a/cmd/clusterctl/pkg/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/pkg/internal/test/fake_proxy.go
@@ -121,8 +121,9 @@ func (f *FakeProxy) WithProviderInventory(name string, providerType clusterctlv1
 			Namespace: targetNamespace,
 			Name:      name,
 			Labels: map[string]string{
-				clusterctlv1.ClusterctlLabelName:         "",
-				clusterctlv1.ClusterctlProviderLabelName: name,
+				clusterctlv1.ClusterctlLabelName:     "",
+				clusterv1.ProviderLabelName:          name,
+				clusterctlv1.ClusterctlCoreLabelName: "inventory",
 			},
 		},
 		Type:             string(providerType),

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -216,7 +216,7 @@ subsequent moments of the provider's lifecycle, e.g. upgrades.
  ```bash
  labels:
  - clusterctl.cluster.x-k8s.io: ""
- - clusterctl.cluster.x-k8s.io/provider: "<provider-name>"
+ - cluster.x-k8s.io/provider: "<provider-name>"
  ```
   
 * An additional `Provider` object is created in the target namespace where the provider is installed.
@@ -227,7 +227,7 @@ for the inventory of the providers currently installed in the management cluster
 
 <h1>Warning</h1>
 
-The `clusterctl.cluster.x-k8s.io` labels and the `Provider` objects MUST NOT altered.
+The `clusterctl.cluster.x-k8s.io` labels, the `cluster.x-k8s.io/provider` labels and the `Provider` objects MUST NOT altered.
 If this happens, there are no guarantees about the proper functioning of `clusterctl`.  
 
 </aside>


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api/pull/2070 introduces a new Cluster API label `cluster.x-k8s.io/provider`

This PR adapt clusterctl to use the above label, and drops the `clusterctl.cluster.x-k8s.io/provider` label that now is a duplicate of the Cluster API one.

Additionally, a new clusterctl label `clusterctl.cluster.x-k8s.io/core` is added and applied to the core component installed by clusterctl, the inventory CRDs and the cert-manager, so it will be possible to implement proper lifecycle for those components as well

**Which issue(s) this PR fixes**:
rif #1729

/area clusterctl
/assign @ncdc
/assign @vincepri
