### PR TITLE
✨Excluded metadata in annotation during conversion

### DIFF
--- a/api/v1alpha2/conversion.go
+++ b/api/v1alpha2/conversion.go
@@ -71,7 +71,7 @@ func (dst *Cluster) ConvertFrom(srcRaw conversion.Hub) error {
 		}
 	}
 
-	// Preserve Hub data on down-conversion.
+	// Preserve Hub data on down-conversion except for metadata
 	if err := utilconversion.MarshalData(src, dst); err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func (dst *Machine) ConvertFrom(srcRaw conversion.Hub) error {
 		delete(src.Annotations, v1alpha3.ExcludeNodeDrainingAnnotation)
 	}
 
-	// Preserve Hub data on down-conversion.
+	// Preserve Hub data on down-conversion except for metadata
 	if err := utilconversion.MarshalData(src, dst); err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func (dst *MachineSet) ConvertFrom(srcRaw conversion.Hub) error {
 		return err
 	}
 
-	// Preserve Hub data on down-conversion.
+	// Preserve Hub data on down-conversion except for metadata
 	if err := utilconversion.MarshalData(src, dst); err != nil {
 		return err
 	}
@@ -257,7 +257,7 @@ func (dst *MachineDeployment) ConvertFrom(srcRaw conversion.Hub) error {
 		convertAnnotations(v3Annotations[i], v2Annotations[i], dst.Annotations)
 	}
 
-	// Preserve Hub data on down-conversion.
+	// Preserve Hub data on down-conversion except for metadata
 	if err := utilconversion.MarshalData(src, dst); err != nil {
 		return err
 	}

--- a/util/conversion/conversion.go
+++ b/util/conversion/conversion.go
@@ -93,8 +93,15 @@ func ConvertReferenceAPIContract(ctx context.Context, c client.Client, ref *core
 }
 
 // MarshalData stores the source object as json data in the destination object annotations map.
+// It ignores the metadata of the source object.
 func MarshalData(src metav1.Object, dst metav1.Object) error {
-	data, err := json.Marshal(src)
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(src)
+	if err != nil {
+		return err
+	}
+	delete(u, "metadata")
+
+	data, err := json.Marshal(u)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR excludes all metadata from annotations when converting objects from hub(v1a3) to v1a2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2441 
