### PR TITLE
🐛   Allow kcp etcd health check to pass

### DIFF
--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -469,10 +469,6 @@ func (c *cluster) etcdIsHealthy(ctx context.Context) (healthCheckResult, error) 
 		}
 	}
 
-	if len(response) > 0 {
-		return response, errors.New("could not check etcd member health")
-	}
-
 	// Check that there is exactly one etcd member for every control plane machine.
 	// There should be no etcd members added "out of band.""
 	if len(controlPlaneNodes.Items) != len(knownMemberIDSet) {


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

I believe this was test code that made it through the review in order to test the recent changes to the error handling. However, it prevents the health check from ever passing if there are 1 or more control plane nodes (aka always)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2467 
