### PR TITLE
🐛 Fix makefile escaping for capd-e2e focus

### DIFF
--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -93,7 +93,7 @@ E2E_CONF_FILE ?= e2e/local-e2e.conf
 SKIP_RESOURCE_CLEANUP ?= false
 FOCUS ?= Basic
 run-e2e:
-	go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath $(E2E_CONF_FILE))" -skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) -ginkgo.focus=$(FOCUS)
+	go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath $(E2E_CONF_FILE))" -skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) -ginkgo.focus='$(FOCUS)'
 
 ## --------------------------------------
 ## Binaries

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Docker", func() {
 			})
 
 			Specify("Full upgrade", func() {
-				// Upgrade control plane
+				By("upgrading the control plane object to a new version")
 				patchHelper, err := patch.NewHelper(controlPlane, client)
 				Expect(err).ToNot(HaveOccurred())
 				controlPlane.Spec.Version = "1.17.2"


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
Forgot to escape the regex. If we don't have this, a regex like 'Basic|Full' will fail.
