### PR TITLE
✨ Added extra columns to print in kubectl get with (-o wide)

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -108,6 +108,12 @@ type KubeadmControlPlaneStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
+// +kubebuilder:printcolumn:name="Ready",type=boolean,JSONPath=".status.ready",description="KubeadmControlPlane API Server is ready to receive requests"
+// +kubebuilder:printcolumn:name="Initialized",type=boolean,JSONPath=".status.initialized",description="This denotes whether or not the control plane has the uploaded kubeadm-config configmap"
+// +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=".status.replicas",description="Total number of non-terminated machines targeted by this control plane"
+// +kubebuilder:printcolumn:name="Ready Replicas",type=integer,JSONPath=".status.readyReplicas",description="Total number of fully running and ready control plane machines"
+// +kubebuilder:printcolumn:name="Updated Replicas",type=integer,JSONPath=".status.updatedReplicas",description="Total number of non-terminated machines targeted by this control plane that have the desired template spec"
+// +kubebuilder:printcolumn:name="Unavailable Replicas",type=integer,JSONPath=".status.unavailableReplicas",description="Total number of unavailable machines targeted by this control plane"
 
 // KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
 type KubeadmControlPlane struct {

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -8,6 +8,34 @@ metadata:
   creationTimestamp: null
   name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.ready
+    description: KubeadmControlPlane API Server is ready to receive requests
+    name: Ready
+    type: boolean
+  - JSONPath: .status.initialized
+    description: This denotes whether or not the control plane has the uploaded kubeadm-config
+      configmap
+    name: Initialized
+    type: boolean
+  - JSONPath: .status.replicas
+    description: Total number of non-terminated machines targeted by this control
+      plane
+    name: Replicas
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Total number of fully running and ready control plane machines
+    name: Ready Replicas
+    type: integer
+  - JSONPath: .status.updatedReplicas
+    description: Total number of non-terminated machines targeted by this control
+      plane that have the desired template spec
+    name: Updated Replicas
+    type: integer
+  - JSONPath: .status.unavailableReplicas
+    description: Total number of unavailable machines targeted by this control plane
+    name: Unavailable Replicas
+    type: integer
   group: controlplane.cluster.x-k8s.io
   names:
     categories:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

It adds extra columns `status.ready` and `status.initialized` for** printing when running `kubectl get kubeadmcontrolplanes` with -o wide

**Which issue(s) this PR fixes**  :
Fixes #2162 
