### PR TITLE
📖 Fix sample Machine and MachineDeployment objects in Quick Start doc

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -261,6 +261,7 @@ metadata:
     cluster.x-k8s.io/control-plane: "true"
     cluster.x-k8s.io/cluster-name: "capi-quickstart"
 spec:
+  clusterName: capi-quickstart
   version: v1.15.3
   bootstrap:
     configRef:
@@ -341,6 +342,7 @@ metadata:
     cluster.x-k8s.io/control-plane: "true"
     cluster.x-k8s.io/cluster-name: "capi-quickstart"
 spec:
+  clusterName: capi-quickstart
   version: v1.16.6
   bootstrap:
     configRef:
@@ -438,6 +440,7 @@ metadata:
     cluster.x-k8s.io/control-plane: "true"
     cluster.x-k8s.io/cluster-name: "capi-quickstart"
 spec:
+  clusterName: capi-quickstart
   version: v1.15.3
   bootstrap:
     configRef:
@@ -493,6 +496,7 @@ metadata:
     cluster.x-k8s.io/control-plane: "true"
     cluster.x-k8s.io/cluster-name: "capi-quickstart"
 spec:
+  clusterName: capi-quickstart
   version: v1.15.3
   bootstrap:
     configRef:
@@ -562,6 +566,7 @@ metadata:
     cluster.x-k8s.io/control-plane: "true"
     cluster.x-k8s.io/cluster-name: "capi-quickstart"
 spec:
+  clusterName: capi-quickstart
   version: v1.16.2
   bootstrap:
     configRef:
@@ -639,6 +644,7 @@ metadata:
     cluster.x-k8s.io/control-plane: "true"
     cluster.x-k8s.io/cluster-name: "capi-quickstart"
 spec:
+  clusterName: capi-quickstart
   version: v1.15.3
   bootstrap:
     configRef:
@@ -845,6 +851,7 @@ spec:
         cluster.x-k8s.io/cluster-name: capi-quickstart
         nodepool: nodepool-0
     spec:
+      clusterName: capi-quickstart
       version: v1.15.3
       bootstrap:
         configRef:
@@ -938,6 +945,7 @@ spec:
         cluster.x-k8s.io/cluster-name: capi-quickstart
         nodepool: nodepool-0
     spec:
+      clusterName: capi-quickstart
       version: v1.16.6
       bootstrap:
         configRef:
@@ -1031,6 +1039,7 @@ spec:
         cluster.x-k8s.io/cluster-name: capi-quickstart
         nodepool: nodepool-0
     spec:
+      clusterName: capi-quickstart
       version: v1.15.3
       bootstrap:
         configRef:
@@ -1102,6 +1111,7 @@ spec:
         cluster.x-k8s.io/cluster-name: capi-quickstart
         nodepool: nodepool-0
     spec:
+      clusterName: capi-quickstart
       version: v1.15.3
       bootstrap:
         configRef:
@@ -1183,6 +1193,7 @@ spec:
         cluster.x-k8s.io/cluster-name: capi-quickstart
         nodepool: nodepool-0
     spec:
+      clusterName: capi-quickstart
       version: v1.16.2
       bootstrap:
         configRef:
@@ -1268,6 +1279,7 @@ spec:
         cluster.x-k8s.io/cluster-name: capi-quickstart
         nodepool: nodepool-0
     spec:
+      clusterName: capi-quickstart
       version: v1.15.3
       bootstrap:
         configRef:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
The Quick Start documentation includes sample YAML definitions for
Machine and MachineDeployments. The spec of both these resources
requires a field called `clusterName`, which is missing from the sample
YAML.

Add the `clusterName` field to all sample Machine and MachineDeployment
resources that exist in the Quick Start section of the Book.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2272 
