### PR TITLE
🐛 Recognize MachinePool as a bootstrap config owner

### DIFF
--- a/bootstrap/util/configowner.go
+++ b/bootstrap/util/configowner.go
@@ -75,7 +75,7 @@ func (co ConfigOwner) IsControlPlaneMachine() bool {
 // GeConfigOwner returns the Unstructured object owning the current resource.
 func GetConfigOwner(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*ConfigOwner, error) {
 	for _, ref := range obj.OwnerReferences {
-		if ref.Kind == "Machine" && ref.APIVersion == clusterv1.GroupVersion.String() {
+		if (ref.Kind == "Machine" || ref.Kind == "MachinePool") && ref.APIVersion == clusterv1.GroupVersion.String() {
 			return GetOwnerByRef(ctx, c, &corev1.ObjectReference{
 				APIVersion: ref.APIVersion,
 				Kind:       ref.Kind,


### PR DESCRIPTION
Signed-off-by: Juan-Lee Pang <jpang@microsoft.com>

**What this PR does / why we need it**:
Adds MachinePool as a valid boostrap provider config owner. Without this, a machine pool's kubeadm boostrap config will never be generated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2405
