### PR TITLE
🐛 Wait for the cluster infra to be ready

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
@@ -139,6 +139,11 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(req ctrl.Request) (res ctrl.Re
 	}
 	logger = logger.WithValues("cluster", cluster.Name)
 
+	// Wait for the cluster infrastructure to be ready before creating machines
+	if !cluster.Status.InfrastructureReady {
+		return ctrl.Result{}, nil
+	}
+
 	defer func() {
 		// Always attempt to update status.
 		if err := r.updateStatus(ctx, kcp, cluster); err != nil {

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -477,6 +477,9 @@ func TestReconcileClusterNoEndpoints(t *testing.T) {
 			Name:      "foo",
 			Namespace: "test",
 		},
+		Status: clusterv1.ClusterStatus{
+			InfrastructureReady: true,
+		},
 	}
 
 	kcp := &controlplanev1.KubeadmControlPlane{
@@ -538,6 +541,9 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 				Host: "test.local",
 				Port: 9999,
 			},
+		},
+		Status: clusterv1.ClusterStatus{
+			InfrastructureReady: true,
 		},
 	}
 
@@ -1058,6 +1064,9 @@ func TestReconcileControlPlaneScaleUp(t *testing.T) {
 				APIVersion: controlplanev1.GroupVersion.String(),
 			},
 		},
+		Status: clusterv1.ClusterStatus{
+			InfrastructureReady: true,
+		},
 	}
 
 	genericMachineTemplate := &unstructured.Unstructured{
@@ -1331,6 +1340,9 @@ func TestReconcileControlPlaneDelete(t *testing.T) {
 				Name:       "kcp-foo",
 				APIVersion: controlplanev1.GroupVersion.String(),
 			},
+		},
+		Status: clusterv1.ClusterStatus{
+			InfrastructureReady: true,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

The assumption with the capd-e2e tests was that the cluster infrastructure was ready before machines were being created. However, this check did not actually exist. The kubeadm control plane controller should wait for the cluster infrastructure to be ready before trying to create machines.

However I have a slight suspicion this might not work so well for CAPV -- @akutz @yastij Is this going to be ok for y'all?

This PR fixes the capd-e2e test failures we're seeing currently.