### PR TITLE
✨Move MachineDeployment annotations under x-k8s.io

### DIFF
--- a/api/v1alpha2/conversion_test.go
+++ b/api/v1alpha2/conversion_test.go
@@ -224,6 +224,26 @@ func TestConvertMachineDeployment(t *testing.T) {
 			g.Expect(dst.Spec.ClusterName).To(Equal("test-cluster"))
 			g.Expect(dst.Spec.Template.Spec.ClusterName).To(Equal("test-cluster"))
 		})
+
+		t.Run("should convert the annotations", func(t *testing.T) {
+			src := &MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						RevisionAnnotation:        "test",
+						RevisionHistoryAnnotation: "test",
+						DesiredReplicasAnnotation: "test",
+						MaxReplicasAnnotation:     "test",
+					},
+				},
+			}
+			dst := &v1alpha3.MachineDeployment{}
+
+			g.Expect(src.ConvertTo(dst)).To(Succeed())
+			g.Expect(dst.Annotations).To(HaveKey(v1alpha3.RevisionAnnotation))
+			g.Expect(dst.Annotations).To(HaveKey(v1alpha3.RevisionHistoryAnnotation))
+			g.Expect(dst.Annotations).To(HaveKey(v1alpha3.DesiredReplicasAnnotation))
+			g.Expect(dst.Annotations).To(HaveKey(v1alpha3.MaxReplicasAnnotation))
+		})
 	})
 
 	t.Run("from hub", func(t *testing.T) {
@@ -254,6 +274,26 @@ func TestConvertMachineDeployment(t *testing.T) {
 			g.Expect(restored.Spec.ClusterName).To(Equal(src.Spec.ClusterName))
 			g.Expect(restored.Spec.Paused).To(Equal(src.Spec.Paused))
 			g.Expect(restored.Spec.Template.Spec.ClusterName).To(Equal(src.Spec.Template.Spec.ClusterName))
+		})
+
+		t.Run("should convert the annotations", func(t *testing.T) {
+			src := &v1alpha3.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1alpha3.RevisionAnnotation:        "test",
+						v1alpha3.RevisionHistoryAnnotation: "test",
+						v1alpha3.DesiredReplicasAnnotation: "test",
+						v1alpha3.MaxReplicasAnnotation:     "test",
+					},
+				},
+			}
+			dst := &MachineDeployment{}
+
+			g.Expect(dst.ConvertFrom(src)).To(Succeed())
+			g.Expect(dst.Annotations).To(HaveKey(RevisionAnnotation))
+			g.Expect(dst.Annotations).To(HaveKey(RevisionHistoryAnnotation))
+			g.Expect(dst.Annotations).To(HaveKey(DesiredReplicasAnnotation))
+			g.Expect(dst.Annotations).To(HaveKey(MaxReplicasAnnotation))
 		})
 	})
 }

--- a/api/v1alpha2/machinedeployment_types.go
+++ b/api/v1alpha2/machinedeployment_types.go
@@ -27,6 +27,19 @@ const (
 	// Replace the old MachineSet by new one using rolling update
 	// i.e. gradually scale down the old MachineSet and scale up the new one.
 	RollingUpdateMachineDeploymentStrategyType MachineDeploymentStrategyType = "RollingUpdate"
+
+	// RevisionAnnotation is the revision annotation of a machine deployment's machine sets which records its rollout sequence
+	RevisionAnnotation = "machinedeployment.clusters.k8s.io/revision"
+	// RevisionHistoryAnnotation maintains the history of all old revisions that a machine set has served for a machine deployment.
+	RevisionHistoryAnnotation = "machinedeployment.clusters.k8s.io/revision-history"
+	// DesiredReplicasAnnotation is the desired replicas for a machine deployment recorded as an annotation
+	// in its machine sets. Helps in separating scaling events from the rollout process and for
+	// determining if the new machine set for a deployment is really saturated.
+	DesiredReplicasAnnotation = "machinedeployment.clusters.k8s.io/desired-replicas"
+	// MaxReplicasAnnotation is the maximum replicas a deployment can have at a given point, which
+	// is machinedeployment.spec.replicas + maxSurge. Used by the underlying machine sets to estimate their
+	// proportions in case the deployment has surge replicas.
+	MaxReplicasAnnotation = "machinedeployment.clusters.k8s.io/max-replicas"
 )
 
 // ANCHOR: MachineDeploymentSpec

--- a/api/v1alpha3/machinedeployment_types.go
+++ b/api/v1alpha3/machinedeployment_types.go
@@ -27,6 +27,19 @@ const (
 	// Replace the old MachineSet by new one using rolling update
 	// i.e. gradually scale down the old MachineSet and scale up the new one.
 	RollingUpdateMachineDeploymentStrategyType MachineDeploymentStrategyType = "RollingUpdate"
+
+	// RevisionAnnotation is the revision annotation of a machine deployment's machine sets which records its rollout sequence
+	RevisionAnnotation = "machinedeployment.clusters.x-k8s.io/revision"
+	// RevisionHistoryAnnotation maintains the history of all old revisions that a machine set has served for a machine deployment.
+	RevisionHistoryAnnotation = "machinedeployment.clusters.x-k8s.io/revision-history"
+	// DesiredReplicasAnnotation is the desired replicas for a machine deployment recorded as an annotation
+	// in its machine sets. Helps in separating scaling events from the rollout process and for
+	// determining if the new machine set for a deployment is really saturated.
+	DesiredReplicasAnnotation = "machinedeployment.clusters.x-k8s.io/desired-replicas"
+	// MaxReplicasAnnotation is the maximum replicas a deployment can have at a given point, which
+	// is machinedeployment.spec.replicas + maxSurge. Used by the underlying machine sets to estimate their
+	// proportions in case the deployment has surge replicas.
+	MaxReplicasAnnotation = "machinedeployment.clusters.x-k8s.io/max-replicas"
 )
 
 // ANCHOR: MachineDeploymentSpec

--- a/controllers/machinedeployment_sync.go
+++ b/controllers/machinedeployment_sync.go
@@ -119,7 +119,7 @@ func (r *MachineDeploymentReconciler) getNewMachineSet(d *clusterv1.MachineDeplo
 
 		// Apply revision annotation from existingNewMS if it is missing from the deployment.
 		err = r.updateMachineDeployment(d, func(innerDeployment *clusterv1.MachineDeployment) {
-			mdutil.SetDeploymentRevision(d, msCopy.Annotations[mdutil.RevisionAnnotation])
+			mdutil.SetDeploymentRevision(d, msCopy.Annotations[clusterv1.RevisionAnnotation])
 		})
 		return msCopy, err
 	}

--- a/controllers/mdutil/util_test.go
+++ b/controllers/mdutil/util_test.go
@@ -719,7 +719,7 @@ func TestAnnotationUtils(t *testing.T) {
 	//Setup
 	tDeployment := generateDeployment("nginx")
 	tMS := generateMS(tDeployment)
-	tDeployment.Annotations[RevisionAnnotation] = "1"
+	tDeployment.Annotations[clusterv1.RevisionAnnotation] = "1"
 	logger := klogr.New()
 
 	//Test Case 1: Check if anotations are copied properly from deployment to MS
@@ -731,8 +731,8 @@ func TestAnnotationUtils(t *testing.T) {
 			SetNewMachineSetAnnotations(&tDeployment, &tMS, nextRevision, true, logger)
 			//Now the MachineSets Revision Annotation should be i+1
 
-			if tMS.Annotations[RevisionAnnotation] != nextRevision {
-				t.Errorf("Revision Expected=%s Obtained=%s", nextRevision, tMS.Annotations[RevisionAnnotation])
+			if tMS.Annotations[clusterv1.RevisionAnnotation] != nextRevision {
+				t.Errorf("Revision Expected=%s Obtained=%s", nextRevision, tMS.Annotations[clusterv1.RevisionAnnotation])
 			}
 		}
 	})
@@ -743,14 +743,14 @@ func TestAnnotationUtils(t *testing.T) {
 		if !updated {
 			t.Errorf("SetReplicasAnnotations() failed")
 		}
-		value, ok := tMS.Annotations[DesiredReplicasAnnotation]
+		value, ok := tMS.Annotations[clusterv1.DesiredReplicasAnnotation]
 		if !ok {
 			t.Errorf("SetReplicasAnnotations did not set DesiredReplicasAnnotation")
 		}
 		if value != "10" {
 			t.Errorf("SetReplicasAnnotations did not set DesiredReplicasAnnotation correctly value=%s", value)
 		}
-		if value, ok = tMS.Annotations[MaxReplicasAnnotation]; !ok {
+		if value, ok = tMS.Annotations[clusterv1.MaxReplicasAnnotation]; !ok {
 			t.Errorf("SetReplicasAnnotations did not set DesiredReplicasAnnotation")
 		}
 		if value != "11" {
@@ -759,7 +759,7 @@ func TestAnnotationUtils(t *testing.T) {
 	})
 
 	//Test Case 3:  Check if annotations reflect deployments state
-	tMS.Annotations[DesiredReplicasAnnotation] = "1"
+	tMS.Annotations[clusterv1.DesiredReplicasAnnotation] = "1"
 	tMS.Status.AvailableReplicas = 1
 	tMS.Spec.Replicas = new(int32)
 	*tMS.Spec.Replicas = 1
@@ -799,7 +799,7 @@ func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "hello",
 					Namespace:   "test",
-					Annotations: map[string]string{DesiredReplicasAnnotation: "8", MaxReplicasAnnotation: maxReplicas},
+					Annotations: map[string]string{clusterv1.DesiredReplicasAnnotation: "8", clusterv1.MaxReplicasAnnotation: maxReplicas},
 				},
 				Spec: clusterv1.MachineSetSpec{
 					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
@@ -813,7 +813,7 @@ func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "hello",
 					Namespace:   "test",
-					Annotations: map[string]string{DesiredReplicasAnnotation: desiredReplicas, MaxReplicasAnnotation: "16"},
+					Annotations: map[string]string{clusterv1.DesiredReplicasAnnotation: desiredReplicas, clusterv1.MaxReplicasAnnotation: "16"},
 				},
 				Spec: clusterv1.MachineSetSpec{
 					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
@@ -827,7 +827,7 @@ func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "hello",
 					Namespace:   "test",
-					Annotations: map[string]string{DesiredReplicasAnnotation: desiredReplicas, MaxReplicasAnnotation: maxReplicas},
+					Annotations: map[string]string{clusterv1.DesiredReplicasAnnotation: desiredReplicas, clusterv1.MaxReplicasAnnotation: maxReplicas},
 				},
 				Spec: clusterv1.MachineSetSpec{
 					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},


### PR DESCRIPTION
This PR moves MachineDeployment annotations from `k8s.io` to `x-k8s.io` and adds conversion logic.

Fixes https://github.com/kubernetes-sigs/cluster-api/issues/1984
