### PR TITLE
🏃 continue improving management/workload abstraction

### DIFF
--- a/controlplane/kubeadm/controllers/fakes_test.go
+++ b/controlplane/kubeadm/controllers/fakes_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"errors"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type fakeManagementCluster struct {
+	// TODO: once all client interactions are moved to the Management cluster this can go away
+	Management          *internal.Management
+	ControlPlaneHealthy bool
+	EtcdHealthy         bool
+	Machines            internal.FilterableMachineCollection
+	Workload            fakeWorkloadCluster
+}
+
+func (f *fakeManagementCluster) GetWorkloadCluster(_ context.Context, _ client.ObjectKey) (internal.WorkloadCluster, error) {
+	return f.Workload, nil
+}
+
+func (f *fakeManagementCluster) GetMachinesForCluster(c context.Context, n client.ObjectKey, filters ...internal.MachineFilter) (internal.FilterableMachineCollection, error) {
+	if f.Management != nil {
+		return f.Management.GetMachinesForCluster(c, n, filters...)
+	}
+	return f.Machines, nil
+}
+
+func (f *fakeManagementCluster) TargetClusterControlPlaneIsHealthy(_ context.Context, _ client.ObjectKey, _ string) error {
+	if !f.ControlPlaneHealthy {
+		return errors.New("control plane is not healthy")
+	}
+	return nil
+}
+
+func (f *fakeManagementCluster) TargetClusterEtcdIsHealthy(_ context.Context, _ client.ObjectKey, _ string) error {
+	if !f.EtcdHealthy {
+		return errors.New("etcd is not healthy")
+	}
+	return nil
+}
+
+type fakeWorkloadCluster struct {
+	*internal.Workload
+	Status internal.ClusterStatus
+}
+
+func (f fakeWorkloadCluster) ForwardEtcdLeadership(_ context.Context, _ *clusterv1.Machine) error {
+	return nil
+}
+
+func (f fakeWorkloadCluster) ClusterStatus(_ context.Context) (internal.ClusterStatus, error) {
+	return f.Status, nil
+}

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -103,7 +103,7 @@ func TestControlPlaneIsHealthy(t *testing.T) {
 			},
 		},
 	}
-	workloadCluster := &Cluster{
+	workloadCluster := &Workload{
 		Client: &fakeClient{
 			list: nodeListForTestControlPlaneIsHealthy(),
 			get: map[string]interface{}{
@@ -117,7 +117,7 @@ func TestControlPlaneIsHealthy(t *testing.T) {
 		},
 	}
 
-	health, err := workloadCluster.controlPlaneIsHealthy(context.Background())
+	health, err := workloadCluster.ControlPlaneIsHealthy(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ func nodeListForTestControlPlaneIsHealthy() *corev1.NodeList {
 }
 
 func TestGetMachinesForCluster(t *testing.T) {
-	m := ManagementCluster{Client: &fakeClient{
+	m := Management{Client: &fakeClient{
 		list: machineListForTestGetMachinesForCluster(),
 	}}
 	clusterKey := client.ObjectKey{
@@ -283,8 +283,8 @@ func TestManagementCluster_healthCheck_NoError(t *testing.T) {
 					controlPlaneMachine("three"),
 				},
 			},
-			check: func(ctx context.Context) (healthCheckResult, error) {
-				return healthCheckResult{
+			check: func(ctx context.Context) (HealthCheckResult, error) {
+				return HealthCheckResult{
 					"one":   nil,
 					"two":   nil,
 					"three": nil,
@@ -297,7 +297,7 @@ func TestManagementCluster_healthCheck_NoError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			m := &ManagementCluster{
+			m := &Management{
 				Client: &fakeClient{list: tt.machineList},
 			}
 			if err := m.healthCheck(ctx, tt.check, tt.clusterKey, tt.controlPlaneName); err != nil {
@@ -327,8 +327,8 @@ func TestManagementCluster_healthCheck_Errors(t *testing.T) {
 					controlPlaneMachine("three"),
 				},
 			},
-			check: func(ctx context.Context) (healthCheckResult, error) {
-				return healthCheckResult{
+			check: func(ctx context.Context) (HealthCheckResult, error) {
+				return HealthCheckResult{
 					"one": nil,
 				}, nil
 			},
@@ -342,8 +342,8 @@ func TestManagementCluster_healthCheck_Errors(t *testing.T) {
 					controlPlaneMachine("three"),
 				},
 			},
-			check: func(ctx context.Context) (healthCheckResult, error) {
-				return healthCheckResult{
+			check: func(ctx context.Context) (HealthCheckResult, error) {
+				return HealthCheckResult{
 					"one":   nil,
 					"two":   errors.New("two"),
 					"three": errors.New("three"),
@@ -360,8 +360,8 @@ func TestManagementCluster_healthCheck_Errors(t *testing.T) {
 					controlPlaneMachine("three"),
 				},
 			},
-			check: func(ctx context.Context) (healthCheckResult, error) {
-				return healthCheckResult{
+			check: func(ctx context.Context) (HealthCheckResult, error) {
+				return HealthCheckResult{
 					"one":   nil,
 					"two":   errors.New("two"),
 					"three": errors.New("three"),
@@ -376,8 +376,8 @@ func TestManagementCluster_healthCheck_Errors(t *testing.T) {
 					controlPlaneMachine("one"),
 				},
 			},
-			check: func(ctx context.Context) (healthCheckResult, error) {
-				return healthCheckResult{
+			check: func(ctx context.Context) (HealthCheckResult, error) {
+				return HealthCheckResult{
 					"one":   nil,
 					"two":   nil,
 					"three": nil,
@@ -393,8 +393,8 @@ func TestManagementCluster_healthCheck_Errors(t *testing.T) {
 					nilNodeRef(controlPlaneMachine("three")),
 				},
 			},
-			check: func(ctx context.Context) (healthCheckResult, error) {
-				return healthCheckResult{
+			check: func(ctx context.Context) (HealthCheckResult, error) {
+				return HealthCheckResult{
 					"one":   nil,
 					"two":   nil,
 					"three": nil,
@@ -408,7 +408,7 @@ func TestManagementCluster_healthCheck_Errors(t *testing.T) {
 			clusterKey := client.ObjectKey{Namespace: "default", Name: "cluster-name"}
 			controlPlaneName := "control-plane-name"
 
-			m := &ManagementCluster{
+			m := &Management{
 				Client: &fakeClient{list: tt.machineList},
 			}
 			err := m.healthCheck(ctx, tt.check, clusterKey, controlPlaneName)
@@ -456,7 +456,7 @@ func TestRemoveMemberForNode_ErrControlPlaneMinNodes(t *testing.T) {
 	t.Run("do not remove the etcd member if the cluster has fewer than 2 control plane nodes", func(t *testing.T) {
 		expectedErr := ErrControlPlaneMinNodes
 
-		workloadCluster := &Cluster{
+		workloadCluster := &Workload{
 			Client: &fakeClient{
 				list: &corev1.NodeList{
 					Items: []corev1.Node{

--- a/controlplane/kubeadm/internal/workload_cluster_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_test.go
@@ -57,7 +57,7 @@ func TestCluster_ReconcileKubeletRBACBinding_NoError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Cluster{
+			c := &Workload{
 				Client: tt.client,
 			}
 			if err := c.ReconcileKubeletRBACBinding(ctx, semver.MustParse("1.12.3")); err != nil {
@@ -92,7 +92,7 @@ func TestCluster_ReconcileKubeletRBACBinding_Error(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Cluster{
+			c := &Workload{
 				Client: tt.client,
 			}
 			if err := c.ReconcileKubeletRBACBinding(ctx, semver.MustParse("1.12.3")); err == nil {


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This is in order to help #2525 test with way less pain and abstraction layer violations. 

The big changes here are:

1) Define the management cluster interface -> this work is incomplete as the reconciler still directly interfaces with the client, but this work can be done in future PRs
2) Define the workload cluster interface -> This allows us to more closely unit test the reconciler and control the behavior of various sub-systems.
3) Inlining of several functions as they were only single use, not complex, not independently tested and short
4) Refactored the `Cluster` struct to a more useful name, `Workload` and updated receivers.

/cc @alexander-demichev @dlipovetsky 
/assign @detiber 