### PR TITLE
✨ Moved MachineDeployment Cluster Label Name to webhook

### DIFF
--- a/api/v1alpha3/machinedeployment_webhook.go
+++ b/api/v1alpha3/machinedeployment_webhook.go
@@ -144,4 +144,7 @@ func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
 		d.Spec.Selector.MatchLabels[MachineDeploymentLabelName] = d.Name
 		d.Spec.Template.Labels[MachineDeploymentLabelName] = d.Name
 	}
+	// Make sure selector and template to be in the same cluster.
+	d.Spec.Selector.MatchLabels[ClusterLabelName] = d.Spec.ClusterName
+	d.Spec.Template.Labels[ClusterLabelName] = d.Spec.ClusterName
 }

--- a/api/v1alpha3/machinedeployment_webhook_test.go
+++ b/api/v1alpha3/machinedeployment_webhook_test.go
@@ -111,3 +111,21 @@ func TestMachineDeploymentValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestMachineDeploymentWithSpec(t *testing.T) {
+	g := NewWithT(t)
+	md := MachineDeployment{
+		Spec: MachineDeploymentSpec{
+			ClusterName: "test-cluster",
+			Template: MachineTemplateSpec{
+				Spec: MachineSpec{
+					ClusterName: "test-cluster",
+				},
+			},
+		},
+	}
+
+	md.Default()
+	g.Expect(md.Spec.Selector.MatchLabels).To(HaveKeyWithValue(ClusterLabelName, "test-cluster"))
+	g.Expect(md.Spec.Template.Labels).To(HaveKeyWithValue(ClusterLabelName, "test-cluster"))
+}

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -148,10 +148,6 @@ func (r *MachineDeploymentReconciler) reconcile(_ context.Context, cluster *clus
 
 	d.Labels[clusterv1.ClusterLabelName] = d.Spec.ClusterName
 
-	// Make sure selector and template to be in the same cluster.
-	d.Spec.Selector.MatchLabels[clusterv1.ClusterLabelName] = d.Spec.ClusterName
-	d.Spec.Template.Labels[clusterv1.ClusterLabelName] = d.Spec.ClusterName
-
 	if r.shouldAdopt(d) {
 		d.OwnerReferences = util.EnsureOwnerRef(d.OwnerReferences, metav1.OwnerReference{
 			APIVersion: clusterv1.GroupVersion.String(),

--- a/controllers/machinedeployment_controller_test.go
+++ b/controllers/machinedeployment_controller_test.go
@@ -62,19 +62,29 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 	})
 
 	It("Should reconcile a MachineDeployment", func() {
-		labels := map[string]string{"foo": "bar"}
+		labels := map[string]string{
+			"foo":                      "bar",
+			clusterv1.ClusterLabelName: testCluster.Name,
+		}
 		version := "1.10.3"
 		deployment := &clusterv1.MachineDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "md-",
 				Namespace:    namespace.Name,
+				Labels: map[string]string{
+					clusterv1.ClusterLabelName: testCluster.Name,
+				},
 			},
 			Spec: clusterv1.MachineDeploymentSpec{
 				ClusterName:          testCluster.Name,
 				MinReadySeconds:      pointer.Int32Ptr(0),
 				Replicas:             pointer.Int32Ptr(2),
 				RevisionHistoryLimit: pointer.Int32Ptr(0),
-				Selector:             metav1.LabelSelector{},
+				Selector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						clusterv1.ClusterLabelName: testCluster.Name,
+					},
+				},
 				Strategy: &clusterv1.MachineDeploymentStrategy{
 					Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
 					RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
@@ -306,7 +316,8 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		oldLabels[clusterv1.MachineDeploymentLabelName] = deployment.Name
 
 		newLabels := map[string]string{
-			"new-key": "new-value",
+			"new-key":                  "new-value",
+			clusterv1.ClusterLabelName: testCluster.Name,
 		}
 
 		By("Updating MachineDeployment label")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Moved MachineDeployment Cluster Label Name to webhook as per #2302 

**Which issue(s) this PR fixes**  :
Fixes #2302
