### PR TITLE
🏃Disable Interfacer Linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - whitespace
     - gocognit
     - gomnd
+    - interfacer
   # Run with --fast=false for more extensive checks
   fast: true
 issues:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR disables the [Interfacer linter](https://github.com/mvdan/interfacer) which has been deprecated and is currently blocking #2494 from merging

/cc @ncdc 
