### PR TITLE
✨ Ensure every directory with a module is included in the top level makefile's modules target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,9 +304,7 @@ generate-kubeadm-control-plane-manifests: $(CONTROLLER_GEN) ## Generate manifest
 
 .PHONY: modules
 modules: ## Runs go mod to ensure modules are up to date.
-	go mod tidy
-	cd $(TOOLS_DIR); go mod tidy
-	cd $(CAPD_DIR); $(MAKE) modules
+	@find $$(pwd) -name go.mod | xargs -L 1 bash -c 'cd $$(dirname "$$0") && echo "ensure modules: $$(pwd)" && go mod tidy'
 
 ## --------------------------------------
 ## Docker


### PR DESCRIPTION

Signed-off-by: SataQiu <1527062125@qq.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Ensure every directory with a module is included in the top level makefile's modules target.
Make test/framework as a module to resolve :
```
shida@machine:~/Documents/Develop/work/src/sigs.k8s.io/cluster-api/cmd/clusterctl/test/e2e [master] $ go mod tidy
go: sigs.k8s.io/cluster-api/test/framework@v0.0.0-20200125173702-54f26d7fd2b5: parsing ../../../../test/framework/go.mod: open /Users/shida/Documents/Develop/work/src/sigs.k8s.io/cluster-api/test/framework/go.mod: no such file or directory
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2457

/cc @chuckha 
