### PR TITLE
🐛small fix to quick-start

### DIFF
--- a/docs/book/src/clusterctl/commands/config-cluster.md
+++ b/docs/book/src/clusterctl/commands/config-cluster.md
@@ -5,7 +5,7 @@ The `clusterctl config cluster` command returns a YAML template for creating a w
 For example
 
 ```
-clusterctl config cluster my-cluster --kubernetes-version v1.16.3 > my-cluster.yaml
+clusterctl config cluster my-cluster --kubernetes-version v1.16.3 --control-plane-machine-count=3 --worker-machine-count=3 > my-cluster.yaml
 ```
 
 Creates a YAML file named `my-cluster.yaml` with a predefined list of Cluster API objects; Cluster, Machines,

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -94,7 +94,7 @@ variables required by a cluster templates.
 For the purpose of this tutorial, we’ll name our cluster capi-quickstart.
 
 ```
-clusterctl config cluster capi-quickstart --kubernetes-version v1.17.0 > capi-quickstart.yaml
+clusterctl config cluster capi-quickstart --kubernetes-version v1.17.0 --control-plane-machine-count=3 --worker-machine-count=3 > capi-quickstart.yaml
 ```
 
 Creates a YAML file named `capi-quickstart.yaml` with a predefined list of Cluster API objects; Cluster, Machines,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes a small fix to the quick start so the user explicitly asks for a given number of control-plane and worker machines.

By being explicit here we can hopefully avoid questions/feedbacks that can arise by the default (arbitrary) number of control-plane and worker machines being used when the parameters are not set.

/assign @vincepri 