### PR TITLE
Separate tabs in quick start

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -277,7 +277,7 @@ discover the list of variables required by a cluster templates.
 Depending on the infrastructure provider you are planning to use, some additional prerequisites should be satisfied
 before configuring a cluster with Cluster API.
 
-{{#tabs name:"tab-installation-infrastructure" tabs:"AWS,Azure,Docker,GCP,vSphere,OpenStack,Metal3"}}
+{{#tabs name:"tab-configuration-infrastructure" tabs:"AWS,Azure,Docker,GCP,vSphere,OpenStack,Metal3"}}
 {{#tab AWS}}
 
 Download the latest binary of `clusterawsadm` from the [AWS provider releases] and make sure to place it in your path.


### PR DESCRIPTION
Fixes something reported by @detiber 

> Just noticed an issue with the docs thanks to a discussion with @christianh814. It looks like if you click on one of the tabs in this section https://cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers, it expands and links to the associated tab in the Initialization for common providers section rather than it's own section