### PR TITLE
:sparkles: Remove etcd membership when doing a KubeadmControlPlane scale down

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	KubeadmControlPlaneFinalizer    = "kubeadm.controlplane.cluster.x-k8s.io"
-	KubeadmControlPlaneHashLabelKey = "kubeadm.controlplane.cluster.x-k8s.io/hash"
-	SelectedForUpgradeAnnotation    = "kubeadm.controlplane.cluster.x-k8s.io/selected-for-upgrade"
-	DeleteForScaleDownAnnotation    = "kubeadm.controlplane.cluster.x-k8s.io/delete-for-scale-down"
+	KubeadmControlPlaneFinalizer         = "kubeadm.controlplane.cluster.x-k8s.io"
+	KubeadmControlPlaneHashLabelKey      = "kubeadm.controlplane.cluster.x-k8s.io/hash"
+	SelectedForUpgradeAnnotation         = "kubeadm.controlplane.cluster.x-k8s.io/selected-for-upgrade"
+	DeleteForScaleDownAnnotation         = "kubeadm.controlplane.cluster.x-k8s.io/delete-for-scale-down"
+	ScaleDownEtcdMemberRemovedAnnotation = "kubeadm.controlplane.cluster.x-k8s.io/scale-down-etcd-member-removed"
 )
 
 // KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -1344,6 +1344,10 @@ func (f *fakeManagementCluster) TargetClusterEtcdIsHealthy(ctx context.Context, 
 	return nil
 }
 
+func (f *fakeManagementCluster) RemoveEtcdMemberForMachine(ctx context.Context, clusterKey types.NamespacedName, machine *clusterv1.Machine) error {
+	return nil
+}
+
 func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 	t.Run("creates a control plane Machine if health checks pass", func(t *testing.T) {
 		g := NewWithT(t)


### PR DESCRIPTION
**What this PR does / why we need it**:
Properly removes etcd membership when doing a KubeadmControlPlane scale down

Related to #2242
Builds on #2379 #2380 #2381 