### PR TITLE
🏃Add NoExecute taint check for KubeadmControlPlane nodes

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -91,10 +91,17 @@ func (c *Cluster) controlPlaneIsHealthy(ctx context.Context) (healthCheckResult,
 	for _, node := range controlPlaneNodes.Items {
 		name := node.Name
 		response[name] = nil
+
+		if err := checkNodeNoExecuteCondition(node); err != nil {
+			response[name] = err
+			continue
+		}
+
 		apiServerPodKey := ctrlclient.ObjectKey{
 			Namespace: metav1.NamespaceSystem,
 			Name:      staticPodName("kube-apiserver", name),
 		}
+
 		apiServerPod := &corev1.Pod{}
 		if err := c.Client.Get(ctx, apiServerPodKey, apiServerPod); err != nil {
 			response[name] = err
@@ -499,6 +506,15 @@ func checkStaticPodReadyCondition(pod *corev1.Pod) error {
 	}
 	if !found {
 		return errors.Errorf("pod does not have ready condition: %v", pod.Name)
+	}
+	return nil
+}
+
+func checkNodeNoExecuteCondition(node corev1.Node) error {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == corev1.TaintNodeUnreachable && taint.Effect == corev1.TaintEffectNoExecute {
+			return errors.Errorf("node has NoExecute taint: %v", node.Name)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a health check that looks for NoExecute taint on control plane nodes.
**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2469
