### PR TITLE
✨clusterctl: read templates from different sources

### DIFF
--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -55,36 +55,6 @@ type InitOptions struct {
 	LogUsageInstructions bool
 }
 
-// GetClusterTemplateOptions carries the options supported by GetClusterTemplate.
-type GetClusterTemplateOptions struct {
-	// Kubeconfig file to use for accessing the management cluster. If empty, default rules for kubeconfig
-	// discovery will be used.
-	Kubeconfig string
-
-	// InfrastructureProvider that should be used for creating the workload cluster.
-	InfrastructureProvider string
-
-	// Flavor defines the template variant to be used for creating the workload cluster.
-	Flavor string
-
-	// TargetNamespace where the objects describing the workload cluster should be deployed. If not specified,
-	// the current namespace will be used.
-	TargetNamespace string
-
-	// ClusterName to be used for the workload cluster.
-	ClusterName string
-
-	// KubernetesVersion to use for the workload cluster. By default (empty), the value from os env variables
-	// or the .cluster-api/clusterctl.yaml config file will be used.
-	KubernetesVersion string
-
-	// ControlPlaneMachineCount defines the number of control plane machines to be added to the workload cluster.
-	ControlPlaneMachineCount int
-
-	// WorkerMachineCount defines number of worker machines to be added to the workload cluster.
-	WorkerMachineCount int
-}
-
 // DeleteOptions carries the options supported by Delete.
 type DeleteOptions struct {
 	// Kubeconfig file to use for accessing the management cluster. If empty, default rules for kubeconfig

--- a/cmd/clusterctl/pkg/client/client_test.go
+++ b/cmd/clusterctl/pkg/client/client_test.go
@@ -223,6 +223,10 @@ func (f *fakeClusterClient) ProviderUpgrader() cluster.ProviderUpgrader {
 	return f.internalclient.ProviderUpgrader()
 }
 
+func (f *fakeClusterClient) Template() cluster.TemplateClient {
+	return f.internalclient.Template()
+}
+
 func (f *fakeClusterClient) WithObjs(objs ...runtime.Object) *fakeClusterClient {
 	f.fakeProxy.WithObjs(objs...)
 	return f

--- a/cmd/clusterctl/pkg/client/cluster/client.go
+++ b/cmd/clusterctl/pkg/client/cluster/client.go
@@ -66,6 +66,9 @@ type Client interface {
 
 	// ProviderUpgrader returns a ProviderUpgrader that supports upgrading Cluster API providers.
 	ProviderUpgrader() ProviderUpgrader
+
+	// Template has methods to work with templates stored in the cluster.
+	Template() TemplateClient
 }
 
 // PollImmediateWaiter tries a condition func until it returns true, an error, or the timeout is reached.
@@ -73,9 +76,9 @@ type PollImmediateWaiter func(interval, timeout time.Duration, condition wait.Co
 
 // clusterClient implements Client.
 type clusterClient struct {
+	configClient            config.Client
 	kubeconfig              string
 	proxy                   Proxy
-	configClient            config.Client
 	repositoryClientFactory RepositoryClientFactory
 	pollImmediateWaiter     PollImmediateWaiter
 }
@@ -115,6 +118,10 @@ func (c *clusterClient) ObjectMover() ObjectMover {
 
 func (c *clusterClient) ProviderUpgrader() ProviderUpgrader {
 	return newProviderUpgrader(c.configClient, c.repositoryClientFactory, c.ProviderInventory(), c.ProviderComponents())
+}
+
+func (c *clusterClient) Template() TemplateClient {
+	return newTemplateClient(c.proxy, c.configClient)
 }
 
 // Option is a configuration option supplied to New

--- a/cmd/clusterctl/pkg/client/cluster/template.go
+++ b/cmd/clusterctl/pkg/client/cluster/template.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"encoding/base64"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TemplateClient has methods to work with templates stored in the cluster/out of the provider repository.
+type TemplateClient interface {
+	// GetFromConfigMap returns a workload cluster template from the given ConfigMap.
+	GetFromConfigMap(namespace, name, dataKey, targetNamespace string, listVariablesOnly bool) (repository.Template, error)
+
+	// GetFromURL returns a workload cluster template from the given URL.
+	GetFromURL(templateURL, targetNamespace string, listVariablesOnly bool) (repository.Template, error)
+}
+
+// templateClient implements TemplateClient.
+type templateClient struct {
+	proxy               Proxy
+	configClient        config.Client
+	gitHubClientFactory func(configVariablesClient config.VariablesClient) (*github.Client, error)
+}
+
+// ensure templateClient implements TemplateClient.
+var _ TemplateClient = &templateClient{}
+
+// newTemplateClient returns a templateClient.
+func newTemplateClient(proxy Proxy, configClient config.Client) *templateClient {
+	return &templateClient{
+		proxy:               proxy,
+		configClient:        configClient,
+		gitHubClientFactory: getGitHubClient,
+	}
+}
+
+func (t *templateClient) GetFromConfigMap(configMapNamespace, configMapName, configMapDataKey, targetNamespace string, listVariablesOnly bool) (repository.Template, error) {
+	if configMapNamespace == "" {
+		return nil, errors.New("invalid GetFromConfigMap operation: missing configMapNamespace value")
+	}
+	if configMapName == "" {
+		return nil, errors.New("invalid GetFromConfigMap operation: missing configMapName value")
+	}
+
+	c, err := t.proxy.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	configMap := &corev1.ConfigMap{}
+	key := client.ObjectKey{
+		Namespace: configMapNamespace,
+		Name:      configMapName,
+	}
+
+	if err := c.Get(ctx, key, configMap); err != nil {
+		return nil, errors.Wrapf(err, "error reading ConfigMap %s/%s", configMapNamespace, configMapName)
+	}
+
+	data, ok := configMap.Data[configMapDataKey]
+	if !ok {
+		return nil, errors.Errorf("the ConfigMap %s/%s does not have the %q data key", configMapNamespace, configMapName, configMapDataKey)
+	}
+
+	return repository.NewTemplate([]byte(data), t.configClient.Variables(), targetNamespace, listVariablesOnly)
+}
+
+func (t *templateClient) GetFromURL(templateURL, targetNamespace string, listVariablesOnly bool) (repository.Template, error) {
+	if templateURL == "" {
+		return nil, errors.New("invalid GetFromURL operation: missing templateURL value")
+	}
+
+	content, err := t.getURLContent(templateURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid GetFromURL operation")
+	}
+
+	return repository.NewTemplate(content, t.configClient.Variables(), targetNamespace, listVariablesOnly)
+}
+
+func (t *templateClient) getURLContent(templateURL string) ([]byte, error) {
+	rURL, err := url.Parse(templateURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse %q", templateURL)
+	}
+
+	if rURL.Scheme == "https" && rURL.Host == "github.com" {
+		return t.getGitHubFileContent(rURL)
+	}
+
+	if rURL.Scheme == "file" || rURL.Scheme == "" {
+		return t.getLocalFileContent(rURL)
+	}
+
+	return nil, errors.Errorf("unable to read content from %q. Only reading from GitHub and local file system is supported", templateURL)
+}
+
+func (t *templateClient) getLocalFileContent(rURL *url.URL) ([]byte, error) {
+	f, err := os.Stat(rURL.Path)
+	if err != nil {
+		return nil, errors.Errorf("failed to read file %q", rURL.Path)
+	}
+	if f.IsDir() {
+		return nil, errors.Errorf("invalid path: file %q is actually a directory", rURL.Path)
+	}
+	content, err := ioutil.ReadFile(rURL.Path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read file %q", rURL.Path)
+	}
+
+	return content, nil
+}
+
+func (t *templateClient) getGitHubFileContent(rURL *url.URL) ([]byte, error) {
+	// Check if the path is in the expected format,
+	urlSplit := strings.Split(strings.TrimPrefix(rURL.Path, "/"), "/")
+	if len(urlSplit) < 5 {
+		return nil, errors.Errorf(
+			"invalid GitHub url %q: a GitHub url should be in the form https://github.com/{owner}/{repository}/blob/{branch}/{path-to-file}", rURL,
+		)
+	}
+
+	// Extract all the info from url split.
+	owner := urlSplit[0]
+	repository := urlSplit[1]
+	branch := urlSplit[3]
+	path := strings.Join(urlSplit[4:], "/")
+
+	// gets the GitHub client
+	client, err := t.gitHubClientFactory(t.configClient.Variables())
+	if err != nil {
+		return nil, err
+	}
+
+	// gets the file from GiHub
+	fileContent, _, _, err := client.Repositories.GetContents(context.TODO(), owner, repository, path, &github.RepositoryContentGetOptions{Ref: branch})
+	if err != nil {
+		return nil, handleGithubErr(err, "failed to get %q", rURL.Path)
+	}
+	if fileContent == nil {
+		return nil, errors.Errorf("%q does not return a valid file content", rURL.Path)
+	}
+	if fileContent.Encoding == nil || *fileContent.Encoding != "base64" {
+		return nil, errors.Errorf("invalid encoding detected for %q. Only base64 encoding supported", rURL.Path)
+	}
+
+	content, err := base64.StdEncoding.DecodeString(*fileContent.Content)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to decode file %q", rURL.Path)
+	}
+	return content, nil
+}
+
+func getGitHubClient(configVariablesClient config.VariablesClient) (*github.Client, error) {
+	var authenticatingHTTPClient *http.Client
+	if token, err := configVariablesClient.Get(config.GitHubTokenVariable); err == nil {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: token},
+		)
+		authenticatingHTTPClient = oauth2.NewClient(context.TODO(), ts)
+	}
+
+	return github.NewClient(authenticatingHTTPClient), nil
+}
+
+// handleGithubErr wraps error messages
+func handleGithubErr(err error, message string, args ...interface{}) error {
+	if _, ok := err.(*github.RateLimitError); ok {
+		return errors.New("rate limit for github api has been reached. Please wait one hour or get a personal API tokens a assign it to the GITHUB_TOKEN environment variable")
+	}
+	return errors.Wrapf(err, message, args...)
+}

--- a/cmd/clusterctl/pkg/client/cluster/template_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/template_test.go
@@ -1,0 +1,379 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/github"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
+)
+
+var template = "apiVersion: cluster.x-k8s.io/v1alpha3\n" +
+	"kind: Cluster\n" +
+	"---\n" +
+	"apiVersion: cluster.x-k8s.io/v1alpha3\n" +
+	"kind: Machine"
+
+func Test_templateClient_GetFromConfigMap(t *testing.T) {
+	configClient, err := config.New("", config.InjectReader(test.NewFakeReader()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "my-template",
+		},
+		Data: map[string]string{
+			"prod": template,
+		},
+	}
+
+	type fields struct {
+		proxy        Proxy
+		configClient config.Client
+	}
+	type args struct {
+		configMapNamespace string
+		configMapName      string
+		configMapDataKey   string
+		targetNamespace    string
+		listVariablesOnly  bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Return template",
+			fields: fields{
+				proxy:        test.NewFakeProxy().WithObjs(configMap),
+				configClient: configClient,
+			},
+			args: args{
+				configMapNamespace: "ns1",
+				configMapName:      "my-template",
+				configMapDataKey:   "prod",
+				targetNamespace:    "",
+				listVariablesOnly:  false,
+			},
+			want:    template,
+			wantErr: false,
+		},
+		{
+			name: "Config map does not exists",
+			fields: fields{
+				proxy:        test.NewFakeProxy().WithObjs(configMap),
+				configClient: configClient,
+			},
+			args: args{
+				configMapNamespace: "ns1",
+				configMapName:      "something-else",
+				configMapDataKey:   "prod",
+				targetNamespace:    "",
+				listVariablesOnly:  false,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Config map key does not exists",
+			fields: fields{
+				proxy:        test.NewFakeProxy().WithObjs(configMap),
+				configClient: configClient,
+			},
+			args: args{
+				configMapNamespace: "ns1",
+				configMapName:      "my-template",
+				configMapDataKey:   "something-else",
+				targetNamespace:    "",
+				listVariablesOnly:  false,
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &templateClient{
+				proxy:        tt.fields.proxy,
+				configClient: tt.fields.configClient,
+			}
+			got, err := tc.GetFromConfigMap(tt.args.configMapNamespace, tt.args.configMapName, tt.args.configMapDataKey, tt.args.targetNamespace, tt.args.listVariablesOnly)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			wantTemplate, err := repository.NewTemplate([]byte(tt.want), configClient.Variables(), tt.args.targetNamespace, tt.args.listVariablesOnly)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, wantTemplate) {
+				t.Errorf("got = %v, want %v", got, wantTemplate)
+			}
+		})
+	}
+}
+
+func Test_templateClient_getGitHubFileContent(t *testing.T) {
+	client, mux, teardown := test.NewFakeGitHub()
+	defer teardown()
+
+	configClient, err := config.New("", config.InjectReader(test.NewFakeReader()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux.HandleFunc("/repos/kubernetes-sigs/cluster-api/contents/config/default/cluster-template.yaml", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{
+		  "type": "file",
+		  "encoding": "base64",
+		  "content": "`+base64.StdEncoding.EncodeToString([]byte(template))+`",
+		  "sha": "f5f369044773ff9c6383c087466d12adb6fa0828",
+		  "size": 12,
+		  "name": "cluster-template.yaml",
+		  "path": "config/default/cluster-template.yaml"
+		}`)
+	})
+
+	type args struct {
+		rURL *url.URL
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "Return custom template",
+			args: args{
+				rURL: mustParseURL("https://github.com/kubernetes-sigs/cluster-api/blob/master/config/default/cluster-template.yaml"),
+			},
+			want:    []byte(template),
+			wantErr: false,
+		},
+		{
+			name: "Wrong url",
+			args: args{
+				rURL: mustParseURL("https://github.com/kubernetes-sigs/cluster-api/blob/master/config/default/something-else.yaml"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &templateClient{
+				configClient: configClient,
+				gitHubClientFactory: func(configVariablesClient config.VariablesClient) (*github.Client, error) {
+					return client, nil
+				},
+			}
+			got, err := c.getGitHubFileContent(tt.args.rURL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_templateClient_getLocalFileContent(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "cc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	path := filepath.Join(tmpDir, "cluster-template.yaml")
+	if err := ioutil.WriteFile(path, []byte(template), 0644); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	type args struct {
+		rURL *url.URL
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "Return custom template",
+			args: args{
+				rURL: mustParseURL(path),
+			},
+			want:    []byte(template),
+			wantErr: false,
+		},
+		{
+			name: "Wrong path",
+			args: args{
+				rURL: mustParseURL(filepath.Join(tmpDir, "something-else.yaml")),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &templateClient{}
+			got, err := c.getLocalFileContent(tt.args.rURL)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_templateClient_GetFromURL(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "cc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	configClient, err := config.New("", config.InjectReader(test.NewFakeReader()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, mux, teardown := test.NewFakeGitHub()
+	defer teardown()
+
+	mux.HandleFunc("/repos/kubernetes-sigs/cluster-api/contents/config/default/cluster-template.yaml", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{
+		  "type": "file",
+		  "encoding": "base64",
+		  "content": "`+base64.StdEncoding.EncodeToString([]byte(template))+`",
+		  "sha": "f5f369044773ff9c6383c087466d12adb6fa0828",
+		  "size": 12,
+		  "name": "cluster-template.yaml",
+		  "path": "config/default/cluster-template.yaml"
+		}`)
+	})
+
+	path := filepath.Join(tmpDir, "cluster-template.yaml")
+	if err := ioutil.WriteFile(path, []byte(template), 0644); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	type args struct {
+		templateURL       string
+		targetNamespace   string
+		listVariablesOnly bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Get from local file system",
+			args: args{
+				templateURL:       path,
+				targetNamespace:   "",
+				listVariablesOnly: false,
+			},
+			want:    template,
+			wantErr: false,
+		},
+		{
+			name: "Get from GitHub",
+			args: args{
+				templateURL:       "https://github.com/kubernetes-sigs/cluster-api/blob/master/config/default/cluster-template.yaml",
+				targetNamespace:   "",
+				listVariablesOnly: false,
+			},
+			want:    template,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &templateClient{
+				configClient: configClient,
+				gitHubClientFactory: func(configVariablesClient config.VariablesClient) (*github.Client, error) {
+					return client, nil
+				},
+			}
+			got, err := c.GetFromURL(tt.args.templateURL, tt.args.targetNamespace, tt.args.listVariablesOnly)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			wantTemplate, err := repository.NewTemplate([]byte(tt.want), configClient.Variables(), tt.args.targetNamespace, tt.args.listVariablesOnly)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, wantTemplate) {
+				t.Errorf("got = %v, want %v", got, wantTemplate)
+			}
+		})
+	}
+}
+
+func mustParseURL(rawURL string) *url.URL {
+	rURL, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+	return rURL
+}

--- a/cmd/clusterctl/pkg/client/config.go
+++ b/cmd/clusterctl/pkg/client/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/version"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/cluster"
 )
 
 func (c *clusterctlClient) GetProvidersConfig() ([]Provider, error) {
@@ -47,19 +48,150 @@ func (c *clusterctlClient) GetProviderComponents(provider, targetNameSpace, watc
 	return components, nil
 }
 
-func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions) (Template, error) {
+// GetClusterTemplateOptions carries the options supported by GetClusterTemplate.
+type GetClusterTemplateOptions struct {
+	// Kubeconfig file to use for accessing the management cluster. If empty, default rules for kubeconfig
+	// discovery will be used.
+	Kubeconfig string
 
+	// ProviderRepositorySource to be used for reading the workload cluster template from a provider repository;
+	// only one template source can be used at time; if not other source will be set, a ProviderRepositorySource
+	// will be generated inferring values from the cluster.
+	ProviderRepositorySource *ProviderRepositorySourceOptions
+
+	// URLSource to be used for reading the workload cluster template; only one template source can be used at time.
+	URLSource *URLSourceOptions
+
+	// ConfigMapSource to be used for reading the workload cluster template; only one template source can be used at time.
+	ConfigMapSource *ConfigMapSourceOptions
+
+	// TargetNamespace where the objects describing the workload cluster should be deployed. If not specified,
+	// the current namespace will be used.
+	TargetNamespace string
+
+	// ClusterName to be used for the workload cluster.
+	ClusterName string
+
+	// KubernetesVersion to use for the workload cluster. By default (empty), the value from os env variables
+	// or the .cluster-api/clusterctl.yaml config file will be used.
+	KubernetesVersion string
+
+	// ControlPlaneMachineCount defines the number of control plane machines to be added to the workload cluster.
+	ControlPlaneMachineCount int
+
+	// WorkerMachineCount defines number of worker machines to be added to the workload cluster.
+	WorkerMachineCount int
+
+	// listVariablesOnly sets the GetClusterTemplate method to return the list of variables expected by the template
+	// without executing any further processing.
+	ListVariablesOnly bool
+}
+
+// numSources return the number of template sources currently set on a GetClusterTemplateOptions.
+func (o *GetClusterTemplateOptions) numSources() int {
+	numSources := 0
+	if o.ProviderRepositorySource != nil {
+		numSources++
+	}
+	if o.ConfigMapSource != nil {
+		numSources++
+	}
+	if o.URLSource != nil {
+		numSources++
+	}
+	return numSources
+}
+
+// ProviderRepositorySourceOptions defines the options to be used when reading a workload cluster template
+// from a provider repository.
+type ProviderRepositorySourceOptions struct {
+	// InfrastructureProvider to read the workload cluster template from. By default (empty), the default
+	// infrastructure provider will be used if no other sources are specified.
+	InfrastructureProvider string
+
+	// Flavor defines The workload cluster template variant to be used when reading from the infrastructure
+	// provider repository. By default (empty), the default cluster template will be used.
+	Flavor string
+}
+
+// URLSourceOptions defines the options to be used when reading a workload cluster template from an URL.
+type URLSourceOptions struct {
+	// URL to read the workload cluster template from.
+	URL string
+}
+
+// DefaultCustomTemplateConfigMapKey  where the workload cluster template is hosted.
+const DefaultCustomTemplateConfigMapKey = "template"
+
+// ConfigMapSourceOptions defines the options to be used when reading a workload cluster template from a ConfigMap.
+type ConfigMapSourceOptions struct {
+	// Namespace where the ConfigMap exists. By default (empty), the current namespace will be used.
+	Namespace string
+
+	// Name to read the workload cluster template from.
+	Name string
+
+	// DataKey where the workload cluster template is hosted. By default (empty), the
+	// DefaultCustomTemplateConfigMapKey will be used.
+	DataKey string
+}
+
+func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions) (Template, error) {
+	// Checks that no more than on source is set
+	numsSource := options.numSources()
+	if numsSource > 1 {
+		return nil, errors.New("invalid cluster template source: only one template can be used at time")
+	}
+
+	// If no source is set, defaults to using an empty ProviderRepositorySource so values will be
+	// inferred from the cluster inventory.
+	if numsSource == 0 {
+		options.ProviderRepositorySource = &ProviderRepositorySourceOptions{}
+	}
+
+	// Gets  the client for the current management cluster
 	cluster, err := c.clusterClientFactory(options.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}
 
+	// If the option specifying the targetNamespace is empty, try to detect it.
+	if options.TargetNamespace == "" {
+		currentNamespace, err := cluster.Proxy().CurrentNamespace()
+		if err != nil {
+			return nil, err
+		}
+		options.TargetNamespace = currentNamespace
+	}
+
+	// Inject some of the templateOptions into the configClient so they can be consumed as a variables from the template.
+	if err := c.templateOptionsToVariables(options); err != nil {
+		return nil, err
+	}
+
+	// Gets the workload cluster template from the selected source
+	if options.ProviderRepositorySource != nil {
+		return c.getTemplateFromRepository(cluster, *options.ProviderRepositorySource, options.TargetNamespace, options.ListVariablesOnly)
+	}
+	if options.ConfigMapSource != nil {
+		return c.getTemplateFromConfigMap(cluster, *options.ConfigMapSource, options.TargetNamespace, options.ListVariablesOnly)
+	}
+	if options.URLSource != nil {
+		return c.getTemplateFromURL(cluster, *options.URLSource, options.TargetNamespace, options.ListVariablesOnly)
+	}
+
+	return nil, errors.New("unable to read custom template. Please specify a template source")
+}
+
+// getTemplateFromRepository returns a workload cluster template from a provider repository.
+func (c *clusterctlClient) getTemplateFromRepository(cluster cluster.Client, source ProviderRepositorySourceOptions, targetNamespace string, listVariablesOnly bool) (Template, error) {
+	// ensure the custom resource definitions required by clusterctl are in place
 	if err := cluster.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
 		return nil, err
 	}
 
 	// If the option specifying the name of the infrastructure provider to get templates from is empty, try to detect it.
-	provider := options.InfrastructureProvider
+	provider := source.InfrastructureProvider
 	if provider == "" {
 		defaultProviderName, err := cluster.ProviderInventory().GetDefaultProviderName(clusterctlv1.InfrastructureProviderType)
 		if err != nil {
@@ -91,20 +223,6 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 		version = defaultProviderVersion
 	}
 
-	// If the option specifying the targetNamespace is empty, try to detect it.
-	if options.TargetNamespace == "" {
-		currentNamespace, err := cluster.Proxy().CurrentNamespace()
-		if err != nil {
-			return nil, err
-		}
-		options.TargetNamespace = currentNamespace
-	}
-
-	// Inject some of the templateOptions into the configClient so they can be consumed as a variables from the template.
-	if err := c.templateOptionsToVariables(options); err != nil {
-		return nil, err
-	}
-
 	// Get the template from the template repository.
 	providerConfig, err := c.configClient.Providers().Get(name)
 	if err != nil {
@@ -116,11 +234,35 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 		return nil, err
 	}
 
-	template, err := repo.Templates(version).Get(options.Flavor, options.TargetNamespace)
+	template, err := repo.Templates(version).Get(source.Flavor, targetNamespace, listVariablesOnly)
 	if err != nil {
 		return nil, err
 	}
 	return template, nil
+}
+
+// getTemplateFromConfigMap returns a workload cluster template from a ConfigMap.
+func (c *clusterctlClient) getTemplateFromConfigMap(cluster cluster.Client, source ConfigMapSourceOptions, targetNamespace string, listVariablesOnly bool) (Template, error) {
+	// If the option specifying the configMapNamespace is empty, default it to the current namespace.
+	if source.Namespace == "" {
+		currentNamespace, err := cluster.Proxy().CurrentNamespace()
+		if err != nil {
+			return nil, err
+		}
+		source.Namespace = currentNamespace
+	}
+
+	// If the option specifying the configMapDataKey is empty, default it.
+	if source.DataKey == "" {
+		source.DataKey = DefaultCustomTemplateConfigMapKey
+	}
+
+	return cluster.Template().GetFromConfigMap(source.Namespace, source.Name, source.DataKey, targetNamespace, listVariablesOnly)
+}
+
+// getTemplateFromURL returns a workload cluster template from an URL.
+func (c *clusterctlClient) getTemplateFromURL(cluster cluster.Client, source URLSourceOptions, targetNamespace string, listVariablesOnly bool) (Template, error) {
+	return cluster.Template().GetFromURL(source.URL, targetNamespace, listVariablesOnly)
 }
 
 // templateOptionsToVariables injects some of the templateOptions to the configClient so they can be consumed as a variables from the template.

--- a/cmd/clusterctl/pkg/client/config/variables_client.go
+++ b/cmd/clusterctl/pkg/client/config/variables_client.go
@@ -18,6 +18,11 @@ package config
 
 import "sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
 
+const (
+	// GitHubTokenVariable defines a variable hosting the GitHub access token
+	GitHubTokenVariable = "github-token"
+)
+
 // VariablesClient has methods to work with environment variables and with variables defined in the clusterctl configuration file.
 type VariablesClient interface {
 	// Get returns a variable value. If the variable is not defined an error is returned.

--- a/cmd/clusterctl/pkg/client/repository/repository_github.go
+++ b/cmd/clusterctl/pkg/client/repository/repository_github.go
@@ -34,7 +34,6 @@ import (
 const (
 	httpsScheme              = "https"
 	githubDomain             = "github.com"
-	githubTokeVariable       = "github-token"
 	githubReleaseRepository  = "releases"
 	githubLatestReleaseLabel = "latest"
 )
@@ -145,8 +144,7 @@ func newGitHubRepository(providerConfig config.Provider, configVariablesClient c
 		componentsPath:        componentsPath,
 	}
 
-	token, err := configVariablesClient.Get(githubTokeVariable)
-	if err == nil {
+	if token, err := configVariablesClient.Get(config.GitHubTokenVariable); err == nil {
 		repo.setClientToken(token)
 	}
 

--- a/cmd/clusterctl/pkg/client/repository/template.go
+++ b/cmd/clusterctl/pkg/client/repository/template.go
@@ -70,9 +70,15 @@ func (t *template) Yaml() ([]byte, error) {
 }
 
 // NewTemplate returns a new objects embedding a cluster template YAML file.
-func NewTemplate(rawYaml []byte, configVariablesClient config.VariablesClient, targetNamespace string) (*template, error) {
+func NewTemplate(rawYaml []byte, configVariablesClient config.VariablesClient, targetNamespace string, listVariablesOnly bool) (*template, error) {
 	// Inspect variables and replace with values from the configuration.
 	variables := inspectVariables(rawYaml)
+	if listVariablesOnly {
+		return &template{
+			variables:       variables,
+			targetNamespace: targetNamespace,
+		}, nil
+	}
 
 	yaml, err := replaceVariables(rawYaml, variables, configVariablesClient)
 	if err != nil {

--- a/cmd/clusterctl/pkg/client/repository/template_client.go
+++ b/cmd/clusterctl/pkg/client/repository/template_client.go
@@ -39,7 +39,7 @@ type TemplateOptions struct {
 // TemplateClient has methods to work with cluster templates hosted on a provider repository.
 // Templates are yaml files to be used for creating a guest cluster.
 type TemplateClient interface {
-	Get(flavor, targetNamespace string) (Template, error)
+	Get(flavor, targetNamespace string, listVariablesOnly bool) (Template, error)
 }
 
 // templateClient implements TemplateClient.
@@ -66,7 +66,7 @@ func newTemplateClient(provider config.Provider, version string, repository Repo
 // Get return the template for the flavor specified.
 // In case the template does not exists, an error is returned.
 // Get assumes the following naming convention for templates: cluster-template[-<flavor_name>].yaml
-func (c *templateClient) Get(flavor, targetNamespace string) (Template, error) {
+func (c *templateClient) Get(flavor, targetNamespace string, listVariablesOnly bool) (Template, error) {
 	log := logf.Log
 
 	if targetNamespace == "" {
@@ -100,5 +100,5 @@ func (c *templateClient) Get(flavor, targetNamespace string) (Template, error) {
 		log.V(1).Info("Using", "Override", name, "Provider", c.provider.Name(), "Version", version)
 	}
 
-	return NewTemplate(rawYaml, c.configVariablesClient, targetNamespace)
+	return NewTemplate(rawYaml, c.configVariablesClient, targetNamespace, listVariablesOnly)
 }

--- a/cmd/clusterctl/pkg/client/repository/template_test.go
+++ b/cmd/clusterctl/pkg/client/repository/template_test.go
@@ -40,6 +40,7 @@ func Test_newTemplate(t *testing.T) {
 		rawYaml               []byte
 		configVariablesClient config.VariablesClient
 		targetNamespace       string
+		listVariablesOnly     bool
 	}
 	type want struct {
 		variables       []string
@@ -57,6 +58,21 @@ func Test_newTemplate(t *testing.T) {
 				rawYaml:               templateMapYaml,
 				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 				targetNamespace:       "ns1",
+				listVariablesOnly:     false,
+			},
+			want: want{
+				variables:       []string{variableName},
+				targetNamespace: "ns1",
+			},
+			wantErr: false,
+		},
+		{
+			name: "List variable only",
+			args: args{
+				rawYaml:               templateMapYaml,
+				configVariablesClient: test.NewFakeVariableClient(),
+				targetNamespace:       "ns1",
+				listVariablesOnly:     true,
 			},
 			want: want{
 				variables:       []string{variableName},
@@ -67,7 +83,7 @@ func Test_newTemplate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewTemplate(tt.args.rawYaml, tt.args.configVariablesClient, tt.args.targetNamespace)
+			got, err := NewTemplate(tt.args.rawYaml, tt.args.configVariablesClient, tt.args.targetNamespace, tt.args.listVariablesOnly)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -81,6 +97,10 @@ func Test_newTemplate(t *testing.T) {
 
 			if !reflect.DeepEqual(got.TargetNamespace(), tt.want.targetNamespace) {
 				t.Errorf("got.TargetNamespace() = %v, want = %v ", got.TargetNamespace(), tt.want.targetNamespace)
+			}
+
+			if tt.args.listVariablesOnly {
+				return
 			}
 
 			// check variable replaced in components

--- a/cmd/clusterctl/pkg/internal/test/fake_github.go
+++ b/cmd/clusterctl/pkg/internal/test/fake_github.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-github/github"
+)
+
+const baseURLPath = "/api-v3"
+
+// NewFakeGitHub sets up a test HTTP server along with a github.Client that is
+// configured to talk to that test server. Tests should register handlers on
+// mux which provide mock responses for the API method being tested.
+func NewFakeGitHub() (client *github.Client, mux *http.ServeMux, teardown func()) {
+	// mux is the HTTP request multiplexer used with the test server.
+	mux = http.NewServeMux()
+
+	apiHandler := http.NewServeMux()
+	apiHandler.Handle(baseURLPath+"/", http.StripPrefix(baseURLPath, mux))
+
+	// server is a test HTTP server used to provide mock API responses.
+	server := httptest.NewServer(apiHandler)
+
+	// client is the GitHub client being tested and is configured to use test server.
+	client = github.NewClient(nil)
+	url, _ := url.Parse(server.URL + baseURLPath + "/")
+	client.BaseURL = url
+	client.UploadURL = url
+
+	return client, mux, server.Close
+}
+
+func TestMethod(t *testing.T, r *http.Request, want string) {
+	if got := r.Method; got != want {
+		t.Errorf("Request method: %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces to clusterctl support for reading cluster templates from a location different than the provider repository.

Supported locations are GitHub repository, local file system, and ConfiMaps.

It also adds support for returning the list of variables in a template.

**Which issue(s) this PR fixes**:
Fixes #2133

/area clusterctl
/assign @ncdc
/assign @vincepri