### PR TITLE
🏃 Use e2e config for capd e2es

### DIFF
--- a/docs/book/src/developer/tests.md
+++ b/docs/book/src/developer/tests.md
@@ -1,0 +1,31 @@
+# Running Cluster API tests
+
+## Unit tests
+
+Unit tests run very quickly. They don't require any additional services and can be run using default go tools or through
+the `test` make target, e.g. `make test`.
+
+## Integration tests
+
+Integration tests use a real cluster and real dependencies to run tests. The dependencies are managed manually and are
+not meant to be run locally. See `scripts/ci-integration.sh` for more details.
+
+## End-to-end tests
+
+The end-to-end tests are similar to the integration tests except they are designed to manage dependencies for you and 
+have a more complete test using a docker provider to test the Cluster API mechanisms. The end-to-end tests run best on 
+CI, but work locally if you're looking for early signal.
+
+To run the tests, first, build the images needed for Cluster API from your local checkout. Then build the docker 
+provider manager image. After that you can run the tests directly from make. Here are the commands to do the above steps. 
+
+```
+make docker-build REGISTRY=gcr.io/k8s-staging-cluster-api
+make -C test/infrastructure/docker docker-build REGISTRY=gcr.io/k8s-staging-capi-docker
+make -C test/infrastructure/docker run-e2e
+```
+
+These images only need to be built once. They can be reused if nothing changes. However, if a manager for a particular
+image changes then the docker image will need to be rebuilt to see the changes reflected in the tests.
+
+These end-to-end tests can be configured with a configuration file. Please take a look at our framework for more details.

--- a/scripts/ci-capd-e2e.sh
+++ b/scripts/ci-capd-e2e.sh
@@ -53,7 +53,11 @@ export CAPI_KUBEADM_BOOTSTRAP_IMAGE=${REGISTRY}/${KUBEADM_BOOTSTRAP_IMAGE_NAME}-
 export CAPI_KUBEADM_CONTROL_PLANE_IMAGE=${REGISTRY}/${KUBEADM_CONTROL_PLANE_IMAGE_NAME}-${ARCH}:${TAG}
 export MANAGER_IMAGE=${REGISTRY}/${DOCKER_MANAGER_IMAGE}-${ARCH}:${TAG}
 
-echo "*** Testing Cluster API Provider Docker e2es ***"
 cd "${REPO_ROOT}/test/infrastructure/docker"
+
+# The values above must match the values found in the configuration file below
+export E2E_CONF_FILE=e2e/ci-e2e.conf
+
+echo "*** Testing Cluster API Provider Docker e2es ***"
 CONTROLLER_IMG=${REGISTRY}/${DOCKER_MANAGER_IMAGE} make docker-build
 ARTIFACTS="${ARTIFACTS}" make run-e2e

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -89,8 +89,9 @@ test-e2e: ## Run the end-to-end tests
 		CAPI_KUBEADM_CONTROL_PLANE_IMAGE=$(KUBEADM_CONTROL_PLANE_CONTROLLER_IMG) \
 		$(MAKE) run-e2e
 
+E2E_CONF_FILE ?= e2e/local-e2e.conf
 run-e2e:
-	go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath e2e/e2e.conf)"
+	go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath $(E2E_CONF_FILE))"
 
 ## --------------------------------------
 ## Binaries

--- a/test/infrastructure/docker/e2e/ci-e2e.conf
+++ b/test/infrastructure/docker/e2e/ci-e2e.conf
@@ -1,0 +1,71 @@
+---
+images:
+- name: ci-registry/docker-provider-manager-amd64:ci
+  loadBehavior: mustLoad
+- name: ci-registry/core-manager-amd64:ci
+  loadBehavior: mustLoad
+- name: ci-registry/kubeadm-bootstrap-manager-amd64:ci
+  loadBehavior: mustLoad
+- name: ci-registry/kubeadm-control-plane-manager-amd64:ci
+  loadBehavior: mustLoad
+
+components:
+
+# Load the certificate manager and wait for all of its pods and service to
+# become available.
+- name:    cert-manager
+  sources:
+  - type:  url
+    value: https://github.com/jetstack/cert-manager/releases/download/v0.11.1/cert-manager.yaml
+  waiters:
+  - type:  service
+    value: v1beta1.webhook.cert-manager.io
+  - value: cert-manager
+
+# Load CAPI core and wait for its pods to become available.
+- name:    capi
+  sources:
+  - value: ../../../../config/default
+    replacements:
+    - old: "imagePullPolicy: Always"
+      new: "imagePullPolicy: IfNotPresent"
+    - old: "--enable-leader-election"
+      new: "--enable-leader-election=false"
+  waiters:
+  - value: capi-system
+
+# Load the CAPI kubeadm bootstrapper and wait for its pods to become available.
+- name:    capi-kubeadm-bootstrap
+  sources:
+  - value: ../../../../bootstrap/kubeadm/config/default
+    replacements:
+    - old: "imagePullPolicy: Always"
+      new: "imagePullPolicy: IfNotPresent"
+    - old: "--enable-leader-election"
+      new: "--enable-leader-election=false"
+  waiters:
+  - value: capi-kubeadm-bootstrap-system
+
+# Load the CAPI kubeadm control plane and wait for its pods to become available.
+- name:    capi-kubeadm-control-plane
+  sources:
+  - value: ../../../../controlplane/kubeadm/config/default
+    replacements:
+    - old: "imagePullPolicy: Always"
+      new: "imagePullPolicy: IfNotPresent"
+    - old: "--enable-leader-election"
+      new: "--enable-leader-election=false"
+  waiters:
+  - value: capi-kubeadm-control-plane-system
+
+# Load CAPD and wait for its pods to become available.
+- name:    capd
+  sources:
+  - value: ../config/default
+    replacements:
+    - old: "imagePullPolicy: Always"
+      new: "imagePullPolicy: IfNotPresent"
+    - old: "--enable-leader-election"
+      new: "--enable-leader-election=false"
+  waiters:
+  - value: capd-system

--- a/test/infrastructure/docker/e2e/local-e2e.conf
+++ b/test/infrastructure/docker/e2e/local-e2e.conf
@@ -1,13 +1,16 @@
 ---
 images:
+# Using the Makefile found in the docker provider, run `make docker-build REGISTRY=gcr.io/k8s-staging-capi-docker`.
 - name: gcr.io/k8s-staging-capi-docker/capd-manager-amd64:dev
   loadBehavior: mustLoad
-- name: gcr.io/k8s-staging-cluster-api/cluster-api-controller:master
+# Use `make docker-build REGISTRY=gcr.io/k8s-staging-cluster-api` to build these images.
+- name: gcr.io/k8s-staging-cluster-api/cluster-api-controller-amd64:dev
   loadBehavior: tryLoad
-- name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:master
+- name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller-amd64:dev
   loadBehavior: tryLoad
-- name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:master
+- name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-amd64:dev
   loadBehavior: tryLoad
+# Make a custom config file if you'd like to test just docker changes against latest published staging master image.
 
 components:
 
@@ -29,6 +32,8 @@ components:
     replacements:
     - old: "imagePullPolicy: Always"
       new: "imagePullPolicy: IfNotPresent"
+    - old: "--enable-leader-election"
+      new: "--enable-leader-election=false"
   waiters:
   - value: capi-system
 
@@ -39,6 +44,8 @@ components:
     replacements:
     - old: "imagePullPolicy: Always"
       new: "imagePullPolicy: IfNotPresent"
+    - old: "--enable-leader-election"
+      new: "--enable-leader-election=false"
   waiters:
   - value: capi-kubeadm-bootstrap-system
 
@@ -49,6 +56,8 @@ components:
     replacements:
     - old: "imagePullPolicy: Always"
       new: "imagePullPolicy: IfNotPresent"
+    - old: "--enable-leader-election"
+      new: "--enable-leader-election=false"
   waiters:
   - value: capi-kubeadm-control-plane-system
 
@@ -59,5 +68,7 @@ components:
     replacements:
     - old: "imagePullPolicy: Always"
       new: "imagePullPolicy: IfNotPresent"
+    - old: "--enable-leader-election"
+      new: "--enable-leader-election=false"
   waiters:
   - value: capd-system


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR uses the new e2e config file to run the capd e2e tests.

Also removes leader election on the managers which speeds things up. When I tested it with just the CAPD manager it helped to remove flakes and sped up the test by 5-10 seconds.

Also adds documentation for running cluster-api tests.
