### PR TITLE
Sets default configFolder to config/default

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -171,7 +171,7 @@ def enable_provider(name):
     )
 
     # Apply the kustomized yaml for this provider
-    yaml = str(kustomize(context + "/config"))
+    yaml = str(kustomize(context + "/" + p.get("kustomize_dir", "config")))
     substitutions = settings.get("kustomize_substitutions", {})
     for substitution in substitutions:
         value = substitutions[substitution]

--- a/cmd/clusterctl/hack/local-overrides.py
+++ b/cmd/clusterctl/hack/local-overrides.py
@@ -140,7 +140,7 @@ def create_local_overrides():
         assert p is not None, 'invalid configuration: please specify the configuration for the {} provider'.format(provider)
 
         repo = p.get('repo', '.')
-        config_folder = p.get('configFolder', 'config')
+        config_folder = p.get('configFolder', 'config/default')
 
         next_version = p.get('nextVersion')
         assert next_version is not None, 'invalid configuration for provider {}: please provide nextVersion value'.format(provider)

--- a/cmd/clusterctl/hack/local-overrides.py
+++ b/cmd/clusterctl/hack/local-overrides.py
@@ -54,6 +54,7 @@ providers = {
               'componentsFile': 'core-components.yaml',
               'nextVersion': 'v0.3.0',
               'type': 'CoreProvider',
+              'configFolder': 'config',
       },
       'kubeadm-bootstrap': {
             'componentsFile': 'bootstrap-components.yaml',


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Fixes the error below:
```
 cluster-api git:(master) ./cmd/clusterctl/hack/local-overrides.py
clusterctl local overrides generated from local repositories for the cluster-api, kubeadm-bootstrap, kubeadm-control-plane, aws providers.
in order to use them, please run:

clusterctl init --core cluster-api:v0.3.0 --bootstrap kubeadm-bootstrap:v0.3.0 --control-plane kubeadm-control-plane:v0.3.0 --infrastructure aws:v0.5.0

 cluster-api git:(master) cat ~/.cluster-api/overrides/aws/v0.5.0/infrastructure-components.yaml
Error: unable to find one of 'kustomization.yaml', 'kustomization.yml' or 'Kustomization' in directory '/Users/mvillacorta/git/newrelic/cluster-api-provider-aws/config'
```

If this PR is merged then also consider this CAPA PR: https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1571