### PR TITLE
🐛clusterctl: fix config provider command

### DIFF
--- a/cmd/clusterctl/cmd/config_repositories.go
+++ b/cmd/clusterctl/cmd/config_repositories.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client"
+)
+
+var configRepositoryCmd = &cobra.Command{
+	Use:   "repositories",
+	Args:  cobra.NoArgs,
+	Short: "Display the list of Cluster API providers and their repository configuration",
+	Long: LongDesc(`
+		Displays the list of the Cluster API provider's and their repository configuration.
+		
+		clusterctl ships with a list of well-known providers; if necessary, edit
+		the $HOME/.cluster-api/clusterctl.yaml file to add new provider configurations or to customize existing ones.`),
+
+	Example: Examples(`
+		# Displays the list of available providers.
+		clusterctl config repositories`),
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGetRepositories()
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configRepositoryCmd)
+}
+
+func runGetRepositories() error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	repositoryList, err := c.GetProvidersConfig()
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 10, 4, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tTYPE\tURL")
+	for _, r := range repositoryList {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", r.Name(), r.Type(), r.URL())
+	}
+	w.Flush()
+
+	return nil
+}

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -14,7 +14,7 @@ The `clusterctl init` command accepts in input a list of providers to install.
 
 <h1> Which providers can I use? </h1>
 
-You can use the `clusterctl config providers` command to get the list of supported providers.
+You can use the `clusterctl config repositories` command to get a list of supported providers and their repository configuration.
  
 If the provider of your choice is missing, you can customize the list of supported providers by using the
 [clusterctl configuration](../configuration.md) file. 

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -12,8 +12,8 @@ The `clusterctl` CLI is designed to work with providers implementing the [cluste
 Each provider is expected to define a provider repository, a well-known place where release assets are published. 
 
 By default, `clusterctl` ships with providers sponsored by SIG Cluster
-Lifecycle. Use `clusterctl config providers` to get a list of supported
-providers.
+Lifecycle. Use `clusterctl config repositories` to get a list of supported
+providers and their repository configuration.
 
 Users can customize the list of available providers using the `clusterctl` configuration file, as shown in the following example:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
clusterctl support the `clusterctl config provider` (with a `clusterctl config providers` alias) command that can be used to:
- get the list of providers/repositories
- get info about a specific provider

However, having two function under the same command can lead to confusion, as documented in https://github.com/kubernetes-sigs/cluster-api/issues/2170, so this PR is splitting `clusterctl config provider/s` command into two separated commands, `clusterctl config provider` and `clusterctl config repositories`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2170

/milestone v0.3.0
/area clusterctl
/assign @ncdc
/assign @vincepri
