### PR TITLE
:sparkles: Remove configmap entry when doing a KubeadmControlPlane scale down

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -25,11 +25,12 @@ import (
 )
 
 const (
-	KubeadmControlPlaneFinalizer         = "kubeadm.controlplane.cluster.x-k8s.io"
-	KubeadmControlPlaneHashLabelKey      = "kubeadm.controlplane.cluster.x-k8s.io/hash"
-	SelectedForUpgradeAnnotation         = "kubeadm.controlplane.cluster.x-k8s.io/selected-for-upgrade"
-	DeleteForScaleDownAnnotation         = "kubeadm.controlplane.cluster.x-k8s.io/delete-for-scale-down"
-	ScaleDownEtcdMemberRemovedAnnotation = "kubeadm.controlplane.cluster.x-k8s.io/scale-down-etcd-member-removed"
+	KubeadmControlPlaneFinalizer             = "kubeadm.controlplane.cluster.x-k8s.io"
+	KubeadmControlPlaneHashLabelKey          = "kubeadm.controlplane.cluster.x-k8s.io/hash"
+	SelectedForUpgradeAnnotation             = "kubeadm.controlplane.cluster.x-k8s.io/selected-for-upgrade"
+	DeleteForScaleDownAnnotation             = "kubeadm.controlplane.cluster.x-k8s.io/delete-for-scale-down"
+	ScaleDownEtcdMemberRemovedAnnotation     = "kubeadm.controlplane.cluster.x-k8s.io/scale-down-etcd-member-removed"
+	ScaleDownConfigMapEntryRemovedAnnotation = "kubeadm.controlplane.cluster.x-k8s.io/scale-down-configmap-entry-removed"
 )
 
 // KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -1348,6 +1348,10 @@ func (f *fakeManagementCluster) RemoveEtcdMemberForMachine(ctx context.Context, 
 	return nil
 }
 
+func (f *fakeManagementCluster) RemoveMachineFromKubeadmConfigMap(ctx context.Context, clusterKey types.NamespacedName, machine *clusterv1.Machine) error {
+	return nil
+}
+
 func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 	t.Run("creates a control plane Machine if health checks pass", func(t *testing.T) {
 		g := NewWithT(t)

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/grpc v1.23.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/yaml.v2 v2.2.7 // indirect
+	gopkg.in/yaml.v2 v2.2.7
 	k8s.io/api v0.17.2
 	k8s.io/apiextensions-apiserver v0.17.2
 	k8s.io/apimachinery v0.17.2


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the machine's kubeadm configmap entry when doing a KubeadmControlPlane scale down

Related to #2242
Builds on #2379 #2380 #2381 #2382