### PR TITLE
🐛 Fix the bug that clusterctl version command does not show correct output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,7 @@ release-binary: $(RELEASE_DIR)
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
 		golang:1.13.8 \
-		go build -a -ldflags '-extldflags "-static"' \
+		go build -a -ldflags "$(LDFLAGS) -extldflags '-static'" \
 		-o $(RELEASE_DIR)/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(RELEASE_BINARY)
 
 .PHONY: release-staging


### PR DESCRIPTION
Signed-off-by: SataQiu <1527062125@qq.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Fix the bug that clusterctl version command does not show correct output

Test result:
```
# out/clusterctl-darwin-amd64 version
clusterctl version: &version.Info{Major:"0", Minor:"2", GitVersion:"v0.2.5-1108-91703dd55221c7", GitCommit:"91703dd55221c76e151783255133526f751840ba", GitTreeState:"clean", BuildDate:"2020-03-02T05:23:39Z", GoVersion:"go1.13.5", Compiler:"gc", Platform:"darwin/amd64"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2449
