### PR TITLE
📖 Fix book CSS for 7th column on provider tab

### DIFF
--- a/docs/book/theme/css/general.css
+++ b/docs/book/theme/css/general.css
@@ -534,7 +534,8 @@ cite.literate-source > a::before {
 .tabset > input:nth-child(5):checked ~ .tab-panels > .tab-panel:nth-child(3),
 .tabset > input:nth-child(7):checked ~ .tab-panels > .tab-panel:nth-child(4),
 .tabset > input:nth-child(9):checked ~ .tab-panels > .tab-panel:nth-child(5),
-.tabset > input:nth-child(11):checked ~ .tab-panels > .tab-panel:nth-child(6) {
+.tabset > input:nth-child(11):checked ~ .tab-panels > .tab-panel:nth-child(6),
+.tabset > input:nth-child(13):checked ~ .tab-panels > .tab-panel:nth-child(7) {
   display: block;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The current clusterctl pre-requesites baremetal tab is not visible : https://master.cluster-api.sigs.k8s.io/clusterctl/overview.html#prerequisites . This is because some changes in the CSS were missing to add one element. This PR adds the CSS change to fix the issue.

/assign @vincepri 
