### PR TITLE
🐛CoreDNS validation should only look at major.minor.patch

### DIFF
--- a/util/util_test.go
+++ b/util/util_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/blang/semver"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +34,54 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+func TestParseMajorMinorPatch(t *testing.T) {
+	g := NewWithT(t)
+
+	var testcases = []struct {
+		name        string
+		input       string
+		output      semver.Version
+		expectError bool
+	}{
+		{
+			name:  "should parse an OCI compliant string",
+			input: "v1.2.16_foo-1",
+			output: semver.Version{
+				Major: 1,
+				Minor: 2,
+				Patch: 16,
+			},
+		},
+		{
+			name:  "should parse a valid semver",
+			input: "v1.16.6+foobar-0",
+			output: semver.Version{
+				Major: 1,
+				Minor: 16,
+				Patch: 6,
+			},
+		},
+		{
+			name:        "should error if there is no patch version",
+			input:       "v1.16+foobar-0",
+			expectError: true,
+		},
+		{
+			name:        "should error if there is no minor and patch",
+			input:       "v1+foobar-0",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := ParseMajorMinorPatch(tc.input)
+			g.Expect(err != nil).To(Equal(tc.expectError))
+			g.Expect(out).To(Equal(tc.output))
+		})
+	}
+}
 
 func TestMachineToInfrastructureMapFunc(t *testing.T) {
 	g := NewWithT(t)


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
/assign @fabriziopandini 
