### PR TITLE
✨manager/docker: add liveness/readiness probes

### DIFF
--- a/test/infrastructure/docker/config/manager/manager.yaml
+++ b/test/infrastructure/docker/config/manager/manager.yaml
@@ -20,6 +20,18 @@ spec:
         - --enable-leader-election
         image: controller:latest
         name: manager
+        ports:
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
         volumeMounts:
           - mountPath: /var/run/docker.sock
             name: dockersock

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -31,12 +31,20 @@ import (
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/controllers"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	// +kubebuilder:scaffold:imports
 )
 
 var (
 	myscheme = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	//flags
+	metricsAddr          string
+	enableLeaderElection bool
+	syncPeriod           time.Duration
+	concurrency          int
+	healthAddr           string
 )
 
 func init() {
@@ -48,32 +56,54 @@ func init() {
 
 func main() {
 	klog.InitFlags(nil)
-	var metricsAddr string
-	var enableLeaderElection bool
-	var syncPeriod time.Duration
-	var concurrency int
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.IntVar(&concurrency, "concurrency", 10, "The number of docker machines to process simultaneously")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
+	flag.StringVar(&healthAddr, "health-addr", ":9440", "The address the health endpoint binds to.")
 	flag.Parse()
 
 	ctrl.SetLogger(klogr.New())
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:             myscheme,
-		MetricsBindAddress: metricsAddr,
-		LeaderElection:     enableLeaderElection,
-		LeaderElectionID:   "controller-leader-election-capd",
-		SyncPeriod:         &syncPeriod,
+		Scheme:                 myscheme,
+		MetricsBindAddress:     metricsAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "controller-leader-election-capd",
+		SyncPeriod:             &syncPeriod,
+		HealthProbeBindAddress: healthAddr,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
 
+	setupChecks(mgr)
+	setupReconcilers(mgr)
+
+	// +kubebuilder:scaffold:builder
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+
+func setupChecks(mgr ctrl.Manager) {
+	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to create ready check")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to create health check")
+		os.Exit(1)
+	}
+}
+
+func setupReconcilers(mgr ctrl.Manager) {
 	if err := (&controllers.DockerMachineReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("DockerMachine"),
@@ -84,18 +114,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.DockerClusterReconciler{
+	if err := (&controllers.DockerClusterReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("DockerCluster"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DockerCluster")
-		os.Exit(1)
-	}
-	// +kubebuilder:scaffold:builder
-
-	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add liveness/readiness probes similar did here https://github.com/kubernetes-sigs/cluster-api/pull/2156
- also change a bit the code to be similar that is made in capi

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
related https://github.com/kubernetes-sigs/cluster-api/issues/1855

/cc @vincepri 
