### PR TITLE
🐛clusterctl: wait inventory crd

### DIFF
--- a/cmd/clusterctl/pkg/client/client_test.go
+++ b/cmd/clusterctl/pkg/client/client_test.go
@@ -18,9 +18,11 @@ package client
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
@@ -140,7 +142,11 @@ func (f *fakeClient) WithRepository(repositoryClient repository.Client) *fakeCli
 func newFakeCluster(kubeconfig string) *fakeClusterClient {
 	fakeProxy := test.NewFakeProxy()
 
-	client := cluster.New("", cluster.InjectProxy(fakeProxy))
+	pollImmediateWaiter := func(interval, timeout time.Duration, condition wait.ConditionFunc) error {
+		return nil
+	}
+
+	client := cluster.New("", cluster.InjectProxy(fakeProxy), cluster.InjectPollImmediateWaiter(pollImmediateWaiter))
 
 	return &fakeClusterClient{
 		kubeconfig:     kubeconfig,

--- a/cmd/clusterctl/pkg/client/cluster/inventory_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory_test.go
@@ -19,12 +19,18 @@ package cluster
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
 )
+
+func fakePollImmediateWaiter(interval, timeout time.Duration, condition wait.ConditionFunc) error {
+	return nil
+}
 
 func Test_inventoryClient_EnsureCustomResourceDefinitions(t *testing.T) {
 	type fields struct {
@@ -52,7 +58,7 @@ func Test_inventoryClient_EnsureCustomResourceDefinitions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newInventoryClient(test.NewFakeProxy())
+			p := newInventoryClient(test.NewFakeProxy(), fakePollImmediateWaiter)
 			if tt.fields.alreadyHasCRD {
 				//forcing creation of metadata before test
 				if err := p.EnsureCustomResourceDefinitions(); err != nil {
@@ -97,7 +103,7 @@ func Test_inventoryClient_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := newInventoryClient(test.NewFakeProxy().WithObjs(tt.fields.initObjs...))
+			p := newInventoryClient(test.NewFakeProxy().WithObjs(tt.fields.initObjs...), fakePollImmediateWaiter)
 			got, err := p.List()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("List() error = %v, wantErr %v", err, tt.wantErr)

--- a/cmd/clusterctl/pkg/client/cluster/upgrader_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/upgrader_test.go
@@ -426,7 +426,7 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				repositoryClientFactory: func(provider config.Provider, configVariablesClient config.VariablesClient, options ...repository.Option) (repository.Client, error) {
 					return repository.New(provider, configVariablesClient, repository.InjectRepository(tt.fields.repository[provider.Name()]))
 				},
-				providerInventory: newInventoryClient(tt.fields.proxy),
+				providerInventory: newInventoryClient(tt.fields.proxy, nil),
 			}
 			got, err := u.Plan()
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes clusterctl flakiness when reading objects from the inventory immediately after CRDs creation.

**Which issue(s) this PR fixes**:
/area clusterctl
/assign @ncdc
/assign @vincepri