### PR TITLE
[Doc] Fix machine not found

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -737,7 +737,7 @@ spec:
 To verify the control plane is up, check if the control plane machine
 has a ProviderID.
 ```
-kubectl get machines --selector cluster.x-k8s.io/control-plane
+kubectl get machines --selector cluster.x-k8s.io/control-plane --all-namespaces
 ```
 
 If the control plane is deployed using a control plane provider, such as


### PR DESCRIPTION
As some sample files provide namespace settings for controller
and if that's fulfilled, the command provided in this doc
will lead to machine not found result. so update this doc
to avoid this kind of situation

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
