### PR TITLE
✨clusterctl: make template object more generic

### DIFF
--- a/cmd/clusterctl/pkg/client/config_test.go
+++ b/cmd/clusterctl/pkg/client/config_test.go
@@ -322,11 +322,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 	}
 
 	type templateValues struct {
-		name            string
-		url             string
-		providerType    clusterctlv1.ProviderType
-		version         string
-		flavor          string
 		variables       []string
 		targetNamespace string
 		yaml            []byte
@@ -351,11 +346,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 				},
 			},
 			want: templateValues{
-				name:            "infra",
-				url:             "url",
-				providerType:    clusterctlv1.InfrastructureProviderType,
-				version:         "v3.0.0",
-				flavor:          "",
 				variables:       []string{"CLUSTER_NAME"}, // variable detected
 				targetNamespace: "ns1",
 				yaml:            templateYAML("ns1", "test"), // original template modified with target namespace and variable replacement
@@ -374,11 +364,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 				},
 			},
 			want: templateValues{
-				name:            "infra",
-				url:             "url",
-				providerType:    clusterctlv1.InfrastructureProviderType,
-				version:         "v3.0.0",
-				flavor:          "",
 				variables:       []string{"CLUSTER_NAME"}, // variable detected
 				targetNamespace: "ns1",
 				yaml:            templateYAML("ns1", "test"), // original template modified with target namespace and variable replacement
@@ -397,11 +382,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 				},
 			},
 			want: templateValues{
-				name:            "infra",
-				url:             "url",
-				providerType:    clusterctlv1.InfrastructureProviderType,
-				version:         "v3.0.0",
-				flavor:          "",
 				variables:       []string{"CLUSTER_NAME"}, // variable detected
 				targetNamespace: "default",
 				yaml:            templateYAML("default", "test"), // original template modified with target namespace and variable replacement
@@ -418,21 +398,6 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 				return
 			}
 
-			if got.Name() != tt.want.name {
-				t.Errorf("Name() got = %v, want %v", got.Name(), tt.want.name)
-			}
-			if got.URL() != tt.want.url {
-				t.Errorf("URL() got = %v, want %v", got.URL(), tt.want.url)
-			}
-			if got.Type() != tt.want.providerType {
-				t.Errorf("Type() got = %v, want %v", got.Type(), tt.want.providerType)
-			}
-			if got.Version() != tt.want.version {
-				t.Errorf("Version() got = %v, want %v", got.Version(), tt.want.version)
-			}
-			if got.Flavor() != tt.want.flavor {
-				t.Errorf("Flavor() got = %v, want %v", got.Flavor(), tt.want.flavor)
-			}
 			if !reflect.DeepEqual(got.Variables(), tt.want.variables) {
 				t.Errorf("Variables() got = %v, want %v", got.Variables(), tt.want.variables)
 			}

--- a/cmd/clusterctl/pkg/client/repository/template_client.go
+++ b/cmd/clusterctl/pkg/client/repository/template_client.go
@@ -94,12 +94,5 @@ func (c *templateClient) Get(flavor, targetNamespace string) (Template, error) {
 		}
 	}
 
-	return newTemplate(newTemplateOptions{
-		provider:              c.provider,
-		version:               version,
-		flavor:                flavor,
-		rawYaml:               rawYaml,
-		configVariablesClient: c.configVariablesClient,
-		targetNamespace:       targetNamespace,
-	})
+	return NewTemplate(rawYaml, c.configVariablesClient, targetNamespace)
 }

--- a/cmd/clusterctl/pkg/client/repository/template_client_test.go
+++ b/cmd/clusterctl/pkg/client/repository/template_client_test.go
@@ -41,9 +41,6 @@ func Test_templates_Get(t *testing.T) {
 		targetNamespace string
 	}
 	type want struct {
-		provider        config.Provider
-		version         string
-		flavor          string
 		variables       []string
 		targetNamespace string
 	}
@@ -70,9 +67,6 @@ func Test_templates_Get(t *testing.T) {
 				targetNamespace: "ns1",
 			},
 			want: want{
-				provider:        p1,
-				version:         "v1.0",
-				flavor:          "",
 				variables:       []string{variableName},
 				targetNamespace: "ns1",
 			},
@@ -94,9 +88,6 @@ func Test_templates_Get(t *testing.T) {
 				targetNamespace: "ns1",
 			},
 			want: want{
-				provider:        p1,
-				version:         "v1.0",
-				flavor:          "prod",
 				variables:       []string{variableName},
 				targetNamespace: "ns1",
 			},
@@ -128,18 +119,6 @@ func Test_templates_Get(t *testing.T) {
 			}
 			if tt.wantErr {
 				return
-			}
-
-			if got.Name() != tt.want.provider.Name() {
-				t.Errorf("got.Name() = %v, want = %v ", got.Name(), tt.want.provider.Name())
-			}
-
-			if got.Type() != tt.want.provider.Type() {
-				t.Errorf("got.Type() = %v, want = %v ", got.Type(), tt.want.provider.Type())
-			}
-
-			if got.Version() != tt.want.version {
-				t.Errorf("got.Version() = %v, want = %v ", got.Version(), tt.want.version)
 			}
 
 			if !reflect.DeepEqual(got.Variables(), tt.want.variables) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR creates the ground for implementing https://github.com/kubernetes-sigs/cluster-api/issues/2133 by dropping all the template attributes derived by the provider repository.
Those attributes were originally implemented mirroring the solution implemented for the component YAML, but today they are not used anywhere.

As soon as the simplified Template object is ready, then it will be easier to add code for reading templates from sources different than the provider repository (GitHub, FileSystem, ConfigMaps)

**Which issue(s) this PR fixes** 
Rif https://github.com/kubernetes-sigs/cluster-api/issues/2133

/area clusterctl
/assign @ncdc
/assign @vincepri
