### PR TITLE
:book: Fix provider activity diagram URLs

### DIFF
--- a/docs/book/src/developer/providers/bootstrap.md
+++ b/docs/book/src/developer/providers/bootstrap.md
@@ -45,7 +45,7 @@ accordingly.
 
 The following diagram shows the typical logic for a bootstrap provider:
 
-![Bootstrap provider activity diagram](../images/bootstrap-provider.png)
+![Bootstrap provider activity diagram](../../images/bootstrap-provider.png)
 
 1. If the resource does not have a `Machine` owner, exit the reconciliation
     1. The Cluster API `Machine` reconciler populates this based on the value in the `Machine`'s `spec.bootstrap.configRef`

--- a/docs/book/src/developer/providers/cluster-infrastructure.md
+++ b/docs/book/src/developer/providers/cluster-infrastructure.md
@@ -36,7 +36,7 @@ accordingly.
 
 The following diagram shows the typical logic for a cluster infrastructure provider:
 
-![Cluster infrastructure provider activity diagram](../images/cluster-infra-provider.png)
+![Cluster infrastructure provider activity diagram](../../images/cluster-infra-provider.png)
 
 ### Normal resource
 

--- a/docs/book/src/developer/providers/machine-infrastructure.md
+++ b/docs/book/src/developer/providers/machine-infrastructure.md
@@ -38,7 +38,7 @@ accordingly.
 
 The following diagram shows the typical logic for a machine infrastructure provider:
 
-![Machine infrastructure provider activity diagram](../images/machine-infra-provider.png)
+![Machine infrastructure provider activity diagram](../../images/machine-infra-provider.png)
 
 ### Normal resource
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix provider activity diagram URLs that were accidentally broken in #2146

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/kind documentation
/milestone v0.3.0
/priority important-soon