### PR TITLE
🏃  Update clusterctl overview to remove confusion on presence of GUI

### DIFF
--- a/docs/book/src/clusterctl/overview.md
+++ b/docs/book/src/clusterctl/overview.md
@@ -2,7 +2,7 @@
 
 The `clusterctl` CLI tool handles the lifecycle of a Cluster API [management cluster].
 
-The `clusterctl` user interface is specifically designed for providing a simple "day 1 experience" and a
+The `clusterctl` command line interface is specifically designed for providing a simple "day 1 experience" and a
 quick start with Cluster API; it automates fetching the YAML files defining [provider components] and installing them.
 
 Additionally it encodes a set of best practices in managing providers, that helps the user in avoiding 


### PR DESCRIPTION
Make it a little clearer that there is no GUI for `clusterctl`

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
