### PR TITLE
✨ Defaulting webhooks should always set label from Spec.ClusterName

### DIFF
--- a/api/v1alpha3/machine_webhook.go
+++ b/api/v1alpha3/machine_webhook.go
@@ -40,6 +40,11 @@ var _ webhook.Defaulter = &Machine{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (m *Machine) Default() {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+	m.Labels[ClusterLabelName] = m.Spec.ClusterName
+
 	if m.Spec.Bootstrap.ConfigRef != nil && len(m.Spec.Bootstrap.ConfigRef.Namespace) == 0 {
 		m.Spec.Bootstrap.ConfigRef.Namespace = m.Namespace
 	}

--- a/api/v1alpha3/machine_webhook_test.go
+++ b/api/v1alpha3/machine_webhook_test.go
@@ -39,6 +39,7 @@ func TestMachineDefault(t *testing.T) {
 
 	m.Default()
 
+	g.Expect(m.Labels[ClusterLabelName]).To(Equal(m.Spec.ClusterName))
 	g.Expect(m.Spec.Bootstrap.ConfigRef.Namespace).To(Equal(m.Namespace))
 	g.Expect(m.Spec.InfrastructureRef.Namespace).To(Equal(m.Namespace))
 }

--- a/api/v1alpha3/machinedeployment_webhook.go
+++ b/api/v1alpha3/machinedeployment_webhook.go
@@ -102,6 +102,11 @@ func (m *MachineDeployment) validate(old *MachineDeployment) error {
 // PopulateDefaultsMachineDeployment fills in default field values.
 // This is also called during MachineDeployment sync.
 func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
+	if d.Labels == nil {
+		d.Labels = make(map[string]string)
+	}
+	d.Labels[ClusterLabelName] = d.Spec.ClusterName
+
 	if d.Spec.Replicas == nil {
 		d.Spec.Replicas = pointer.Int32Ptr(1)
 	}

--- a/api/v1alpha3/machinedeployment_webhook_test.go
+++ b/api/v1alpha3/machinedeployment_webhook_test.go
@@ -34,6 +34,7 @@ func TestMachineDeploymentDefault(t *testing.T) {
 
 	md.Default()
 
+	g.Expect(md.Labels[ClusterLabelName]).To(Equal(md.Spec.ClusterName))
 	g.Expect(md.Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
 	g.Expect(md.Spec.MinReadySeconds).To(Equal(pointer.Int32Ptr(0)))
 	g.Expect(md.Spec.RevisionHistoryLimit).To(Equal(pointer.Int32Ptr(1)))

--- a/api/v1alpha3/machinehealthcheck_webhook.go
+++ b/api/v1alpha3/machinehealthcheck_webhook.go
@@ -51,6 +51,11 @@ var _ webhook.Validator = &MachineHealthCheck{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (m *MachineHealthCheck) Default() {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+	m.Labels[ClusterLabelName] = m.Spec.ClusterName
+
 	if m.Spec.MaxUnhealthy == nil {
 		defaultMaxUnhealthy := intstr.FromString("100%")
 		m.Spec.MaxUnhealthy = &defaultMaxUnhealthy

--- a/api/v1alpha3/machinehealthcheck_webhook_test.go
+++ b/api/v1alpha3/machinehealthcheck_webhook_test.go
@@ -31,6 +31,7 @@ func TestMachineHealthCheckDefault(t *testing.T) {
 
 	mhc.Default()
 
+	g.Expect(mhc.Labels[ClusterLabelName]).To(Equal(mhc.Spec.ClusterName))
 	g.Expect(mhc.Spec.MaxUnhealthy.String()).To(Equal("100%"))
 	g.Expect(mhc.Spec.NodeStartupTimeout).ToNot(BeNil())
 	g.Expect(*mhc.Spec.NodeStartupTimeout).To(Equal(metav1.Duration{Duration: 10 * time.Minute}))

--- a/api/v1alpha3/machineset_webhook.go
+++ b/api/v1alpha3/machineset_webhook.go
@@ -43,6 +43,11 @@ var _ webhook.Validator = &MachineSet{}
 
 // DefaultingFunction sets default MachineSet field values.
 func (m *MachineSet) Default() {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+	m.Labels[ClusterLabelName] = m.Spec.ClusterName
+
 	if m.Spec.Replicas == nil {
 		m.Spec.Replicas = pointer.Int32Ptr(1)
 	}

--- a/api/v1alpha3/machineset_webhook_test.go
+++ b/api/v1alpha3/machineset_webhook_test.go
@@ -34,6 +34,7 @@ func TestMachineSetDefault(t *testing.T) {
 
 	md.Default()
 
+	g.Expect(md.Labels[ClusterLabelName]).To(Equal(md.Spec.ClusterName))
 	g.Expect(md.Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
 	g.Expect(md.Spec.DeletePolicy).To(Equal(string(RandomMachineSetDeletePolicy)))
 	g.Expect(md.Spec.Selector.MatchLabels).To(HaveKeyWithValue(MachineSetLabelName, "test-ms"))

--- a/exp/api/v1alpha3/machinepool_webhook.go
+++ b/exp/api/v1alpha3/machinepool_webhook.go
@@ -22,6 +22,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -40,6 +41,11 @@ var _ webhook.Validator = &MachinePool{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (m *MachinePool) Default() {
+	if m.Labels == nil {
+		m.Labels = make(map[string]string)
+	}
+	m.Labels[clusterv1.ClusterLabelName] = m.Spec.ClusterName
+
 	if m.Spec.Template.Spec.Bootstrap.ConfigRef != nil && len(m.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace) == 0 {
 		m.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace = m.Namespace
 	}

--- a/exp/api/v1alpha3/machinepool_webhook_test.go
+++ b/exp/api/v1alpha3/machinepool_webhook_test.go
@@ -44,6 +44,7 @@ func TestMachinePoolDefault(t *testing.T) {
 
 	m.Default()
 
+	g.Expect(m.Labels[clusterv1.ClusterLabelName]).To(Equal(m.Spec.ClusterName))
 	g.Expect(m.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace).To(Equal(m.Namespace))
 	g.Expect(m.Spec.Template.Spec.InfrastructureRef.Namespace).To(Equal(m.Namespace))
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2438 
