### PR TITLE
⚠️  Pass context through remote get client

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
@@ -233,7 +233,7 @@ func TestKubeadmConfigReconciler_Reconcile_MigrateToSecret(t *testing.T) {
 		t.Fatal("did not expect to requeue after")
 	}
 
-	if err := k.Client.Get(context.TODO(), types.NamespacedName{Name: config.Name, Namespace: config.Namespace}, config); err != nil {
+	if err := k.Client.Get(context.Background(), types.NamespacedName{Name: config.Name, Namespace: config.Namespace}, config); err != nil {
 		t.Fatalf("failed to get KubeadmConfig: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func TestKubeadmConfigReconciler_Reconcile_MigrateToSecret(t *testing.T) {
 	}
 
 	secret := &corev1.Secret{}
-	if err := k.Client.Get(context.TODO(), types.NamespacedName{Namespace: config.Namespace, Name: *config.Status.DataSecretName}, secret); err != nil {
+	if err := k.Client.Get(context.Background(), types.NamespacedName{Namespace: config.Namespace, Name: *config.Status.DataSecretName}, secret); err != nil {
 		t.Fatalf("failed to get Secret bootstrap data for KubeadmConfig: %v", err)
 	}
 
@@ -684,7 +684,7 @@ func TestReconcileIfJoinNodesAndControlPlaneIsReady(t *testing.T) {
 			}
 
 			l := &corev1.SecretList{}
-			if err := myclient.List(context.TODO(), l, client.ListOption(client.InNamespace(metav1.NamespaceSystem))); err != nil {
+			if err := myclient.List(context.Background(), l, client.ListOption(client.InNamespace(metav1.NamespaceSystem))); err != nil {
 				t.Fatal(errors.Wrap(err, "failed to get l after reconcile"))
 			}
 
@@ -778,7 +778,7 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 	}
 
 	l := &corev1.SecretList{}
-	if err := myclient.List(context.TODO(), l, client.ListOption(client.InNamespace(metav1.NamespaceSystem))); err != nil {
+	if err := myclient.List(context.Background(), l, client.ListOption(client.InNamespace(metav1.NamespaceSystem))); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to get l after reconcile"))
 	}
 
@@ -820,7 +820,7 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 	}
 
 	l = &corev1.SecretList{}
-	if err := myclient.List(context.TODO(), l, client.ListOption(client.InNamespace(metav1.NamespaceSystem))); err != nil {
+	if err := myclient.List(context.Background(), l, client.ListOption(client.InNamespace(metav1.NamespaceSystem))); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to get l after reconcile"))
 	}
 
@@ -878,7 +878,7 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 	}
 
 	l = &corev1.SecretList{}
-	if err := myclient.List(context.TODO(), l, client.ListOption(client.InNamespace(metav1.NamespaceSystem))); err != nil {
+	if err := myclient.List(context.Background(), l, client.ListOption(client.InNamespace(metav1.NamespaceSystem))); err != nil {
 		t.Fatal(errors.Wrap(err, "failed to get l after reconcile"))
 	}
 
@@ -1041,7 +1041,7 @@ func TestKubeadmConfigReconciler_Reconcile_DisocveryReconcileBehaviors(t *testin
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := k.reconcileDiscovery(tc.cluster, tc.config, secret.Certificates{})
+			err := k.reconcileDiscovery(context.Background(), tc.cluster, tc.config, secret.Certificates{})
 			if err != nil {
 				t.Errorf("expected nil, got error %v", err)
 			}
@@ -1084,7 +1084,7 @@ func TestKubeadmConfigReconciler_Reconcile_DisocveryReconcileFailureBehaviors(t 
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := k.reconcileDiscovery(tc.cluster, tc.config, secret.Certificates{})
+			err := k.reconcileDiscovery(context.Background(), tc.cluster, tc.config, secret.Certificates{})
 			if err == nil {
 				t.Error("expected error, got nil")
 			}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -188,8 +188,7 @@ func (r *ClusterReconciler) reconcileMetrics(_ context.Context, cluster *cluster
 		metrics.ClusterInfrastructureReady.WithLabelValues(cluster.Name, cluster.Namespace).Set(0)
 	}
 
-	// TODO: [wfernandes] pass context here
-	_, err := secret.Get(r.Client, cluster, secret.Kubeconfig)
+	_, err := secret.Get(context.Background(), r.Client, cluster, secret.Kubeconfig)
 	if err != nil {
 		metrics.ClusterKubeconfigReady.WithLabelValues(cluster.Name, cluster.Namespace).Set(0)
 	} else {

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -232,7 +232,7 @@ func (r *ClusterReconciler) reconcileKubeconfig(ctx context.Context, cluster *cl
 		return nil
 	}
 
-	_, err := secret.Get(r.Client, cluster, secret.Kubeconfig)
+	_, err := secret.Get(ctx, r.Client, cluster, secret.Kubeconfig)
 	switch {
 	case apierrors.IsNotFound(err):
 		if err := kubeconfig.CreateSecret(ctx, r.Client, cluster); err != nil {

--- a/controllers/machine_controller_noderef.go
+++ b/controllers/machine_controller_noderef.go
@@ -33,7 +33,7 @@ var (
 	ErrNodeNotFound = errors.New("cannot find node with matching ProviderID")
 )
 
-func (r *MachineReconciler) reconcileNodeRef(_ context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
+func (r *MachineReconciler) reconcileNodeRef(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	logger := r.Log.WithValues("machine", machine.Name, "namespace", machine.Namespace)
 	// Check that the Machine hasn't been deleted or in the process.
 	if !machine.DeletionTimestamp.IsZero() {
@@ -64,7 +64,7 @@ func (r *MachineReconciler) reconcileNodeRef(_ context.Context, cluster *cluster
 		return err
 	}
 
-	clusterClient, err := remote.NewClusterClient(r.Client, cluster, r.scheme)
+	clusterClient, err := remote.NewClusterClient(ctx, r.Client, cluster, r.scheme)
 	if err != nil {
 		return err
 	}

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -709,7 +709,7 @@ func (r *MachineSetReconciler) patchMachineSetStatus(ctx context.Context, ms *cl
 }
 
 func (r *MachineSetReconciler) getMachineNode(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (*corev1.Node, error) {
-	c, err := remote.NewClusterClient(r.Client, cluster, r.scheme)
+	c, err := remote.NewClusterClient(ctx, r.Client, cluster, r.scheme)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -17,6 +17,8 @@ limitations under the License.
 package remote
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	restclient "k8s.io/client-go/rest"
@@ -28,11 +30,11 @@ import (
 )
 
 // ClusterClientGetter returns a new remote client.
-type ClusterClientGetter func(c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error)
+type ClusterClientGetter func(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error)
 
 // NewClusterClient returns a Client for interacting with a remote Cluster using the given scheme for encoding and decoding objects.
-func NewClusterClient(c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error) {
-	restConfig, err := RESTConfig(c, cluster)
+func NewClusterClient(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error) {
+	restConfig, err := RESTConfig(ctx, c, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +51,8 @@ func NewClusterClient(c client.Client, cluster *clusterv1.Cluster, scheme *runti
 }
 
 // RESTConfig returns a configuration instance to be used with a Kubernetes client.
-func RESTConfig(c client.Client, cluster *clusterv1.Cluster) (*restclient.Config, error) {
-	kubeConfig, err := kcfg.FromSecret(c, cluster)
+func RESTConfig(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (*restclient.Config, error) {
+	kubeConfig, err := kcfg.FromSecret(ctx, c, cluster)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve kubeconfig secret for Cluster %s/%s", cluster.Namespace, cluster.Name)
 	}

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package remote
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -96,27 +97,27 @@ func TestNewClusterClient(t *testing.T) {
 
 	testScheme := runtime.NewScheme()
 	g.Expect(scheme.AddToScheme(testScheme)).To(Succeed())
-
+	ctx := context.Background()
 	t.Run("cluster with valid kubeconfig", func(t *testing.T) {
 		client := fake.NewFakeClientWithScheme(testScheme, validSecret)
-		c, err := NewClusterClient(client, clusterWithValidKubeConfig, testScheme)
+		c, err := NewClusterClient(ctx, client, clusterWithValidKubeConfig, testScheme)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(c).NotTo(BeNil())
 
-		restConfig, err := RESTConfig(client, clusterWithValidKubeConfig)
+		restConfig, err := RESTConfig(ctx, client, clusterWithValidKubeConfig)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(restConfig.Host).To(Equal("https://test-cluster-api:6443"))
 	})
 
 	t.Run("cluster with no kubeconfig", func(t *testing.T) {
 		client := fake.NewFakeClientWithScheme(testScheme)
-		_, err := NewClusterClient(client, clusterWithNoKubeConfig, testScheme)
+		_, err := NewClusterClient(ctx, client, clusterWithNoKubeConfig, testScheme)
 		g.Expect(err).To(MatchError(ContainSubstring("not found")))
 	})
 
 	t.Run("cluster with invalid kubeconfig", func(t *testing.T) {
 		client := fake.NewFakeClientWithScheme(testScheme, invalidSecret)
-		_, err := NewClusterClient(client, clusterWithInvalidKubeConfig, testScheme)
+		_, err := NewClusterClient(ctx, client, clusterWithInvalidKubeConfig, testScheme)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(apierrors.IsNotFound(err)).To(BeFalse())
 	})

--- a/controllers/remote/fake/cluster.go
+++ b/controllers/remote/fake/cluster.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +26,6 @@ import (
 
 // NewClusterClient returns the same client passed as input, as output. It is assumed that the client is a
 // fake controller-runtime client
-func NewClusterClient(c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error) {
+func NewClusterClient(_ context.Context, c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
 	return c, nil
 }

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
@@ -290,7 +290,7 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 	// TODO: take into account configuration hash once upgrades are in place
 	kcp.Status.Replicas = replicas
 
-	remoteClient, err := r.remoteClientGetter(r.Client, cluster, r.scheme)
+	remoteClient, err := r.remoteClientGetter(ctx, r.Client, cluster, r.scheme)
 	if err != nil && !apierrors.IsNotFound(errors.Cause(err)) {
 		return errors.Wrap(err, "failed to create remote cluster client")
 	}
@@ -556,7 +556,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 		return nil
 	}
 
-	_, err := secret.GetFromNamespacedName(r.Client, clusterName, secret.Kubeconfig)
+	_, err := secret.GetFromNamespacedName(ctx, r.Client, clusterName, secret.Kubeconfig)
 	switch {
 	case apierrors.IsNotFound(err):
 		createErr := kubeconfig.CreateSecretWithOwner(

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -520,7 +520,7 @@ func TestReconcileClusterNoEndpoints(t *testing.T) {
 
 	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
 
-	_, err = secret.GetFromNamespacedName(fakeClient, client.ObjectKey{Namespace: "test", Name: "foo"}, secret.ClusterCA)
+	_, err = secret.GetFromNamespacedName(context.Background(), fakeClient, client.ObjectKey{Namespace: "test", Name: "foo"}, secret.ClusterCA)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	machineList := &clusterv1.MachineList{}
@@ -632,13 +632,13 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
 	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(1))
 
-	s, err := secret.GetFromNamespacedName(fakeClient, client.ObjectKey{Namespace: "test", Name: "foo"}, secret.ClusterCA)
+	s, err := secret.GetFromNamespacedName(context.Background(), fakeClient, client.ObjectKey{Namespace: "test", Name: "foo"}, secret.ClusterCA)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(s).NotTo(BeNil())
 	g.Expect(s.Data).NotTo(BeEmpty())
 	g.Expect(s.Labels).To(Equal(expectedLabels))
 
-	k, err := kubeconfig.FromSecret(fakeClient, cluster)
+	k, err := kubeconfig.FromSecret(context.Background(), fakeClient, cluster)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(k).NotTo(BeEmpty())
 

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -40,8 +40,8 @@ var (
 )
 
 // FromSecret fetches the Kubeconfig for a Cluster.
-func FromSecret(c client.Client, cluster *clusterv1.Cluster) ([]byte, error) {
-	out, err := secret.Get(c, cluster, secret.Kubeconfig)
+func FromSecret(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) ([]byte, error) {
+	out, err := secret.Get(ctx, c, cluster, secret.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func CreateSecret(ctx context.Context, c client.Client, cluster *clusterv1.Clust
 
 // CreateSecretWithOwner creates the Kubeconfig secret for the given cluster name, namespace, endpoint, and owner reference.
 func CreateSecretWithOwner(ctx context.Context, c client.Client, clusterName types.NamespacedName, endpoint string, owner metav1.OwnerReference) error {
-	clusterCA, err := secret.GetFromNamespacedName(c, clusterName, secret.ClusterCA)
+	clusterCA, err := secret.GetFromNamespacedName(ctx, c, clusterName, secret.ClusterCA)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return ErrDependentCertificateNotFound

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -85,7 +85,7 @@ func setupScheme() *runtime.Scheme {
 
 func TestGetKubeConfigSecret(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(setupScheme(), validSecret)
-	found, err := FromSecret(client, &clusterv1.Cluster{
+	found, err := FromSecret(context.Background(), client, &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "test"},
 	})
 	if err != nil {

--- a/util/secret/secret.go
+++ b/util/secret/secret.go
@@ -28,21 +28,21 @@ import (
 
 // Get retrieves the specified Secret (if any) from the given
 // cluster name and namespace.
-func Get(c client.Client, cluster *clusterv1.Cluster, purpose Purpose) (*corev1.Secret, error) {
+func Get(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, purpose Purpose) (*corev1.Secret, error) {
 	name := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
-	return GetFromNamespacedName(c, name, purpose)
+	return GetFromNamespacedName(ctx, c, name, purpose)
 }
 
 // GetFromNamespacedName retrieves the specified Secret (if any) from the given
 // cluster name and namespace.
-func GetFromNamespacedName(c client.Client, clusterName types.NamespacedName, purpose Purpose) (*corev1.Secret, error) {
+func GetFromNamespacedName(ctx context.Context, c client.Client, clusterName types.NamespacedName, purpose Purpose) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	secretKey := client.ObjectKey{
 		Namespace: clusterName.Namespace,
 		Name:      Name(clusterName.Name, purpose),
 	}
 
-	if err := c.Get(context.TODO(), secretKey, secret); err != nil {
+	if err := c.Get(ctx, secretKey, secret); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This is a breaking API change that should get merged before v0.3.0. The main goal is to remove one context.TODO() found inside a util command that should be appropriately passed through. In doing so, many files needed to get updated.
