### PR TITLE
Rename v1 to metav1 in imports

### DIFF
--- a/api/v1alpha3/machinedeployment_webhook_test.go
+++ b/api/v1alpha3/machinedeployment_webhook_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
@@ -85,7 +85,7 @@ func TestMachineDeploymentValidation(t *testing.T) {
 			g := NewWithT(t)
 			md := &MachineDeployment{
 				Spec: MachineDeploymentSpec{
-					Selector: v1.LabelSelector{
+					Selector: metav1.LabelSelector{
 						MatchLabels: tt.selectors,
 					},
 					Template: MachineTemplateSpec{

--- a/api/v1alpha3/machineset_webhook_test.go
+++ b/api/v1alpha3/machineset_webhook_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMachineSetLabelSelectorMatchValidation(t *testing.T) {
@@ -67,7 +67,7 @@ func TestMachineSetLabelSelectorMatchValidation(t *testing.T) {
 			g := NewWithT(t)
 			ms := &MachineSet{
 				Spec: MachineSetSpec{
-					Selector: v1.LabelSelector{
+					Selector: metav1.LabelSelector{
 						MatchLabels: tt.selectors,
 					},
 					Template: MachineTemplateSpec{

--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -296,7 +295,7 @@ func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Contex
 
 	if scope.Config.Spec.InitConfiguration == nil {
 		scope.Config.Spec.InitConfiguration = &kubeadmv1beta1.InitConfiguration{
-			TypeMeta: v1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				APIVersion: "kubeadm.k8s.io/v1beta1",
 				Kind:       "InitConfiguration",
 			},
@@ -310,7 +309,7 @@ func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Contex
 
 	if scope.Config.Spec.ClusterConfiguration == nil {
 		scope.Config.Spec.ClusterConfiguration = &kubeadmv1beta1.ClusterConfiguration{
-			TypeMeta: v1.TypeMeta{
+			TypeMeta: metav1.TypeMeta{
 				APIVersion: "kubeadm.k8s.io/v1beta1",
 				Kind:       "ClusterConfiguration",
 			},
@@ -669,13 +668,13 @@ func (r *KubeadmConfigReconciler) reconcileTopLevelObjectSettings(cluster *clust
 // sets the reference in the configuration status and ready to true.
 func (r *KubeadmConfigReconciler) storeBootstrapData(ctx context.Context, scope *Scope, data []byte) error {
 	secret := &corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      scope.Config.Name,
 			Namespace: scope.Config.Namespace,
 			Labels: map[string]string{
 				clusterv1.ClusterLabelName: scope.Cluster.Name,
 			},
-			OwnerReferences: []v1.OwnerReference{
+			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: bootstrapv1.GroupVersion.String(),
 					Kind:       "KubeadmConfig",

--- a/controllers/cluster_controller_phases_test.go
+++ b/controllers/cluster_controller_phases_test.go
@@ -23,7 +23,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -36,7 +36,7 @@ import (
 func TestClusterReconcilePhases(t *testing.T) {
 	t.Run("reconcile infrastructure", func(t *testing.T) {
 		cluster := &clusterv1.Cluster{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster",
 				Namespace: "test-namespace",
 			},
@@ -64,7 +64,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 		}{
 			{
 				name:      "returns no error if infrastructure ref is nil",
-				cluster:   &clusterv1.Cluster{ObjectMeta: v1.ObjectMeta{Name: "test-cluster", Namespace: "test-namespace"}},
+				cluster:   &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "test-namespace"}},
 				expectErr: false,
 			},
 			{
@@ -148,7 +148,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 
 	t.Run("reconcile kubeconfig", func(t *testing.T) {
 		cluster := &clusterv1.Cluster{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-cluster",
 			},
 			Spec: clusterv1.ClusterSpec{
@@ -175,7 +175,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 				name:    "kubeconfig secret found",
 				cluster: cluster,
 				secret: &corev1.Secret{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-cluster-kubeconfig",
 					},
 				},
@@ -191,7 +191,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 				name:    "invalid ca secret, should return error",
 				cluster: cluster,
 				secret: &corev1.Secret{
-					ObjectMeta: v1.ObjectMeta{
+					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-cluster-ca",
 					},
 				},
@@ -225,7 +225,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 
 func TestClusterReconciler_reconcilePhase(t *testing.T) {
 	cluster := &clusterv1.Cluster{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",
 		},
 		Status: clusterv1.ClusterStatus{},
@@ -247,7 +247,7 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 		{
 			name: "cluster has infrastructureRef",
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
 				Status: clusterv1.ClusterStatus{},
@@ -261,7 +261,7 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 		{
 			name: "cluster infrastructure is ready",
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
 				Status: clusterv1.ClusterStatus{
@@ -277,7 +277,7 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 		{
 			name: "cluster infrastructure is ready and ControlPlaneEndpoint is set",
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
 				Spec: clusterv1.ClusterSpec{
@@ -297,7 +297,7 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 		{
 			name: "cluster status has FailureReason",
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
 				Status: clusterv1.ClusterStatus{
@@ -314,7 +314,7 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 		{
 			name: "cluster status has FailureMessage",
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
 				Status: clusterv1.ClusterStatus{
@@ -331,9 +331,9 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 		{
 			name: "cluster has deletion timestamp",
 			cluster: &clusterv1.Cluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-cluster",
-					DeletionTimestamp: &v1.Time{Time: time.Now().UTC()},
+					DeletionTimestamp: &metav1.Time{Time: time.Now().UTC()},
 				},
 				Status: clusterv1.ClusterStatus{
 					InfrastructureReady: true,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Rename imports of `k8s.io/apimachinery/pkg/apis/meta/v1` from `v1` to `metav1`.

I believe I've done all occurrences apart from two files ([1](https://github.com/kubernetes-sigs/cluster-api/blob/master/bootstrap/kubeadm/types/v1beta1/zz_generated.deepcopy.go) & [2](https://github.com/kubernetes-sigs/cluster-api/blob/master/bootstrap/kubeadm/types/v1beta2/zz_generated.deepcopy.go)) , but these are generated deepcopy files so I can't modify those by hand.

Though this does beg the question as to why those are importing under the wrong alias but others (eg [api/v1alpha3](https://github.com/kubernetes-sigs/cluster-api/blob/76ea21f93aaea325f5e44e815e364fc02b3008b0/api/v1alpha3/zz_generated.deepcopy.go#L25)) are importing under the correct alias 🤔 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2195 
