### PR TITLE
✨  Etcd version

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller.go
@@ -352,6 +352,13 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(ctx context.Context,
 		return ctrl.Result{}, errors.Wrap(err, "failed to update the kubernetes version in the kubeadm config map")
 	}
 
+	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local != nil {
+		meta := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageMeta
+		if err := workloadCluster.UpdateEtcdVersionInKubeadmConfigMap(ctx, meta.ImageRepository, meta.ImageTag); err != nil {
+			return ctrl.Result{}, errors.Wrap(err, "failed to update the etcd version in the kubeadm config map")
+		}
+	}
+
 	if err := workloadCluster.UpdateKubeletConfigMap(ctx, parsedVersion); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to upgrade kubelet config map")
 	}


### PR DESCRIPTION
~/hold~
~Depends on #2553~

**What this PR does / why we need it**:
This PR allows KCP to keep track of the local etcd version and manage the value stored in the kubeadm config map. The result is that when an upgrade is performed it will use the value found in the kubeadm config map.

The workflow I tested with was:

1. Create a 3 node control plane cluster where the control plane is managed by a kubeadm control plane resource
2. Find the image tag of etcd (3.3.15-0)
3. Locate a list of existing etcd versions found at `k8s.gcr.io/etcd` (`gcloud container images list-tags k8s.gcr.io/etcd`)
4. Pick a newer patch version (3.3.17-0)
5. Update the kubeadm control plane's kubeadm cluster local etcd configuration to use the tag `3.3.17-0`.
6. Wait for the upgrade to finish
7. Check the image of etcd on each of the new nodes to confirm it's 3.3.17-0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2543
