### PR TITLE
:bug: Fix cluster name conversions a2 > a3

### DIFF
--- a/api/v1alpha2/conversion.go
+++ b/api/v1alpha2/conversion.go
@@ -150,6 +150,7 @@ func (src *MachineSet) ConvertTo(dstRaw conversion.Hub) error {
 	// This conversion can be overwritten when restoring the ClusterName field.
 	if name, ok := src.Labels[MachineClusterLabelName]; ok {
 		dst.Spec.ClusterName = name
+		dst.Spec.Template.Spec.ClusterName = name
 	}
 
 	// Manually restore data.
@@ -202,6 +203,7 @@ func (src *MachineDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	// This conversion can be overwritten when restoring the ClusterName field.
 	if name, ok := src.Labels[MachineClusterLabelName]; ok {
 		dst.Spec.ClusterName = name
+		dst.Spec.Template.Spec.ClusterName = name
 	}
 
 	// Manually restore data.

--- a/api/v1alpha2/conversion_test.go
+++ b/api/v1alpha2/conversion_test.go
@@ -159,6 +159,7 @@ func TestConvertMachineSet(t *testing.T) {
 
 			g.Expect(src.ConvertTo(dst)).To(Succeed())
 			g.Expect(dst.Spec.ClusterName).To(Equal("test-cluster"))
+			g.Expect(dst.Spec.Template.Spec.ClusterName).To(Equal("test-cluster"))
 		})
 	})
 
@@ -207,6 +208,7 @@ func TestConvertMachineDeployment(t *testing.T) {
 
 			g.Expect(src.ConvertTo(dst)).To(Succeed())
 			g.Expect(dst.Spec.ClusterName).To(Equal("test-cluster"))
+			g.Expect(dst.Spec.Template.Spec.ClusterName).To(Equal("test-cluster"))
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: John Harris <joharris@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Adds the cluster name field to the MachineDeployment and MachineSet templates when converting from v1alpha2 > v1alpha3. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2153 
