### PR TITLE
✨clusterctl: add godoc and doc

### DIFF
--- a/cmd/clusterctl/cmd/config_cluster.go
+++ b/cmd/clusterctl/cmd/config_cluster.go
@@ -86,7 +86,7 @@ func init() {
 
 	configClusterClusterCmd.Flags().StringVarP(&cc.flavor, "flavor", "f", "", "The template variant to be used for creating the workload cluster")
 	configClusterClusterCmd.Flags().StringVarP(&cc.targetNamespace, "target-namespace", "n", "", "The namespace where the objects describing the workload cluster should be deployed. If not specified, the current namespace will be used")
-	configClusterClusterCmd.Flags().StringVarP(&cc.kubernetesVersion, "kubernetes-version", "", "", "The Kubernetes version to use for the workload cluster. By default (empty), the value from os env variables or the .clusterctl config file will be used")
+	configClusterClusterCmd.Flags().StringVarP(&cc.kubernetesVersion, "kubernetes-version", "", "", "The Kubernetes version to use for the workload cluster. By default (empty), the value from os env variables or the .cluster-api/clusterctl.yaml config file will be used")
 	configClusterClusterCmd.Flags().IntVarP(&cc.controlPlaneMachineCount, "control-plane-machine-count", "", 1, "The number of control plane machines to be added to the workload cluster.")
 	configClusterClusterCmd.Flags().IntVarP(&cc.workerMachineCount, "worker-machine-count", "", 0, "The number of worker machines to be added to the workload cluster.")
 

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -108,7 +108,7 @@ func runInit() error {
 		BootstrapProviders:      io.bootstrapProviders,
 		ControlPlaneProviders:   io.controlPlaneProviders,
 		InfrastructureProviders: io.infrastructureProviders,
-		TargetNameSpace:         io.targetNamespace,
+		TargetNamespace:         io.targetNamespace,
 		WatchingNamespace:       io.watchingNamespace,
 	})
 	if err != nil {

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -24,42 +24,100 @@ import (
 
 // InitOptions carries the options supported by Init.
 type InitOptions struct {
-	Kubeconfig              string
-	CoreProvider            string
-	BootstrapProviders      []string
-	ControlPlaneProviders   []string
+	// Kubeconfig file to use for accessing the management cluster. If empty, default rules for kubeconfig
+	// discovery will be used.
+	Kubeconfig string
+
+	// CoreProvider version (e.g. cluster-api:v0.3.0) to add to the management cluster. By default (empty), the
+	// cluster-api core provider's latest release is used.
+	CoreProvider string
+
+	// BootstrapProviders and versions (e.g. kubeadm-bootstrap:v0.3.0) to add to the management cluster.
+	// By default (empty), the kubeadm bootstrap provider's latest release is used.
+	BootstrapProviders []string
+
+	// InfrastructureProviders and versions (e.g. aws:v0.5.0) to add to the management cluster.
 	InfrastructureProviders []string
-	TargetNameSpace         string
-	WatchingNamespace       string
+
+	// ControlPlaneProviders and versions (e.g. kubeadm-control-plane:v0.3.0) to add to the management cluster.
+	// By default (empty), the kubeadm control plane provider latest release is used.
+	ControlPlaneProviders []string
+
+	// TargetNamespace defines the namespace where the providers should be deployed. If not specified, each provider
+	// will be installed in a provider's default namespace.
+	TargetNamespace string
+
+	// WatchingNamespace defines the namespace the providers should watch to reconcile Cluster API objects.
+	// If unspecified, the providers watches for Cluster API objects across all namespaces.
+	WatchingNamespace string
 }
 
 // GetClusterTemplateOptions carries the options supported by GetClusterTemplate.
 type GetClusterTemplateOptions struct {
-	Kubeconfig               string
-	InfrastructureProvider   string
-	Flavor                   string
-	BootstrapProvider        string
-	ClusterName              string
-	TargetNamespace          string
-	KubernetesVersion        string
+	// Kubeconfig file to use for accessing the management cluster. If empty, default rules for kubeconfig
+	// discovery will be used.
+	Kubeconfig string
+
+	// InfrastructureProvider that should be used for creating the workload cluster.
+	InfrastructureProvider string
+
+	// BootstrapProvider that should be used for bootstrapping Kubernetes nodes in the workload cluster.
+	BootstrapProvider string
+
+	// Flavor defines the template variant to be used for creating the workload cluster.
+	Flavor string
+
+	// TargetNamespace where the objects describing the workload cluster should be deployed. If not specified,
+	// the current namespace will be used.
+	TargetNamespace string
+
+	// ClusterName to be used for the workload cluster.
+	ClusterName string
+
+	// KubernetesVersion to use for the workload cluster. By default (empty), the value from os env variables
+	// or the .cluster-api/clusterctl.yaml config file will be used.
+	KubernetesVersion string
+
+	// ControlPlaneMachineCount defines the number of control plane machines to be added to the workload cluster.
 	ControlPlaneMachineCount int
-	WorkerMachineCount       int
+
+	// WorkerMachineCount defines number of worker machines to be added to the workload cluster.
+	WorkerMachineCount int
 }
 
 // DeleteOptions carries the options supported by Delete.
 type DeleteOptions struct {
-	Kubeconfig           string
+	// Kubeconfig file to use for accessing the management cluster. If empty, default rules for kubeconfig
+	// discovery will be used.
+	Kubeconfig string
+
+	// ForceDeleteNamespace forces the deletion of the namespace where the providers are hosted
+	// (and of all the contained objects).
 	ForceDeleteNamespace bool
-	ForceDeleteCRD       bool
-	Namespace            string
-	Providers            []string
+
+	// ForceDeleteCRD forces the deletion of the provider's CRDs (and of all the related objects)".
+	ForceDeleteCRD bool
+
+	// Namespace where the provider to be deleted lives. If not specified, the namespace name will be inferred
+	// from the current configuration.
+	Namespace string
+
+	// Providers to be delete. By default (empty), all the provider will be deleted.
+	Providers []string
 }
 
 // MoveOptions carries the options supported by move.
 type MoveOptions struct {
+	// FromKubeconfig defines the kubeconfig file to use for accessing the source management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
 	FromKubeconfig string
-	ToKubeconfig   string
-	Namespace      string
+
+	// ToKubeconfig defines the path to the kubeconfig file to use for accessing the target management cluster.
+	ToKubeconfig string
+
+	// Namespace where the objects describing the workload cluster exists. If not specified, the current
+	// namespace will be used.
+	Namespace string
 }
 
 // Client is exposes the clusterctl high-level client library.

--- a/cmd/clusterctl/pkg/client/config.go
+++ b/cmd/clusterctl/pkg/client/config.go
@@ -91,7 +91,7 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 		version = defaultProviderVersion
 	}
 
-	// If the option specifyng the targetNamespace is empty, try to detect it.
+	// If the option specifying the targetNamespace is empty, try to detect it.
 	if options.TargetNamespace == "" {
 		currentNamespace, err := cluster.Proxy().CurrentNamespace()
 		if err != nil {

--- a/cmd/clusterctl/pkg/client/init.go
+++ b/cmd/clusterctl/pkg/client/init.go
@@ -64,7 +64,7 @@ func (c *clusterctlClient) Init(options InitOptions) ([]Components, bool, error)
 
 	addOptions := addToInstallerOptions{
 		installer:         installer,
-		targetNameSpace:   options.TargetNameSpace,
+		targetNameSpace:   options.TargetNamespace,
 		watchingNamespace: options.WatchingNamespace,
 	}
 

--- a/cmd/clusterctl/pkg/client/init_test.go
+++ b/cmd/clusterctl/pkg/client/init_test.go
@@ -334,7 +334,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				BootstrapProviders:      tt.args.bootstrapProvider,
 				ControlPlaneProviders:   tt.args.controlPlaneProvider,
 				InfrastructureProviders: tt.args.infrastructureProvider,
-				TargetNameSpace:         tt.args.targetNameSpace,
+				TargetNamespace:         tt.args.targetNameSpace,
 				WatchingNamespace:       tt.args.watchingNamespace,
 			})
 

--- a/cmd/clusterctl/pkg/client/move.go
+++ b/cmd/clusterctl/pkg/client/move.go
@@ -39,6 +39,15 @@ func (c *clusterctlClient) Move(options MoveOptions) error {
 		return err
 	}
 
+	// If the option specifying the Namespace is empty, try to detect it.
+	if options.Namespace == "" {
+		currentNamespace, err := fromCluster.Proxy().CurrentNamespace()
+		if err != nil {
+			return err
+		}
+		options.Namespace = currentNamespace
+	}
+
 	if err := fromCluster.ObjectMover().Move(options.Namespace, toCluster); err != nil {
 		return err
 	}

--- a/docs/book/src/clusterctl/commands/delete.md
+++ b/docs/book/src/clusterctl/commands/delete.md
@@ -1,1 +1,39 @@
 # clusterctl delete
+
+The `clusterctl delete` command deletes the provider components from the management cluster.
+
+The operation is designed to prevent accidental deletion of user created objects. For example:
+
+```shell
+clusterctl delete aws
+```
+
+Deletes the aws provider components, while preserving the namespace where the provider components are hosted and
+the provider's CRDs.
+
+<aside class="note warning">
+
+<h1>Warning</h1>
+
+If you want to delete the namespace where the provider components are hosted, you can use the `--delete-namespace` flag.
+
+Be aware that this operation deletes all the object existing in a namespace, not only the provider's components.
+
+</aside> 
+
+<aside class="note warning">
+
+<h1>Warning</h1>
+
+If you want to delete the provider's CRDs, you can use the `--delete-crd` flag.
+
+Be aware that this operation deletes all the object of Kind defined in the provider's CRDs, e.g. when deleting
+the aws provider, it deletes all the `AWSCluster`, `AWSMachine` etc.
+
+</aside> 
+
+If you want to delete all the providers in a single operation , you can use the `--all` flag.
+
+```shell
+clusterctl delete --all
+```

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -235,7 +235,7 @@ for the inventory of the providers currently installed in the management cluster
 
 <h1>Warning</h1>
 
-The `clusterctl.cluster.x-k8s.io` labels, the `cluster.x-k8s.io/provider` labels and the `Provider` objects MUST NOT altered.
+The `clusterctl.cluster.x-k8s.io` labels, the `cluster.x-k8s.io/provider` labels and the `Provider` objects MUST NOT be altered.
 If this happens, there are no guarantees about the proper functioning of `clusterctl`.  
 
 </aside>

--- a/docs/book/src/clusterctl/commands/move.md
+++ b/docs/book/src/clusterctl/commands/move.md
@@ -21,8 +21,8 @@ You can use:
 clusterctl move --to-kubeconfig="path-to-target-kubeconfig.yaml"
 ```
 
-To move all the Cluster API objects objects in the source management cluster; in case if you want to move only the
-Cluster API objects defined in a specific namespace, you can use the `--namespace` flag.
+To move the Cluster API objects existing in the current namespace of the source management cluster; in case if you want
+to move the Cluster API objects defined in another namespace, you can use the `--namespace` flag.
 
 <aside class="note">
 
@@ -31,6 +31,7 @@ Cluster API objects defined in a specific namespace, you can use the `--namespac
 Before moving a `Cluster`, clusterctl sets the `Cluster.Spec.Paused` field to `true` stopping
 the controllers to reconcile the workload cluster _in the source management cluster_.
 
-The `Cluster` object created in the target management cluster instead will be actively reconciled. 
+The `Cluster` object created in the target management cluster instead will be actively reconciled as soon as the move
+process completes. 
 
 </aside>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR
- Add some godoc (as requested by @vincepri https://github.com/kubernetes-sigs/cluster-api/pull/2078#discussion_r370844357)
- Add docs for the delete command + fixes some minor
- Fixes a behaviour of a Move parameter to make it consistent with what agreed for the command line (`--namespace`defaults to the current namespace, not anymore to all the namespaces) 

**Which issue(s) this PR fixes**:
rif #1729

/area clusterctl
/assign @ncdc
/assign @vincepri
