### PR TITLE
test: Set kindest image to 1.16 for CRDv1 compat

### DIFF
--- a/test/helpers/kind/setup.go
+++ b/test/helpers/kind/setup.go
@@ -35,6 +35,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	kindestImage = "kindest/node:v1.16.4"
+)
+
 var (
 	kindBinary    = flag.String("kindBinary", "kind", "path to the kind binary")
 	kubectlBinary = flag.String("kubectlBinary", "kubectl", "path to the kubectl binary")
@@ -55,7 +59,7 @@ func (c *Cluster) Setup() {
 	c.tmpDir, err = ioutil.TempDir("", "kind-home")
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	fmt.Fprintf(ginkgo.GinkgoWriter, "creating Kind cluster named %q\n", c.Name)
-	c.run(exec.Command(*kindBinary, "create", "cluster", "--name", c.Name))
+	c.run(exec.Command(*kindBinary, "create", "cluster", "--image", kindestImage, "--name", c.Name))
 	path := c.runWithOutput(exec.Command(*kindBinary, "get", "kubeconfig-path", "--name", c.Name))
 	c.kubepath = strings.TrimSpace(string(path))
 	fmt.Fprintf(ginkgo.GinkgoWriter, "kubeconfig path: %q. Can use the following to access the cluster:\n", c.kubepath)


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2396 
Makes tests less dependent on the specific version of kind.
