### PR TITLE
:sparkles: Implement KubeadmControlPlane upgrade functionality

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -28,6 +28,7 @@ const (
 	KubeadmControlPlaneFinalizer             = "kubeadm.controlplane.cluster.x-k8s.io"
 	KubeadmControlPlaneHashLabelKey          = "kubeadm.controlplane.cluster.x-k8s.io/hash"
 	SelectedForUpgradeAnnotation             = "kubeadm.controlplane.cluster.x-k8s.io/selected-for-upgrade"
+	UpgradeReplacementCreatedAnnotation      = "kubeadm.controlplane.cluster.x-k8s.io/upgrade-replacement-created"
 	DeleteForScaleDownAnnotation             = "kubeadm.controlplane.cluster.x-k8s.io/delete-for-scale-down"
 	ScaleDownEtcdMemberRemovedAnnotation     = "kubeadm.controlplane.cluster.x-k8s.io/scale-down-etcd-member-removed"
 	ScaleDownConfigMapEntryRemovedAnnotation = "kubeadm.controlplane.cluster.x-k8s.io/scale-down-configmap-entry-removed"

--- a/controlplane/kubeadm/config/rbac/role.yaml
+++ b/controlplane/kubeadm/config/rbac/role.yaml
@@ -62,3 +62,39 @@ rules:
   - list
   - patch
   - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: manager-role
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac
+  resources:
+  - roles
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
@@ -834,16 +834,16 @@ func (r *KubeadmControlPlaneReconciler) reconcileDelete(ctx context.Context, clu
 	}
 	ownedMachines := allMachines.Filter(internal.OwnedControlPlaneMachines(kcp.Name))
 
-	// Verify that only control plane machines remain
-	if len(allMachines) != len(ownedMachines) {
-		logger.Info("Non control plane machines exist and must be removed before control plane machines are removed")
-		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: DeleteRequeueAfter}
-	}
-
 	// If no control plane machines remain, remove the finalizer
 	if len(ownedMachines) == 0 {
 		controllerutil.RemoveFinalizer(kcp, controlplanev1.KubeadmControlPlaneFinalizer)
 		return ctrl.Result{}, nil
+	}
+
+	// Verify that only control plane machines remain
+	if len(allMachines) != len(ownedMachines) {
+		logger.Info("Non control plane machines exist and must be removed before control plane machines are removed")
+		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: DeleteRequeueAfter}
 	}
 
 	// Delete control plane machines in parallel

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
@@ -22,9 +22,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -63,6 +65,10 @@ const (
 	// HealthCheckFailedRequeueAfter is how long to wait before trying to scale
 	// up/down if some target cluster health check has failed
 	HealthCheckFailedRequeueAfter = 20 * time.Second
+
+	// DependentCertRequeueAfter is how long to wait before checking again to see if
+	// dependent certificates have been created.
+	DependentCertRequeueAfter = 30 * time.Second
 )
 
 type managementCluster interface {
@@ -75,6 +81,9 @@ type managementCluster interface {
 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;patch
+// +kubebuilder:rbac:groups=core,resources=configmaps,namespace=kube-system,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=rbac,resources=roles,namespace=kube-system,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=rbac,resources=rolebindings,namespace=kube-system,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io;controlplane.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch;create;update;patch;delete
@@ -166,6 +175,12 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(req ctrl.Request) (res ctrl.Re
 	}
 
 	defer func() {
+		if requeueErr, ok := errors.Cause(reterr).(capierrors.HasRequeueAfterError); ok {
+			if res.RequeueAfter == 0 {
+				res.RequeueAfter = requeueErr.GetRequeueAfter()
+				reterr = nil
+			}
+		}
 		// Always attempt to update status.
 		if err := r.updateStatus(ctx, kcp, cluster); err != nil {
 			logger.Error(err, "Failed to update KubeadmControlPlane Status")
@@ -189,7 +204,7 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(req ctrl.Request) (res ctrl.Re
 }
 
 // reconcile handles KubeadmControlPlane reconciliation.
-func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane) (_ ctrl.Result, reterr error) {
+func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane) (res ctrl.Result, reterr error) {
 	logger := r.Log.WithValues("namespace", kcp.Namespace, "kubeadmControlPlane", kcp.Name, "cluster", cluster.Name)
 
 	// If object doesn't have a finalizer, add one.
@@ -221,12 +236,6 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, cluster *
 
 	// Generate Cluster Kubeconfig if needed
 	if err := r.reconcileKubeconfig(ctx, util.ObjectKey(cluster), cluster.Spec.ControlPlaneEndpoint, kcp); err != nil {
-		if requeueErr, ok := errors.Cause(err).(capierrors.HasRequeueAfterError); ok {
-			logger.Error(err, "required certificates not found, requeueing")
-			return ctrl.Result{
-				RequeueAfter: requeueErr.GetRequeueAfter(),
-			}, nil
-		}
 		logger.Error(err, "failed to reconcile Kubeconfig")
 		return ctrl.Result{}, err
 	}
@@ -238,16 +247,21 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, cluster *
 		return ctrl.Result{}, err
 	}
 
-	currentConfigurationHash := hash.Compute(&kcp.Spec)
-	requireUpgrade := ownedMachines.AnyFilter(
-		internal.Not(internal.MatchesConfigurationHash(currentConfigurationHash)),
-		internal.OlderThan(kcp.Spec.UpgradeAfter),
-	)
+	now := metav1.Now()
+	var requireUpgrade internal.FilterableMachineCollection
+	if kcp.Spec.UpgradeAfter != nil && kcp.Spec.UpgradeAfter.Before(&now) {
+		requireUpgrade = ownedMachines.AnyFilter(
+			internal.Not(internal.MatchesConfigurationHash(hash.Compute(&kcp.Spec))),
+			internal.OlderThan(kcp.Spec.UpgradeAfter),
+		)
+	} else {
+		requireUpgrade = ownedMachines.Filter(internal.Not(internal.MatchesConfigurationHash(hash.Compute(&kcp.Spec))))
+	}
 
 	// Upgrade takes precedence over other operations
 	if len(requireUpgrade) > 0 {
 		logger.Info("Upgrading Control Plane")
-		return r.upgradeControlPlane(ctx, cluster, kcp)
+		return r.upgradeControlPlane(ctx, cluster, kcp, ownedMachines, requireUpgrade)
 	}
 
 	// If we've made it this far, we we can assume that all ownedMachines are up to date
@@ -327,20 +341,168 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 	return nil
 }
 
-func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(_ context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane) (ctrl.Result, error) { //nolint
-	_ = r.Log.WithValues("namespace", kcp.Namespace, "kubeadmControlPlane", kcp.Name, "cluster", cluster.Name)
-	// TODO: verify health for each existing replica
-	// TODO: mark an old Machine via the label kubeadm.controlplane.cluster.x-k8s.io/selected-for-upgrade
-	// TODO: check full cluster health
-	// TODO: provision new Machine to replace marked Machine
-	// TODO: wait for health of all existing replicas, ideally in a re-entrant way to avoid waiting in process
-	// TODO: wait for full cluster health, ideally in a re-entrant way to avoid waiting in process
-	// TODO: Remove etcd membership for old Machine instance
-	// TODO: Update the kubeadm configmap
-	// TODO: Delete the Marked ControlPlane machine
-	// TODO: Continue with next OldMachine
+func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(ctx context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, ownedMachines internal.FilterableMachineCollection, requireUpgrade internal.FilterableMachineCollection) (ctrl.Result, error) {
+	logger := r.Log.WithValues("namespace", kcp.Namespace, "kubeadmControlPlane", kcp.Name, "cluster", cluster.Name)
 
-	return ctrl.Result{}, nil
+	// TODO: handle reconciliation of etcd members and kubeadm config in case they get out of sync with cluster
+
+	// Reconcile the remote cluster kubelet configmap and RBAC
+	if err := r.reconcileKubeletConfigAndRBAC(ctx, kcp.Spec.Version, util.ObjectKey(cluster)); err != nil {
+		logger.Error(err, "failed reconcile remote cluster kubelet configmap and RBAC")
+		return ctrl.Result{}, err
+	}
+
+	// If there is not already a Machine that is marked for upgrade, find one and mark it
+	selectedForUpgrade := requireUpgrade.Filter(internal.HasAnnotationKey(controlplanev1.SelectedForUpgradeAnnotation))
+	if len(selectedForUpgrade) == 0 {
+		selectedMachine, err := r.selectMachineForUpgrade(ctx, cluster, requireUpgrade)
+		if err != nil {
+			logger.Error(err, "failed to select machine for upgrade")
+			return ctrl.Result{}, err
+		}
+		selectedForUpgrade = selectedForUpgrade.Insert(selectedMachine)
+	}
+
+	replacementCreated := selectedForUpgrade.Filter(internal.HasAnnotationKey(controlplanev1.UpgradeReplacementCreatedAnnotation))
+	if len(replacementCreated) == 0 {
+		// TODO: should we also add a check here to ensure that current machines not > kcp.spec.replicas+1?
+		// We haven't created a replacement machine for the cluster yet
+		// return here to avoid blocking while waiting for the new control plane Machine to come up
+		result, err := r.scaleUpControlPlane(ctx, cluster, kcp, ownedMachines)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := r.markWithAnnotationKey(ctx, selectedForUpgrade.Oldest(), controlplanev1.UpgradeReplacementCreatedAnnotation); err != nil {
+			return ctrl.Result{}, err
+		}
+		return result, nil
+	}
+
+	return r.scaleDownControlPlane(ctx, cluster, kcp, replacementCreated)
+}
+
+func (r *KubeadmControlPlaneReconciler) reconcileKubeletConfigAndRBAC(ctx context.Context, version string, clusterKey client.ObjectKey) error {
+	parsedVersion, err := semver.ParseTolerant(version)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse kubernetes version %q", version)
+	}
+
+	remoteClient, err := r.remoteClientGetter(ctx, r.Client, clusterKey, r.scheme)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create remote cluster client ")
+	}
+
+	if err := reconcileKubeletConfigMap(ctx, remoteClient, parsedVersion); err != nil {
+		return errors.Wrapf(err, "failed to reconcile the remote kubelet configmap")
+	}
+
+	if err := reconcileKubeletRBACRole(ctx, remoteClient, parsedVersion); err != nil {
+		return errors.Wrapf(err, "failed to reconcile the remote kubelet RBAC role")
+	}
+
+	if err := reconcileKubeletRBACBinding(ctx, remoteClient, parsedVersion); err != nil {
+		return errors.Wrapf(err, "failed to reconcile the remote kubelet RBAC binding")
+	}
+
+	return nil
+}
+
+func reconcileKubeletConfigMap(ctx context.Context, remoteClient client.Client, version semver.Version) error {
+	cmName := fmt.Sprintf("kubelet-config-%d.%d", version.Major, version.Minor)
+	kubeletConfigMap := &corev1.ConfigMap{}
+	if err := remoteClient.Get(ctx, client.ObjectKey{Name: cmName, Namespace: metav1.NamespaceSystem}, kubeletConfigMap); err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to determine if kubelet configmap %q already exists", cmName)
+	} else if err == nil {
+		// The required configmap already exists, nothing left to do
+		return nil
+	}
+
+	// Attempt to retrieve the kubelet configmap for the previous minor version
+	prevCMName := fmt.Sprintf("kubelet-config-%d.%d", version.Major, version.Minor-1)
+	if err := remoteClient.Get(ctx, client.ObjectKey{Name: prevCMName, Namespace: metav1.NamespaceSystem}, kubeletConfigMap); err != nil {
+		return errors.Wrapf(err, "failed to retrieve kubelet configmap %q for previous kubernetes version", prevCMName)
+	}
+
+	kubeletConfigMap.Name = prevCMName
+	kubeletConfigMap.ResourceVersion = ""
+	if err := remoteClient.Create(ctx, kubeletConfigMap); err != nil && !apierrors.IsAlreadyExists(err) {
+		return errors.Wrapf(err, "failed to create kubelet configmap %q for desired kubernetes version", cmName)
+	}
+
+	return nil
+}
+
+func reconcileKubeletRBACRole(ctx context.Context, remoteClient client.Client, version semver.Version) error {
+	majorMinor := fmt.Sprintf("%d.%d", version.Major, version.Minor)
+	roleName := fmt.Sprintf("kubeadm:kubelet-config-%s", majorMinor)
+	role := &rbacv1.Role{}
+	if err := remoteClient.Get(ctx, client.ObjectKey{Name: roleName, Namespace: metav1.NamespaceSystem}, role); err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to determine if kubelet config rbac role %q already exists", roleName)
+	} else if err == nil {
+		// The required role already exists, nothing left to do
+		return nil
+	}
+
+	newRole := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: metav1.NamespaceSystem,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"get"},
+				APIGroups:     []string{""},
+				Resources:     []string{"configmaps"},
+				ResourceNames: []string{fmt.Sprintf("kubelet-config-%s", majorMinor)},
+			},
+		},
+	}
+	if err := remoteClient.Create(ctx, newRole); err != nil && !apierrors.IsAlreadyExists(err) {
+		return errors.Wrapf(err, "failed to create kubelet rbac role %q", roleName)
+	}
+
+	return nil
+}
+
+func reconcileKubeletRBACBinding(ctx context.Context, remoteClient client.Client, version semver.Version) error {
+	majorMinor := fmt.Sprintf("%d.%d", version.Major, version.Minor)
+	roleName := fmt.Sprintf("kubeadm:kubelet-config-%s", majorMinor)
+	roleBinding := &rbacv1.RoleBinding{}
+	if err := remoteClient.Get(ctx, client.ObjectKey{Name: roleName, Namespace: metav1.NamespaceSystem}, roleBinding); err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to determine if kubelet config rbac role binding %q already exists", roleName)
+	} else if err == nil {
+		// The required role binding already exists, nothing left to do
+		return nil
+	}
+
+	newRoleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: metav1.NamespaceSystem,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Group",
+				Name:     "system:nodes",
+			},
+			{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Group",
+				Name:     "system:bootstrappers:kubeadm:default-node-token",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     roleName,
+		},
+	}
+	if err := remoteClient.Create(ctx, newRoleBinding); err != nil && !apierrors.IsAlreadyExists(err) {
+		return errors.Wrapf(err, "failed to create kubelet rbac role binding %q", roleName)
+	}
+
+	return nil
 }
 
 func (r *KubeadmControlPlaneReconciler) markWithAnnotationKey(ctx context.Context, machine *clusterv1.Machine, annotationKey string) error {
@@ -361,6 +523,19 @@ func (r *KubeadmControlPlaneReconciler) markWithAnnotationKey(ctx context.Contex
 		return errors.Wrapf(err, "failed to patch machine %s selected for upgrade", machine.Name)
 	}
 	return nil
+}
+
+func (r *KubeadmControlPlaneReconciler) selectMachineForUpgrade(ctx context.Context, cluster *clusterv1.Cluster, requireUpgrade internal.FilterableMachineCollection) (*clusterv1.Machine, error) {
+	failureDomain := r.failureDomainForScaleDown(cluster, requireUpgrade)
+
+	inFailureDomain := requireUpgrade.Filter(internal.InFailureDomains(failureDomain))
+	selected := inFailureDomain.Oldest()
+
+	if err := r.markWithAnnotationKey(ctx, selected, controlplanev1.SelectedForUpgradeAnnotation); err != nil {
+		return nil, errors.Wrap(err, "failed to select and mark a machine for upgrade")
+	}
+
+	return selected, nil
 }
 
 func (r *KubeadmControlPlaneReconciler) initializeControlPlane(ctx context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane) (ctrl.Result, error) {
@@ -385,13 +560,13 @@ func (r *KubeadmControlPlaneReconciler) scaleUpControlPlane(ctx context.Context,
 	if err := r.managementCluster.TargetClusterControlPlaneIsHealthy(ctx, util.ObjectKey(cluster), kcp.Name); err != nil {
 		logger.Error(err, "waiting for control plane to pass control plane health check before adding an additional control plane machine")
 		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "ControlPlaneUnhealthy", "Waiting for control plane to pass control plane health check before adding additional control plane machine: %v", err)
-		return ctrl.Result{RequeueAfter: HealthCheckFailedRequeueAfter}, nil
+		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: HealthCheckFailedRequeueAfter}
 	}
 
 	if err := r.managementCluster.TargetClusterEtcdIsHealthy(ctx, util.ObjectKey(cluster), kcp.Name); err != nil {
 		logger.Error(err, "waiting for control plane to pass etcd health check before adding an additional control plane machine")
 		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "ControlPlaneUnhealthy", "Waiting for control plane to pass etcd health check before adding additional control plane machine: %v", err)
-		return ctrl.Result{RequeueAfter: HealthCheckFailedRequeueAfter}, nil
+		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: HealthCheckFailedRequeueAfter}
 	}
 
 	// Create the bootstrap configuration
@@ -416,7 +591,7 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(ctx context.Contex
 
 	// Wait for any delete in progress to complete before deleting another Machine
 	if len(machines.Filter(internal.HasDeletionTimestamp)) > 0 {
-		return ctrl.Result{RequeueAfter: DeleteRequeueAfter}, nil
+		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: DeleteRequeueAfter}
 	}
 
 	markedForDeletion := machines.Filter(internal.HasAnnotationKey(controlplanev1.DeleteForScaleDownAnnotation))
@@ -445,7 +620,8 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(ctx context.Contex
 		if err := r.managementCluster.TargetClusterEtcdIsHealthy(ctx, util.ObjectKey(cluster), kcp.Name); err != nil {
 			logger.Error(err, "waiting for control plane to pass etcd health check before adding removing a control plane machine")
 			r.recorder.Eventf(kcp, corev1.EventTypeWarning, "ControlPlaneUnhealthy", "Waiting for control plane to pass etcd health check before removing a control plane machine: %v", err)
-			return ctrl.Result{RequeueAfter: HealthCheckFailedRequeueAfter}, nil
+			return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: HealthCheckFailedRequeueAfter}
+
 		}
 		if err := r.managementCluster.RemoveEtcdMemberForMachine(ctx, util.ObjectKey(cluster), machineToDelete); err != nil {
 			logger.Error(err, "failed to remove etcd member for machine")
@@ -460,7 +636,8 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(ctx context.Contex
 		if err := r.managementCluster.TargetClusterControlPlaneIsHealthy(ctx, util.ObjectKey(cluster), kcp.Name); err != nil {
 			logger.Error(err, "waiting for control plane to pass control plane health check before removing a control plane machine")
 			r.recorder.Eventf(kcp, corev1.EventTypeWarning, "ControlPlaneUnhealthy", "Waiting for control plane to pass control plane health check before removing a control plane machine: %v", err)
-			return ctrl.Result{RequeueAfter: HealthCheckFailedRequeueAfter}, nil
+			return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: HealthCheckFailedRequeueAfter}
+
 		}
 		if err := r.managementCluster.RemoveMachineFromKubeadmConfigMap(ctx, util.ObjectKey(cluster), machineToDelete); err != nil {
 			logger.Error(err, "failed to remove machine from kubeadm ConfigMap")
@@ -475,7 +652,7 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(ctx context.Contex
 	if err := r.managementCluster.TargetClusterControlPlaneIsHealthy(ctx, util.ObjectKey(cluster), kcp.Name); err != nil {
 		logger.Error(err, "waiting for control plane to pass control plane health check before removing a control plane machine")
 		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "ControlPlaneUnhealthy", "Waiting for control plane to pass control plane health check before removing a control plane machine: %v", err)
-		return ctrl.Result{RequeueAfter: HealthCheckFailedRequeueAfter}, nil
+		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: HealthCheckFailedRequeueAfter}
 	}
 	logger = logger.WithValues("machine", machineToDelete)
 	if err := r.Client.Delete(ctx, machineToDelete); err != nil && !apierrors.IsNotFound(err) {
@@ -595,11 +772,6 @@ func (r *KubeadmControlPlaneReconciler) generateKubeadmConfig(ctx context.Contex
 }
 
 func (r *KubeadmControlPlaneReconciler) failureDomainForScaleDown(cluster *clusterv1.Cluster, machines internal.FilterableMachineCollection) *string {
-	// Don't do anything if there are no failure domains defined on the cluster.
-	if len(cluster.Status.FailureDomains.FilterControlPlane()) == 0 {
-		return nil
-	}
-
 	// See if there are any Machines that are not in currently defined failure domains first.
 	notInFailureDomains := machines.Filter(internal.Not(internal.InFailureDomains(cluster.Status.FailureDomains.FilterControlPlane().GetIDs()...)))
 	if len(notInFailureDomains) > 0 {
@@ -610,8 +782,7 @@ func (r *KubeadmControlPlaneReconciler) failureDomainForScaleDown(cluster *clust
 	}
 
 	// Otherwise pick the currently known failure domain with the most Machines
-	failureDomain := internal.PickMost(cluster.Status.FailureDomains.FilterControlPlane(), machines)
-	return &failureDomain
+	return internal.PickMost(cluster.Status.FailureDomains.FilterControlPlane(), machines)
 }
 
 func (r *KubeadmControlPlaneReconciler) failureDomainForScaleUp(cluster *clusterv1.Cluster, machines internal.FilterableMachineCollection) *string {
@@ -619,8 +790,7 @@ func (r *KubeadmControlPlaneReconciler) failureDomainForScaleUp(cluster *cluster
 	if len(cluster.Status.FailureDomains.FilterControlPlane()) == 0 {
 		return nil
 	}
-	failureDomain := internal.PickFewest(cluster.Status.FailureDomains.FilterControlPlane(), machines)
-	return &failureDomain
+	return internal.PickFewest(cluster.Status.FailureDomains.FilterControlPlane(), machines)
 }
 
 func (r *KubeadmControlPlaneReconciler) generateMachine(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane, cluster *clusterv1.Cluster, infraRef, bootstrapRef *corev1.ObjectReference, failureDomain *string) error {
@@ -667,7 +837,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileDelete(ctx context.Context, clu
 	// Verify that only control plane machines remain
 	if len(allMachines) != len(ownedMachines) {
 		logger.Info("Non control plane machines exist and must be removed before control plane machines are removed")
-		return ctrl.Result{RequeueAfter: DeleteRequeueAfter}, nil
+		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: DeleteRequeueAfter}
 	}
 
 	// If no control plane machines remain, remove the finalizer
@@ -692,7 +862,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileDelete(ctx context.Context, clu
 		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "FailedDelete", "Failed to delete control plane Machines for cluster %s/%s control plane: %v", cluster.Namespace, cluster.Name, err)
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{RequeueAfter: DeleteRequeueAfter}, nil
+	return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: DeleteRequeueAfter}
 }
 
 func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context, clusterName types.NamespacedName, endpoint clusterv1.APIEndpoint, kcp *controlplanev1.KubeadmControlPlane) error {
@@ -712,7 +882,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 		)
 		if createErr != nil {
 			if createErr == kubeconfig.ErrDependentCertificateNotFound {
-				return errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: 30 * time.Second},
+				return errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: DependentCertRequeueAfter},
 					"could not find secret %q for Cluster %q in namespace %q, requeuing",
 					secret.ClusterCA, clusterName.Name, clusterName.Namespace)
 			}

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -159,6 +159,7 @@ func (m *ManagementCluster) healthCheck(ctx context.Context, check healthCheck, 
 
 // TargetClusterControlPlaneIsHealthy checks every node for control plane health.
 func (m *ManagementCluster) TargetClusterControlPlaneIsHealthy(ctx context.Context, clusterKey types.NamespacedName, controlPlaneName string) error {
+	// TODO: add checks for expected taints/labels
 	cluster, err := m.getCluster(ctx, clusterKey)
 	if err != nil {
 		return err

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -38,6 +37,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controllers/remote"

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -21,13 +21,26 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+var (
+	HaveOccurred     = gomega.HaveOccurred
+	Succeed          = gomega.Succeed
+	SatisfyAll       = gomega.SatisfyAll
+	HaveLen          = gomega.HaveLen
+	HaveKey          = gomega.HaveKey
+	HaveKeyWithValue = gomega.HaveKeyWithValue
+	WithTransform    = gomega.WithTransform
+	BeEmpty          = gomega.BeEmpty
 )
 
 func podReady(isReady corev1.ConditionStatus) corev1.PodCondition {
@@ -124,6 +137,62 @@ func TestControlPlaneIsHealthy(t *testing.T) {
 	if len(health) != len(nodeListForTestControlPlaneIsHealthy().Items) {
 		t.Fatal("not all nodes were checked")
 	}
+}
+
+func Test_removeNodeFromKubeadmConfigMapClusterStatusAPIEndpoints(t *testing.T) {
+	g := gomega.NewWithT(t)
+	original := &corev1.ConfigMap{
+		Data: map[string]string{
+			"ClusterStatus": `apiEndpoints:
+  ip-10-0-0-1.ec2.internal:
+    advertiseAddress: 10.0.0.1
+    bindPort: 6443
+    someFieldThatIsAddedInTheFuture: foo
+  ip-10-0-0-2.ec2.internal:
+    advertiseAddress: 10.0.0.2
+    bindPort: 6443
+    someFieldThatIsAddedInTheFuture: bar
+  ip-10-0-0-3.ec2.internal:
+    advertiseAddress: 10.0.0.3
+    bindPort: 6443
+    someFieldThatIsAddedInTheFuture: baz
+  ip-10-0-0-4.ec2.internal:
+    advertiseAddress: 10.0.0.4
+    bindPort: 6443
+    someFieldThatIsAddedInTheFuture: fizzbuzz
+apiVersion: kubeadm.k8s.io/vNbetaM
+kind: ClusterStatus`,
+		},
+	}
+
+	cm, err := removeNodeFromKubeadmConfigMapClusterStatusAPIEndpoints(original, "ip-10-0-0-3.ec2.internal")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(cm.Data).To(HaveKey("ClusterStatus"))
+	var status struct {
+		APIEndpoints map[string]interface{} `yaml:"apiEndpoints"`
+		APIVersion   string                 `yaml:"apiVersion"`
+		Kind         string                 `yaml:"kind"`
+
+		Extra map[string]interface{} `yaml:",inline"`
+	}
+	g.Expect(yaml.UnmarshalStrict([]byte(cm.Data["ClusterStatus"]), &status)).To(Succeed())
+	g.Expect(status.Extra).To(BeEmpty())
+
+	g.Expect(status.APIEndpoints).To(SatisfyAll(
+		HaveLen(3),
+		HaveKey("ip-10-0-0-1.ec2.internal"),
+		HaveKey("ip-10-0-0-2.ec2.internal"),
+		HaveKey("ip-10-0-0-4.ec2.internal"),
+		WithTransform(func(ep map[string]interface{}) interface{} {
+			return ep["ip-10-0-0-4.ec2.internal"]
+		}, SatisfyAll(
+			HaveKeyWithValue("advertiseAddress", "10.0.0.4"),
+			HaveKey("bindPort"),
+			HaveKey("someFieldThatIsAddedInTheFuture"),
+		)),
+	))
+
 }
 
 func nodeListForTestControlPlaneIsHealthy() *corev1.NodeList {

--- a/controlplane/kubeadm/internal/failure_domain.go
+++ b/controlplane/kubeadm/internal/failure_domain.go
@@ -20,6 +20,8 @@ import (
 	"sort"
 
 	"k8s.io/klog/klogr"
+	"k8s.io/utils/pointer"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
@@ -49,24 +51,24 @@ func (f failureDomainAggregations) Swap(i, j int) {
 }
 
 // PickMost returns the failure domain with the most number of machines.
-func PickMost(failureDomains clusterv1.FailureDomains, machines FilterableMachineCollection) string {
+func PickMost(failureDomains clusterv1.FailureDomains, machines FilterableMachineCollection) *string {
 	aggregations := pick(failureDomains, machines)
 	if len(aggregations) == 0 {
-		return ""
+		return nil
 	}
 	sort.Sort(sort.Reverse(aggregations))
-	return aggregations[0].id
+	return pointer.StringPtr(aggregations[0].id)
 
 }
 
 // PickFewest returns the failure domain with the fewest number of machines.
-func PickFewest(failureDomains clusterv1.FailureDomains, machines FilterableMachineCollection) string {
+func PickFewest(failureDomains clusterv1.FailureDomains, machines FilterableMachineCollection) *string {
 	aggregations := pick(failureDomains, machines)
 	if len(aggregations) == 0 {
-		return ""
+		return nil
 	}
 	sort.Sort(aggregations)
-	return aggregations[0].id
+	return pointer.StringPtr(aggregations[0].id)
 }
 
 func pick(failureDomains clusterv1.FailureDomains, machines FilterableMachineCollection) failureDomainAggregations {

--- a/controlplane/kubeadm/internal/machine_collection.go
+++ b/controlplane/kubeadm/internal/machine_collection.go
@@ -39,14 +39,14 @@ type FilterableMachineCollection map[string]*clusterv1.Machine
 
 // NewFilterableMachineCollection creates a FilterableMachineCollection from a list of values.
 func NewFilterableMachineCollection(machines ...*clusterv1.Machine) FilterableMachineCollection {
-	ss := FilterableMachineCollection{}
+	ss := make(FilterableMachineCollection, len(machines))
 	ss.Insert(machines...)
 	return ss
 }
 
 // NewFilterableMachineCollectionFromMachineList creates a FilterableMachineCollection from the given MachineList
 func NewFilterableMachineCollectionFromMachineList(machineList *clusterv1.MachineList) FilterableMachineCollection {
-	ss := FilterableMachineCollection{}
+	ss := make(FilterableMachineCollection, len(machineList.Items))
 	if machineList != nil {
 		for i := range machineList.Items {
 			ss.Insert(&machineList.Items[i])
@@ -91,7 +91,7 @@ func (s FilterableMachineCollection) Len() int {
 }
 
 func newFilteredMachineCollection(filter MachineFilter, machines ...*clusterv1.Machine) FilterableMachineCollection {
-	ss := FilterableMachineCollection{}
+	ss := make(FilterableMachineCollection, len(machines))
 	for i := range machines {
 		m := machines[i]
 		if filter(m) {
@@ -116,12 +116,12 @@ func (s FilterableMachineCollection) Oldest() *clusterv1.Machine {
 	if len(s) == 0 {
 		return nil
 	}
-	return s.list()[len(s)-1]
+	return s.list()[0]
 }
 
 // DeepCopy returns a deep copy
 func (s FilterableMachineCollection) DeepCopy() FilterableMachineCollection {
-	result := NewFilterableMachineCollection()
+	result := make(FilterableMachineCollection, len(s))
 	for _, m := range s {
 		result.Insert(m.DeepCopy())
 	}

--- a/controlplane/kubeadm/internal/machine_filters_test.go
+++ b/controlplane/kubeadm/internal/machine_filters_test.go
@@ -27,26 +27,50 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
+func falseFilter(machine *clusterv1.Machine) bool {
+	return false
+}
+
+func trueFilter(machine *clusterv1.Machine) bool {
+	return true
+}
+
 func TestNot(t *testing.T) {
 	t.Run("returns false given a machine filter that returns true", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		m := &clusterv1.Machine{}
-		f := func() MachineFilter {
-			return func(machine *clusterv1.Machine) bool {
-				return true
-			}
-		}
-		g.Expect(Not(f())(m)).To(gomega.BeFalse())
+		g.Expect(Not(trueFilter)(m)).To(gomega.BeFalse())
 	})
 	t.Run("returns true given a machine filter that returns false", func(t *testing.T) {
 		g := gomega.NewWithT(t)
 		m := &clusterv1.Machine{}
-		f := func() MachineFilter {
-			return func(machine *clusterv1.Machine) bool {
-				return false
-			}
-		}
-		g.Expect(Not(f())(m)).To(gomega.BeTrue())
+		g.Expect(Not(falseFilter)(m)).To(gomega.BeTrue())
+	})
+}
+
+func TestAnd(t *testing.T) {
+	t.Run("returns true if both given machine filters return true", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		m := &clusterv1.Machine{}
+		g.Expect(And(trueFilter, trueFilter)(m)).To(gomega.BeTrue())
+	})
+	t.Run("returns false if either given machine filter returns false", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		m := &clusterv1.Machine{}
+		g.Expect(And(trueFilter, falseFilter)(m)).To(gomega.BeFalse())
+	})
+}
+
+func TestOr(t *testing.T) {
+	t.Run("returns true if either given machine filters return true", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		m := &clusterv1.Machine{}
+		g.Expect(Or(trueFilter, falseFilter)(m)).To(gomega.BeTrue())
+	})
+	t.Run("returns false if both given machine filter returns false", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		m := &clusterv1.Machine{}
+		g.Expect(Or(falseFilter, falseFilter)(m)).To(gomega.BeFalse())
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
+	github.com/blang/semver v3.5.0+incompatible
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-logr/logr v0.1.0
 	github.com/gogo/protobuf v1.3.1
@@ -33,7 +34,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/grpc v1.23.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/yaml.v2 v2.2.7
+	gopkg.in/yaml.v2 v2.2.7 // indirect
 	k8s.io/api v0.17.2
 	k8s.io/apiextensions-apiserver v0.17.2
 	k8s.io/apimachinery v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
@@ -57,8 +58,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0 h1:w3NnFcKR5241cfmQU5ZZAsf0xcpId6mWOupTvJlUX2U=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements the functionality for the KubeadmControlPlane upgrades

**Which issue(s) this PR fixes**:
Fixes #2242 
Builds on #2379 #2380 #2381 #2382 #2383 