### PR TITLE
:bug: controlplane: Normalise image name for kube-proxy, and validate Kubernetes versions

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -43,7 +43,8 @@ type KubeadmControlPlaneSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Version defines the desired Kubernetes version.
-	// +kubebuilder:validation:MinLength:=1
+	// +kubebuilder:validation:MinLength:=2
+	// +kubebuilder:validation:Pattern:=^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$
 	Version string `json:"version"`
 
 	// InfrastructureTemplate is a required reference to a custom resource

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
@@ -221,6 +221,21 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			ImageTag: "v9.1.1",
 		},
 	}
+
+	etcdLocalImageBuildTag := before.DeepCopy()
+	etcdLocalImageBuildTag.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local = &kubeadmv1beta1.LocalEtcd{
+		ImageMeta: kubeadmv1beta1.ImageMeta{
+			ImageTag: "v9.1.1_validBuild1",
+		},
+	}
+
+	etcdLocalImageInvalidTag := before.DeepCopy()
+	etcdLocalImageInvalidTag.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local = &kubeadmv1beta1.LocalEtcd{
+		ImageMeta: kubeadmv1beta1.ImageMeta{
+			ImageTag: "v9.1.1+invalidBuild1",
+		},
+	}
+
 	unsetEtcd := etcdLocalImageTag.DeepCopy()
 	unsetEtcd.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local = nil
 
@@ -253,6 +268,22 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 		ImageMeta: kubeadmv1beta1.ImageMeta{
 			ImageRepository: "gcr.io/capi-test",
 			ImageTag:        "v0.20.0",
+		},
+	}
+
+	dnsBuildTag := before.DeepCopy()
+	dnsBuildTag.Spec.KubeadmConfigSpec.ClusterConfiguration.DNS = kubeadmv1beta1.DNS{
+		ImageMeta: kubeadmv1beta1.ImageMeta{
+			ImageRepository: "gcr.io/capi-test",
+			ImageTag:        "v0.20.0_build1",
+		},
+	}
+
+	dnsInvalidTag := before.DeepCopy()
+	dnsInvalidTag.Spec.KubeadmConfigSpec.ClusterConfiguration.DNS = kubeadmv1beta1.DNS{
+		ImageMeta: kubeadmv1beta1.ImageMeta{
+			ImageRepository: "gcr.io/capi-test",
+			ImageTag:        "v0.20.0+invalidBuild1",
 		},
 	}
 
@@ -393,6 +424,18 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			kcp:       etcdLocalImageTag,
 		},
 		{
+			name:      "should succeed when making a change to the local etcd image tag",
+			expectErr: false,
+			before:    before,
+			kcp:       etcdLocalImageBuildTag,
+		},
+		{
+			name:      "should fail when using an invalid etcd image tag",
+			expectErr: true,
+			before:    before,
+			kcp:       etcdLocalImageInvalidTag,
+		},
+		{
 			name:      "should fail when making a change to the cluster config's networking struct",
 			expectErr: true,
 			before:    before,
@@ -429,10 +472,22 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			kcp:       scheduler,
 		},
 		{
-			name:      "should fail when making a change to the cluster config's dns",
+			name:      "should succeed when making a change to the cluster config's dns",
 			expectErr: false,
 			before:    before,
 			kcp:       dns,
+		},
+		{
+			name:      "should succeed when using an valid DNS build",
+			expectErr: false,
+			before:    before,
+			kcp:       dnsBuildTag,
+		},
+		{
+			name:      "should fail when using an invalid DNS build",
+			expectErr: true,
+			before:    before,
+			kcp:       dnsInvalidTag,
 		},
 		{
 			name:      "should fail when making a change to the cluster config's certificatesDir",

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -908,7 +908,8 @@ spec:
                 type: string
               version:
                 description: Version defines the desired Kubernetes version.
-                minLength: 1
+                minLength: 2
+                pattern: ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$
                 type: string
             required:
             - infrastructureTemplate

--- a/controlplane/kubeadm/internal/workload_cluster_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_test.go
@@ -26,9 +26,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCluster_ReconcileKubeletRBACBinding_NoError(t *testing.T) {
@@ -108,53 +111,75 @@ func TestCluster_ReconcileKubeletRBACBinding_Error(t *testing.T) {
 	}
 }
 
-func TestUpdateKubeProxyImageInfo(t *testing.T) {
-	ds := &appsv1.DaemonSet{
+func newKubeProxyDS() appsv1.DaemonSet {
+	return appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeProxyKey,
+			Namespace: metav1.NamespaceSystem,
+		},
 		Spec: appsv1.DaemonSetSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Image: "k8s.gcr.io/kube-proxy:v1.16.2"}},
+					Containers: []corev1.Container{
+						{
+							Image: "k8s.gcr.io/kube-proxy:v1.16.2",
+							Name:  "kube-proxy",
+						},
+					},
 				},
 			},
 		},
 	}
+}
 
-	dsImageInDigestFormat := ds.DeepCopy()
-	dsImageInDigestFormat.Spec.Template.Spec.Containers[0].Image = "k8s.gcr.io/kube-proxy@sha256:47bfd"
+func newKubeProxyDSWithImage(image string) appsv1.DaemonSet {
+	ds := newKubeProxyDS()
+	ds.Spec.Template.Spec.Containers[0].Image = image
+	return ds
+}
 
-	dsImageEmpty := ds.DeepCopy()
-	dsImageEmpty.Spec.Template.Spec.Containers[0].Image = ""
+func TestUpdateKubeProxyImageInfo(t *testing.T) {
+
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("unable to setup scheme: %s", err)
+	}
 
 	tests := []struct {
-		name      string
-		ds        *appsv1.DaemonSet
-		expectErr bool
-		clientGet map[string]interface{}
-		patchErr  error
+		name        string
+		ds          appsv1.DaemonSet
+		expectErr   bool
+		expectImage string
+		clientGet   map[string]interface{}
+		patchErr    error
+		KCP         *v1alpha3.KubeadmControlPlane
 	}{
 		{
-			name:      "succeeds if patch correctly",
-			ds:        ds,
-			expectErr: false,
-			clientGet: map[string]interface{}{
-				"kube-system/" + kubeProxyDaemonSetName: ds,
-			},
+			name:        "succeeds if patch correctly",
+			ds:          newKubeProxyDS(),
+			expectErr:   false,
+			expectImage: "k8s.gcr.io/kube-proxy:v1.16.3",
+			KCP:         &v1alpha3.KubeadmControlPlane{Spec: v1alpha3.KubeadmControlPlaneSpec{Version: "v1.16.3"}},
 		},
 		{
-			name:      "returns error if image in kube-proxy ds was in digest format",
-			ds:        dsImageInDigestFormat,
-			expectErr: true,
-			clientGet: map[string]interface{}{
-				"kube-system/" + kubeProxyDaemonSetName: dsImageInDigestFormat,
-			},
+			name:        "returns error if image in kube-proxy ds was in digest format",
+			ds:          newKubeProxyDSWithImage("k8s.gcr.io/kube-proxy@sha256:47bfd"),
+			expectErr:   true,
+			expectImage: "k8s.gcr.io/kube-proxy@sha256:47bfd",
+			KCP:         &v1alpha3.KubeadmControlPlane{Spec: v1alpha3.KubeadmControlPlaneSpec{Version: "v1.16.3"}},
+		},
+		{
+			name:        "expects OCI compatible format of tag",
+			ds:          newKubeProxyDS(),
+			expectErr:   false,
+			expectImage: "k8s.gcr.io/kube-proxy:v1.16.3_build1",
+			KCP:         &v1alpha3.KubeadmControlPlane{Spec: v1alpha3.KubeadmControlPlaneSpec{Version: "v1.16.3+build1"}},
 		},
 		{
 			name:      "returns error if image in kube-proxy ds was in wrong format",
-			ds:        ds,
+			ds:        newKubeProxyDSWithImage(""),
 			expectErr: true,
-			clientGet: map[string]interface{}{
-				"kube-system/" + kubeProxyDaemonSetName: dsImageEmpty,
-			},
+			KCP:       &v1alpha3.KubeadmControlPlane{Spec: v1alpha3.KubeadmControlPlaneSpec{Version: "v1.16.3"}},
 		},
 	}
 
@@ -162,21 +187,43 @@ func TestUpdateKubeProxyImageInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			fakeClient := &fakeClient{
-				get: tt.clientGet,
+			objects := []runtime.Object{
+				&tt.ds,
 			}
-			c := &Workload{
+			fakeClient := fake.NewFakeClientWithScheme(scheme, objects...)
+			w := &Workload{
 				Client: fakeClient,
 			}
-			err := c.UpdateKubeProxyImageInfo(ctx, &v1alpha3.KubeadmControlPlane{Spec: v1alpha3.KubeadmControlPlaneSpec{Version: "v1.16.3"}})
+			err := w.UpdateKubeProxyImageInfo(ctx, tt.KCP)
 			if err != nil && !tt.expectErr {
 				t.Fatalf("expected no error, got %s", err)
 			}
 			if err == nil && tt.expectErr {
 				t.Fatal("expected error but got none")
 			}
-
+			proxyImage, err := getProxyImageInfo(ctx, w.Client)
+			if err != nil {
+				t.Fatalf("expected no error, got %s", err)
+			}
+			if proxyImage != tt.expectImage {
+				t.Fatalf("expected proxy image %s, got %s", tt.expectImage, proxyImage)
+			}
 		})
 	}
+}
+
+func getProxyImageInfo(ctx context.Context, client ctrlclient.Client) (string, error) {
+	ds := &appsv1.DaemonSet{}
+
+	if err := client.Get(ctx, ctrlclient.ObjectKey{Name: kubeProxyKey, Namespace: metav1.NamespaceSystem}, ds); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", errors.New("no image found")
+		}
+		return "", errors.New("failed to determine if daemonset already exists")
+	}
+	container := findKubeProxyContainer(ds)
+	if container == nil {
+		return "", errors.New("unable to find container")
+	}
+	return container.Image, nil
 }

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -311,7 +311,7 @@ type ClusterGenerator struct {
 func (c *ClusterGenerator) GenerateCluster(namespace string, replicas int32) (*clusterv1.Cluster, *infrav1.DockerCluster, *controlplanev1.KubeadmControlPlane, *infrav1.DockerMachineTemplate) {
 	generatedName := fmt.Sprintf("test-%d", c.counter)
 	c.counter++
-	version := "1.16.3"
+	version := "v1.16.3"
 
 	infraCluster := &infrav1.DockerCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/util/util.go
+++ b/util/util.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strings"
 	"time"
 
@@ -51,6 +52,7 @@ var (
 	rnd                          = rand.New(rand.NewSource(time.Now().UnixNano()))
 	ErrNoCluster                 = fmt.Errorf("no %q label present", clusterv1.ClusterLabelName)
 	ErrUnstructuredFieldNotFound = fmt.Errorf("field not found")
+	ociTagAllowedChars           = regexp.MustCompile(`[^-a-zA-Z0-9_\.]`)
 )
 
 // RandomString returns a random alphanumeric string.
@@ -64,6 +66,8 @@ func RandomString(n int) string {
 
 // ModifyImageTag takes an imageName (e.g., registry/repo:tag), and returns an image name with updated tag
 func ModifyImageTag(imageName, tagName string) (string, error) {
+	normalisedTagName := SemverToOCIImageTag(tagName)
+
 	namedRef, err := reference.ParseNormalizedNamed(imageName)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse image name")
@@ -75,12 +79,17 @@ func ModifyImageTag(imageName, tagName string) (string, error) {
 	}
 
 	// update the image tag with tagName
-	namedTagged, err := reference.WithTag(namedRef, tagName)
+	namedTagged, err := reference.WithTag(namedRef, normalisedTagName)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to update image tag")
 	}
 
 	return reference.FamiliarString(reference.TagNameOnly(namedTagged)), nil
+}
+
+// ImageTagIsValid ensures that a given image tag is compliant with the OCI spec
+func ImageTagIsValid(tagName string) bool {
+	return !ociTagAllowedChars.MatchString(tagName)
 }
 
 // GetMachinesForCluster returns a list of machines associated with the cluster.
@@ -97,6 +106,17 @@ func GetMachinesForCluster(ctx context.Context, c client.Client, cluster *cluste
 		return nil, err
 	}
 	return &machines, nil
+}
+
+// SemVerToOCIImageTag is a helper function that replaces all
+// non-allowed symbols in tag strings with underscores.
+// Image tag can only contain lowercase and uppercase letters, digits,
+// underscores, periods and dashes.
+// Current usage is for CI images where all of symbols except '+' are valid,
+// but function is for generic usage where input can't be always pre-validated.
+// Taken from k8s.io/cmd/kubeadm/app/util
+func SemverToOCIImageTag(version string) string {
+	return ociTagAllowedChars.ReplaceAllString(version, "_")
 }
 
 // GetControlPlaneMachines returns a slice containing control plane machines.

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -428,6 +428,17 @@ func TestGetMachinesForCluster(t *testing.T) {
 	g.Expect(machines.Items[0].Labels[clusterv1.ClusterLabelName]).To(Equal(cluster.Name))
 }
 
+func TestModifyImageTag(t *testing.T) {
+	g := NewGomegaWithT(t)
+	t.Run("should ensure image is a docker compatible tag", func(t *testing.T) {
+		testTag := "v1.17.4+build1"
+		image := "example.com/image:1.17.3"
+		res, err := ModifyImageTag(image, testTag)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res).To(Equal("example.com/image:v1.17.4_build1"))
+	})
+}
+
 func TestEnsureOwnerRef(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Normalises the image name for kube-proxy to support build suffixes for versioning.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2689 

Marking as WIP as smoke tests are conducted.