### PR TITLE
🏃 capd: Make ready an optional field

### DIFF
--- a/test/infrastructure/docker/api/v1alpha3/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1alpha3/dockermachine_types.go
@@ -46,7 +46,9 @@ type DockerMachineSpec struct {
 // DockerMachineStatus defines the observed state of DockerMachine
 type DockerMachineStatus struct {
 	// Ready denotes that the machine (docker container) is ready
+	// +optional
 	Ready bool `json:"ready"`
+
 	// LoadBalancerConfigured denotes that the machine has been
 	// added to the load balancer
 	// +optional

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -62,8 +62,6 @@ spec:
                 description: Ready denotes that the machine (docker container) is
                   ready
                 type: boolean
-            required:
-            - ready
             type: object
         type: object
     served: true


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR changes the ready field to be optional. This cause an error log to be produced that was unnecessary.

/cc @randomvariable 