### PR TITLE
🏃 Disallow modification of KCP kubeadm config spec

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
@@ -65,26 +65,17 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 	allErrs := in.validateCommon()
 
 	prev := old.(*KubeadmControlPlane)
-	// Verify that we are not making any changes to the InitConfiguration of KubeadmConfigSpec
-	if !reflect.DeepEqual(in.Spec.KubeadmConfigSpec.InitConfiguration, prev.Spec.KubeadmConfigSpec.InitConfiguration) {
+	if !reflect.DeepEqual(in.Spec.KubeadmConfigSpec, prev.Spec.KubeadmConfigSpec) {
 		allErrs = append(
 			allErrs,
 			field.Forbidden(
-				field.NewPath("spec", "kubeadmConfigSpec", "initConfiguration"),
+				field.NewPath("spec", "kubeadmConfigSpec"),
 				"cannot be modified",
 			),
 		)
 	}
-	// Verify that we are not making any changes to the ClusterConfiguration of KubeadmConfigSpec
-	if !reflect.DeepEqual(in.Spec.KubeadmConfigSpec.ClusterConfiguration, prev.Spec.KubeadmConfigSpec.ClusterConfiguration) {
-		allErrs = append(
-			allErrs,
-			field.Forbidden(
-				field.NewPath("spec", "kubeadmConfigSpec", "clusterConfiguration"),
-				"cannot be modified",
-			),
-		)
-	}
+
+	// In order to make the kubeadm config spec mutable, please see https://github.com/kubernetes-sigs/cluster-api/pull/2388/files
 
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(GroupVersion.WithKind("KubeadmControlPlane").GroupKind(), in.Name, allErrs)

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
@@ -237,8 +237,8 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			kcp:       invalidUpdateKubeadmConfigCluster,
 		},
 		{
-			name:      "should not return error when trying to mutate the kubeadmconfigspec joinconfiguration",
-			expectErr: false,
+			name:      "should return error when trying to mutate the kubeadmconfigspec joinconfiguration",
+			expectErr: true,
 			before:    before,
 			kcp:       validUpdateKubeadmConfigJoin,
 		},


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
As discussed in the meeting on tuesday, and here in slack: https://kubernetes.slack.com/archives/C8TSNPY4T/p1582233010327500,  we're going to hold off on allowing changes to the kubeadm config spec until after the v0.3.0 release.

/assign @rudoi

