### PR TITLE
:running: kubeadm control plane validating webhook: allow even number of control plane replicas when using managed etcd

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
@@ -75,25 +75,6 @@ func (r *KubeadmControlPlane) ValidateCreate() error {
 		)
 	}
 
-	externalEtcd := false
-	if r.Spec.KubeadmConfigSpec.InitConfiguration != nil {
-		if r.Spec.KubeadmConfigSpec.InitConfiguration.Etcd.External != nil {
-			externalEtcd = true
-		}
-	}
-
-	if !externalEtcd {
-		if r.Spec.Replicas != nil && *r.Spec.Replicas%2 == 0 {
-			allErrs = append(
-				allErrs,
-				field.Forbidden(
-					field.NewPath("spec", "replicas"),
-					"cannot be an even number when using managed etcd",
-				),
-			)
-		}
-	}
-
 	if r.Spec.InfrastructureTemplate.Namespace != r.Namespace {
 		allErrs = append(
 			allErrs,

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
@@ -107,8 +107,8 @@ func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
 			kcp:       zeroReplicas,
 		},
 		{
-			name:      "should return error when replicas is even",
-			expectErr: true,
+			name:      "should allow even replicas when using managed etcd",
+			expectErr: false,
 			kcp:       evenReplicas,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
When we wrote the kubeadm control plane KEP, we decided to not support managing an even number of etcd members when using managed etcd, As unwise as an even number of etcd members may be in production, it can be useful for testing.

### TODO
- [ ] Update the KEP

/assign @detiber @chuckha @randomvariable 