### PR TITLE
:running: Use pointers for Machine manipulation in KubeadmControlPlane

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
@@ -308,8 +308,7 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 
 	readyMachines := int32(0)
 	for i := range ownedMachines {
-		m := &ownedMachines[i]
-		node, err := getMachineNode(ctx, remoteClient, m)
+		node, err := getMachineNode(ctx, remoteClient, ownedMachines[i])
 		if err != nil {
 			return errors.Wrap(err, "failed to get referenced Node")
 		}
@@ -331,7 +330,7 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 	return nil
 }
 
-func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(ctx context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, requireUpgrade []clusterv1.Machine) error {
+func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(ctx context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, requireUpgrade []*clusterv1.Machine) error {
 
 	// TODO: verify health for each existing replica
 	// TODO: mark an old Machine via the label kubeadm.controlplane.cluster.x-k8s.io/selected-for-upgrade
@@ -552,8 +551,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileDelete(ctx context.Context, clu
 	// Delete control plane machines in parallel
 	var errs []error
 	for i := range ownedMachines {
-		m := &ownedMachines[i]
-		if err := r.Client.Delete(ctx, m); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.Client.Delete(ctx, ownedMachines[i]); err != nil && !apierrors.IsNotFound(err) {
 			errs = append(errs, errors.Wrap(err, "failed to cleanup owned machines"))
 		}
 	}

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -168,7 +168,7 @@ func TestGetMachinesForCluster(t *testing.T) {
 	}
 
 	// Test that the filters use AND logic instead of OR logic
-	nameFilter := func(cluster clusterv1.Machine) bool {
+	nameFilter := func(cluster *clusterv1.Machine) bool {
 		return cluster.Name == "first-machine"
 	}
 	machines, err = m.GetMachinesForCluster(context.Background(), clusterKey, OwnedControlPlaneMachines("my-control-plane"), nameFilter)

--- a/controlplane/kubeadm/internal/failure_domain.go
+++ b/controlplane/kubeadm/internal/failure_domain.go
@@ -49,7 +49,7 @@ func (f failureDomainAggregations) Swap(i, j int) {
 }
 
 // PickMost returns the failure domain with the most number of machines.
-func PickMost(failureDomains clusterv1.FailureDomains, machines []clusterv1.Machine) string {
+func PickMost(failureDomains clusterv1.FailureDomains, machines []*clusterv1.Machine) string {
 	aggregations := pick(failureDomains, machines)
 	if len(aggregations) == 0 {
 		return ""
@@ -60,7 +60,7 @@ func PickMost(failureDomains clusterv1.FailureDomains, machines []clusterv1.Mach
 }
 
 // PickFewest returns the failure domain with the fewest number of machines.
-func PickFewest(failureDomains clusterv1.FailureDomains, machines []clusterv1.Machine) string {
+func PickFewest(failureDomains clusterv1.FailureDomains, machines []*clusterv1.Machine) string {
 	aggregations := pick(failureDomains, machines)
 	if len(aggregations) == 0 {
 		return ""
@@ -69,7 +69,7 @@ func PickFewest(failureDomains clusterv1.FailureDomains, machines []clusterv1.Ma
 	return aggregations[0].id
 }
 
-func pick(failureDomains clusterv1.FailureDomains, machines []clusterv1.Machine) failureDomainAggregations {
+func pick(failureDomains clusterv1.FailureDomains, machines []*clusterv1.Machine) failureDomainAggregations {
 	if len(failureDomains) == 0 {
 		return failureDomainAggregations{}
 	}

--- a/controlplane/kubeadm/internal/failure_domain_test.go
+++ b/controlplane/kubeadm/internal/failure_domain_test.go
@@ -30,14 +30,14 @@ func TestNewFailureDomainPicker(t *testing.T) {
 		a: clusterv1.FailureDomainSpec{},
 		b: clusterv1.FailureDomainSpec{},
 	}
-	machinea := clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: &a}}
-	machineb := clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: &b}}
-	machinenil := clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: nil}}
+	machinea := &clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: &a}}
+	machineb := &clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: &b}}
+	machinenil := &clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: nil}}
 
 	testcases := []struct {
 		name     string
 		fds      clusterv1.FailureDomains
-		machines []clusterv1.Machine
+		machines []*clusterv1.Machine
 		expected []string
 	}{
 		{
@@ -54,8 +54,8 @@ func TestNewFailureDomainPicker(t *testing.T) {
 		{
 			name: "one machine in a failure domain",
 			fds:  fds,
-			machines: []clusterv1.Machine{
-				machinea,
+			machines: []*clusterv1.Machine{
+				machinea.DeepCopy(),
 			},
 			expected: []string{b},
 		},
@@ -64,8 +64,8 @@ func TestNewFailureDomainPicker(t *testing.T) {
 			fds: clusterv1.FailureDomains{
 				a: clusterv1.FailureDomainSpec{},
 			},
-			machines: []clusterv1.Machine{
-				machinenil,
+			machines: []*clusterv1.Machine{
+				machinenil.DeepCopy(),
 			},
 			expected: []string{a, b},
 		},
@@ -74,15 +74,15 @@ func TestNewFailureDomainPicker(t *testing.T) {
 			fds: clusterv1.FailureDomains{
 				a: clusterv1.FailureDomainSpec{},
 			},
-			machines: []clusterv1.Machine{
-				machineb,
+			machines: []*clusterv1.Machine{
+				machineb.DeepCopy(),
 			},
 			expected: []string{a},
 		},
 		{
 			name:     "failure domains and no machines should return a valid failure domain",
 			fds:      fds,
-			machines: []clusterv1.Machine{},
+			machines: []*clusterv1.Machine{},
 			expected: []string{a, b},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously a lot of the Machine manipulation helpers were using []Machine and Machine, which created a bit of a awkward usage when interacting with the controller runtime Client.

