### PR TITLE
🐛clusterctl: fix-to-unstructured

### DIFF
--- a/cmd/clusterctl/pkg/internal/util/yaml.go
+++ b/cmd/clusterctl/pkg/internal/util/yaml.go
@@ -17,10 +17,13 @@ limitations under the License.
 package util
 
 import (
+	"bufio"
 	"bytes"
+	"io"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/yaml"
 )
 
@@ -52,21 +55,28 @@ func JoinYaml(yamls ...[]byte) []byte {
 // ToUnstructured takes a YAML and converts it to a list of Unstructured objects
 func ToUnstructured(rawyaml []byte) ([]unstructured.Unstructured, error) {
 	var ret []unstructured.Unstructured //nolint
-	for _, data := range bytes.Split(rawyaml, yamlSeparator) {
-		var m map[string]interface{}
-		err := yaml.Unmarshal(data, &m)
+
+	reader := utilyaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(rawyaml)))
+	for {
+		// Read one YAML document at a time, until io.EOF is returned
+		b, err := reader.Read()
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal yaml fragment: %q", string(data))
+			if err == io.EOF {
+				break
+			}
+			return nil, errors.Wrapf(err, "failed to read yaml")
+		}
+		if len(b) == 0 {
+			break
+		}
+
+		var m map[string]interface{}
+		if err := yaml.Unmarshal(b, &m); err != nil {
+			return nil, errors.Wrapf(err, "failed to unmarshal yaml fragment: %q", string(b))
 		}
 
 		var u unstructured.Unstructured
 		u.SetUnstructuredContent(m)
-
-		// Ignore empty objects.
-		// Empty objects are generated if there are weird things in manifest files like e.g. two --- in a row without a yaml doc in the middle
-		if u.Object == nil {
-			continue
-		}
 
 		ret = append(ret, u)
 	}

--- a/cmd/clusterctl/pkg/internal/util/yaml_test.go
+++ b/cmd/clusterctl/pkg/internal/util/yaml_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestToUnstructured(t *testing.T) {
+	type args struct {
+		rawyaml []byte
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantObjsCount int
+		wantErr       bool
+	}{
+		{
+			name: "single object",
+			args: args{
+				rawyaml: []byte("apiVersion: v1\n" +
+					"kind: ConfigMap\n"),
+			},
+			wantObjsCount: 1,
+			wantErr:       false,
+		},
+		{
+			name: "multiple objects are detected",
+			args: args{
+				rawyaml: []byte("apiVersion: v1\n" +
+					"kind: ConfigMap\n" +
+					"---\n" +
+					"apiVersion: v1\n" +
+					"kind: Secret\n"),
+			},
+			wantObjsCount: 2,
+			wantErr:       false,
+		},
+		{
+			name: "empty object are dropped",
+			args: args{
+				rawyaml: []byte("---\n" + //empty object before
+					"apiVersion: v1\n" +
+					"kind: ConfigMap\n" +
+					"---\n" + // empty object in the middle
+					"---\n" +
+					"apiVersion: v1\n" +
+					"kind: Secret\n" +
+					"---\n"), //empty object after
+			},
+			wantObjsCount: 2,
+			wantErr:       false,
+		},
+		{
+			name: "--- in the middle of objects are ignored",
+			args: args{
+				[]byte("apiVersion: v1\n" +
+					"kind: ConfigMap\n" +
+					"data: \n" +
+					" key: |\n" +
+					"  ··Several lines of text,\n" +
+					"  ··with some --- \n" +
+					"  ---\n" +
+					"  ··in the middle\n" +
+					"---\n" +
+					"apiVersion: v1\n" +
+					"kind: Secret\n"),
+			},
+			wantObjsCount: 2,
+			wantErr:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToUnstructured(tt.args.rawyaml)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if !reflect.DeepEqual(len(got), tt.wantObjsCount) {
+				t.Errorf("got = %v object, want %v", len(got), tt.wantObjsCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the to ToUnstructured func so it can handle --- strings in the middle of values

**Which issue(s) this PR fixes**:

/area clusterctl
/assign @vincepri 
/assign @wfernandes 
