### PR TITLE
📖 Add documentation around failure domains for provider implementers

### DIFF
--- a/docs/book/src/developer/providers/cluster-infrastructure.md
+++ b/docs/book/src/developer/providers/cluster-infrastructure.md
@@ -27,6 +27,11 @@ A cluster infrastructure provider must define an API type for "infrastructure cl
             meant to be suitable for programmatic interpretation
         2. `failureMessage` (string): indicates there is a fatal problem reconciling the provider's infrastructure;
             meant to be a more descriptive value than `failureReason`
+        3. `failureDomains` (`failureDomains`): the failure domains that machines should be placed in. `failureDomains`
+            is a map, defined as `map[string]FailureDomainSpec`. A unique key must be used for each `FailureDomainSpec`.
+            `FailureDomainSpec` is defined as:
+            - `controlPlane` (bool): indicates if failure domain is appropriate for running control plane instances.
+            - `attributes` (`map[string]string`): arbitrary attributes for users to apply to a failure domain.
 
 ## Behavior
 
@@ -48,6 +53,7 @@ The following diagram shows the typical logic for a cluster infrastructure provi
     1. If any errors are encountered, exit the reconciliation
 1. If the provider created a load balancer for the control plane, record its hostname or IP in `spec.controlPlaneEndpoint`
 1. Set `status.ready` to `true`
+1. Set `status.failureDomains` based on available provider failure domains (optional)
 1. Patch the resource to persist changes
 
 ### Deleted resource

--- a/docs/book/src/developer/providers/machine-infrastructure.md
+++ b/docs/book/src/developer/providers/machine-infrastructure.md
@@ -16,6 +16,8 @@ A machine infrastructure provider must define an API type for "infrastructure ma
 5. Must have a `spec` field with the following:
     1. Required fields:
         1. `providerID` (string): the identifier for the provider's machine instance
+    2. Optional fields:
+        1. `failureDomain` (string): the string identifier of the failure domain the instance is running in
 6. Must have a `status` field with the following:
     1. Required fields:
         1. `ready` (boolean): indicates the provider-specific infrastructure has been provisioned and is ready
@@ -59,6 +61,7 @@ The following diagram shows the typical logic for a machine infrastructure provi
 1. Set `spec.providerID` to the provider-specific identifier for the provider's machine instance
 1. Set `status.ready` to `true`
 1. Set `status.addresses` to the provider-specific set of instance addresses (optional) 
+1. Set `spec.failureDomain` to the provider-specific failure domain the instance is running in (optional)
 1. Patch the resource to persist changes
 
 ### Deleted resource

--- a/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md
@@ -141,3 +141,16 @@ outside of the existing module.
 - A new annotation `cluster.x-k8s.io/paused` provides the ability to pause reconciliation on specific objects.
 - A new field `Cluster.Spec.Paused` provides the ability to pause reconciliation on a Cluster and all associated objects.
 - A helper function `util.IsPaused` can be used on any Kubernetes object associated with a Cluster.
+
+## Optional support for failure domains.
+
+An infrastructure provider may or may not implement the failure domains feature. Failure domains gives Cluster API
+just enough information to spread machines out reducing the risk of a target cluster failing due to a domain outage.
+This is particularly useful for Control Plane providers. They are now able to put control plane nodes in different
+domains.
+
+An infrastructure provider can implement this by setting the `InfraCluster.Spec.FailureDomains` field with a map of
+unique keys to `failureDomainSpec`s as well as respecting a set `Machine.Spec.FailureDomain` field when creating
+instances.
+
+Please see the cluster and machine infrastructure provider specifications for more detail.


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This books documents what infrastructure providers must do to support failure domains for future releases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2184 

/cc @yastij 
