### PR TITLE
quick-start.md: fix typo related to clusterctl

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -54,7 +54,7 @@ Once the management cluster is ready, you can create the first workload cluster.
 
 ### Preparing the Workload cluster configuration
 
-The `clusterctl create config` command returns a YAML template for creating a [workload cluster].
+The `clusterctl config cluster` command returns a YAML template for creating a [workload cluster].
 
 <aside class="note">
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Fixes a typo in the quick start guide.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2639