### PR TITLE
🐛 clusterctl: Allow pre-release and metadata versions for local repos

### DIFF
--- a/cmd/clusterctl/pkg/client/repository/repository_local_unix.go
+++ b/cmd/clusterctl/pkg/client/repository/repository_local_unix.go
@@ -115,13 +115,9 @@ func (r *localRepository) GetVersions() ([]string, error) {
 			continue
 		}
 		r := f.Name()
-		sv, err := version.ParseSemantic(r)
+		_, err := version.ParseSemantic(r)
 		if err != nil {
 			// discard releases with tags that are not a valid semantic versions (the user can point explicitly to such releases)
-			continue
-		}
-		if sv.PreRelease() != "" || sv.BuildMetadata() != "" {
-			// discard pre-releases or build releases (the user can point explicitly to such releases)
 			continue
 		}
 		versions = append(versions, r)

--- a/cmd/clusterctl/pkg/client/repository/repository_local_unix_test.go
+++ b/cmd/clusterctl/pkg/client/repository/repository_local_unix_test.go
@@ -305,6 +305,8 @@ func Test_localRepository_GetVersions(t *testing.T) {
 	createLocalTestProviderFile(t, tmpDir, "provider-2/v1.0.0/bootstrap-components.yaml", "version: v1.0.0")
 	createLocalTestProviderFile(t, tmpDir, "provider-2/v1.0.1/bootstrap-components.yaml", "version: v1.0.1")
 	createLocalTestProviderFile(t, tmpDir, "provider-2/v2.0.1/bootstrap-components.yaml", "version: v2.0.1")
+	createLocalTestProviderFile(t, tmpDir, "provider-2/v2.0.2+exp.sha.5114f85/bootstrap-components.yaml", "version: v2.0.2+exp.sha.5114f85")
+	createLocalTestProviderFile(t, tmpDir, "provider-2/v2.0.3-alpha/bootstrap-components.yaml", "version: v2.0.3-alpha")
 	createLocalTestProviderFile(t, tmpDir, "provider-2/Foo.Bar/bootstrap-components.yaml", "version: Foo.Bar")
 	createLocalTestProviderFile(t, tmpDir, "provider-2/foo.file", "foo: bar")
 	p2URLLatest := "provider-2/latest/bootstrap-components.yaml"
@@ -342,7 +344,7 @@ func Test_localRepository_GetVersions(t *testing.T) {
 				configVariablesClient: test.NewFakeVariableClient(),
 			},
 			want: want{
-				versions: []string{"v1.0.0", "v1.0.1", "v2.0.1"},
+				versions: []string{"v1.0.0", "v1.0.1", "v2.0.1", "v2.0.2+exp.sha.5114f85", "v2.0.3-alpha"},
 			},
 			wantErr: false,
 		},
@@ -362,7 +364,7 @@ func Test_localRepository_GetVersions(t *testing.T) {
 				return
 			}
 			if len(got) != len(tt.want.versions) {
-				t.Fatalf("got %v, expected %v versions", len(tt.want.versions), len(got))
+				t.Fatalf("got %v, expected %v versions", len(got), len(tt.want.versions))
 			}
 			sort.Strings(tt.want.versions)
 			sort.Strings(got)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Allow pre-release and metadata versions for local file system providers in clusterctl.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2157 
