### PR TITLE
✨ KCP: Move etcd leadership to newest Machine when upgrading

### DIFF
--- a/controlplane/kubeadm/controllers/fakes_test.go
+++ b/controlplane/kubeadm/controllers/fakes_test.go
@@ -66,7 +66,7 @@ type fakeWorkloadCluster struct {
 	Status internal.ClusterStatus
 }
 
-func (f fakeWorkloadCluster) ForwardEtcdLeadership(_ context.Context, _ *clusterv1.Machine) error {
+func (f fakeWorkloadCluster) ForwardEtcdLeadership(_ context.Context, _ *clusterv1.Machine, _ *clusterv1.Machine) error {
 	return nil
 }
 

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -1665,7 +1665,7 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 		},
 	}
 
-	_, err := r.scaleDownControlPlane(context.Background(), &clusterv1.Cluster{}, &controlplanev1.KubeadmControlPlane{}, machines)
+	_, err := r.scaleDownControlPlane(context.Background(), &clusterv1.Cluster{}, &controlplanev1.KubeadmControlPlane{}, machines, machines)
 	g.Expect(err).ToNot(HaveOccurred())
 }
 

--- a/controlplane/kubeadm/internal/machine_collection.go
+++ b/controlplane/kubeadm/internal/machine_collection.go
@@ -120,6 +120,14 @@ func (s FilterableMachineCollection) Oldest() *clusterv1.Machine {
 	return s.list()[0]
 }
 
+// Newest returns the Machine with the most recent CreationTimestamp
+func (s FilterableMachineCollection) Newest() *clusterv1.Machine {
+	if len(s) == 0 {
+		return nil
+	}
+	return s.list()[len(s)-1]
+}
+
 // DeepCopy returns a deep copy
 func (s FilterableMachineCollection) DeepCopy() FilterableMachineCollection {
 	result := make(FilterableMachineCollection, len(s))


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR is a follow-up to #2525. To avoid multiple leadership changes, we now use the information available to the controller to always move the leadership to the last Machine created.

/milestone v0.3.2
/priority critical-urgent
/assign @detiber @ncdc 
/cc @chuckha @rudoi @sethp-nr 
