### PR TITLE
✨LeaderElection configuration as flags

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -59,13 +59,16 @@ func init() {
 }
 
 var (
-	metricsAddr              string
-	enableLeaderElection     bool
-	watchNamespace           string
-	profilerAddress          string
-	kubeadmConfigConcurrency int
-	syncPeriod               time.Duration
-	webhookPort              int
+	metricsAddr                 string
+	enableLeaderElection        bool
+	leaderElectionLeaseDuration time.Duration
+	leaderElectionRenewDeadline time.Duration
+	leaderElectionRetryPeriod   time.Duration
+	watchNamespace              string
+	profilerAddress             string
+	kubeadmConfigConcurrency    int
+	syncPeriod                  time.Duration
+	webhookPort                 int
 )
 
 func InitFlags(fs *pflag.FlagSet) {
@@ -74,6 +77,15 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+
+	fs.DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second,
+		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)")
+
+	fs.DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second,
+		"Duration that the acting master will retry refreshing leadership before giving up (duration string)")
+
+	fs.DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second,
+		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
 	fs.StringVar(&watchNamespace, "namespace", "",
 		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
@@ -115,6 +127,9 @@ func main() {
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "kubeadm-bootstrap-manager-leader-election-capi",
+		LeaseDuration:      &leaderElectionLeaseDuration,
+		RenewDeadline:      &leaderElectionRenewDeadline,
+		RetryPeriod:        &leaderElectionRetryPeriod,
 		Namespace:          watchNamespace,
 		SyncPeriod:         &syncPeriod,
 		NewClient:          newClientFunc,

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -58,6 +58,9 @@ func init() {
 var (
 	metricsAddr                    string
 	enableLeaderElection           bool
+	leaderElectionLeaseDuration    time.Duration
+	leaderElectionRenewDeadline    time.Duration
+	leaderElectionRetryPeriod      time.Duration
 	watchNamespace                 string
 	profilerAddress                string
 	kubeadmControlPlaneConcurrency int
@@ -72,6 +75,15 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+
+	fs.DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second,
+		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)")
+
+	fs.DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second,
+		"Duration that the acting master will retry refreshing leadership before giving up (duration string)")
+
+	fs.DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second,
+		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
 	fs.StringVar(&watchNamespace, "namespace", "",
 		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
@@ -107,6 +119,9 @@ func main() {
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "kubeadm-control-plane-manager-leader-election-capi",
+		LeaseDuration:      &leaderElectionLeaseDuration,
+		RenewDeadline:      &leaderElectionRenewDeadline,
+		RetryPeriod:        &leaderElectionRetryPeriod,
 		Namespace:          watchNamespace,
 		SyncPeriod:         &syncPeriod,
 		NewClient:          newClientFunc,

--- a/main.go
+++ b/main.go
@@ -50,6 +50,9 @@ var (
 	// flags
 	metricsAddr                   string
 	enableLeaderElection          bool
+	leaderElectionLeaseDuration   time.Duration
+	leaderElectionRenewDeadline   time.Duration
+	leaderElectionRetryPeriod     time.Duration
 	watchNamespace                string
 	profilerAddress               string
 	clusterConcurrency            int
@@ -81,6 +84,15 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+
+	fs.DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second,
+		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)")
+
+	fs.DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second,
+		"Duration that the acting master will retry refreshing leadership before giving up (duration string)")
+
+	fs.DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second,
+		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
 	fs.StringVar(&watchNamespace, "namespace", "",
 		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
@@ -137,6 +149,9 @@ func main() {
 		MetricsBindAddress:     metricsAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "controller-leader-election-capi",
+		LeaseDuration:          &leaderElectionLeaseDuration,
+		RenewDeadline:          &leaderElectionRenewDeadline,
+		RetryPeriod:            &leaderElectionRetryPeriod,
 		Namespace:              watchNamespace,
 		SyncPeriod:             &syncPeriod,
 		NewClient:              newClientFunc,

--- a/third_party/kubernetes-drain/README.md
+++ b/third_party/kubernetes-drain/README.md
@@ -1,2 +1,2 @@
 The code in this directory has been copied from:
-github.com/kubernetes/kubectl/pkg/drain@846b394714fe1cb467fca0e259890b8ba2ec4544
+github.com/kubernetes/kubectl/pkg/drain@a17d91f9f5b34c73bed0bfc75b70bd762b725231

--- a/third_party/kubernetes-drain/drain.go
+++ b/third_party/kubernetes-drain/drain.go
@@ -357,7 +357,6 @@ func waitForDelete(params waitForDeleteParams) ([]corev1.Pod, error) {
 			default:
 				return false, nil
 			}
-			return false, nil
 		}
 		return true, nil
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables setting manager LeaderElection options via command line flags

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #2653 

I just implemented the optional settings in these two files but there's 3 other files where they could be implemented as well:

https://github.com/kubernetes-sigs/cluster-api/blob/master/controlplane/kubeadm/main.go
https://github.com/kubernetes-sigs/cluster-api/blob/master/test/infrastructure/docker/main.go
https://github.com/kubernetes-sigs/cluster-api/blob/master/cmd/example-provider/main.go

Do you think it makes sense to add the flags there too?