### PR TITLE
✨only add machinedeployment name selector when selector is empty

### DIFF
--- a/api/v1alpha3/machinedeployment_webhook.go
+++ b/api/v1alpha3/machinedeployment_webhook.go
@@ -107,12 +107,20 @@ func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
 		d.Spec.ProgressDeadlineSeconds = pointer.Int32Ptr(600)
 	}
 
+	if d.Spec.Selector.MatchLabels == nil {
+		d.Spec.Selector.MatchLabels = make(map[string]string)
+	}
+
 	if d.Spec.Strategy == nil {
 		d.Spec.Strategy = &MachineDeploymentStrategy{}
 	}
 
 	if d.Spec.Strategy.Type == "" {
 		d.Spec.Strategy.Type = RollingUpdateMachineDeploymentStrategyType
+	}
+
+	if d.Spec.Template.Labels == nil {
+		d.Spec.Template.Labels = make(map[string]string)
 	}
 
 	// Default RollingUpdate strategy only if strategy type is RollingUpdate.
@@ -128,5 +136,12 @@ func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
 			ios0 := intstr.FromInt(0)
 			d.Spec.Strategy.RollingUpdate.MaxUnavailable = &ios0
 		}
+	}
+
+	// If no selector has been provided, add label and selector for the
+	// MachineDeployment's name as a default way of providing uniqueness.
+	if len(d.Spec.Selector.MatchLabels) == 0 && len(d.Spec.Selector.MatchExpressions) == 0 {
+		d.Spec.Selector.MatchLabels[MachineDeploymentLabelName] = d.Name
+		d.Spec.Template.Labels[MachineDeploymentLabelName] = d.Name
 	}
 }

--- a/api/v1alpha3/machinedeployment_webhook_test.go
+++ b/api/v1alpha3/machinedeployment_webhook_test.go
@@ -26,7 +26,11 @@ import (
 
 func TestMachineDeploymentDefault(t *testing.T) {
 	g := NewWithT(t)
-	md := &MachineDeployment{}
+	md := &MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-md",
+		},
+	}
 
 	md.Default()
 
@@ -35,6 +39,8 @@ func TestMachineDeploymentDefault(t *testing.T) {
 	g.Expect(md.Spec.RevisionHistoryLimit).To(Equal(pointer.Int32Ptr(1)))
 	g.Expect(md.Spec.ProgressDeadlineSeconds).To(Equal(pointer.Int32Ptr(600)))
 	g.Expect(md.Spec.Strategy).ToNot(BeNil())
+	g.Expect(md.Spec.Selector.MatchLabels).To(HaveKeyWithValue(MachineDeploymentLabelName, "test-md"))
+	g.Expect(md.Spec.Template.Labels).To(HaveKeyWithValue(MachineDeploymentLabelName, "test-md"))
 	g.Expect(md.Spec.Strategy.Type).To(Equal(RollingUpdateMachineDeploymentStrategyType))
 	g.Expect(md.Spec.Strategy.RollingUpdate).ToNot(BeNil())
 	g.Expect(md.Spec.Strategy.RollingUpdate.MaxSurge.IntValue()).To(Equal(1))

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -152,10 +152,6 @@ func (r *MachineDeploymentReconciler) reconcile(_ context.Context, cluster *clus
 	d.Spec.Selector.MatchLabels[clusterv1.ClusterLabelName] = d.Spec.ClusterName
 	d.Spec.Template.Labels[clusterv1.ClusterLabelName] = d.Spec.ClusterName
 
-	// Add label and selector based on the MachineDeployment's name.
-	d.Spec.Selector.MatchLabels[clusterv1.MachineDeploymentLabelName] = d.Name
-	d.Spec.Template.Labels[clusterv1.MachineDeploymentLabelName] = d.Name
-
 	if r.shouldAdopt(d) {
 		d.OwnerReferences = util.EnsureOwnerRef(d.OwnerReferences, metav1.OwnerReference{
 			APIVersion: clusterv1.GroupVersion.String(),

--- a/controllers/machinedeployment_controller_test.go
+++ b/controllers/machinedeployment_controller_test.go
@@ -74,7 +74,7 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 				MinReadySeconds:      pointer.Int32Ptr(0),
 				Replicas:             pointer.Int32Ptr(2),
 				RevisionHistoryLimit: pointer.Int32Ptr(0),
-				Selector:             metav1.LabelSelector{MatchLabels: labels},
+				Selector:             metav1.LabelSelector{},
 				Strategy: &clusterv1.MachineDeploymentStrategy{
 					Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
 					RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
@@ -192,7 +192,7 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		// Verify that machines has MachineSetLabelName and MachineDeploymentLabelName labels
 		By("Verify machines have expected MachineSetLabelName and MachineDeploymentLabelName")
 		for _, m := range machines.Items {
-			Expect(m.Labels[clusterv1.MachineDeploymentLabelName]).To(Equal(deployment.Name))
+			Expect(m.Labels[clusterv1.ClusterLabelName]).To(Equal(testCluster.Name))
 			Expect(m.Labels[clusterv1.MachineSetLabelName]).To(Equal(machineSets.Items[0].Name))
 		}
 
@@ -303,6 +303,8 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		// expect old MachineSets with old labels to be deleted
 		//
 		oldLabels := deployment.Spec.Selector.MatchLabels
+		oldLabels[clusterv1.MachineDeploymentLabelName] = deployment.Name
+
 		newLabels := map[string]string{
 			"new-key": "new-value",
 		}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Changes MachineDeployment reconciliation to only add MachineDeployment name as a label to selector/template when no other form of selector has been provided. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2287 
