### PR TITLE
:sparkles: Add liveness/readiness probes

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,18 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+        ports:
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
       terminationGracePeriodSeconds: 10
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
**What this PR does / why we need it**:
similar from https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1487 this adds a health endpoint for CAPI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
 - Fixes https://github.com/kubernetes-sigs/cluster-api/issues/1855
