### PR TITLE
📖Fixes broken link clusterctl configuration #2340

### DIFF
--- a/docs/book/src/clusterctl/commands/config-cluster.md
+++ b/docs/book/src/clusterctl/commands/config-cluster.md
@@ -95,4 +95,4 @@ should ensure the corresponding environment variable to be set before executing 
 Please refer to the providers documentation for more info about the required variables or use the 
 `clusterctl config cluster --list-variables` flag to get a list of variables names required by a cluster template.
 
-The [clusterctl configuration](configuration.md) file can be used as alternative to environment variables.
+The [clusterctl configuration](./commands/configuration.md) file can be used as alternative to environment variables.

--- a/docs/book/src/clusterctl/commands/config-cluster.md
+++ b/docs/book/src/clusterctl/commands/config-cluster.md
@@ -95,4 +95,4 @@ should ensure the corresponding environment variable to be set before executing 
 Please refer to the providers documentation for more info about the required variables or use the 
 `clusterctl config cluster --list-variables` flag to get a list of variables names required by a cluster template.
 
-The [clusterctl configuration](./commands/configuration.md) file can be used as alternative to environment variables.
+The [clusterctl configuration](./../configuration.md) file can be used as alternative to environment variables.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will update clusterctl configuration link at the bottom of https://master.cluster-api.sigs.k8s.io/clusterctl/commands/config-cluster.html#variables to use clusterctl/configuration.html instead of clusterctl/commands/configuration.html(broken link)

**Which issue(s) this PR fixes** :
Fixes #2340 
