### PR TITLE
🏃 Do not kubeadm reset in capd any more

### DIFF
--- a/test/infrastructure/docker/docker/machine.go
+++ b/test/infrastructure/docker/docker/machine.go
@@ -238,23 +238,6 @@ func (m *Machine) getKubectlNode() (*types.Node, error) {
 	return kubectlNodes[0], nil
 }
 
-// KubeadmReset will run `kubeadm reset` on the machine.
-func (m *Machine) KubeadmReset(ctx context.Context) error {
-	if m.container != nil {
-		m.log.Info("Running kubeadm reset on the machine")
-		cmd := m.container.Commander.Command("kubeadm", "reset", "--force")
-		lines, err := cmd.RunLoggingOutputOnFail(ctx)
-		if err != nil {
-			for _, line := range lines {
-				m.log.Info(line)
-			}
-			return errors.Wrap(err, "failed to reset node")
-		}
-	}
-
-	return nil
-}
-
 // Delete deletes a docker container hosting a Kubernetes node.
 func (m *Machine) Delete(ctx context.Context) error {
 	// Delete if exists.


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This was the cause of a number of failures. I believe there is some condition we hit that causes `kubeadm reset` to hang. However, we have this functionality in the KubeadmControlPlane which is used as part of the e2es so the docker machine controller doesn't need to run kubeadm reset any more.

This has the added benefit of aligning with other providers that don't have direct access to running commands on nodes. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2618 

/assign @fabriziopandini 