### PR TITLE
:running: cleanup deletion timestamp handling on external objects

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -247,7 +247,7 @@ func (r *ClusterReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 				continue
 			}
 
-			if accessor.GetDeletionTimestamp() != nil && !accessor.GetDeletionTimestamp().IsZero() {
+			if !accessor.GetDeletionTimestamp().IsZero() {
 				// Don't handle deleted child
 				continue
 			}

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -151,7 +151,7 @@ func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster
 	infraConfig := infraReconcileResult.Result
 
 	// There's no need to go any further if the Cluster is marked for deletion.
-	if infraConfig.GetDeletionTimestamp() != nil && !infraConfig.GetDeletionTimestamp().IsZero() {
+	if !infraConfig.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 
@@ -201,7 +201,7 @@ func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, cluster *
 	controlPlaneConfig := controlPlaneReconcileResult.Result
 
 	// There's no need to go any further if the control plane resource is marked for deletion.
-	if controlPlaneConfig.GetDeletionTimestamp() != nil && !controlPlaneConfig.GetDeletionTimestamp().IsZero() {
+	if !controlPlaneConfig.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -169,7 +169,7 @@ func (r *MachineReconciler) reconcileBootstrap(ctx context.Context, cluster *clu
 	}
 
 	// If the bootstrap config is being deleted, return early.
-	if bootstrapConfig.GetDeletionTimestamp() != nil && !bootstrapConfig.GetDeletionTimestamp().IsZero() {
+	if !bootstrapConfig.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 
@@ -216,7 +216,7 @@ func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, cluster
 	}
 	infraConfig := infraReconcileResult.Result
 
-	if infraConfig.GetDeletionTimestamp() != nil && !infraConfig.GetDeletionTimestamp().IsZero() {
+	if !infraConfig.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 

--- a/controllers/machinepool_controller_phases.go
+++ b/controllers/machinepool_controller_phases.go
@@ -169,7 +169,7 @@ func (r *MachinePoolReconciler) reconcileBootstrap(ctx context.Context, cluster 
 	}
 
 	// If the bootstrap config is being deleted, return early.
-	if bootstrapConfig.GetDeletionTimestamp() != nil && !bootstrapConfig.GetDeletionTimestamp().IsZero() {
+	if !bootstrapConfig.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 
@@ -215,7 +215,7 @@ func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, clu
 	}
 	infraConfig := infraReconcileResult.Result
 
-	if infraConfig.GetDeletionTimestamp() != nil && !infraConfig.GetDeletionTimestamp().IsZero() {
+	if !infraConfig.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
/assign @ncdc 