### PR TITLE
✨ cleanup use controller-runtime utilities for finalizers

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -42,6 +42,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -142,9 +143,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cl
 	logger := r.Log.WithValues("cluster", cluster.Name, "namespace", cluster.Namespace)
 
 	// If object doesn't have a finalizer, add one.
-	if !util.Contains(cluster.Finalizers, clusterv1.ClusterFinalizer) {
-		cluster.Finalizers = append(cluster.Finalizers, clusterv1.ClusterFinalizer)
-	}
+	controllerutil.AddFinalizer(cluster, clusterv1.ClusterFinalizer)
 
 	// Call the inner reconciliation methods.
 	reconciliationErrors := []error{
@@ -296,7 +295,7 @@ func (r *ClusterReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 		}
 	}
 
-	cluster.Finalizers = util.Filter(cluster.Finalizers, clusterv1.ClusterFinalizer)
+	controllerutil.RemoveFinalizer(cluster, clusterv1.ClusterFinalizer)
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -46,6 +46,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var (
@@ -164,9 +165,7 @@ func (r *MachineReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cl
 	}
 
 	// If the Machine doesn't have a finalizer, add one.
-	if !util.Contains(m.Finalizers, clusterv1.MachineFinalizer) {
-		m.Finalizers = append(m.Finalizers, clusterv1.MachineFinalizer)
-	}
+	controllerutil.AddFinalizer(m, clusterv1.MachineFinalizer)
 
 	// Call the inner reconciliation methods.
 	reconciliationErrors := []error{
@@ -257,7 +256,7 @@ func (r *MachineReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 		return ctrl.Result{}, err
 	}
 
-	m.ObjectMeta.Finalizers = util.Filter(m.ObjectMeta.Finalizers, clusterv1.MachineFinalizer)
+	controllerutil.RemoveFinalizer(m, clusterv1.MachineFinalizer)
 	return ctrl.Result{}, nil
 }
 

--- a/test/infrastructure/docker/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/controllers/dockercluster_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -112,9 +113,7 @@ func (r *DockerClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 
 func reconcileNormal(dockerCluster *infrav1.DockerCluster, externalLoadBalancer *docker.LoadBalancer) (ctrl.Result, error) {
 	// If the DockerCluster doesn't have finalizer, add it.
-	if !util.Contains(dockerCluster.Finalizers, infrav1.ClusterFinalizer) {
-		dockerCluster.Finalizers = append(dockerCluster.Finalizers, infrav1.ClusterFinalizer)
-	}
+	controllerutil.AddFinalizer(dockerCluster, infrav1.ClusterFinalizer)
 
 	//Create the docker container hosting the load balancer
 	if err := externalLoadBalancer.Create(); err != nil {
@@ -145,7 +144,7 @@ func reconcileDelete(dockerCluster *infrav1.DockerCluster, externalLoadBalancer 
 	}
 
 	// Cluster is deleted so remove the finalizer.
-	dockerCluster.Finalizers = util.Filter(dockerCluster.Finalizers, infrav1.ClusterFinalizer)
+	controllerutil.RemoveFinalizer(dockerCluster, infrav1.ClusterFinalizer)
 
 	return ctrl.Result{}, nil
 }

--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
@@ -34,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
@@ -153,9 +154,7 @@ func (r *DockerMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 
 func (r *DockerMachineReconciler) reconcileNormal(ctx context.Context, machine *clusterv1.Machine, dockerMachine *infrav1.DockerMachine, externalMachine *docker.Machine, externalLoadBalancer *docker.LoadBalancer, log logr.Logger) (ctrl.Result, error) {
 	// If the DockerMachine doesn't have finalizer, add it.
-	if !util.Contains(dockerMachine.Finalizers, infrav1.MachineFinalizer) {
-		dockerMachine.Finalizers = append(dockerMachine.Finalizers, infrav1.MachineFinalizer)
-	}
+	controllerutil.AddFinalizer(dockerMachine, infrav1.MachineFinalizer)
 
 	// if the machine is already provisioned, return
 	if dockerMachine.Spec.ProviderID != nil {
@@ -239,8 +238,7 @@ func (r *DockerMachineReconciler) reconcileDelete(machine *clusterv1.Machine, do
 	}
 
 	// Machine is deleted so remove the finalizer.
-	dockerMachine.Finalizers = util.Filter(dockerMachine.Finalizers, infrav1.MachineFinalizer)
-
+	controllerutil.RemoveFinalizer(dockerMachine, infrav1.MachineFinalizer)
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**: 
Standardizes finalizer utils around controller-runtime

**Which issue(s) this PR fixes** :
Fixes #2198
