### PR TITLE
🐛 clusterctl: allow build releases

### DIFF
--- a/cmd/clusterctl/pkg/client/repository/repository_github.go
+++ b/cmd/clusterctl/pkg/client/repository/repository_github.go
@@ -206,13 +206,8 @@ func (g *gitHubRepository) getVersions() ([]string, error) {
 			continue
 		}
 		tagName := *r.TagName
-		sv, err := version.ParseSemantic(tagName)
-		if err != nil {
+		if _, err := version.ParseSemantic(tagName); err != nil {
 			// Discard releases with tags that are not a valid semantic versions (the user can point explicitly to such releases).
-			continue
-		}
-		if sv.PreRelease() != "" || sv.BuildMetadata() != "" {
-			// Discard pre-releases or build releases (the user can point explicitly to such releases).
 			continue
 		}
 		versions = append(versions, tagName)

--- a/cmd/clusterctl/pkg/client/repository/repository_github_test.go
+++ b/cmd/clusterctl/pkg/client/repository/repository_github_test.go
@@ -68,7 +68,7 @@ func Test_gitHubRepository_getVersions(t *testing.T) {
 			field: field{
 				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/v0.4.1/path", clusterctlv1.CoreProviderType),
 			},
-			want:    []string{"v0.4.0", "v0.4.1", "v0.4.2"},
+			want:    []string{"v0.4.0", "v0.4.1", "v0.4.2", "v0.4.3-alpha"},
 			wantErr: false,
 		},
 	}
@@ -130,7 +130,7 @@ func Test_gitHubRepository_getLatestRelease(t *testing.T) {
 			field: field{
 				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/v0.4.1/path", clusterctlv1.CoreProviderType),
 			},
-			want:    "v0.4.2",
+			want:    "v0.4.3-alpha", // prerelease/build releaese are considered as well
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow clusterctl to read any release published in a provider repository

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2157
