### PR TITLE
:sparkles: Add support for pausing KubeadmControlPlane and its external references

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -64,6 +64,7 @@ type ClusterReconciler struct {
 	Client client.Client
 	Log    logr.Logger
 
+	scheme          *runtime.Scheme
 	recorder        record.EventRecorder
 	externalTracker external.ObjectTracker
 }
@@ -83,6 +84,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager, options controlle
 	}
 
 	r.recorder = mgr.GetEventRecorderFor("cluster-controller")
+	r.scheme = mgr.GetScheme()
 	r.externalTracker = external.ObjectTracker{
 		Controller: controller,
 	}

--- a/controllers/cluster_controller_phases_test.go
+++ b/controllers/cluster_controller_phases_test.go
@@ -133,6 +133,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 				r := &ClusterReconciler{
 					Client: c,
 					Log:    log.Log,
+					scheme: scheme.Scheme,
 				}
 
 				err := r.reconcileInfrastructure(context.Background(), tt.cluster)
@@ -209,6 +210,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 				}
 				r := &ClusterReconciler{
 					Client: c,
+					scheme: scheme.Scheme,
 				}
 				err := r.reconcileKubeconfig(context.Background(), tt.cluster)
 				if tt.wantErr {
@@ -356,6 +358,7 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 
 			r := &ClusterReconciler{
 				Client: c,
+				scheme: scheme.Scheme,
 			}
 			r.reconcilePhase(context.TODO(), tt.cluster)
 			g.Expect(tt.cluster.Status.GetTypedPhase()).To(Equal(tt.wantPhase))

--- a/controllers/machine_controller_phases_test.go
+++ b/controllers/machine_controller_phases_test.go
@@ -114,6 +114,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
 			Log:    log.Log,
+			scheme: scheme.Scheme,
 		}
 
 		res, err := r.reconcile(context.Background(), defaultCluster, machine)
@@ -141,6 +142,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
 			Log:    log.Log,
+			scheme: scheme.Scheme,
 		}
 
 		res, err := r.reconcile(context.Background(), defaultCluster, machine)
@@ -166,6 +168,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
 			Log:    log.Log,
+			scheme: scheme.Scheme,
 		}
 
 		res, err := r.reconcile(context.Background(), defaultCluster, machine)
@@ -213,6 +216,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
 			Log:    log.Log,
+			scheme: scheme.Scheme,
 		}
 
 		res, err := r.reconcile(context.Background(), defaultCluster, machine)
@@ -249,6 +253,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
 			Log:    log.Log,
+			scheme: scheme.Scheme,
 		}
 
 		res, err := r.reconcile(context.Background(), defaultCluster, machine)
@@ -297,6 +302,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
 			Log:    log.Log,
+			scheme: scheme.Scheme,
 		}
 
 		res, err := r.reconcile(context.Background(), defaultCluster, machine)
@@ -325,6 +331,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
 			Log:    log.Log,
+			scheme: scheme.Scheme,
 		}
 
 		res, err := r.reconcile(context.Background(), defaultCluster, machine)
@@ -375,6 +382,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme, defaultCluster, defaultKubeconfigSecret, machine, bootstrapConfig, infraConfig),
 			Log:    log.Log,
+			scheme: scheme.Scheme,
 		}
 
 		res, err := r.reconcile(context.Background(), defaultCluster, machine)
@@ -605,6 +613,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			r := &MachineReconciler{
 				Client: fake.NewFakeClientWithScheme(scheme.Scheme, tc.machine, bootstrapConfig),
 				Log:    log.Log,
+				scheme: scheme.Scheme,
 			}
 
 			err := r.reconcileBootstrap(context.Background(), defaultCluster, tc.machine)
@@ -800,6 +809,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			r := &MachineReconciler{
 				Client: fake.NewFakeClientWithScheme(scheme.Scheme, tc.machine, infraConfig),
 				Log:    log.Log,
+				scheme: scheme.Scheme,
 			}
 
 			err := r.reconcileInfrastructure(context.Background(), defaultCluster, tc.machine)

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -116,7 +116,8 @@ func TestMachineFinalizer(t *testing.T) {
 					machineValidCluster,
 					machineWithFinalizer,
 				),
-				Log: log.Log,
+				Log:    log.Log,
+				scheme: scheme.Scheme,
 			}
 
 			_, _ = mr.Reconcile(tc.request)
@@ -244,7 +245,8 @@ func TestMachineOwnerReference(t *testing.T) {
 					machineValidCluster,
 					machineValidMachine,
 				),
-				Log: log.Log,
+				Log:    log.Log,
+				scheme: scheme.Scheme,
 			}
 
 			_, _ = mr.Reconcile(tc.request)
@@ -400,6 +402,7 @@ func TestReconcileRequest(t *testing.T) {
 			r := &MachineReconciler{
 				Client: client,
 				Log:    log.Log,
+				scheme: scheme.Scheme,
 			}
 
 			result, err := r.Reconcile(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tc.machine.Namespace, Name: tc.machine.Name}})
@@ -519,6 +522,7 @@ func TestReconcileDeleteExternal(t *testing.T) {
 			r := &MachineReconciler{
 				Client: fake.NewFakeClientWithScheme(scheme.Scheme, objs...),
 				Log:    log.Log,
+				scheme: scheme.Scheme,
 			}
 
 			ok, err := r.reconcileDeleteExternal(ctx, machine)
@@ -564,6 +568,7 @@ func TestRemoveMachineFinalizerAfterDeleteReconcile(t *testing.T) {
 	mr := &MachineReconciler{
 		Client: fake.NewFakeClientWithScheme(scheme.Scheme, testCluster, m),
 		Log:    log.Log,
+		scheme: scheme.Scheme,
 	}
 	_, err := mr.Reconcile(reconcile.Request{NamespacedName: key})
 	g.Expect(err).ToNot(HaveOccurred())
@@ -641,6 +646,7 @@ func TestReconcileMetrics(t *testing.T) {
 			r := &MachineReconciler{
 				Client: fake.NewFakeClientWithScheme(scheme.Scheme, objs...),
 				Log:    log.Log,
+				scheme: scheme.Scheme,
 			}
 
 			r.reconcileMetrics(context.TODO(), machine)

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -609,6 +609,7 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 		Client:             fakeClient,
 		Log:                log.Log,
 		remoteClientGetter: fakeremote.NewClusterClient,
+		scheme:             scheme.Scheme,
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
@@ -733,7 +734,11 @@ func TestKubeadmControlPlaneReconciler_generateKubeadmConfig(t *testing.T) {
 	expectedReferenceKind := "KubeadmConfig"
 	expectedReferenceAPIVersion := bootstrapv1.GroupVersion.String()
 	expectedLabels := map[string]string{clusterv1.ClusterLabelName: cluster.Name}
-	expectedOwner := *metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))
+	expectedOwner := metav1.OwnerReference{
+		Kind:       "KubeadmControlPlane",
+		APIVersion: controlplanev1.GroupVersion.String(),
+		Name:       kcp.Name,
+	}
 
 	r := &KubeadmControlPlaneReconciler{
 		Client: fakeClient,
@@ -840,6 +845,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusNoMachines(t *testing.T) {
 		Client:             fakeClient,
 		Log:                log.Log,
 		remoteClientGetter: fakeremote.NewClusterClient,
+		scheme:             scheme.Scheme,
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
@@ -927,6 +933,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesNotReady(t *testin
 		Client:             fakeClient,
 		Log:                log.Log,
 		remoteClientGetter: fakeremote.NewClusterClient,
+		scheme:             scheme.Scheme,
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
@@ -976,6 +983,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T
 		Client:             fakeClient,
 		Log:                log.Log,
 		remoteClientGetter: fakeremote.NewClusterClient,
+		scheme:             scheme.Scheme,
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
@@ -1029,6 +1037,7 @@ func TestKubeadmControlPlaneReconciler_updateStatusMachinesReadyMixed(t *testing
 		Client:             fakeClient,
 		Log:                log.Log,
 		remoteClientGetter: fakeremote.NewClusterClient,
+		scheme:             scheme.Scheme,
 	}
 
 	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
@@ -1146,6 +1155,7 @@ func TestReconcileControlPlaneScaleUp(t *testing.T) {
 		Log:                log.Log,
 		remoteClientGetter: fakeremote.NewClusterClient,
 		recorder:           record.NewFakeRecorder(32),
+		scheme:             scheme.Scheme,
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
@@ -1225,6 +1235,7 @@ func TestScaleUpControlPlaneAddsANewMachine(t *testing.T) {
 		Client:   fakeClient,
 		Log:      log.Log,
 		recorder: record.NewFakeRecorder(32),
+		scheme:   scheme.Scheme,
 	}
 
 	g.Expect(r.scaleUpControlPlane(context.Background(), cluster, kcp, 2)).To(Succeed())
@@ -1295,6 +1306,7 @@ func TestCloneConfigsAndGenerateMachine(t *testing.T) {
 		Client:   fakeClient,
 		Log:      log.Log,
 		recorder: record.NewFakeRecorder(32),
+		scheme:   scheme.Scheme,
 	}
 
 	bootstrapSpec := &bootstrapv1.KubeadmConfigSpec{
@@ -1426,6 +1438,7 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 			Log:                log.Log,
 			remoteClientGetter: fakeremote.NewClusterClient,
 			recorder:           record.NewFakeRecorder(32),
+			scheme:             scheme.Scheme,
 		}
 
 		// Create control plane machines
@@ -1527,6 +1540,7 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 			Log:                log.Log,
 			remoteClientGetter: fakeremote.NewClusterClient,
 			recorder:           record.NewFakeRecorder(32),
+			scheme:             scheme.Scheme,
 		}
 
 		result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds pause support to KubeadmControlPlane

During review it was noted that we could be using the SetControllerReference method from sigs.k8s.io/controller-runtime/pkg/controller/controllerutil, so this PR adopts that approach and also adjusts related usage of OwnerRefs.

