### PR TITLE
🏃 Update kubeadm config on upgrade

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -1225,29 +1226,37 @@ type fakeManagementCluster struct {
 	Machines            internal.FilterableMachineCollection
 }
 
-func (f *fakeManagementCluster) GetMachinesForCluster(ctx context.Context, cluster types.NamespacedName, filters ...internal.MachineFilter) (internal.FilterableMachineCollection, error) {
+func (f *fakeManagementCluster) GetMachinesForCluster(_ context.Context, _ types.NamespacedName, _ ...internal.MachineFilter) (internal.FilterableMachineCollection, error) {
 	return f.Machines, nil
 }
 
-func (f *fakeManagementCluster) TargetClusterControlPlaneIsHealthy(ctx context.Context, clusterKey types.NamespacedName, controlPlaneName string) error {
+func (f *fakeManagementCluster) TargetClusterControlPlaneIsHealthy(_ context.Context, _ types.NamespacedName, _ string) error {
 	if !f.ControlPlaneHealthy {
 		return errors.New("control plane is not healthy")
 	}
 	return nil
 }
 
-func (f *fakeManagementCluster) TargetClusterEtcdIsHealthy(ctx context.Context, clusterKey types.NamespacedName, controlPlaneName string) error {
+func (f *fakeManagementCluster) TargetClusterEtcdIsHealthy(_ context.Context, _ types.NamespacedName, _ string) error {
 	if !f.EtcdHealthy {
 		return errors.New("etcd is not healthy")
 	}
 	return nil
 }
 
-func (f *fakeManagementCluster) RemoveEtcdMemberForMachine(ctx context.Context, clusterKey types.NamespacedName, machine *clusterv1.Machine) error {
+func (f *fakeManagementCluster) RemoveEtcdMemberForMachine(_ context.Context, _ types.NamespacedName, _ *clusterv1.Machine) error {
 	return nil
 }
 
-func (f *fakeManagementCluster) RemoveMachineFromKubeadmConfigMap(ctx context.Context, clusterKey types.NamespacedName, machine *clusterv1.Machine) error {
+func (f *fakeManagementCluster) RemoveMachineFromKubeadmConfigMap(_ context.Context, _ types.NamespacedName, _ *clusterv1.Machine) error {
+	return nil
+}
+
+func (f *fakeManagementCluster) UpdateKubernetesVersionInKubeadmConfigMap(_ context.Context, _ types.NamespacedName, _ string) error {
+	return nil
+}
+
+func (f *fakeManagementCluster) UpdateKubeletConfigMap(_ context.Context, _ types.NamespacedName, _ semver.Version) error {
 	return nil
 }
 

--- a/controlplane/kubeadm/internal/kubeadm_config_map.go
+++ b/controlplane/kubeadm/internal/kubeadm_config_map.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	clusterStatusKey        = "ClusterStatus"
+	clusterConfigurationKey = "ClusterConfiguration"
+	statusAPIEndpointsKey   = "apiEndpoints"
+	configVersionKey        = "kubernetesVersion"
+)
+
+// kubeadmConfig wraps up interactions necessary for modifying the kubeadm config during an upgrade.
+type kubeadmConfig struct {
+	ConfigMap *corev1.ConfigMap
+}
+
+// RemoveAPIEndpoint removes an APIEndpoint fromt he kubeadm config cluster status config map
+func (k *kubeadmConfig) RemoveAPIEndpoint(endpoint string) error {
+	data, ok := k.ConfigMap.Data[clusterStatusKey]
+	if !ok {
+		return errors.Errorf("could not find key %q in kubeadm config", clusterStatusKey)
+	}
+	status, err := yamlToUnstructured([]byte(data))
+	if err != nil {
+		return errors.Wrap(err, "unable to convert YAML to unstructured")
+	}
+	endpoints, _, err := unstructured.NestedMap(status.UnstructuredContent(), statusAPIEndpointsKey)
+	if err != nil {
+		return errors.Wrap(err, "unable to extract apiEndpoints from kubeadm config map")
+	}
+	delete(endpoints, endpoint)
+	if err := unstructured.SetNestedMap(status.UnstructuredContent(), endpoints, statusAPIEndpointsKey); err != nil {
+		return errors.Wrap(err, "unable to set apiEndpoints on kubeadm config map")
+	}
+	updated, err := yaml.Marshal(status)
+	if err != nil {
+		return errors.Wrap(err, "error encoding kubeadm ClusterStatus object")
+	}
+	k.ConfigMap.Data[clusterStatusKey] = string(updated)
+	return nil
+}
+
+// UpdateKubernetesVersion changes the kubernetes version found in the kubeadm config map
+func (k *kubeadmConfig) UpdateKubernetesVersion(version string) error {
+	data, ok := k.ConfigMap.Data[clusterConfigurationKey]
+	if !ok {
+		return errors.Errorf("could not find key %q in kubeadm config", clusterConfigurationKey)
+	}
+	configuration, err := yamlToUnstructured([]byte(data))
+	if err != nil {
+		return errors.Wrap(err, "unable to convert YAML to unstructured")
+	}
+	if err := unstructured.SetNestedField(configuration.UnstructuredContent(), version, configVersionKey); err != nil {
+		return errors.Wrap(err, "unable to update kubernetes version on kubeadm config map")
+	}
+	updated, err := yaml.Marshal(configuration)
+	if err != nil {
+		return errors.Wrap(err, "error encoding kubeadm cluster configuration object")
+	}
+	k.ConfigMap.Data[clusterConfigurationKey] = string(updated)
+	return nil
+}
+
+// yamlToUnstructured looks inside a config map for a specific key and extracts the embedded YAML into an
+// *unstructured.Unstructured.
+func yamlToUnstructured(rawYAML []byte) (*unstructured.Unstructured, error) {
+	unst := &unstructured.Unstructured{}
+	err := yaml.Unmarshal(rawYAML, unst)
+	return unst, err
+}

--- a/controlplane/kubeadm/internal/kubeadm_config_map_test.go
+++ b/controlplane/kubeadm/internal/kubeadm_config_map_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	HaveOccurred     = gomega.HaveOccurred
+	Succeed          = gomega.Succeed
+	SatisfyAll       = gomega.SatisfyAll
+	HaveLen          = gomega.HaveLen
+	HaveKey          = gomega.HaveKey
+	HaveKeyWithValue = gomega.HaveKeyWithValue
+	WithTransform    = gomega.WithTransform
+	BeEmpty          = gomega.BeEmpty
+)
+
+func Test_kubeadmConfig_RemoveAPIEndpoint(t *testing.T) {
+	g := gomega.NewWithT(t)
+	original := &corev1.ConfigMap{
+		Data: map[string]string{
+			"ClusterStatus": `apiEndpoints:
+  ip-10-0-0-1.ec2.internal:
+    advertiseAddress: 10.0.0.1
+    bindPort: 6443
+  ip-10-0-0-2.ec2.internal:
+    advertiseAddress: 10.0.0.2
+    bindPort: 6443
+    someFieldThatIsAddedInTheFuture: bar
+  ip-10-0-0-3.ec2.internal:
+    advertiseAddress: 10.0.0.3
+    bindPort: 6443
+    someFieldThatIsAddedInTheFuture: baz
+  ip-10-0-0-4.ec2.internal:
+    advertiseAddress: 10.0.0.4
+    bindPort: 6443
+    someFieldThatIsAddedInTheFuture: fizzbuzz
+apiVersion: kubeadm.k8s.io/vNbetaM
+kind: ClusterStatus`,
+		},
+	}
+	kc := kubeadmConfig{ConfigMap: original}
+	g.Expect(kc.RemoveAPIEndpoint("ip-10-0-0-3.ec2.internal")).ToNot(HaveOccurred())
+	g.Expect(kc.ConfigMap.Data).To(HaveKey("ClusterStatus"))
+	var status struct {
+		APIEndpoints map[string]interface{} `yaml:"apiEndpoints"`
+		APIVersion   string                 `yaml:"apiVersion"`
+		Kind         string                 `yaml:"kind"`
+
+		Extra map[string]interface{} `yaml:",inline"`
+	}
+	g.Expect(yaml.UnmarshalStrict([]byte(kc.ConfigMap.Data["ClusterStatus"]), &status)).To(Succeed())
+	g.Expect(status.Extra).To(BeEmpty())
+
+	g.Expect(status.APIEndpoints).To(SatisfyAll(
+		HaveLen(3),
+		HaveKey("ip-10-0-0-1.ec2.internal"),
+		HaveKey("ip-10-0-0-2.ec2.internal"),
+		HaveKey("ip-10-0-0-4.ec2.internal"),
+		WithTransform(func(ep map[string]interface{}) interface{} {
+			return ep["ip-10-0-0-4.ec2.internal"]
+		}, SatisfyAll(
+			HaveKeyWithValue("advertiseAddress", "10.0.0.4"),
+			HaveKey("bindPort"),
+			HaveKey("someFieldThatIsAddedInTheFuture"),
+		)),
+	))
+}


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR updates the kubernetes version found in the kubeadm configuration config map as well as refactors some of the kubelet upgrading to keep it outside of the reconciler

This PR intentionally includes code that is easily refactored. I do not intend to consolidate repeated code in this PR and will save that for an exercise for later.

To run a test locally with this PR, first check it out, then run

```
export FOCUS='Basic|Full` # I know, I know...but it's fine for now
make test-capd-e2e-images
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2448 
Fixes #2427 
Fixes #2429 

This is the upgraded cluster. The machine deployment was not upgraded as it's not managed buy the kubeadm control plane
```
chuckh-a02:cluster-api cha$ k get nodes
NAME                                STATUS     ROLES    AGE     VERSION
test-0-test-0-9v4p6                 NotReady   master   10m     v1.17.2
test-0-test-0-k6x4q                 NotReady   master   12m     v1.17.2
test-0-test-0-md-5c6f99b8bf-7qvsc   NotReady   <none>   17m     v1.16.3
test-0-test-0-xq7nw                 NotReady   master   8m28s   v1.17.2
```

This is a random log from one of the kubelets. It is expected since there is no CNI installed (this set of logs means it's working).
```
Feb 26 17:09:48 test-0-test-0-xq7nw kubelet[459]: E0226 17:09:48.244762     459 kubelet.go:2183] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
Feb 26 17:09:53 test-0-test-0-xq7nw kubelet[459]: E0226 17:09:53.246961     459 kubelet.go:2183] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
Feb 26 17:09:58 test-0-test-0-xq7nw kubelet[459]: E0226 17:09:58.248183     459 kubelet.go:2183] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
Feb 26 17:10:03 test-0-test-0-xq7nw kubelet[459]: E0226 17:10:03.251303     459 kubelet.go:2183] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
Feb 26 17:10:08 test-0-test-0-xq7nw kubelet[459]: E0226 17:10:08.252986     459 kubelet.go:2183] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
Feb 26 17:10:13 test-0-test-0-xq7nw kubelet[459]: E0226 17:10:13.255484     459 kubelet.go:2183] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
Feb 26 17:10:18 test-0-test-0-xq7nw kubelet[459]: E0226 17:10:18.257761     459 kubelet.go:2183] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
Feb 26 17:10:23 test-0-test-0-xq7nw kubelet[459]: E0226 17:10:23.258997     459 kubelet.go:2183] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
Feb 26 17:10:28 test-0-test-0-xq7nw kubelet[459]: E0226 17:10:28.261498     459 kubelet.go:2183] Container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized
```

/cc @dlipovetsky @randomvariable 
/assign @detiber 