### PR TITLE
✨ Add CAPO to clusterctl embedded metadata

### DIFF
--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -199,6 +199,17 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 					// older version are not supported by clusterctl
 				},
 			}
+		case config.OpenStackProviderName:
+			return &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "Metadata",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					// v1alpha3 release series
+					{Major: 0, Minor: 3, Contract: "v1alpha3"},
+				},
+			}
 		case config.VSphereProviderName:
 			return &clusterctlv1.Metadata{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

Add CAPO to the embedded hardcoded metadata. For the v0.3.* series of CAPO releases we will keep the metadata.yaml to avoid breaking old clusterctl versions

