### PR TITLE
:running: Move KCP/internal machine filters in a package

### DIFF
--- a/controlplane/kubeadm/controllers/fakes_test.go
+++ b/controlplane/kubeadm/controllers/fakes_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blang/semver"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/machinefilters"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,7 +40,7 @@ func (f *fakeManagementCluster) GetWorkloadCluster(_ context.Context, _ client.O
 	return f.Workload, nil
 }
 
-func (f *fakeManagementCluster) GetMachinesForCluster(c context.Context, n client.ObjectKey, filters ...internal.MachineFilter) (internal.FilterableMachineCollection, error) {
+func (f *fakeManagementCluster) GetMachinesForCluster(c context.Context, n client.ObjectKey, filters ...machinefilters.Func) (internal.FilterableMachineCollection, error) {
 	if f.Management != nil {
 		return f.Management.GetMachinesForCluster(c, n, filters...)
 	}

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/machinefilters"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -165,7 +166,7 @@ func TestGetMachinesForCluster(t *testing.T) {
 	}
 
 	// Test the OwnedControlPlaneMachines works
-	machines, err = m.GetMachinesForCluster(context.Background(), clusterKey, OwnedControlPlaneMachines("my-control-plane"))
+	machines, err = m.GetMachinesForCluster(context.Background(), clusterKey, machinefilters.OwnedControlPlaneMachines("my-control-plane"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +178,7 @@ func TestGetMachinesForCluster(t *testing.T) {
 	nameFilter := func(cluster *clusterv1.Machine) bool {
 		return cluster.Name == "first-machine"
 	}
-	machines, err = m.GetMachinesForCluster(context.Background(), clusterKey, OwnedControlPlaneMachines("my-control-plane"), nameFilter)
+	machines, err = m.GetMachinesForCluster(context.Background(), clusterKey, machinefilters.OwnedControlPlaneMachines("my-control-plane"), nameFilter)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/controlplane/kubeadm/internal/machine_collection.go
+++ b/controlplane/kubeadm/internal/machine_collection.go
@@ -31,6 +31,7 @@ import (
 	"sort"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/machinefilters"
 	"sigs.k8s.io/cluster-api/util"
 )
 
@@ -90,7 +91,7 @@ func (s FilterableMachineCollection) Len() int {
 	return len(s)
 }
 
-func newFilteredMachineCollection(filter MachineFilter, machines ...*clusterv1.Machine) FilterableMachineCollection {
+func newFilteredMachineCollection(filter machinefilters.Func, machines ...*clusterv1.Machine) FilterableMachineCollection {
 	ss := make(FilterableMachineCollection, len(machines))
 	for i := range machines {
 		m := machines[i]
@@ -102,13 +103,13 @@ func newFilteredMachineCollection(filter MachineFilter, machines ...*clusterv1.M
 }
 
 // Filter returns a FilterableMachineCollection containing only the Machines that match all of the given MachineFilters
-func (s FilterableMachineCollection) Filter(filters ...MachineFilter) FilterableMachineCollection {
-	return newFilteredMachineCollection(And(filters...), s.unsortedList()...)
+func (s FilterableMachineCollection) Filter(filters ...machinefilters.Func) FilterableMachineCollection {
+	return newFilteredMachineCollection(machinefilters.And(filters...), s.unsortedList()...)
 }
 
 // AnyFilter returns a FilterableMachineCollection containing only the Machines that match any of the given MachineFilters
-func (s FilterableMachineCollection) AnyFilter(filters ...MachineFilter) FilterableMachineCollection {
-	return newFilteredMachineCollection(Or(filters...), s.unsortedList()...)
+func (s FilterableMachineCollection) AnyFilter(filters ...machinefilters.Func) FilterableMachineCollection {
+	return newFilteredMachineCollection(machinefilters.Or(filters...), s.unsortedList()...)
 }
 
 // Oldest returns the Machine with the oldest CreationTimestamp

--- a/controlplane/kubeadm/internal/machinefilters/machine_filters_test.go
+++ b/controlplane/kubeadm/internal/machinefilters/machine_filters_test.go
@@ -14,18 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package internal
+package machinefilters_test
 
 import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/machinefilters"
 )
 
 func falseFilter(machine *clusterv1.Machine) bool {
@@ -38,153 +39,153 @@ func trueFilter(machine *clusterv1.Machine) bool {
 
 func TestNot(t *testing.T) {
 	t.Run("returns false given a machine filter that returns true", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(Not(trueFilter)(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.Not(trueFilter)(m)).To(BeFalse())
 	})
 	t.Run("returns true given a machine filter that returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(Not(falseFilter)(m)).To(gomega.BeTrue())
+		g.Expect(machinefilters.Not(falseFilter)(m)).To(BeTrue())
 	})
 }
 
 func TestAnd(t *testing.T) {
 	t.Run("returns true if both given machine filters return true", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(And(trueFilter, trueFilter)(m)).To(gomega.BeTrue())
+		g.Expect(machinefilters.And(trueFilter, trueFilter)(m)).To(BeTrue())
 	})
 	t.Run("returns false if either given machine filter returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(And(trueFilter, falseFilter)(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.And(trueFilter, falseFilter)(m)).To(BeFalse())
 	})
 }
 
 func TestOr(t *testing.T) {
 	t.Run("returns true if either given machine filters return true", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(Or(trueFilter, falseFilter)(m)).To(gomega.BeTrue())
+		g.Expect(machinefilters.Or(trueFilter, falseFilter)(m)).To(BeTrue())
 	})
 	t.Run("returns false if both given machine filter returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(Or(falseFilter, falseFilter)(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.Or(falseFilter, falseFilter)(m)).To(BeFalse())
 	})
 }
 
 func TestHasDeletionTimestamp(t *testing.T) {
 	t.Run("machine with deletion timestamp returns true", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
 		now := metav1.Now()
 		m.SetDeletionTimestamp(&now)
-		g.Expect(HasDeletionTimestamp(m)).To(gomega.BeTrue())
+		g.Expect(machinefilters.HasDeletionTimestamp(m)).To(BeTrue())
 	})
 	t.Run("machine with nil deletion timestamp returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(HasDeletionTimestamp(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.HasDeletionTimestamp(m)).To(BeFalse())
 	})
 	t.Run("machine with zero deletion timestamp returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
 		zero := metav1.NewTime(time.Time{})
 		m.SetDeletionTimestamp(&zero)
-		g.Expect(HasDeletionTimestamp(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.HasDeletionTimestamp(m)).To(BeFalse())
 	})
 }
 
 func TestMatchesConfigurationHash(t *testing.T) {
 	t.Run("machine with configuration hash returns true", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		m.SetLabels(ControlPlaneLabelsForClusterWithHash("test", "hashValue"))
-		g.Expect(MatchesConfigurationHash("hashValue")(m)).To(gomega.BeTrue())
+		m.SetLabels(internal.ControlPlaneLabelsForClusterWithHash("test", "hashValue"))
+		g.Expect(machinefilters.MatchesConfigurationHash("hashValue")(m)).To(BeTrue())
 	})
 	t.Run("machine with wrong configuration hash returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		m.SetLabels(ControlPlaneLabelsForClusterWithHash("test", "notHashValue"))
-		g.Expect(MatchesConfigurationHash("hashValue")(m)).To(gomega.BeFalse())
+		m.SetLabels(internal.ControlPlaneLabelsForClusterWithHash("test", "notHashValue"))
+		g.Expect(machinefilters.MatchesConfigurationHash("hashValue")(m)).To(BeFalse())
 	})
 	t.Run("machine without configuration hash returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(MatchesConfigurationHash("hashValue")(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.MatchesConfigurationHash("hashValue")(m)).To(BeFalse())
 	})
 }
 
 func TestOlderThan(t *testing.T) {
 	t.Run("machine with creation timestamp older than given returns true", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
 		m.SetCreationTimestamp(metav1.NewTime(time.Now().Add(-1 * time.Hour)))
 		now := metav1.Now()
-		g.Expect(OlderThan(&now)(m)).To(gomega.BeTrue())
+		g.Expect(machinefilters.OlderThan(&now)(m)).To(BeTrue())
 	})
 	t.Run("machine with creation timestamp equal to given returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
 		now := metav1.Now()
 		m.SetCreationTimestamp(now)
-		g.Expect(OlderThan(&now)(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.OlderThan(&now)(m)).To(BeFalse())
 	})
 	t.Run("machine with creation timestamp after given returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
 		m.SetCreationTimestamp(metav1.NewTime(time.Now().Add(+1 * time.Hour)))
 		now := metav1.Now()
-		g.Expect(OlderThan(&now)(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.OlderThan(&now)(m)).To(BeFalse())
 	})
 }
 
 func TestHashAnnotationKey(t *testing.T) {
 	t.Run("machine with specified annotation returns true", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
 		m.SetAnnotations(map[string]string{"test": ""})
-		g.Expect(HasAnnotationKey("test")(m)).To(gomega.BeTrue())
+		g.Expect(machinefilters.HasAnnotationKey("test")(m)).To(BeTrue())
 	})
 	t.Run("machine with specified annotation with non-empty value returns true", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
 		m.SetAnnotations(map[string]string{"test": "blue"})
-		g.Expect(HasAnnotationKey("test")(m)).To(gomega.BeTrue())
+		g.Expect(machinefilters.HasAnnotationKey("test")(m)).To(BeTrue())
 	})
 	t.Run("machine without specified annotation returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(HasAnnotationKey("foo")(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.HasAnnotationKey("foo")(m)).To(BeFalse())
 	})
 }
 
 func TestInFailureDomain(t *testing.T) {
 	t.Run("machine with given failure domain returns true", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: pointer.StringPtr("test")}}
-		g.Expect(InFailureDomains(pointer.StringPtr("test"))(m)).To(gomega.BeTrue())
+		g.Expect(machinefilters.InFailureDomains(pointer.StringPtr("test"))(m)).To(BeTrue())
 	})
 	t.Run("machine with a different failure domain returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: pointer.StringPtr("notTest")}}
-		g.Expect(InFailureDomains(pointer.StringPtr("test"), pointer.StringPtr("foo"))(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.InFailureDomains(pointer.StringPtr("test"), pointer.StringPtr("foo"))(m)).To(BeFalse())
 	})
 	t.Run("machine without failure domain returns false", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(InFailureDomains(pointer.StringPtr("test"))(m)).To(gomega.BeFalse())
+		g.Expect(machinefilters.InFailureDomains(pointer.StringPtr("test"))(m)).To(BeFalse())
 	})
 	t.Run("machine without failure domain returns true, when nil used for failure domain", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{}
-		g.Expect(InFailureDomains(nil)(m)).To(gomega.BeTrue())
+		g.Expect(machinefilters.InFailureDomains(nil)(m)).To(BeTrue())
 	})
 	t.Run("machine with failure domain returns true, when one of multiple failure domains match", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		m := &clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: pointer.StringPtr("test")}}
-		g.Expect(InFailureDomains(pointer.StringPtr("foo"), pointer.StringPtr("test"))(m)).To(gomega.BeTrue())
+		g.Expect(machinefilters.InFailureDomains(pointer.StringPtr("foo"), pointer.StringPtr("test"))(m)).To(BeTrue())
 	})
 }


### PR DESCRIPTION
Related to #2423, by moving these filters out and rewriting the tests to only work with the exposed APIs, this allows us to continue standardizing around dot-import gomega in the kcp/internal package.

/assign @cpanato 
/cc @detiber 
/milestone v0.3.1