### PR TITLE
🏃 KCP cleanup

### DIFF
--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -190,21 +190,6 @@ func (m *ManagementCluster) TargetClusterEtcdIsHealthy(ctx context.Context, clus
 	return nil
 }
 
-// ControlPlaneLabels returns a set of labels to add to a control plane machine for this specific cluster.
-func (m *ManagementCluster) ControlPlaneLabelsForCluster(clusterName string) map[string]string {
-	return map[string]string{
-		clusterv1.ClusterLabelName:             clusterName,
-		clusterv1.MachineControlPlaneLabelName: "",
-	}
-}
-
-// ControlPlaneSelectorForCluster returns the label selector necessary to get control plane machines for a given cluster.
-func (m *ManagementCluster) ControlPlaneSelectorForCluster(clusterName string) *metav1.LabelSelector {
-	return &metav1.LabelSelector{
-		MatchLabels: m.ControlPlaneLabelsForCluster(clusterName),
-	}
-}
-
 // cluster are operations on target clusters.
 type cluster struct {
 	client ctrlclient.Client

--- a/controlplane/kubeadm/internal/cluster_labels.go
+++ b/controlplane/kubeadm/internal/cluster_labels.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+// ControlPlaneLabels returns a set of labels to add to a control plane machine for this specific cluster.
+func ControlPlaneLabelsForCluster(clusterName string) map[string]string {
+	return map[string]string{
+		clusterv1.ClusterLabelName:             clusterName,
+		clusterv1.MachineControlPlaneLabelName: "",
+	}
+}
+
+// ControlPlaneSelectorForCluster returns the label selector necessary to get control plane machines for a given cluster.
+func ControlPlaneSelectorForCluster(clusterName string) *metav1.LabelSelector {
+	return &metav1.LabelSelector{
+		MatchLabels: ControlPlaneLabelsForCluster(clusterName),
+	}
+}

--- a/controlplane/kubeadm/internal/failure_domain_test.go
+++ b/controlplane/kubeadm/internal/failure_domain_test.go
@@ -19,7 +19,6 @@ package internal
 import (
 	"testing"
 
-	"k8s.io/klog/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
@@ -37,7 +36,6 @@ func TestNewFailureDomainPicker(t *testing.T) {
 
 	testcases := []struct {
 		name     string
-		logger   logger
 		fds      clusterv1.FailureDomains
 		machines []clusterv1.Machine
 		expected []string
@@ -72,8 +70,7 @@ func TestNewFailureDomainPicker(t *testing.T) {
 			expected: []string{a, b},
 		},
 		{
-			name:   "mismatched failure domain on machine",
-			logger: klogr.New(),
+			name: "mismatched failure domain on machine",
 			fds: clusterv1.FailureDomains{
 				a: clusterv1.FailureDomainSpec{},
 			},
@@ -91,8 +88,7 @@ func TestNewFailureDomainPicker(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			picker := FailureDomainPicker{Log: tc.logger}
-			fd := picker.PickFewest(tc.fds, tc.machines)
+			fd := PickFewest(tc.fds, tc.machines)
 
 			found := false
 			for _, expectation := range tc.expected {


### PR DESCRIPTION
/hold

This depends on #2295 

**What this PR does / why we need it**:
This PR cleans up a few things from #2193. This will make the change to get the etcd health check even smaller and more integrated feeling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #2243 

/assign @detiber @dlipovetsky @randomvariable 

To expand a little bit on what's going on here: This is a minimal diff to start using the ManagementCluster and remove the functionality off the reconciler. Moving forward I'd like to take almost all of the logic in the reconciler and put it on the management cluster. This will keep the reconciler small and testable while focused on passing data to the right dependencies. 