### PR TITLE
:bug: KCP spec.clusterConfiguration.imageRepository should not have "coredns/"

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -1071,7 +1071,7 @@ func TestKubeadmControlPlaneReconciler_updateCoreDNS(t *testing.T) {
 					DNS: kubeadmv1.DNS{
 						Type: kubeadmv1.CoreDNS,
 						ImageMeta: kubeadmv1.ImageMeta{
-							ImageRepository: "k8s.gcr.io/coredns",
+							ImageRepository: "k8s.gcr.io",
 							ImageTag:        "1.7.2",
 						},
 					},

--- a/controlplane/kubeadm/internal/workload_cluster_coredns.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns.go
@@ -151,7 +151,7 @@ func (w *Workload) getCoreDNSInfo(ctx context.Context, dns *kubeadmv1.DNS) (*cor
 	// Handle imageRepository.
 	toImageRepository := fmt.Sprintf("%s/%s", reference.Domain(parsedImage), reference.Path(parsedImage))
 	if dns.ImageRepository != "" {
-		toImageRepository = dns.ImageRepository
+		toImageRepository = fmt.Sprintf("%s/%s", dns.ImageRepository, reference.Path(parsedImage))
 	}
 
 	// Handle imageTag.

--- a/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
@@ -318,7 +318,7 @@ func TestGetCoreDNSInfo(t *testing.T) {
 
 		dns := &kubeadmv1.DNS{
 			ImageMeta: kubeadmv1.ImageMeta{
-				ImageRepository: "myrepo/coredns",
+				ImageRepository: "myrepo",
 				ImageTag:        "1.7.2-foobar.1",
 			},
 		}


### PR DESCRIPTION


Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
/assign @frapposelli 
/milestone v0.3.2
/priority critical-urgent