### PR TITLE
 📖 Add kubeadm-control-plane to the example providers in clusterctl docs

### DIFF
--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -5,7 +5,7 @@ This document describes how to use `clusterctl` during the development workflow.
 ## Prerequisites
 
 * A Cluster API development setup (go, git, etc.)
-* A local clone of the Cluster API GitHub repository  
+* A local clone of the Cluster API GitHub repository
 * A local clone of the GitHub repositories for the providers you want to install
 
 ## Getting started
@@ -27,7 +27,7 @@ Next, create a `clusterctl-settings.json` file and place it in your local copy o
 
 ```yaml
 {
-  "providers": [ "cluster-api", "kubeadm-bootstrap", "aws"],
+  "providers": ["kubeadm-bootstrap","kubeadm-control-plane", "aws"],
   "provider_repos": ["../cluster-api-provider-aws"]
 }
 ```
@@ -57,7 +57,7 @@ in order to use them, please run:
 clusterctl init  --core cluster-api:v0.3.0 --bootstrap kubeadm-bootstrap:v0.3.0 --infrastructure aws:v0.5.0
 ```
 
-## Available providers 
+## Available providers
 
 The following providers are currently defined in the script:
 


### PR DESCRIPTION


<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Missing "kubeadm-control-plane" in example providers for clusterctl developer docs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
