### PR TITLE
🐛clusterctl: fix public library inconsistencies

### DIFF
--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -231,13 +231,13 @@ func newClusterctlClient(path string, options ...Option) (*clusterctlClient, err
 // defaultClusterFactory is a ClusterClientFactory func the uses the default client provided by the cluster low level library.
 func defaultClusterFactory() func(kubeconfig string) (cluster.Client, error) {
 	return func(kubeconfig string) (cluster.Client, error) {
-		return cluster.New(kubeconfig, cluster.Options{}), nil
+		return cluster.New(kubeconfig), nil
 	}
 }
 
 // defaultRepositoryFactory is a RepositoryClientFactory func the uses the default client provided by the repository low level library.
 func defaultRepositoryFactory(configClient config.Client) func(providerConfig config.Provider) (repository.Client, error) {
 	return func(providerConfig config.Provider) (repository.Client, error) {
-		return repository.New(providerConfig, configClient.Variables(), repository.Options{})
+		return repository.New(providerConfig, configClient.Variables())
 	}
 }

--- a/cmd/clusterctl/pkg/client/client_test.go
+++ b/cmd/clusterctl/pkg/client/client_test.go
@@ -140,11 +140,7 @@ func (f *fakeClient) WithRepository(repositoryClient repository.Client) *fakeCli
 func newFakeCluster(kubeconfig string) *fakeClusterClient {
 	fakeProxy := test.NewFakeProxy()
 
-	options := cluster.Options{
-		InjectProxy: fakeProxy,
-	}
-
-	client := cluster.New("", options)
+	client := cluster.New("", cluster.InjectProxy(fakeProxy))
 
 	return &fakeClusterClient{
 		kubeconfig:     kubeconfig,
@@ -257,15 +253,12 @@ func (f *fakeConfigClient) WithProvider(provider config.Provider) *fakeConfigCli
 // the WithPaths or WithDefaultVersion methods to configure the repository and WithFile to set the map values.
 func newFakeRepository(provider config.Provider, configVariablesClient config.VariablesClient) *fakeRepositoryClient {
 	fakeRepository := test.NewFakeRepository()
-	options := repository.Options{
-		InjectRepository: fakeRepository,
-	}
 
 	if configVariablesClient == nil {
 		configVariablesClient = newFakeConfig().Variables()
 	}
 
-	client, _ := repository.New(provider, configVariablesClient, options)
+	client, _ := repository.New(provider, configVariablesClient, repository.InjectRepository(fakeRepository))
 
 	return &fakeRepositoryClient{
 		Provider:       provider,

--- a/cmd/clusterctl/pkg/client/config/client.go
+++ b/cmd/clusterctl/pkg/client/config/client.go
@@ -75,6 +75,7 @@ func newConfigClient(path string, options ...Option) (*configClient, error) {
 		o(cfg)
 	}
 
+	// if there is an injected reader, use it, otherwise use a default one
 	reader := cfg.injectReader
 	if reader == nil {
 		reader = newViperReader()

--- a/cmd/clusterctl/pkg/client/repository/client.go
+++ b/cmd/clusterctl/pkg/client/repository/client.go
@@ -93,12 +93,18 @@ func InjectRepository(repository Repository) Option {
 }
 
 // New returns a Client.
-func New(provider config.Provider, configVariablesClient config.VariablesClient, options Options) (Client, error) {
-	return newRepositoryClient(provider, configVariablesClient, options)
+func New(provider config.Provider, configVariablesClient config.VariablesClient, options ...Option) (Client, error) {
+	return newRepositoryClient(provider, configVariablesClient, options...)
 }
 
-func newRepositoryClient(provider config.Provider, configVariablesClient config.VariablesClient, options Options) (*repositoryClient, error) {
-	repository := options.InjectRepository
+func newRepositoryClient(provider config.Provider, configVariablesClient config.VariablesClient, options ...Option) (*repositoryClient, error) {
+	cfg := &NewOptions{}
+	for _, o := range options {
+		o(cfg)
+	}
+
+	// if there is an injected repository, use it, otherwise use a default one
+	repository := cfg.injectRepository
 	if repository == nil {
 		r, err := repositoryFactory(provider, configVariablesClient)
 		if err != nil {
@@ -112,11 +118,6 @@ func newRepositoryClient(provider config.Provider, configVariablesClient config.
 		repository:            repository,
 		configVariablesClient: configVariablesClient,
 	}, nil
-}
-
-// Options allow to set Client options
-type Options struct {
-	InjectRepository Repository
 }
 
 // Repository defines the behavior of a repository implementation.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes some inconsistencies in the clusterctl public library, so now all the objects implement a unique approach for injecting values (based on a variadic list of options)

**Which issue(s) this PR fixes** 
rif #1729

/area clusterctl
/milestone v0.3.0
/assign @ncdc
/assign @vincepri