### PR TITLE
[WIP] 🐛  Theoretical fix for the e2e tests

### DIFF
--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -179,10 +179,12 @@ func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster
 
 	// Get and parse Spec.ControlPlaneEndpoint field from the infrastructure provider.
 	if cluster.Spec.ControlPlaneEndpoint.IsZero() {
-		if err := util.UnstructuredUnmarshalField(infraConfig, &cluster.Spec.ControlPlaneEndpoint, "spec", "controlPlaneEndpoint"); err != nil {
+		controlPlaneEndpoint := clusterv1.APIEndpoint{}
+		if err := util.UnstructuredUnmarshalField(infraConfig, &controlPlaneEndpoint, "spec", "controlPlaneEndpoint"); err != nil {
 			return errors.Wrapf(err, "failed to retrieve Spec.ControlPlaneEndpoint from infrastructure provider for Cluster %q in namespace %q",
 				cluster.Name, cluster.Namespace)
 		}
+		cluster.Spec.ControlPlaneEndpoint = controlPlaneEndpoint
 	}
 
 	// Get and parse Status.FailureDomains from the infrastructure provider.


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

/hold

This is just a test. I suspect the call to Unsutructured.Unmarshal is assigning a value but then returning an error and this is causing some unexpected behavior with the KubeadmControlPlane. But we'll see.