### PR TITLE
:warning: Remove use of apiutil.NewDynamicRESTMapper

### DIFF
--- a/cmd/clusterctl/pkg/client/cluster/proxy.go
+++ b/cmd/clusterctl/pkg/client/cluster/proxy.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/pkg/internal/scheme"
 	"sigs.k8s.io/cluster-api/cmd/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 var (
@@ -70,12 +69,7 @@ func (k *proxy) NewClient() (client.Client, error) {
 		return nil, errors.Wrap(err, "failed to create controller-runtime client")
 	}
 
-	mapper, err := apiutil.NewDynamicRESTMapper(config, apiutil.WithLazyDiscovery)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create the controller-runtime DynamicRESTMapper")
-	}
-
-	c, err := client.New(config, client.Options{Scheme: Scheme, Mapper: mapper})
+	c, err := client.New(config, client.Options{Scheme: Scheme})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create controller-runtime client")
 	}

--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // ClusterClientGetter returns a new remote client.
@@ -37,11 +36,7 @@ func NewClusterClient(ctx context.Context, c client.Client, cluster client.Objec
 	if err != nil {
 		return nil, err
 	}
-	mapper, err := apiutil.NewDynamicRESTMapper(restConfig, apiutil.WithLazyDiscovery)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create a DynamicRESTMapper for Cluster %s/%s", cluster.Namespace, cluster.Name)
-	}
-	ret, err := client.New(restConfig, client.Options{Scheme: scheme, Mapper: mapper})
+	ret, err := client.New(restConfig, client.Options{Scheme: scheme})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create client for Cluster %s/%s", cluster.Namespace, cluster.Name)
 	}

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -94,9 +94,10 @@ func TestNewClusterClient(t *testing.T) {
 	ctx := context.Background()
 	t.Run("cluster with valid kubeconfig", func(t *testing.T) {
 		client := fake.NewFakeClientWithScheme(testScheme, validSecret)
-		c, err := NewClusterClient(ctx, client, clusterWithValidKubeConfig, testScheme)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(c).NotTo(BeNil())
+		_, err := NewClusterClient(ctx, client, clusterWithValidKubeConfig, testScheme)
+		// Since we do not have a remote server to connect to, we should expect to get
+		// an error to that effect for the purpose of this test.
+		g.Expect(err).To(MatchError(ContainSubstring("no such host")))
 
 		restConfig, err := RESTConfig(ctx, client, clusterWithValidKubeConfig)
 		g.Expect(err).NotTo(HaveOccurred())

--- a/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md
@@ -65,11 +65,11 @@
 ### Related changes to `sigs.k8s.io/cluster-api/util`
 
 - A helper function `util.ObjectKey` could be used to get `client.ObjectKey` for a Cluster, Machine etc.
+- The returned client is no longer configured for lazy discovery. Any consumers that attempt to create
+  a client prior to the server being available will now see an error.
 - Getter for a kubeconfig secret, associated with a cluster requires `client.ObjectKey` instead of a cluster reference. Signature change:
-
-    From: `func Get(ctx context.Context, c client.Client, cluster client.ObjectKey, purpose Purpose) (*corev1.Secret, error)`
-
-    To: `func Get(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, purpose Purpose) (*corev1.Secret, error)`
+  - From: `func Get(ctx context.Context, c client.Client, cluster client.ObjectKey, purpose Purpose) (*corev1.Secret, error)`
+  - To: `func Get(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, purpose Purpose) (*corev1.Secret, error)`
 
 ## A Machine is now considered a control plane if it has `cluster.x-k8s.io/control-plane` set, regardless of value
 

--- a/test/framework/management/kind/mgmt.go
+++ b/test/framework/management/kind/mgmt.go
@@ -30,15 +30,15 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/cluster-api/test/framework/exec"
-	"sigs.k8s.io/cluster-api/test/framework/options"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
 	"sigs.k8s.io/kind/pkg/cmd"
 	"sigs.k8s.io/kind/pkg/fs"
+
+	"sigs.k8s.io/cluster-api/test/framework/exec"
+	"sigs.k8s.io/cluster-api/test/framework/options"
 )
 
 // Shells out to `kind`, `kubectl`
@@ -238,15 +238,7 @@ func (c *Cluster) Teardown(ctx context.Context) {
 
 // ClientFromRestConfig returns a controller-runtime client from a RESTConfig.
 func (c *Cluster) ClientFromRestConfig(restConfig *rest.Config) (client.Client, error) {
-	// Adding mapper to auto-discover schemes
-	restMapper, err := apiutil.NewDynamicRESTMapper(restConfig)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	cl, err := client.New(restConfig, client.Options{
-		Scheme: c.Scheme,
-		Mapper: restMapper,
-	})
+	cl, err := client.New(restConfig, client.Options{Scheme: c.Scheme})
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we are now using controller-runtime v0.5.0 we no longer need
to override the default restmapper when initializing a controller-runtime
client because the dynamic restmapper is now the default.

This does change some of the semantics of how we are interacting with clients where we were previously setting `WithLazyDiscovery`, but those changes should be limited just to the ability to get a client for a not-yet-ready remote server.

/assign @vincepri 