### PR TITLE
🏃clusterctl: cleanup inventory

### DIFF
--- a/cmd/clusterctl/api/v1alpha3/metadata_type.go
+++ b/cmd/clusterctl/api/v1alpha3/metadata_type.go
@@ -32,7 +32,7 @@ type Metadata struct {
 	ReleaseSeries []ReleaseSeries `json:"releaseSeries"`
 }
 
-// ReleaseSeries maps a provider release series (major/minor) with a ClusterAPIVersion
+// ReleaseSeries maps a provider release series (major/minor) with a API Version of Cluster API (contract).
 type ReleaseSeries struct {
 	// Major version of the release series
 	Major uint `json:"major,omitempty"`
@@ -40,21 +40,21 @@ type ReleaseSeries struct {
 	// Minor version of the release series
 	Minor uint `json:"minor,omitempty"`
 
-	// ClusterAPIVersion indicates the cluster API supported version.
-	ClusterAPIVersion string `json:"clusterAPIVersion,omitempty"`
+	// Contract defines the API Version of Cluster API (contract) supported by the ReleaseSeries.
+	Contract string `json:"contract,omitempty"`
 }
 
 func init() {
 	SchemeBuilder.Register(&Metadata{})
 }
 
-// HasReleaseSeriesForVersion return true if the given version is in one of the ReleaseSeries.
-func (m *Metadata) HasReleaseSeriesForVersion(version *version.Version) bool {
+// GetReleaseSeriesForVersion return the release series for a given version.
+func (m *Metadata) GetReleaseSeriesForVersion(version *version.Version) *ReleaseSeries {
 	for _, releaseSeries := range m.ReleaseSeries {
 		if version.Major() == releaseSeries.Major && version.Minor() == releaseSeries.Minor {
-			return true
+			return &releaseSeries
 		}
 	}
 
-	return false
+	return nil
 }

--- a/cmd/clusterctl/cmd/upgrade.go
+++ b/cmd/clusterctl/cmd/upgrade.go
@@ -46,12 +46,12 @@ var upgradePlanCmd = &cobra.Command{
 	Long: LongDesc(`
 		The upgrade plan command provides a list of recommended target versions for upgrading Cluster API providers in a management cluster.
 		
-		The providers are grouped into management groups, each one defining a set of providers that should be supporting the same cluster API version
-		in order to guarantee the proper functioning of the management cluster.
+		The providers are grouped into management groups, each one defining a set of providers that should be supporting 
+		the same API Version of Cluster API (contract) in order to guarantee the proper functioning of the management cluster.
 
 		Then, for each provider in a management group, the following upgrade options are provided:
-		- The latest patch release for the current Cluster API version.
-		- The latest patch release for the next Cluster API version, if available.`),
+		- The latest patch release for the current API Version of Cluster API (contract).
+		- The latest patch release for the next API Version of Cluster API (contract), if available.`),
 
 	Example: Examples(`
 		# Gets the recommended target versions for upgrading Cluster API providers.
@@ -83,7 +83,7 @@ func runUpgradePlan() error {
 		return err
 	}
 
-	// ensure upgrade plans are sorted consistently (by CoreProvider.Namespace, ClusterAPIVersion).
+	// ensure upgrade plans are sorted consistently (by CoreProvider.Namespace, Contract).
 	sortUpgradePlans(upgradePlans)
 
 	if len(upgradePlans) == 0 {
@@ -98,7 +98,7 @@ func runUpgradePlan() error {
 		upgradeAvailable := false
 
 		fmt.Println("")
-		fmt.Printf("Management group: %s/%s, latest release available for the %s Cluster API version:\n", plan.CoreProvider.Namespace, plan.CoreProvider.Name, plan.ClusterAPIVersion)
+		fmt.Printf("Management group: %s, latest release available for the %s API Version of Cluster API (contract):\n", plan.CoreProvider.InstanceName(), plan.Contract)
 		fmt.Println("")
 		w := tabwriter.NewWriter(os.Stdout, 10, 4, 3, ' ', 0)
 		fmt.Fprintln(w, "NAME\tNAMESPACE\tTYPE\tCURRENT VERSION\tNEXT VERSION")
@@ -114,7 +114,7 @@ func runUpgradePlan() error {
 		if upgradeAvailable {
 			fmt.Println("You can now apply the upgrade by executing the following command:")
 			fmt.Println("")
-			fmt.Println(fmt.Sprintf("   upgrade apply --management-group %s/%s --cluster-api-version %s", plan.CoreProvider.Namespace, plan.CoreProvider.Name, plan.ClusterAPIVersion))
+			fmt.Println(fmt.Sprintf("   upgrade apply --management-group %s --cluster-api-version %s", plan.CoreProvider.InstanceName(), plan.Contract))
 		} else {
 			fmt.Println("You are already up to date!")
 		}
@@ -136,7 +136,7 @@ func sortUpgradeItems(plan client.UpgradePlan) {
 func sortUpgradePlans(upgradePlans []client.UpgradePlan) {
 	sort.Slice(upgradePlans, func(i, j int) bool {
 		return upgradePlans[i].CoreProvider.Namespace < upgradePlans[j].CoreProvider.Namespace ||
-			(upgradePlans[i].CoreProvider.Namespace == upgradePlans[j].CoreProvider.Namespace && upgradePlans[i].ClusterAPIVersion < upgradePlans[j].ClusterAPIVersion)
+			(upgradePlans[i].CoreProvider.Namespace == upgradePlans[j].CoreProvider.Namespace && upgradePlans[i].Contract < upgradePlans[j].Contract)
 	})
 }
 

--- a/cmd/clusterctl/config/crd/bases/clusterctl.cluster.x-k8s.io_metadata.yaml
+++ b/cmd/clusterctl/config/crd/bases/clusterctl.cluster.x-k8s.io_metadata.yaml
@@ -35,11 +35,11 @@ spec:
         releaseSeries:
           items:
             description: ReleaseSeries maps a provider release series (major/minor)
-              with a ClusterAPIVersion
+              with a API Version of Cluster API (contract).
             properties:
-              clusterAPIVersion:
-                description: ClusterAPIVersion indicates the cluster API supported
-                  version.
+              contract:
+                description: Contract defines the API Version of Cluster API (contract)
+                  supported by the ReleaseSeries.
                 type: string
               major:
                 description: Major version of the release series

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -148,7 +148,7 @@ type Client interface {
 
 	// PlanUpgrade returns a set of suggested Upgrade plans for the cluster, and more specifically:
 	// - Each management group gets separated upgrade plans.
-	// - For each management group, an upgrade plan is generated for each ClusterAPIVersion available, e.g.
+	// - For each management group, an upgrade plan is generated for each API Version of Cluster API (contract) available, e.g.
 	//   - Upgrade to the latest version in the the v1alpha2 series: ....
 	//   - Upgrade to the latest version in the the v1alpha3 series: ....
 	PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePlan, error)

--- a/cmd/clusterctl/pkg/client/cluster/inventory.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory.go
@@ -53,7 +53,7 @@ type InventoryClient interface {
 	Create(clusterctlv1.Provider) error
 
 	// List returns the inventory items for all the provider instances installed in the cluster.
-	List() ([]clusterctlv1.Provider, error)
+	List() (*clusterctlv1.ProviderList, error)
 
 	// GetDefaultProviderName returns the default provider for a given ProviderType.
 	// In case there is only a single provider for a given type, e.g. only the AWS infrastructure Provider, it returns
@@ -71,15 +71,7 @@ type InventoryClient interface {
 	GetDefaultProviderNamespace(provider string) (string, error)
 
 	// GetManagementGroups returns the list of management groups defined in the management cluster.
-	GetManagementGroups() ([]ManagementGroup, error)
-}
-
-// ManagementGroup is a group of providers composed by a CoreProvider and a set of Bootstrap/ControlPlane/Infrastructure providers
-// watching objects in the same namespace. For example, a management group can be used for upgrades, in order to ensure all the providers
-// in a management group support the same ClusterAPI version.
-type ManagementGroup struct {
-	CoreProvider clusterctlv1.Provider
-	Providers    []clusterctlv1.Provider
+	GetManagementGroups() (ManagementGroupList, error)
 }
 
 // inventoryClient implements InventoryClient.
@@ -178,7 +170,7 @@ func (p *inventoryClient) EnsureCustomResourceDefinitions() error {
 }
 
 func (p *inventoryClient) Validate(m clusterctlv1.Provider) error {
-	providerList, err := p.list()
+	providerList, err := p.List()
 	if err != nil {
 		return err
 	}
@@ -242,15 +234,7 @@ func (p *inventoryClient) Create(m clusterctlv1.Provider) error {
 	return nil
 }
 
-func (p *inventoryClient) List() ([]clusterctlv1.Provider, error) {
-	providerList, err := p.list()
-	if err != nil {
-		return nil, err
-	}
-	return providerList.Items, nil
-}
-
-func (p *inventoryClient) list() (*clusterctlv1.ProviderList, error) {
+func (p *inventoryClient) List() (*clusterctlv1.ProviderList, error) {
 	cl, err := p.proxy.NewClient()
 	if err != nil {
 		return nil, err
@@ -264,7 +248,7 @@ func (p *inventoryClient) list() (*clusterctlv1.ProviderList, error) {
 }
 
 func (p *inventoryClient) GetDefaultProviderName(providerType clusterctlv1.ProviderType) (string, error) {
-	providerList, err := p.list()
+	providerList, err := p.List()
 	if err != nil {
 		return "", err
 	}
@@ -285,7 +269,7 @@ func (p *inventoryClient) GetDefaultProviderName(providerType clusterctlv1.Provi
 }
 
 func (p *inventoryClient) GetDefaultProviderVersion(provider string) (string, error) {
-	providerList, err := p.list()
+	providerList, err := p.List()
 	if err != nil {
 		return "", err
 	}
@@ -305,7 +289,7 @@ func (p *inventoryClient) GetDefaultProviderVersion(provider string) (string, er
 }
 
 func (p *inventoryClient) GetDefaultProviderNamespace(provider string) (string, error) {
-	providerList, err := p.list()
+	providerList, err := p.List()
 	if err != nil {
 		return "", err
 	}

--- a/cmd/clusterctl/pkg/client/cluster/inventory_managementgroup_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory_managementgroup_test.go
@@ -20,7 +20,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
@@ -34,7 +33,7 @@ func Test_inventoryClient_GetManagementGroups(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		want    []ManagementGroup
+		want    ManagementGroupList
 		wantErr bool
 	}{
 		{
@@ -45,7 +44,7 @@ func Test_inventoryClient_GetManagementGroups(t *testing.T) {
 					WithProviderInventory("bootstrap", clusterctlv1.BootstrapProviderType, "v1.0.0", "bootstrap-system", "").
 					WithProviderInventory("infrastructure", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra-system", ""),
 			},
-			want: []ManagementGroup{ // One Group
+			want: ManagementGroupList{ // One Group
 				{
 					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
 					Providers: []clusterctlv1.Provider{
@@ -66,7 +65,7 @@ func Test_inventoryClient_GetManagementGroups(t *testing.T) {
 					WithProviderInventory("infrastructure", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra-system1", "ns1").
 					WithProviderInventory("infrastructure", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra-system2", "ns2"),
 			},
-			want: []ManagementGroup{ // One Group
+			want: ManagementGroupList{ // One Group
 				{
 					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
 					Providers: []clusterctlv1.Provider{
@@ -90,7 +89,7 @@ func Test_inventoryClient_GetManagementGroups(t *testing.T) {
 					WithProviderInventory("bootstrap", clusterctlv1.BootstrapProviderType, "v1.0.0", "bootstrap-system2", "ns2").
 					WithProviderInventory("infrastructure", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra-system2", "ns2"),
 			},
-			want: []ManagementGroup{ // Two Groups
+			want: ManagementGroupList{ // Two Groups
 				{
 					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system1", "ns1"),
 					Providers: []clusterctlv1.Provider{
@@ -157,7 +156,6 @@ func Test_inventoryClient_GetManagementGroups(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(got, tt.want) {
-				spew.Dump(got, tt.want)
 				t.Errorf("got = %v, want %v", got, tt.want)
 			}
 		})

--- a/cmd/clusterctl/pkg/client/cluster/inventory_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/inventory_test.go
@@ -110,8 +110,8 @@ func Test_inventoryClient_List(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
+			if !reflect.DeepEqual(got.Items, tt.want) {
+				t.Errorf("got = %v, want %v", got.Items, tt.want)
 			}
 		})
 	}

--- a/cmd/clusterctl/pkg/client/cluster/upgrader_info.go
+++ b/cmd/clusterctl/pkg/client/cluster/upgrader_info.go
@@ -28,7 +28,7 @@ import (
 
 // upgradeInfo holds all the information required for taking upgrade decisions for a provider
 type upgradeInfo struct {
-	// metadata holds the information about releaseSeries and the link between release series and Cluster API/API versions.
+	// metadata holds the information about releaseSeries and the link between release series and the API Version of Cluster API (contract).
 	// e.g. release series 0.5.x for the AWS provider --> v1alpha3
 	metadata *clusterctlv1.Metadata
 
@@ -59,7 +59,7 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 	}
 
 	if len(repositoryVersions) == 0 {
-		return nil, errors.Errorf("failed to get available versions for the %s/%s provider", provider.Namespace, provider.Name)
+		return nil, errors.Errorf("failed to get available versions for the %s provider", provider.InstanceName())
 	}
 
 	//  Pick the provider's latest version available in the repository and use it to get the most recent metadata for the provider.
@@ -67,7 +67,7 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 	for _, availableVersion := range repositoryVersions {
 		availableSemVersion, err := version.ParseSemantic(availableVersion)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to parse available version for the %s/%s provider", provider.Namespace, provider.Name)
+			return nil, errors.Wrapf(err, "failed to parse available version for the %s provider", provider.InstanceName())
 		}
 		if latestVersion == nil || latestVersion.LessThan(availableSemVersion) {
 			latestVersion = availableSemVersion
@@ -82,11 +82,11 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 	// Get current provider version and check if the releaseSeries defined in metadata includes it.
 	currentVersion, err := version.ParseSemantic(provider.Version)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse current version for the %s/%s provider", provider.Namespace, provider.Name)
+		return nil, errors.Wrapf(err, "failed to parse current version for the %s provider", provider.InstanceName())
 	}
 
-	if !latestMetadata.HasReleaseSeriesForVersion(currentVersion) {
-		return nil, errors.Errorf("invalid provider metadata: version %s (the current version) for the provider %s/%s does not match any release series", provider.Version, provider.Namespace, provider.Name)
+	if latestMetadata.GetReleaseSeriesForVersion(currentVersion) == nil {
+		return nil, errors.Errorf("invalid provider metadata: version %s (the current version) for the provider %s does not match any release series", provider.Version, provider.InstanceName())
 	}
 
 	// Filters the versions to be considered for upgrading the provider (next versions) and checks if the releaseSeries defined in metadata includes all of them.
@@ -101,8 +101,8 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 			continue
 		}
 
-		if !latestMetadata.HasReleaseSeriesForVersion(repositorySemVersion) {
-			return nil, errors.Errorf("invalid provider metadata: version %s (one of the available versions) for the provider %s/%s does not match any release series", repositoryVersion, provider.Namespace, provider.Name)
+		if latestMetadata.GetReleaseSeriesForVersion(repositorySemVersion) == nil {
+			return nil, errors.Errorf("invalid provider metadata: version %s (one of the available versions) for the provider %s does not match any release series", repositoryVersion, provider.InstanceName())
 		}
 
 		nextVersions = append(nextVersions, *repositorySemVersion)
@@ -112,7 +112,7 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 }
 
 func newUpgradeInfo(metadata *clusterctlv1.Metadata, currentVersion *version.Version, nextVersions []version.Version) *upgradeInfo {
-	// Sorts release series; this ensures also an implicit ordering of ClusterAPI/API version.
+	// Sorts release series; this ensures also an implicit ordering of API Version of Cluster API (contract).
 	sort.Slice(metadata.ReleaseSeries, func(i, j int) bool {
 		return metadata.ReleaseSeries[i].Major < metadata.ReleaseSeries[j].Major ||
 			(metadata.ReleaseSeries[i].Major == metadata.ReleaseSeries[j].Major && metadata.ReleaseSeries[i].Minor < metadata.ReleaseSeries[j].Minor)
@@ -130,29 +130,29 @@ func newUpgradeInfo(metadata *clusterctlv1.Metadata, currentVersion *version.Ver
 	}
 }
 
-// getAPIVersionsForUpgrade return the list of ClusterAPI/API version available for a provider upgrade. e.g.
-// - If the current version of the provider support v1alpha3 ClusterAPI/APIVersion (the latest), it returns v1alpha3
-// - If the current version of the provider support v1alpha3 ClusterAPI/APIVersion but there is also the v1alpha4 ClusterAPI/APIVersion available, it returns v1alpha3, v1alpha4
-func (i *upgradeInfo) getAPIVersionsForUpgrade() []string {
-	apiVersionsForUpgrade := sets.NewString()
+// getContractsForUpgrade return the list of API Version of Cluster API (contract) version available for a provider upgrade. e.g.
+// - If the current version of the provider support v1alpha3 contract (the latest), it returns v1alpha3
+// - If the current version of the provider support v1alpha3 contract but there is also the v1alpha4 contract available, it returns v1alpha3, v1alpha4
+func (i *upgradeInfo) getContractsForUpgrade() []string {
+	contractsForUpgrade := sets.NewString()
 	for _, releaseSeries := range i.metadata.ReleaseSeries {
 		// Drop the release series if older than the current version, because not relevant for upgrade.
 		if i.currentVersion.Major() > releaseSeries.Major || (i.currentVersion.Major() == releaseSeries.Major && i.currentVersion.Minor() > releaseSeries.Minor) {
 			continue
 		}
-		apiVersionsForUpgrade.Insert(releaseSeries.ClusterAPIVersion)
+		contractsForUpgrade.Insert(releaseSeries.Contract)
 	}
 
-	return apiVersionsForUpgrade.List()
+	return contractsForUpgrade.List()
 }
 
-// getLatestNextVersion returns the next available version for a provider within the target ClusterAPI/API version.
-// the next available version is tha latest version available in the for the target ClusterAPI/API version.
-func (i *upgradeInfo) getLatestNextVersion(targetAPIVersion string) *version.Version {
+// getLatestNextVersion returns the next available version for a provider within the target API Version of Cluster API (contract).
+// the next available version is tha latest version available in the for the target contract version.
+func (i *upgradeInfo) getLatestNextVersion(contract string) *version.Version {
 	var latestNextVersion *version.Version
 	for _, releaseSeries := range i.metadata.ReleaseSeries {
-		// Skip the release series if not linked with the target ClusterAPI/API version version
-		if releaseSeries.ClusterAPIVersion != targetAPIVersion {
+		// Skip the release series if not linked with the target contract version version
+		if releaseSeries.Contract != contract {
 			continue
 		}
 

--- a/cmd/clusterctl/pkg/client/cluster/upgrader_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/upgrader_test.go
@@ -39,26 +39,26 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Single Management group, no multi-tenancy, upgrade within the same Cluster API version",
+			name: "Single Management group, no multi-tenancy, upgrade within the same contact",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("core", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version in the v1alpha3 ClusterAPIVersion
+				// two provider repositories, each with a new version in the v1alpha3 contract
 				repository: map[string]repository.Repository{
 					"core": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1").
 						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, ClusterAPIVersion: "v1alpha3"},
+								{Major: 1, Minor: 0, Contract: "v1alpha3"},
 							},
 						}),
 					"infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1").
 						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, ClusterAPIVersion: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: "v1alpha3"},
 							},
 						}),
 				},
@@ -68,9 +68,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases the v1alpha3 ClusterAPIVersion
-					ClusterAPIVersion: "v1alpha3",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
+				{ // one upgrade plan with the latest releases the v1alpha3 contract
+					Contract:     "v1alpha3",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
@@ -86,28 +86,28 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, no multi-tenancy, upgrade for two Cluster API versions",
+			name: "Single Management group, no multi-tenancy, upgrade for two contacts",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("core", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version for current v1alpha3 ClusterAPIVersion and a new version for the v1alpha4 ClusterAPIVersion
+				// two provider repositories, each with a new version for current v1alpha3 contract and a new version for the v1alpha4 contract
 				repository: map[string]repository.Repository{
 					"core": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, ClusterAPIVersion: "v1alpha3"},
-								{Major: 2, Minor: 0, ClusterAPIVersion: "v1alpha4"},
+								{Major: 1, Minor: 0, Contract: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: "v1alpha4"},
 							},
 						}),
 					"infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, ClusterAPIVersion: "v1alpha3"},
-								{Major: 3, Minor: 0, ClusterAPIVersion: "v1alpha4"},
+								{Major: 2, Minor: 0, Contract: "v1alpha3"},
+								{Major: 3, Minor: 0, Contract: "v1alpha4"},
 							},
 						}),
 				},
@@ -117,9 +117,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 ClusterAPIVersion
-					ClusterAPIVersion: "v1alpha3",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
+				{ // one upgrade plan with the latest releases in the v1alpha3 contract
+					Contract:     "v1alpha3",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
@@ -131,9 +131,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 ClusterAPIVersion
-					ClusterAPIVersion: "v1alpha4",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
+				{ // one upgrade plan with the latest releases in the v1alpha4 contract
+					Contract:     "v1alpha4",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
@@ -149,26 +149,26 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Infra multi-tenancy, upgrade within the same Cluster API version",
+			name: "Single Management group, n-Infra multi-tenancy, upgrade within the same contact",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("core", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version in the v1alpha3 ClusterAPIVersion
+				// two provider repositories, each with a new version in the v1alpha3 contract
 				repository: map[string]repository.Repository{
 					"core": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1").
 						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, ClusterAPIVersion: "v1alpha3"},
+								{Major: 1, Minor: 0, Contract: "v1alpha3"},
 							},
 						}),
 					"infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1").
 						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, ClusterAPIVersion: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: "v1alpha3"},
 							},
 						}),
 				},
@@ -179,9 +179,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 ClusterAPIVersion
-					ClusterAPIVersion: "v1alpha3",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
+				{ // one upgrade plan with the latest releases in the v1alpha3 contract
+					Contract:     "v1alpha3",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
@@ -201,28 +201,28 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Infra multi-tenancy, upgrade for two Cluster API versions",
+			name: "Single Management group, n-Infra multi-tenancy, upgrade for two contacts",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("core", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version for current v1alpha3 ClusterAPIVersion and a new version for the v1alpha4 ClusterAPIVersion
+				// two provider repositories, each with a new version for current v1alpha3 contract and a new version for the v1alpha4 contract
 				repository: map[string]repository.Repository{
 					"core": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, ClusterAPIVersion: "v1alpha3"},
-								{Major: 2, Minor: 0, ClusterAPIVersion: "v1alpha4"},
+								{Major: 1, Minor: 0, Contract: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: "v1alpha4"},
 							},
 						}),
 					"infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, ClusterAPIVersion: "v1alpha3"},
-								{Major: 3, Minor: 0, ClusterAPIVersion: "v1alpha4"},
+								{Major: 2, Minor: 0, Contract: "v1alpha3"},
+								{Major: 3, Minor: 0, Contract: "v1alpha4"},
 							},
 						}),
 				},
@@ -233,9 +233,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 ClusterAPIVersion
-					ClusterAPIVersion: "v1alpha3",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
+				{ // one upgrade plan with the latest releases in the v1alpha3 contract
+					Contract:     "v1alpha3",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
@@ -251,9 +251,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 ClusterAPIVersion
-					ClusterAPIVersion: "v1alpha4",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
+				{ // one upgrade plan with the latest releases in the v1alpha4 contract
+					Contract:     "v1alpha4",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
@@ -273,26 +273,26 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Core multi-tenancy, upgrade within the same Cluster API version",
+			name: "Single Management group, n-Core multi-tenancy, upgrade within the same contact",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("core", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version in the v1alpha3 ClusterAPIVersion
+				// two provider repositories, each with a new version in the v1alpha3 contract
 				repository: map[string]repository.Repository{
 					"core": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1").
 						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, ClusterAPIVersion: "v1alpha3"},
+								{Major: 1, Minor: 0, Contract: "v1alpha3"},
 							},
 						}),
 					"infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1").
 						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, ClusterAPIVersion: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: "v1alpha3"},
 							},
 						}),
 				},
@@ -304,9 +304,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 ClusterAPIVersion for the first management group
-					ClusterAPIVersion: "v1alpha3",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system1", "ns1"),
+				{ // one upgrade plan with the latest releases in the v1alpha3 contract for the first management group
+					Contract:     "v1alpha3",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system1", "ns1"),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system1", "ns1"),
@@ -318,9 +318,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha3 ClusterAPIVersion for the second management group
-					ClusterAPIVersion: "v1alpha3",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system2", "ns2"),
+				{ // one upgrade plan with the latest releases in the v1alpha3 contract for the second management group
+					Contract:     "v1alpha3",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system2", "ns2"),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system2", "ns2"),
@@ -336,28 +336,28 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Core multi-tenancy, upgrade for two Cluster API versions",
+			name: "Single Management group, n-Core multi-tenancy, upgrade for two contacts",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("core", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version for current v1alpha3 ClusterAPIVersion and a new version for the v1alpha4 ClusterAPIVersion
+				// two provider repositories, each with a new version for current v1alpha3 contract and a new version for the v1alpha4 contract
 				repository: map[string]repository.Repository{
 					"core": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, ClusterAPIVersion: "v1alpha3"},
-								{Major: 2, Minor: 0, ClusterAPIVersion: "v1alpha4"},
+								{Major: 1, Minor: 0, Contract: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: "v1alpha4"},
 							},
 						}),
 					"infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, ClusterAPIVersion: "v1alpha3"},
-								{Major: 3, Minor: 0, ClusterAPIVersion: "v1alpha4"},
+								{Major: 2, Minor: 0, Contract: "v1alpha3"},
+								{Major: 3, Minor: 0, Contract: "v1alpha4"},
 							},
 						}),
 				},
@@ -369,9 +369,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 ClusterAPIVersion for the first management group
-					ClusterAPIVersion: "v1alpha3",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system1", "ns1"),
+				{ // one upgrade plan with the latest releases in the v1alpha3 contract for the first management group
+					Contract:     "v1alpha3",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system1", "ns1"),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system1", "ns1"),
@@ -383,9 +383,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 ClusterAPIVersion for the first management group
-					ClusterAPIVersion: "v1alpha4",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system1", "ns1"),
+				{ // one upgrade plan with the latest releases in the v1alpha4 contract for the first management group
+					Contract:     "v1alpha4",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system1", "ns1"),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system1", "ns1"),
@@ -397,9 +397,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha3 ClusterAPIVersion for the second management group
-					ClusterAPIVersion: "v1alpha3",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system2", "ns2"),
+				{ // one upgrade plan with the latest releases in the v1alpha3 contract for the second management group
+					Contract:     "v1alpha3",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system2", "ns2"),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system2", "ns2"),
@@ -411,9 +411,9 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 ClusterAPIVersion for the second management group
-					ClusterAPIVersion: "v1alpha4",
-					CoreProvider:      fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system2", "ns2"),
+				{ // one upgrade plan with the latest releases in the v1alpha4 contract for the second management group
+					Contract:     "v1alpha4",
+					CoreProvider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system2", "ns2"),
 					Providers: []UpgradeItem{
 						{
 							Provider:    fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system2", "ns2"),

--- a/cmd/clusterctl/pkg/client/delete.go
+++ b/cmd/clusterctl/pkg/client/delete.go
@@ -44,7 +44,7 @@ func (c *clusterctlClient) Delete(options DeleteOptions) error {
 	var providers []clusterctlv1.Provider
 
 	if len(options.Providers) == 0 {
-		providers = installedProviders
+		providers = installedProviders.Items
 	} else {
 		// Otherwise we are deleting only a subset of providers.
 		for _, provider := range options.Providers {
@@ -71,7 +71,7 @@ func (c *clusterctlClient) Delete(options DeleteOptions) error {
 
 			// Check the provider/namespace tuple actually matches one of the installed providers.
 			found := false
-			for _, ip := range installedProviders {
+			for _, ip := range installedProviders.Items {
 				if ip.Name == name && ip.Namespace == namespace {
 					found = true
 					providers = append(providers, ip)

--- a/cmd/clusterctl/pkg/client/repository/metadata_client.go
+++ b/cmd/clusterctl/pkg/client/repository/metadata_client.go
@@ -108,9 +108,9 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 			},
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
 				// v1alpha3 release series
-				{Major: 0, Minor: 3, ClusterAPIVersion: "v1alpha3"},
+				{Major: 0, Minor: 3, Contract: "v1alpha3"},
 				// v1alpha2 release series are supported only for upgrades
-				{Major: 0, Minor: 2, ClusterAPIVersion: "v1alpha2"},
+				{Major: 0, Minor: 2, Contract: "v1alpha2"},
 				// older version are not supported by clusterctl
 			},
 		}
@@ -122,9 +122,9 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 			},
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
 				// v1alpha3 release series
-				{Major: 0, Minor: 3, ClusterAPIVersion: "v1alpha3"}, // From this release series CAPD version scheme is linked to CAPI
+				{Major: 0, Minor: 3, Contract: "v1alpha3"}, // From this release series CAPD version scheme is linked to CAPI
 				// v1alpha2 release series are supported only for upgrades
-				{Major: 0, Minor: 2, ClusterAPIVersion: "v1alpha2"}, // This release was hosted on a different repository
+				{Major: 0, Minor: 2, Contract: "v1alpha2"}, // This release was hosted on a different repository
 				// older version are not supported by clusterctl
 			},
 		}
@@ -136,9 +136,9 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 			},
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
 				// v1alpha3 release series
-				{Major: 0, Minor: 3, ClusterAPIVersion: "v1alpha3"}, // From this release series CABPK version scheme is linked to CAPI; The 0.2 release series was skipped when doing this change.
+				{Major: 0, Minor: 3, Contract: "v1alpha3"}, // From this release series CABPK version scheme is linked to CAPI; The 0.2 release series was skipped when doing this change.
 				// v1alpha2 release series are supported only for upgrades
-				{Major: 0, Minor: 1, ClusterAPIVersion: "v1alpha2"}, // This release was hosted on a different repository
+				{Major: 0, Minor: 1, Contract: "v1alpha2"}, // This release was hosted on a different repository
 				// older version are not supported by clusterctl
 			},
 		}
@@ -150,9 +150,9 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 			},
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
 				// v1alpha3 release series
-				{Major: 0, Minor: 5, ClusterAPIVersion: "v1alpha3"},
+				{Major: 0, Minor: 5, Contract: "v1alpha3"},
 				// v1alpha2 release series are supported only for upgrades
-				{Major: 0, Minor: 4, ClusterAPIVersion: "v1alpha2"},
+				{Major: 0, Minor: 4, Contract: "v1alpha2"},
 				// older version are not supported by clusterctl
 			},
 		}
@@ -164,9 +164,9 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 			},
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
 				// v1alpha3 release series
-				{Major: 0, Minor: 6, ClusterAPIVersion: "v1alpha3"},
+				{Major: 0, Minor: 6, Contract: "v1alpha3"},
 				// v1alpha2 release series are supported only for upgrades
-				{Major: 0, Minor: 5, ClusterAPIVersion: "v1alpha2"},
+				{Major: 0, Minor: 5, Contract: "v1alpha2"},
 				// older version are not supported by clusterctl
 			},
 		}

--- a/cmd/clusterctl/pkg/client/repository/metadata_client_test.go
+++ b/cmd/clusterctl/pkg/client/repository/metadata_client_test.go
@@ -31,7 +31,7 @@ var metadataYaml = []byte("apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3\n" +
 	"releaseSeries:\n" +
 	" - major: 1\n" +
 	"   minor: 2\n" +
-	"   clusterAPIVersion: v1alpha3\n" +
+	"   contract: v1alpha3\n" +
 	"")
 
 func Test_metadataClient_Get(t *testing.T) {
@@ -63,9 +63,9 @@ func Test_metadataClient_Get(t *testing.T) {
 				},
 				ReleaseSeries: []clusterctlv1.ReleaseSeries{
 					{
-						Major:             1,
-						Minor:             2,
-						ClusterAPIVersion: "v1alpha3",
+						Major:    1,
+						Minor:    2,
+						Contract: "v1alpha3",
 					},
 				},
 			},
@@ -86,8 +86,8 @@ func Test_metadataClient_Get(t *testing.T) {
 					Kind:       "Metadata",
 				},
 				ReleaseSeries: []clusterctlv1.ReleaseSeries{
-					{Major: 0, Minor: 3, ClusterAPIVersion: "v1alpha3"},
-					{Major: 0, Minor: 2, ClusterAPIVersion: "v1alpha2"},
+					{Major: 0, Minor: 3, Contract: "v1alpha3"},
+					{Major: 0, Minor: 2, Contract: "v1alpha2"},
 				},
 			},
 			wantErr: false,

--- a/cmd/clusterctl/pkg/client/upgrade.go
+++ b/cmd/clusterctl/pkg/client/upgrade.go
@@ -37,9 +37,9 @@ func (c *clusterctlClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePla
 	aliasUpgradePlan := make([]UpgradePlan, len(upgradePlan))
 	for i, plan := range upgradePlan {
 		aliasUpgradePlan[i] = UpgradePlan{
-			ClusterAPIVersion: plan.ClusterAPIVersion,
-			CoreProvider:      plan.CoreProvider,
-			Providers:         plan.Providers,
+			Contract:     plan.Contract,
+			CoreProvider: plan.CoreProvider,
+			Providers:    plan.Providers,
 		}
 	}
 

--- a/cmd/clusterctl/pkg/internal/util/yaml.go
+++ b/cmd/clusterctl/pkg/internal/util/yaml.go
@@ -80,7 +80,7 @@ func FromUnstructured(objs []unstructured.Unstructured) ([]byte, error) {
 	for _, o := range objs {
 		content, err := yaml.Marshal(o.UnstructuredContent())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to marshal yaml for %s/%s", o.GetNamespace(), o.GetName())
+			return nil, errors.Wrapf(err, "failed to marshal yaml for %s, %s/%s", o.GroupVersionKind(), o.GetNamespace(), o.GetName())
 		}
 		ret = append(ret, content)
 	}

--- a/docs/book/src/clusterctl/provider-contract.md
+++ b/docs/book/src/clusterctl/provider-contract.md
@@ -38,7 +38,7 @@ It is possible to customize the list of providers for `clusterctl` by changing t
 
 The provider is required to generate a **metadata YAML** file and publish it to the provider's repository.
 
-The metadata YAML file documents the release series of each provider and maps each release series to a Cluster API version.
+The metadata YAML file documents the release series of each provider and maps each release series to an API Version of Cluster API (contract).
 
 For example, for Cluster API:
 
@@ -48,10 +48,10 @@ kind: Metadata
 releaseSeries:
 - major: 0
   minor: 3
-  clusterAPIVersion: v1alpha3
+  contract: v1alpha3
 - major: 0
   minor: 2
-  clusterAPIVersion: v1alpha2
+  contract: v1alpha2
 ```
 
 <aside class="note">


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cleanup the inventory types and set the stages for implementing:
- clusterctl upgrade apply
- validation of the contract version during init

I have added comments explaining the main changes

**Which issue(s) this PR fixes**:
rif #1729 


