### PR TITLE
Fixes the 'make all' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ endif
 # Set build time variables including version details
 LDFLAGS := $(shell hack/version.sh)
 
-all: test manager clusterctl
+all: test managers clusterctl
 
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Fixes the error below:
```
make all
< ... >
    --- PASS: TestParseMachineYaml/valid_unified_for_cluster_with_invalid_Machine_(old_top-level_items_list)_and_a_configmap (0.00s)
    --- PASS: TestParseMachineYaml/gibberish_in_file (0.00s)
PASS
ok  	sigs.k8s.io/cluster-api/util/yaml	(cached)
make: *** No rule to make target `manager', needed by `all'.  Stop.
```
