### PR TITLE
:sparkles: KubeadmControlPlane scale up serially

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -383,8 +383,9 @@ func TestKubeadmControlPlaneReconciler_initializeControlPlane(t *testing.T) {
 	)
 
 	r := &KubeadmControlPlaneReconciler{
-		Client: fakeClient,
-		Log:    log.Log,
+		Client:            fakeClient,
+		Log:               log.Log,
+		managementCluster: &internal.ManagementCluster{Client: fakeClient},
 	}
 
 	g.Expect(r.initializeControlPlane(context.Background(), cluster, kcp)).To(Succeed())
@@ -956,6 +957,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesNotReady(t *testin
 		Log:                log.Log,
 		remoteClientGetter: fakeremote.NewClusterClient,
 		scheme:             scheme.Scheme,
+		managementCluster:  &internal.ManagementCluster{Client: fakeClient},
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
@@ -1006,6 +1008,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T
 		Log:                log.Log,
 		remoteClientGetter: fakeremote.NewClusterClient,
 		scheme:             scheme.Scheme,
+		managementCluster:  &internal.ManagementCluster{Client: fakeClient},
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
@@ -1060,6 +1063,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusMachinesReadyMixed(t *testing
 		Log:                log.Log,
 		remoteClientGetter: fakeremote.NewClusterClient,
 		scheme:             scheme.Scheme,
+		managementCluster:  &internal.ManagementCluster{Client: fakeClient},
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
@@ -1098,6 +1102,7 @@ func TestReconcileControlPlaneScaleUp(t *testing.T) {
 		recorder:           record.NewFakeRecorder(32),
 		scheme:             scheme.Scheme,
 		remoteClientGetter: fakeremote.NewClusterClient,
+		managementCluster:  &internal.ManagementCluster{Client: fakeClient},
 	}
 
 	for i := 1; i <= desiredReplicas; i++ {
@@ -1239,6 +1244,7 @@ func TestScaleUpControlPlaneAddsANewMachine(t *testing.T) {
 		recorder:           record.NewFakeRecorder(32),
 		scheme:             scheme.Scheme,
 		remoteClientGetter: fakeremote.NewClusterClient,
+		managementCluster:  &internal.ManagementCluster{Client: fakeClient},
 	}
 
 	// Create the first control plane replica
@@ -1380,6 +1386,7 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 			remoteClientGetter: fakeremote.NewClusterClient,
 			recorder:           record.NewFakeRecorder(32),
 			scheme:             scheme.Scheme,
+			managementCluster:  &internal.ManagementCluster{Client: fakeClient},
 		}
 
 		// Create control plane machines
@@ -1432,6 +1439,7 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 			remoteClientGetter: fakeremote.NewClusterClient,
 			recorder:           record.NewFakeRecorder(32),
 			scheme:             scheme.Scheme,
+			managementCluster:  &internal.ManagementCluster{Client: fakeClient},
 		}
 
 		// Create control plane machines

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -1,0 +1,377 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
+	etcdutil "sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd/util"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/proxy"
+	"sigs.k8s.io/cluster-api/util/certs"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ManagementCluster holds operations on the ManagementCluster
+type ManagementCluster struct {
+	Client ctrlclient.Client
+}
+
+// FilterMachines filters a list of machines. If the filter returns true we keep it, if not we discard it.
+type FilterMachines func(machine clusterv1.Machine) bool
+
+// OwnedControlPlaneMachines returns a FilterMachines function to find all owned control plane machines.
+// Usage: managementCluster.GetMachinesForCluster(ctx, cluster, OwnedControlPlaneMachines(controlPlane.Name))
+func OwnedControlPlaneMachines(controlPlaneName string) FilterMachines {
+	return func(machine clusterv1.Machine) bool {
+		controllerRef := metav1.GetControllerOf(&machine)
+		if controllerRef == nil {
+			return false
+		}
+		return controllerRef.Kind == "KubeadmControlPlane" && controllerRef.Name == controlPlaneName
+	}
+}
+
+// GetMachinesForTargetCluster returns a list of machines that can be filtered or not.
+// If no filter is supplied then all machines associated with the target cluster are returned.
+func (m *ManagementCluster) GetMachinesForCluster(ctx context.Context, cluster types.NamespacedName, filters ...FilterMachines) ([]clusterv1.Machine, error) {
+	selector := m.ControlPlaneLabelsForCluster(cluster.Name)
+	allMachines := &clusterv1.MachineList{}
+	if err := m.Client.List(ctx, allMachines, client.InNamespace(cluster.Namespace), client.MatchingLabels(selector)); err != nil {
+		return nil, errors.Wrap(err, "failed to list machines")
+	}
+	if len(filters) == 0 {
+		return allMachines.Items, nil
+	}
+	filteredMachines := []clusterv1.Machine{}
+	for _, filter := range filters {
+		for _, machine := range allMachines.Items {
+			if filter(machine) {
+				filteredMachines = append(filteredMachines, machine)
+			}
+		}
+	}
+	return filteredMachines, nil
+}
+
+// getCluster builds a cluster object.
+// The cluster is also populated with secrets stored on the management cluster that is required for
+// secure internal pod connections.
+func (m *ManagementCluster) getCluster(ctx context.Context, clusterKey types.NamespacedName) (*cluster, error) {
+	// This adapter is for interop with the `remote` package.
+	adapterCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterKey.Namespace,
+			Name: clusterKey.Name,
+		},
+	}
+
+	// TODO(chuckha): Unroll remote.NewClusterClient if we are unhappy with getting a restConfig twice.
+	// TODO(chuckha): Fix this chain to accept a context
+	restConfig, err := remote.RESTConfig(m.Client, adapterCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(chuckha): Fix this entire chain to accept a context.
+	c, err := remote.NewClusterClient(m.Client, adapterCluster, scheme.Scheme)
+	if err != nil {
+		return nil, err
+	}
+	etcdCACert, etcdCAKey, err := m.GetEtcdCerts(ctx, clusterKey)
+	if err != nil {
+		return nil, err
+	}
+	return &cluster{
+		client:     c,
+		restConfig: restConfig,
+		etcdCACert: etcdCACert,
+		etcdCAkey:  etcdCAKey,
+	}, nil
+}
+
+// GetEtcdCA returns the EtcdCA Cert and Key for a given cluster.
+func (m *ManagementCluster) GetEtcdCerts(ctx context.Context, cluster types.NamespacedName) ([]byte, []byte, error) {
+	etcdCASecret := &corev1.Secret{}
+	etcdCAObjectKey := types.NamespacedName{
+		Namespace: cluster.Namespace,
+		Name:      fmt.Sprintf("%s-etcd", cluster.Name),
+	}
+	if err := m.Client.Get(ctx, etcdCAObjectKey, etcdCASecret); err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to get secret; etcd CA bundle %s/%s", etcdCAObjectKey.Namespace, etcdCAObjectKey.Name)
+	}
+	return etcdCASecret.Data["tls.crt"], etcdCASecret.Data["tls.key"], nil
+}
+
+// TargetClusterEtcdIsHealthy runs a series of checks over a target cluster's etcd cluster.
+// This is also responsible for ensuring there are no additional etcd members outside the purview of Cluster API.
+func (m *ManagementCluster) TargetClusterEtcdIsHealthy(ctx context.Context, clusterKey types.NamespacedName, controlPlaneName string) error {
+	cluster, err := m.getCluster(ctx, clusterKey)
+	if err != nil {
+		return err
+	}
+	resp, err := cluster.etcdIsHealthy(ctx)
+	if err != nil {
+		return err
+	}
+	errorList := []error{}
+	for nodeName, err := range resp {
+		if err != nil {
+			errorList = append(errorList, fmt.Errorf("node %q: %v", nodeName, err))
+		}
+	}
+	if len(errorList) != 0 {
+		return kerrors.NewAggregate(errorList)
+	}
+
+	// Make sure Cluster API is aware of all the nodes.
+	machines, err := m.GetMachinesForCluster(ctx, clusterKey, OwnedControlPlaneMachines(controlPlaneName))
+	if err != nil {
+		return err
+	}
+
+	for _, machine := range machines {
+		if machine.Status.NodeRef == nil {
+			return errors.Errorf("control plane machine %q has no node ref", machine.Name)
+		}
+		if _, ok := resp[machine.Status.NodeRef.Name]; !ok {
+			return errors.Errorf("machine's (%q) node (%q) was not checked", machine.Name, machine.Status.NodeRef.Name)
+		}
+	}
+	if len(resp) != len(machines) {
+		return errors.Errorf("number of nodes and machines did not correspond: %d nodes %d machines", len(resp), len(machines))
+	}
+	return nil
+}
+
+// ControlPlaneLabels returns a set of labels to add to a control plane machine for this specific cluster.
+func (m *ManagementCluster) ControlPlaneLabelsForCluster(clusterName string) map[string]string {
+	return map[string]string{
+		clusterv1.ClusterLabelName:             clusterName,
+		clusterv1.MachineControlPlaneLabelName: "",
+	}
+}
+
+// ControlPlaneSelectorForCluster returns the label selector necessary to get control plane machines for a given cluster.
+func (m *ManagementCluster) ControlPlaneSelectorForCluster(clusterName string) *metav1.LabelSelector {
+	return &metav1.LabelSelector{
+		MatchLabels: m.ControlPlaneLabelsForCluster(clusterName),
+	}
+}
+
+// cluster are operations on target clusters.
+type cluster struct {
+	client ctrlclient.Client
+	// restConfig is required for the proxy.
+	restConfig            *rest.Config
+	etcdCACert, etcdCAkey []byte
+}
+
+// generateEtcdTLSClientBundle builds an etcd client TLS bundle from the Etcd CA for this cluster.
+func (c *cluster) generateEtcdTLSClientBundle() (*tls.Config, error) {
+	clientCert, err := generateClientCert(c.etcdCACert,c.etcdCAkey)
+	if err != nil {
+		return nil, err
+	}
+
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(c.etcdCACert)
+
+	return &tls.Config{
+		RootCAs:      caPool,
+		Certificates: []tls.Certificate{clientCert},
+	}, nil
+}
+
+// etcdIsHealthyResponse is a map of node provider IDs to the etcd health check that failed or nil if no checks failed.
+type etcdIsHealthyResponse map[string]error
+
+// etcdIsHealthy runs checks for every etcd member in the cluster to satisfy our definition of healthy.
+// This is a best effort check and nodes can become unhealthy after the check is complete. It is not a guarantee.
+// It's used a signal for if we should allow a target cluster to scale up, scale down or upgrade.
+// It returns a list of nodes checked so the layer above can confirm it has the correct number of nodes expected.
+func (c *cluster) etcdIsHealthy(ctx context.Context) (etcdIsHealthyResponse, error) {
+	var knownClusterID uint64
+	var knownMemberIDSet etcdutil.UInt64
+
+	controlPlaneNodes := &corev1.NodeList{}
+	controlPlaneNodeLabels := map[string]string{
+		"node-role.kubernetes.io/master": "",
+	}
+
+	if err := c.client.List(ctx, controlPlaneNodes, client.MatchingLabels(controlPlaneNodeLabels)); err != nil {
+		return nil, err
+	}
+
+	tlsConfig, err := c.generateEtcdTLSClientBundle()
+	if err != nil {
+		return nil, err
+	}
+
+	response := etcdIsHealthyResponse{}
+	// TODO: Do we need a way to see if there is a 1:1 correspondence of Machines to Nodes?
+	for _, node := range controlPlaneNodes.Items {
+		if node.Spec.ProviderID == "" {
+			response[node.Name] = errors.New("empty provider ID")
+			continue
+		}
+
+		// Create the etcd client for the etcd Pod scheduled on the Node
+		etcdClient, err := c.getEtcdClientForNode(node.Name, tlsConfig)
+		if err != nil {
+			response[node.Name] = errors.New("failed to create etcd client")
+			continue
+		}
+
+		// List etcd members. This checks that the member is healthy, because the request goes through consensus.
+		members, err := etcdClient.Members(ctx)
+		if err != nil {
+			response[node.Name] = errors.New("failed to list etcd members using etcd client")
+			continue
+		}
+		member := etcdutil.MemberForName(members, node.Name)
+
+		// Check that the member reports no alarms.
+		if len(member.Alarms) > 0 {
+			response[node.Name] = errors.Errorf("etcd member reports alarms: %v", node.Name, member.Alarms)
+			continue
+		}
+
+		// Check that the member belongs to the same cluster as all other members.
+		clusterID := member.ClusterID
+		if knownClusterID == 0 {
+			knownClusterID = clusterID
+		} else if knownClusterID != clusterID {
+			response[node.Name] = errors.Errorf("etcd member has cluster ID %d, but all previously seen etcd members have cluster ID %d", clusterID, knownClusterID)
+			continue
+		}
+
+		// Check that the member list is stable.
+		// TODO: this isn't necessary but reduces the race condition as much as possible.
+		memberIDSet := etcdutil.MemberIDSet(members)
+		if knownMemberIDSet.Len() == 0 {
+			knownMemberIDSet = memberIDSet
+		} else {
+			unknownMembers := memberIDSet.Difference(knownMemberIDSet)
+			if unknownMembers.Len() > 0 {
+				response[node.Name] = errors.Errorf("etcd member reports members IDs %v, but all previously seen etcd members reported member IDs %v", memberIDSet.UnsortedList(), knownMemberIDSet.UnsortedList())
+			}
+			continue
+		}
+		response[node.Name] = nil
+	}
+
+	// Check that there is exactly one etcd member for every control plane machine.
+	// There should be no etcd members added "out of band.""
+	if len(controlPlaneNodes.Items) != len(knownMemberIDSet) {
+		return response, errors.Errorf("there are %d control plane nodes, but %d etcd members", len(controlPlaneNodes.Items), len(knownMemberIDSet))
+	}
+
+	return response, nil
+}
+
+// getEtcdClientForNode returns a client that talks directly to an etcd instance living on a particular node.
+func (c *cluster) getEtcdClientForNode(nodeName string, tlsConfig *tls.Config) (*etcd.Client, error) {
+	// This does not support external etcd.
+	p := proxy.Proxy{
+		Kind:         "pods",
+		Namespace:    "kube-system", // TODO, can etcd ever run in a different namespace?
+		ResourceName: fmt.Sprintf("etcd-%s", nodeName),
+		KubeConfig:   c.restConfig,
+		TLSConfig:    tlsConfig,
+		Port:         2379, // TODO: the pod doesn't expose a port. Is this a problem?
+	}
+	dialer, err := proxy.NewDialer(p)
+	if err != nil {
+		return nil, err
+	}
+	etcdclient, err := etcd.NewEtcdClient("127.0.0.1", dialer.DialContextWithAddr, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+	customClient, err := etcd.NewClientWithEtcd(etcdclient)
+	if err != nil {
+		return nil, err
+	}
+	return customClient, nil
+}
+
+func generateClientCert(caCertEncoded, caKeyEncoded []byte) (tls.Certificate, error) {
+	privKey, err := certs.NewPrivateKey()
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	caCert, err := certs.DecodeCertPEM(caCertEncoded)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	caKey, err := certs.DecodePrivateKeyPEM(caKeyEncoded)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	x509Cert, err := newClientCert(caCert, privKey, caKey)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	return tls.X509KeyPair(certs.EncodeCertPEM(x509Cert),  certs.EncodePrivateKeyPEM(privKey))
+}
+
+func newClientCert(caCert *x509.Certificate, key *rsa.PrivateKey, caKey *rsa.PrivateKey) (*x509.Certificate, error) {
+	cfg := certs.Config{
+		CommonName: "cluster-api.x-k8s.io",
+	}
+
+	now := time.Now().UTC()
+
+	tmpl := x509.Certificate{
+		SerialNumber: new(big.Int).SetInt64(0),
+		Subject: pkix.Name{
+			CommonName:   cfg.CommonName,
+			Organization: cfg.Organization,
+		},
+		NotBefore:   now.Add(time.Minute * -5),
+		NotAfter:    now.Add(time.Hour * 24 * 365 * 10), // 10 years
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	b, err := x509.CreateCertificate(rand.Reader, &tmpl, caCert, key.Public(), caKey)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create signed client certificate: %+v", tmpl)
+	}
+
+	c, err := x509.ParseCertificate(b)
+	return c, errors.WithStack(err)
+}

--- a/controlplane/kubeadm/internal/etcd/fake/client.go
+++ b/controlplane/kubeadm/internal/etcd/fake/client.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fake
 
 import (

--- a/controlplane/kubeadm/internal/etcd/fake/client.go
+++ b/controlplane/kubeadm/internal/etcd/fake/client.go
@@ -1,0 +1,174 @@
+package fake
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
+)
+
+type FakeEtcdClient struct {
+	leaderID uint64
+	members  map[uint64]*etcd.Member
+	healthy  map[uint64]bool
+	alarms   []etcd.MemberAlarm
+}
+
+func NewClient() *FakeEtcdClient {
+	c := FakeEtcdClient{
+		members: make(map[uint64]*etcd.Member),
+		healthy: make(map[uint64]bool),
+	}
+	return &c
+}
+
+// Receivers that manipulate the state of the fake etcd cluster.
+
+func (c *FakeEtcdClient) AddMember(memberID uint64, peerURLs []string) error {
+	_, ok := c.members[memberID]
+	if ok {
+		return fmt.Errorf("member with ID %d already exists", memberID)
+	}
+	c.members[memberID] = &etcd.Member{
+		ID:       memberID,
+		PeerURLs: peerURLs,
+	}
+	c.healthy[memberID] = false
+	return nil
+}
+
+func (c *FakeEtcdClient) StartMember(memberID uint64, name string, clientURLs []string) error {
+	m, ok := c.members[memberID]
+	if !ok {
+		return fmt.Errorf("no member with ID %d", memberID)
+	}
+	m.Name = name
+	m.ClientURLs = clientURLs
+	c.healthy[memberID] = true
+	return nil
+}
+
+func (c *FakeEtcdClient) SetHealthy(memberID uint64) error {
+	_, ok := c.members[memberID]
+	if !ok {
+		return fmt.Errorf("no member with ID %d", memberID)
+	}
+	c.healthy[memberID] = true
+	return nil
+}
+
+func (c *FakeEtcdClient) SetUnhealthy(memberID uint64) error {
+	_, ok := c.members[memberID]
+	if !ok {
+		return fmt.Errorf("no member with ID %d", memberID)
+	}
+	c.healthy[memberID] = false
+	return nil
+}
+
+func (c *FakeEtcdClient) SetLeader(memberID uint64) error {
+	_, ok := c.members[memberID]
+	if !ok {
+		return fmt.Errorf("no member with ID %d", memberID)
+	}
+	c.leaderID = memberID
+	return nil
+}
+
+func (c *FakeEtcdClient) Leader() (*etcd.Member, error) {
+	leader, ok := c.members[c.leaderID]
+	if !ok {
+		return nil, errors.New("cluster has no leader")
+	}
+	return leader, nil
+}
+
+func (c *FakeEtcdClient) SetAlarm(alarmType etcd.AlarmType, memberID uint64) error {
+	_, ok := c.members[memberID]
+	if !ok {
+		return fmt.Errorf("no member with ID %d", memberID)
+	}
+	for _, a := range c.alarms {
+		if a.Type == alarmType && a.MemberID == memberID {
+			// Alarm is already set
+			return nil
+		}
+	}
+	mAlarm := etcd.MemberAlarm{
+		MemberID: memberID,
+		Type:     alarmType,
+	}
+	c.alarms = append(c.alarms, mAlarm)
+	return nil
+}
+
+func (c *FakeEtcdClient) ClearAlarm(alarmType etcd.AlarmType, memberID uint64) error {
+	_, ok := c.members[memberID]
+	if !ok {
+		return fmt.Errorf("no member with ID %d", memberID)
+	}
+	indexToDelete := -1
+	for i, a := range c.alarms {
+		if a.Type == alarmType && a.MemberID == memberID {
+			indexToDelete = i
+			break
+		}
+	}
+	if indexToDelete >= 0 {
+		c.alarms = append(c.alarms[:indexToDelete], c.alarms[indexToDelete:]...)
+	}
+	return nil
+}
+
+// Receivers that implement the controllers.EtcdClient interface.
+
+func (c *FakeEtcdClient) Close() error {
+	return nil
+}
+
+func (c *FakeEtcdClient) Members(ctx context.Context) ([]*etcd.Member, error) {
+	members := []*etcd.Member{}
+	for i := range c.members {
+		members = append(members, c.members[i])
+	}
+	return members, nil
+}
+
+func (c *FakeEtcdClient) MoveLeader(ctx context.Context, memberID uint64) error {
+	_, ok := c.members[memberID]
+	if !ok {
+		return fmt.Errorf("no member with ID %d", memberID)
+	}
+	c.leaderID = memberID
+	return nil
+}
+
+func (c *FakeEtcdClient) RemoveMember(ctx context.Context, memberID uint64) error {
+	_, ok := c.members[memberID]
+	if !ok {
+		return fmt.Errorf("no member with ID %d", memberID)
+	}
+	if c.leaderID == memberID {
+		c.leaderID = 0
+	}
+	delete(c.members, memberID)
+	return nil
+}
+
+func (c *FakeEtcdClient) UpdateMemberPeerURLs(ctx context.Context, memberID uint64, peerURLs []string) ([]*etcd.Member, error) {
+	m, ok := c.members[memberID]
+	if !ok {
+		return nil, fmt.Errorf("no member with ID %d", memberID)
+	}
+	m.PeerURLs = peerURLs
+	return c.Members(ctx)
+}
+
+func (c *FakeEtcdClient) Alarms(ctx context.Context) ([]etcd.MemberAlarm, error) {
+	alarms := []etcd.MemberAlarm{}
+	for i := range c.alarms {
+		alarms = append(alarms, c.alarms[i])
+	}
+	return alarms, nil
+}

--- a/controlplane/kubeadm/internal/etcd/util/set.go
+++ b/controlplane/kubeadm/internal/etcd/util/set.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controlplane/kubeadm/internal/etcd/util/set.go
+++ b/controlplane/kubeadm/internal/etcd/util/set.go
@@ -1,0 +1,207 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Modified copy of k8s.io/apimachinery/pkg/util/sets/int64.go
+
+package util
+
+import (
+	"reflect"
+	"sort"
+)
+
+type Empty struct{}
+
+// sets.UInt64 is a set of int64s, implemented via map[uint64]struct{} for minimal memory consumption.
+type UInt64 map[uint64]Empty
+
+// NewUInt64 creates a UInt64 from a list of values.
+func NewUInt64(items ...uint64) UInt64 {
+	ss := UInt64{}
+	ss.Insert(items...)
+	return ss
+}
+
+// Int64KeySet creates a UInt64 from a keys of a map[uint64](? extends interface{}).
+// If the value passed in is not actually a map, this will panic.
+func Int64KeySet(theMap interface{}) UInt64 {
+	v := reflect.ValueOf(theMap)
+	ret := UInt64{}
+
+	for _, keyValue := range v.MapKeys() {
+		ret.Insert(keyValue.Interface().(uint64))
+	}
+	return ret
+}
+
+// Insert adds items to the set.
+func (s UInt64) Insert(items ...uint64) UInt64 {
+	for _, item := range items {
+		s[item] = Empty{}
+	}
+	return s
+}
+
+// Delete removes all items from the set.
+func (s UInt64) Delete(items ...uint64) UInt64 {
+	for _, item := range items {
+		delete(s, item)
+	}
+	return s
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s UInt64) Has(item uint64) bool {
+	_, contained := s[item]
+	return contained
+}
+
+// HasAll returns true if and only if all items are contained in the set.
+func (s UInt64) HasAll(items ...uint64) bool {
+	for _, item := range items {
+		if !s.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// HasAny returns true if any items are contained in the set.
+func (s UInt64) HasAny(items ...uint64) bool {
+	for _, item := range items {
+		if s.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s UInt64) Difference(s2 UInt64) UInt64 {
+	result := NewUInt64()
+	for key := range s {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+// For example:
+// s1 = {a1, a2}
+// s2 = {a3, a4}
+// s1.Union(s2) = {a1, a2, a3, a4}
+// s2.Union(s1) = {a1, a2, a3, a4}
+func (s1 UInt64) Union(s2 UInt64) UInt64 {
+	result := NewUInt64()
+	for key := range s1 {
+		result.Insert(key)
+	}
+	for key := range s2 {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Intersection returns a new set which includes the item in BOTH s1 and s2
+// For example:
+// s1 = {a1, a2}
+// s2 = {a2, a3}
+// s1.Intersection(s2) = {a2}
+func (s1 UInt64) Intersection(s2 UInt64) UInt64 {
+	var walk, other UInt64
+	result := NewUInt64()
+	if s1.Len() < s2.Len() {
+		walk = s1
+		other = s2
+	} else {
+		walk = s2
+		other = s1
+	}
+	for key := range walk {
+		if other.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 UInt64) IsSuperset(s2 UInt64) bool {
+	for item := range s2 {
+		if !s1.Has(item) {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 UInt64) Equal(s2 UInt64) bool {
+	return len(s1) == len(s2) && s1.IsSuperset(s2)
+}
+
+type sortableSliceOfInt64 []uint64
+
+func (s sortableSliceOfInt64) Len() int           { return len(s) }
+func (s sortableSliceOfInt64) Less(i, j int) bool { return lessInt64(s[i], s[j]) }
+func (s sortableSliceOfInt64) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// List returns the contents as a sorted uint64 slice.
+func (s UInt64) List() []uint64 {
+	res := make(sortableSliceOfInt64, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	sort.Sort(res)
+	return []uint64(res)
+}
+
+// UnsortedList returns the slice with contents in random order.
+func (s UInt64) UnsortedList() []uint64 {
+	res := make([]uint64, 0, len(s))
+	for key := range s {
+		res = append(res, key)
+	}
+	return res
+}
+
+// Returns a single element from the set.
+func (s UInt64) PopAny() (uint64, bool) {
+	for key := range s {
+		s.Delete(key)
+		return key, true
+	}
+	var zeroValue uint64
+	return zeroValue, false
+}
+
+// Len returns the size of the set.
+func (s UInt64) Len() int {
+	return len(s)
+}
+
+func lessInt64(lhs, rhs uint64) bool {
+	return lhs < rhs
+}

--- a/controlplane/kubeadm/internal/etcd/util/set.go
+++ b/controlplane/kubeadm/internal/etcd/util/set.go
@@ -23,10 +23,10 @@ import (
 	"sort"
 )
 
-type Empty struct{}
+type empty struct{}
 
 // sets.UInt64 is a set of int64s, implemented via map[uint64]struct{} for minimal memory consumption.
-type UInt64 map[uint64]Empty
+type UInt64 map[uint64]empty
 
 // NewUInt64 creates a UInt64 from a list of values.
 func NewUInt64(items ...uint64) UInt64 {
@@ -50,7 +50,7 @@ func Int64KeySet(theMap interface{}) UInt64 {
 // Insert adds items to the set.
 func (s UInt64) Insert(items ...uint64) UInt64 {
 	for _, item := range items {
-		s[item] = Empty{}
+		s[item] = empty{}
 	}
 	return s
 }
@@ -111,7 +111,8 @@ func (s UInt64) Difference(s2 UInt64) UInt64 {
 // s2 = {a3, a4}
 // s1.Union(s2) = {a1, a2, a3, a4}
 // s2.Union(s1) = {a1, a2, a3, a4}
-func (s1 UInt64) Union(s2 UInt64) UInt64 {
+func (s UInt64) Union(s2 UInt64) UInt64 {
+	s1 := s
 	result := NewUInt64()
 	for key := range s1 {
 		result.Insert(key)
@@ -127,7 +128,8 @@ func (s1 UInt64) Union(s2 UInt64) UInt64 {
 // s1 = {a1, a2}
 // s2 = {a2, a3}
 // s1.Intersection(s2) = {a2}
-func (s1 UInt64) Intersection(s2 UInt64) UInt64 {
+func (s UInt64) Intersection(s2 UInt64) UInt64 {
+	s1 := s
 	var walk, other UInt64
 	result := NewUInt64()
 	if s1.Len() < s2.Len() {
@@ -146,7 +148,8 @@ func (s1 UInt64) Intersection(s2 UInt64) UInt64 {
 }
 
 // IsSuperset returns true if and only if s1 is a superset of s2.
-func (s1 UInt64) IsSuperset(s2 UInt64) bool {
+func (s UInt64) IsSuperset(s2 UInt64) bool {
+	s1 := s
 	for item := range s2 {
 		if !s1.Has(item) {
 			return false
@@ -158,7 +161,8 @@ func (s1 UInt64) IsSuperset(s2 UInt64) bool {
 // Equal returns true if and only if s1 is equal (as a set) to s2.
 // Two sets are equal if their membership is identical.
 // (In practice, this means same elements, order doesn't matter)
-func (s1 UInt64) Equal(s2 UInt64) bool {
+func (s UInt64) Equal(s2 UInt64) bool {
+	s1 := s
 	return len(s1) == len(s2) && s1.IsSuperset(s2)
 }
 

--- a/controlplane/kubeadm/internal/etcd/util/util.go
+++ b/controlplane/kubeadm/internal/etcd/util/util.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/controlplane/kubeadm/internal/etcd/util/util.go
+++ b/controlplane/kubeadm/internal/etcd/util/util.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
+)
+
+// MemberStarted checks whether a member has started.
+func MemberStarted(member *etcd.Member) bool {
+	return len(member.Name) > 0
+}
+
+// MemberForName returns the etcd member with the matching name.
+func MemberForName(members []*etcd.Member, name string) *etcd.Member {
+	for _, m := range members {
+		if m.Name == name {
+			return m
+		}
+	}
+	return nil
+}
+
+// MemberIDSet returns a set of member IDs.
+func MemberIDSet(members []*etcd.Member) UInt64 {
+	set := UInt64{}
+	for _, m := range members {
+		set.Insert(m.ID)
+	}
+	return set
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The control plane needs to be scaled one replica at a time. Also, before a replica is added with, all etcd endpoint should be healthy, and all existing members should be started.

This PR is a collaborative effort. I started the etcd health check work in the scale up function itself. @chuckha factored that out. More importantly, he added abstractions for the management and target cluster, and wired up the etcd client (merged in #2237).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2016, #2243 

/hold
/assign @randomvariable @detiber 