### PR TITLE
:running: kubeadm control plane validating webhook: forbid scaling to zero

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
@@ -127,6 +127,19 @@ func (r *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		)
 	}
 
+	if *r.Spec.Replicas <= 0 {
+		// The use of the scale subresource should provide a guarantee that negative values
+		// should not be accepted for this field, but since we have to validate that Replicas != 0
+		// it doesn't hurt to also additionally validate for negative numbers here as well.
+		allErrs = append(
+			allErrs,
+			field.Forbidden(
+				field.NewPath("spec", "replicas"),
+				"cannot be less than or equal to 0",
+			),
+		)
+	}
+
 	if len(allErrs) == 0 {
 		return nil
 	}

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
@@ -155,6 +155,9 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	validUpdate.Spec.InfrastructureTemplate.Name = "orange"
 	validUpdate.Spec.Replicas = pointer.Int32Ptr(5)
 
+	scaleToZero := before.DeepCopy()
+	scaleToZero.Spec.Replicas = pointer.Int32Ptr(0)
+
 	tests := []struct {
 		name      string
 		expectErr bool
@@ -169,6 +172,11 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			name:      "should return error when trying to mutate the kubeadmconfigspec",
 			expectErr: true,
 			kcp:       invalidUpdate,
+		},
+		{
+			name:      "should return error when trying to scale to zero",
+			expectErr: true,
+			kcp:       scaleToZero,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The kubeadm control plane does not support scaling to zero replicas, so forbid it on update.

/assign @detiber @chuckha 
