### PR TITLE
🐛clusterctl: fix deletion of cluster wide resources

### DIFF
--- a/cmd/clusterctl/pkg/client/repository/components.go
+++ b/cmd/clusterctl/pkg/client/repository/components.go
@@ -325,36 +325,12 @@ func fixTargetNamespace(objs []unstructured.Unstructured, targetNamespace string
 		}
 
 		// if the object is namespaced, set the namespace name
-		if isResourceNamespaced(o.GetKind()) {
+		if util.IsResourceNamespaced(o.GetKind()) {
 			o.SetNamespace(targetNamespace)
 		}
 	}
 
 	return objs
-}
-
-func isResourceNamespaced(kind string) bool {
-	switch kind {
-	case "Namespace",
-		"Node",
-		"PersistentVolume",
-		"PodSecurityPolicy",
-		"CertificateSigningRequest",
-		"ClusterRoleBinding",
-		"ClusterRole",
-		"VolumeAttachment",
-		"StorageClass",
-		"CSIDriver",
-		"CSINode",
-		"ValidatingWebhookConfiguration",
-		"MutatingWebhookConfiguration",
-		"CustomResourceDefinition",
-		"PriorityClass",
-		"RuntimeClass":
-		return false
-	default:
-		return true
-	}
 }
 
 const (

--- a/cmd/clusterctl/pkg/internal/util/yaml.go
+++ b/cmd/clusterctl/pkg/internal/util/yaml.go
@@ -97,3 +97,33 @@ func FromUnstructured(objs []unstructured.Unstructured) ([]byte, error) {
 
 	return JoinYaml(ret...), nil
 }
+
+// IsClusterResource returns true if the resource kind is cluster wide (not namespaced).
+func IsClusterResource(kind string) bool {
+	return !IsResourceNamespaced(kind)
+}
+
+// IsResourceNamespaced returns true if the resource kind is namespaced.
+func IsResourceNamespaced(kind string) bool {
+	switch kind {
+	case "Namespace",
+		"Node",
+		"PersistentVolume",
+		"PodSecurityPolicy",
+		"CertificateSigningRequest",
+		"ClusterRoleBinding",
+		"ClusterRole",
+		"VolumeAttachment",
+		"StorageClass",
+		"CSIDriver",
+		"CSINode",
+		"ValidatingWebhookConfiguration",
+		"MutatingWebhookConfiguration",
+		"CustomResourceDefinition",
+		"PriorityClass",
+		"RuntimeClass":
+		return false
+	default:
+		return true
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a problem in `clusterctl delete`, that now deletes all the cluster-wide resources (e.g the ClusterRoles) when deleting a provider instance.

Whit this fix, `clusterctl delete` now deletes only the cluster-wide resources belonging to the instance being deleted.

**Which issue(s) this PR fixes**

/area clusterctl
/assign @vincepri 
/assign @wfernandes 