### PR TITLE
:running: kubeadmcontrolplane: clean up removeMemberForNode

### DIFF
--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -432,9 +432,9 @@ func nilNodeRef(machine clusterv1.Machine) clusterv1.Machine {
 	return machine
 }
 
-func TestRemoveMemberForNode(t *testing.T) {
+func TestRemoveMemberForNode_ErrControlPlaneMinNodes(t *testing.T) {
 	t.Run("do not remove the etcd member if the cluster has fewer than 2 control plane nodes", func(t *testing.T) {
-		expectedErr := errors.New("cluster has fewer than 2 control plane nodes; removing an etcd member is not supported")
+		expectedErr := ErrControlPlaneMinNodes
 
 		workloadCluster := &Cluster{
 			Client: &fakeClient{
@@ -447,7 +447,10 @@ func TestRemoveMemberForNode(t *testing.T) {
 		}
 
 		err := workloadCluster.removeMemberForNode(context.Background(), "first-control-plane")
-		if err == nil || errors.Is(err, expectedErr) {
+		if err == nil {
+			t.Fatalf("expected %v, got no error", expectedErr)
+		}
+		if !errors.Is(err, expectedErr) {
 			t.Fatalf("expected %v, got %v", expectedErr, err)
 		}
 	})

--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -40,6 +40,10 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	ErrControlPlaneMinNodes = errors.New("cluster has fewer than 2 control plane nodes; removing an etcd member is not supported")
+)
+
 type etcdClientFor interface {
 	forNode(name string) (*etcd.Client, error)
 }
@@ -123,7 +127,7 @@ func (c *Cluster) removeMemberForNode(ctx context.Context, name string) error {
 		return err
 	}
 	if len(controlPlaneNodes.Items) < 2 {
-		return errors.New("cluster has fewer than 2 control plane nodes; removing an etcd member is not supported")
+		return ErrControlPlaneMinNodes
 	}
 	anotherNode := firstNodeNotMatchingName(name, controlPlaneNodes.Items)
 	if anotherNode == nil {

--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -33,7 +33,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	etcdutil "sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd/util"
@@ -113,10 +112,24 @@ func (c *Cluster) controlPlaneIsHealthy(ctx context.Context) (healthCheckResult,
 	return response, nil
 }
 
-// removeMemberForNode removes etcd member (nodeToRemove) through another (nodeForEtcdClient).
-// It's create etcd connection using nodeForEtcdClient to removing nodeToRemove.
-func (c *Cluster) removeMemberForNode(ctx context.Context, nodeForEtcdClient, nodeToRemove string) error {
-	etcdClient, err := c.EtcdClientGenerator.forNode(nodeForEtcdClient)
+// removeMemberForNode removes the etcd member for the node. Removing the etcd
+// member when the cluster has one control plane node is not supported. To allow
+// the removal of a failed etcd member, the etcd API requests are sent to a
+// different node.
+func (c *Cluster) removeMemberForNode(ctx context.Context, name string) error {
+	// Pick a different node to talk to etcd
+	controlPlaneNodes, err := c.getControlPlaneNodes(ctx)
+	if err != nil {
+		return err
+	}
+	if len(controlPlaneNodes.Items) < 2 {
+		return errors.New("cluster has fewer than 2 control plane nodes; removing an etcd member is not supported")
+	}
+	anotherNode := firstNodeNotMatchingName(name, controlPlaneNodes.Items)
+	if anotherNode == nil {
+		return errors.Errorf("failed to find a control plane node whose name is not %s", name)
+	}
+	etcdClient, err := c.EtcdClientGenerator.forNode(anotherNode.Name)
 	if err != nil {
 		return errors.Wrap(err, "failed to create etcd Client")
 	}
@@ -126,7 +139,7 @@ func (c *Cluster) removeMemberForNode(ctx context.Context, nodeForEtcdClient, no
 	if err != nil {
 		return errors.Wrap(err, "failed to list etcd members using etcd Client")
 	}
-	member := etcdutil.MemberForName(members, nodeToRemove)
+	member := etcdutil.MemberForName(members, name)
 
 	// The member has already been removed, return immediately
 	if member == nil {
@@ -275,31 +288,7 @@ func (c *Cluster) RemoveEtcdMemberForMachine(ctx context.Context, machine *clust
 		return nil
 	}
 
-	controlPlaneNodes, err := c.getControlPlaneNodes(ctx)
-	if err != nil {
-		return err
-	}
-
-	nodeToRemove := machine.Status.NodeRef.Name
-	errs := []error{}
-
-	// Try all node other than nodeToRemove for proxying etcd Client.
-	// and returns the first successful response.
-	for _, node := range controlPlaneNodes.Items {
-		nodeForEtcdClient := node.Name
-		if nodeForEtcdClient == nodeToRemove {
-			continue
-		}
-
-		err = c.removeMemberForNode(ctx, nodeForEtcdClient, nodeToRemove)
-		if err == nil {
-			return nil
-		}
-
-		errs = append(errs, err)
-	}
-
-	return kerrors.NewAggregate(errs)
+	return c.removeMemberForNode(ctx, machine.Status.NodeRef.Name)
 }
 
 // RemoveMachineFromKubeadmConfigMap removes the entry for the machine from the kubeadm configmap.
@@ -388,6 +377,15 @@ func checkStaticPodReadyCondition(pod *corev1.Pod) error {
 	}
 	if !found {
 		return errors.Errorf("pod does not have ready condition: %v", pod.Name)
+	}
+	return nil
+}
+
+func firstNodeNotMatchingName(name string, nodes []corev1.Node) *corev1.Node {
+	for _, n := range nodes {
+		if n.Name != name {
+			return &n
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
- Don't retry requests for all nodes. Use requeue to retry.
- Don't remove the etcd member if cluster has fewer than 2 control plane nodes.
- Add unit tests.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Addresses feedback for #2435

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2474 

/assign @detiber @chuckha 
