### PR TITLE
🏃Add an option to specify the kind cluster name when using Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -6,6 +6,7 @@ settings = {
     "deploy_cert_manager": True,
     "preload_images_for_kind": True,
     "enable_providers": ["docker"],
+    "kind_cluster_name": "kind",
 }
 
 # global settings
@@ -190,7 +191,7 @@ def deploy_cert_manager():
     if settings.get("preload_images_for_kind"):
         for image in images:
             local("docker pull {}/{}:{}".format(registry, image, version))
-            local("kind load docker-image {}/{}:{}".format(registry, image, version))
+            local("kind load docker-image --name {} {}/{}:{}".format(settings.get("kind_cluster_name"), registry, image, version))
 
     local("kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/{}/cert-manager.yaml".format(version))
 

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -12,7 +12,7 @@ workflow that offers easy deployments and rapid iterative builds.
    (other clusters can be used if `preload_images_for_kind` is set to false)
 1. [kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md) standalone
    (`kubectl kustomize` does not work because it is missing some features of kustomize v3)
-1. [Tilt](https://docs.tilt.dev/install.html)
+1. [Tilt](https://docs.tilt.dev/install.html) v0.10.3 or newer
 1. Clone the [Cluster API](https://github.com/kubernetes-sigs/cluster-api) repository locally
 1. Clone the provider(s) you want to deploy locally as well
 
@@ -32,7 +32,6 @@ Next, create a `tilt-settings.json` file and place it in your local copy of `clu
 
 ```json
 {
-  "allowed_contexts": ["kind-kind"],
   "default_registry": "gcr.io/your-project-name-here",
   "provider_repos": ["../cluster-api-provider-aws"],
   "enable_providers": ["aws", "docker", "kubeadm-bootstrap", "kubeadm-control-plane"],

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -35,7 +35,8 @@ Next, create a `tilt-settings.json` file and place it in your local copy of `clu
   "allowed_contexts": ["kind-kind"],
   "default_registry": "gcr.io/your-project-name-here",
   "provider_repos": ["../cluster-api-provider-aws"],
-  "enable_providers": ["aws", "docker", "kubeadm-bootstrap", "kubeadm-control-plane"]
+  "enable_providers": ["aws", "docker", "kubeadm-bootstrap", "kubeadm-control-plane"],
+  "kind_cluster_name": "kind"
 }
 ```
 
@@ -52,6 +53,8 @@ Next, create a `tilt-settings.json` file and place it in your local copy of `clu
 
 **enable_providers** (Array[]String, default=['docker']): A list of the providers to enable. See [available providers](#available-providers)
 for more details.
+
+**kind_cluster_name** (String, default="kind"): The name of the kind cluster to use when preloading images.
 
 **kustomize_substitutions** (Map{String: String}, default={}): An optional map of substitutions for `${}`-style placeholders in the
 provider's yaml.

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -34,8 +34,7 @@ Next, create a `tilt-settings.json` file and place it in your local copy of `clu
 {
   "default_registry": "gcr.io/your-project-name-here",
   "provider_repos": ["../cluster-api-provider-aws"],
-  "enable_providers": ["aws", "docker", "kubeadm-bootstrap", "kubeadm-control-plane"],
-  "kind_cluster_name": "kind"
+  "enable_providers": ["aws", "docker", "kubeadm-bootstrap", "kubeadm-control-plane"]
 }
 ```
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Before this change, Tilt would attempt to preload images to a kind
cluster named `kind`.

With this change, a developer can use a kind cluster called something
other than `kind` by specifying the cluster name in the
`tilt-settings.json` file.

This commit also updates the docs to include a reference to the new
setting.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2269 
