### PR TITLE
🐛 update worker kubernetes version in capd test template

### DIFF
--- a/cmd/clusterctl/test/testdata/docker/v0.3.0/cluster-template.yaml
+++ b/cmd/clusterctl/test/testdata/docker/v0.3.0/cluster-template.yaml
@@ -81,7 +81,7 @@ metadata:
   name: worker-0
   namespace: default
 spec:
-  version: "v1.14.2"
+  version: ${ KUBERNETES_VERSION }
   clusterName: ${ CLUSTER_NAME }
   bootstrap:
     configRef:


### PR DESCRIPTION

**What this PR does / why we need it**:

This change removes the hardcoded version for a worker node and replaces
it with the same template variable that is used for the master. If used
as a template it would always deploy a worker at version "1.14.2", it
should now properly substitute the same version for both master and
worker nodes.