### PR TITLE
:running: Use controller-runtime's client ObjectKey instead of types.NamespacedName

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -29,7 +29,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -335,7 +334,7 @@ func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Contex
 	err = certificates.LookupOrGenerate(
 		ctx,
 		r.Client,
-		types.NamespacedName{Name: scope.Cluster.Name, Namespace: scope.Cluster.Namespace},
+		util.ObjectKey(scope.Cluster),
 		*metav1.NewControllerRef(scope.Config, bootstrapv1.GroupVersion.WithKind("KubeadmConfig")),
 	)
 	if err != nil {
@@ -379,7 +378,7 @@ func (r *KubeadmConfigReconciler) joinWorker(ctx context.Context, scope *Scope) 
 	err := certificates.Lookup(
 		ctx,
 		r.Client,
-		types.NamespacedName{Name: scope.Cluster.Name, Namespace: scope.Cluster.Namespace},
+		util.ObjectKey(scope.Cluster),
 	)
 	if err != nil {
 		scope.Error(err, "unable to lookup cluster certificates")
@@ -452,7 +451,7 @@ func (r *KubeadmConfigReconciler) joinControlplane(ctx context.Context, scope *S
 	err := certificates.Lookup(
 		ctx,
 		r.Client,
-		types.NamespacedName{Name: scope.Cluster.Name, Namespace: scope.Cluster.Namespace},
+		util.ObjectKey(scope.Cluster),
 	)
 	if err != nil {
 		scope.Error(err, "unable to lookup cluster certificates")

--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller_reconciler_test.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller_reconciler_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -50,7 +49,7 @@ var _ = Describe("KubeadmConfigReconciler", func() {
 			}
 			By("Calling reconcile should requeue")
 			result, err := reconciler.Reconcile(ctrl.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: client.ObjectKey{
 					Namespace: "default",
 					Name:      "my-machine-config",
 				},

--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
@@ -36,6 +36,7 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	kubeadmv1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
 	fakeremote "sigs.k8s.io/cluster-api/controllers/remote/fake"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/secret"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -115,9 +116,9 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfKubeadmConfigIsReady(t *
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: "default",
-			Name:      "cfg",
+		NamespacedName: client.ObjectKey{
+			Name:      "default",
+			Namespace: "cfg",
 		},
 	}
 	result, err := k.Reconcile(request)
@@ -149,7 +150,7 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnErrorIfReferencedMachineIsNotFo
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "cfg",
 		},
@@ -178,7 +179,7 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfMachineHasDataSecretName
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "cfg",
 		},
@@ -216,7 +217,7 @@ func TestKubeadmConfigReconciler_Reconcile_MigrateToSecret(t *testing.T) {
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "cfg",
 		},
@@ -233,7 +234,7 @@ func TestKubeadmConfigReconciler_Reconcile_MigrateToSecret(t *testing.T) {
 		t.Fatal("did not expect to requeue after")
 	}
 
-	if err := k.Client.Get(context.Background(), types.NamespacedName{Name: config.Name, Namespace: config.Namespace}, config); err != nil {
+	if err := k.Client.Get(context.Background(), client.ObjectKey{Name: config.Name, Namespace: config.Namespace}, config); err != nil {
 		t.Fatalf("failed to get KubeadmConfig: %v", err)
 	}
 
@@ -242,7 +243,7 @@ func TestKubeadmConfigReconciler_Reconcile_MigrateToSecret(t *testing.T) {
 	}
 
 	secret := &corev1.Secret{}
-	if err := k.Client.Get(context.Background(), types.NamespacedName{Namespace: config.Namespace, Name: *config.Status.DataSecretName}, secret); err != nil {
+	if err := k.Client.Get(context.Background(), client.ObjectKey{Namespace: config.Namespace, Name: *config.Status.DataSecretName}, secret); err != nil {
 		t.Fatalf("failed to get Secret bootstrap data for KubeadmConfig: %v", err)
 	}
 
@@ -282,7 +283,7 @@ func TestKubeadmConfigReconciler_ReturnEarlyIfClusterInfraNotReady(t *testing.T)
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "cfg",
 		},
@@ -317,7 +318,7 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfMachineHasNoCluster(t *t
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "cfg",
 		},
@@ -345,7 +346,7 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnNilIfMachineDoesNotHaveAssociat
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "cfg",
 		},
@@ -375,7 +376,7 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnNilIfAssociatedClusterIsNotFoun
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "cfg",
 		},
@@ -405,7 +406,7 @@ func TestKubeadmConfigReconciler_Reconcile_RequeueJoiningNodesIfControlPlaneNotI
 		{
 			name: "requeue worker when control plane is not yet initialiezd",
 			request: ctrl.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: client.ObjectKey{
 					Namespace: workerJoinConfig.Namespace,
 					Name:      workerJoinConfig.Name,
 				},
@@ -419,7 +420,7 @@ func TestKubeadmConfigReconciler_Reconcile_RequeueJoiningNodesIfControlPlaneNotI
 		{
 			name: "requeue a secondary control plane when the control plane is not yet initialized",
 			request: ctrl.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: client.ObjectKey{
 					Namespace: controlPlaneJoinConfig.Namespace,
 					Name:      controlPlaneJoinConfig.Name,
 				},
@@ -479,7 +480,7 @@ func TestKubeadmConfigReconciler_Reconcile_GenerateCloudConfigData(t *testing.T)
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "control-plane-init-cfg",
 		},
@@ -543,7 +544,7 @@ func TestKubeadmConfigReconciler_Reconcile_ErrorIfJoiningControlPlaneHasInvalidC
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "control-plane-join-cfg",
 		},
@@ -581,7 +582,7 @@ func TestKubeadmConfigReconciler_Reconcile_RequeueIfControlPlaneIsMissingAPIEndp
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "worker-join-cfg",
 		},
@@ -658,7 +659,7 @@ func TestReconcileIfJoinNodesAndControlPlaneIsReady(t *testing.T) {
 			}
 
 			request := ctrl.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: client.ObjectKey{
 					Namespace: config.GetNamespace(),
 					Name:      rt.configName,
 				},
@@ -748,7 +749,7 @@ func TestReconcileIfJoinNodePoolsAndControlPlaneIsReady(t *testing.T) {
 			}
 
 			request := ctrl.Request{
-				NamespacedName: types.NamespacedName{
+				NamespacedName: client.ObjectKey{
 					Namespace: config.GetNamespace(),
 					Name:      rt.configName,
 				},
@@ -819,7 +820,7 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 		remoteClientGetter: fakeremote.NewClusterClient,
 	}
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "worker-join-cfg",
 		},
@@ -845,7 +846,7 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 		t.Fatal("Expected bootstrap data secret")
 	}
 	request = ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "control-plane-join-cfg",
 		},
@@ -891,13 +892,13 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 
 	for _, req := range []ctrl.Request{
 		{
-			NamespacedName: types.NamespacedName{
+			NamespacedName: client.ObjectKey{
 				Namespace: "default",
 				Name:      "worker-join-cfg",
 			},
 		},
 		{
-			NamespacedName: types.NamespacedName{
+			NamespacedName: client.ObjectKey{
 				Namespace: "default",
 				Name:      "control-plane-join-cfg",
 			},
@@ -946,13 +947,13 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 
 	for _, req := range []ctrl.Request{
 		{
-			NamespacedName: types.NamespacedName{
+			NamespacedName: client.ObjectKey{
 				Namespace: "default",
 				Name:      "worker-join-cfg",
 			},
 		},
 		{
-			NamespacedName: types.NamespacedName{
+			NamespacedName: client.ObjectKey{
 				Namespace: "default",
 				Name:      "control-plane-join-cfg",
 			},
@@ -1355,7 +1356,7 @@ func TestKubeadmConfigReconciler_Reconcile_AlwaysCheckCAVerificationUnlessReques
 
 			wc := newWorkerJoinKubeadmConfig(workerMachine)
 			wc.Spec.JoinConfiguration.Discovery.BootstrapToken = tc.discovery
-			key := types.NamespacedName{Namespace: wc.Namespace, Name: wc.Name}
+			key := client.ObjectKey{Namespace: wc.Namespace, Name: wc.Name}
 			if err := myclient.Create(context.Background(), wc); err != nil {
 				t.Fatal(err)
 			}
@@ -1438,7 +1439,7 @@ func TestKubeadmConfigReconciler_Reconcile_DoesNotFailIfCASecretsAlreadyExist(t 
 		KubeadmInitLock: &myInitLocker{},
 	}
 	req := ctrl.Request{
-		NamespacedName: types.NamespacedName{Namespace: "default", Name: configName},
+		NamespacedName: client.ObjectKey{Namespace: "default", Name: configName},
 	}
 	if _, err := reconciler.Reconcile(req); err != nil {
 		t.Fatal(err)
@@ -1471,7 +1472,7 @@ func TestKubeadmConfigReconciler_Reconcile_ExactlyOneControlPlaneMachineInitiali
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "control-plane-init-cfg-first",
 		},
@@ -1488,7 +1489,7 @@ func TestKubeadmConfigReconciler_Reconcile_ExactlyOneControlPlaneMachineInitiali
 	}
 
 	request = ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "control-plane-init-cfg-second",
 		},
@@ -1537,7 +1538,7 @@ func TestKubeadmConfigReconciler_Reconcile_DoNotPatchWhenErrorOccurred(t *testin
 	}
 
 	request := ctrl.Request{
-		NamespacedName: types.NamespacedName{
+		NamespacedName: client.ObjectKey{
 			Namespace: "default",
 			Name:      "control-plane-init-cfg",
 		},
@@ -1753,7 +1754,7 @@ func createSecrets(t *testing.T, cluster *clusterv1.Cluster, config *bootstrapv1
 		t.Fatal(err)
 	}
 	for _, certificate := range certificates {
-		out = append(out, certificate.AsSecret(types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}, *metav1.NewControllerRef(config, bootstrapv1.GroupVersion.WithKind("KubeadmConfig"))))
+		out = append(out, certificate.AsSecret(util.ObjectKey(cluster), *metav1.NewControllerRef(config, bootstrapv1.GroupVersion.WithKind("KubeadmConfig"))))
 	}
 	return out
 }

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -28,7 +28,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -480,9 +479,6 @@ func (r *ClusterReconciler) controlPlaneMachineToCluster(o handler.MapObject) []
 	}
 
 	return []ctrl.Request{{
-		NamespacedName: types.NamespacedName{
-			Namespace: cluster.Namespace,
-			Name:      cluster.Name,
-		},
+		NamespacedName: util.ObjectKey(cluster),
 	}}
 }

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/cluster-api/util"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -569,10 +570,7 @@ func TestClusterReconciler(t *testing.T) {
 				},
 				want: []ctrl.Request{
 					{
-						NamespacedName: client.ObjectKey{
-							Name:      cluster.Name,
-							Namespace: cluster.Namespace,
-						},
+						NamespacedName: util.ObjectKey(cluster),
 					},
 				},
 			},

--- a/controllers/machinedeployment_sync.go
+++ b/controllers/machinedeployment_sync.go
@@ -26,12 +26,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	apirand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controllers/mdutil"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -503,7 +503,7 @@ func (r *MachineDeploymentReconciler) updateMachineDeployment(d *clusterv1.Machi
 // We have this as standalone variant to be able to use it from the tests
 func updateMachineDeployment(c client.Client, d *clusterv1.MachineDeployment, modify func(*clusterv1.MachineDeployment)) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		if err := c.Get(context.Background(), types.NamespacedName{Namespace: d.Namespace, Name: d.Name}, d); err != nil {
+		if err := c.Get(context.Background(), util.ObjectKey(d), d); err != nil {
 			return err
 		}
 		patchHelper, err := patch.NewHelper(d, c)

--- a/controllers/machinepool_controller_noderef.go
+++ b/controllers/machinepool_controller_noderef.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	apicorev1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
@@ -112,7 +111,7 @@ func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client
 	nodeRefsMap := make(map[string]*apicorev1.Node, len(nodeRefs))
 	for _, nodeRef := range nodeRefs {
 		node := &corev1.Node{}
-		if err := c.Get(ctx, types.NamespacedName{Name: nodeRef.Name}, node); err != nil {
+		if err := c.Get(ctx, client.ObjectKey{Name: nodeRef.Name}, node); err != nil {
 			logger.V(2).Info("Failed to get Node, skipping", "err", err, "nodeRef.Name", nodeRef.Name)
 			continue
 		}

--- a/controllers/machineset_controller_test.go
+++ b/controllers/machineset_controller_test.go
@@ -27,7 +27,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/klogr"
@@ -285,10 +284,7 @@ func TestMachineSetOwnerReference(t *testing.T) {
 		{
 			name: "should add cluster owner reference to machine set",
 			request: reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      ms1.Name,
-					Namespace: ms1.Namespace,
-				},
+				NamespacedName: util.ObjectKey(ms1),
 			},
 			ms: ms1,
 			expectedOR: []metav1.OwnerReference{
@@ -303,10 +299,7 @@ func TestMachineSetOwnerReference(t *testing.T) {
 		{
 			name: "should not add cluster owner reference if machine is owned by a machine deployment",
 			request: reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      ms3.Name,
-					Namespace: ms3.Namespace,
-				},
+				NamespacedName: util.ObjectKey(ms3),
 			},
 			ms: ms3,
 			expectedOR: []metav1.OwnerReference{
@@ -375,10 +368,7 @@ func TestMachineSetReconcile(t *testing.T) {
 			},
 		}
 		request := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      ms.Name,
-				Namespace: ms.Namespace,
-			},
+			NamespacedName: util.ObjectKey(ms),
 		}
 
 		g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
@@ -402,10 +392,7 @@ func TestMachineSetReconcile(t *testing.T) {
 		}
 
 		request := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      ms.Name,
-				Namespace: ms.Namespace,
-			},
+			NamespacedName: util.ObjectKey(ms),
 		}
 
 		g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -152,7 +151,7 @@ func TestGetMachinesForCluster(t *testing.T) {
 	m := ManagementCluster{Client: &fakeClient{
 		list: machineListForTestGetMachinesForCluster(),
 	}}
-	clusterKey := types.NamespacedName{
+	clusterKey := client.ObjectKey{
 		Namespace: "my-namespace",
 		Name:      "my-cluster",
 	}
@@ -272,7 +271,7 @@ func TestManagementCluster_healthCheck_NoError(t *testing.T) {
 		name             string
 		machineList      *clusterv1.MachineList
 		check            healthCheck
-		clusterKey       types.NamespacedName
+		clusterKey       client.ObjectKey
 		controlPlaneName string
 	}{
 		{
@@ -291,7 +290,7 @@ func TestManagementCluster_healthCheck_NoError(t *testing.T) {
 					"three": nil,
 				}, nil
 			},
-			clusterKey:       types.NamespacedName{Namespace: "default", Name: "cluster-name"},
+			clusterKey:       client.ObjectKey{Namespace: "default", Name: "cluster-name"},
 			controlPlaneName: "control-plane-name",
 		},
 	}
@@ -313,7 +312,7 @@ func TestManagementCluster_healthCheck_Errors(t *testing.T) {
 		name             string
 		machineList      *clusterv1.MachineList
 		check            healthCheck
-		clusterKey       types.NamespacedName
+		clusterKey       client.ObjectKey
 		controlPlaneName string
 		// expected errors will ensure the error contains this list of strings.
 		// If not supplied, no check on the error's value will occur.
@@ -406,7 +405,7 @@ func TestManagementCluster_healthCheck_Errors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			clusterKey := types.NamespacedName{Namespace: "default", Name: "cluster-name"}
+			clusterKey := client.ObjectKey{Namespace: "default", Name: "cluster-name"}
 			controlPlaneName := "control-plane-name"
 
 			m := &ManagementCluster{

--- a/test/framework/failure_domains.go
+++ b/test/framework/failure_domains.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -28,7 +27,7 @@ import (
 // AssertControlPlaneFailureDomainsInput is the input for AssertControlPlaneFailureDomains.
 type AssertControlPlaneFailureDomainsInput struct {
 	GetLister  GetLister
-	ClusterKey types.NamespacedName
+	ClusterKey client.ObjectKey
 	// ExpectedFailureDomains is required because this function cannot (easily) infer what success looks like.
 	// In theory this field is not strictly necessary and could be replaced with enough clever logic/math.
 	ExpectedFailureDomains map[string]int

--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/docker"
@@ -102,7 +101,7 @@ func (r *DockerMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 
 	// Fetch the Docker Cluster.
 	dockerCluster := &infrav1.DockerCluster{}
-	dockerClusterName := types.NamespacedName{
+	dockerClusterName := client.ObjectKey{
 		Namespace: dockerMachine.Namespace,
 		Name:      cluster.Spec.InfrastructureRef.Name,
 	}
@@ -308,7 +307,7 @@ func (r *DockerMachineReconciler) getBootstrapData(ctx context.Context, machine 
 	}
 
 	s := &corev1.Secret{}
-	key := types.NamespacedName{Namespace: machine.GetNamespace(), Name: *machine.Spec.Bootstrap.DataSecretName}
+	key := client.ObjectKey{Namespace: machine.GetNamespace(), Name: *machine.Spec.Bootstrap.DataSecretName}
 	if err := r.Client.Get(ctx, key, s); err != nil {
 		return "", errors.Wrapf(err, "failed to retrieve bootstrap data secret for DockerMachine %s/%s", machine.GetNamespace(), machine.GetName())
 	}

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -29,13 +29,13 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/framework"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -175,7 +175,7 @@ var _ = Describe("Docker", func() {
 				// Assert failure domain is working as expected
 				assertControlPlaneFailureDomainInput := framework.AssertControlPlaneFailureDomainsInput{
 					GetLister:  client,
-					ClusterKey: types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name},
+					ClusterKey: util.ObjectKey(cluster),
 					ExpectedFailureDomains: map[string]int{
 						"domain-one":   1,
 						"domain-two":   1,

--- a/util/secret/certificates.go
+++ b/util/secret/certificates.go
@@ -33,7 +33,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/cert"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
@@ -162,7 +161,7 @@ func (c Certificates) GetByPurpose(purpose Purpose) *Certificate {
 }
 
 // Lookup looks up each certificate from secrets and populates the certificate with the secret data.
-func (c Certificates) Lookup(ctx context.Context, ctrlclient client.Client, clusterName types.NamespacedName) error {
+func (c Certificates) Lookup(ctx context.Context, ctrlclient client.Client, clusterName client.ObjectKey) error {
 	// Look up each certificate as a secret and populate the certificate/key
 	for _, certificate := range c {
 		s := &corev1.Secret{}
@@ -231,7 +230,7 @@ func (c Certificates) Generate() error {
 }
 
 // SaveGenerated will save any certificates that have been generated as Kubernetes secrets.
-func (c Certificates) SaveGenerated(ctx context.Context, ctrlclient client.Client, clusterName types.NamespacedName, owner metav1.OwnerReference) error {
+func (c Certificates) SaveGenerated(ctx context.Context, ctrlclient client.Client, clusterName client.ObjectKey, owner metav1.OwnerReference) error {
 	for _, certificate := range c {
 		if !certificate.Generated {
 			continue
@@ -245,7 +244,7 @@ func (c Certificates) SaveGenerated(ctx context.Context, ctrlclient client.Clien
 }
 
 // LookupOrGenerate is a convenience function that wraps cluster bootstrap certificate behavior.
-func (c Certificates) LookupOrGenerate(ctx context.Context, ctrlclient client.Client, clusterName types.NamespacedName, owner metav1.OwnerReference) error {
+func (c Certificates) LookupOrGenerate(ctx context.Context, ctrlclient client.Client, clusterName client.ObjectKey, owner metav1.OwnerReference) error {
 	// Find the certificates that exist
 	if err := c.Lookup(ctx, ctrlclient, clusterName); err != nil {
 		return err
@@ -292,7 +291,7 @@ func hashCert(certificate *x509.Certificate) string {
 }
 
 // AsSecret converts a single certificate into a Kubernetes secret.
-func (c *Certificate) AsSecret(clusterName types.NamespacedName, owner metav1.OwnerReference) *corev1.Secret {
+func (c *Certificate) AsSecret(clusterName client.ObjectKey, owner metav1.OwnerReference) *corev1.Secret {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: clusterName.Namespace,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces types.NamespacedName with client.ObjectKey or utils.ObjectKey whenever controller-runtime is imported.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2459
