### PR TITLE
 🐛 Set LastUpdated on Machine status when Phase changes

### DIFF
--- a/api/v1alpha3/machine_types.go
+++ b/api/v1alpha3/machine_types.go
@@ -89,7 +89,7 @@ type MachineStatus struct {
 	// +optional
 	NodeRef *corev1.ObjectReference `json:"nodeRef,omitempty"`
 
-	// LastUpdated identifies when this status was last observed.
+	// LastUpdated identifies when the phase of the Machine last transitioned.
 	// +optional
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`
 

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -595,7 +595,8 @@ spec:
                   provider.
                 type: boolean
               lastUpdated:
-                description: LastUpdated identifies when this status was last observed.
+                description: LastUpdated identifies when the phase of the Machine
+                  last transitioned.
                 format: date-time
                 type: string
               nodeRef:

--- a/controllers/machine_controller_phases_test.go
+++ b/controllers/machine_controller_phases_test.go
@@ -168,6 +168,9 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		r.reconcilePhase(context.Background(), machine)
 		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhasePending))
+
+		// LastUpdated should be set as the phase changes
+		Expect(machine.Status.LastUpdated).ToNot(BeNil())
 	})
 
 	It("Should set `Provisioning` when bootstrap is ready", func() {
@@ -181,6 +184,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		err = unstructured.SetNestedField(bootstrapConfig.Object, "secret-data", "status", "dataSecretName")
 		Expect(err).NotTo(HaveOccurred())
+
+		// Set the LastUpdated to be able to verify it is updated when the phase changes
+		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
+		machine.Status.LastUpdated = &lastUpdated
 
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme,
@@ -202,6 +209,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		r.reconcilePhase(context.Background(), machine)
 		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioning))
+
+		// Verify that the LastUpdated timestamp was updated
+		Expect(machine.Status.LastUpdated).ToNot(BeNil())
+		Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())
 	})
 
 	It("Should set `Running` when bootstrap and infra is ready", func() {
@@ -241,6 +252,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		// Set NodeRef.
 		machine.Status.NodeRef = &corev1.ObjectReference{Kind: "Node", Name: "machine-test-node"}
 
+		// Set the LastUpdated to be able to verify it is updated when the phase changes
+		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
+		machine.Status.LastUpdated = &lastUpdated
+
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme,
 				defaultCluster,
@@ -263,6 +278,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		r.reconcilePhase(context.Background(), machine)
 		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
+
+		// Verify that the LastUpdated timestamp was updated
+		Expect(machine.Status.LastUpdated).ToNot(BeNil())
+		Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())
 	})
 
 	It("Should set `Running` when bootstrap and infra is ready with no Status.Addresses", func() {
@@ -287,6 +306,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		// Set NodeRef.
 		machine.Status.NodeRef = &corev1.ObjectReference{Kind: "Node", Name: "machine-test-node"}
 
+		// Set the LastUpdated to be able to verify it is updated when the phase changes
+		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
+		machine.Status.LastUpdated = &lastUpdated
+
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme,
 				defaultCluster,
@@ -308,6 +331,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		r.reconcilePhase(context.Background(), machine)
 		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
+
+		// Verify that the LastUpdated timestamp was updated
+		Expect(machine.Status.LastUpdated).ToNot(BeNil())
+		Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())
 	})
 
 	It("Should set `Running` when bootstrap, infra, and NodeRef is ready", func() {
@@ -344,6 +371,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		// Set NodeRef.
 		machine.Status.NodeRef = &corev1.ObjectReference{Kind: "Node", Name: "machine-test-node"}
 
+		// Set the LastUpdated to be able to verify it is updated when the phase changes
+		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
+		machine.Status.LastUpdated = &lastUpdated
+
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme,
 				defaultCluster,
@@ -364,6 +395,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		r.reconcilePhase(context.Background(), machine)
 		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseRunning))
+
+		// Verify that the LastUpdated timestamp was updated
+		Expect(machine.Status.LastUpdated).ToNot(BeNil())
+		Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())
 	})
 
 	It("Should set `Provisioned` when there is a NodeRef but infra is not ready ", func() {
@@ -380,6 +415,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		// Set NodeRef.
 		machine.Status.NodeRef = &corev1.ObjectReference{Kind: "Node", Name: "machine-test-node"}
+
+		// Set the LastUpdated to be able to verify it is updated when the phase changes
+		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
+		machine.Status.LastUpdated = &lastUpdated
 
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme,
@@ -401,6 +440,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		r.reconcilePhase(context.Background(), machine)
 		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseProvisioned))
+
+		// Verify that the LastUpdated timestamp was updated
+		Expect(machine.Status.LastUpdated).ToNot(BeNil())
+		Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())
 	})
 
 	It("Should set `Deleting` when Machine is being deleted", func() {
@@ -440,6 +483,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 		// Set Deletion Timestamp.
 		machine.SetDeletionTimestamp(&deletionTimestamp)
 
+		// Set the LastUpdated to be able to verify it is updated when the phase changes
+		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
+		machine.Status.LastUpdated = &lastUpdated
+
 		r := &MachineReconciler{
 			Client: fake.NewFakeClientWithScheme(scheme.Scheme,
 				defaultCluster,
@@ -460,6 +507,10 @@ var _ = Describe("Reconcile Machine Phases", func() {
 
 		r.reconcilePhase(context.Background(), machine)
 		Expect(machine.Status.GetTypedPhase()).To(Equal(clusterv1.MachinePhaseDeleting))
+
+		// Verify that the LastUpdated timestamp was updated
+		Expect(machine.Status.LastUpdated).ToNot(BeNil())
+		Expect(machine.Status.LastUpdated.After(lastUpdated.Time)).To(BeTrue())
 	})
 })
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Update the `LastUpdated` field in the `Machine` status whenever the `Phase` is changed from one state to another

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2452 
