### PR TITLE
🐛 Validate MHC MaxUnhealthy strings are percentages

### DIFF
--- a/api/v1alpha3/machinehealthcheck_webhook.go
+++ b/api/v1alpha3/machinehealthcheck_webhook.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -117,6 +118,13 @@ func (m *MachineHealthCheck) validate(old *MachineHealthCheck) error {
 				allErrs,
 				field.Invalid(field.NewPath("spec", "maxUnhealthy"), m.Spec.MaxUnhealthy, "must be either an int or a percentage"),
 			)
+		} else if m.Spec.MaxUnhealthy.Type == intstr.String {
+			if len(validation.IsValidPercent(m.Spec.MaxUnhealthy.StrVal)) != 0 {
+				allErrs = append(
+					allErrs,
+					field.Invalid(field.NewPath("spec", "maxUnhealthy"), m.Spec.MaxUnhealthy, "must be either an int or a percentage"),
+				)
+			}
 		}
 	}
 

--- a/api/v1alpha3/machinehealthcheck_webhook_test.go
+++ b/api/v1alpha3/machinehealthcheck_webhook_test.go
@@ -206,6 +206,11 @@ func TestMachineHealthCheckMaxUnhealthy(t *testing.T) {
 			value:     intstr.Parse("abcdef"),
 			expectErr: true,
 		},
+		{
+			name:      "when the value stringified integer",
+			value:     intstr.FromString("10"),
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

It is currently possible to put `{"spec": {"maxUnhealthy": 1}}` and `{"spec": {"maxUnhealthy": "1"}}` and get different behaviour within MHC. Within the `apps` group types, they validate that the string values are valid percentages before persisting, thus allowing the bug that I hit during the demo today to go unnoticed for such a long time.

I've added this validation to the webhook for MHC and this should prevent users from hitting this in the future