### PR TITLE
:sparkles: Adds kubeadm control plane scale up/down

### DIFF
--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -66,6 +66,14 @@ func OwnedControlPlaneMachines(controlPlaneName string) func(machine *clusterv1.
 	}
 }
 
+// HasDeletionTimestamp returns a MachineFilter function to find all machines
+// that have a deletion timestamp.
+func HasDeletionTimestamp() func(machine *clusterv1.Machine) bool {
+	return func(machine *clusterv1.Machine) bool {
+		return machine.GetDeletionTimestamp() != nil
+	}
+}
+
 // HasOutdatedConfiguration returns a MachineFilter function to find all machines
 // that do not match a given KubeadmControlPlane configuration hash.
 func HasOutdatedConfiguration(configHash string) func(machine *clusterv1.Machine) bool {

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Docker", func() {
 					Cluster:      cluster,
 					ControlPlane: controlPlane,
 				}
-				framework.WaitForKubeadmControlPlaneMachinesToExist(ctx, assertKubeadmControlPlaneNodesExistInput)
+				framework.WaitForKubeadmControlPlaneMachinesToExist(ctx, assertKubeadmControlPlaneNodesExistInput, "10m", "10s")
 
 				// Wait for the workload nodes to exist
 				waitForMachineDeploymentNodesToExistInput := framework.WaitForMachineDeploymentNodesToExistInput{

--- a/util/util.go
+++ b/util/util.go
@@ -410,3 +410,15 @@ func IsPaused(cluster *clusterv1.Cluster, v metav1.Object) bool {
 	_, ok := annotations[clusterv1.PausedAnnotation]
 	return ok
 }
+
+// MachinesByCreationTimestamp sorts a list of Machine by creation timestamp, using their names as a tie breaker.
+type MachinesByCreationTimestamp []*clusterv1.Machine
+
+func (o MachinesByCreationTimestamp) Len() int      { return len(o) }
+func (o MachinesByCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+func (o MachinesByCreationTimestamp) Less(i, j int) bool {
+	if o[i].CreationTimestamp.Equal(&o[j].CreationTimestamp) {
+		return o[i].Name < o[j].Name
+	}
+	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubeadm control plane scale up and down, as described in #2241

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2241, #2016 

I'm replacing the scale up unit tests because with the health checks introduced for scale up, they would become integration tests. For the new scale up/down unit tests, I'm going to fake the management cluster.

I'm also replacing the delete unit tests, because the existing ones rely on scaling up the cluster. I'll replace them with a test that works against a static set of machines.

/assign @chuckha @detiber @randomvariable 