### PR TITLE
🐛validation for not having both local and external etcd in control plane

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
@@ -21,11 +21,9 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	kubeadmv1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
 )
@@ -293,6 +291,23 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	scaleToEvenExternalEtcdCluster := beforeExternalEtcdCluster.DeepCopy()
 	scaleToEvenExternalEtcdCluster.Spec.Replicas = pointer.Int32Ptr(2)
 
+	beforeInvalidEtcdCluster := before.DeepCopy()
+	beforeInvalidEtcdCluster.Spec.KubeadmConfigSpec.InitConfiguration.ClusterConfiguration.Etcd = kubeadmv1beta1.Etcd{
+		Local: &kubeadmv1beta1.LocalEtcd{
+			ImageMeta: kubeadmv1beta1.ImageMeta{
+				ImageRepository: "image-repository",
+				ImageTag:        "latest",
+			},
+		},
+	}
+
+	afterInvalidEtcdCluster := beforeInvalidEtcdCluster.DeepCopy()
+	afterInvalidEtcdCluster.Spec.KubeadmConfigSpec.InitConfiguration.ClusterConfiguration.Etcd = kubeadmv1beta1.Etcd{
+		External: &kubeadmv1beta1.ExternalEtcd{
+			Endpoints: []string{"127.0.0.1"},
+		},
+	}
+
 	tests := []struct {
 		name      string
 		expectErr bool
@@ -472,6 +487,12 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: true,
 			before:    localDataDir,
 			kcp:       modifyLocalDataDir,
+		},
+		{
+			name:      "should fail if both local and external etcd are set",
+			expectErr: true,
+			before:    beforeInvalidEtcdCluster,
+			kcp:       afterInvalidEtcdCluster,
 		},
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
- add validation in webhook to check that only one of local and external etcd is set

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2580 
