### PR TITLE
🏃 Adds an upgrade test

### DIFF
--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -91,8 +91,9 @@ test-e2e: ## Run the end-to-end tests
 
 E2E_CONF_FILE ?= e2e/local-e2e.conf
 SKIP_RESOURCE_CLEANUP ?= false
+FOCUS ?= Basic
 run-e2e:
-	go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath $(E2E_CONF_FILE))" -skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP)
+	go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath $(E2E_CONF_FILE))" -skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) -ginkgo.focus=$(FOCUS)
 
 ## --------------------------------------
 ## Binaries


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

By default, the e2e tests will run the basic create test that takes ~300s (5m) on my laptop. However, by modifying the FOCUS var is possible to run the full test (upgrades and any other actions beyond create) that takes closer to 12 minutes on my laptop and is not suitable (my opinion) for every PR.

This can merge before the upgrade PR merges as there is no change in existing default behavior.