### PR TITLE
📖 change some tab displays in the cluster-api book

### DIFF
--- a/docs/book/src/tasks/installation.md
+++ b/docs/book/src/tasks/installation.md
@@ -12,8 +12,8 @@ Cluster API requires an existing kubernetes cluster accessible via kubectl, choo
 
 1. **Kind**
 
-{{#tabs name:"kind-cluster" tabs:"AWS|Azure|GCP|vSphere|OpenStack,Docker"}}
-{{#tab AWS|Azure|GCP|vSphere|OpenStack}}
+{{#tabs name:"kind-cluster" tabs:"AWS/Azure/GCP/vSphere/OpenStack,Docker"}}
+{{#tab AWS/Azure/GCP/vSphere/OpenStack}}
 
 <aside class="note warning">
 

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -749,8 +749,8 @@ kubectl get clusters --output jsonpath="{range .items[*]} [{.metadata.name} {.st
 
 After the control plane node is up, we can retrieve the [workload cluster] Kubeconfig:
 
-{{#tabs name:"tab-getting-kubeconfig" tabs:"AWS|Azure|GCP|vSphere|OpenStack, Docker"}}
-{{#tab AWS|Azure|GCP|vSphere|OpenStack}}
+{{#tabs name:"tab-getting-kubeconfig" tabs:"AWS/Azure/GCP/vSphere/OpenStack, Docker"}}
+{{#tab AWS/Azure/GCP/vSphere/OpenStack}}
 
 ```bash
 kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o json \


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
there are 2 instances where multiple options are provided on a single
tab within the book. this change modifies the separator character from
pipe("|") to slash("/"), to make it easier for users to distinguish the
separate tab options.

**Which issue(s) this PR fixes** 
Fixes #1774 
