### PR TITLE
🐛clusterctl: reset commandline flags

### DIFF
--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -46,6 +46,8 @@ func Execute() {
 }
 
 func init() {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
 	verbosity := flag.CommandLine.Int("v", 0, "number for the log level verbosity")
 	logf.SetLogger(logf.NewLogger(logf.WithThreshold(verbosity)))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR prevents CommandLine flags set in one of the dependencies to leak in the clusterctl CLI

/area clusterctl
/assign @wfernandes 
/assign @vincepri 