### PR TITLE
:bug: Clean up ControlPlaneInitialized handling

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -429,6 +429,11 @@ func splitMachineList(list *clusterv1.MachineList) (*clusterv1.MachineList, *clu
 func (r *ClusterReconciler) reconcileControlPlaneInitialized(ctx context.Context, cluster *clusterv1.Cluster) error {
 	logger := r.Log.WithValues("cluster", cluster.Name, "namespace", cluster.Namespace)
 
+	// Skip checking if the control plane is initialized when using a Control Plane Provider
+	if cluster.Spec.ControlPlaneRef != nil {
+		return nil
+	}
+
 	if cluster.Status.ControlPlaneInitialized {
 		return nil
 	}

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -758,3 +758,26 @@ func TestFilterOwnedDescendants(t *testing.T) {
 
 	g.Expect(actual).To(Equal(expected))
 }
+
+func TestReconcileControlPlaneInitializedControlPlaneRef(t *testing.T) {
+	g := NewWithT(t)
+
+	c := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "c",
+		},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: &corev1.ObjectReference{
+				APIVersion: "test.io/v1",
+				Namespace:  "test",
+				Name:       "foo",
+			},
+		},
+	}
+
+	r := &ClusterReconciler{
+		Log: log.Log,
+	}
+	g.Expect(r.reconcileControlPlaneInitialized(context.Background(), c)).To(Succeed())
+	g.Expect(c.Status.ControlPlaneInitialized).To(BeFalse())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Do not attempt to double reconcile Cluster.Status.ControlPlaneInitialized
  when Cluster.Spec.ControlPlaneRef is set

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2260 
