### PR TITLE
:running: lint-full: increase timeout to 5m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ issues:
   exclude:
     - "G108: Profiling endpoint is automatically exposed on /debug/pprof"
 run:
-  deadline: 2m
+  deadline: 5m
   skip-files:
     - "zz_generated.*\\.go$"
   skip-dirs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase the lint-full timeout to 5 minutes. Some of the recent CI jobs
have been failing because lint-full has been timing out.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2187 