### PR TITLE
🏃 controllers/test: standardize gomega imports

### DIFF
--- a/controllers/machinedeployment_sync_test.go
+++ b/controllers/machinedeployment_sync_test.go
@@ -19,6 +19,8 @@ package controllers
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -26,6 +28,8 @@ import (
 )
 
 func TestMachineDeploymentSyncStatus(t *testing.T) {
+	g := NewWithT(t)
+
 	msStatusError := capierrors.MachineSetStatusError("some failure")
 
 	var tests = map[string]struct {
@@ -212,10 +216,7 @@ func TestMachineDeploymentSyncStatus(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			actualStatus := calculateStatus(test.machineSets, test.newMachineSet, test.deployment)
-			if actualStatus != test.expectedStatus {
-				t.Errorf("Expected %+v but got %+v", test.expectedStatus, actualStatus)
-			}
+			g.Expect(actualStatus).To(Equal(test.expectedStatus))
 		})
-
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
standardize gomega imports for `controllers/` tests

/cc @vincepri @detiber 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubernetes-sigs/cluster-api/issues/2433

