### PR TITLE
✨clusterctl: improve support for air-gapped environments all image overrides

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -186,6 +186,6 @@ func defaultClusterFactory(configClient config.Client) func(kubeconfig string) (
 // defaultRepositoryFactory is a RepositoryClientFactory func the uses the default client provided by the repository low level library.
 func defaultRepositoryFactory(configClient config.Client) func(providerConfig config.Provider) (repository.Client, error) {
 	return func(providerConfig config.Provider) (repository.Client, error) {
-		return repository.New(providerConfig, configClient.Variables())
+		return repository.New(providerConfig, configClient)
 	}
 }

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -83,7 +83,7 @@ type clusterClient struct {
 	pollImmediateWaiter     PollImmediateWaiter
 }
 
-type RepositoryClientFactory func(provider config.Provider, configVariablesClient config.VariablesClient, options ...repository.Option) (repository.Client, error)
+type RepositoryClientFactory func(provider config.Provider, configClient config.Client, options ...repository.Option) (repository.Client, error)
 
 // ensure clusterClient implements Client.
 var _ Client = &clusterClient{}

--- a/cmd/clusterctl/client/cluster/installer.go
+++ b/cmd/clusterctl/client/cluster/installer.go
@@ -223,7 +223,7 @@ func (i *providerInstaller) getProviderContract(providerInstanceContracts map[st
 		return "", err
 	}
 
-	providerRepository, err := i.repositoryClientFactory(configRepository, i.configClient.Variables())
+	providerRepository, err := i.repositoryClientFactory(configRepository, i.configClient)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/clusterctl/client/cluster/installer_test.go
+++ b/cmd/clusterctl/client/cluster/installer_test.go
@@ -198,8 +198,8 @@ func Test_providerInstaller_Validate(t *testing.T) {
 				configClient:      configClient,
 				proxy:             tt.fields.proxy,
 				providerInventory: newInventoryClient(tt.fields.proxy, nil),
-				repositoryClientFactory: func(provider config.Provider, configVariablesClient config.VariablesClient, options ...repository.Option) (repository.Client, error) {
-					return repository.New(provider, configVariablesClient, repository.InjectRepository(repositoryMap[provider.ManifestLabel()]))
+				repositoryClientFactory: func(provider config.Provider, configClient config.Client, options ...repository.Option) (repository.Client, error) {
+					return repository.New(provider, configClient, repository.InjectRepository(repositoryMap[provider.ManifestLabel()]))
 				},
 				installQueue: tt.fields.installQueue,
 			}

--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -320,7 +320,7 @@ func (u *providerUpgrader) getUpgradeComponents(provider UpgradeItem) (repositor
 		return nil, err
 	}
 
-	providerRepository, err := u.repositoryClientFactory(configRepository, u.configClient.Variables())
+	providerRepository, err := u.repositoryClientFactory(configRepository, u.configClient)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/cluster/upgrader_info.go
+++ b/cmd/clusterctl/client/cluster/upgrader_info.go
@@ -51,7 +51,7 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 		return nil, err
 	}
 
-	providerRepository, err := u.repositoryClientFactory(configRepository, u.configClient.Variables())
+	providerRepository, err := u.repositoryClientFactory(configRepository, u.configClient)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/cluster/upgrader_info_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_info_test.go
@@ -152,8 +152,8 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 
 			u := &providerUpgrader{
 				configClient: configClient,
-				repositoryClientFactory: func(provider config.Provider, configVariablesClient config.VariablesClient, options ...repository.Option) (repository.Client, error) {
-					return repository.New(provider, configVariablesClient, repository.InjectRepository(tt.fields.repository))
+				repositoryClientFactory: func(provider config.Provider, configClient config.Client, options ...repository.Option) (repository.Client, error) {
+					return repository.New(provider, configClient, repository.InjectRepository(tt.fields.repository))
 				},
 			}
 			got, err := u.getUpgradeInfo(tt.args.provider)

--- a/cmd/clusterctl/client/cluster/upgrader_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_test.go
@@ -484,8 +484,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 
 			u := &providerUpgrader{
 				configClient: configClient,
-				repositoryClientFactory: func(provider config.Provider, configVariablesClient config.VariablesClient, options ...repository.Option) (repository.Client, error) {
-					return repository.New(provider, configVariablesClient, repository.InjectRepository(tt.fields.repository[provider.ManifestLabel()]))
+				repositoryClientFactory: func(provider config.Provider, configClient config.Client, options ...repository.Option) (repository.Client, error) {
+					return repository.New(provider, configClient, repository.InjectRepository(tt.fields.repository[provider.ManifestLabel()]))
 				},
 				providerInventory: newInventoryClient(tt.fields.proxy, nil),
 			}
@@ -774,8 +774,8 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 
 			u := &providerUpgrader{
 				configClient: configClient,
-				repositoryClientFactory: func(provider config.Provider, configVariablesClient config.VariablesClient, options ...repository.Option) (repository.Client, error) {
-					return repository.New(provider, configVariablesClient, repository.InjectRepository(tt.fields.repository[provider.Name()]))
+				repositoryClientFactory: func(provider config.Provider, configClient config.Client, options ...repository.Option) (repository.Client, error) {
+					return repository.New(provider, configClient, repository.InjectRepository(tt.fields.repository[provider.Name()]))
 				},
 				providerInventory: newInventoryClient(tt.fields.proxy, nil),
 			}

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -108,7 +108,7 @@ func Test_clusterctlClient_GetProviderComponents(t *testing.T) {
 	config1 := newFakeConfig().
 		WithProvider(capiProviderConfig)
 
-	repository1 := newFakeRepository(capiProviderConfig, config1.Variables()).
+	repository1 := newFakeRepository(capiProviderConfig, config1).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v1.0.0").
 		WithFile("v1.0.0", "components.yaml", componentsYAML("ns1"))
@@ -343,7 +343,7 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 	config1 := newFakeConfig().
 		WithProvider(infraProviderConfig)
 
-	repository1 := newFakeRepository(infraProviderConfig, config1.Variables()).
+	repository1 := newFakeRepository(infraProviderConfig, config1).
 		WithPaths("root", "components").
 		WithDefaultVersion("v3.0.0").
 		WithFile("v3.0.0", "cluster-template.yaml", rawTemplate)

--- a/cmd/clusterctl/client/delete_test.go
+++ b/cmd/clusterctl/client/delete_test.go
@@ -143,12 +143,12 @@ func fakeClusterForDelete() *fakeClient {
 		WithProvider(capiProviderConfig).
 		WithProvider(bootstrapProviderConfig)
 
-	repository1 := newFakeRepository(capiProviderConfig, config1.Variables()).
+	repository1 := newFakeRepository(capiProviderConfig, config1).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v1.0.0").
 		WithFile("v1.0.0", "components.yaml", componentsYAML("ns1")).
 		WithFile("v1.1.0", "components.yaml", componentsYAML("ns1"))
-	repository2 := newFakeRepository(bootstrapProviderConfig, config1.Variables()).
+	repository2 := newFakeRepository(bootstrapProviderConfig, config1).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v2.0.0").
 		WithFile("v2.0.0", "components.yaml", componentsYAML("ns2")).

--- a/cmd/clusterctl/client/init_test.go
+++ b/cmd/clusterctl/client/init_test.go
@@ -393,7 +393,7 @@ func fakeEmptyCluster() *fakeClient {
 		WithProvider(controlPlaneProviderConfig).
 		WithProvider(infraProviderConfig)
 
-	repository1 := newFakeRepository(capiProviderConfig, config1.Variables()).
+	repository1 := newFakeRepository(capiProviderConfig, config1).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v1.0.0").
 		WithFile("v1.0.0", "components.yaml", componentsYAML("ns1")).
@@ -408,7 +408,7 @@ func fakeEmptyCluster() *fakeClient {
 				{Major: 1, Minor: 1, Contract: "v1alpha3"},
 			},
 		})
-	repository2 := newFakeRepository(bootstrapProviderConfig, config1.Variables()).
+	repository2 := newFakeRepository(bootstrapProviderConfig, config1).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v2.0.0").
 		WithFile("v2.0.0", "components.yaml", componentsYAML("ns2")).
@@ -423,7 +423,7 @@ func fakeEmptyCluster() *fakeClient {
 				{Major: 2, Minor: 1, Contract: "v1alpha3"},
 			},
 		})
-	repository3 := newFakeRepository(controlPlaneProviderConfig, config1.Variables()).
+	repository3 := newFakeRepository(controlPlaneProviderConfig, config1).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v2.0.0").
 		WithFile("v2.0.0", "components.yaml", componentsYAML("ns3")).
@@ -438,7 +438,7 @@ func fakeEmptyCluster() *fakeClient {
 				{Major: 2, Minor: 1, Contract: "v1alpha3"},
 			},
 		})
-	repository4 := newFakeRepository(infraProviderConfig, config1.Variables()).
+	repository4 := newFakeRepository(infraProviderConfig, config1).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v3.0.0").
 		WithFile("v3.0.0", "components.yaml", componentsYAML("ns4")).

--- a/cmd/clusterctl/client/repository/client_test.go
+++ b/cmd/clusterctl/client/repository/client_test.go
@@ -32,6 +32,11 @@ func Test_newRepositoryClient_LocalFileSystemRepository(t *testing.T) {
 	dst1 := createLocalTestProviderFile(t, tmpDir, "bootstrap-foo/v1.0.0/bootstrap-components.yaml", "")
 	dst2 := createLocalTestProviderFile(t, tmpDir, "bootstrap-bar/v2.0.0/bootstrap-components.yaml", "")
 
+	configClient, err := config.New("", config.InjectReader(test.NewFakeReader()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	type fields struct {
 		provider config.Provider
 	}
@@ -54,7 +59,7 @@ func Test_newRepositoryClient_LocalFileSystemRepository(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repoClient, err := newRepositoryClient(tt.fields.provider, test.NewFakeVariableClient())
+			repoClient, err := newRepositoryClient(tt.fields.provider, configClient)
 			if err != nil {
 				t.Fatalf("got error %v when none was expected", err)
 			}

--- a/cmd/clusterctl/client/repository/components.go
+++ b/cmd/clusterctl/client/repository/components.go
@@ -183,12 +183,12 @@ func (c *components) Yaml() ([]byte, error) {
 // 3. Ensure all the ClusterRoleBinding which are referencing namespaced objects have the name prefixed with the namespace name
 // 4. Set the watching namespace for the provider controller
 // 5. Adds labels to all the components in order to allow easy identification of the provider objects
-func NewComponents(provider config.Provider, version string, rawyaml []byte, configVariablesClient config.VariablesClient, targetNamespace, watchingNamespace string) (*components, error) {
+func NewComponents(provider config.Provider, version string, rawyaml []byte, configClient config.Client, targetNamespace, watchingNamespace string) (*components, error) {
 	// inspect the yaml read from the repository for variables
 	variables := inspectVariables(rawyaml)
 
 	// Replace variables with corresponding values read from the config
-	yaml, err := replaceVariables(rawyaml, variables, configVariablesClient)
+	yaml, err := replaceVariables(rawyaml, variables, configClient.Variables())
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to perform variable substitution")
 	}

--- a/cmd/clusterctl/client/repository/components.go
+++ b/cmd/clusterctl/client/repository/components.go
@@ -199,6 +199,14 @@ func NewComponents(provider config.Provider, version string, rawyaml []byte, con
 		return nil, errors.Wrap(err, "failed to parse yaml")
 	}
 
+	// apply image overrides, if defined
+	objs, err = util.FixImages(objs, func(image string) (string, error) {
+		return configClient.ImageMeta().AlterImage(provider.ManifestLabel(), image)
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to apply image overrides")
+	}
+
 	// inspect the list of objects for the images required by the provider component
 	images, err := util.InspectImages(objs)
 	if err != nil {

--- a/cmd/clusterctl/client/repository/components_client.go
+++ b/cmd/clusterctl/client/repository/components_client.go
@@ -30,20 +30,20 @@ type ComponentsClient interface {
 
 // componentsClient implements ComponentsClient.
 type componentsClient struct {
-	provider              config.Provider
-	repository            Repository
-	configVariablesClient config.VariablesClient
+	provider     config.Provider
+	repository   Repository
+	configClient config.Client
 }
 
 // ensure componentsClient implements ComponentsClient.
 var _ ComponentsClient = &componentsClient{}
 
 // newComponentsClient returns a componentsClient.
-func newComponentsClient(provider config.Provider, repository Repository, configVariablesClient config.VariablesClient) *componentsClient {
+func newComponentsClient(provider config.Provider, repository Repository, configClient config.Client) *componentsClient {
 	return &componentsClient{
-		provider:              provider,
-		repository:            repository,
-		configVariablesClient: configVariablesClient,
+		provider:     provider,
+		repository:   repository,
+		configClient: configClient,
 	}
 }
 
@@ -74,5 +74,5 @@ func (f *componentsClient) Get(version, targetNamespace, watchingNamespace strin
 		log.V(1).Info("Using", "Override", path, "Provider", f.provider.ManifestLabel(), "Version", version)
 	}
 
-	return NewComponents(f.provider, version, file, f.configVariablesClient, targetNamespace, watchingNamespace)
+	return NewComponents(f.provider, version, file, f.configClient, targetNamespace, watchingNamespace)
 }

--- a/cmd/clusterctl/client/repository/components_client_test.go
+++ b/cmd/clusterctl/client/repository/components_client_test.go
@@ -61,10 +61,14 @@ var configMapYaml = []byte("apiVersion: v1\n" +
 func Test_componentsClient_Get(t *testing.T) {
 	p1 := config.NewProvider("p1", "", clusterctlv1.BootstrapProviderType)
 
+	configClient, err := config.New("", config.InjectReader(test.NewFakeReader().WithVar(variableName, variableValue)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	type fields struct {
-		provider              config.Provider
-		repository            Repository
-		configVariablesClient config.VariablesClient
+		provider   config.Provider
+		repository Repository
 	}
 	type args struct {
 		version           string
@@ -93,7 +97,6 @@ func Test_componentsClient_Get(t *testing.T) {
 					WithPaths("root", "components.yaml").
 					WithDefaultVersion("v1.0.0").
 					WithFile("v1.0.0", "components.yaml", util.JoinYaml(namespaceYaml, controllerYaml, configMapYaml)),
-				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 			},
 			args: args{
 				version:           "v1.0.0",
@@ -117,7 +120,6 @@ func Test_componentsClient_Get(t *testing.T) {
 					WithPaths("root", "components.yaml").
 					WithDefaultVersion("v1.0.0").
 					WithFile("v1.0.0", "components.yaml", util.JoinYaml(namespaceYaml, controllerYaml, configMapYaml)),
-				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 			},
 			args: args{
 				version:           "v1.0.0",
@@ -141,7 +143,6 @@ func Test_componentsClient_Get(t *testing.T) {
 					WithPaths("root", "components.yaml").
 					WithDefaultVersion("v1.0.0").
 					WithFile("v1.0.0", "components.yaml", util.JoinYaml(namespaceYaml, controllerYaml, configMapYaml)),
-				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 			},
 			args: args{
 				version:           "v1.0.0",
@@ -164,7 +165,6 @@ func Test_componentsClient_Get(t *testing.T) {
 				repository: test.NewFakeRepository().
 					WithPaths("root", "components.yaml").
 					WithDefaultVersion("v1.0.0"),
-				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 			},
 			args: args{
 				version:           "v1.0.0",
@@ -181,7 +181,6 @@ func Test_componentsClient_Get(t *testing.T) {
 					WithPaths("root", "components.yaml").
 					WithDefaultVersion("v1.0.0").
 					WithFile("v1.0.0", "components.yaml", util.JoinYaml(controllerYaml, configMapYaml)),
-				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 			},
 			args: args{
 				version:           "v1.0.0",
@@ -198,7 +197,6 @@ func Test_componentsClient_Get(t *testing.T) {
 					WithPaths("root", "components.yaml").
 					WithDefaultVersion("v1.0.0").
 					WithFile("v1.0.0", "components.yaml", util.JoinYaml(controllerYaml, configMapYaml)),
-				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 			},
 			args: args{
 				version:           "v1.0.0",
@@ -222,7 +220,6 @@ func Test_componentsClient_Get(t *testing.T) {
 					WithPaths("root", "components.yaml").
 					WithDefaultVersion("v1.0.0").
 					WithFile("v1.0.0", "components.yaml", util.JoinYaml(controllerYaml, configMapYaml)),
-				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 			},
 			args: args{
 				version:           "v2.0.0",
@@ -234,7 +231,7 @@ func Test_componentsClient_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := newComponentsClient(tt.fields.provider, tt.fields.repository, tt.fields.configVariablesClient)
+			f := newComponentsClient(tt.fields.provider, tt.fields.repository, configClient)
 			got, err := f.Get(tt.args.version, tt.args.targetNamespace, tt.args.watchingNamespace)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)

--- a/cmd/clusterctl/client/upgrade_test.go
+++ b/cmd/clusterctl/client/upgrade_test.go
@@ -206,7 +206,7 @@ func fakeClientFoUpgrade() *fakeClient {
 		WithProvider(core).
 		WithProvider(infra)
 
-	repository1 := newFakeRepository(core, config1.Variables()).
+	repository1 := newFakeRepository(core, config1).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v1.0.1").
 		WithFile("v1.0.1", "components.yaml", componentsYAML("ns2")).
@@ -216,7 +216,7 @@ func fakeClientFoUpgrade() *fakeClient {
 				{Major: 1, Minor: 0, Contract: "v1alpha3"},
 			},
 		})
-	repository2 := newFakeRepository(infra, config1.Variables()).
+	repository2 := newFakeRepository(infra, config1).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v2.0.0").
 		WithFile("v2.0.1", "components.yaml", componentsYAML("ns2")).


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow up of https://github.com/kubernetes-sigs/cluster-api/pull/2558 designed to improve clusterctl support for air-gapped environments by supporting the following image override config:
```
images:
  all:
    repository: us.gcr.io/myRepo/cluster-api
```
Thus allowing to use upstream manifest for air-gapped environments without requiring manual modifications to components yaml for all the providers.

The real change is really simple, but unfortunately, it requires refactoring the signature of a method that is used in many places.
For helping reviewers to better understand the above point, the refactor and the real change are in separate commits.

/area clusterctl
/assign @vincepri 
/assign @ncdc

