### PR TITLE
🏃Add validation webhook check to make Spec.ClusterName immutable

### DIFF
--- a/api/v1alpha3/machineset_webhook_test.go
+++ b/api/v1alpha3/machineset_webhook_test.go
@@ -96,12 +96,58 @@ func TestMachineSetLabelSelectorMatchValidation(t *testing.T) {
 			}
 			if tt.expectErr {
 				g.Expect(ms.ValidateCreate()).NotTo(Succeed())
-				g.Expect(ms.ValidateUpdate(nil)).NotTo(Succeed())
+				g.Expect(ms.ValidateUpdate(ms)).NotTo(Succeed())
 			} else {
 				g.Expect(ms.ValidateCreate()).To(Succeed())
-				g.Expect(ms.ValidateUpdate(nil)).To(Succeed())
+				g.Expect(ms.ValidateUpdate(ms)).To(Succeed())
 			}
 		})
 	}
 
+}
+
+func TestMachineSetClusterNameImmutable(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldClusterName string
+		newClusterName string
+		expectErr      bool
+	}{
+		{
+			name:           "when the cluster name has not changed",
+			oldClusterName: "foo",
+			newClusterName: "foo",
+			expectErr:      false,
+		},
+		{
+			name:           "when the cluster name has changed",
+			oldClusterName: "foo",
+			newClusterName: "bar",
+			expectErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			newMS := &MachineSet{
+				Spec: MachineSetSpec{
+					ClusterName: tt.newClusterName,
+				},
+			}
+
+			oldMS := &MachineSet{
+				Spec: MachineSetSpec{
+					ClusterName: tt.oldClusterName,
+				},
+			}
+
+			if tt.expectErr {
+				g.Expect(newMS.ValidateUpdate(oldMS)).NotTo(Succeed())
+			} else {
+				g.Expect(newMS.ValidateUpdate(oldMS)).To(Succeed())
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a validation webhook check to Machine, MachineDeployment, MachineSet, and MachinePool types to make Spec.ClusterName field immutable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/2439
