### PR TITLE
:bug: Fix NPE when validating KCP etcd settings

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
@@ -230,6 +230,10 @@ func (in *KubeadmControlPlane) validateCommon() (allErrs field.ErrorList) {
 }
 
 func (in *KubeadmControlPlane) validateEtcd(prev *KubeadmControlPlane) (allErrs field.ErrorList) {
+	if in.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
+		return allErrs
+	}
+
 	if in.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External != nil && prev.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local != nil {
 		allErrs = append(
 			allErrs,

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
@@ -296,6 +296,9 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 		},
 	}
 
+	withoutClusterConfiguration := before.DeepCopy()
+	withoutClusterConfiguration.Spec.KubeadmConfigSpec.ClusterConfiguration = nil
+
 	tests := []struct {
 		name      string
 		expectErr bool
@@ -475,6 +478,12 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: true,
 			before:    beforeInvalidEtcdCluster,
 			kcp:       afterInvalidEtcdCluster,
+		},
+		{
+			name:      "should pass if ClusterConfiguration is nil",
+			expectErr: false,
+			before:    withoutClusterConfiguration,
+			kcp:       withoutClusterConfiguration,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a panic when validating the etcd settings in KubeadmControlPlane if ClusterConfiguration is nil.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2613
