### PR TITLE
🏃cmd-clusterctl-api/tests: standardize gomega imports - follow up

### DIFF
--- a/cmd/clusterctl/api/v1alpha3/provider_type_test.go
+++ b/cmd/clusterctl/api/v1alpha3/provider_type_test.go
@@ -18,9 +18,13 @@ package v1alpha3
 
 import (
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func Test_Provider_ManifestLabel(t *testing.T) {
+	g := NewWithT(t)
+
 	type fields struct {
 		provider     string
 		providerType ProviderType
@@ -85,9 +89,7 @@ func Test_Provider_ManifestLabel(t *testing.T) {
 				ProviderName: tt.fields.provider,
 				Type:         string(tt.fields.providerType),
 			}
-			if got := p.ManifestLabel(); got != tt.want {
-				t.Errorf("got %v, want %v", got, tt.want)
-			}
+			g.Expect(p.ManifestLabel()).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
standardize gomega imports for `cmd/clusterctl/api/*/***` tests

/cc @vincepri 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubernetes-sigs/cluster-api/issues/2433
