### PR TITLE
🐛clusterctl: drop incomplete plans if contract change

### DIFF
--- a/cmd/clusterctl/pkg/client/cluster/upgrader_info.go
+++ b/cmd/clusterctl/pkg/client/cluster/upgrader_info.go
@@ -35,6 +35,9 @@ type upgradeInfo struct {
 	// currentVersion of the provider
 	currentVersion *version.Version
 
+	// currentContract of the provider
+	currentContract string
+
 	// nextVersions return the list of versions available for upgrades, defined as the list of version available in the provider repository
 	// greater than the currentVersion.
 	nextVersions []version.Version
@@ -123,10 +126,18 @@ func newUpgradeInfo(metadata *clusterctlv1.Metadata, currentVersion *version.Ver
 		return nextVersions[i].LessThan(&nextVersions[j])
 	})
 
+	// Gets the current contract for the provider
+	// Please note this should never be empty, because getUpgradeInfo ensures the releaseSeries defined in metadata includes the current version.
+	currentContract := ""
+	if currentReleaseSeries := metadata.GetReleaseSeriesForVersion(currentVersion); currentReleaseSeries != nil {
+		currentContract = currentReleaseSeries.Contract
+	}
+
 	return &upgradeInfo{
-		metadata:       metadata,
-		currentVersion: currentVersion,
-		nextVersions:   nextVersions,
+		metadata:        metadata,
+		currentVersion:  currentVersion,
+		currentContract: currentContract,
+		nextVersions:    nextVersions,
 	}
 }
 

--- a/cmd/clusterctl/pkg/client/cluster/upgrader_info_test.go
+++ b/cmd/clusterctl/pkg/client/cluster/upgrader_info_test.go
@@ -71,7 +71,8 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 						{Major: 1, Minor: 1, Contract: "v1alpha3"},
 					},
 				},
-				currentVersion: version.MustParseSemantic("v1.0.1"),
+				currentVersion:  version.MustParseSemantic("v1.0.1"),
+				currentContract: "v1alpha3",
 				nextVersions: []version.Version{
 					// v1.0.1 (the current version) and older are ignored
 					*version.MustParseSemantic("v1.0.2"),


### PR DESCRIPTION
**What this PR does / why we need it**:
All the providers in a management group are expected to support the same API Version of Cluster API (contract).

This PR makes upgrade plan fully compatible with the above expectation by dropping incomplete plans - plan where not all the providers have a target version -  when changing the contract version. So

v1alpha3 --> v1alpha3
Incomplete plans are supported (some provider will be updated, some other are already up to date)

v1alpha3 --> v1alpha4
Incomplete plans are dropped because all the provider are required to change the contract at the same time

If instead, the plan is complete (there is a target

**Which issue(s) this PR fixes**:
Rif #1729

/area clusterctl
/assign @wfernandes
/assign @vincepri
