### PR TITLE
:bug: work with kind v0.7.0

### DIFF
--- a/test/helpers/kind/setup.go
+++ b/test/helpers/kind/setup.go
@@ -124,7 +124,7 @@ func (c *Cluster) ApplyYAML(manifestPath string) {
 // RestConfig returns a REST configuration pointed at the provisioned cluster
 func (c *Cluster) RestConfig() *restclient.Config {
 	cfg, err := clientcmd.BuildConfigFromFlags("", c.KubeconfigPath)
-	ExpectWithOffset(1, err).NotTo(==.HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return cfg
 }
 

--- a/test/helpers/kind/setup.go
+++ b/test/helpers/kind/setup.go
@@ -18,7 +18,6 @@ package kind
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -134,13 +133,6 @@ func (c *Cluster) KubeClient() kubernetes.Interface {
 	client, err := kubernetes.NewForConfig(cfg)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return client
-}
-
-func (c *Cluster) runWithOutput(cmd *exec.Cmd) []byte {
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
-	c.run(cmd)
-	return stdout.Bytes()
 }
 
 func (c *Cluster) run(cmd *exec.Cmd) {

--- a/test/helpers/kind/setup.go
+++ b/test/helpers/kind/setup.go
@@ -25,8 +25,9 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -50,7 +51,7 @@ type Cluster struct {
 // Setup creates a Kind cluster
 func (c *Cluster) Setup() {
 	c.init()
-	fmt.Fprintf(ginkgo.GinkgoWriter, "creating Kind cluster named %q\n", c.Name)
+	fmt.Fprintf(GinkgoWriter, "creating Kind cluster named %q\n", c.Name)
 
 	cmd := exec.Command(
 		c.kindBinary,
@@ -81,9 +82,9 @@ func (c *Cluster) init() {
 	}
 	var err error
 	c.kindBinary, err = exec.LookPath("kind")
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 	c.kubectlBinary, err = exec.LookPath("kubectl")
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 }
 
 // Teardown attempts to delete the Kind cluster
@@ -99,7 +100,7 @@ func (c *Cluster) Teardown() {
 // LoadImage loads the specified image archive into the Kind cluster
 func (c *Cluster) LoadImage(image string) {
 	fmt.Fprintf(
-		ginkgo.GinkgoWriter,
+		GinkgoWriter,
 		"loading image %q into Kind node\n",
 		image)
 	c.run(exec.Command(
@@ -123,7 +124,7 @@ func (c *Cluster) ApplyYAML(manifestPath string) {
 // RestConfig returns a REST configuration pointed at the provisioned cluster
 func (c *Cluster) RestConfig() *restclient.Config {
 	cfg, err := clientcmd.BuildConfigFromFlags("", c.KubeconfigPath)
-	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(==.HaveOccurred())
 	return cfg
 }
 
@@ -131,7 +132,7 @@ func (c *Cluster) RestConfig() *restclient.Config {
 func (c *Cluster) KubeClient() kubernetes.Interface {
 	cfg := c.RestConfig()
 	client, err := kubernetes.NewForConfig(cfg)
-	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	return client
 }
 
@@ -145,7 +146,7 @@ func (c *Cluster) runWithOutput(cmd *exec.Cmd) []byte {
 func (c *Cluster) run(cmd *exec.Cmd) {
 	var wg sync.WaitGroup
 	errPipe, err := cmd.StderrPipe()
-	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	cmd.Env = append(
 		cmd.Env,
@@ -162,14 +163,14 @@ func (c *Cluster) run(cmd *exec.Cmd) {
 	go captureOutput(&wg, errPipe, "stderr")
 	if cmd.Stdout == nil {
 		outPipe, err := cmd.StdoutPipe()
-		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		wg.Add(1)
 		go captureOutput(&wg, outPipe, "stdout")
 	}
 
-	gomega.Expect(cmd.Start()).To(gomega.Succeed())
+	Expect(cmd.Start()).To(Succeed())
 	wg.Wait()
-	gomega.Expect(cmd.Wait()).To(gomega.Succeed())
+	Expect(cmd.Wait()).To(Succeed())
 }
 
 func captureOutput(wg *sync.WaitGroup, r io.Reader, label string) {
@@ -178,7 +179,7 @@ func captureOutput(wg *sync.WaitGroup, r io.Reader, label string) {
 
 	for {
 		line, err := reader.ReadString('\n')
-		fmt.Fprintf(ginkgo.GinkgoWriter, "[%s] %s", label, line)
+		fmt.Fprintf(GinkgoWriter, "[%s] %s", label, line)
 		if err != nil {
 			return
 		}

--- a/test/helpers/kind/setup.go
+++ b/test/helpers/kind/setup.go
@@ -52,7 +52,7 @@ func (c *Cluster) Setup() {
 	c.init()
 	fmt.Fprintf(GinkgoWriter, "creating Kind cluster named %q\n", c.Name)
 
-	cmd := exec.Command(
+	cmd := exec.Command( //nolint:gosec
 		c.kindBinary,
 		"create", "cluster",
 		"--name", c.Name,
@@ -88,7 +88,7 @@ func (c *Cluster) init() {
 
 // Teardown attempts to delete the Kind cluster
 func (c *Cluster) Teardown() {
-	c.run(exec.Command(
+	c.run(exec.Command( //nolint:gosec
 		c.kindBinary,
 		"delete", "cluster",
 		"--name", c.Name,
@@ -102,7 +102,7 @@ func (c *Cluster) LoadImage(image string) {
 		GinkgoWriter,
 		"loading image %q into Kind node\n",
 		image)
-	c.run(exec.Command(
+	c.run(exec.Command( //nolint:gosec
 		c.kindBinary,
 		"load", "docker-image",
 		"--name", c.Name,
@@ -112,7 +112,7 @@ func (c *Cluster) LoadImage(image string) {
 
 // ApplyYAML applies the provided manifest to the Kind cluster
 func (c *Cluster) ApplyYAML(manifestPath string) {
-	c.run(exec.Command(
+	c.run(exec.Command( //nolint:gosec
 		c.kubectlBinary,
 		"apply",
 		"--kubeconfig", c.KubeconfigPath,


### PR DESCRIPTION

**What this PR does / why we need it**:

Updates package to work with newer versions of `kind`. There's been some deprecations and changes in `v0.7.0`, especially the removal of `kind get kubeconfig-path` subcommand which makes this package fail when creating clusters.

This PR also adds a few more cluster configuration options for better fine-tuning and granularity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

NONE
