### PR TITLE
Ignore empty objects again (revert)

### DIFF
--- a/cmd/clusterctl/pkg/internal/util/yaml.go
+++ b/cmd/clusterctl/pkg/internal/util/yaml.go
@@ -78,6 +78,12 @@ func ToUnstructured(rawyaml []byte) ([]unstructured.Unstructured, error) {
 		var u unstructured.Unstructured
 		u.SetUnstructuredContent(m)
 
+		// Ignore empty objects.
+		// Empty objects are generated if there are weird things in manifest files like e.g. two --- in a row without a yaml doc in the middle
+		if u.Object == nil {
+			continue
+		}
+
 		ret = append(ret, u)
 	}
 

--- a/cmd/clusterctl/pkg/internal/util/yaml_test.go
+++ b/cmd/clusterctl/pkg/internal/util/yaml_test.go
@@ -56,13 +56,15 @@ func TestToUnstructured(t *testing.T) {
 			name: "empty object are dropped",
 			args: args{
 				rawyaml: []byte("---\n" + //empty object before
+					"---\n" +
 					"apiVersion: v1\n" +
 					"kind: ConfigMap\n" +
 					"---\n" + // empty object in the middle
 					"---\n" +
 					"apiVersion: v1\n" +
 					"kind: Secret\n" +
-					"---\n"), //empty object after
+					"---\n" + //empty object after
+					"---\n"),
 			},
 			wantObjsCount: 2,
 			wantErr:       false,

--- a/cmd/clusterctl/pkg/internal/util/yaml_test.go
+++ b/cmd/clusterctl/pkg/internal/util/yaml_test.go
@@ -55,15 +55,18 @@ func TestToUnstructured(t *testing.T) {
 		{
 			name: "empty object are dropped",
 			args: args{
-				rawyaml: []byte("---\n" + //empty object before
+				rawyaml: []byte("---\n" + //empty objects before
+					"---\n" +
 					"---\n" +
 					"apiVersion: v1\n" +
 					"kind: ConfigMap\n" +
-					"---\n" + // empty object in the middle
+					"---\n" + // empty objects in the middle
+					"---\n" +
 					"---\n" +
 					"apiVersion: v1\n" +
 					"kind: Secret\n" +
-					"---\n" + //empty object after
+					"---\n" + //empty objects after
+					"---\n" +
 					"---\n"),
 			},
 			wantObjsCount: 2,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Fixes the error below:
```
 ~ clusterctl init -v 5 \
--core cluster-api:v0.3.0 \
--bootstrap kubeadm-bootstrap:v0.3.0 \
--control-plane kubeadm-control-plane:v0.3.0 \
--infrastructure aws:v0.5.0
Fetching providers
Using Override="core-components.yaml" Provider="cluster-api" Version="v0.3.0"
Using Override="bootstrap-components.yaml" Provider="kubeadm-bootstrap" Version="v0.3.0"
Using Override="control-plane-components.yaml" Provider="kubeadm-control-plane" Version="v0.3.0"
Using Override="infrastructure-components.yaml" Provider="aws" Version="v0.5.0"
Fetching File="metadata.yaml" Provider="cluster-api" Version="v0.3.0"
Fetching File="metadata.yaml" Provider="kubeadm-bootstrap" Version="v0.3.0"
Fetching File="metadata.yaml" Provider="kubeadm-control-plane" Version="v0.3.0"
Fetching File="metadata.yaml" Provider="aws" Version="v0.5.0"
Installing cert-manager
Creating Namespace="cert-manager"
Creating CustomResourceDefinition="challenges.acme.cert-manager.io"
Creating CustomResourceDefinition="orders.acme.cert-manager.io"
Creating CustomResourceDefinition="certificaterequests.cert-manager.io"
Creating CustomResourceDefinition="certificates.cert-manager.io"
Creating CustomResourceDefinition="clusterissuers.cert-manager.io"
Creating CustomResourceDefinition="issuers.cert-manager.io"
Creating ServiceAccount="cert-manager-cainjector" Namespace="cert-manager"
Creating ServiceAccount="cert-manager" Namespace="cert-manager"
Creating ServiceAccount="cert-manager-webhook" Namespace="cert-manager"
Creating =""
Error: failed to create cert-manager component: /, Kind=, /: no matches for kind "" in version ""
```
