### PR TITLE
🏃test/tests: standardize gomega imports

### DIFF
--- a/test/framework/types_test.go
+++ b/test/framework/types_test.go
@@ -19,14 +19,15 @@ package framework_test
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"sigs.k8s.io/cluster-api/test/framework"
 )
 
 func TestTypeToKind(t *testing.T) {
+	g := NewWithT(t)
+
 	type hello struct{}
 
-	out := framework.TypeToKind(&hello{})
-	if out != "hello" {
-		t.Fatalf("Expected %q from pointer input but got %q", "hello", out)
-	}
+	g.Expect(framework.TypeToKind(&hello{})).To(Equal("hello"))
 }

--- a/test/infrastructure/docker/cloudinit/kindadapter_test.go
+++ b/test/infrastructure/docker/cloudinit/kindadapter_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package cloudinit
 
 import (
-	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestRealUseCase(t *testing.T) {
+	g := NewWithT(t)
+
 	cloudData := []byte(`
 #cloud-config
 
@@ -137,19 +140,12 @@ write_files:
 	}
 
 	commands, err := Commands(cloudData)
-	if err != nil {
-		t.Fatalf("Run returned unexpected errors %v", err)
-	}
-	if len(commands) != len(expectedCmds) {
-		t.Fatal("commands and expected commands should be the same length")
-	}
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(commands).To(HaveLen(len(expectedCmds)))
+
 	for i, cmd := range commands {
 		expected := expectedCmds[i]
-		if cmd.Cmd != expected.Cmd {
-			t.Fatalf("commands should be the same: %s vs %s", cmd.Cmd, expected.Cmd)
-		}
-		if !reflect.DeepEqual(cmd.Args, expected.Args) {
-			t.Fatalf("command args should be the same: %v vs %v", cmd.Args, expected.Cmd)
-		}
+		g.Expect(cmd.Cmd).To(Equal(expected.Cmd))
+		g.Expect(cmd.Args).To(ConsistOf(expected.Args))
 	}
 }

--- a/test/infrastructure/docker/cloudinit/unknown_test.go
+++ b/test/infrastructure/docker/cloudinit/unknown_test.go
@@ -17,34 +17,29 @@ limitations under the License.
 package cloudinit
 
 import (
-	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestUnknown_Run(t *testing.T) {
+	g := NewWithT(t)
+
 	u := &unknown{
 		lines: []string{},
 	}
 	lines, err := u.Commands()
-	if err != nil {
-		t.Fatal("err should always be nil")
-	}
-	if len(lines) != 0 {
-		t.Fatalf("return exactly what was parsed. did not expect anything here but got: %v", lines)
-	}
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(lines).To(HaveLen(0))
 }
 
 func TestUnknown_Unmarshal(t *testing.T) {
+	g := NewWithT(t)
+
 	u := &unknown{}
 	expected := []string{"test 1", "test 2", "test 3"}
 	input := `["test 1", "test 2", "test 3"]`
-	if err := u.Unmarshal([]byte(input)); err != nil {
-		t.Fatalf("should not return an error but got: %v", err)
-	}
-	if len(u.lines) != len(expected) {
-		t.Fatalf("expected exactly %v lines but got %v", 3, u.lines)
-	}
-	if !reflect.DeepEqual(u.lines, expected) {
-		t.Fatalf("lines should be %v but it is %v", expected, u.lines)
-	}
+
+	g.Expect(u.Unmarshal([]byte(input))).To(Succeed())
+	g.Expect(u.lines).To(Equal(expected))
 }

--- a/test/infrastructure/docker/cloudinit/writefiles_test.go
+++ b/test/infrastructure/docker/cloudinit/writefiles_test.go
@@ -19,11 +19,14 @@ package cloudinit
 import (
 	"bytes"
 	"compress/gzip"
-	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestWriteFiles(t *testing.T) {
+	g := NewWithT(t)
+
 	var useCases = []struct {
 		name         string
 		w            writeFilesAction
@@ -87,18 +90,15 @@ func TestWriteFiles(t *testing.T) {
 	for _, rt := range useCases {
 		t.Run(rt.name, func(t *testing.T) {
 			cmds, err := rt.w.Commands()
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if !reflect.DeepEqual(rt.expectedCmds, cmds) {
-				t.Errorf("Expected %s, got %s", rt.expectedCmds, cmds)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(rt.expectedCmds).To(Equal(cmds))
 		})
 	}
 }
 
 func TestFixContent(t *testing.T) {
+	g := NewWithT(t)
+
 	v := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	gv, _ := gZipData([]byte(v))
 	var useCases = []struct {
@@ -131,28 +131,24 @@ func TestFixContent(t *testing.T) {
 		t.Run(rt.name, func(t *testing.T) {
 			encoding := fixEncoding(rt.encoding)
 			c, err := fixContent(rt.content, encoding)
-
-			if err == nil && rt.expectedError {
-				t.Error("Expected error, got nil")
-			}
-			if err != nil && !rt.expectedError {
-				t.Errorf("Expected nil, got error %v", err)
+			if rt.expectedError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
 			}
 
-			if rt.expectedContent != c {
-				t.Errorf("Expected %s, got %s", rt.expectedContent, c)
-			}
+			g.Expect(rt.expectedContent).To(Equal(c))
 		})
 	}
 }
 
 func TestUnzipData(t *testing.T) {
+	g := NewWithT(t)
+
 	value := []byte("foobarbazquxfoobarbazquxfoobarbazquxfoobarbazquxfoobarbazquxfoobarbazquxfoobarbazquxfoobarbazquxfoobarbazqux")
 	gvalue, _ := gZipData(value)
 	dvalue, _ := gUnzipData(gvalue)
-	if !bytes.Equal(value, dvalue) {
-		t.Errorf("ss")
-	}
+	g.Expect(value).To(Equal(dvalue))
 }
 
 func gZipData(data []byte) ([]byte, error) {

--- a/test/infrastructure/docker/controllers/dockermachine_controller_test.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller_test.go
@@ -19,6 +19,8 @@ package controllers
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,6 +48,8 @@ func setupScheme() *runtime.Scheme {
 }
 
 func TestDockerMachineReconciler_DockerClusterToDockerMachines(t *testing.T) {
+	g := NewWithT(t)
+
 	clusterName := "my-cluster"
 	dockerCluster := newDockerCluster(clusterName, "my-docker-cluster")
 	dockerMachine1 := newDockerMachine("my-docker-machine-0")
@@ -71,23 +75,8 @@ func TestDockerMachineReconciler_DockerClusterToDockerMachines(t *testing.T) {
 	for i := range out {
 		machineNames[i] = out[i].Name
 	}
-	if len(out) != 2 {
-		t.Fatal("expected 2 docker machines to reconcile but got", len(out))
-	}
-	for _, expectedName := range []string{"my-machine-0", "my-machine-1"} {
-		if !contains(machineNames, expectedName) {
-			t.Fatalf("expected %q in slice %v", expectedName, machineNames)
-		}
-	}
-}
-
-func contains(haystack []string, needle string) bool {
-	for _, straw := range haystack {
-		if straw == needle {
-			return true
-		}
-	}
-	return false
+	g.Expect(out).To(HaveLen(2))
+	g.Expect(machineNames).To(ConsistOf("my-machine-0", "my-machine-1"))
 }
 
 func newCluster(clusterName string) *clusterv1.Cluster {


### PR DESCRIPTION
**What this PR does / why we need it**:
standardize gomega imports for `test/*/***` tests
will open other PR for the other folders to make easier the review


/cc @vincepri @detiber 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to https://github.com/kubernetes-sigs/cluster-api/issues/2433

