### PR TITLE
🏃 speed up e2e image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,4 +11,7 @@ scripts/
 tilt-settings.json
 tilt.d/
 Tiltfile
+**/.tiltbuild
+test/infrastructure/docker/e2e/logs/**
+**/config/**/*.yaml
 _artifacts

--- a/Tiltfile
+++ b/Tiltfile
@@ -118,7 +118,7 @@ FROM gcr.io/distroless/base:debug as tilt
 WORKDIR /
 COPY --from=tilt-helper /start.sh .
 COPY --from=tilt-helper /restart.sh .
-COPY .tiltbuild/manager .
+COPY manager .
 """
 
 # Configures a provider by doing the following:
@@ -160,11 +160,11 @@ def enable_provider(name):
     # build into the container.
     docker_build(
         ref = p.get("image"),
-        context = context,
+        context = context + "/.tiltbuild/",
         dockerfile_contents = dockerfile_contents,
         target = "tilt",
         entrypoint = ["sh", "/start.sh", "/manager"],
-        only = ".tiltbuild/manager",
+        only = "manager",
         live_update = [
             sync(context + "/.tiltbuild/manager", "/manager"),
             run("sh /restart.sh"),

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -18,6 +18,20 @@ FROM golang:1.13.8 as builder
 ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
 
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Essentially, change directories into CAPD
+WORKDIR /workspace/test/infrastructure/docker
+# Copy the Go Modules manifests
+COPY test/infrastructure/docker/go.mod go.mod
+COPY test/infrastructure/docker/go.sum go.sum
+
+# Cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
 # This needs to build with the entire Cluster API context
 WORKDIR /workspace
 # Copy in cluster-api (which includes the test/infrastructure/docker subdirectory)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Reduced repeat work on image builds, and shrinks the docker context that gets sent over the wire.

