### PR TITLE
:bug: Enable linting of all our go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,14 @@ RELEASE_NOTES_BIN := bin/release-notes
 RELEASE_NOTES := $(TOOLS_DIR)/$(RELEASE_NOTES_BIN)
 
 # Binaries.
-KUSTOMIZE := $(TOOLS_BIN_DIR)/kustomize
-CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
-GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
-CONVERSION_GEN := $(TOOLS_BIN_DIR)/conversion-gen
+# Need to use abspath so we can invoke these from subdirectories
+KUSTOMIZE := $(abspath $(TOOLS_BIN_DIR)/kustomize)
+CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/controller-gen)
+GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/golangci-lint)
+CONVERSION_GEN := $(abspath $(TOOLS_BIN_DIR)/conversion-gen)
 
 # Bindata.
-GOBINDATA := $(TOOLS_BIN_DIR)/go-bindata
+GOBINDATA := $(abspath $(TOOLS_BIN_DIR)/go-bindata)
 GOBINDATA_CLUSTERCTL_DIR := cmd/clusterctl/config
 CERTMANAGER_COMPONENTS_GENERATED_FILE := cert-manager.yaml
 
@@ -176,9 +177,13 @@ e2e-framework: ## Builds the CAPI e2e framework
 .PHONY: lint lint-full
 lint: $(GOLANGCI_LINT) ## Lint codebase
 	$(GOLANGCI_LINT) run -v
+	cd $(E2E_FRAMEWORK_DIR); $(GOLANGCI_LINT) run -v
+	cd $(CAPD_DIR); $(GOLANGCI_LINT) run -v
 
 lint-full: $(GOLANGCI_LINT) ## Run slower linters to detect possible issues
 	$(GOLANGCI_LINT) run -v --fast=false
+	cd $(E2E_FRAMEWORK_DIR); $(GOLANGCI_LINT) run -v --fast=false
+	cd $(CAPD_DIR); $(GOLANGCI_LINT) run -v --fast=false
 
 ## --------------------------------------
 ## Generate / Manifests

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -260,9 +260,9 @@ func (c *Config) Validate() error {
 		}
 		switch containerImage.LoadBehavior {
 		case MustLoadImage, TryLoadImage:
-				// Valid
-			default:
-				return errInvalidArg("Images[%d].LoadBehavior=%q", i, containerImage.LoadBehavior)
+			// Valid
+		default:
+			return errInvalidArg("Images[%d].LoadBehavior=%q", i, containerImage.LoadBehavior)
 		}
 	}
 	return nil

--- a/test/framework/control_plane.go
+++ b/test/framework/control_plane.go
@@ -93,7 +93,8 @@ func (input *ControlplaneClusterInput) ControlPlaneCluster() {
 	}, input.CreateTimeout, eventuallyInterval).Should(BeNil())
 
 	By("creating related resources")
-	for _, obj := range input.RelatedResources {
+	for i := range input.RelatedResources {
+		obj := input.RelatedResources[i]
 		By(fmt.Sprintf("creating a/an %s resource", obj.GetObjectKind().GroupVersionKind()))
 		Eventually(func() error {
 			return mgmtClient.Create(ctx, obj)
@@ -217,7 +218,7 @@ func (input *ControlplaneClusterInput) CleanUpCoreArtifacts() {
 	ensureArtifactsDeleted(ctx, mgmtClient, listOpts)
 }
 
-func ensureArtifactsDeleted(ctx context.Context, mgmtClient client.Client, opt *client.ListOptions) {
+func ensureArtifactsDeleted(ctx context.Context, mgmtClient client.Client, opt client.ListOption) {
 	// assertions
 	ml := &clusterv1.MachineList{}
 	Expect(mgmtClient.List(ctx, ml, opt)).To(Succeed())

--- a/test/framework/management_cluster.go
+++ b/test/framework/management_cluster.go
@@ -92,7 +92,7 @@ func InitManagementCluster(ctx context.Context, input *InitManagementClusterInpu
 				Expect(imageLoader.LoadImage(ctx, image.Name)).To(Succeed())
 			case TryLoadImage:
 				By(fmt.Sprintf("try to load image %s into the management cluster", image.Name))
-				imageLoader.LoadImage(ctx, image.Name)
+				imageLoader.LoadImage(ctx, image.Name) //nolint:errcheck
 			}
 		}
 	}

--- a/test/framework/types.go
+++ b/test/framework/types.go
@@ -44,4 +44,3 @@ type MachineDeployment struct {
 	BootstrapConfigTemplate runtime.Object
 	InfraMachineTemplate    runtime.Object
 }
-


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable linting of all our go modules. We have to invoke `golangci-lint` in each directory that has a `go.mod` file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2208

/priority important-soon
/kind bug
/milestone v0.3.0
