### PR TITLE
🏃cmd-clusterctl-client-repository/test: standardize gomega imports

### DIFF
--- a/cmd/clusterctl/client/repository/client_test.go
+++ b/cmd/clusterctl/client/repository/client_test.go
@@ -20,12 +20,16 @@ import (
 	"os"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 )
 
 func Test_newRepositoryClient_LocalFileSystemRepository(t *testing.T) {
+	g := NewWithT(t)
+
 	tmpDir := createTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
@@ -33,9 +37,7 @@ func Test_newRepositoryClient_LocalFileSystemRepository(t *testing.T) {
 	dst2 := createLocalTestProviderFile(t, tmpDir, "bootstrap-bar/v2.0.0/bootstrap-components.yaml", "")
 
 	configClient, err := config.New("", config.InjectReader(test.NewFakeReader()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
 
 	type fields struct {
 		provider config.Provider
@@ -60,12 +62,10 @@ func Test_newRepositoryClient_LocalFileSystemRepository(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			repoClient, err := newRepositoryClient(tt.fields.provider, configClient)
-			if err != nil {
-				t.Fatalf("got error %v when none was expected", err)
-			}
-			if _, ok := repoClient.repository.(*localRepository); !ok {
-				t.Fatalf("got repository of type %T when *repository.localRepository was expected", repoClient.repository)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+
+			_, ok := repoClient.repository.(*localRepository)
+			g.Expect(ok).To(BeTrue())
 		})
 	}
 }

--- a/cmd/clusterctl/client/repository/metadata_client_test.go
+++ b/cmd/clusterctl/client/repository/metadata_client_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package repository
 
 import (
-	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
@@ -35,6 +36,8 @@ var metadataYaml = []byte("apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3\n" +
 	"")
 
 func Test_metadataClient_Get(t *testing.T) {
+	g := NewWithT(t)
+
 	type fields struct {
 		provider   config.Provider
 		version    string
@@ -139,16 +142,13 @@ func Test_metadataClient_Get(t *testing.T) {
 				repository: tt.fields.repository,
 			}
 			got, err := f.Get()
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
standardize gomega imports for `cmd/clusterctl/client/repository/**` tests
will open other PR for the other folders to make easier the review

/cc @vincepri @detiber 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubernetes-sigs/cluster-api/issues/2433
