### PR TITLE
🏃mark defaulted fields as optional

### DIFF
--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -104,8 +104,9 @@ spec:
                       values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                     type: string
                   certificatesDir:
-                    description: CertificatesDir specifies where to store or look
-                      for all required certificates.
+                    description: 'CertificatesDir specifies where to store or look
+                      for all required certificates. NB: if not provided, this will
+                      default to `/etc/kubernetes/pki`'
                     type: string
                   clusterName:
                     description: The cluster name
@@ -187,7 +188,8 @@ spec:
                         type: string
                     type: object
                   etcd:
-                    description: Etcd holds configuration for etcd.
+                    description: 'Etcd holds configuration for etcd. NB: This value
+                      defaults to a Local (stacked) etcd'
                     properties:
                       external:
                         description: External describes how to connect to an external
@@ -292,14 +294,16 @@ spec:
                           Defaults to "cluster.local".
                         type: string
                       podSubnet:
-                        description: PodSubnet is the subnet used by pods.
+                        description: PodSubnet is the subnet used by pods. If unset,
+                          the API server will not allocate CIDR ranges for every node.
+                          Defaults to the first element of the Cluster object's spec.clusterNetwork.services.cidrBlocks
+                          if that is set
                         type: string
                       serviceSubnet:
                         description: ServiceSubnet is the subnet used by k8s services.
-                          Defaults to "10.96.0.0/12".
+                          Defaults to the first element of the Cluster object's spec.clusterNetwork.pods.cidrBlocks
+                          field, or to "10.96.0.0/12" if that's unset.
                         type: string
-                    required:
-                    - podSubnet
                     type: object
                   scheduler:
                     description: Scheduler contains extra settings for the scheduler
@@ -720,8 +724,6 @@ spec:
                           type: object
                         type: array
                     type: object
-                required:
-                - nodeRegistration
                 type: object
               ntp:
                 description: NTP specifies NTP configuration
@@ -907,8 +909,9 @@ spec:
                       values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                     type: string
                   certificatesDir:
-                    description: CertificatesDir specifies where to store or look
-                      for all required certificates.
+                    description: 'CertificatesDir specifies where to store or look
+                      for all required certificates. NB: if not provided, this will
+                      default to `/etc/kubernetes/pki`'
                     type: string
                   clusterName:
                     description: The cluster name
@@ -990,7 +993,8 @@ spec:
                         type: string
                     type: object
                   etcd:
-                    description: Etcd holds configuration for etcd.
+                    description: 'Etcd holds configuration for etcd. NB: This value
+                      defaults to a Local (stacked) etcd'
                     properties:
                       external:
                         description: External describes how to connect to an external
@@ -1095,14 +1099,16 @@ spec:
                           Defaults to "cluster.local".
                         type: string
                       podSubnet:
-                        description: PodSubnet is the subnet used by pods.
+                        description: PodSubnet is the subnet used by pods. If unset,
+                          the API server will not allocate CIDR ranges for every node.
+                          Defaults to the first element of the Cluster object's spec.clusterNetwork.services.cidrBlocks
+                          if that is set
                         type: string
                       serviceSubnet:
                         description: ServiceSubnet is the subnet used by k8s services.
-                          Defaults to "10.96.0.0/12".
+                          Defaults to the first element of the Cluster object's spec.clusterNetwork.pods.cidrBlocks
+                          field, or to "10.96.0.0/12" if that's unset.
                         type: string
-                    required:
-                    - podSubnet
                     type: object
                   scheduler:
                     description: Scheduler contains extra settings for the scheduler
@@ -1523,8 +1529,6 @@ spec:
                           type: object
                         type: array
                     type: object
-                required:
-                - nodeRegistration
                 type: object
               ntp:
                 description: NTP specifies NTP configuration

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -113,8 +113,9 @@ spec:
                               and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                             type: string
                           certificatesDir:
-                            description: CertificatesDir specifies where to store
-                              or look for all required certificates.
+                            description: 'CertificatesDir specifies where to store
+                              or look for all required certificates. NB: if not provided,
+                              this will default to `/etc/kubernetes/pki`'
                             type: string
                           clusterName:
                             description: The cluster name
@@ -201,7 +202,8 @@ spec:
                                 type: string
                             type: object
                           etcd:
-                            description: Etcd holds configuration for etcd.
+                            description: 'Etcd holds configuration for etcd. NB: This
+                              value defaults to a Local (stacked) etcd'
                             properties:
                               external:
                                 description: External describes how to connect to
@@ -314,13 +316,17 @@ spec:
                                 type: string
                               podSubnet:
                                 description: PodSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR
+                                  ranges for every node. Defaults to the first element
+                                  of the Cluster object's spec.clusterNetwork.services.cidrBlocks
+                                  if that is set
                                 type: string
                               serviceSubnet:
                                 description: ServiceSubnet is the subnet used by k8s
-                                  services. Defaults to "10.96.0.0/12".
+                                  services. Defaults to the first element of the Cluster
+                                  object's spec.clusterNetwork.pods.cidrBlocks field,
+                                  or to "10.96.0.0/12" if that's unset.
                                 type: string
-                            required:
-                            - podSubnet
                             type: object
                           scheduler:
                             description: Scheduler contains extra settings for the
@@ -764,8 +770,6 @@ spec:
                                   type: object
                                 type: array
                             type: object
-                        required:
-                        - nodeRegistration
                         type: object
                       ntp:
                         description: NTP specifies NTP configuration
@@ -947,8 +951,9 @@ spec:
                               and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                             type: string
                           certificatesDir:
-                            description: CertificatesDir specifies where to store
-                              or look for all required certificates.
+                            description: 'CertificatesDir specifies where to store
+                              or look for all required certificates. NB: if not provided,
+                              this will default to `/etc/kubernetes/pki`'
                             type: string
                           clusterName:
                             description: The cluster name
@@ -1035,7 +1040,8 @@ spec:
                                 type: string
                             type: object
                           etcd:
-                            description: Etcd holds configuration for etcd.
+                            description: 'Etcd holds configuration for etcd. NB: This
+                              value defaults to a Local (stacked) etcd'
                             properties:
                               external:
                                 description: External describes how to connect to
@@ -1148,13 +1154,17 @@ spec:
                                 type: string
                               podSubnet:
                                 description: PodSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR
+                                  ranges for every node. Defaults to the first element
+                                  of the Cluster object's spec.clusterNetwork.services.cidrBlocks
+                                  if that is set
                                 type: string
                               serviceSubnet:
                                 description: ServiceSubnet is the subnet used by k8s
-                                  services. Defaults to "10.96.0.0/12".
+                                  services. Defaults to the first element of the Cluster
+                                  object's spec.clusterNetwork.pods.cidrBlocks field,
+                                  or to "10.96.0.0/12" if that's unset.
                                 type: string
-                            required:
-                            - podSubnet
                             type: object
                           scheduler:
                             description: Scheduler contains extra settings for the
@@ -1598,8 +1608,6 @@ spec:
                                   type: object
                                 type: array
                             type: object
-                        required:
-                        - nodeRegistration
                         type: object
                       ntp:
                         description: NTP specifies NTP configuration

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -175,8 +175,9 @@ spec:
                           values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                         type: string
                       certificatesDir:
-                        description: CertificatesDir specifies where to store or look
-                          for all required certificates.
+                        description: 'CertificatesDir specifies where to store or
+                          look for all required certificates. NB: if not provided,
+                          this will default to `/etc/kubernetes/pki`'
                         type: string
                       clusterName:
                         description: The cluster name
@@ -261,7 +262,8 @@ spec:
                             type: string
                         type: object
                       etcd:
-                        description: Etcd holds configuration for etcd.
+                        description: 'Etcd holds configuration for etcd. NB: This
+                          value defaults to a Local (stacked) etcd'
                         properties:
                           external:
                             description: External describes how to connect to an external
@@ -368,14 +370,18 @@ spec:
                               Defaults to "cluster.local".
                             type: string
                           podSubnet:
-                            description: PodSubnet is the subnet used by pods.
+                            description: PodSubnet is the subnet used by pods. If
+                              unset, the API server will not allocate CIDR ranges
+                              for every node. Defaults to the first element of the
+                              Cluster object's spec.clusterNetwork.services.cidrBlocks
+                              if that is set
                             type: string
                           serviceSubnet:
                             description: ServiceSubnet is the subnet used by k8s services.
-                              Defaults to "10.96.0.0/12".
+                              Defaults to the first element of the Cluster object's
+                              spec.clusterNetwork.pods.cidrBlocks field, or to "10.96.0.0/12"
+                              if that's unset.
                             type: string
-                        required:
-                        - podSubnet
                         type: object
                       scheduler:
                         description: Scheduler contains extra settings for the scheduler
@@ -809,8 +815,6 @@ spec:
                               type: object
                             type: array
                         type: object
-                    required:
-                    - nodeRegistration
                     type: object
                   ntp:
                     description: NTP specifies NTP configuration


### PR DESCRIPTION
Perhaps easier to iterate on than a full kubernetes cluster

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Addresses some odd defaulting behavior in the KCP webhook, as well as smoothing out some UX.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1941
