### PR TITLE
🐛clusterctl: allow empty variables

### DIFF
--- a/cmd/clusterctl/client/config/reader_viper.go
+++ b/cmd/clusterctl/client/config/reader_viper.go
@@ -58,7 +58,7 @@ func (v *viperReader) Init(path string) error {
 	// the SetEnvKeyReplacer forces matching to name use the _ delimiter instead (- is not allowed in linux env variable names).
 	replacer := strings.NewReplacer("-", "_")
 	viper.SetEnvKeyReplacer(replacer)
-
+	viper.AllowEmptyEnv(true)
 	viper.AutomaticEnv()
 
 	// If a path file is found, read it in.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR make clusterctl to consider the empty env variables (because empty is different than unset !)
xref https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/800

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2497

/area clusterctl
/assign @randomvariable 
/assign @vincepri 