### PR TITLE
✨clusterctl: clusterctl init preflight

### DIFF
--- a/cmd/clusterctl/pkg/client/cluster/client.go
+++ b/cmd/clusterctl/pkg/client/cluster/client.go
@@ -109,7 +109,7 @@ func (c *clusterClient) ProviderInventory() InventoryClient {
 }
 
 func (c *clusterClient) ProviderInstaller() ProviderInstaller {
-	return newProviderInstaller(c.proxy, c.ProviderInventory(), c.ProviderComponents())
+	return newProviderInstaller(c.configClient, c.repositoryClientFactory, c.proxy, c.ProviderInventory(), c.ProviderComponents())
 }
 
 func (c *clusterClient) ObjectMover() ObjectMover {

--- a/cmd/clusterctl/pkg/client/cluster/installer.go
+++ b/cmd/clusterctl/pkg/client/cluster/installer.go
@@ -17,6 +17,10 @@ limitations under the License.
 package cluster
 
 import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/version"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
 )
 
@@ -25,29 +29,35 @@ type ProviderInstaller interface {
 	// Add adds a provider to the install queue.
 	// NB. By deferring the installation, the installer service can perform validation of the target state of the management cluster
 	// before actually starting the installation of new providers.
-	Add(repository.Components) error
+	Add(repository.Components)
 
 	// Install performs the installation of the providers ready in the install queue.
 	Install() ([]repository.Components, error)
+
+	// Validate performs steps to validate a management cluster by looking at the current state and the providers in the queue.
+	// The following checks are performed in order to ensure a fully operational cluster:
+	// - There must be only one instance of the same provider per namespace
+	// - Instances of the same provider must not be fighting for objects (no watching overlap)
+	// - Providers must combine in valid management groups
+	//   - All the providers must belong to one/only one management groups
+	//   - All the providers in a management group must support the same API Version of Cluster API (contract)
+	Validate() error
 }
 
 // providerInstaller implements ProviderInstaller
 type providerInstaller struct {
-	proxy              Proxy
-	providerComponents ComponentsClient
-	providerInventory  InventoryClient
-	installQueue       []repository.Components
+	configClient            config.Client
+	repositoryClientFactory RepositoryClientFactory
+	proxy                   Proxy
+	providerComponents      ComponentsClient
+	providerInventory       InventoryClient
+	installQueue            []repository.Components
 }
 
 var _ ProviderInstaller = &providerInstaller{}
 
-func (i *providerInstaller) Add(components repository.Components) error {
-	if err := i.providerInventory.Validate(components.InventoryObject()); err != nil {
-		return err
-	}
-
+func (i *providerInstaller) Add(components repository.Components) {
 	i.installQueue = append(i.installQueue, components)
-	return nil
 }
 
 func (i *providerInstaller) Install() ([]repository.Components, error) {
@@ -74,10 +84,131 @@ func installComponentsAndUpdateInventory(components repository.Components, provi
 	return nil
 }
 
-func newProviderInstaller(proxy Proxy, providerMetadata InventoryClient, providerComponents ComponentsClient) *providerInstaller {
+func (i *providerInstaller) Validate() error {
+	// Get the list of providers currently in the cluster.
+	providerList, err := i.providerInventory.List()
+	if err != nil {
+		return err
+	}
+
+	// Starts simulating what will be the resulting management cluster by adding to the list the providers in the installQueue.
+	// During this operation following checks are performed:
+	// - There must be only one instance of the same provider per namespace
+	// - Instances of the same provider must not be fighting for objects (no watching overlap)
+	for _, components := range i.installQueue {
+		if providerList, err = simulateInstall(providerList, components); err != nil {
+			return errors.Wrapf(err, "installing provider %q can lead to a non functioning management cluster", components.Name())
+		}
+	}
+
+	// Now that the provider list contains all the providers that are scheduled for install, gets the resulting management groups.
+	// During this operation following check is performed:
+	// - Providers must combine in valid management groups
+	//   - All the providers must belong to one/only one management group
+	managementGroups, err := deriveManagementGroups(providerList)
+	if err != nil {
+		return err
+	}
+
+	// Checks if all the providers supports the same API Version of Cluster API (contract) of the corresponding management group.
+	providerInstanceContracts := map[string]string{}
+	for _, components := range i.installQueue {
+		provider := components.InventoryObject()
+
+		// Gets the management group the providers belongs to, and then retrieve the API Version of Cluster API (contract)
+		// all the providers in the management group must support.
+		managementGroup := managementGroups.FindManagementGroupByProviderInstanceName(provider.InstanceName())
+		managementGroupContract, err := i.getProviderContract(providerInstanceContracts, managementGroup.CoreProvider)
+		if err != nil {
+			return err
+		}
+
+		// Gets the API Version of Cluster API (contract) the provider support and compare it with the  management group contract.
+		providerContract, err := i.getProviderContract(providerInstanceContracts, provider)
+		if err != nil {
+			return err
+		}
+		if providerContract != managementGroupContract {
+			return errors.Errorf("installing provider %q can lead to a non functioning management cluster: the target version for the provider supports the %s API Version of Cluster API (contract), while the management group is using %s", components.Name(), providerContract, managementGroupContract)
+		}
+	}
+	return nil
+}
+
+// getProviderContract returns the API Version of Cluster API (contract) for a provider instance.
+func (i *providerInstaller) getProviderContract(providerInstanceContracts map[string]string, provider clusterctlv1.Provider) (string, error) {
+	// If the contract for the provider instance is already known, return it.
+	if contract, ok := providerInstanceContracts[provider.InstanceName()]; ok {
+		return contract, nil
+	}
+
+	// Otherwise get the contract for the providers instance.
+
+	// Gets the providers metadata.
+	configRepository, err := i.configClient.Providers().Get(provider.Name)
+	if err != nil {
+		return "", err
+	}
+
+	providerRepository, err := i.repositoryClientFactory(configRepository, i.configClient.Variables())
+	if err != nil {
+		return "", err
+	}
+
+	latestMetadata, err := providerRepository.Metadata(provider.Version).Get()
+	if err != nil {
+		return "", err
+	}
+
+	// Gets the contract for the current release.
+	currentVersion, err := version.ParseSemantic(provider.Version)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse current version for the %s provider", provider.InstanceName())
+	}
+
+	releaseSeries := latestMetadata.GetReleaseSeriesForVersion(currentVersion)
+	if releaseSeries == nil {
+		return "", errors.Errorf("invalid provider metadata: version %s for the provider %s does not match any release series", provider.Version, provider.InstanceName())
+	}
+
+	providerInstanceContracts[provider.InstanceName()] = releaseSeries.Contract
+	return releaseSeries.Contract, nil
+}
+
+// simulateInstall adds a provider to the list of providers in a cluster (without installing it).
+func simulateInstall(providerList *clusterctlv1.ProviderList, components repository.Components) (*clusterctlv1.ProviderList, error) {
+	provider := components.InventoryObject()
+
+	existingInstances := providerList.FilterByName(provider.Name)
+
+	// Target Namespace check
+	// Installing two instances of the same provider in the same namespace won't be supported
+	for _, i := range existingInstances {
+		if i.Namespace == provider.Namespace {
+			return providerList, errors.Errorf("there is already an instance of the %q provider installed in the %q namespace", provider.Name, provider.Namespace)
+		}
+	}
+
+	// Watching Namespace check:
+	// If we are going to install an instance of a provider watching objects in namespaces already controlled by other providers
+	// then there will be providers fighting for objects...
+	for _, i := range existingInstances {
+		if i.HasWatchingOverlapWith(provider) {
+			return providerList, errors.Errorf("the new instance of the %q provider is going to watch for objects in the namespace %q that is already controlled by other providers", provider.Name, provider.WatchedNamespace)
+		}
+	}
+
+	providerList.Items = append(providerList.Items, provider)
+
+	return providerList, nil
+}
+
+func newProviderInstaller(configClient config.Client, repositoryClientFactory RepositoryClientFactory, proxy Proxy, providerMetadata InventoryClient, providerComponents ComponentsClient) *providerInstaller {
 	return &providerInstaller{
-		proxy:              proxy,
-		providerInventory:  providerMetadata,
-		providerComponents: providerComponents,
+		configClient:            configClient,
+		repositoryClientFactory: repositoryClientFactory,
+		proxy:                   proxy,
+		providerComponents:      providerComponents,
+		providerInventory:       providerMetadata,
 	}
 }

--- a/cmd/clusterctl/pkg/client/cluster/installer_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/installer_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
+)
+
+func Test_providerInstaller_Validate(t *testing.T) {
+	fakeReader := test.NewFakeReader().
+		WithProvider("core", clusterctlv1.CoreProviderType, "https://somewhere.com").
+		WithProvider("infra1", clusterctlv1.InfrastructureProviderType, "https://somewhere.com").
+		WithProvider("infra2", clusterctlv1.InfrastructureProviderType, "https://somewhere.com")
+
+	repositoryMap := map[string]repository.Repository{
+		"core": test.NewFakeRepository().
+			WithVersions("v1.0.0", "v1.0.1").
+			WithMetadata("v1.0.0", &clusterctlv1.Metadata{
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 1, Minor: 0, Contract: "v1alpha3"},
+				},
+			}).
+			WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 1, Minor: 0, Contract: "v1alpha3"},
+					{Major: 2, Minor: 0, Contract: "v1alpha4"},
+				},
+			}),
+		"infra1": test.NewFakeRepository().
+			WithVersions("v1.0.0", "v1.0.1").
+			WithMetadata("v1.0.0", &clusterctlv1.Metadata{
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 1, Minor: 0, Contract: "v1alpha3"},
+				},
+			}).
+			WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 1, Minor: 0, Contract: "v1alpha3"},
+					{Major: 2, Minor: 0, Contract: "v1alpha4"},
+				},
+			}),
+		"infra2": test.NewFakeRepository().
+			WithVersions("v1.0.0", "v1.0.1").
+			WithMetadata("v1.0.0", &clusterctlv1.Metadata{
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 1, Minor: 0, Contract: "v1alpha3"},
+				},
+			}).
+			WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 1, Minor: 0, Contract: "v1alpha3"},
+					{Major: 2, Minor: 0, Contract: "v1alpha4"},
+				},
+			}),
+	}
+
+	type fields struct {
+		proxy        Proxy
+		installQueue []repository.Components
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "install core + infra1 on an empty cluster",
+			fields: fields{
+				proxy: test.NewFakeProxy(), //empty cluster
+				installQueue: []repository.Components{ // install core + infra1, v1alpha3 contract
+					newFakeComponents("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra1-system", ""),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "install infra2 on a cluster already initialized with core + infra1",
+			fields: fields{
+				proxy: test.NewFakeProxy(). // cluster with core + infra1, v1alpha3 contract
+								WithProviderInventory("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", "").
+								WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra1-system", ""),
+				installQueue: []repository.Components{ // install infra2, v1alpha3 contract
+					newFakeComponents("infra2", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra2-system", ""),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "install another instance of infra1 on a cluster already initialized with core + infra1, no overlaps",
+			fields: fields{
+				proxy: test.NewFakeProxy(). // cluster with core + infra1, v1alpha3 contract
+								WithProviderInventory("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", "").
+								WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "ns1", "ns1"),
+				installQueue: []repository.Components{ // install infra2, v1alpha3 contract
+					newFakeComponents("infra2", clusterctlv1.InfrastructureProviderType, "v1.0.0", "ns2", "ns2"),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "install another instance of infra1 on a cluster already initialized with core + infra1, same namespace of the existing infra1",
+			fields: fields{
+				proxy: test.NewFakeProxy(). // cluster with core + infra1, v1alpha3 contract
+								WithProviderInventory("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", "").
+								WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "n1", ""),
+				installQueue: []repository.Components{ // install infra1, v1alpha3 contract
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "n1", ""),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "install another instance of infra1 on a cluster already initialized with core + infra1, watching overlap with the existing infra1",
+			fields: fields{
+				proxy: test.NewFakeProxy(). // cluster with core + infra1, v1alpha3 contract
+								WithProviderInventory("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", "").
+								WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra1-system", ""),
+				installQueue: []repository.Components{ // install infra1, v1alpha3 contract
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra2-system", ""),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "install another instance of infra1 on a cluster already initialized with core + infra1, not part of the existing management group",
+			fields: fields{
+				proxy: test.NewFakeProxy(). // cluster with core + infra1, v1alpha3 contract
+								WithProviderInventory("core", clusterctlv1.CoreProviderType, "v1.0.0", "ns1", "ns1").
+								WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "ns1", "ns1"),
+				installQueue: []repository.Components{ // install infra1, v1alpha3 contract
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "ns2", "ns2"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "install an instance of infra1 on a cluster already initialized with two core, but it is part of two management group",
+			fields: fields{
+				proxy: test.NewFakeProxy(). // cluster with two core (two management groups)
+								WithProviderInventory("core", clusterctlv1.CoreProviderType, "v1.0.0", "ns1", "ns1").
+								WithProviderInventory("core", clusterctlv1.CoreProviderType, "v1.0.0", "ns2", "ns2"),
+				installQueue: []repository.Components{ // install infra1, v1alpha3 contract
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra1-system", ""),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "install core@v1alpha3 + infra1@v1alpha4 on an empty cluster",
+			fields: fields{
+				proxy: test.NewFakeProxy(), //empty cluster
+				installQueue: []repository.Components{ // install core + infra1, v1alpha3 contract
+					newFakeComponents("core", clusterctlv1.CoreProviderType, "v1.0.0", "core-system", ""),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra1-system", ""),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "install infra1@v1alpha4 on a cluster already initialized with core@v1alpha3 +",
+			fields: fields{
+				proxy: test.NewFakeProxy(). // cluster with one core, v1alpha3 contract
+								WithProviderInventory("core", clusterctlv1.CoreProviderType, "v1.0.0", "ns1", "ns1"),
+				installQueue: []repository.Components{ // install infra1, v1alpha4 contract
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra1-system", ""),
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configClient, _ := config.New("", config.InjectReader(fakeReader))
+
+			i := &providerInstaller{
+				configClient:      configClient,
+				proxy:             tt.fields.proxy,
+				providerInventory: newInventoryClient(tt.fields.proxy, nil),
+				repositoryClientFactory: func(provider config.Provider, configVariablesClient config.VariablesClient, options ...repository.Option) (repository.Client, error) {
+					return repository.New(provider, configVariablesClient, repository.InjectRepository(repositoryMap[provider.Name()]))
+				},
+				installQueue: tt.fields.installQueue,
+			}
+			if err := i.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+		})
+	}
+}
+
+type fakeComponents struct {
+	config.Provider
+	inventoryObject clusterctlv1.Provider
+}
+
+func (c *fakeComponents) Version() string {
+	panic("not implemented")
+}
+
+func (c *fakeComponents) Variables() []string {
+	panic("not implemented")
+}
+
+func (c *fakeComponents) Images() []string {
+	panic("not implemented")
+}
+
+func (c *fakeComponents) TargetNamespace() string {
+	panic("not implemented")
+}
+
+func (c *fakeComponents) WatchingNamespace() string {
+	panic("not implemented")
+}
+
+func (c *fakeComponents) InventoryObject() clusterctlv1.Provider {
+	return c.inventoryObject
+}
+
+func (c *fakeComponents) Objs() []unstructured.Unstructured {
+	panic("not implemented")
+}
+
+func (c *fakeComponents) Yaml() ([]byte, error) {
+	panic("not implemented")
+}
+
+func newFakeComponents(name string, providerType clusterctlv1.ProviderType, version, targetNamespace, watchingNamespace string) repository.Components {
+	inventoryObject := fakeProvider(name, providerType, version, targetNamespace, watchingNamespace)
+	return &fakeComponents{
+		Provider:        config.NewProvider(inventoryObject.Name, "", clusterctlv1.ProviderType(inventoryObject.Type)),
+		inventoryObject: inventoryObject,
+	}
+}

--- a/cmd/clusterctl/pkg/client/init_test.go
+++ b/cmd/clusterctl/pkg/client/init_test.go
@@ -397,25 +397,70 @@ func fakeEmptyCluster() *fakeClient {
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v1.0.0").
 		WithFile("v1.0.0", "components.yaml", componentsYAML("ns1")).
-		WithFile("v1.1.0", "components.yaml", componentsYAML("ns1"))
+		WithMetadata("v1.0.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 1, Minor: 0, Contract: "v1alpha3"},
+			},
+		}).
+		WithFile("v1.1.0", "components.yaml", componentsYAML("ns1")).
+		WithMetadata("v1.1.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 1, Minor: 1, Contract: "v1alpha3"},
+			},
+		})
 	repository2 := newFakeRepository(bootstrapProviderConfig, config1.Variables()).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v2.0.0").
 		WithFile("v2.0.0", "components.yaml", componentsYAML("ns2")).
-		WithFile("v2.1.0", "components.yaml", componentsYAML("ns2"))
+		WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 2, Minor: 0, Contract: "v1alpha3"},
+			},
+		}).
+		WithFile("v2.1.0", "components.yaml", componentsYAML("ns2")).
+		WithMetadata("v2.1.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 2, Minor: 1, Contract: "v1alpha3"},
+			},
+		})
 	repository3 := newFakeRepository(controlPlaneProviderConfig, config1.Variables()).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v2.0.0").
 		WithFile("v2.0.0", "components.yaml", componentsYAML("ns3")).
-		WithFile("v2.1.0", "components.yaml", componentsYAML("ns3"))
+		WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 2, Minor: 0, Contract: "v1alpha3"},
+			},
+		}).
+		WithFile("v2.1.0", "components.yaml", componentsYAML("ns3")).
+		WithMetadata("v2.1.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 2, Minor: 1, Contract: "v1alpha3"},
+			},
+		})
 	repository4 := newFakeRepository(infraProviderConfig, config1.Variables()).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v3.0.0").
 		WithFile("v3.0.0", "components.yaml", componentsYAML("ns4")).
+		WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 3, Minor: 0, Contract: "v1alpha3"},
+			},
+		}).
 		WithFile("v3.1.0", "components.yaml", componentsYAML("ns4")).
+		WithMetadata("v3.1.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 3, Minor: 1, Contract: "v1alpha3"},
+			},
+		}).
 		WithFile("v3.0.0", "cluster-template.yaml", templateYAML("ns4", "test"))
 
-	cluster1 := newFakeCluster("kubeconfig", config1)
+	cluster1 := newFakeCluster("kubeconfig", config1).
+		// fake repository for capi, bootstrap and infra provider (matching provider's config)
+		WithRepository(repository1).
+		WithRepository(repository2).
+		WithRepository(repository3).
+		WithRepository(repository4)
 
 	client := newFakeClient(config1).
 		// fake repository for capi, bootstrap and infra provider (matching provider's config)

--- a/cmd/clusterctl/pkg/client/repository/components.go
+++ b/cmd/clusterctl/pkg/client/repository/components.go
@@ -154,7 +154,7 @@ func (c *components) Yaml() ([]byte, error) {
 // 3. Ensure all the ClusterRoleBinding which are referencing namespaced objects have the name prefixed with the namespace name
 // 4. Set the watching namespace for the provider controller
 // 5. Adds labels to all the components in order to allow easy identification of the provider objects
-func newComponents(provider config.Provider, version string, rawyaml []byte, configVariablesClient config.VariablesClient, targetNamespace, watchingNamespace string) (*components, error) {
+func NewComponents(provider config.Provider, version string, rawyaml []byte, configVariablesClient config.VariablesClient, targetNamespace, watchingNamespace string) (*components, error) {
 	// inspect the yaml read from the repository for variables
 	variables := inspectVariables(rawyaml)
 

--- a/cmd/clusterctl/pkg/client/repository/components_client.go
+++ b/cmd/clusterctl/pkg/client/repository/components_client.go
@@ -74,5 +74,5 @@ func (f *componentsClient) Get(version, targetNamespace, watchingNamespace strin
 		log.V(1).Info("Using", "Override", path, "Provider", f.provider.Name(), "Version", version)
 	}
 
-	return newComponents(f.provider, version, file, f.configVariablesClient, targetNamespace, watchingNamespace)
+	return NewComponents(f.provider, version, file, f.configVariablesClient, targetNamespace, watchingNamespace)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR implements a preflight check that runs before `clusterctl init` ensuring that the target cluster respects the following rules:

- There must be only one instance of the same provider per namespace.
- Instances of the same provider must not be fighting for objects (no watching overlap).
- Providers must combine into a valid management groups
   - All the providers must belong to one/only one management groups
   - All the providers in a management group must support the same API Version of Cluster API (contract)

**Which issue(s) this PR fixes**:
Rif #1729
/area clusterctl
/assign @ncdc
/assign @vincepri