### PR TITLE
 🐛 Remove variables from ci that are already declared in Makefile

### DIFF
--- a/scripts/ci-integration.sh
+++ b/scripts/ci-integration.sh
@@ -33,8 +33,6 @@ CONTROLLER_REPO_KUBEADM_BOOTSTRAP="controller-ci-kubeadm-bootstrap"
 CONTROLLER_REPO_KUBEADM_CONTROL_PLANE="controller-ci-kubeadm-control-plane"
 EXAMPLE_PROVIDER_REPO="example-provider-ci"
 CERT_MANAGER_URL="https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml"
-TOOLS_DIR="hack/tools"
-TOOLS_BIN_DIR="${TOOLS_DIR}/bin"
 
 GOOS=$(go env GOOS)
 GOARCH=$(go env GOARCH)
@@ -59,12 +57,6 @@ install_kustomize() {
 
 build_containers() {
    VERSION="$(git describe --exact-match 2> /dev/null || git describe --match="$(git rev-parse --short=8 HEAD)" --always --dirty --abbrev=8)"
-   export CONTROLLER_GEN="${PWD}/${TOOLS_BIN_DIR}/controller-gen"
-   export CONVERSION_GEN="${PWD}/${TOOLS_BIN_DIR}/conversion-gen"
-   export KUSTOMIZE="${PWD}/${TOOLS_BIN_DIR}/kustomize"
-   export GOBINDATA="${PWD}/${TOOLS_BIN_DIR}/go-bindata"
-   export GOBINDATA_CLUSTERCTL_DIR="cmd/clusterctl/config"
-   export CERTMANAGER_COMPONENTS_GENERATED_FILE="cert-manager.yaml"
    export CONTROLLER_IMG="${CONTROLLER_REPO}"
    export KUBEADM_BOOTSTRAP_CONTROLLER_IMG="${CONTROLLER_REPO_KUBEADM_BOOTSTRAP}"
    export KUBEADM_CONTROL_PLANE_CONTROLLER_IMG="${CONTROLLER_REPO_KUBEADM_CONTROL_PLANE}"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Removes the variables that were not required in `ci-integration.sh`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow up to #2297 
