### PR TITLE
🏃 Modify Metal3 provider repository

### DIFF
--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -91,7 +91,7 @@ func (p *providersClient) defaults() []Provider {
 		},
 		&provider{
 			name:         Metal3ProviderName,
-			url:          "https://github.com/metal3-io/cluster-api-provider-baremetal/releases/latest/infrastructure-components.yaml",
+			url:          "https://github.com/metal3-io/cluster-api-provider-metal3/releases/latest/infrastructure-components.yaml",
 			providerType: clusterctlv1.InfrastructureProviderType,
 		},
 		&provider{

--- a/docs/book/src/clusterctl/overview.md
+++ b/docs/book/src/clusterctl/overview.md
@@ -154,7 +154,7 @@ Please visit the [getting started guide](https://github.com/kubernetes-sigs/clus
 {{#/tab }}
 {{#tab Metal3}}
 
-Please visit the [getting started guide](https://github.com/metal3-io/cluster-api-provider-baremetal/blob/master/docs/getting-started.md).
+Please visit the [getting started guide](https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/docs/getting-started.md).
 
 {{#/tab }}
 {{#/tabs }}

--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -14,7 +14,7 @@ support v1alpha2 API types.
 - [**AWS**](https://github.com/kubernetes-sigs/cluster-api-provider-aws)
 - [Azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure)
 - [Baidu Cloud](https://github.com/baidu/cluster-api-provider-baiducloud)
-- [Metal3](https://github.com/metal3-io/cluster-api-provider-baremetal)
+- [Metal3](https://github.com/metal3-io/cluster-api-provider-metal3)
 - [DigitalOcean](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean)
 - [Exoscale](https://github.com/exoscale/cluster-api-provider-exoscale)
 - [GCP](https://github.com/kubernetes-sigs/cluster-api-provider-gcp)


### PR DESCRIPTION
**What this PR does / why we need it**:
Metal3 Provider repository was renamed from cluster-api-provider-baremetal to
cluster-api-provider-metal3. This PR updates those references.
