### PR TITLE
✨clusterctl use global logger

### DIFF
--- a/cmd/clusterctl/cmd/config_provider.go
+++ b/cmd/clusterctl/cmd/config_provider.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -99,7 +100,9 @@ func componentsYAMLOutput(c client.Components) error {
 		return err
 	}
 
-	fmt.Println(string(yaml))
+	if _, err := os.Stdout.Write(yaml); err != nil {
+		return errors.Wrap(err, "failed to write yaml to Stdout")
+	}
 	return err
 }
 

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client"
 )
@@ -100,9 +98,7 @@ func runInit() error {
 		return err
 	}
 
-	fmt.Println("performing init...")
-
-	componentList, firstExecution, err := c.Init(client.InitOptions{
+	_, err = c.Init(client.InitOptions{
 		Kubeconfig:              io.kubeconfig,
 		CoreProvider:            io.coreProvider,
 		BootstrapProviders:      io.bootstrapProviders,
@@ -110,21 +106,10 @@ func runInit() error {
 		InfrastructureProviders: io.infrastructureProviders,
 		TargetNamespace:         io.targetNamespace,
 		WatchingNamespace:       io.watchingNamespace,
+		LogUsageInstructions:    true,
 	})
 	if err != nil {
 		return err
 	}
-
-	for _, components := range componentList {
-		fmt.Printf(" - %s %s installed (%s)\n", components.Name(), components.Type(), components.Version())
-	}
-
-	if firstExecution {
-		fmt.Println("\nYour cluster API management cluster has been initialized successfully!")
-		fmt.Println("\nYou can now create your first workload cluster by running the following:")
-		fmt.Println("\n  clusterctl config cluster [name] --kubernetes-version [version] | kubectl apply -f -")
-		fmt.Println("")
-	}
-
 	return nil
 }

--- a/cmd/clusterctl/cmd/move.go
+++ b/cmd/clusterctl/cmd/move.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client"
@@ -66,7 +64,7 @@ func runMove() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("Performing move...")
+
 	if err := c.Move(client.MoveOptions{
 		FromKubeconfig: mo.fromKubeconfig,
 		ToKubeconfig:   mo.toKubeconfig,

--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
+	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/log"
 )
 
 var cfgFile string
@@ -46,29 +46,10 @@ func Execute() {
 }
 
 func init() {
+	verbosity := flag.CommandLine.Int("v", 0, "number for the log level verbosity")
+	logf.SetLogger(logf.NewLogger(logf.WithThreshold(verbosity)))
 
-	klog.InitFlags(flag.CommandLine)
 	RootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
-
-	// hiding all the klog flags except
-	// --log_dir
-	// --log_file
-	// --log_file_max_size
-	// -v, --v Level
-
-	_ = RootCmd.PersistentFlags().MarkHidden("alsologtostderr")
-	_ = RootCmd.PersistentFlags().MarkHidden("log_backtrace_at")
-	_ = RootCmd.PersistentFlags().MarkHidden("logtostderr")
-	_ = RootCmd.PersistentFlags().MarkHidden("stderrthreshold")
-	_ = RootCmd.PersistentFlags().MarkHidden("vmodule")
-	_ = RootCmd.PersistentFlags().MarkHidden("skip_log_headers")
-	_ = RootCmd.PersistentFlags().MarkHidden("skip_headers")
-	_ = RootCmd.PersistentFlags().MarkHidden("add_dir_header")
-
-	// makes logs look nicer for a CLI app
-	_ = RootCmd.PersistentFlags().Set("skip_headers", "true")
-	_ = RootCmd.PersistentFlags().Set("logtostderr", "true")
-
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Path to the the clusterctl config file (default is $HOME/.cluster-api/clusterctl.yaml)")
 }
 

--- a/cmd/clusterctl/cmd/upgrade.go
+++ b/cmd/clusterctl/cmd/upgrade.go
@@ -76,8 +76,6 @@ func runUpgradePlan() error {
 		return err
 	}
 
-	//TODO: switch to klog as soon as https://github.com/kubernetes-sigs/cluster-api/pull/2150 merge
-	fmt.Println("Checking new release availability...")
 	upgradePlans, err := c.PlanUpgrade(client.PlanUpgradeOptions{
 		Kubeconfig: up.kubeconfig,
 	})

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -50,6 +50,9 @@ type InitOptions struct {
 	// WatchingNamespace defines the namespace the providers should watch to reconcile Cluster API objects.
 	// If unspecified, the providers watches for Cluster API objects across all namespaces.
 	WatchingNamespace string
+
+	// LogUsageInstructions instructs the init command to print the usage instructions in case of first run.
+	LogUsageInstructions bool
 }
 
 // GetClusterTemplateOptions carries the options supported by GetClusterTemplate.
@@ -132,7 +135,7 @@ type Client interface {
 	GetProviderComponents(provider, targetNameSpace, watchingNamespace string) (Components, error)
 
 	// Init initializes a management cluster by adding the requested list of providers.
-	Init(options InitOptions) ([]Components, bool, error)
+	Init(options InitOptions) ([]Components, error)
 
 	// GetClusterTemplate returns a workload cluster template.
 	GetClusterTemplate(options GetClusterTemplateOptions) (Template, error)

--- a/cmd/clusterctl/pkg/client/client_test.go
+++ b/cmd/clusterctl/pkg/client/client_test.go
@@ -76,7 +76,7 @@ func (f fakeClient) GetClusterTemplate(options GetClusterTemplateOptions) (Templ
 	return f.internalClient.GetClusterTemplate(options)
 }
 
-func (f fakeClient) Init(options InitOptions) ([]Components, bool, error) {
+func (f fakeClient) Init(options InitOptions) ([]Components, error) {
 	return f.internalClient.Init(options)
 }
 
@@ -159,12 +159,12 @@ func newFakeCluster(kubeconfig string) *fakeClusterClient {
 	}
 }
 
-type fakeCertMangerClient struct {
+type fakeCertManagerClient struct {
 }
 
-var _ cluster.CertMangerClient = &fakeCertMangerClient{}
+var _ cluster.CertManagerClient = &fakeCertManagerClient{}
 
-func (p *fakeCertMangerClient) EnsureWebHook() error {
+func (p *fakeCertManagerClient) EnsureWebHook() error {
 	// For unit test, we are not installing the cert-manager WebHook so we always return no error without doing additional steps.
 	return nil
 }
@@ -185,8 +185,8 @@ func (f fakeClusterClient) Proxy() cluster.Proxy {
 	return f.fakeProxy
 }
 
-func (f *fakeClusterClient) CertManger() cluster.CertMangerClient {
-	return &fakeCertMangerClient{}
+func (f *fakeClusterClient) CertManager() cluster.CertManagerClient {
+	return &fakeCertManagerClient{}
 }
 
 func (f fakeClusterClient) ProviderComponents() cluster.ComponentsClient {

--- a/cmd/clusterctl/pkg/client/cluster/client.go
+++ b/cmd/clusterctl/pkg/client/cluster/client.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/klogr"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
@@ -45,9 +44,9 @@ type Client interface {
 	// Proxy return the Proxy used for operating objects in the management cluster.
 	Proxy() Proxy
 
-	// CertManger returns a CertMangerClient that can be user for
+	// CertManager returns a CertManagerClient that can be user for
 	// operating the cert-manager components in the cluster.
-	CertManger() CertMangerClient
+	CertManager() CertManagerClient
 
 	// ProviderComponents returns a ComponentsClient object that can be user for
 	// operating provider components objects in the management cluster (e.g. the CRDs, controllers, RBAC).
@@ -94,7 +93,7 @@ func (c *clusterClient) Proxy() Proxy {
 	return c.proxy
 }
 
-func (c *clusterClient) CertManger() CertMangerClient {
+func (c *clusterClient) CertManager() CertManagerClient {
 	return newCertMangerClient(c.proxy, c.pollImmediateWaiter)
 }
 
@@ -111,9 +110,7 @@ func (c *clusterClient) ProviderInstaller() ProviderInstaller {
 }
 
 func (c *clusterClient) ObjectMover() ObjectMover {
-	//TODO: make the logger to flow down all the chain
-	log := klogr.New()
-	return newObjectMover(c.proxy, log)
+	return newObjectMover(c.proxy)
 }
 
 func (c *clusterClient) ProviderUpgrader() ProviderUpgrader {

--- a/cmd/clusterctl/pkg/client/cluster/installer.go
+++ b/cmd/clusterctl/pkg/client/cluster/installer.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"github.com/pkg/errors"
-	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
 )
 
@@ -45,7 +43,7 @@ var _ ProviderInstaller = &providerInstaller{}
 
 func (i *providerInstaller) Add(components repository.Components) error {
 	if err := i.providerInventory.Validate(components.InventoryObject()); err != nil {
-		return errors.Wrapf(err, "Installing provider %q can lead to a non functioning management cluster.", components.Name())
+		return err
 	}
 
 	i.installQueue = append(i.installQueue, components)
@@ -55,8 +53,6 @@ func (i *providerInstaller) Add(components repository.Components) error {
 func (i *providerInstaller) Install() ([]repository.Components, error) {
 	ret := make([]repository.Components, 0, len(i.installQueue))
 	for _, components := range i.installQueue {
-		klog.V(3).Infof("Installing provider %s/%s:%s", components.TargetNamespace(), components.Name(), components.Version())
-
 		if err := i.providerComponents.Create(components); err != nil {
 			return nil, err
 		}
@@ -67,7 +63,6 @@ func (i *providerInstaller) Install() ([]repository.Components, error) {
 
 		ret = append(ret, components)
 	}
-
 	return ret, nil
 }
 

--- a/cmd/clusterctl/pkg/client/cluster/mover_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/mover_test.go
@@ -422,7 +422,6 @@ func Test_objectMover_move(t *testing.T) {
 			// Run move
 			mover := objectMover{
 				fromProxy: graph.proxy,
-				log:       graph.log,
 			}
 
 			err = mover.move(graph, toProxy)
@@ -664,7 +663,6 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 
 			o := &objectMover{
 				fromProxy: graph.proxy,
-				log:       graph.log,
 			}
 			if err := o.checkProvisioningCompleted(graph); (err != nil) != tt.wantErr {
 				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)

--- a/cmd/clusterctl/pkg/client/cluster/objectgraph_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/objectgraph_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	logrtesting "github.com/go-logr/logr/testing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -62,7 +61,7 @@ func TestObjectGraph_getDiscoveryTypeMetaList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			graph := newObjectGraph(tt.fields.proxy, nil)
+			graph := newObjectGraph(tt.fields.proxy)
 			got, err := graph.getDiscoveryTypes()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
@@ -324,7 +323,7 @@ func TestObjectGraph_addObj(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			graph := newObjectGraph(nil, nil)
+			graph := newObjectGraph(nil)
 			for _, o := range tt.args.objs {
 				graph.addObj(o)
 			}
@@ -874,7 +873,7 @@ var objectGraphsTests = []struct {
 }
 
 func getDetachedObjectGraphWihObjs(objs []runtime.Object) (*objectGraph, error) {
-	graph := newObjectGraph(nil, nil) // detached from any cluster
+	graph := newObjectGraph(nil) // detached from any cluster
 	for _, o := range objs {
 		u := &unstructured.Unstructured{}
 		if err := test.FakeScheme.Convert(o, u, nil); err != nil { //nolint
@@ -909,7 +908,7 @@ func getObjectGraphWithObjs(objs []runtime.Object) *objectGraph {
 		fromProxy.WithObjs(o)
 	}
 
-	return newObjectGraph(fromProxy, logrtesting.NullLogger{})
+	return newObjectGraph(fromProxy)
 }
 
 func getFakeProxyWithCRDs() *test.FakeProxy {

--- a/cmd/clusterctl/pkg/client/cluster/proxy.go
+++ b/cmd/clusterctl/pkg/client/cluster/proxy.go
@@ -161,6 +161,10 @@ func (k *proxy) getConfig() (*rest.Config, error) {
 	}
 	restConfig.UserAgent = fmt.Sprintf("clusterctl/%s (%s)", version.Get().GitVersion, version.Get().Platform)
 
+	// Set QPS and Burst to a threshold that ensures the controller runtime client/client go does't generate throttling log messages
+	restConfig.QPS = 20
+	restConfig.Burst = 100
+
 	return restConfig, nil
 }
 

--- a/cmd/clusterctl/pkg/client/cluster/upgrader.go
+++ b/cmd/clusterctl/pkg/client/cluster/upgrader.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
+	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/log"
 )
 
 // ProviderUpgrader defines methods for supporting provider upgrade.
@@ -67,6 +68,9 @@ type providerUpgrader struct {
 var _ ProviderUpgrader = &providerUpgrader{}
 
 func (u *providerUpgrader) Plan() ([]UpgradePlan, error) {
+	log := logf.Log
+	log.Info("Checking new release availability...")
+
 	managementGroups, err := u.providerInventory.GetManagementGroups()
 	if err != nil {
 		return nil, err

--- a/cmd/clusterctl/pkg/client/config/providers_client.go
+++ b/cmd/clusterctl/pkg/client/config/providers_client.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/klog"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 )
 
@@ -148,7 +147,6 @@ func (p *providersClient) List() ([]Provider, error) {
 			if providers[i].Name() == provider.Name() {
 				providers[i] = provider
 				override = true
-				klog.V(3).Infof("The clusterctl configuration file overrides default configuration for provider %s", provider.Name())
 			}
 		}
 

--- a/cmd/clusterctl/pkg/client/config/reader_viper.go
+++ b/cmd/clusterctl/pkg/client/config/reader_viper.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/util/homedir"
-	"k8s.io/klog"
+	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/log"
 )
 
 // ConfigFolder defines the name of the config folder under $home
@@ -41,6 +41,8 @@ func newViperReader() Reader {
 
 // Init initialize the viperReader.
 func (v *viperReader) Init(path string) error {
+	log := logf.Log
+
 	if path != "" {
 		// Use path file from the flag.
 		viper.SetConfigFile(path)
@@ -61,7 +63,7 @@ func (v *viperReader) Init(path string) error {
 
 	// If a path file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		klog.V(1).Infof("Using %q configuration file", viper.ConfigFileUsed())
+		log.V(5).Info("Reading configuration", "File", viper.ConfigFileUsed())
 	}
 
 	return nil

--- a/cmd/clusterctl/pkg/client/delete.go
+++ b/cmd/clusterctl/pkg/client/delete.go
@@ -70,11 +70,16 @@ func (c *clusterctlClient) Delete(options DeleteOptions) error {
 			}
 
 			// Check the provider/namespace tuple actually matches one of the installed providers.
+			found := false
 			for _, ip := range installedProviders {
 				if ip.Name == name && ip.Namespace == namespace {
+					found = true
 					providers = append(providers, ip)
 					break
 				}
+			}
+			if found {
+				break
 			}
 
 			// In case the provider does not match any installed providers, we still force deletion

--- a/cmd/clusterctl/pkg/client/init_test.go
+++ b/cmd/clusterctl/pkg/client/init_test.go
@@ -328,7 +328,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				}
 			}
 
-			got, _, err := tt.field.client.Init(InitOptions{
+			got, err := tt.field.client.Init(InitOptions{
 				Kubeconfig:              "kubeconfig",
 				CoreProvider:            tt.args.coreProvider,
 				BootstrapProviders:      tt.args.bootstrapProvider,

--- a/cmd/clusterctl/pkg/client/repository/repository_github.go
+++ b/cmd/clusterctl/pkg/client/repository/repository_github.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 	"k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 )
 
@@ -147,9 +146,6 @@ func newGitHubRepository(providerConfig config.Provider, configVariablesClient c
 	}
 
 	token, err := configVariablesClient.Get(githubTokeVariable)
-	if err != nil {
-		klog.V(1).Infof("The %q configuration variable is missing. Falling back to unauthenticated requests that allows for up to 60 requests per hour.", githubTokeVariable)
-	}
 	if err == nil {
 		repo.setClientToken(token)
 	}

--- a/cmd/clusterctl/pkg/log/doc.go
+++ b/cmd/clusterctl/pkg/log/doc.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package log mirrors the controller runtime approach to logging, by defining a global logger
+that defaults to NullLogger.
+
+You can set a custom logger by calling log.SetLogger.
+
+NewLogger returns a clusterctl friendly logr.Logger derived from
+https://github.com/kubernetes/klog/blob/master/klogr/klogr.go.
+
+The logger is designed to print logs to stdout with a formatting that is easy to read for users
+but also simple to parse for identifying specific values.
+
+Note: the clusterctl library also support usage of other loggers as long as they conform to the github.com/go-logr/logr.Logger interface.
+
+Following logging conventions are used in clusterctl library:
+
+Message:
+
+All messages should start with a capital letter.
+
+Log level:
+
+Use Level 0 (the default, if you don't specify a level) for the most important user feedback only, e.g.
+- reporting command progress for long running actions
+- reporting command results when required
+
+Use logging Levels 1 providing more info about the command's internal workflow.
+
+Use logging Levels 5 for for providing all the information required for debug purposes/problem investigation.
+
+Logging WithValues:
+
+Logging WithValues should be preferred to embedding values into log messages because it allows
+machine readability.
+
+Variables name should start with a capital letter.
+
+Logging WithNames:
+
+Logging WithNames should be used carefully.
+Please consider that practices like prefixing the logs with something indicating which part of code
+is generating the log entry might be useful for developers, but it can create confusion for
+the end users because it increases the verbosity without providing information the user can understand/take benefit from.
+
+Logging errors:
+
+A proper error management should always be preferred to the usage of log.Error.
+*/
+package log

--- a/cmd/clusterctl/pkg/log/log.go
+++ b/cmd/clusterctl/pkg/log/log.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// SetLogger sets a concrete logging implementation for all deferred Loggers.
+func SetLogger(l logr.Logger) {
+	Log.Fulfill(l)
+}
+
+// Log is the base logger used by kubebuilder.  It delegates
+// to another logr.Logger.  You *must* call SetLogger to
+// get any actual logging.
+var Log = log.NewDelegatingLogger(log.NullLogger{})

--- a/cmd/clusterctl/pkg/log/util.go
+++ b/cmd/clusterctl/pkg/log/util.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// UnstructuredToValues provide a utility function for creation values describing an Unstructured objects. e.g.
+// Deployment="capd-controller-manager" Namespace="capd-system"  (<Kind>=<name> Namespace=<Namespace>)
+// CustomResourceDefinition="dockerclusters.infrastructure.cluster.x-k8s.io" (omit Namespace if it does not apply)
+func UnstructuredToValues(obj unstructured.Unstructured) []interface{} {
+	values := []interface{}{
+		obj.GetKind(), obj.GetName(),
+	}
+	if obj.GetNamespace() != "" {
+		values = append(values, "Namespace", obj.GetNamespace())
+	}
+	return values
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

As per discussion on https://github.com/kubernetes-sigs/cluster-api/pull/2151 (thanks @chuckha) this PR implements a global logger based on the controller runtime one (see the log.go file).

The PR validates the global logger approach by removing all the klog calls and implementing a   reviewed/finalized clusterctl init output.

After testing the two approaches discussed for logging, I'm +1 for this solution in clusterctl, but to complete the work we still need a custom logger...

**Which issue(s) this PR fixes**:
rif #1729

/area clusterctl
/assign @ncdc
/assign @vincepri
/assign @chuckha 