### PR TITLE
:sparkles: Sync failureDomain from infraMachine.Spec to Machine.Spec

### DIFF
--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -152,6 +152,19 @@ func FailuresFrom(obj *unstructured.Unstructured) (string, string, error) {
 	return failureReason, failureMessage, nil
 }
 
+// FailureDomain returns the FailureDomain from the external object spec.
+func FailureDomain(obj *unstructured.Unstructured) *string {
+	result, found, err := unstructured.NestedFieldNoCopy(obj.Object, "spec", "failureDomain")
+	if err != nil || !found {
+		return nil
+	}
+	failureDomain, ok := result.(*string)
+	if !ok {
+		return nil
+	}
+	return failureDomain
+}
+
 // IsReady returns true if the Status.Ready field on an external object is true.
 func IsReady(obj *unstructured.Unstructured) (bool, error) {
 	ready, found, err := unstructured.NestedBool(obj.Object, "status", "ready")

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -229,6 +229,11 @@ func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, cluster
 		return nil
 	}
 
+	// Pull the failureDomain from the infrastructure provider if it is not already set.
+	if m.Spec.FailureDomain == nil {
+		m.Spec.FailureDomain = external.FailureDomain(infraConfig)
+	}
+
 	// Determine if the infrastructure provider is ready.
 	ready, err := external.IsReady(infraConfig)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements the failureDomain sync process described in the failureDomain implementation docs.
- This facilitates the migration of formerly provider-specific fields to the common Machine.Spec.FailureDomain field.
