### PR TITLE
✨Add kubeadm control plane manager role aggregation label

### DIFF
--- a/controlplane/kubeadm/config/default/kustomization.yaml
+++ b/controlplane/kubeadm/config/default/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
 bases:
 - ../rbac
 - ../manager
+
+patchesStrategicMerge:
+- manager_role_aggregation_patch.yaml

--- a/controlplane/kubeadm/config/default/manager_role_aggregation_patch.yaml
+++ b/controlplane/kubeadm/config/default/manager_role_aggregation_patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manager-role
+  labels:
+    kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aggregated-manager-role

--- a/controlplane/kubeadm/config/rbac/aggregated_role.yaml
+++ b/controlplane/kubeadm/config/rbac/aggregated_role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aggregated-manager-role
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+rules: []

--- a/controlplane/kubeadm/config/rbac/kustomization.yaml
+++ b/controlplane/kubeadm/config/rbac/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
+- aggregated_role.yaml


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**: In a similar way to https://github.com/kubernetes-sigs/cluster-api/pull/1980 this PR adds an aggregation label to the kubeadm control plane manager role to ease integration with non-SIG sponsored infrastructure providers.

Not too sure if there's a good place for some documentation - I'm not sure what the minimal permissions are, but I believe the following would be enough for any foo infrastructure provider:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: capi-kubeadm-control-plane-foo
  labels:
    kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
rules:
- apiGroups:
  - infrastructure.foo.com
  resources:
  - foomachines
  - foomachinetemplates
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
```