### PR TITLE
:bug: Disable link checker for external links in book

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,7 @@ verify-docker-provider:
 .PHONY: verify-book-links
 verify-book-links: $(LINK_CHECKER)
 	 # Ignore localhost links and set concurrency to a reasonable number
-	$(LINK_CHECKER) -r docs/book -x "^https?://localhost($|[:/].*)" -c 10
+	$(LINK_CHECKER) -r docs/book -x "^https?://" -c 10
 ## --------------------------------------
 ## Others / Utilities
 ## --------------------------------------


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR fixes the verify job by only checking local links and not external links.

