### PR TITLE
🏃 Wire up kubeadm control plane Ready status

### DIFF
--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -129,22 +129,13 @@ var _ = Describe("Docker", func() {
 				}
 				framework.WaitForClusterToProvision(ctx, assertClusterProvisionsInput)
 
-				// Create the workload nodes
-				createMachineDeploymentinput := framework.CreateMachineDeploymentInput{
-					Creator:                 client,
-					MachineDeployment:       md,
-					BootstrapConfigTemplate: bootstrapTemplate,
-					InfraMachineTemplate:    infraTemplate,
-				}
-				framework.CreateMachineDeployment(ctx, createMachineDeploymentinput)
-
-				// Wait for the controlplane nodes to exist
-				assertKubeadmControlPlaneNodesExistInput := framework.WaitForKubeadmControlPlaneMachinesToExistInput{
+				// Wait for at least one control plane node to be ready
+				waitForOneKubeadmControlPlaneMachineToExistInput := framework.WaitForOneKubeadmControlPlaneMachineToExistInput{
 					Lister:       client,
 					Cluster:      cluster,
 					ControlPlane: controlPlane,
 				}
-				framework.WaitForKubeadmControlPlaneMachinesToExist(ctx, assertKubeadmControlPlaneNodesExistInput, "10m", "10s")
+				framework.WaitForOneKubeadmControlPlaneMachineToExist(ctx, waitForOneKubeadmControlPlaneMachineToExistInput)
 
 				// Insatll a networking solution on the workload cluster
 				workloadClient, err := mgmt.GetWorkloadClient(ctx, cluster.Namespace, cluster.Name)
@@ -156,6 +147,23 @@ var _ = Describe("Docker", func() {
 					Scheme:        mgmt.Scheme,
 				}
 				framework.ApplyYAMLURL(ctx, applyYAMLURLInput)
+
+				// Wait for the controlplane nodes to exist
+				assertKubeadmControlPlaneNodesExistInput := framework.WaitForKubeadmControlPlaneMachinesToExistInput{
+					Lister:       client,
+					Cluster:      cluster,
+					ControlPlane: controlPlane,
+				}
+				framework.WaitForKubeadmControlPlaneMachinesToExist(ctx, assertKubeadmControlPlaneNodesExistInput, "10m", "10s")
+
+				// Create the workload nodes
+				createMachineDeploymentinput := framework.CreateMachineDeploymentInput{
+					Creator:                 client,
+					MachineDeployment:       md,
+					BootstrapConfigTemplate: bootstrapTemplate,
+					InfraMachineTemplate:    infraTemplate,
+				}
+				framework.CreateMachineDeployment(ctx, createMachineDeploymentinput)
 
 				// Wait for the workload nodes to exist
 				waitForMachineDeploymentNodesToExistInput := framework.WaitForMachineDeploymentNodesToExistInput{


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR aligns the KCP `Initialized` field with the comment on the field in the API type as well as sets the `Ready` status when it is appropriate to set. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2480 

~I'm holding this because I might have to make changes to the capd e2es now that we're actually setting Ready based on NodeReady which requires CNI to exist on the cluster. CAPD may now how to install a CNI to pass which it really should do anyway in order to scale machine deployments.~

In general, my experience with the tests for the reconciler are that we are testing many things throughout the whole Reconcile function. This is good in some ways and it's bad in others. There must be some way to make these tests more readable/understandable because it takes me forever to understand what it's doing and why an assertion is being made.