### PR TITLE
:running: Cleanup FailureDomain support for KubeadmControlPlane

### DIFF
--- a/api/v1alpha3/cluster_types.go
+++ b/api/v1alpha3/cluster_types.go
@@ -21,6 +21,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 
@@ -213,6 +215,15 @@ func (in FailureDomains) FilterControlPlane() FailureDomains {
 		}
 	}
 	return res
+}
+
+// GetIDs returns a slice containing the ids for failure domains
+func (in FailureDomains) GetIDs() []*string {
+	ids := make([]*string, 0, len(in))
+	for id := range in {
+		ids = append(ids, pointer.StringPtr(id))
+	}
+	return ids
 }
 
 // FailureDomainSpec is the Schema for Cluster API failure domains.

--- a/controlplane/kubeadm/internal/machine_collection.go
+++ b/controlplane/kubeadm/internal/machine_collection.go
@@ -118,3 +118,12 @@ func (s FilterableMachineCollection) Oldest() *clusterv1.Machine {
 	}
 	return s.list()[len(s)-1]
 }
+
+// DeepCopy returns a deep copy
+func (s FilterableMachineCollection) DeepCopy() FilterableMachineCollection {
+	result := NewFilterableMachineCollection()
+	for _, m := range s {
+		result.Insert(m.DeepCopy())
+	}
+	return result
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleans up and makes the failure domain support within KubeadmControlPlane more consistent

Related to: #2242