### PR TITLE
KCP etcd upgrade: handle conditional update & add tests

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -266,7 +266,8 @@ func (w *Workload) UpdateEtcdVersionInKubeadmConfigMap(ctx context.Context, imag
 		return err
 	}
 	config := &kubeadmConfig{ConfigMap: kubeadmConfigMap}
-	if err := config.UpdateEtcdMeta(imageRepository, imageTag); err != nil {
+	changed, err := config.UpdateEtcdMeta(imageRepository, imageTag)
+	if err != nil || !changed {
 		return err
 	}
 	if err := w.Client.Update(ctx, config.ConfigMap); err != nil {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Follow-up to #2579 

- Adds a conditional check to avoid issuing an Update to the ConfigMap hasn't changed.
- Adds unit tests against `UpdateEtcdMeta`.

/assign @chuckha @ncdc 
/cc @wfernandes 
/milestone v0.3.0
