### PR TITLE
:bug: Allow noderef setting to be re-entrant in CAPD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ scripts/
 tilt-settings.json
 tilt.d/
 Tiltfile
+_artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ tilt-settings.json
 
 # User-supplied clusterctl hacks settings
 clusterctl-settings.json
+
+# test results
+_artifacts

--- a/scripts/ci-capd-e2e.sh
+++ b/scripts/ci-capd-e2e.sh
@@ -58,4 +58,4 @@ export E2E_CONF_FILE=e2e/ci-e2e.conf
 
 echo "*** Testing Cluster API Provider Docker e2es ***"
 CONTROLLER_IMG=${REGISTRY}/${DOCKER_MANAGER_IMAGE} make docker-build
-ARTIFACTS="${ARTIFACTS}" make run-e2e
+ARTIFACTS="${ARTIFACTS}" make run-e2e "$@"

--- a/test/infrastructure/docker/.gitignore
+++ b/test/infrastructure/docker/.gitignore
@@ -13,3 +13,6 @@ bin
 manager_image_patch.yaml-e
 cover.out
 manager
+
+# test results
+*.xml

--- a/test/infrastructure/docker/api/v1alpha3/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1alpha3/dockermachine_types.go
@@ -36,12 +36,21 @@ type DockerMachineSpec struct {
 	// running the machine
 	// +optional
 	CustomImage string `json:"customImage,omitempty"`
+
+	// Bootstrapped is true when the kubeadm bootstrapping has been run
+	// against this machine
+	// +optional
+	Bootstrapped bool `json:"bootstrapped,omitempty"`
 }
 
 // DockerMachineStatus defines the observed state of DockerMachine
 type DockerMachineStatus struct {
 	// Ready denotes that the machine (docker container) is ready
 	Ready bool `json:"ready"`
+	// LoadBalancerConfigured denotes that the machine has been
+	// added to the load balancer
+	// +optional
+	LoadBalancerConfigured bool `json:"loadBalancerConfigured,omitempty"`
 }
 
 // +kubebuilder:resource:path=dockermachines,scope=Namespaced,categories=cluster-api

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -38,6 +38,10 @@ spec:
           spec:
             description: DockerMachineSpec defines the desired state of DockerMachine
             properties:
+              bootstrapped:
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
+                type: boolean
               customImage:
                 description: CustomImage allows customizing the container image that
                   is used for running the machine
@@ -50,6 +54,10 @@ spec:
           status:
             description: DockerMachineStatus defines the observed state of DockerMachine
             properties:
+              loadBalancerConfigured:
+                description: LoadBalancerConfigured denotes that the machine has been
+                  added to the load balancer
+                type: boolean
               ready:
                 description: Ready denotes that the machine (docker container) is
                   ready

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
@@ -47,6 +47,10 @@ spec:
                     description: Spec is the specification of the desired behavior
                       of the machine.
                     properties:
+                      bootstrapped:
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
+                        type: boolean
                       customImage:
                         description: CustomImage allows customizing the container
                           image that is used for running the machine


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Stops flakes in PR tests

