### PR TITLE
🐛 Etcd should talk to leader when moving leadership

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -541,6 +541,12 @@ func (w *Workload) ForwardEtcdLeadership(ctx context.Context, machine *clusterv1
 		return nil
 	}
 
+	// Move the etcd client to the current leader, which in this case is the machine we're about to delete.
+	etcdClient, err = w.etcdClientGenerator.forNode(ctx, machine.Status.NodeRef.Name)
+	if err != nil {
+		return errors.Wrap(err, "failed to create etcd Client")
+	}
+
 	// If we don't have a leader candidate, move the leader to the next available machine.
 	if leaderCandidate == nil || leaderCandidate.Status.NodeRef == nil {
 		for _, member := range members {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
/assign @chuckha 
