### PR TITLE
✨clusterctl: move shared objects

### DIFF
--- a/cmd/clusterctl/pkg/client/cluster/client.go
+++ b/cmd/clusterctl/pkg/client/cluster/client.go
@@ -68,9 +68,8 @@ type Client interface {
 
 // clusterClient implements Client.
 type clusterClient struct {
-	kubeconfig    string
-	proxy         Proxy
-	machineWaiter MachineWaiter
+	kubeconfig string
+	proxy      Proxy
 }
 
 // ensure clusterClient implements Client.
@@ -107,7 +106,7 @@ func (c *clusterClient) ProviderInstaller() ProviderInstaller {
 func (c *clusterClient) ObjectMover() ObjectMover {
 	//TODO: make the logger to flow down all the chain
 	log := klogr.New()
-	return newObjectMover(c.proxy, c.machineWaiter, log)
+	return newObjectMover(c.proxy, log)
 }
 
 // New returns a cluster.Client.
@@ -122,23 +121,15 @@ func newClusterClient(kubeconfig string, options Options) *clusterClient {
 		proxy = newProxy(kubeconfig)
 	}
 
-	// if there is an injected machineWaiter, use it, otherwise use the default one
-	machineWaiter := options.InjectMachineWaiter
-	if machineWaiter == nil {
-		machineWaiter = waitForMachineReady
-	}
-
 	return &clusterClient{
-		kubeconfig:    kubeconfig,
-		proxy:         proxy,
-		machineWaiter: machineWaiter,
+		kubeconfig: kubeconfig,
+		proxy:      proxy,
 	}
 }
 
 // Options allow to set ConfigClient options
 type Options struct {
-	InjectProxy         Proxy
-	InjectMachineWaiter MachineWaiter
+	InjectProxy Proxy
 }
 
 type Proxy interface {

--- a/cmd/clusterctl/pkg/client/cluster/mover_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/mover_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cluster
 
 import (
+	"reflect"
+	"sort"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,90 +28,376 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Test_objectMover_move(t *testing.T) {
-	type fields struct {
-		objs []runtime.Object
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		wantErr bool
-	}{
-		{
-			name: "Cluster",
-			fields: fields{
-				objs: test.NewFakeCluster("ns1", "foo").Objs(),
-			},
-			wantErr: false,
+type moveTestsFields struct {
+	objs []runtime.Object
+}
+
+var moveTests = []struct {
+	name           string
+	fields         moveTestsFields
+	wantMoveGroups [][]string
+	wantErr        bool
+}{
+	{
+		name: "Cluster",
+		fields: moveTestsFields{
+			objs: test.NewFakeCluster("ns1", "foo").Objs(),
 		},
-		{
-			name: "Cluster with machine",
-			fields: fields{
-				objs: test.NewFakeCluster("ns1", "cluster1").
-					WithMachines(
-						test.NewFakeMachine("m1"),
-						test.NewFakeMachine("m2"),
-					).Objs(),
+		wantMoveGroups: [][]string{
+			{ //group 1
+				"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/foo",
 			},
-			wantErr: false,
+			{ //group 2 (objects with ownerReferences in group 1)
+				// owned by Clusters
+				"/v1, Kind=Secret, ns1/foo-ca",
+				"/v1, Kind=Secret, ns1/foo-kubeconfig",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureCluster, ns1/foo",
+			},
 		},
-		{
-			name: "Cluster with MachineSet",
-			fields: fields{
-				objs: test.NewFakeCluster("ns1", "cluster1").
+		wantErr: false,
+	},
+	{
+		name: "Cluster with machine",
+		fields: moveTestsFields{
+			objs: test.NewFakeCluster("ns1", "cluster1").
+				WithMachines(
+					test.NewFakeMachine("m1"),
+					test.NewFakeMachine("m2"),
+				).Objs(),
+		},
+		wantMoveGroups: [][]string{
+			{ //group 1
+				"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/cluster1",
+			},
+			{ //group 2 (objects with ownerReferences in group 1)
+				// owned by Clusters
+				"/v1, Kind=Secret, ns1/cluster1-kubeconfig",
+				"/v1, Kind=Secret, ns1/cluster1-ca",
+				"cluster.x-k8s.io/v1alpha3, Kind=Machine, ns1/m1",
+				"cluster.x-k8s.io/v1alpha3, Kind=Machine, ns1/m2",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureCluster, ns1/cluster1",
+			},
+			{ //group 3 (objects with ownerReferences in group 1,2)
+				// owned by Machines
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfig, ns1/m1",
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfig, ns1/m2",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachine, ns1/m1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachine, ns1/m2",
+			},
+			{ //group 4 (objects with ownerReferences in group 1,2,3)
+				// owned by DummyBootstrapConfigs
+				"/v1, Kind=Secret, ns1/cluster1-sa",
+				"/v1, Kind=Secret, ns1/m1",
+				"/v1, Kind=Secret, ns1/m2",
+			},
+		},
+		wantErr: false,
+	},
+	{
+		name: "Cluster with MachineSet",
+		fields: moveTestsFields{
+			objs: test.NewFakeCluster("ns1", "cluster1").
+				WithMachineSets(
+					test.NewFakeMachineSet("ms1").
+						WithMachines(
+							test.NewFakeMachine("m1"),
+							test.NewFakeMachine("m2"),
+						),
+				).Objs(),
+		},
+		wantMoveGroups: [][]string{
+			{ //group 1
+				"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/cluster1",
+			},
+			{ //group 2 (objects with ownerReferences in group 1)
+				// owned by Clusters
+				"/v1, Kind=Secret, ns1/cluster1-ca",
+				"/v1, Kind=Secret, ns1/cluster1-kubeconfig",
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfigTemplate, ns1/ms1",
+				"cluster.x-k8s.io/v1alpha3, Kind=MachineSet, ns1/ms1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureCluster, ns1/cluster1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachineTemplate, ns1/ms1",
+			},
+			{ //group 3 (objects with ownerReferences in group 1,2)
+				// owned by MachineSets
+				"cluster.x-k8s.io/v1alpha3, Kind=Machine, ns1/m1",
+				"cluster.x-k8s.io/v1alpha3, Kind=Machine, ns1/m2",
+			},
+			{ //group 4 (objects with ownerReferences in group 1,2,3)
+				// owned by Machines
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfig, ns1/m1",
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfig, ns1/m2",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachine, ns1/m1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachine, ns1/m2",
+			},
+			{ //group 5 (objects with ownerReferences in group 1,2,3,4)
+				// owned by DummyBootstrapConfigs
+				"/v1, Kind=Secret, ns1/m1",
+				"/v1, Kind=Secret, ns1/m2",
+			},
+		},
+		wantErr: false,
+	},
+	{
+		name: "Cluster with MachineDeployment",
+		fields: moveTestsFields{
+			objs: test.NewFakeCluster("ns1", "cluster1").
+				WithMachineDeployments(
+					test.NewFakeMachineDeployment("md1").
+						WithMachineSets(
+							test.NewFakeMachineSet("ms1").
+								WithMachines(
+									test.NewFakeMachine("m1"),
+									test.NewFakeMachine("m2"),
+								),
+						),
+				).Objs(),
+		},
+		wantMoveGroups: [][]string{
+			{ //group 1
+				"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/cluster1",
+			},
+			{ //group 2 (objects with ownerReferences in group 1)
+				// owned by Clusters
+				"/v1, Kind=Secret, ns1/cluster1-ca",
+				"/v1, Kind=Secret, ns1/cluster1-kubeconfig",
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfigTemplate, ns1/md1",
+				"cluster.x-k8s.io/v1alpha3, Kind=MachineDeployment, ns1/md1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureCluster, ns1/cluster1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachineTemplate, ns1/md1",
+			},
+			{ //group 3 (objects with ownerReferences in group 1,2)
+				// owned by MachineDeployments
+				"cluster.x-k8s.io/v1alpha3, Kind=MachineSet, ns1/ms1",
+			},
+			{ //group 4 (objects with ownerReferences in group 1,2,3)
+				// owned by MachineSets
+				"cluster.x-k8s.io/v1alpha3, Kind=Machine, ns1/m1",
+				"cluster.x-k8s.io/v1alpha3, Kind=Machine, ns1/m2",
+			},
+			{ //group 5 (objects with ownerReferences in group 1,2,3,4)
+				// owned by Machines
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfig, ns1/m1",
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfig, ns1/m2",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachine, ns1/m1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachine, ns1/m2",
+			},
+			{ //group 6 (objects with ownerReferences in group 1,2,3,5,6)
+				// owned by DummyBootstrapConfigs
+				"/v1, Kind=Secret, ns1/m1",
+				"/v1, Kind=Secret, ns1/m2",
+			},
+		},
+		wantErr: false,
+	},
+	{
+		name: "Cluster with Control Plane",
+		fields: moveTestsFields{
+			objs: test.NewFakeCluster("ns1", "cluster1").
+				WithControlPlane(
+					test.NewFakeControlPlane("cp1").
+						WithMachines(
+							test.NewFakeMachine("m1"),
+							test.NewFakeMachine("m2"),
+						),
+				).Objs(),
+		},
+		wantMoveGroups: [][]string{
+			{ //group 1
+				"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/cluster1",
+			},
+			{ //group 2 (objects with ownerReferences in group 1)
+				// owned by Clusters
+				"/v1, Kind=Secret, ns1/cluster1-ca",
+				"controlplane.cluster.x-k8s.io/v1alpha3, Kind=DummyControlPlane, ns1/cp1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureCluster, ns1/cluster1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachineTemplate, ns1/cp1",
+			},
+			{ //group 3 (objects with ownerReferences in group 1,2)
+				"/v1, Kind=Secret, ns1/cluster1-kubeconfig",
+				"/v1, Kind=Secret, ns1/cluster1-sa",
+				"cluster.x-k8s.io/v1alpha3, Kind=Machine, ns1/m1",
+				"cluster.x-k8s.io/v1alpha3, Kind=Machine, ns1/m2",
+			},
+			{ //group 4 (objects with ownerReferences in group 1,2,3)
+				// owned by Machines
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfig, ns1/m1",
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfig, ns1/m2",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachine, ns1/m1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachine, ns1/m2",
+			},
+			{ //group 5 (objects with ownerReferences in group 1,2,3,4)
+				// owned by DummyBootstrapConfigs
+				"/v1, Kind=Secret, ns1/m1",
+				"/v1, Kind=Secret, ns1/m2",
+			},
+		},
+		wantErr: false,
+	},
+	{
+		name: "Cluster with MachinePool",
+		fields: moveTestsFields{
+			objs: test.NewFakeCluster("ns1", "cluster1").
+				WithMachinePools(
+					test.NewFakeMachinePool("mp1"),
+				).Objs(),
+		},
+		wantMoveGroups: [][]string{
+			{ //group 1
+				"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/cluster1",
+			},
+			{ //group 2 (objects with ownerReferences in group 1)
+				// owned by Clusters
+				"/v1, Kind=Secret, ns1/cluster1-ca",
+				"/v1, Kind=Secret, ns1/cluster1-kubeconfig",
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfigTemplate, ns1/mp1",
+				"cluster.x-k8s.io/v1alpha3, Kind=MachinePool, ns1/mp1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureCluster, ns1/cluster1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachineTemplate, ns1/mp1",
+			},
+		},
+		wantErr: false,
+	},
+	{
+		name: "Two clusters",
+		fields: moveTestsFields{
+			objs: func() []runtime.Object {
+				objs := []runtime.Object{}
+				objs = append(objs, test.NewFakeCluster("ns1", "foo").Objs()...)
+				objs = append(objs, test.NewFakeCluster("ns1", "bar").Objs()...)
+				return objs
+			}(),
+		},
+		wantMoveGroups: [][]string{
+			{ //group 1
+				"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/foo",
+				"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/bar",
+			},
+			{ //group 2 (objects with ownerReferences in group 1)
+				// owned by Clusters
+				"/v1, Kind=Secret, ns1/foo-ca",
+				"/v1, Kind=Secret, ns1/foo-kubeconfig",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureCluster, ns1/foo",
+				"/v1, Kind=Secret, ns1/bar-ca",
+				"/v1, Kind=Secret, ns1/bar-kubeconfig",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureCluster, ns1/bar",
+			},
+		},
+	},
+	{
+		name: "Two clusters with a shared object",
+		fields: moveTestsFields{
+			objs: func() []runtime.Object {
+				sharedInfrastructureTemplate := test.NewFakeInfrastructureTemplate("shared")
+
+				objs := []runtime.Object{
+					sharedInfrastructureTemplate,
+				}
+
+				objs = append(objs, test.NewFakeCluster("ns1", "cluster1").
 					WithMachineSets(
-						test.NewFakeMachineSet("ms1").
+						test.NewFakeMachineSet("cluster1-ms1").
+							WithInfrastructureTemplate(sharedInfrastructureTemplate).
 							WithMachines(
-								test.NewFakeMachine("m1"),
-								test.NewFakeMachine("m2"),
+								test.NewFakeMachine("cluster1-m1"),
 							),
-					).Objs(),
-			},
-			wantErr: false,
-		},
-		{
-			name: "Cluster with MachineDeployment",
-			fields: fields{
-				objs: test.NewFakeCluster("ns1", "cluster1").
-					WithMachineDeployments(
-						test.NewFakeMachineDeployment("md1").
-							WithMachineSets(
-								test.NewFakeMachineSet("ms1").
-									WithMachines(
-										test.NewFakeMachine("m1"),
-										test.NewFakeMachine("m2"),
-									),
-							),
-					).Objs(),
-			},
-			wantErr: false,
-		},
-		{
-			name: "Cluster with Control Plane",
-			fields: fields{
-				objs: test.NewFakeCluster("ns1", "cluster1").
-					WithControlPlane(
-						test.NewFakeControlPlane("cp1").
+					).Objs()...)
+
+				objs = append(objs, test.NewFakeCluster("ns1", "cluster2").
+					WithMachineSets(
+						test.NewFakeMachineSet("cluster2-ms1").
+							WithInfrastructureTemplate(sharedInfrastructureTemplate).
 							WithMachines(
-								test.NewFakeMachine("m1"),
-								test.NewFakeMachine("m2"),
+								test.NewFakeMachine("cluster2-m1"),
 							),
-					).Objs(),
-			},
-			wantErr: false,
+					).Objs()...)
+
+				return objs
+			}(),
 		},
-		{
-			name: "Cluster with MachinePool",
-			fields: fields{
-				objs: test.NewFakeCluster("ns1", "cluster1").
-					WithMachinePools(
-						test.NewFakeMachinePool("mp1"),
-					).Objs(),
+		wantMoveGroups: [][]string{
+			{ //group 1
+				"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/cluster1",
+				"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/cluster2",
 			},
-			wantErr: false,
+			{ //group 2 (objects with ownerReferences in group 1)
+				// owned by Clusters
+				"/v1, Kind=Secret, ns1/cluster1-ca",
+				"/v1, Kind=Secret, ns1/cluster1-kubeconfig",
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfigTemplate, ns1/cluster1-ms1",
+				"cluster.x-k8s.io/v1alpha3, Kind=MachineSet, ns1/cluster1-ms1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureCluster, ns1/cluster1",
+				"/v1, Kind=Secret, ns1/cluster2-ca",
+				"/v1, Kind=Secret, ns1/cluster2-kubeconfig",
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfigTemplate, ns1/cluster2-ms1",
+				"cluster.x-k8s.io/v1alpha3, Kind=MachineSet, ns1/cluster2-ms1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureCluster, ns1/cluster2",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachineTemplate, ns1/shared", //shared object
+			},
+			{ //group 3 (objects with ownerReferences in group 1,2)
+				// owned by MachineSets
+				"cluster.x-k8s.io/v1alpha3, Kind=Machine, ns1/cluster1-m1",
+				"cluster.x-k8s.io/v1alpha3, Kind=Machine, ns1/cluster2-m1",
+			},
+			{ //group 4 (objects with ownerReferences in group 1,2,3)
+				// owned by Machines
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfig, ns1/cluster1-m1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachine, ns1/cluster1-m1",
+				"bootstrap.cluster.x-k8s.io/v1alpha3, Kind=DummyBootstrapConfig, ns1/cluster2-m1",
+				"infrastructure.cluster.x-k8s.io/v1alpha3, Kind=DummyInfrastructureMachine, ns1/cluster2-m1",
+			},
+			{ //group 5 (objects with ownerReferences in group 1,2,3,4)
+				// owned by DummyBootstrapConfigs
+				"/v1, Kind=Secret, ns1/cluster1-m1",
+				"/v1, Kind=Secret, ns1/cluster2-m1",
+			},
 		},
+	},
+}
+
+func Test_getMoveSequence(t *testing.T) {
+	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
+	for _, tt := range moveTests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create an objectGraph bound a source cluster with all the CRDs for the types involved in the test.
+			graph := getObjectGraphWithObjs(tt.fields.objs)
+
+			// Get all the types to be considered for discovery
+			discoveryTypes, err := getFakeDiscoveryTypes(graph)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// trigger discovery the content of the source cluster
+			if err := graph.Discovery("ns1", discoveryTypes); err != nil {
+				t.Fatal(err)
+			}
+
+			moveSequence := getMoveSequence(graph)
+			if len(moveSequence.groups) != len(tt.wantMoveGroups) {
+				t.Fatalf("got = %d groups, want %d", len(moveSequence.groups), len(tt.wantMoveGroups))
+			}
+			for i, gotGroup := range moveSequence.groups {
+				wantGroup := tt.wantMoveGroups[i]
+				gotNodes := []string{}
+				for _, node := range gotGroup {
+					gotNodes = append(gotNodes, string(node.identity.UID))
+				}
+
+				sort.Strings(gotNodes)
+				sort.Strings(wantGroup)
+
+				if !reflect.DeepEqual(gotNodes, wantGroup) {
+					t.Errorf("group[%d], got = %s, expected = %s", i, gotNodes, wantGroup)
+				}
+			}
+		})
 	}
-	for _, tt := range tests {
+}
+
+func Test_objectMover_move(t *testing.T) {
+	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
+	for _, tt := range moveTests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create an objectGraph bound a source cluster with all the CRDs for the types involved in the test.
 			graph := getObjectGraphWithObjs(tt.fields.objs)
@@ -130,9 +418,8 @@ func Test_objectMover_move(t *testing.T) {
 
 			// Run move
 			mover := objectMover{
-				fromProxy:     graph.proxy,
-				machineWaiter: fakeMachineWaiter,
-				log:           graph.log,
+				fromProxy: graph.proxy,
+				log:       graph.log,
 			}
 
 			err = mover.move(graph, toProxy)
@@ -186,8 +473,4 @@ func Test_objectMover_move(t *testing.T) {
 			}
 		})
 	}
-}
-
-func fakeMachineWaiter(proxy Proxy, machineKey client.ObjectKey) error {
-	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors clusterctl in order to support move when two or move clusters are sharing some objects (like e.g. Templates or LoadBalancers).

The PR takes a generic approach to solve this problem and the move sequence is defined by processing the ownerReference chain, so we ensure that a node is moved only after its owners.

Additionally, nodes are grouped, so each group of nodes can be moved in parallel. e.g.
- All the Clusters should be moved first because they have no OwenerReferences
- All the MachineDeployments should be moved second because they have OwenerReferences to clusters, which are moved as part of the first group
- then all the MachineSets should be moved second because they have OwenerReferences to MachineDeployments, which are moved as part of the second group
- etc.

**Which issue(s) this PR fixes**:
rif: #1729 

/area clusterctl
/assign @ncdc
/assign @vincepri