### PR TITLE
✨clusterctl: allow cert-manager image overrides

### DIFF
--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -283,6 +283,10 @@ func (f fakeConfigClient) Variables() config.VariablesClient {
 	return f.internalclient.Variables()
 }
 
+func (f fakeConfigClient) ImageMeta() config.ImageMetaClient {
+	return f.internalclient.ImageMeta()
+}
+
 func (f *fakeConfigClient) WithVar(key, value string) *fakeConfigClient {
 	f.fakeReader.WithVar(key, value)
 	return f

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -97,7 +97,7 @@ func (c *clusterClient) Proxy() Proxy {
 }
 
 func (c *clusterClient) CertManager() CertManagerClient {
-	return newCertMangerClient(c.proxy, c.pollImmediateWaiter)
+	return newCertMangerClient(c.configClient, c.proxy, c.pollImmediateWaiter)
 }
 
 func (c *clusterClient) ProviderComponents() ComponentsClient {

--- a/cmd/clusterctl/client/config/client.go
+++ b/cmd/clusterctl/client/config/client.go
@@ -22,15 +22,19 @@ import (
 )
 
 // Client is used to interact with the clusterctl configurations.
-// Clusterctl v2 handles two types of configs:
+// Clusterctl v2 handles the following configurations:
 // 1. The configuration of the providers (name, type and URL of the provider repository)
 // 2. Variables used when installing providers/creating clusters. Variables can be read from the environment or from the config file
+// 3. The configuration about image overrides
 type Client interface {
 	// Providers provide access to provider configurations.
 	Providers() ProvidersClient
 
 	// Variables provide access to environment variables and/or variables defined in the clusterctl configuration file.
 	Variables() VariablesClient
+
+	// ImageMeta provide access to to image meta configurations.
+	ImageMeta() ImageMetaClient
 }
 
 // configClient implements Client.
@@ -47,6 +51,10 @@ func (c *configClient) Providers() ProvidersClient {
 
 func (c *configClient) Variables() VariablesClient {
 	return newVariablesClient(c.reader)
+}
+
+func (c *configClient) ImageMeta() ImageMetaClient {
+	return newImageMetaClient(c.reader)
 }
 
 // Option is a configuration option supplied to New

--- a/cmd/clusterctl/client/config/imagemeta_client.go
+++ b/cmd/clusterctl/client/config/imagemeta_client.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/distribution/reference"
+	"github.com/pkg/errors"
+)
+
+const (
+	imagesConfigKey = "images"
+	allImageConfig  = "all"
+)
+
+// ImageMetaClient has methods to work with image meta configurations.
+type ImageMetaClient interface {
+	// AlterImage alters an image name according to the current image override configurations.
+	AlterImage(component, image string) (string, error)
+}
+
+// imageMetaClient implements ImageMetaClient.
+type imageMetaClient struct {
+	reader         Reader
+	imageMetaCache map[string]*imageMeta
+}
+
+// ensure imageMetaClient implements ImageMetaClient.
+var _ ImageMetaClient = &imageMetaClient{}
+
+func newImageMetaClient(reader Reader) *imageMetaClient {
+	return &imageMetaClient{
+		reader:         reader,
+		imageMetaCache: map[string]*imageMeta{},
+	}
+}
+
+func (p *imageMetaClient) AlterImage(component, image string) (string, error) {
+	// Gets the image meta that applies to the selected component; if none, returns early
+	meta, err := p.getImageMetaByComponent(component)
+	if err != nil {
+		return "", err
+	}
+	if meta == nil {
+		return image, nil
+	}
+
+	// Apply the image meta to image name
+	return meta.ApplyToImage(image)
+}
+
+// getImageMetaByComponent returns the image meta that applies to the selected component
+func (p *imageMetaClient) getImageMetaByComponent(component string) (*imageMeta, error) {
+	// if the image meta for the component is already known, return it
+	if im, ok := p.imageMetaCache[component]; ok {
+		return im, nil
+	}
+
+	// Otherwise read the image override configurations.
+	var meta map[string]imageMeta
+	if err := p.reader.UnmarshalKey(imagesConfigKey, &meta); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal image override configurations")
+	}
+
+	// If there are not image override configurations, return.
+	if meta == nil {
+		p.imageMetaCache[component] = nil
+		return nil, nil
+	}
+
+	// Gets the image configuration and to the specific component, and returns the union of the two.
+	m := &imageMeta{}
+	if allMeta, ok := meta[allImageConfig]; ok {
+		m.Union(&allMeta)
+	}
+	if componentMeta, ok := meta[component]; ok {
+		m.Union(&componentMeta)
+	}
+
+	p.imageMetaCache[component] = m
+	return m, nil
+}
+
+// imageMeta allows to define transformations to apply to the image contained in the YAML manifests.
+type imageMeta struct {
+	// repository sets the container registry to pull images from.
+	Repository string `json:"repository,omitempty"`
+
+	// Tag allows to specify a tag for the images.
+	Tag string `json:"tag,omitempty"`
+}
+
+// Union allows to merge two imageMeta transformation; in case both the imageMeta defines new values for the same field,
+// the other transformation takes precedence on the existing one.
+func (i *imageMeta) Union(other *imageMeta) {
+	if other.Repository != "" {
+		i.Repository = other.Repository
+	}
+	if other.Tag != "" {
+		i.Tag = other.Tag
+	}
+}
+
+// ApplyToImage changes an image name applying the transformations defined in the current imageMeta.
+func (i *imageMeta) ApplyToImage(image string) (string, error) {
+	// Splits the image name into its own composing parts
+	ref, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return "", err
+	}
+
+	// apply transformations
+	if i.Repository != "" {
+		// store tag & digest for rebuilding the image name
+		tagged, hasTag := ref.(reference.Tagged)
+		digested, hasDigest := ref.(reference.Digested)
+
+		// detect the image name, dropping host and path if any
+		name := ref.Name()
+		imageNameIndex := strings.LastIndex(name, "/")
+		if imageNameIndex != -1 {
+			name = strings.TrimPrefix(name[imageNameIndex+1:], "/")
+		}
+
+		// parse the new image resulting by concatenating the new repository and the image name
+		ref, err = reference.ParseNormalizedNamed(fmt.Sprintf("%s/%s", strings.TrimSuffix(i.Repository, "/"), name))
+		if err != nil {
+			return "", err
+		}
+
+		// applies back tag & digest
+		if hasTag {
+			ref, err = reference.WithTag(ref, tagged.Tag())
+			if err != nil {
+				return "", err
+			}
+		}
+
+		if hasDigest {
+			ref, err = reference.WithDigest(ref, digested.Digest())
+			if err != nil {
+				return "", err
+			}
+		}
+	}
+	if i.Tag != "" {
+		ref, err = reference.WithTag(reference.TrimNamed(ref), i.Tag)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// returns the resulting image name
+	return ref.String(), nil
+}

--- a/cmd/clusterctl/client/config/imagemeta_client_test.go
+++ b/cmd/clusterctl/client/config/imagemeta_client_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
+)
+
+func Test_imageMetaClient_AlterImage(t *testing.T) {
+	type fields struct {
+		reader Reader
+	}
+	type args struct {
+		component string
+		image     string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "no image config, image should not be changes",
+			fields: fields{
+				reader: test.NewFakeReader(),
+			},
+			args: args{
+				component: "any",
+				image:     "quay.io/jetstack/cert-manager-cainjector:v0.11.0",
+			},
+			want:    "quay.io/jetstack/cert-manager-cainjector:v0.11.0",
+			wantErr: false,
+		},
+		{
+			name: "image config for cert-manager, image for the cert-manager should be changed",
+			fields: fields{
+				reader: test.NewFakeReader().WithImageMeta("cert-manager", "foo-repository.io", "foo-tag"),
+			},
+			args: args{
+				component: "cert-manager",
+				image:     "quay.io/jetstack/cert-manager-cainjector:v0.11.0",
+			},
+			want:    "foo-repository.io/cert-manager-cainjector:foo-tag",
+			wantErr: false,
+		},
+		{
+			name: "image config for all, image for the cert-manager should be changed",
+			fields: fields{
+				reader: test.NewFakeReader().WithImageMeta(allImageConfig, "foo-repository.io", "foo-tag"),
+			},
+			args: args{
+				component: "cert-manager",
+				image:     "quay.io/jetstack/cert-manager-cainjector:v0.11.0",
+			},
+			want:    "foo-repository.io/cert-manager-cainjector:foo-tag",
+			wantErr: false,
+		},
+		{
+			name: "image config for all and image config for cert-manager, image for the cert-manager should be changed according to the most specific",
+			fields: fields{
+				reader: test.NewFakeReader().
+					WithImageMeta(allImageConfig, "foo-repository.io", "foo-tag").
+					WithImageMeta("cert-manager", "bar-repository.io", "bar-tag"),
+			},
+			args: args{
+				component: "cert-manager",
+				image:     "quay.io/jetstack/cert-manager-cainjector:v0.11.0",
+			},
+			want:    "bar-repository.io/cert-manager-cainjector:bar-tag",
+			wantErr: false,
+		},
+		{
+			name: "image config for all and image config for cert-manager, image for the cert-manager should be changed according to the most specific (mixed case)",
+			fields: fields{
+				reader: test.NewFakeReader().
+					WithImageMeta(allImageConfig, "foo-repository.io", "").
+					WithImageMeta("cert-manager", "", "bar-tag"),
+			},
+			args: args{
+				component: "cert-manager",
+				image:     "quay.io/jetstack/cert-manager-cainjector:v0.11.0",
+			},
+			want:    "foo-repository.io/cert-manager-cainjector:bar-tag",
+			wantErr: false,
+		},
+		{
+			name: "fails if wrong image config",
+			fields: fields{
+				reader: test.NewFakeReader().WithVar(imagesConfigKey, "invalid"),
+			},
+			args: args{
+				component: "any",
+				image:     "any",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "fails if wrong image name",
+			fields: fields{
+				reader: test.NewFakeReader().WithImageMeta(allImageConfig, "foo-Repository.io", ""),
+			},
+			args: args{
+				component: "any",
+				image:     "invalid:invalid:invalid",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newImageMetaClient(tt.fields.reader)
+
+			got, err := p.AlterImage(tt.args.component, tt.args.image)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/clusterctl/test/e2e/go.sum
+++ b/cmd/clusterctl/test/e2e/go.sum
@@ -65,6 +65,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -273,6 +275,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
+github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
@@ -16,6 +17,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.0
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -290,6 +292,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
+github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=

--- a/test/infrastructure/docker/go.sum
+++ b/test/infrastructure/docker/go.sum
@@ -66,6 +66,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -265,6 +266,7 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=


### PR DESCRIPTION
**What this PR does / why we need it**:
The cert-manager manifest is embedded in clusterctl so it cannot be easily changed like e.g. provider manifests. This PR adds configurations to allow to set imageRepository/ImageTag (similar to ImageMeta for etcd/CoreDns in kubeadm)

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2555

/area clusterctl
/assing  @vincepri @ncdc 
