### PR TITLE
🐛clusterctl: fix webhooks

### DIFF
--- a/cmd/clusterctl/api/v1alpha3/labels.go
+++ b/cmd/clusterctl/api/v1alpha3/labels.go
@@ -22,4 +22,8 @@ const (
 
 	// ClusterctlCoreLabelName defines the label that is applied to all the core objects managed by clusterctl.
 	ClusterctlCoreLabelName = "clusterctl.cluster.x-k8s.io/core"
+
+	// ClusterctlSharedResourceLabelName defines the label that is applied to all the objects that are shared between
+	// instances of the same provider. e.g. CRDs, ValidatingWebhookConfiguration, MutatingWebhookConfiguration etc.
+	ClusterctlSharedResourceLabelName = "clusterctl.cluster.x-k8s.io/shared"
 )

--- a/cmd/clusterctl/api/v1alpha3/labels.go
+++ b/cmd/clusterctl/api/v1alpha3/labels.go
@@ -23,7 +23,18 @@ const (
 	// ClusterctlCoreLabelName defines the label that is applied to all the core objects managed by clusterctl.
 	ClusterctlCoreLabelName = "clusterctl.cluster.x-k8s.io/core"
 
-	// ClusterctlSharedResourceLabelName defines the label that is applied to all the objects that are shared between
-	// instances of the same provider. e.g. CRDs, ValidatingWebhookConfiguration, MutatingWebhookConfiguration etc.
-	ClusterctlSharedResourceLabelName = "clusterctl.cluster.x-k8s.io/shared"
+	// ClusterctlResourceLifecyleLabelName defines the label that documents the lifecyle for a specific resource.
+	// e.g. resources shared between instances of the same provider. e.g. CRDs, ValidatingWebhookConfiguration, MutatingWebhookConfiguration etc.
+	// are marked as shared
+	ClusterctlResourceLifecyleLabelName = "clusterctl.cluster.x-k8s.io/lifecycle"
+)
+
+// ResourceLifecycle configures the lifecycle of a resource
+type ResourceLifecycle string
+
+const (
+	// ResourceLifecycleShared is the value we use when tagging resources to indicate
+	// that the resource is shared between multiple instance of a provider, and should not be deleted
+	// if an instance of the provider is deleted.
+	ResourceLifecycleShared = ResourceLifecycle("shared")
 )

--- a/cmd/clusterctl/cmd/delete.go
+++ b/cmd/clusterctl/cmd/delete.go
@@ -23,11 +23,11 @@ import (
 )
 
 type deleteOptions struct {
-	kubeconfig           string
-	targetNamespace      string
-	forceDeleteNamespace bool
-	forceDeleteCRD       bool
-	deleteAll            bool
+	kubeconfig       string
+	targetNamespace  string
+	includeNamespace bool
+	includeCRD       bool
+	deleteAll        bool
 }
 
 var dd = &deleteOptions{}
@@ -59,18 +59,18 @@ var deleteCmd = &cobra.Command{
 		# all the related objects (e.g. AWSClusters, AWSMachines etc.).
 		# Important! As a consequence of this operation, all the corresponding resources managed by
 		# the AWS infrastructure provider are orphaned and there might be ongoing costs incurred as a result of this.
-		clusterctl delete aws --delete-crd
+		clusterctl delete aws --include-crd
 
 		# Delete the AWS provider and its hosting Namespace. Please note that this forces deletion of 
 		# all objects existing in the namespace. 
 		# Important! As a consequence of this operation, all the corresponding resources managed by
 		# Cluster API Providers are orphaned and there might be ongoing costs incurred as a result of this.
-		clusterctl delete aws --delete-namespace
+		clusterctl delete aws --include-namespace
 
 		# Reset the management cluster to its original state
 		# Important! As a consequence of this operation all the corresponding resources on target clouds
 		# are "orphaned" and thus there may be ongoing costs incurred as a result of this.
-		clusterctl delete --all --delete-crd  --delete-namespace`),
+		clusterctl delete --all --include-crd  --include-namespace`),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if dd.deleteAll && len(args) > 0 {
@@ -89,8 +89,8 @@ func init() {
 	deleteCmd.Flags().StringVarP(&dd.kubeconfig, "kubeconfig", "", "", "Path to the kubeconfig file to use for accessing the management cluster. If empty, default rules for kubeconfig discovery will be used")
 	deleteCmd.Flags().StringVarP(&dd.targetNamespace, "namespace", "", "", "The namespace where the provider to be deleted lives. If not specified, the namespace name will be inferred from the current configuration")
 
-	deleteCmd.Flags().BoolVarP(&dd.forceDeleteNamespace, "delete-namespace", "n", false, "Forces the deletion of the namespace where the providers are hosted (and of all the contained objects)")
-	deleteCmd.Flags().BoolVarP(&dd.forceDeleteCRD, "delete-crd", "c", false, "Forces the deletion of the provider's CRDs (and of all the related objects)")
+	deleteCmd.Flags().BoolVarP(&dd.includeNamespace, "include-namespace", "n", false, "Forces the deletion of the namespace where the providers are hosted (and of all the contained objects)")
+	deleteCmd.Flags().BoolVarP(&dd.includeCRD, "include-crd", "c", false, "Forces the deletion of the provider's CRDs (and of all the related objects)")
 	deleteCmd.Flags().BoolVarP(&dd.deleteAll, "all", "", false, "Force deletion of all the providers")
 
 	RootCmd.AddCommand(deleteCmd)
@@ -103,11 +103,11 @@ func runDelete(args []string) error {
 	}
 
 	if err := c.Delete(client.DeleteOptions{
-		Kubeconfig:           dd.kubeconfig,
-		ForceDeleteNamespace: dd.forceDeleteNamespace,
-		ForceDeleteCRD:       dd.forceDeleteCRD,
-		Namespace:            dd.targetNamespace,
-		Providers:            args,
+		Kubeconfig:       dd.kubeconfig,
+		IncludeNamespace: dd.includeNamespace,
+		IncludeCRD:       dd.includeCRD,
+		Namespace:        dd.targetNamespace,
+		Providers:        args,
 	}); err != nil {
 		return err
 	}

--- a/cmd/clusterctl/cmd/delete.go
+++ b/cmd/clusterctl/cmd/delete.go
@@ -26,7 +26,7 @@ type deleteOptions struct {
 	kubeconfig       string
 	targetNamespace  string
 	includeNamespace bool
-	includeCRD       bool
+	includeCRDs      bool
 	deleteAll        bool
 }
 
@@ -90,7 +90,7 @@ func init() {
 	deleteCmd.Flags().StringVarP(&dd.targetNamespace, "namespace", "", "", "The namespace where the provider to be deleted lives. If not specified, the namespace name will be inferred from the current configuration")
 
 	deleteCmd.Flags().BoolVarP(&dd.includeNamespace, "include-namespace", "n", false, "Forces the deletion of the namespace where the providers are hosted (and of all the contained objects)")
-	deleteCmd.Flags().BoolVarP(&dd.includeCRD, "include-crd", "c", false, "Forces the deletion of the provider's CRDs (and of all the related objects)")
+	deleteCmd.Flags().BoolVarP(&dd.includeCRDs, "include-crd", "c", false, "Forces the deletion of the provider's CRDs (and of all the related objects)")
 	deleteCmd.Flags().BoolVarP(&dd.deleteAll, "all", "", false, "Force deletion of all the providers")
 
 	RootCmd.AddCommand(deleteCmd)
@@ -105,7 +105,7 @@ func runDelete(args []string) error {
 	if err := c.Delete(client.DeleteOptions{
 		Kubeconfig:       dd.kubeconfig,
 		IncludeNamespace: dd.includeNamespace,
-		IncludeCRD:       dd.includeCRD,
+		IncludeCRDs:      dd.includeCRDs,
 		Namespace:        dd.targetNamespace,
 		Providers:        args,
 	}); err != nil {

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -61,12 +61,13 @@ type DeleteOptions struct {
 	// discovery will be used.
 	Kubeconfig string
 
-	// ForceDeleteNamespace forces the deletion of the namespace where the providers are hosted
+	// IncludeNamespace forces the deletion of the namespace where the providers are hosted
 	// (and of all the contained objects).
-	ForceDeleteNamespace bool
+	IncludeNamespace bool
 
-	// ForceDeleteCRD forces the deletion of the provider's CRDs (and of all the related objects)".
-	ForceDeleteCRD bool
+	// IncludeCRD forces the deletion of the provider's CRDs (and of all the related objects).
+	// By Extension, this forces the deletion of all the resources shared among provider instances, like e.g. web-hooks.
+	IncludeCRD bool
 
 	// Namespace where the provider to be deleted lives. If not specified, the namespace name will be inferred
 	// from the current configuration.

--- a/cmd/clusterctl/pkg/client/client.go
+++ b/cmd/clusterctl/pkg/client/client.go
@@ -65,9 +65,9 @@ type DeleteOptions struct {
 	// (and of all the contained objects).
 	IncludeNamespace bool
 
-	// IncludeCRD forces the deletion of the provider's CRDs (and of all the related objects).
+	// IncludeCRDs forces the deletion of the provider's CRDs (and of all the related objects).
 	// By Extension, this forces the deletion of all the resources shared among provider instances, like e.g. web-hooks.
-	IncludeCRD bool
+	IncludeCRDs bool
 
 	// Namespace where the provider to be deleted lives. If not specified, the namespace name will be inferred
 	// from the current configuration.

--- a/cmd/clusterctl/pkg/client/cluster/client.go
+++ b/cmd/clusterctl/pkg/client/cluster/client.go
@@ -188,9 +188,8 @@ type Proxy interface {
 	// NewClient returns a new controller runtime Client object for working on the management cluster
 	NewClient() (client.Client, error)
 
-	// ListResources returns all the Kubernetes objects existing in a namespace (or in all namespaces if empty)
-	// with the given labels.
-	ListResources(namespace string, labels map[string]string) ([]unstructured.Unstructured, error)
+	// ListResources returns all the Kubernetes objects with the given labels existing the listed namespaces.
+	ListResources(labels map[string]string, namespaces ...string) ([]unstructured.Unstructured, error)
 }
 
 var _ Proxy = &test.FakeProxy{}

--- a/cmd/clusterctl/pkg/client/cluster/components.go
+++ b/cmd/clusterctl/pkg/client/cluster/components.go
@@ -34,9 +34,9 @@ import (
 )
 
 type DeleteOptions struct {
-	Provider             clusterctlv1.Provider
-	ForceDeleteNamespace bool
-	ForceDeleteCRD       bool
+	Provider         clusterctlv1.Provider
+	IncludeNamespace bool
+	IncludeCRD       bool
 }
 
 // ComponentsClient has methods to work with provider components in the cluster.
@@ -110,14 +110,14 @@ func (p *providerComponents) Delete(options DeleteOptions) error {
 	// in multi-tenant scenario, because a single operation could delete both instance specific and shared CRDs/web-hook components.
 	// This is considered acceptable because we are considering the multi-tenant scenario an advanced use case, and the assumption
 	// is that user in this case understand the potential impacts of this operation.
-	// TODO: in future we can eventually block delete --ForceDeleteCRD in case more than one instance of a provider exists
+	// TODO: in future we can eventually block delete --IncludeCRD in case more than one instance of a provider exists
 	labels := map[string]string{
 		clusterctlv1.ClusterctlLabelName: "",
 		clusterv1.ProviderLabelName:      options.Provider.Name,
 	}
 
 	namespaces := []string{options.Provider.Namespace}
-	if options.ForceDeleteCRD {
+	if options.IncludeCRD {
 		namespaces = append(namespaces, repository.WebhookNamespaceName)
 	}
 
@@ -133,8 +133,8 @@ func (p *providerComponents) Delete(options DeleteOptions) error {
 	for _, obj := range resources {
 		// If the CRDs (and by extensions, all the shared resources) should NOT be deleted, skip it;
 		// NB. Skipping CRDs deletion ensures that also the objects of Kind defined in the CRDs Kind are not deleted.
-		_, isSharedReource := obj.GetLabels()[clusterctlv1.ClusterctlSharedResourceLabelName]
-		if !options.ForceDeleteCRD && isSharedReource {
+		isSharedReource := util.IsSharedResource(obj)
+		if !options.IncludeCRD && isSharedReource {
 			continue
 		}
 
@@ -147,7 +147,7 @@ func (p *providerComponents) Delete(options DeleteOptions) error {
 			}
 			// If the  Namespace should NOT be deleted, skip it, otherwise keep track of the namespaces we are deleting;
 			// NB. Skipping Namespaces deletion ensures that also the objects hosted in the namespace but without the "clusterctl.cluster.x-k8s.io" and the "cluster.x-k8s.io/provider" label are not deleted.
-			if !options.ForceDeleteNamespace {
+			if !options.IncludeNamespace {
 				continue
 			}
 			namespacesToDelete.Insert(obj.GetName())

--- a/cmd/clusterctl/pkg/client/cluster/components.go
+++ b/cmd/clusterctl/pkg/client/cluster/components.go
@@ -36,7 +36,7 @@ import (
 type DeleteOptions struct {
 	Provider         clusterctlv1.Provider
 	IncludeNamespace bool
-	IncludeCRD       bool
+	IncludeCRDs      bool
 }
 
 // ComponentsClient has methods to work with provider components in the cluster.
@@ -110,14 +110,14 @@ func (p *providerComponents) Delete(options DeleteOptions) error {
 	// in multi-tenant scenario, because a single operation could delete both instance specific and shared CRDs/web-hook components.
 	// This is considered acceptable because we are considering the multi-tenant scenario an advanced use case, and the assumption
 	// is that user in this case understand the potential impacts of this operation.
-	// TODO: in future we can eventually block delete --IncludeCRD in case more than one instance of a provider exists
+	// TODO: in future we can eventually block delete --IncludeCRDs in case more than one instance of a provider exists
 	labels := map[string]string{
 		clusterctlv1.ClusterctlLabelName: "",
 		clusterv1.ProviderLabelName:      options.Provider.Name,
 	}
 
 	namespaces := []string{options.Provider.Namespace}
-	if options.IncludeCRD {
+	if options.IncludeCRDs {
 		namespaces = append(namespaces, repository.WebhookNamespaceName)
 	}
 
@@ -134,7 +134,7 @@ func (p *providerComponents) Delete(options DeleteOptions) error {
 		// If the CRDs (and by extensions, all the shared resources) should NOT be deleted, skip it;
 		// NB. Skipping CRDs deletion ensures that also the objects of Kind defined in the CRDs Kind are not deleted.
 		isSharedReource := util.IsSharedResource(obj)
-		if !options.IncludeCRD && isSharedReource {
+		if !options.IncludeCRDs && isSharedReource {
 			continue
 		}
 

--- a/cmd/clusterctl/pkg/client/cluster/components_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/components_test.go
@@ -20,12 +20,14 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/test"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -34,12 +36,22 @@ func Test_providerComponents_Delete(t *testing.T) {
 	labels := map[string]string{
 		clusterv1.ProviderLabelName: "infra",
 	}
+	sharedLabels := map[string]string{
+		clusterv1.ProviderLabelName:                    "infra",
+		clusterctlv1.ClusterctlSharedResourceLabelName: "",
+	}
 
 	crd := unstructured.Unstructured{}
 	crd.SetAPIVersion("apiextensions.k8s.io/v1beta1")
 	crd.SetKind("CustomResourceDefinition")
 	crd.SetName("crd1")
-	crd.SetLabels(labels)
+	crd.SetLabels(sharedLabels)
+
+	mutatingWebhook := unstructured.Unstructured{}
+	mutatingWebhook.SetAPIVersion("admissionregistration.k8s.io/v1beta1")
+	mutatingWebhook.SetKind("MutatingWebhookConfiguration")
+	mutatingWebhook.SetName("mwh1")
+	mutatingWebhook.SetLabels(sharedLabels)
 
 	initObjs := []runtime.Object{
 		// Namespace (should be deleted only if forceDeleteNamespace)
@@ -52,7 +64,7 @@ func Test_providerComponents_Delete(t *testing.T) {
 				Labels: labels,
 			},
 		},
-		// A provider component (should always be deleted)
+		// A namespaced provider component (should always be deleted)
 		&corev1.Pod{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Pod",
@@ -75,6 +87,48 @@ func Test_providerComponents_Delete(t *testing.T) {
 		},
 		// CRDs (should be deleted only if forceDeleteCRD)
 		&crd,
+		&mutatingWebhook,
+		&corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Namespace",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: repository.WebhookNamespaceName,
+				Labels: map[string]string{
+					clusterctlv1.ClusterctlSharedResourceLabelName: "", //NB. the capi-webhook-system namespace doe not have a provider label (see fixCapiWebHookLabel)
+				},
+			},
+		},
+		&corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Pod",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: repository.WebhookNamespaceName,
+				Name:      "podx",
+				Labels:    sharedLabels,
+			},
+		},
+		// A cluster-wide provider component (should always be deleted)
+		&rbacv1.ClusterRole{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "ClusterRole",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "ns1-cluster-role", // global objects belonging to the provider have a namespace prefix.
+				Labels: labels,
+			},
+		},
+		// Another cluster-wide object (should never be deleted)
+		&rbacv1.ClusterRole{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "ClusterRole",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "some-cluster-role",
+				Labels: labels,
+			},
+		},
 		// Another object out of the provider namespace (should never be deleted)
 		&corev1.Pod{
 			TypeMeta: metav1.TypeMeta{
@@ -112,11 +166,16 @@ func Test_providerComponents_Delete(t *testing.T) {
 				forceDeleteCRD:       false,
 			},
 			wantDiff: []wantDiff{
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: false},                                           //namespace should be preserved
-				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: false}, //crd should be preserved
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                               // provider components should be deleted
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: false},                              // other objects in the namespace should not be deleted
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                              // this object is in another namespace, and should never be touched by delete
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: false},                                                       // namespace should be preserved
+				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: false},             // crd should be preserved
+				{object: corev1.ObjectReference{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "MutatingWebhookConfiguration", Name: "mwh1"}, deleted: false}, // MutatingWebhookConfiguration should be preserved
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: repository.WebhookNamespaceName}, deleted: false},                             // capi-webhook-system namespace should never be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: repository.WebhookNamespaceName, Name: "podx"}, deleted: false},                // provider objects in the capi-webhook-system namespace should be preserved
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                                           // provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: false},                                          // other objects in the namespace should not be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                                          // this object is in another namespace, and should never be touched by delete
+				{object: corev1.ObjectReference{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: "ns1-cluster-role"}, deleted: true},               // cluster-wide provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: "some-cluster-role"}, deleted: false},             // other cluster-wide objects should be preserved
 			},
 			wantErr: false,
 		},
@@ -128,15 +187,19 @@ func Test_providerComponents_Delete(t *testing.T) {
 				forceDeleteCRD:       false,
 			},
 			wantDiff: []wantDiff{
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: true},                                            //namespace should be deleted
-				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: false}, //crd should be preserved
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                               // provider components should be deleted
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: true},                               // other objects in the namespace goes away when deleting the namespace
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                              // this object is in another namespace, and should never be touched by delete
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: true},                                                        // namespace should be deleted
+				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: false},             // crd should be preserved
+				{object: corev1.ObjectReference{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "MutatingWebhookConfiguration", Name: "mwh1"}, deleted: false}, // MutatingWebhookConfiguration should be preserved
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: repository.WebhookNamespaceName}, deleted: false},                             // capi-webhook-system namespace should never be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: repository.WebhookNamespaceName, Name: "podx"}, deleted: false},                // provider objects in the capi-webhook-system namespace should be preserved
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                                           // provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: true},                                           // other objects in the namespace goes away when deleting the namespace
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                                          // this object is in another namespace, and should never be touched by delete
+				{object: corev1.ObjectReference{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: "ns1-cluster-role"}, deleted: true},               // cluster-wide provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: "some-cluster-role"}, deleted: false},             // other cluster-wide objects should be preserved
 			},
 			wantErr: false,
 		},
-
 		{
 			name: "Delete provider and provider CRDs, while preserving the provider namespace",
 			args: args{
@@ -145,15 +208,19 @@ func Test_providerComponents_Delete(t *testing.T) {
 				forceDeleteCRD:       true,
 			},
 			wantDiff: []wantDiff{
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: false},                                          //namespace should be preserved
-				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: true}, //crd should be deleted
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                              // provider components should be deleted
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: false},                             // other objects in the namespace should not be deleted
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                             // this object is in another namespace, and should never be touched by delete
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: false},                                                      // namespace should be preserved
+				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: true},             // crd should be deleted
+				{object: corev1.ObjectReference{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "MutatingWebhookConfiguration", Name: "mwh1"}, deleted: true}, // MutatingWebhookConfiguration should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: repository.WebhookNamespaceName}, deleted: false},                            // capi-webhook-system namespace should never be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: repository.WebhookNamespaceName, Name: "podx"}, deleted: true},                // provider objects in the capi-webhook-system namespace should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                                          // provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: false},                                         // other objects in the namespace should not be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                                         // this object is in another namespace, and should never be touched by delete
+				{object: corev1.ObjectReference{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: "ns1-cluster-role"}, deleted: true},              // cluster-wide provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: "some-cluster-role"}, deleted: false},            // other cluster-wide objects should be preserved
 			},
 			wantErr: false,
 		},
-
 		{
 			name: "Delete provider, provider namespace and provider CRDs",
 			args: args{
@@ -162,11 +229,16 @@ func Test_providerComponents_Delete(t *testing.T) {
 				forceDeleteCRD:       true,
 			},
 			wantDiff: []wantDiff{
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: true},                                           //namespace should be deleted
-				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: true}, //crd should be deleted
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                              // provider components should be deleted
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: true},                              // other objects in the namespace goes away when deleting the namespace
-				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                             // this object is in another namespace, and should never be touched by delete
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: "ns1"}, deleted: true},                                                       // namespace should be deleted
+				{object: corev1.ObjectReference{APIVersion: "apiextensions.k8s.io/v1beta1", Kind: "CustomResourceDefinition", Name: "crd1"}, deleted: true},             // crd should be deleted
+				{object: corev1.ObjectReference{APIVersion: "admissionregistration.k8s.io/v1beta1", Kind: "MutatingWebhookConfiguration", Name: "mwh1"}, deleted: true}, // MutatingWebhookConfiguration should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Namespace", Name: repository.WebhookNamespaceName}, deleted: false},                            // capi-webhook-namespace should never be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: repository.WebhookNamespaceName, Name: "podx"}, deleted: true},                // provider objects in the capi-webhook-namespace should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod1"}, deleted: true},                                          // provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns1", Name: "pod2"}, deleted: true},                                          // other objects in the namespace goes away when deleting the namespace
+				{object: corev1.ObjectReference{APIVersion: "v1", Kind: "Pod", Namespace: "ns2", Name: "pod3"}, deleted: false},                                         // this object is in another namespace, and should never be touched by delete
+				{object: corev1.ObjectReference{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: "ns1-cluster-role"}, deleted: true},              // cluster-wide provider components should be deleted
+				{object: corev1.ObjectReference{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: "some-cluster-role"}, deleted: false},            // other cluster-wide objects should be preserved
 			},
 			wantErr: false,
 		},

--- a/cmd/clusterctl/pkg/client/cluster/components_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/components_test.go
@@ -251,7 +251,7 @@ func Test_providerComponents_Delete(t *testing.T) {
 			err := c.Delete(DeleteOptions{
 				Provider:         tt.args.provider,
 				IncludeNamespace: tt.args.includeNamespace,
-				IncludeCRD:       tt.args.includeCRD,
+				IncludeCRDs:      tt.args.includeCRD,
 			})
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)

--- a/cmd/clusterctl/pkg/client/cluster/installer.go
+++ b/cmd/clusterctl/pkg/client/cluster/installer.go
@@ -93,7 +93,7 @@ func installComponentsAndUpdateInventory(components repository.Components, provi
 		return err
 	}
 
-	installSharedComponents, err := mustInstallSharedComponents(providerList, inventoryObject)
+	installSharedComponents, err := shouldInstallSharedComponents(providerList, inventoryObject)
 	if err != nil {
 		return err
 	}
@@ -123,8 +123,8 @@ func installComponentsAndUpdateInventory(components repository.Components, provi
 	return nil
 }
 
-// mustInstallSharedComponents checks if it is required to install shared components for a provider.
-func mustInstallSharedComponents(providerList *clusterctlv1.ProviderList, provider clusterctlv1.Provider) (bool, error) {
+// shouldInstallSharedComponents checks if it is required to install shared components for a provider.
+func shouldInstallSharedComponents(providerList *clusterctlv1.ProviderList, provider clusterctlv1.Provider) (bool, error) {
 	// Get the max version of the provider already installed in the cluster.
 	var maxVersion *version.Version
 	for _, other := range providerList.FilterByName(provider.Name) {

--- a/cmd/clusterctl/pkg/client/cluster/installer.go
+++ b/cmd/clusterctl/pkg/client/cluster/installer.go
@@ -23,6 +23,7 @@ import (
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/client/repository"
+	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/log"
 )
 
 // ProviderInstaller defines methods for enforcing consistency rules for provider installation.
@@ -77,15 +78,83 @@ func (i *providerInstaller) Install() ([]repository.Components, error) {
 }
 
 func installComponentsAndUpdateInventory(components repository.Components, providerComponents ComponentsClient, providerInventory InventoryClient) error {
-	if err := providerComponents.Create(components); err != nil {
+	log := logf.Log
+	log.Info("Installing", "Provider", components.Name(), "Version", components.Version(), "TargetNamespace", components.TargetNamespace())
+
+	inventoryObject := components.InventoryObject()
+
+	// Check the list of providers currently in the cluster and decide if to install shared components (CRDs, web-hooks) or not.
+	// We are required to install shared components in two cases:
+	// - when this is the first instance of the provider being installed.
+	// - when the version of the provider being installed is newer than the max version already installed in the cluster.
+	// Nb. this assumes the newer version of shared components are fully retro-compatible.
+	providerList, err := providerInventory.List()
+	if err != nil {
 		return err
 	}
 
-	if err := providerInventory.Create(components.InventoryObject()); err != nil {
+	installSharedComponents, err := mustInstallSharedComponents(providerList, inventoryObject)
+	if err != nil {
+		return err
+	}
+	if installSharedComponents {
+		log.V(1).Info("Creating shared objects", "Provider", components.Name(), "Version", components.Version())
+		// TODO: currently shared components overrides existing shared components. As a future improvement we should
+		//  consider if to delete (preserving CRDs) before installing so there will be no left-overs in case the list of resources changes
+		if err := providerComponents.Create(components.SharedObjs()); err != nil {
+			return err
+		}
+	} else {
+		log.V(1).Info("Shared objects already up to date", "Provider", components.Name())
+	}
+
+	// Then always install the instance specific objects and the then inventory item for the provider
+
+	log.V(1).Info("Creating instance objects", "Provider", components.Name(), "Version", components.Version(), "TargetNamespace", components.TargetNamespace())
+	if err := providerComponents.Create(components.InstanceObjs()); err != nil {
+		return err
+	}
+
+	log.V(1).Info("Creating inventory entry", "Provider", components.Name(), "Version", components.Version(), "TargetNamespace", components.TargetNamespace())
+	if err := providerInventory.Create(inventoryObject); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// mustInstallSharedComponents checks if it is required to install shared components for a provider.
+func mustInstallSharedComponents(providerList *clusterctlv1.ProviderList, provider clusterctlv1.Provider) (bool, error) {
+	// Get the max version of the provider already installed in the cluster.
+	var maxVersion *version.Version
+	for _, other := range providerList.FilterByName(provider.Name) {
+		otherVersion, err := version.ParseSemantic(other.Version)
+		if err != nil {
+			return false, errors.Wrapf(err, "failed to parse version for the %s provider", other.InstanceName())
+		}
+		if maxVersion == nil || otherVersion.AtLeast(maxVersion) {
+			maxVersion = otherVersion
+		}
+	}
+	// If there is no max version, this is the first instance of the provider being installed, so it is required
+	// to install the shared components.
+	if maxVersion == nil {
+		return true, nil
+	}
+
+	// If the installed version is newer or equal than than the version of the provider being installed,
+	// return false because we should not down grade the shared components.
+	providerVersion, err := version.ParseSemantic(provider.Version)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to parse version for the %s provider", provider.InstanceName())
+	}
+	if maxVersion.AtLeast(providerVersion) {
+		return false, nil
+	}
+
+	// Otherwise, the version of the provider being installed is newer that the current max version, so it is
+	// required to install also the new version of shared components.
+	return true, nil
 }
 
 func (i *providerInstaller) Validate() error {

--- a/cmd/clusterctl/pkg/client/cluster/installer_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/installer_test.go
@@ -240,7 +240,11 @@ func (c *fakeComponents) InventoryObject() clusterctlv1.Provider {
 	return c.inventoryObject
 }
 
-func (c *fakeComponents) Objs() []unstructured.Unstructured {
+func (c *fakeComponents) InstanceObjs() []unstructured.Unstructured {
+	panic("not implemented")
+}
+
+func (c *fakeComponents) SharedObjs() []unstructured.Unstructured {
 	panic("not implemented")
 }
 
@@ -253,5 +257,77 @@ func newFakeComponents(name string, providerType clusterctlv1.ProviderType, vers
 	return &fakeComponents{
 		Provider:        config.NewProvider(inventoryObject.Name, "", clusterctlv1.ProviderType(inventoryObject.Type)),
 		inventoryObject: inventoryObject,
+	}
+}
+
+func Test_mustInstallSharedComponents(t *testing.T) {
+	type args struct {
+		providerList *clusterctlv1.ProviderList
+		provider     clusterctlv1.Provider
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "First instance of the provider, must install shared components",
+			args: args{
+				providerList: &clusterctlv1.ProviderList{Items: []clusterctlv1.Provider{}}, // no core provider installed
+				provider:     fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", "", ""),
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Second instance of the provider, same version, must NOT install shared components",
+			args: args{
+				providerList: &clusterctlv1.ProviderList{Items: []clusterctlv1.Provider{
+					fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", "", ""),
+				}},
+				provider: fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", "", ""),
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Second instance of the provider, older version, must NOT install shared components",
+			args: args{
+				providerList: &clusterctlv1.ProviderList{Items: []clusterctlv1.Provider{
+					fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", "", ""),
+				}},
+				provider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "", ""),
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Second instance of the provider, newer version, must install shared components",
+			args: args{
+				providerList: &clusterctlv1.ProviderList{Items: []clusterctlv1.Provider{
+					fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", "", ""),
+				}},
+				provider: fakeProvider("core", clusterctlv1.CoreProviderType, "v3.0.0", "", ""),
+			},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mustInstallSharedComponents(tt.args.providerList, tt.args.provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/clusterctl/pkg/client/cluster/installer_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/installer_test.go
@@ -260,7 +260,7 @@ func newFakeComponents(name string, providerType clusterctlv1.ProviderType, vers
 	}
 }
 
-func Test_mustInstallSharedComponents(t *testing.T) {
+func Test_shouldInstallSharedComponents(t *testing.T) {
 	type args struct {
 		providerList *clusterctlv1.ProviderList
 		provider     clusterctlv1.Provider
@@ -316,7 +316,7 @@ func Test_mustInstallSharedComponents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := mustInstallSharedComponents(tt.args.providerList, tt.args.provider)
+			got, err := shouldInstallSharedComponents(tt.args.providerList, tt.args.provider)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/clusterctl/pkg/client/cluster/upgrader.go
+++ b/cmd/clusterctl/pkg/client/cluster/upgrader.go
@@ -218,9 +218,9 @@ func (u *providerUpgrader) doUpgrade(upgradePlan *UpgradePlan) error {
 
 		// Delete the provider, preserving CRD and namespace.
 		if err := u.providerComponents.Delete(DeleteOptions{
-			Provider:             upgradeItem.Provider,
-			ForceDeleteNamespace: false,
-			ForceDeleteCRD:       false,
+			Provider:         upgradeItem.Provider,
+			IncludeNamespace: false,
+			IncludeCRD:       false,
 		}); err != nil {
 			return err
 		}

--- a/cmd/clusterctl/pkg/client/cluster/upgrader.go
+++ b/cmd/clusterctl/pkg/client/cluster/upgrader.go
@@ -220,7 +220,7 @@ func (u *providerUpgrader) doUpgrade(upgradePlan *UpgradePlan) error {
 		if err := u.providerComponents.Delete(DeleteOptions{
 			Provider:         upgradeItem.Provider,
 			IncludeNamespace: false,
-			IncludeCRD:       false,
+			IncludeCRDs:      false,
 		}); err != nil {
 			return err
 		}

--- a/cmd/clusterctl/pkg/client/delete.go
+++ b/cmd/clusterctl/pkg/client/delete.go
@@ -93,7 +93,7 @@ func (c *clusterctlClient) Delete(options DeleteOptions) error {
 
 	// Delete the selected providers
 	for _, provider := range providers {
-		if err := clusterClient.ProviderComponents().Delete(cluster.DeleteOptions{Provider: provider, ForceDeleteNamespace: options.ForceDeleteNamespace, ForceDeleteCRD: options.ForceDeleteCRD}); err != nil {
+		if err := clusterClient.ProviderComponents().Delete(cluster.DeleteOptions{Provider: provider, IncludeNamespace: options.IncludeNamespace, IncludeCRD: options.IncludeCRD}); err != nil {
 			return err
 		}
 	}

--- a/cmd/clusterctl/pkg/client/delete.go
+++ b/cmd/clusterctl/pkg/client/delete.go
@@ -93,7 +93,7 @@ func (c *clusterctlClient) Delete(options DeleteOptions) error {
 
 	// Delete the selected providers
 	for _, provider := range providers {
-		if err := clusterClient.ProviderComponents().Delete(cluster.DeleteOptions{Provider: provider, IncludeNamespace: options.IncludeNamespace, IncludeCRD: options.IncludeCRD}); err != nil {
+		if err := clusterClient.ProviderComponents().Delete(cluster.DeleteOptions{Provider: provider, IncludeNamespace: options.IncludeNamespace, IncludeCRDs: options.IncludeCRDs}); err != nil {
 			return err
 		}
 	}

--- a/cmd/clusterctl/pkg/client/delete_test.go
+++ b/cmd/clusterctl/pkg/client/delete_test.go
@@ -46,11 +46,11 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 			},
 			args: args{
 				options: DeleteOptions{
-					Kubeconfig:           "kubeconfig",
-					ForceDeleteNamespace: false,
-					ForceDeleteCRD:       false,
-					Namespace:            "",
-					Providers:            nil, // nil means all the providers
+					Kubeconfig:       "kubeconfig",
+					IncludeNamespace: false,
+					IncludeCRD:       false,
+					Namespace:        "",
+					Providers:        nil, // nil means all the providers
 				},
 			},
 			wantProviders: sets.NewString(),
@@ -63,11 +63,11 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 			},
 			args: args{
 				options: DeleteOptions{
-					Kubeconfig:           "kubeconfig",
-					ForceDeleteNamespace: false,
-					ForceDeleteCRD:       false,
-					Namespace:            "capbpk-system",
-					Providers:            []string{bootstrapProviderConfig.Name()},
+					Kubeconfig:       "kubeconfig",
+					IncludeNamespace: false,
+					IncludeCRD:       false,
+					Namespace:        "capbpk-system",
+					Providers:        []string{bootstrapProviderConfig.Name()},
 				},
 			},
 			wantProviders: sets.NewString(capiProviderConfig.Name()),
@@ -80,11 +80,11 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 			},
 			args: args{
 				options: DeleteOptions{
-					Kubeconfig:           "kubeconfig",
-					ForceDeleteNamespace: false,
-					ForceDeleteCRD:       false,
-					Namespace:            "", // empty namespace triggers namespace auto detection
-					Providers:            []string{bootstrapProviderConfig.Name()},
+					Kubeconfig:       "kubeconfig",
+					IncludeNamespace: false,
+					IncludeCRD:       false,
+					Namespace:        "", // empty namespace triggers namespace auto detection
+					Providers:        []string{bootstrapProviderConfig.Name()},
 				},
 			},
 			wantProviders: sets.NewString(capiProviderConfig.Name()),

--- a/cmd/clusterctl/pkg/client/delete_test.go
+++ b/cmd/clusterctl/pkg/client/delete_test.go
@@ -48,7 +48,7 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 				options: DeleteOptions{
 					Kubeconfig:       "kubeconfig",
 					IncludeNamespace: false,
-					IncludeCRD:       false,
+					IncludeCRDs:      false,
 					Namespace:        "",
 					Providers:        nil, // nil means all the providers
 				},
@@ -65,7 +65,7 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 				options: DeleteOptions{
 					Kubeconfig:       "kubeconfig",
 					IncludeNamespace: false,
-					IncludeCRD:       false,
+					IncludeCRDs:      false,
 					Namespace:        "capbpk-system",
 					Providers:        []string{bootstrapProviderConfig.Name()},
 				},
@@ -82,7 +82,7 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 				options: DeleteOptions{
 					Kubeconfig:       "kubeconfig",
 					IncludeNamespace: false,
-					IncludeCRD:       false,
+					IncludeCRDs:      false,
 					Namespace:        "", // empty namespace triggers namespace auto detection
 					Providers:        []string{bootstrapProviderConfig.Name()},
 				},

--- a/cmd/clusterctl/pkg/client/repository/components_client.go
+++ b/cmd/clusterctl/pkg/client/repository/components_client.go
@@ -65,7 +65,7 @@ func (f *componentsClient) Get(version, targetNamespace, watchingNamespace strin
 	}
 
 	if file == nil {
-		log.V(1).Info("Fetching", "File", path, "Provider", f.provider.Name(), "Version", version)
+		log.V(5).Info("Fetching", "File", path, "Provider", f.provider.Name(), "Version", version)
 		file, err = f.repository.GetFile(version, path)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read %q from provider's repository %q", path, f.provider.Name())

--- a/cmd/clusterctl/pkg/client/repository/components_client_test.go
+++ b/cmd/clusterctl/pkg/client/repository/components_client_test.go
@@ -290,7 +290,7 @@ func Test_componentsClient_Get(t *testing.T) {
 			}
 
 			for _, o := range got.SharedObjs() {
-				for _, v := range []string{clusterctlv1.ClusterctlLabelName, clusterv1.ProviderLabelName, clusterctlv1.ClusterctlSharedResourceLabelName} {
+				for _, v := range []string{clusterctlv1.ClusterctlLabelName, clusterv1.ProviderLabelName, clusterctlv1.ClusterctlResourceLifecyleLabelName} {
 					if _, ok := o.GetLabels()[v]; !ok {
 						t.Errorf("got.SharedObjs() object %s does not contains %s label", o.GetName(), v)
 					}

--- a/cmd/clusterctl/pkg/client/repository/components_client_test.go
+++ b/cmd/clusterctl/pkg/client/repository/components_client_test.go
@@ -281,10 +281,18 @@ func Test_componentsClient_Get(t *testing.T) {
 				t.Errorf("got.Yaml() does not containt value %s that is a replacement of %s variable", variableValue, variableName)
 			}
 
-			for _, o := range got.Objs() {
+			for _, o := range got.InstanceObjs() {
 				for _, v := range []string{clusterctlv1.ClusterctlLabelName, clusterv1.ProviderLabelName} {
 					if _, ok := o.GetLabels()[v]; !ok {
-						t.Errorf("got.Objs() object %s does not contains %s label", o.GetName(), v)
+						t.Errorf("got.InstanceObjs() object %s does not contains %s label", o.GetName(), v)
+					}
+				}
+			}
+
+			for _, o := range got.SharedObjs() {
+				for _, v := range []string{clusterctlv1.ClusterctlLabelName, clusterv1.ProviderLabelName, clusterctlv1.ClusterctlSharedResourceLabelName} {
+					if _, ok := o.GetLabels()[v]; !ok {
+						t.Errorf("got.SharedObjs() object %s does not contains %s label", o.GetName(), v)
 					}
 				}
 			}

--- a/cmd/clusterctl/pkg/client/repository/metadata_client.go
+++ b/cmd/clusterctl/pkg/client/repository/metadata_client.go
@@ -65,7 +65,7 @@ func (f *metadataClient) Get() (*clusterctlv1.Metadata, error) {
 		return nil, err
 	}
 	if file == nil {
-		log.V(1).Info("Fetching", "File", name, "Provider", f.provider.Name(), "Version", version)
+		log.V(5).Info("Fetching", "File", name, "Provider", f.provider.Name(), "Version", version)
 		file, err = f.repository.GetFile(version, name)
 		if err != nil {
 			// if there are problems in reading the metadata file from the repository, check if there are embedded metadata for the provider, if yes use them

--- a/cmd/clusterctl/pkg/client/repository/template_client.go
+++ b/cmd/clusterctl/pkg/client/repository/template_client.go
@@ -91,7 +91,7 @@ func (c *templateClient) Get(flavor, targetNamespace string, listVariablesOnly b
 	}
 
 	if rawYaml == nil {
-		log.V(1).Info("Fetching", "File", name, "Provider", c.provider.Name(), "Version", version)
+		log.V(5).Info("Fetching", "File", name, "Provider", c.provider.Name(), "Version", version)
 		rawYaml, err = c.repository.GetFile(version, name)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read %q from provider's repository %q", name, c.provider.Name())

--- a/cmd/clusterctl/pkg/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/pkg/internal/test/fake_proxy.go
@@ -65,7 +65,7 @@ func (f *FakeProxy) NewClient() (client.Client, error) {
 }
 
 // ListResources returns all the resources known by the FakeProxy
-func (f *FakeProxy) ListResources(namespace string, labels map[string]string) ([]unstructured.Unstructured, error) {
+func (f *FakeProxy) ListResources(labels map[string]string, namespaces ...string) ([]unstructured.Unstructured, error) {
 	var ret []unstructured.Unstructured //nolint
 	for _, o := range f.objs {
 		u := unstructured.Unstructured{}
@@ -75,8 +75,17 @@ func (f *FakeProxy) ListResources(namespace string, labels map[string]string) ([
 		}
 
 		// filter by namespace, if any
-		if namespace != "" && u.GetNamespace() != "" && u.GetNamespace() != namespace {
-			continue
+		if len(namespaces) > 0 && u.GetNamespace() != "" {
+			inNamespaces := false
+			for _, namespace := range namespaces {
+				if u.GetNamespace() == namespace {
+					inNamespaces = true
+					break
+				}
+			}
+			if !inNamespaces {
+				continue
+			}
 		}
 
 		// filter by label, if any

--- a/cmd/clusterctl/pkg/internal/util/objs.go
+++ b/cmd/clusterctl/pkg/internal/util/objs.go
@@ -19,6 +19,7 @@ package util
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/scheme"
 )
 
@@ -82,4 +83,16 @@ func IsResourceNamespaced(kind string) bool {
 	default:
 		return true
 	}
+}
+
+// IsSharedResource returns true if the resource lifecycle is shared.
+func IsSharedResource(o unstructured.Unstructured) bool {
+	lifecycle, ok := o.GetLabels()[clusterctlv1.ClusterctlResourceLifecyleLabelName]
+	if !ok {
+		return false
+	}
+	if lifecycle == string(clusterctlv1.ResourceLifecycleShared) {
+		return true
+	}
+	return false
 }

--- a/cmd/clusterctl/pkg/internal/util/objs.go
+++ b/cmd/clusterctl/pkg/internal/util/objs.go
@@ -53,3 +53,33 @@ func InspectImages(objs []unstructured.Unstructured) ([]string, error) {
 
 	return images, nil
 }
+
+// IsClusterResource returns true if the resource kind is cluster wide (not namespaced).
+func IsClusterResource(kind string) bool {
+	return !IsResourceNamespaced(kind)
+}
+
+// IsResourceNamespaced returns true if the resource kind is namespaced.
+func IsResourceNamespaced(kind string) bool {
+	switch kind {
+	case "Namespace",
+		"Node",
+		"PersistentVolume",
+		"PodSecurityPolicy",
+		"CertificateSigningRequest",
+		"ClusterRoleBinding",
+		"ClusterRole",
+		"VolumeAttachment",
+		"StorageClass",
+		"CSIDriver",
+		"CSINode",
+		"ValidatingWebhookConfiguration",
+		"MutatingWebhookConfiguration",
+		"CustomResourceDefinition",
+		"PriorityClass",
+		"RuntimeClass":
+		return false
+	default:
+		return true
+	}
+}

--- a/docs/book/src/clusterctl/commands/delete.md
+++ b/docs/book/src/clusterctl/commands/delete.md
@@ -30,6 +30,8 @@ If you want to delete the provider's CRDs, you can use the `--delete-crd` flag.
 Be aware that this operation deletes all the object of Kind defined in the provider's CRDs, e.g. when deleting
 the aws provider, it deletes all the `AWSCluster`, `AWSMachine` etc.
 
+Also, this 
+
 </aside> 
 
 If you want to delete all the providers in a single operation , you can use the `--all` flag.

--- a/docs/book/src/clusterctl/commands/delete.md
+++ b/docs/book/src/clusterctl/commands/delete.md
@@ -30,8 +30,6 @@ If you want to delete the provider's CRDs, you can use the `--delete-crd` flag.
 Be aware that this operation deletes all the object of Kind defined in the provider's CRDs, e.g. when deleting
 the aws provider, it deletes all the `AWSCluster`, `AWSMachine` etc.
 
-Also, this 
-
 </aside> 
 
 If you want to delete all the providers in a single operation , you can use the `--all` flag.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adapt clusterctl to changes introduced by https://github.com/kubernetes-sigs/cluster-api/pull/2279

More specifically
- when installing a provider clusterctl splits instance-specific resources and resources shared between many intances
- shared resources are installed/overwritten only if we are installing a version newer than the max version in the cluster
- clusterctl delete handles deleting resources accordingly

**Which issue(s) this PR fixes**:
Rif #1729
/area clusterctl
/assign @ncdc
/assign @vincepri
