### PR TITLE
🐛 Remove a troublesome annotation

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -30,7 +30,6 @@ const (
 	SelectedForUpgradeAnnotation             = "kubeadm.controlplane.cluster.x-k8s.io/selected-for-upgrade"
 	UpgradeReplacementCreatedAnnotation      = "kubeadm.controlplane.cluster.x-k8s.io/upgrade-replacement-created"
 	DeleteForScaleDownAnnotation             = "kubeadm.controlplane.cluster.x-k8s.io/delete-for-scale-down"
-	ScaleDownEtcdMemberRemovedAnnotation     = "kubeadm.controlplane.cluster.x-k8s.io/scale-down-etcd-member-removed"
 	ScaleDownConfigMapEntryRemovedAnnotation = "kubeadm.controlplane.cluster.x-k8s.io/scale-down-configmap-entry-removed"
 )
 

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Docker", func() {
 				By("upgrading the control plane object to a new version")
 				patchHelper, err := patch.NewHelper(controlPlane, client)
 				Expect(err).ToNot(HaveOccurred())
-				controlPlane.Spec.Version = "1.17.2"
+				controlPlane.Spec.Version = "v1.17.2"
 				Expect(patchHelper.Patch(ctx, controlPlane)).To(Succeed())
 				By("waiting for all control plane nodes to exist")
 				inClustersNamespaceListOption := ctrlclient.InNamespace(cluster.Namespace)


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR removes the concept of marking a machine after removing the etcd member on that node. Since all the functions being called are now idempotent, it's ok if the process crashes at any point, it will not fail on these three specific lines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #2702 


