### PR TITLE
✨ clusterctl: Add automatic selection of repository backend based on URL

### DIFF
--- a/cmd/clusterctl/pkg/client/repository/client.go
+++ b/cmd/clusterctl/pkg/client/repository/client.go
@@ -164,8 +164,14 @@ func repositoryFactory(providerConfig config.Provider, configVariablesClient con
 		return repo, err
 	}
 
-	// if the url is a local repository
-	//TODO: implement in a follow up PR
+	// if the url is a local filesystem repository
+	if rURL.Scheme == "file" || rURL.Scheme == "" {
+		repo, err := newLocalRepository(providerConfig, configVariablesClient)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating the local filesystem repository client")
+		}
+		return repo, err
+	}
 
 	return nil, errors.Errorf("invalid provider url. there are no provider implementation for %q schema", rURL.Scheme)
 }

--- a/cmd/clusterctl/pkg/client/repository/client_test.go
+++ b/cmd/clusterctl/pkg/client/repository/client_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repository
+
+import (
+	"os"
+	"testing"
+
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
+)
+
+func Test_newRepositoryClient_LocalFileSystemRepository(t *testing.T) {
+	tmpDir := createTempDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	dst1 := createLocalTestProviderFile(t, tmpDir, "provider-1/v1.0.0/bootstrap-components.yaml", "")
+	dst2 := createLocalTestProviderFile(t, tmpDir, "provider-2/v2.0.0/bootstrap-components.yaml", "")
+
+	type fields struct {
+		provider config.Provider
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{
+			name: "successfully creates repository client with local filesystem backend and scheme == \"\"",
+			fields: fields{
+				provider: config.NewProvider("provider-1", dst1, clusterctlv1.BootstrapProviderType),
+			},
+		},
+		{
+			name: "successfully creates repository client with local filesystem backend and scheme == \"file\"",
+			fields: fields{
+				provider: config.NewProvider("provider-2", "file://"+dst2, clusterctlv1.BootstrapProviderType),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoClient, err := newRepositoryClient(tt.fields.provider, test.NewFakeVariableClient())
+			if err != nil {
+				t.Fatalf("got error %v when none was expected", err)
+			}
+			if _, ok := repoClient.repository.(*localRepository); !ok {
+				t.Fatalf("got repository of type %T when *repository.localRepository was expected", repoClient.repository)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables local file system repositories to be included in clusterctl. It identifies a repo as being local by seeing if its URL begins with "file://"

This is a follow up to: https://github.com/kubernetes-sigs/cluster-api/pull/1963 

A sample clusterctl config with a local repo may look like this:
```
$ cat ~/.cluster-api/clusterctl.yaml 
providers:
- name: infra-foo
  url: file:///home/awander/.cluster-api/infra-foo/v0.1.0/infrastructure-components.yaml
  type: InfrastructureProvider
```

**Which issue(s) this PR fixes** 
Rif: https://github.com/kubernetes-sigs/cluster-api/issues/1729

/assign @fabriziopandini 
/cc @ncdc @vincepri 