### PR TITLE
🏃cmd-clusterctl-client-cluster/tests: standardize gomega imports

### DIFF
--- a/cmd/clusterctl/client/cluster/components_test.go
+++ b/cmd/clusterctl/client/cluster/components_test.go
@@ -19,6 +19,8 @@ package cluster
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,6 +35,8 @@ import (
 )
 
 func Test_providerComponents_Delete(t *testing.T) {
+	g := NewWithT(t)
+
 	labels := map[string]string{
 		clusterv1.ProviderLabelName: "infrastructure-infra",
 	}
@@ -253,17 +257,16 @@ func Test_providerComponents_Delete(t *testing.T) {
 				IncludeNamespace: tt.args.includeNamespace,
 				IncludeCRDs:      tt.args.includeCRD,
 			})
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
+			g.Expect(err).NotTo(HaveOccurred())
+
 			cs, err := proxy.NewClient()
-			if err != nil {
-				t.Fatalf("NewClient() error = %v", err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+
 			for _, want := range tt.wantDiff {
 				obj := &unstructured.Unstructured{}
 				obj.SetAPIVersion(want.object.APIVersion)

--- a/cmd/clusterctl/client/cluster/installer_test.go
+++ b/cmd/clusterctl/client/cluster/installer_test.go
@@ -19,6 +19,8 @@ package cluster
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
@@ -27,6 +29,8 @@ import (
 )
 
 func Test_providerInstaller_Validate(t *testing.T) {
+	g := NewWithT(t)
+
 	fakeReader := test.NewFakeReader().
 		WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 		WithProvider("infra1", clusterctlv1.InfrastructureProviderType, "https://somewhere.com").
@@ -203,10 +207,13 @@ func Test_providerInstaller_Validate(t *testing.T) {
 				},
 				installQueue: tt.fields.installQueue,
 			}
-			if err := i.Validate(); (err != nil) != tt.wantErr {
-				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
 
+			err := i.Validate()
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
 		})
 	}
 }
@@ -261,6 +268,8 @@ func newFakeComponents(name string, providerType clusterctlv1.ProviderType, vers
 }
 
 func Test_shouldInstallSharedComponents(t *testing.T) {
+	g := NewWithT(t)
+
 	type args struct {
 		providerList *clusterctlv1.ProviderList
 		provider     clusterctlv1.Provider
@@ -317,17 +326,12 @@ func Test_shouldInstallSharedComponents(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := shouldInstallSharedComponents(tt.args.providerList, tt.args.provider)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
-
-			if got != tt.want {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }

--- a/cmd/clusterctl/client/cluster/inventory_managementgroup_test.go
+++ b/cmd/clusterctl/client/cluster/inventory_managementgroup_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package cluster
 
 import (
-	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -27,6 +28,8 @@ import (
 )
 
 func Test_inventoryClient_GetManagementGroups(t *testing.T) {
+	g := NewWithT(t)
+
 	type fields struct {
 		proxy Proxy
 	}
@@ -147,17 +150,12 @@ func Test_inventoryClient_GetManagementGroups(t *testing.T) {
 				proxy: tt.fields.proxy,
 			}
 			got, err := p.GetManagementGroups()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
-
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }

--- a/cmd/clusterctl/client/cluster/upgrader_info_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_info_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package cluster
 
 import (
-	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -29,6 +30,8 @@ import (
 )
 
 func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
+	g := NewWithT(t)
+
 	type fields struct {
 		reader     config.Reader
 		repository repository.Repository
@@ -157,17 +160,19 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 				},
 			}
 			got, err := u.getUpgradeInfo(tt.args.provider)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
 
 func Test_upgradeInfo_getContractsForUpgrade(t *testing.T) {
+	g := NewWithT(t)
+
 	type field struct {
 		currentVersion string
 		metadata       *clusterctlv1.Metadata
@@ -231,15 +236,14 @@ func Test_upgradeInfo_getContractsForUpgrade(t *testing.T) {
 			upgradeInfo := newUpgradeInfo(tt.field.metadata, version.MustParseSemantic(tt.field.currentVersion), nil)
 
 			got := upgradeInfo.getContractsForUpgrade()
-
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
 
 func Test_upgradeInfo_getLatestNextVersion(t *testing.T) {
+	g := NewWithT(t)
+
 	type field struct {
 		currentVersion string
 		nextVersions   []string
@@ -328,10 +332,7 @@ func Test_upgradeInfo_getLatestNextVersion(t *testing.T) {
 			upgradeInfo := newUpgradeInfo(tt.field.metadata, version.MustParseSemantic(tt.field.currentVersion), toSemanticVersions(tt.field.nextVersions))
 
 			got := upgradeInfo.getLatestNextVersion(tt.args.contract)
-
-			if versionTag(got) != tt.want {
-				t.Errorf("got = %v, want %v", versionTag(got), tt.want)
-			}
+			g.Expect(versionTag(got)).To(Equal(tt.want))
 		})
 	}
 }

--- a/cmd/clusterctl/client/cluster/upgrader_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package cluster
 
 import (
-	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
@@ -27,6 +28,8 @@ import (
 )
 
 func Test_providerUpgrader_Plan(t *testing.T) {
+	g := NewWithT(t)
+
 	type fields struct {
 		reader     config.Reader
 		repository map[string]repository.Repository
@@ -490,21 +493,20 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				providerInventory: newInventoryClient(tt.fields.proxy, nil),
 			}
 			got, err := u.Plan()
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
 
 func Test_providerUpgrader_createCustomPlan(t *testing.T) {
+	g := NewWithT(t)
+
 	type fields struct {
 		reader     config.Reader
 		repository map[string]repository.Repository
@@ -780,16 +782,13 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				providerInventory: newInventoryClient(tt.fields.proxy, nil),
 			}
 			got, err := u.createCustomPlan(tt.args.coreProvider, tt.args.providersToUpgrade)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
standardize gomega imports for `cmd/clusterctl/client/cluster/**` tests
will open other PR for the other folders to make easier the review

/cc @vincepri @detiber 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubernetes-sigs/cluster-api/issues/2433
