### PR TITLE
✨ Implement failureDomain on machine objects

### DIFF
--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -245,6 +245,17 @@ func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, cluster
 		return errors.Wrapf(err, "failed to retrieve addresses from infrastructure provider for Machine %q in namespace %q", m.Name, m.Namespace)
 	}
 
+	// Get and set the failure domain from the infrastructure provider.
+	var failureDomain string
+	err = util.UnstructuredUnmarshalField(infraConfig, &failureDomain, "spec", "failureDomain")
+	switch {
+	case err == util.ErrUnstructuredFieldNotFound: // no-op
+	case err != nil:
+		return errors.Wrapf(err, "failed to failure domain from infrastructure provider for Machine %q in namespace %q", m.Name, m.Namespace)
+	default:
+		m.Spec.FailureDomain = pointer.StringPtr(failureDomain)
+	}
+
 	m.Spec.ProviderID = pointer.StringPtr(providerID)
 	return nil
 }

--- a/controllers/machine_controller_phases_test.go
+++ b/controllers/machine_controller_phases_test.go
@@ -195,6 +195,9 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		err = unstructured.SetNestedField(infraConfig.Object, "test://id-1", "spec", "providerID")
 		Expect(err).NotTo(HaveOccurred())
 
+		err = unstructured.SetNestedField(infraConfig.Object, "us-east-2a", "spec", "failureDomain")
+		Expect(err).NotTo(HaveOccurred())
+
 		err = unstructured.SetNestedField(infraConfig.Object, []interface{}{
 			map[string]interface{}{
 				"type":    "InternalIP",
@@ -219,6 +222,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Requeue).To(BeFalse())
 		Expect(machine.Status.Addresses).To(HaveLen(2))
+		Expect(*machine.Spec.FailureDomain).To(Equal("us-east-2a"))
 
 		r.reconcilePhase(context.Background(), machine)
 		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

This is the last *code* that is needed to support these two scenarios.

## Scenario one (already supported on master)

A control plane is brought up with failure domains defined on the cluster object

## Scenario two (this PR adds support)

A control plane is brought up before failure domains are defined. After the control plane has been running the user decides they want failure domain support. They then add failure domains to the Cluster object. A scale up or scale down event on the control plane will respect failure domains.

In order for this scenario to work the Machine controller must make the assumption that the infrastructure provider will put the failure domain on the InfraMachine.Spec.FailureDomainID.

Fixes #2185 
