### PR TITLE
:running: Refactor OWNERS files throughout the repo

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,31 +2,74 @@
 
 aliases:
   sig-cluster-lifecycle-leads:
-    - luxas
-    - justinsb
-    - timothysc
+  - neolit123
+  - justinsb
+  - timothysc
+
+  # -----------------------------------------------------------
+  # OWNER_ALIASES for Cluster API
+  # -----------------------------------------------------------
+
+  # active folks who can be contacted to perform admin-related
+  # tasks on the repo, or otherwise approve any PRS.
   cluster-api-admins:
-    - justinsb
-    - detiber
-    - davidewatson
-    - vincepri
+  - justinsb
+  - detiber
+  - davidewatson
+  - vincepri
+
+  # non-admin folks who have write-access and can approve any PRs in the repo
   cluster-api-maintainers:
-    - justinsb
-    - detiber
-    - ncdc
-    - vincepri
-    - chuckha
+  - justinsb
+  - detiber
+  - ncdc
+  - vincepri
+  - chuckha
+
+  # folks who can review and LGTM any PRs in the repo
   cluster-api-reviewers:
-    - CecileRobertMichon
+  - CecileRobertMichon
+  - vincepri
+
+  # -----------------------------------------------------------
+  # OWNER_ALIASES for docs/book
+  # -----------------------------------------------------------
+
+  # folks who can review and LGTM any PRs under docs/book
+  cluster-api-book-reviewers:
+  - randomvariable
+  - moshloop
+
+  # -----------------------------------------------------------
+  # OWNER_ALIASES for test/infrastructure/docker
+  # -----------------------------------------------------------
+
   cluster-api-provider-docker-maintainers:
-    - chuckha
-    - ncdc
+  - chuckha
+  - ncdc
+
+  # -----------------------------------------------------------
+  # OWNER_ALIASES for bootstrap/kubeadm
+  # -----------------------------------------------------------
+
   cluster-api-bootstrap-provider-kubeadm-maintainers:
-    - chuckha
-    - fabriziopandini
-    - ncdc
-    - SataQiu
+  - chuckha
+  - fabriziopandini
+  - ncdc
+  - SataQiu
+
   cluster-api-bootstrap-provider-kubeadm-reviewers:
-    - chuckha
-    - fabriziopandini
-    - ncdc
+  - chuckha
+  - fabriziopandini
+  - ncdc
+
+  # -----------------------------------------------------------
+  # OWNER_ALIASES for cmd/clusterctl
+  # -----------------------------------------------------------
+
+  cluster-api-clusterctl-maintainers:
+  - fabriziopandini
+
+  cluster-api-clusterctl-reviewers:
+  - fabriziopandini
+  - wfernandes

--- a/bootstrap/kubeadm/OWNERS
+++ b/bootstrap/kubeadm/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - cluster-api-admins
-  - cluster-api-maintainers
-  - sig-cluster-lifecycle-leads
   - cluster-api-bootstrap-provider-kubeadm-maintainers
 
 reviewers:
+  - cluster-api-reviewers
   - cluster-api-bootstrap-provider-kubeadm-reviewers

--- a/cmd/clusterctl/OWNERS
+++ b/cmd/clusterctl/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-cluster-lifecycle-leads
+  - cluster-api-admins
+  - cluster-api-maintainers
+  - cluster-api-clusterctl-maintainers
+
+reviewers:
+  - cluster-api-reviewers
+  - cluster-api-clusterctl-reviewers

--- a/docs/book/OWNERS
+++ b/docs/book/OWNERS
@@ -1,5 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - randomvariable
-  - moshloop
+- cluster-api-reviewers
+- cluster-api-book-reviewers

--- a/test/infrastructure/docker/OWNERS
+++ b/test/infrastructure/docker/OWNERS
@@ -1,9 +1,6 @@
 # See the OWNERS docs: http://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - sig-cluster-lifecycle-leads
-  - cluster-api-admins
-  - cluster-api-maintainers
   - cluster-api-provider-docker-maintainers
 
 reviewers:


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

- Moves all groups to be in OWNER_ALIASES
- Creates a group dedicated for `clusterctl` with maintainers and reviewers