### PR TITLE
🏃 cloud init package has reduced responsibilities

### DIFF
--- a/test/infrastructure/docker/cloudinit/unknown.go
+++ b/test/infrastructure/docker/cloudinit/unknown.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 
 	"github.com/pkg/errors"
-	"sigs.k8s.io/kind/pkg/exec"
 )
 
 type unknown struct {
@@ -32,7 +31,7 @@ func newUnknown(module string) action {
 	return &unknown{module: module}
 }
 
-// Unmarshal will unmarshall unknown actions and slurp the value
+// Unmarshal will unmarshal unknown actions and slurp the value
 func (u *unknown) Unmarshal(data []byte) error {
 	// try unmarshalling to a slice of strings
 	var s1 []string
@@ -55,7 +54,6 @@ func (u *unknown) Unmarshal(data []byte) error {
 	return nil
 }
 
-// Run will do nothing since the cloud config module is unknown.
-func (u *unknown) Run(_ exec.Cmder) ([]string, error) {
-	return u.lines, nil
+func (u *unknown) Commands() ([]Cmd, error) {
+	return []Cmd{}, nil
 }

--- a/test/infrastructure/docker/cloudinit/unknown_test.go
+++ b/test/infrastructure/docker/cloudinit/unknown_test.go
@@ -25,7 +25,7 @@ func TestUnknown_Run(t *testing.T) {
 	u := &unknown{
 		lines: []string{},
 	}
-	lines, err := u.Run(nil)
+	lines, err := u.Commands()
 	if err != nil {
 		t.Fatal("err should always be nil")
 	}

--- a/test/infrastructure/docker/e2e/local-e2e.conf
+++ b/test/infrastructure/docker/e2e/local-e2e.conf
@@ -10,6 +10,12 @@ images:
   loadBehavior: tryLoad
 - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-amd64:dev
   loadBehavior: tryLoad
+- name: quay.io/jetstack/cert-manager-webhook:v0.11.1
+  loadBehavior: tryLoad
+- name: quay.io/jetstack/cert-manager-controller:v0.11.1
+  loadBehavior: tryLoad
+- name: quay.io/jetstack/cert-manager-cainjector:v0.11.1
+  loadBehavior: tryLoad
 # Make a custom config file if you'd like to test just docker changes against latest published staging master image.
 
 components:


### PR DESCRIPTION
This removes the cloud init package from running commands and only generating
the commands equivalent to a cloud init configuration file.

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR reduces the scope of the cloud init module in CAPD in order to take advantage of the new CommandContext available in `kind` (this will come in a following PR since it's fairly invasive).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to reducing flakes in capd

/cc @fabriziopandini 
