### PR TITLE
🐛 Add dependencies for capi-e2e tests

### DIFF
--- a/scripts/ci-capi-e2e.sh
+++ b/scripts/ci-capi-e2e.sh
@@ -19,7 +19,17 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}" || exit 1
+
+# shellcheck source=./hack/ensure-go.sh
+source "${REPO_ROOT}/hack/ensure-go.sh"
+# shellcheck source=./hack/ensure-kind.sh
+source "${REPO_ROOT}/hack/ensure-kind.sh"
+# shellcheck source=./hack/ensure-kubectl.sh
+source "${REPO_ROOT}/hack/ensure-kubectl.sh"
+# shellcheck source=./hack/ensure-kustomize.sh
+source "${REPO_ROOT}/hack/ensure-kustomize.sh"
 
 echo "*** Running Cluster API e2e tests ***"
 
-cd "${REPO_ROOT}" && make test-e2e
+make test-e2e


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
To get CI passing

related to #1884 