### PR TITLE
:running: KCP: set managementCluster in SetupWithManager

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
@@ -118,6 +118,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager, optio
 	r.scheme = mgr.GetScheme()
 	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("kubeadm-control-plane-controller")
+	r.managementCluster = &internal.ManagementCluster{Client: r.Client}
 	if r.remoteClientGetter == nil {
 		r.remoteClientGetter = remote.NewClusterClient
 	}
@@ -159,7 +160,6 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(req ctrl.Request) (res ctrl.Re
 		logger.Info("Reconciliation is paused")
 		return ctrl.Result{}, nil
 	}
-	r.managementCluster = &internal.ManagementCluster{Client: r.Client}
 
 	// Wait for the cluster infrastructure to be ready before creating machines
 	if !cluster.Status.InfrastructureReady {
@@ -916,7 +916,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileExternalReference(ctx context.C
 	return nil
 }
 
-// ClusterToKubeadmControlPlane is a handler.ToRequestsFunc to be used to enqeue requests for reconciliation
+// ClusterToKubeadmControlPlane is a handler.ToRequestsFunc to be used to enqueue requests for reconciliation
 // for KubeadmControlPlane based on updates to a Cluster.
 func (r *KubeadmControlPlaneReconciler) ClusterToKubeadmControlPlane(o handler.MapObject) []ctrl.Request {
 	c, ok := o.Object.(*clusterv1.Cluster)

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -444,6 +444,7 @@ func TestReconcileClusterNoEndpoints(t *testing.T) {
 		Log:                log.Log,
 		remoteClientGetter: fakeremote.NewClusterClient,
 		recorder:           record.NewFakeRecorder(32),
+		managementCluster:  &internal.ManagementCluster{Client: fakeClient},
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})
@@ -539,6 +540,7 @@ func TestReconcileInitializeControlPlane(t *testing.T) {
 		remoteClientGetter: fakeremote.NewClusterClient,
 		scheme:             scheme.Scheme,
 		recorder:           record.NewFakeRecorder(32),
+		managementCluster:  &internal.ManagementCluster{Client: fakeClient},
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}})


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of assigning r.managementCluster every time Reconcile() is
invoked, do it once, in SetupWithManager.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
