### PR TITLE
✨ [e2e framework]: add skip-resource-cleanup flag to allow skipping any clean up

### DIFF
--- a/test/framework/control_plane.go
+++ b/test/framework/control_plane.go
@@ -31,6 +31,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	cabpkv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/test/framework/options"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -270,6 +271,9 @@ type DeleteClusterInput struct {
 
 // DeleteCluster deletes the cluster and waits for everything the cluster owned to actually be gone.
 func DeleteCluster(ctx context.Context, input DeleteClusterInput) {
+	if options.SkipResourceCleanup {
+		return
+	}
 	By(fmt.Sprintf("deleting cluster %s", input.Cluster.GetName()))
 	Expect(input.Deleter.Delete(ctx, input.Cluster)).To(Succeed())
 }
@@ -282,6 +286,9 @@ type WaitForClusterDeletedInput struct {
 
 // WaitForClusterDeleted waits until the cluster object has been deleted.
 func WaitForClusterDeleted(ctx context.Context, input WaitForClusterDeletedInput, intervals ...interface{}) {
+	if options.SkipResourceCleanup {
+		return
+	}
 	By(fmt.Sprintf("waiting for cluster %s to be deleted", input.Cluster.GetName()))
 	Eventually(func() bool {
 		cluster := &clusterv1.Cluster{}
@@ -301,6 +308,9 @@ type AssertAllClusterAPIResourcesAreGoneInput struct {
 
 // AssertAllClusterAPIResourcesAreGone ensures that all known Cluster API resources have been remvoed.
 func AssertAllClusterAPIResourcesAreGone(ctx context.Context, input AssertAllClusterAPIResourcesAreGoneInput) {
+	if options.SkipResourceCleanup {
+		return
+	}
 	lbl, err := labels.Parse(fmt.Sprintf("%s=%s", clusterv1.ClusterLabelName, input.Cluster.GetClusterName()))
 	Expect(err).ToNot(HaveOccurred())
 	opt := &client.ListOptions{LabelSelector: lbl}

--- a/test/framework/management/kind/mgmt.go
+++ b/test/framework/management/kind/mgmt.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/test/framework/exec"
+	"sigs.k8s.io/cluster-api/test/framework/options"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -214,6 +215,9 @@ func (c *Cluster) Wait(ctx context.Context, args ...string) error {
 // Teardown deletes all the tmp files and cleans up the kind cluster.
 // This does not return an error so that it can clean as much up as possible regardless of error.
 func (c *Cluster) Teardown(ctx context.Context) {
+	if options.SkipResourceCleanup {
+		return
+	}
 	if c == nil {
 		return
 	}

--- a/test/framework/options/generic.go
+++ b/test/framework/options/generic.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"flag"
+)
+
+var (
+	SkipResourceCleanup bool
+)
+
+func init() {
+	flag.BoolVar(&SkipResourceCleanup, "skip-resource-cleanup", SkipResourceCleanup, "if true, the resource cleanup after tests will be skipped")
+}

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -90,8 +90,9 @@ test-e2e: ## Run the end-to-end tests
 		$(MAKE) run-e2e
 
 E2E_CONF_FILE ?= e2e/local-e2e.conf
+SKIP_RESOURCE_CLEANUP ?= false
 run-e2e:
-	go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath $(E2E_CONF_FILE))"
+	go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath $(E2E_CONF_FILE))" -skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP)
 
 ## --------------------------------------
 ## Binaries

--- a/test/infrastructure/docker/e2e/custom_assertions.go
+++ b/test/infrastructure/docker/e2e/custom_assertions.go
@@ -28,6 +28,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/options"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -40,6 +41,9 @@ type ensureDockerArtifactsDeletedInput struct {
 
 // ensureDockerArtifactsDeleted ensure we have cleaned up provider specific objects.
 func ensureDockerArtifactsDeleted(input ensureDockerArtifactsDeletedInput) {
+	if options.SkipResourceCleanup {
+		return
+	}
 	By("Ensuring docker artifacts have been deleted")
 	ctx := context.Background()
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Feature: add `-skip-resource-cleanup` flag to allow skipping any clean up
Now we can run e2e test like this to skip cleanup:
```
go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath $(E2E_CONF_FILE))" -skip-resource-cleanup
```
or 
```
make run-e2e SKIP_RESOURCE_CLEANUP=true
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2268
