### PR TITLE
🐛capd: reconcile status ready after move

### DIFF
--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
@@ -158,6 +158,9 @@ func (r *DockerMachineReconciler) reconcileNormal(ctx context.Context, machine *
 
 	// if the machine is already provisioned, return
 	if dockerMachine.Spec.ProviderID != nil {
+		// ensure ready state is set.
+		// This is required after move, bacuse status is not moved to the target cluster.
+		dockerMachine.Status.Ready = true
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the following problem
-> Create two kind clusters, clusterctl Init with CAPD on both
-> create a workload cluster on first kind cluster, clusterctl move to a second kind cluster
-> CAPD not reconciling `dockermachine.status.Ready` because of `dockermachine.spec.ProviderID` is already set
--> CAPI not reconciling machine (requeuig) due to Infrastructure not ready even if the infrastructure is there (`dockermachine.spec.ProviderID` set)
