### PR TITLE
🐛clusterctl: fix cert-manager timeout

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -34,7 +34,7 @@ const (
 	embeddedCertManagerManifestPath = "cmd/clusterctl/config/manifest/cert-manager.yaml"
 
 	waitCertManagerInterval = 1 * time.Second
-	waitCertManagerTimeout  = 5 * time.Minute
+	waitCertManagerTimeout  = 10 * time.Minute
 
 	retryCreateCertManagerObject         = 3
 	retryIntervalCreateCertManagerObject = 1 * time.Second


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR restores cert-manager waiting timeout to 10 minutes

/assign @vincepri 