### PR TITLE
🏃 clusterctl: log which value clusterctl mover is setting when pausing

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -286,7 +286,7 @@ func setClusterPause(proxy Proxy, clusters []*node, value bool) error {
 	patch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"spec\":{\"paused\":%t}}", value)))
 
 	for _, cluster := range clusters {
-		log.V(5).Info("Set Cluster.Spec.Paused", value, "Cluster", cluster.identity.Name, "Namespace", cluster.identity.Namespace)
+		log.V(5).Info("Set Cluster.Spec.Paused", "Paused", value, "Cluster", cluster.identity.Name, "Namespace", cluster.identity.Namespace)
 
 		cFrom, err := proxy.NewClient()
 		if err != nil {

--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -286,7 +286,7 @@ func setClusterPause(proxy Proxy, clusters []*node, value bool) error {
 	patch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"spec\":{\"paused\":%t}}", value)))
 
 	for _, cluster := range clusters {
-		log.V(5).Info("Set Cluster.Spec.Paused", "Cluster", cluster.identity.Name, "Namespace", cluster.identity.Namespace)
+		log.V(5).Info("Set Cluster.Spec.Paused", value, "Cluster", cluster.identity.Name, "Namespace", cluster.identity.Namespace)
 
 		cFrom, err := proxy.NewClient()
 		if err != nil {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
 clusterctl: log which value clusterctl mover is setting when pausing

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2677
