### PR TITLE
:bug: leadership forwarding for removed members

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -498,7 +498,7 @@ func (w *Workload) ForwardEtcdLeadership(ctx context.Context, machine *clusterv1
 
 	// TODO we'd probably prefer to pass in all the known nodes and let grpc handle retrying connections across them
 	clientMachineName := machine.Status.NodeRef.Name
-	if leaderCandidate != nil && leaderCandidate.Status.NodeRef == nil {
+	if leaderCandidate != nil && leaderCandidate.Status.NodeRef != nil {
 		// connect to the new leader candidate, in case machine's etcd membership has already been removed
 		clientMachineName = leaderCandidate.Status.NodeRef.Name
 	}
@@ -515,10 +515,7 @@ func (w *Workload) ForwardEtcdLeadership(ctx context.Context, machine *clusterv1
 	}
 
 	currentMember := etcdutil.MemberForName(members, machine.Status.NodeRef.Name)
-	if currentMember == nil {
-		return errors.Errorf("failed to get etcd member from node %q", machine.Status.NodeRef.Name)
-	}
-	if currentMember.ID != etcdClient.LeaderID {
+	if currentMember == nil || currentMember.ID != etcdClient.LeaderID {
 		return nil
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

If a node is not a member, it can't be a leader. Instead of erroring, consider it a job well done.

Also fixes a typo in my previous PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
