### PR TITLE
🏃 clean up tests

### DIFF
--- a/controlplane/kubeadm/internal/failure_domain_test.go
+++ b/controlplane/kubeadm/internal/failure_domain_test.go
@@ -19,7 +19,7 @@ package internal
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"k8s.io/utils/pointer"
 
@@ -84,13 +84,13 @@ func TestNewFailureDomainPicker(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		t.Run(tc.name, func(t *testing.T) {
 			fd := PickFewest(tc.fds, tc.machines)
 			if tc.expected == nil {
-				g.Expect(fd).To(gomega.BeNil())
+				g.Expect(fd).To(BeNil())
 			} else {
-				g.Expect(fd).To(gomega.BeElementOf(tc.expected))
+				g.Expect(fd).To(BeElementOf(tc.expected))
 			}
 		})
 	}
@@ -155,13 +155,13 @@ func TestNewFailureDomainPickMost(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			fd := PickMost(tc.fds, tc.machines)
 			if tc.expected == nil {
-				g.Expect(fd).To(gomega.BeNil())
+				g.Expect(fd).To(BeNil())
 			} else {
-				g.Expect(fd).To(gomega.BeElementOf(tc.expected))
+				g.Expect(fd).To(BeElementOf(tc.expected))
 			}
 		})
 	}

--- a/controlplane/kubeadm/internal/kubeadm_config_map_test.go
+++ b/controlplane/kubeadm/internal/kubeadm_config_map_test.go
@@ -20,31 +20,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
 	"sigs.k8s.io/yaml"
 )
 
-var (
-	HaveOccurred     = gomega.HaveOccurred
-	Succeed          = gomega.Succeed
-	SatisfyAll       = gomega.SatisfyAll
-	HaveLen          = gomega.HaveLen
-	HaveKey          = gomega.HaveKey
-	HaveKeyWithValue = gomega.HaveKeyWithValue
-	WithTransform    = gomega.WithTransform
-	BeEmpty          = gomega.BeEmpty
-	Equal            = gomega.Equal
-	BeEquivalentTo   = gomega.BeEquivalentTo
-	BeTrue           = gomega.BeTrue
-	ContainSubstring = gomega.ContainSubstring
-	ConsistOf        = gomega.ConsistOf
-)
-
 func Test_kubeadmConfig_RemoveAPIEndpoint(t *testing.T) {
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	original := &corev1.ConfigMap{
 		Data: map[string]string{
 			"ClusterStatus": `apiEndpoints:
@@ -198,7 +182,7 @@ etcd:
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 
 			kconfig := &kubeadmConfig{
 				ConfigMap: &corev1.ConfigMap{
@@ -213,16 +197,16 @@ etcd:
 				g.Expect(err).ToNot(HaveOccurred())
 			} else {
 				g.Expect(err).To(HaveOccurred())
-				g.Expect(err.Error()).To(gomega.ContainSubstring(test.expectErr.Error()))
+				g.Expect(err.Error()).To(ContainSubstring(test.expectErr.Error()))
 			}
 
-			g.Expect(changed).To(gomega.Equal(test.expectChanged))
+			g.Expect(changed).To(Equal(test.expectChanged))
 			if changed {
 				if test.imageRepository != "" {
-					g.Expect(kconfig.ConfigMap.Data[clusterConfigurationKey]).To(gomega.ContainSubstring(test.imageRepository))
+					g.Expect(kconfig.ConfigMap.Data[clusterConfigurationKey]).To(ContainSubstring(test.imageRepository))
 				}
 				if test.imageTag != "" {
-					g.Expect(kconfig.ConfigMap.Data[clusterConfigurationKey]).To(gomega.ContainSubstring(test.imageTag))
+					g.Expect(kconfig.ConfigMap.Data[clusterConfigurationKey]).To(ContainSubstring(test.imageTag))
 				}
 			}
 
@@ -294,7 +278,7 @@ scheduler: {}`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			imageRepository := "gcr.io/example"
 			imageTag := "v1.0.1-sometag"
 			kc := kubeadmConfig{ConfigMap: tt.cm}

--- a/controlplane/kubeadm/internal/machine_collection.go
+++ b/controlplane/kubeadm/internal/machine_collection.go
@@ -67,8 +67,8 @@ func (s FilterableMachineCollection) Insert(machines ...*clusterv1.Machine) Filt
 	return s
 }
 
-// list returns the contents as a sorted Machine slice.
-func (s FilterableMachineCollection) list() []*clusterv1.Machine {
+// SortedByCreationTimestamp returns the machines sorted by creation timestamp
+func (s FilterableMachineCollection) SortedByCreationTimestamp() []*clusterv1.Machine {
 	res := make(util.MachinesByCreationTimestamp, 0, len(s))
 	for _, value := range s {
 		res = append(res, value)
@@ -117,7 +117,7 @@ func (s FilterableMachineCollection) Oldest() *clusterv1.Machine {
 	if len(s) == 0 {
 		return nil
 	}
-	return s.list()[0]
+	return s.SortedByCreationTimestamp()[0]
 }
 
 // Newest returns the Machine with the most recent CreationTimestamp
@@ -125,7 +125,7 @@ func (s FilterableMachineCollection) Newest() *clusterv1.Machine {
 	if len(s) == 0 {
 		return nil
 	}
-	return s.list()[len(s)-1]
+	return s.SortedByCreationTimestamp()[len(s)-1]
 }
 
 // DeepCopy returns a deep copy

--- a/controlplane/kubeadm/internal/machine_collection_test.go
+++ b/controlplane/kubeadm/internal/machine_collection_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+func TestMachineCollection(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Machine Collection Suite")
+}
+
+var _ = Describe("Machine Collection", func() {
+	Describe("FilterableMachineCollection", func() {
+		var collection FilterableMachineCollection
+		BeforeEach(func() {
+			collection = FilterableMachineCollection{
+				"machine-4": machine("machine-4", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 04, 02, 03, 04, 05, 06, time.UTC)})),
+				"machine-5": machine("machine-5", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 05, 02, 03, 04, 05, 06, time.UTC)})),
+				"machine-2": machine("machine-2", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 02, 02, 03, 04, 05, 06, time.UTC)})),
+				"machine-1": machine("machine-1", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 01, 02, 03, 04, 05, 06, time.UTC)})),
+				"machine-3": machine("machine-3", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 03, 02, 03, 04, 05, 06, time.UTC)})),
+			}
+		})
+		Context("SortedByAge", func() {
+			It("should return the same number of machines as are in the collection", func() {
+				sortedMachines := collection.SortedByCreationTimestamp()
+				Expect(sortedMachines).To(HaveLen(len(collection)))
+				Expect(sortedMachines[0].Name).To(Equal("machine-1"))
+				Expect(sortedMachines[len(sortedMachines)-1].Name).To(Equal("machine-5"))
+			})
+		})
+	})
+})
+
+/* Helper functions to build machine objects for tests */
+
+type machineOpt func(*clusterv1.Machine)
+
+func withCreationTimestamp(timestamp metav1.Time) machineOpt {
+	return func(m *clusterv1.Machine) {
+		m.CreationTimestamp = timestamp
+	}
+}
+
+func machine(name string, opts ...machineOpt) *clusterv1.Machine {
+	m := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}

--- a/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -94,7 +94,7 @@ func TestValidateCoreDNSImageTag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			err := validateCoreDNSImageTag(tt.fromVer, tt.toVer)
 			if tt.expectErrSubStr != "" {
 				g.Expect(err.Error()).To(ContainSubstring(tt.expectErrSubStr))
@@ -152,7 +152,7 @@ func TestUpdateCoreDNSCorefile(t *testing.T) {
 	}
 
 	t.Run("returns error if migrate failed to update corefile", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		objs := []runtime.Object{depl, cm}
 		fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, objs...)
 		fakeMigrator := &fakeMigrator{
@@ -182,7 +182,7 @@ func TestUpdateCoreDNSCorefile(t *testing.T) {
 	})
 
 	t.Run("creates a backup of the corefile", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		// Not including the deployment so as to fail early and verify that
 		// the intermediate config map update occurred
 		objs := []runtime.Object{cm}
@@ -214,7 +214,7 @@ func TestUpdateCoreDNSCorefile(t *testing.T) {
 	})
 
 	t.Run("patches the core dns deployment to point to the backup corefile before migration", func(t *testing.T) {
-		g := gomega.NewWithT(t)
+		g := NewWithT(t)
 		objs := []runtime.Object{depl, cm}
 		fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, objs...)
 		fakeMigrator := &fakeMigrator{
@@ -387,7 +387,7 @@ func TestGetCoreDNSInfo(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				g := gomega.NewWithT(t)
+				g := NewWithT(t)
 				fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, tt.objs...)
 				w := &Workload{
 					Client: fakeClient,
@@ -497,7 +497,7 @@ scheduler: {}`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, tt.objs...)
 			w := &Workload{
 				Client: fakeClient,
@@ -601,7 +601,7 @@ func TestUpdateCoreDNSDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			fakeClient := fake.NewFakeClientWithScheme(scheme.Scheme, tt.objs...)
 
 			w := &Workload{


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
The cleans up the imports since there is no longer any name conflict and adds a test to machine collection as well as exports a necessary field for use in fixing #2702 

