### PR TITLE
⚠️ remote.{NewClusterClient, RESTConfig} now accepts client.ObjectKey instead of *clusterv1.Cluster

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -202,7 +202,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 
 			token := config.Spec.JoinConfiguration.Discovery.BootstrapToken.Token
 
-			remoteClient, err := r.remoteClientGetter(ctx, r.Client, cluster, r.scheme)
+			remoteClient, err := r.remoteClientGetter(ctx, r.Client, util.ObjectKey(cluster), r.scheme)
 			if err != nil {
 				log.Error(err, "error creating remote cluster client")
 				return ctrl.Result{}, err
@@ -618,7 +618,7 @@ func (r *KubeadmConfigReconciler) reconcileDiscovery(ctx context.Context, cluste
 
 	// if BootstrapToken already contains a token, respect it; otherwise create a new bootstrap token for the node to join
 	if config.Spec.JoinConfiguration.Discovery.BootstrapToken.Token == "" {
-		remoteClient, err := r.remoteClientGetter(ctx, r.Client, cluster, r.scheme)
+		remoteClient, err := r.remoteClientGetter(ctx, r.Client, util.ObjectKey(cluster), r.scheme)
 		if err != nil {
 			return err
 		}

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -189,7 +189,7 @@ func (r *ClusterReconciler) reconcileMetrics(_ context.Context, cluster *cluster
 		metrics.ClusterInfrastructureReady.WithLabelValues(cluster.Name, cluster.Namespace).Set(0)
 	}
 
-	_, err := secret.Get(context.Background(), r.Client, cluster, secret.Kubeconfig)
+	_, err := secret.Get(context.Background(), r.Client, util.ObjectKey(cluster), secret.Kubeconfig)
 	if err != nil {
 		metrics.ClusterKubeconfigReady.WithLabelValues(cluster.Name, cluster.Namespace).Set(0)
 	} else {

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -237,7 +237,7 @@ func (r *ClusterReconciler) reconcileKubeconfig(ctx context.Context, cluster *cl
 		return nil
 	}
 
-	_, err := secret.Get(ctx, r.Client, cluster, secret.Kubeconfig)
+	_, err := secret.Get(ctx, r.Client, util.ObjectKey(cluster), secret.Kubeconfig)
 	switch {
 	case apierrors.IsNotFound(err):
 		if err := kubeconfig.CreateSecret(ctx, r.Client, cluster); err != nil {

--- a/controllers/machine_controller_noderef.go
+++ b/controllers/machine_controller_noderef.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	capierrors "sigs.k8s.io/cluster-api/errors"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,12 +46,6 @@ func (r *MachineReconciler) reconcileNodeRef(ctx context.Context, cluster *clust
 		return nil
 	}
 
-	// Check that Cluster isn't nil.
-	if cluster == nil {
-		logger.V(2).Info("Machine doesn't have a linked cluster, won't assign NodeRef")
-		return nil
-	}
-
 	logger = logger.WithValues("cluster", cluster.Name)
 
 	// Check that the Machine has a valid ProviderID.
@@ -64,7 +59,7 @@ func (r *MachineReconciler) reconcileNodeRef(ctx context.Context, cluster *clust
 		return err
 	}
 
-	clusterClient, err := remote.NewClusterClient(ctx, r.Client, cluster, r.scheme)
+	clusterClient, err := remote.NewClusterClient(ctx, r.Client, util.ObjectKey(cluster), r.scheme)
 	if err != nil {
 		return err
 	}

--- a/controllers/machinepool_controller.go
+++ b/controllers/machinepool_controller.go
@@ -197,7 +197,7 @@ func (r *MachinePoolReconciler) reconcileDeleteNodes(ctx context.Context, cluste
 		return nil
 	}
 
-	clusterClient, err := remote.NewClusterClient(ctx, r.Client, cluster, r.scheme)
+	clusterClient, err := remote.NewClusterClient(ctx, r.Client, util.ObjectKey(cluster), r.scheme)
 	if err != nil {
 		return err
 	}

--- a/controllers/machinepool_controller_noderef.go
+++ b/controllers/machinepool_controller_noderef.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	capierrors "sigs.k8s.io/cluster-api/errors"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -68,7 +69,7 @@ func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, cluster *
 		return nil
 	}
 
-	clusterClient, err := remote.NewClusterClient(ctx, r.Client, cluster, r.scheme)
+	clusterClient, err := remote.NewClusterClient(ctx, r.Client, util.ObjectKey(cluster), r.scheme)
 	if err != nil {
 		return err
 	}

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -678,7 +678,7 @@ func (r *MachineSetReconciler) patchMachineSetStatus(ctx context.Context, ms *cl
 }
 
 func (r *MachineSetReconciler) getMachineNode(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (*corev1.Node, error) {
-	c, err := remote.NewClusterClient(ctx, r.Client, cluster, r.scheme)
+	c, err := remote.NewClusterClient(ctx, r.Client, util.ObjectKey(cluster), r.scheme)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -23,17 +23,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // ClusterClientGetter returns a new remote client.
-type ClusterClientGetter func(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error)
+type ClusterClientGetter func(ctx context.Context, c client.Client, cluster client.ObjectKey, scheme *runtime.Scheme) (client.Client, error)
 
 // NewClusterClient returns a Client for interacting with a remote Cluster using the given scheme for encoding and decoding objects.
-func NewClusterClient(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error) {
+func NewClusterClient(ctx context.Context, c client.Client, cluster client.ObjectKey, scheme *runtime.Scheme) (client.Client, error) {
 	restConfig, err := RESTConfig(ctx, c, cluster)
 	if err != nil {
 		return nil, err
@@ -51,7 +50,7 @@ func NewClusterClient(ctx context.Context, c client.Client, cluster *clusterv1.C
 }
 
 // RESTConfig returns a configuration instance to be used with a Kubernetes client.
-func RESTConfig(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (*restclient.Config, error) {
+func RESTConfig(ctx context.Context, c client.Client, cluster client.ObjectKey) (*restclient.Config, error) {
 	kubeConfig, err := kcfg.FromSecret(ctx, c, cluster)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve kubeconfig secret for Cluster %s/%s", cluster.Namespace, cluster.Name)

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -26,32 +26,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util/secret"
 )
 
 var (
-	clusterWithValidKubeConfig = &clusterv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test1",
-			Namespace: "test",
-		},
+	clusterWithValidKubeConfig = client.ObjectKey{
+		Name:      "test1",
+		Namespace: "test",
 	}
 
-	clusterWithInvalidKubeConfig = &clusterv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test2",
-			Namespace: "test",
-		},
+	clusterWithInvalidKubeConfig = client.ObjectKey{
+		Name:      "test2",
+		Namespace: "test",
 	}
 
-	clusterWithNoKubeConfig = &clusterv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test3",
-			Namespace: "test",
-		},
+	clusterWithNoKubeConfig = client.ObjectKey{
+		Name:      "test3",
+		Namespace: "test",
 	}
 
 	validKubeConfig = `

--- a/controllers/remote/fake/cluster.go
+++ b/controllers/remote/fake/cluster.go
@@ -20,12 +20,11 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewClusterClient returns the same client passed as input, as output. It is assumed that the client is a
 // fake controller-runtime client
-func NewClusterClient(_ context.Context, c client.Client, _ *clusterv1.Cluster, _ *runtime.Scheme) (client.Client, error) {
+func NewClusterClient(_ context.Context, c client.Client, _ client.ObjectKey, _ *runtime.Scheme) (client.Client, error) {
 	return c, nil
 }

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -46,6 +46,7 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/hash"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/secret"
 )
@@ -644,7 +645,7 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 	g.Expect(s.Data).NotTo(BeEmpty())
 	g.Expect(s.Labels).To(Equal(expectedLabels))
 
-	k, err := kubeconfig.FromSecret(context.Background(), fakeClient, cluster)
+	k, err := kubeconfig.FromSecret(context.Background(), fakeClient, util.ObjectKey(cluster))
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(k).NotTo(BeEmpty())
 

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -155,22 +155,14 @@ func (m *ManagementCluster) GetMachinesForCluster(ctx context.Context, cluster t
 // The cluster is also populated with secrets stored on the management cluster that is required for
 // secure internal pod connections.
 func (m *ManagementCluster) getCluster(ctx context.Context, clusterKey types.NamespacedName) (*cluster, error) {
-	// This adapter is for interop with the `remote` package.
-	adapterCluster := &clusterv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: clusterKey.Namespace,
-			Name:      clusterKey.Name,
-		},
-	}
-
 	// TODO(chuckha): Unroll remote.NewClusterClient if we are unhappy with getting a restConfig twice.
 	// TODO(chuckha): Inject this dependency if necessary.
-	restConfig, err := remote.RESTConfig(ctx, m.Client, adapterCluster)
+	restConfig, err := remote.RESTConfig(ctx, m.Client, clusterKey)
 	if err != nil {
 		return nil, err
 	}
 
-	c, err := remote.NewClusterClient(ctx, m.Client, adapterCluster, scheme.Scheme)
+	c, err := remote.NewClusterClient(ctx, m.Client, clusterKey, scheme.Scheme)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md
@@ -52,13 +52,24 @@
 ## Changes to `sigs.k8s.io/cluster-api/controllers/remote`
 
 -  The `ClusterClient` interface has been removed.
-- `remote.NewClusterClient` now returns a `sigs.k8s.io/controller-runtime/pkg/client` Client. The signature changed from
+- `remote.NewClusterClient` now returns a `sigs.k8s.io/controller-runtime/pkg/client` Client. It also requires `client.ObjectKey` instead of a cluster reference. The signature changed:
+  - From: `func NewClusterClient(c client.Client, cluster *clusterv1.Cluster) (ClusterClient, error)`
+  - To: `func NewClusterClient(c client.Client, cluster client.ObjectKey, scheme runtime.Scheme) (client.Client, error)`
+- Same for the remote client `ClusterClientGetter` interface:
+  - From: `type ClusterClientGetter func(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, scheme *runtime.Scheme) (client.Client, error)`
+  - To: `type ClusterClientGetter func(ctx context.Context, c client.Client, cluster client.ObjectKey, scheme *runtime.Scheme) (client.Client, error)`
+- `remote.RESTConfig` now uses `client.ObjectKey` instead of a cluster reference. Signature change:
+  - From: `func RESTConfig(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) (*restclient.Config, error)`
+  - To: `func RESTConfig(ctx context.Context, c client.Client, cluster client.ObjectKey) (*restclient.Config, error)`
 
-    `func NewClusterClient(c client.Client, cluster *clusterv1.Cluster) (ClusterClient, error)`
+### Related changes to `sigs.k8s.io/cluster-api/util`
 
-    to
+- A helper function `util.ObjectKey` could be used to get `client.ObjectKey` for a Cluster, Machine etc.
+- Getter for a kubeconfig secret, associated with a cluster requires `client.ObjectKey` instead of a cluster reference. Signature change:
 
-    `func NewClusterClient(c client.Client, cluster *clusterv1.Cluster, scheme runtime.Scheme) (client.Client, error)`
+    From: `func Get(ctx context.Context, c client.Client, cluster client.ObjectKey, purpose Purpose) (*corev1.Secret, error)`
+
+    To: `func Get(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, purpose Purpose) (*corev1.Secret, error)`
 
 ## A Machine is now considered a control plane if it has `cluster.x-k8s.io/control-plane` set, regardless of value
 

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -40,7 +40,7 @@ var (
 )
 
 // FromSecret fetches the Kubeconfig for a Cluster.
-func FromSecret(ctx context.Context, c client.Client, cluster *clusterv1.Cluster) ([]byte, error) {
+func FromSecret(ctx context.Context, c client.Client, cluster client.ObjectKey) ([]byte, error) {
 	out, err := secret.Get(ctx, c, cluster, secret.Kubeconfig)
 	if err != nil {
 		return nil, err

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -84,10 +84,12 @@ func setupScheme() *runtime.Scheme {
 }
 
 func TestGetKubeConfigSecret(t *testing.T) {
+	clusterKey := client.ObjectKey{
+		Name:      "test1",
+		Namespace: "test",
+	}
 	client := fake.NewFakeClientWithScheme(setupScheme(), validSecret)
-	found, err := FromSecret(context.Background(), client, &clusterv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "test1", Namespace: "test"},
-	})
+	found, err := FromSecret(context.Background(), client, clusterKey)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}

--- a/util/secret/secret.go
+++ b/util/secret/secret.go
@@ -21,21 +21,18 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Get retrieves the specified Secret (if any) from the given
 // cluster name and namespace.
-func Get(ctx context.Context, c client.Client, cluster *clusterv1.Cluster, purpose Purpose) (*corev1.Secret, error) {
-	name := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
-	return GetFromNamespacedName(ctx, c, name, purpose)
+func Get(ctx context.Context, c client.Client, cluster client.ObjectKey, purpose Purpose) (*corev1.Secret, error) {
+	return GetFromNamespacedName(ctx, c, cluster, purpose)
 }
 
 // GetFromNamespacedName retrieves the specified Secret (if any) from the given
 // cluster name and namespace.
-func GetFromNamespacedName(ctx context.Context, c client.Client, clusterName types.NamespacedName, purpose Purpose) (*corev1.Secret, error) {
+func GetFromNamespacedName(ctx context.Context, c client.Client, clusterName client.ObjectKey, purpose Purpose) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	secretKey := client.ObjectKey{
 		Namespace: clusterName.Namespace,

--- a/util/util.go
+++ b/util/util.go
@@ -204,6 +204,14 @@ func GetClusterByName(ctx context.Context, c client.Client, namespace, name stri
 	return cluster, nil
 }
 
+// ObjectKey returns client.ObjectKey for the object
+func ObjectKey(object metav1.Object) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: object.GetNamespace(),
+		Name:      object.GetName(),
+	}
+}
+
 // ClusterToInfrastructureMapFunc returns a handler.ToRequestsFunc that watches for
 // Cluster events and returns reconciliation requests for an infrastructure provider object.
 func ClusterToInfrastructureMapFunc(gvk schema.GroupVersionKind) handler.ToRequestsFunc {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

`remote.NewClusterClient` and all related functions are now using `NamespaceName`, as they don't require cluster object. Minor refactoring of machineset controller, allowing to drop unnecessary cluster reference and check for a pause in couple of them.

Fixes #2304
