### PR TITLE
:running: Kcp scale down improvements

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -28,6 +28,7 @@ const (
 	KubeadmControlPlaneFinalizer    = "kubeadm.controlplane.cluster.x-k8s.io"
 	KubeadmControlPlaneHashLabelKey = "kubeadm.controlplane.cluster.x-k8s.io/hash"
 	SelectedForUpgradeAnnotation    = "kubeadm.controlplane.cluster.x-k8s.io/selected-for-upgrade"
+	DeleteForScaleDownAnnotation    = "kubeadm.controlplane.cluster.x-k8s.io/delete-for-scale-down"
 )
 
 // KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.


### PR DESCRIPTION
**What this PR does / why we need it**:

Lays the foundation for improved re-entrancy for scaling down KubeadmControlPlane

Related to #2242
Builds on #2379 #2380 