### PR TITLE
🐛 Fixes default control, worker machine counts overriding user specified values

### DIFF
--- a/cmd/clusterctl/test/e2e/helpers.go
+++ b/cmd/clusterctl/test/e2e/helpers.go
@@ -137,8 +137,8 @@ func createTestWorkloadCluster(ctx context.Context, mgmtInfo testMgmtClusterInfo
 		ClusterName:              workloadInfo.workloadClusterName,
 		Flavor:                   "",
 		KubernetesVersion:        workloadInfo.kubernetesVersion,
-		ControlPlaneMachineCount: workloadInfo.controlPlaneMachineCount,
-		WorkerMachineCount:       workloadInfo.workerMachineCount,
+		ControlPlaneMachineCount: &workloadInfo.controlPlaneMachineCount,
+		WorkerMachineCount:       &workloadInfo.workerMachineCount,
 	}
 	template, err := c.GetClusterTemplate(options)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
Replica counts set by the user through ENV vars or config file isn't being used as the flag options take precedence. The flags for control and worker counts default to 1 and 0 respectively and were overriding any values set as ENV vars. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2560 
