### PR TITLE
🐛 Machine controller should expect bootstrap data only in secret

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -247,7 +247,7 @@ func (r *ClusterReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 				continue
 			}
 
-			if !accessor.GetDeletionTimestamp().IsZero() {
+			if accessor.GetDeletionTimestamp() != nil && !accessor.GetDeletionTimestamp().IsZero() {
 				// Don't handle deleted child
 				continue
 			}

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -151,7 +151,7 @@ func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster
 	infraConfig := infraReconcileResult.Result
 
 	// There's no need to go any further if the Cluster is marked for deletion.
-	if !infraConfig.GetDeletionTimestamp().IsZero() {
+	if infraConfig.GetDeletionTimestamp() != nil && !infraConfig.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 
@@ -201,7 +201,7 @@ func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, cluster *
 	controlPlaneConfig := controlPlaneReconcileResult.Result
 
 	// There's no need to go any further if the control plane resource is marked for deletion.
-	if !controlPlaneConfig.GetDeletionTimestamp().IsZero() {
+	if controlPlaneConfig.GetDeletionTimestamp() != nil && !controlPlaneConfig.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -163,7 +163,7 @@ func (r *MachineReconciler) reconcileBootstrap(ctx context.Context, cluster *clu
 	}
 
 	// If the bootstrap data is populated, set ready and return.
-	if m.Spec.Bootstrap.Data != nil || m.Spec.Bootstrap.DataSecretName != nil {
+	if m.Spec.Bootstrap.DataSecretName != nil {
 		m.Status.BootstrapReady = true
 		return nil
 	}
@@ -190,6 +190,7 @@ func (r *MachineReconciler) reconcileBootstrap(ctx context.Context, cluster *clu
 		return errors.Errorf("retrieved empty dataSecretName from bootstrap provider for Machine %q in namespace %q", m.Name, m.Namespace)
 	}
 
+	m.Spec.Bootstrap.Data = nil
 	m.Spec.Bootstrap.DataSecretName = pointer.StringPtr(secretName)
 	m.Status.BootstrapReady = true
 	return nil

--- a/controllers/machine_controller_phases_test.go
+++ b/controllers/machine_controller_phases_test.go
@@ -624,11 +624,12 @@ func TestReconcileBootstrap(t *testing.T) {
 			expectError: false,
 			expected: func(g *WithT, m *clusterv1.Machine) {
 				g.Expect(m.Status.BootstrapReady).To(BeTrue())
-				g.Expect(*m.Spec.Bootstrap.Data).To(Equal("#!/bin/bash ... data"))
+				g.Expect(m.Spec.Bootstrap.Data).To(BeNil())
+				g.Expect(*m.Spec.Bootstrap.DataSecretName).To(BeEquivalentTo("secret-data"))
 			},
 		},
 		{
-			name: "existing machine, bootstrap provider is to not ready",
+			name: "existing machine, bootstrap provider is not ready",
 			bootstrapConfig: map[string]interface{}{
 				"kind":       "BootstrapMachine",
 				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
@@ -639,7 +640,6 @@ func TestReconcileBootstrap(t *testing.T) {
 				"spec": map[string]interface{}{},
 				"status": map[string]interface{}{
 					"ready": false,
-					"data":  "#!/bin/bash ... data",
 				},
 			},
 			machine: &clusterv1.Machine{
@@ -654,17 +654,13 @@ func TestReconcileBootstrap(t *testing.T) {
 							Kind:       "BootstrapMachine",
 							Name:       "bootstrap-config1",
 						},
-						Data: pointer.StringPtr("#!/bin/bash ... data"),
 					},
 				},
 				Status: clusterv1.MachineStatus{
 					BootstrapReady: true,
 				},
 			},
-			expectError: false,
-			expected: func(g *WithT, m *clusterv1.Machine) {
-				g.Expect(m.Status.BootstrapReady).To(BeTrue())
-			},
+			expectError: true,
 		},
 	}
 

--- a/controllers/machinepool_controller_phases.go
+++ b/controllers/machinepool_controller_phases.go
@@ -169,7 +169,7 @@ func (r *MachinePoolReconciler) reconcileBootstrap(ctx context.Context, cluster 
 	}
 
 	// If the bootstrap config is being deleted, return early.
-	if !bootstrapConfig.GetDeletionTimestamp().IsZero() {
+	if bootstrapConfig.GetDeletionTimestamp() != nil && !bootstrapConfig.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 
@@ -215,7 +215,7 @@ func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, clu
 	}
 	infraConfig := infraReconcileResult.Result
 
-	if !infraConfig.GetDeletionTimestamp().IsZero() {
+	if infraConfig.GetDeletionTimestamp() != nil && !infraConfig.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR changes the machine controller behavior when looking at external bootstrap resources. In particular, it only considers the bootstrap resource ready if `DataSecretName` is set.

It also makes sure to wipe out any plaintext data that we might have stored.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2363
