### PR TITLE
🐛clusterctl: simplify cluster template naming

### DIFF
--- a/cmd/clusterctl/cmd/config_cluster.go
+++ b/cmd/clusterctl/cmd/config_cluster.go
@@ -27,7 +27,6 @@ import (
 type configClusterOptions struct {
 	kubeconfig             string
 	flavor                 string
-	bootstrapProvider      string
 	infrastructureProvider string
 
 	targetNamespace          string
@@ -54,10 +53,6 @@ var configClusterClusterCmd = &cobra.Command{
 		clusterctl config cluster my-cluster
  
 		# Generates a yaml file for creating a Cluster API workload cluster using
-		# specified infrastructure and bootstrap provider
-		clusterctl config cluster my-cluster --infrastructure=aws --bootstrap=kubeadm
- 
-		# Generates a yaml file for creating a Cluster API workload cluster using
 		# specified version of the AWS infrastructure provider
 		clusterctl config cluster my-cluster --infrastructure=aws:v0.4.1
 
@@ -82,7 +77,6 @@ func init() {
 	configClusterClusterCmd.Flags().StringVarP(&cc.kubeconfig, "kubeconfig", "", "", "Path to the kubeconfig file to use for accessing the management cluster. If empty, default rules for kubeconfig discovery will be used")
 
 	configClusterClusterCmd.Flags().StringVarP(&cc.infrastructureProvider, "infrastructure", "i", "", "The infrastructure provider that should be used for creating the workload cluster")
-	configClusterClusterCmd.Flags().StringVarP(&cc.bootstrapProvider, "bootstrap", "b", "kubeadm", "The provider that should be used for bootstrapping Kubernetes nodes in the workload cluster")
 
 	configClusterClusterCmd.Flags().StringVarP(&cc.flavor, "flavor", "f", "", "The template variant to be used for creating the workload cluster")
 	configClusterClusterCmd.Flags().StringVarP(&cc.targetNamespace, "target-namespace", "n", "", "The namespace where the objects describing the workload cluster should be deployed. If not specified, the current namespace will be used")
@@ -103,7 +97,6 @@ func runGenerateCluster(name string) error {
 		Kubeconfig:               cc.kubeconfig,
 		InfrastructureProvider:   cc.infrastructureProvider,
 		Flavor:                   cc.flavor,
-		BootstrapProvider:        cc.bootstrapProvider,
 		ClusterName:              name,
 		TargetNamespace:          cc.targetNamespace,
 		KubernetesVersion:        cc.kubernetesVersion,

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -61,9 +61,6 @@ type GetClusterTemplateOptions struct {
 	// InfrastructureProvider that should be used for creating the workload cluster.
 	InfrastructureProvider string
 
-	// BootstrapProvider that should be used for bootstrapping Kubernetes nodes in the workload cluster.
-	BootstrapProvider string
-
 	// Flavor defines the template variant to be used for creating the workload cluster.
 	Flavor string
 

--- a/cmd/clusterctl/pkg/client/config.go
+++ b/cmd/clusterctl/pkg/client/config.go
@@ -116,7 +116,7 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 		return nil, err
 	}
 
-	template, err := repo.Templates(version).Get(options.Flavor, options.BootstrapProvider, options.TargetNamespace)
+	template, err := repo.Templates(version).Get(options.Flavor, options.TargetNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/pkg/client/config_test.go
+++ b/cmd/clusterctl/pkg/client/config_test.go
@@ -308,7 +308,7 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 	repository1 := newFakeRepository(infraProviderConfig, config1.Variables()).
 		WithPaths("root", "components").
 		WithDefaultVersion("v3.0.0").
-		WithFile("v3.0.0", "config-kubeadm.yaml", templateYAML("ns3", "${ CLUSTER_NAME }"))
+		WithFile("v3.0.0", "cluster-template.yaml", templateYAML("ns3", "${ CLUSTER_NAME }"))
 
 	cluster1 := newFakeCluster("kubeconfig").
 		WithProviderInventory(infraProviderConfig.Name(), infraProviderConfig.Type(), "v3.0.0", "foo", "bar")
@@ -327,8 +327,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 		providerType    clusterctlv1.ProviderType
 		version         string
 		flavor          string
-		bootstrap       string
-		path            string
 		variables       []string
 		targetNamespace string
 		yaml            []byte
@@ -347,7 +345,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 					Kubeconfig:               "kubeconfig",
 					InfrastructureProvider:   "infra:v3.0.0",
 					Flavor:                   "",
-					BootstrapProvider:        "kubeadm",
 					ClusterName:              "test",
 					TargetNamespace:          "ns1",
 					ControlPlaneMachineCount: 1,
@@ -359,8 +356,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 				providerType:    clusterctlv1.InfrastructureProviderType,
 				version:         "v3.0.0",
 				flavor:          "",
-				bootstrap:       "kubeadm",
-				path:            "config-kubeadm.yaml",
 				variables:       []string{"CLUSTER_NAME"}, // variable detected
 				targetNamespace: "ns1",
 				yaml:            templateYAML("ns1", "test"), // original template modified with target namespace and variable replacement
@@ -373,7 +368,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 					Kubeconfig:               "kubeconfig",
 					InfrastructureProvider:   "", // empty triggers auto-detection of the provider name/version
 					Flavor:                   "",
-					BootstrapProvider:        "kubeadm",
 					ClusterName:              "test",
 					TargetNamespace:          "ns1",
 					ControlPlaneMachineCount: 1,
@@ -385,8 +379,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 				providerType:    clusterctlv1.InfrastructureProviderType,
 				version:         "v3.0.0",
 				flavor:          "",
-				bootstrap:       "kubeadm",
-				path:            "config-kubeadm.yaml",
 				variables:       []string{"CLUSTER_NAME"}, // variable detected
 				targetNamespace: "ns1",
 				yaml:            templateYAML("ns1", "test"), // original template modified with target namespace and variable replacement
@@ -399,7 +391,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 					Kubeconfig:               "kubeconfig",
 					InfrastructureProvider:   "infra:v3.0.0",
 					Flavor:                   "",
-					BootstrapProvider:        "kubeadm",
 					ClusterName:              "test",
 					TargetNamespace:          "", // empty triggers usage of the current namespace
 					ControlPlaneMachineCount: 1,
@@ -411,8 +402,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 				providerType:    clusterctlv1.InfrastructureProviderType,
 				version:         "v3.0.0",
 				flavor:          "",
-				bootstrap:       "kubeadm",
-				path:            "config-kubeadm.yaml",
 				variables:       []string{"CLUSTER_NAME"}, // variable detected
 				targetNamespace: "default",
 				yaml:            templateYAML("default", "test"), // original template modified with target namespace and variable replacement
@@ -443,9 +432,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 			}
 			if got.Flavor() != tt.want.flavor {
 				t.Errorf("Flavor() got = %v, want %v", got.Flavor(), tt.want.flavor)
-			}
-			if got.Bootstrap() != tt.want.bootstrap {
-				t.Errorf("Bootstrap() got = %v, want %v", got.Bootstrap(), tt.want.bootstrap)
 			}
 			if !reflect.DeepEqual(got.Variables(), tt.want.variables) {
 				t.Errorf("Variables() got = %v, want %v", got.Variables(), tt.want.variables)

--- a/cmd/clusterctl/pkg/client/init_test.go
+++ b/cmd/clusterctl/pkg/client/init_test.go
@@ -413,7 +413,7 @@ func fakeEmptyCluster() *fakeClient {
 		WithDefaultVersion("v3.0.0").
 		WithFile("v3.0.0", "components.yaml", componentsYAML("ns4")).
 		WithFile("v3.1.0", "components.yaml", componentsYAML("ns4")).
-		WithFile("v3.0.0", "config-kubeadm.yaml", templateYAML("ns4", "test"))
+		WithFile("v3.0.0", "cluster-template.yaml", templateYAML("ns4", "test"))
 
 	cluster1 := newFakeCluster("kubeconfig")
 

--- a/cmd/clusterctl/pkg/client/repository/template.go
+++ b/cmd/clusterctl/pkg/client/repository/template.go
@@ -39,9 +39,6 @@ type Template interface {
 	// A flavor is a variant of cluster template supported by the provider, like e.g. Prod, Test.
 	Flavor() string
 
-	// Bootstrap provider used by the cluster template.
-	Bootstrap() string
-
 	// Variables required by the template.
 	// This value is derived by the template YAML.
 	Variables() []string
@@ -61,7 +58,6 @@ type template struct {
 	config.Provider
 	version         string
 	flavor          string
-	bootstrap       string
 	variables       []string
 	targetNamespace string
 	objs            []unstructured.Unstructured
@@ -76,10 +72,6 @@ func (t *template) Version() string {
 
 func (t *template) Flavor() string {
 	return t.flavor
-}
-
-func (t *template) Bootstrap() string {
-	return t.bootstrap
 }
 
 func (t *template) Variables() []string {
@@ -103,7 +95,6 @@ type newTemplateOptions struct {
 	provider              config.Provider
 	version               string
 	flavor                string
-	bootstrap             string
 	rawYaml               []byte
 	configVariablesClient config.VariablesClient
 	targetNamespace       string
@@ -134,7 +125,6 @@ func newTemplate(options newTemplateOptions) (*template, error) {
 		Provider:        options.provider,
 		version:         options.version,
 		flavor:          options.flavor,
-		bootstrap:       options.bootstrap,
 		variables:       variables,
 		targetNamespace: options.targetNamespace,
 		objs:            objs,

--- a/cmd/clusterctl/pkg/client/repository/template_client_test.go
+++ b/cmd/clusterctl/pkg/client/repository/template_client_test.go
@@ -38,14 +38,12 @@ func Test_templates_Get(t *testing.T) {
 	}
 	type args struct {
 		flavor          string
-		bootstrap       string
 		targetNamespace string
 	}
 	type want struct {
 		provider        config.Provider
 		version         string
 		flavor          string
-		bootstrap       string
 		variables       []string
 		targetNamespace string
 	}
@@ -64,19 +62,17 @@ func Test_templates_Get(t *testing.T) {
 				repository: test.NewFakeRepository().
 					WithPaths("root", "").
 					WithDefaultVersion("v1.0").
-					WithFile("v1.0", "config-kubeadm.yaml", templateMapYaml),
+					WithFile("v1.0", "cluster-template.yaml", templateMapYaml),
 				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 			},
 			args: args{
 				flavor:          "",
-				bootstrap:       "kubeadm",
 				targetNamespace: "ns1",
 			},
 			want: want{
 				provider:        p1,
 				version:         "v1.0",
 				flavor:          "",
-				bootstrap:       "kubeadm",
 				variables:       []string{variableName},
 				targetNamespace: "ns1",
 			},
@@ -90,19 +86,17 @@ func Test_templates_Get(t *testing.T) {
 				repository: test.NewFakeRepository().
 					WithPaths("root", "").
 					WithDefaultVersion("v1.0").
-					WithFile("v1.0", "config-prod-kubeadm.yaml", templateMapYaml),
+					WithFile("v1.0", "cluster-template-prod.yaml", templateMapYaml),
 				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 			},
 			args: args{
 				flavor:          "prod",
-				bootstrap:       "kubeadm",
 				targetNamespace: "ns1",
 			},
 			want: want{
 				provider:        p1,
 				version:         "v1.0",
 				flavor:          "prod",
-				bootstrap:       "kubeadm",
 				variables:       []string{variableName},
 				targetNamespace: "ns1",
 			},
@@ -120,7 +114,6 @@ func Test_templates_Get(t *testing.T) {
 			},
 			args: args{
 				flavor:          "",
-				bootstrap:       "kubeadm",
 				targetNamespace: "ns1",
 			},
 			wantErr: true,
@@ -129,7 +122,7 @@ func Test_templates_Get(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newTemplateClient(tt.fields.provider, tt.fields.version, tt.fields.repository, tt.fields.configVariablesClient)
-			got, err := f.Get(tt.args.flavor, tt.args.bootstrap, tt.args.targetNamespace)
+			got, err := f.Get(tt.args.flavor, tt.args.targetNamespace)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -147,10 +140,6 @@ func Test_templates_Get(t *testing.T) {
 
 			if got.Version() != tt.want.version {
 				t.Errorf("got.Version() = %v, want = %v ", got.Version(), tt.want.version)
-			}
-
-			if got.Bootstrap() != tt.want.bootstrap {
-				t.Errorf("got.Bootstrap() = %v, want = %v ", got.Bootstrap(), tt.want.bootstrap)
 			}
 
 			if !reflect.DeepEqual(got.Variables(), tt.want.variables) {

--- a/cmd/clusterctl/pkg/client/repository/template_test.go
+++ b/cmd/clusterctl/pkg/client/repository/template_test.go
@@ -43,7 +43,6 @@ func Test_newTemplate(t *testing.T) {
 		provider              config.Provider
 		version               string
 		flavor                string
-		bootstrap             string
 		rawYaml               []byte
 		configVariablesClient config.VariablesClient
 		targetNamespace       string
@@ -52,7 +51,6 @@ func Test_newTemplate(t *testing.T) {
 		provider        config.Provider
 		version         string
 		flavor          string
-		bootstrap       string
 		variables       []string
 		targetNamespace string
 	}
@@ -68,7 +66,6 @@ func Test_newTemplate(t *testing.T) {
 				provider:              p1,
 				version:               "v1.2.3",
 				flavor:                "flavor",
-				bootstrap:             "bootstrap",
 				rawYaml:               templateMapYaml,
 				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 				targetNamespace:       "ns1",
@@ -77,7 +74,6 @@ func Test_newTemplate(t *testing.T) {
 				provider:        p1,
 				version:         "v1.2.3",
 				flavor:          "flavor",
-				bootstrap:       "bootstrap",
 				variables:       []string{variableName},
 				targetNamespace: "ns1",
 			},
@@ -90,7 +86,6 @@ func Test_newTemplate(t *testing.T) {
 				provider:              tt.args.provider,
 				version:               tt.args.version,
 				flavor:                tt.args.flavor,
-				bootstrap:             tt.args.bootstrap,
 				rawYaml:               tt.args.rawYaml,
 				configVariablesClient: tt.args.configVariablesClient,
 				targetNamespace:       tt.args.targetNamespace,
@@ -112,10 +107,6 @@ func Test_newTemplate(t *testing.T) {
 
 			if got.Version() != tt.want.version {
 				t.Errorf("got.Version() = %v, want = %v ", got.Version(), tt.want.version)
-			}
-
-			if got.Bootstrap() != tt.want.bootstrap {
-				t.Errorf("got.Bootstrap() = %v, want = %v ", got.Bootstrap(), tt.want.bootstrap)
 			}
 
 			if !reflect.DeepEqual(got.Variables(), tt.want.variables) {

--- a/docs/book/src/clusterctl/provider-contract.md
+++ b/docs/book/src/clusterctl/provider-contract.md
@@ -142,11 +142,10 @@ The following rules apply:
 #### Naming conventions
 
 Cluster templates MUST be stored in the same folder as the component YAML and follow this naming convention:
-1. The default cluster template should be named `config-{bootstrap}.yaml`. e.g `config-kubeadm.yaml`
-2. Additional cluster template should be named `config-{flavor}-{bootstrap}.yaml`. e.g `config-production-kubeadm.yaml`
+1. The default cluster template should be named `cluster-template.yaml`.
+2. Additional cluster template should be named `cluster-template-{flavor}.yaml`. e.g `cluster-template-prod.yaml`
 
-`{bootstrap}` is the name of the bootstrap provider used in the template; `{flavor}` is the name the user can pass to the
-`clusterctl config cluster --flavor` flag to identify the specific template to use.
+`{flavor}` is the name the user can pass to the `clusterctl config cluster --flavor` flag to identify the specific template to use.
  
 Each provider SHOULD create user facing documentation with the list of available cluster templates.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR simplifies the cluster template naming by:

1. Changes the `config` prefix, which is really generic, into a more appropriate `cluster-template`
2. Drops the `-{bootstrap-provider}` part of the file name. The rationale for this is that it is unlikely that an infrastructure provider is going to have template variants for each supported bootstrap provider; additionally, going through this path could potentially leat to adding the `-{control-plane}` variant as well, resulting in an over-complicated template name. So I decided it is better to drop "hard-coded" variants from the name; in case a provider wants to manage several template variants, it is still possible using the flavor name.

As a result e.g.

- The default template will be named `cluster-template.yaml` instead of `config-kubeadm.yaml`
- The template for the `prod` flavor will be named `cluster-template-prod.yaml` instead of `config-kubeadm-prod.yaml`

**Which issue(s) this PR fixes** 
rif #1729

/area clusterctl
/milestone v0.3.0
/assign @ncdc
/assign @vincepri
