### PR TITLE
🐛 Fix CAPD Calico manifest URL

### DIFF
--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Docker", func() {
 				applyYAMLURLInput := framework.ApplyYAMLURLInput{
 					Client:        workloadClient,
 					HTTPGetter:    http.DefaultClient,
-					NetworkingURL: "https://docs.projectcalico.org/v3.12/manifests/calico.yaml",
+					NetworkingURL: "https://docs.projectcalico.org/manifests/calico.yaml",
 					Scheme:        mgmt.Scheme,
 				}
 				framework.ApplyYAMLURL(ctx, applyYAMLURLInput)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Calico have removed the `v3.12` hosted version of their docs ([the link 404s](https://docs.projectcalico.org/v3.12/manifests/calico.yaml)) and now the [CAPD tests are failing](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/2549/pull-cluster-api-capd-e2e/1235856630076149760) because the file they're downloading is not valid YAML

I've quickly verified and calico currently seem to host the calico manifest at three locations: 
- `manifests/calico.yaml` (this matches the current latest release)
- `v3.13/manifests/calico.yaml`
- `master/manifests/calico.yaml`

If we use a specific release, it's likely this test is going to break regularly as they create new releases, I propose we use the naked `manifests/calico.yaml` as it should always match the latest release and should be stable

I suspect this got broken with this https://github.com/projectcalico/calico/commit/5ba055a047866bb448436a7720e34befdbd3d823
