### PR TITLE
🐛kubeadmbootstrapconfig passwd field in v1alpha2 is omitempty since its optional

### DIFF
--- a/bootstrap/kubeadm/api/v1alpha2/kubeadmbootstrapconfig_types.go
+++ b/bootstrap/kubeadm/api/v1alpha2/kubeadmbootstrapconfig_types.go
@@ -167,7 +167,7 @@ type User struct {
 
 	// Passwd specifies a hashed password for the user
 	// +optional
-	Passwd *string `json:"passwd"`
+	Passwd *string `json:"passwd,omitempty"`
 
 	// PrimaryGroup specifies the primary group for the user
 	// +optional


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
- passwd field in v1alpha2 is omitempty since its optional

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
