### PR TITLE
🏃Improve capd e2e artifact output

### DIFF
--- a/test/infrastructure/docker/e2e/docker_suite_test.go
+++ b/test/infrastructure/docker/e2e/docker_suite_test.go
@@ -113,18 +113,11 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	// Dump the logs of the providers before deleting them.
 	Expect(writeLogs(mgmt, "capi-system", "capi-controller-manager", logPath)).To(Succeed())
 	Expect(writeLogs(mgmt, "capi-kubeadm-bootstrap-system", "capi-kubeadm-bootstrap-controller-manager", logPath)).To(Succeed())
 	Expect(writeLogs(mgmt, "capi-kubeadm-control-plane-system", "capi-kubeadm-control-plane-controller-manager", logPath)).To(Succeed())
 	Expect(writeLogs(mgmt, "capd-system", "capd-controller-manager", logPath)).To(Succeed())
-
-	// Dump cluster API and docker related resources to artifacts
-	Expect(framework.DumpResources(mgmt, resourcesPath, GinkgoWriter)).To(Succeed())
-	resources := map[string]runtime.Object{
-		"DockerCluster": &infrav1.DockerClusterList{},
-		"DockerMachine": &infrav1.DockerMachineList{},
-	}
-	Expect(framework.DumpProviderResources(mgmt, resources, resourcesPath, GinkgoWriter)).To(Succeed())
 
 	By("Deleting the management cluster")
 	// If any part of teardown fails it will print what must be manually cleaned up

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,6 +57,15 @@ var _ = Describe("Docker", func() {
 		})
 
 		AfterEach(func() {
+			// Dump cluster API and docker related resources to artifacts before deleting them.
+			Expect(framework.DumpResources(mgmt, resourcesPath, GinkgoWriter)).To(Succeed())
+			resources := map[string]runtime.Object{
+				"DockerCluster":         &infrav1.DockerClusterList{},
+				"DockerMachine":         &infrav1.DockerMachineList{},
+				"DockerMachineTemplate": &infrav1.DockerMachineTemplateList{},
+			}
+			Expect(framework.DumpProviderResources(mgmt, resources, resourcesPath, GinkgoWriter)).To(Succeed())
+
 			deleteClusterInput := framework.DeleteClusterInput{
 				Deleter: client,
 				Cluster: cluster,


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This prints all of the resources before they get deleted in order to improve debug-ability in prow-like environments.

Related to #2593 