### PR TITLE
:running: Add a validation check in place against client-go@incompatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -537,6 +537,10 @@ verify-modules: modules
 		git diff; \
 		echo "go module files are out of date"; exit 1; \
 	fi
+	@if (find . -name 'go.mod' -print0 | xargs -n1 grep -q -i 'k8s.io/client-go.*+incompatible'); then \
+		find . -name "go.mod" -exec grep -i 'k8s.io/client-go.*+incompatible' {} \; -print; \
+		echo "go module contains an incompatible client-go version"; exit 1; \
+	fi
 
 .PHONY: verify-gen
 verify-gen: generate

--- a/cmd/clusterctl/test/e2e/go.mod
+++ b/cmd/clusterctl/test/e2e/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/pkg/errors v0.9.0
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
-	k8s.io/client-go v11.0.0+incompatible
+	k8s.io/client-go v0.17.2
 	sigs.k8s.io/cluster-api v0.3.0-rc.2.0.20200302175844-3011d8c2580c
 	sigs.k8s.io/cluster-api/test/framework v0.0.0-20200125173702-54f26d7fd2b5
 	sigs.k8s.io/cluster-api/test/infrastructure/docker v0.0.0-20200125173702-54f26d7fd2b5


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This sneaks in way too often, let's add a validation check for it

/milestone v0.3.0
