### PR TITLE
🏃cmd-clusterctl-client-config/tests: standardize gomega imports

### DIFF
--- a/cmd/clusterctl/client/config/imagemeta_client_test.go
+++ b/cmd/clusterctl/client/config/imagemeta_client_test.go
@@ -19,10 +19,14 @@ package config
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 )
 
 func Test_imageMetaClient_AlterImage(t *testing.T) {
+	g := NewWithT(t)
+
 	type fields struct {
 		reader Reader
 	}
@@ -131,16 +135,13 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 			p := newImageMetaClient(tt.fields.reader)
 
 			got, err := p.AlterImage(tt.args.component, tt.args.image)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			if got != tt.want {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }

--- a/cmd/clusterctl/client/config/providers_client_test.go
+++ b/cmd/clusterctl/client/config/providers_client_test.go
@@ -18,15 +18,18 @@ package config
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 )
 
 func Test_providers_List(t *testing.T) {
+	g := NewWithT(t)
+
 	reader := test.NewFakeReader()
 
 	p := &providersClient{
@@ -121,21 +124,20 @@ func Test_providers_List(t *testing.T) {
 				reader: tt.fields.configGetter,
 			}
 			got, err := p.List()
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
 
 func Test_validateProvider(t *testing.T) {
+	g := NewWithT(t)
+
 	type args struct {
 		r Provider
 	}
@@ -217,8 +219,11 @@ func Test_validateProvider(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := validateProvider(tt.args.r); (err != nil) != tt.wantErr {
-				t.Errorf("error = %v, wantErr %v", err, tt.wantErr)
+			err := validateProvider(tt.args.r)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 		})
 	}
@@ -227,6 +232,8 @@ func Test_validateProvider(t *testing.T) {
 // check if Defaults returns valid provider repository configurations
 // this is a safeguard for catching changes leading to formally invalid default configurations
 func Test_providers_Defaults(t *testing.T) {
+	g := NewWithT(t)
+
 	reader := test.NewFakeReader()
 
 	p := &providersClient{
@@ -237,13 +244,13 @@ func Test_providers_Defaults(t *testing.T) {
 
 	for _, d := range defaults {
 		err := validateProvider(d)
-		if err != nil {
-			t.Errorf("error = %v, want %v", err, nil)
-		}
+		g.Expect(err).NotTo(HaveOccurred())
 	}
 }
 
 func Test_providers_Get(t *testing.T) {
+	g := NewWithT(t)
+
 	reader := test.NewFakeReader()
 
 	p := &providersClient{
@@ -314,16 +321,13 @@ func Test_providers_Get(t *testing.T) {
 				reader: reader,
 			}
 			got, err := p.Get(tt.args.name, tt.args.providerType)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }

--- a/cmd/clusterctl/client/config/reader_viper_test.go
+++ b/cmd/clusterctl/client/config/reader_viper_test.go
@@ -21,22 +21,21 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func Test_viperReader_Get(t *testing.T) {
+	g := NewWithT(t)
+
 	dir, err := ioutil.TempDir("", "clusterctl")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir() error = %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
 	defer os.RemoveAll(dir)
 
 	os.Setenv("FOO", "foo")
 
 	configFile := filepath.Join(dir, ".clusterctl.yaml")
-
-	if err := ioutil.WriteFile(configFile, []byte("bar: bar"), 0640); err != nil {
-		t.Fatalf("ioutil.WriteFile() error = %v", err)
-	}
+	g.Expect(ioutil.WriteFile(configFile, []byte("bar: bar"), 0640)).To(Succeed())
 
 	type args struct {
 		key string
@@ -76,40 +75,32 @@ func Test_viperReader_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			v := &viperReader{}
 
-			err := v.Init(configFile)
-			if err != nil {
-				t.Fatal(err)
-			}
+			g.Expect(v.Init(configFile)).To(Succeed())
 
 			got, err := v.Get(tt.args.key)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			if got != tt.want {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
 
 func Test_viperReader_Set(t *testing.T) {
+	g := NewWithT(t)
+
 	dir, err := ioutil.TempDir("", "clusterctl")
-	if err != nil {
-		t.Fatalf("ioutil.TempDir() error = %v", err)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
 	defer os.RemoveAll(dir)
 
 	os.Setenv("FOO", "foo")
 
 	configFile := filepath.Join(dir, ".clusterctl.yaml")
 
-	if err := ioutil.WriteFile(configFile, []byte("bar: bar"), 0640); err != nil {
-		t.Fatalf("ioutil.WriteFile() error = %v", err)
-	}
+	g.Expect(ioutil.WriteFile(configFile, []byte("bar: bar"), 0640)).To(Succeed())
 
 	type args struct {
 		key   string
@@ -133,21 +124,13 @@ func Test_viperReader_Set(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			v := &viperReader{}
 
-			err := v.Init(configFile)
-			if err != nil {
-				t.Fatal(err)
-			}
+			g.Expect(v.Init(configFile)).To(Succeed())
 
 			v.Set(tt.args.key, tt.args.value)
 
 			got, err := v.Get(tt.args.key)
-			if err != nil {
-				t.Fatalf("error = %v", err)
-			}
-
-			if got != tt.want {
-				t.Errorf("got = %v, want %v (Set() did not worked)", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }

--- a/cmd/clusterctl/client/config/variables_client_test.go
+++ b/cmd/clusterctl/client/config/variables_client_test.go
@@ -19,10 +19,14 @@ package config
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 )
 
 func Test_variables_Get(t *testing.T) {
+	g := NewWithT(t)
+
 	reader := test.NewFakeReader().WithVar("foo", "bar")
 
 	type args struct {
@@ -57,16 +61,13 @@ func Test_variables_Get(t *testing.T) {
 				reader: reader,
 			}
 			got, err := p.Get(tt.args.key)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			if got != tt.want {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
standardize gomega imports for `cmd/clusterctl/client/config/**` tests
will open other PR for the other folders to make easier the review

/cc @vincepri @detiber 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubernetes-sigs/cluster-api/issues/2433
