### PR TITLE
wip: 🏃 Refactor common parameter into object field

### DIFF
--- a/controlplane/kubeadm/controllers/fakes_test.go
+++ b/controlplane/kubeadm/controllers/fakes_test.go
@@ -36,25 +36,29 @@ type fakeManagementCluster struct {
 	Workload            fakeWorkloadCluster
 }
 
-func (f *fakeManagementCluster) GetWorkloadCluster(_ context.Context, _ client.ObjectKey) (internal.WorkloadCluster, error) {
+func (f *fakeManagementCluster) SetClusterKeyIfEmpty(key client.ObjectKey) {
+	f.Management.SetClusterKeyIfEmpty(key)
+}
+
+func (f *fakeManagementCluster) GetWorkloadCluster(_ context.Context) (internal.WorkloadCluster, error) {
 	return f.Workload, nil
 }
 
-func (f *fakeManagementCluster) GetMachinesForCluster(c context.Context, n client.ObjectKey, filters ...machinefilters.Func) (internal.FilterableMachineCollection, error) {
+func (f *fakeManagementCluster) GetMachinesForCluster(c context.Context, filters ...machinefilters.Func) (internal.FilterableMachineCollection, error) {
 	if f.Management != nil {
-		return f.Management.GetMachinesForCluster(c, n, filters...)
+		return f.Management.GetMachinesForCluster(c, filters...)
 	}
 	return f.Machines, nil
 }
 
-func (f *fakeManagementCluster) TargetClusterControlPlaneIsHealthy(_ context.Context, _ client.ObjectKey, _ string) error {
+func (f *fakeManagementCluster) TargetClusterControlPlaneIsHealthy(_ context.Context, _ string) error {
 	if !f.ControlPlaneHealthy {
 		return errors.New("control plane is not healthy")
 	}
 	return nil
 }
 
-func (f *fakeManagementCluster) TargetClusterEtcdIsHealthy(_ context.Context, _ client.ObjectKey, _ string) error {
+func (f *fakeManagementCluster) TargetClusterEtcdIsHealthy(_ context.Context, _ string) error {
 	if !f.EtcdHealthy {
 		return errors.New("etcd is not healthy")
 	}
@@ -74,23 +78,23 @@ func (f fakeWorkloadCluster) ClusterStatus(_ context.Context) (internal.ClusterS
 	return f.Status, nil
 }
 
-func (f fakeWorkloadCluster) ReconcileKubeletRBACRole(ctx context.Context, version semver.Version) error {
+func (f fakeWorkloadCluster) ReconcileKubeletRBACRole(_ context.Context, _ semver.Version) error {
 	return nil
 }
 
-func (f fakeWorkloadCluster) ReconcileKubeletRBACBinding(ctx context.Context, version semver.Version) error {
+func (f fakeWorkloadCluster) ReconcileKubeletRBACBinding(_ context.Context, _ semver.Version) error {
 	return nil
 }
 
-func (f fakeWorkloadCluster) UpdateKubernetesVersionInKubeadmConfigMap(ctx context.Context, version semver.Version) error {
+func (f fakeWorkloadCluster) UpdateKubernetesVersionInKubeadmConfigMap(_ context.Context, _ semver.Version) error {
 	return nil
 }
 
-func (f fakeWorkloadCluster) UpdateEtcdVersionInKubeadmConfigMap(ctx context.Context, imageRepository, imageTag string) error {
+func (f fakeWorkloadCluster) UpdateEtcdVersionInKubeadmConfigMap(_ context.Context, _, _ string) error {
 	return nil
 }
 
-func (f fakeWorkloadCluster) UpdateKubeletConfigMap(ctx context.Context, version semver.Version) error {
+func (f fakeWorkloadCluster) UpdateKubeletConfigMap(_ context.Context, _ semver.Version) error {
 	return nil
 }
 
@@ -100,7 +104,7 @@ type fakeMigrator struct {
 	migratedCorefile string
 }
 
-func (m *fakeMigrator) Migrate(current, to, corefile string, deprecations bool) (string, error) {
+func (m *fakeMigrator) Migrate(_, _, _ string, _ bool) (string, error) {
 	m.migrateCalled = true
 	if m.migrateErr != nil {
 		return "", m.migrateErr

--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -1452,8 +1452,11 @@ func TestKubeadmControlPlaneReconciler_reconcileDelete(t *testing.T) {
 			managementCluster: &fakeManagementCluster{
 				ControlPlaneHealthy: true,
 				EtcdHealthy:         true,
-				Management:          &internal.Management{Client: fakeClient},
-				Workload:            fakeWorkloadCluster{},
+				Management: &internal.Management{
+					Client:     fakeClient,
+					ClusterKey: util.ObjectKey(cluster),
+				},
+				Workload: fakeWorkloadCluster{},
 			},
 			Log:      log.Log,
 			recorder: record.NewFakeRecorder(32),
@@ -1503,8 +1506,11 @@ func TestKubeadmControlPlaneReconciler_reconcileDelete(t *testing.T) {
 			managementCluster: &fakeManagementCluster{
 				ControlPlaneHealthy: true,
 				EtcdHealthy:         true,
-				Management:          &internal.Management{Client: fakeClient},
-				Workload:            fakeWorkloadCluster{},
+				Management: &internal.Management{
+					Client:     fakeClient,
+					ClusterKey: util.ObjectKey(cluster),
+				},
+				Workload: fakeWorkloadCluster{},
 			},
 			Log:      log.Log,
 			recorder: record.NewFakeRecorder(32),

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -38,25 +38,34 @@ import (
 
 // ManagementCluster defines all behaviors necessary for something to function as a management cluster.
 type ManagementCluster interface {
-	GetMachinesForCluster(ctx context.Context, cluster client.ObjectKey, filters ...machinefilters.Func) (FilterableMachineCollection, error)
-	TargetClusterEtcdIsHealthy(ctx context.Context, clusterKey client.ObjectKey, controlPlaneName string) error
-	TargetClusterControlPlaneIsHealthy(ctx context.Context, clusterKey client.ObjectKey, controlPlaneName string) error
-	GetWorkloadCluster(ctx context.Context, clusterKey client.ObjectKey) (WorkloadCluster, error)
+	GetMachinesForCluster(ctx context.Context, filters ...machinefilters.Func) (FilterableMachineCollection, error)
+	TargetClusterEtcdIsHealthy(ctx context.Context, controlPlaneName string) error
+	TargetClusterControlPlaneIsHealthy(ctx context.Context, controlPlaneName string) error
+	GetWorkloadCluster(ctx context.Context) (WorkloadCluster, error)
+	SetClusterKeyIfEmpty(clusterKey client.ObjectKey)
 }
 
 // Management holds operations on the management cluster.
 type Management struct {
-	Client ctrlclient.Client
+	Client     ctrlclient.Client
+	ClusterKey client.ObjectKey
+}
+
+// SetClusterKeyIfEmpty will set the cluster key if one has not already been set.
+func (m *Management) SetClusterKeyIfEmpty(clusterKey client.ObjectKey) {
+	if m.ClusterKey.Namespace == "" && m.ClusterKey.Name == "" {
+		m.ClusterKey = clusterKey
+	}
 }
 
 // GetMachinesForCluster returns a list of machines that can be filtered or not.
 // If no filter is supplied then all machines associated with the target cluster are returned.
-func (m *Management) GetMachinesForCluster(ctx context.Context, cluster client.ObjectKey, filters ...machinefilters.Func) (FilterableMachineCollection, error) {
+func (m *Management) GetMachinesForCluster(ctx context.Context, filters ...machinefilters.Func) (FilterableMachineCollection, error) {
 	selector := map[string]string{
-		clusterv1.ClusterLabelName: cluster.Name,
+		clusterv1.ClusterLabelName: m.ClusterKey.Name,
 	}
 	ml := &clusterv1.MachineList{}
-	if err := m.Client.List(ctx, ml, client.InNamespace(cluster.Namespace), client.MatchingLabels(selector)); err != nil {
+	if err := m.Client.List(ctx, ml, client.InNamespace(m.ClusterKey.Namespace), client.MatchingLabels(selector)); err != nil {
 		return nil, errors.Wrap(err, "failed to list machines")
 	}
 
@@ -66,35 +75,35 @@ func (m *Management) GetMachinesForCluster(ctx context.Context, cluster client.O
 
 // GetWorkloadCluster builds a cluster object.
 // The cluster comes with an etcd client generator to connect to any etcd pod living on a managed machine.
-func (m *Management) GetWorkloadCluster(ctx context.Context, clusterKey client.ObjectKey) (WorkloadCluster, error) {
+func (m *Management) GetWorkloadCluster(ctx context.Context) (WorkloadCluster, error) {
 	// TODO(chuckha): Inject this dependency.
 	// TODO(chuckha): memoize this function. The workload client only exists as long as a reconciliation loop.
-	restConfig, err := remote.RESTConfig(ctx, m.Client, clusterKey)
-	restConfig.Timeout = 30 * time.Second
+	restConfig, err := remote.RESTConfig(ctx, m.Client, m.ClusterKey)
 	if err != nil {
 		return nil, err
 	}
+	restConfig.Timeout = 30 * time.Second
 
 	c, err := client.New(restConfig, client.Options{Scheme: scheme.Scheme})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create client for workload cluster %v", clusterKey)
+		return nil, errors.Wrapf(err, "failed to create client for workload cluster %v", m.ClusterKey)
 	}
 
 	etcdCASecret := &corev1.Secret{}
 	etcdCAObjectKey := ctrlclient.ObjectKey{
-		Namespace: clusterKey.Namespace,
-		Name:      fmt.Sprintf("%s-etcd", clusterKey.Name),
+		Namespace: m.ClusterKey.Namespace,
+		Name:      fmt.Sprintf("%s-etcd", m.ClusterKey.Name),
 	}
 	if err := m.Client.Get(ctx, etcdCAObjectKey, etcdCASecret); err != nil {
 		return nil, errors.Wrapf(err, "failed to get secret; etcd CA bundle %s/%s", etcdCAObjectKey.Namespace, etcdCAObjectKey.Name)
 	}
 	crtData, ok := etcdCASecret.Data[secret.TLSCrtDataName]
 	if !ok {
-		return nil, errors.Errorf("etcd tls crt does not exist for cluster %s/%s", clusterKey.Namespace, clusterKey.Name)
+		return nil, errors.Errorf("etcd tls crt does not exist for cluster %s/%s", m.ClusterKey.Namespace, m.ClusterKey.Name)
 	}
 	keyData, ok := etcdCASecret.Data[secret.TLSKeyDataName]
 	if !ok {
-		return nil, errors.Errorf("etcd tls key does not exist for cluster %s/%s", clusterKey.Namespace, clusterKey.Name)
+		return nil, errors.Errorf("etcd tls key does not exist for cluster %s/%s", m.ClusterKey.Namespace, m.ClusterKey.Name)
 	}
 
 	clientCert, err := generateClientCert(crtData, keyData)
@@ -122,7 +131,7 @@ type healthCheck func(context.Context) (HealthCheckResult, error)
 
 // HealthCheck will run a generic health check function and report any errors discovered.
 // In addition to the health check, it also ensures there is a 1;1 match between nodes and machines.
-func (m *Management) healthCheck(ctx context.Context, check healthCheck, clusterKey client.ObjectKey, controlPlaneName string) error {
+func (m *Management) healthCheck(ctx context.Context, check healthCheck, controlPlaneName string) error {
 	var errorList []error
 	nodeChecks, err := check(ctx)
 	if err != nil {
@@ -138,7 +147,7 @@ func (m *Management) healthCheck(ctx context.Context, check healthCheck, cluster
 	}
 
 	// Make sure Cluster API is aware of all the nodes.
-	machines, err := m.GetMachinesForCluster(ctx, clusterKey, machinefilters.OwnedControlPlaneMachines(controlPlaneName))
+	machines, err := m.GetMachinesForCluster(ctx, machinefilters.OwnedControlPlaneMachines(controlPlaneName))
 	if err != nil {
 		return err
 	}
@@ -154,27 +163,27 @@ func (m *Management) healthCheck(ctx context.Context, check healthCheck, cluster
 		}
 	}
 	if len(nodeChecks) != len(machines) {
-		return errors.Errorf("number of nodes and machines in namespace %s did not match: %d nodes %d machines", clusterKey.Namespace, len(nodeChecks), len(machines))
+		return errors.Errorf("number of nodes and machines in namespace %s did not match: %d nodes %d machines", m.ClusterKey.Namespace, len(nodeChecks), len(machines))
 	}
 	return nil
 }
 
 // TargetClusterControlPlaneIsHealthy checks every node for control plane health.
-func (m *Management) TargetClusterControlPlaneIsHealthy(ctx context.Context, clusterKey client.ObjectKey, controlPlaneName string) error {
+func (m *Management) TargetClusterControlPlaneIsHealthy(ctx context.Context, controlPlaneName string) error {
 	// TODO: add checks for expected taints/labels
-	cluster, err := m.GetWorkloadCluster(ctx, clusterKey)
+	cluster, err := m.GetWorkloadCluster(ctx)
 	if err != nil {
 		return err
 	}
-	return m.healthCheck(ctx, cluster.ControlPlaneIsHealthy, clusterKey, controlPlaneName)
+	return m.healthCheck(ctx, cluster.ControlPlaneIsHealthy, controlPlaneName)
 }
 
 // TargetClusterEtcdIsHealthy runs a series of checks over a target cluster's etcd cluster.
 // In addition, it verifies that there are the same number of etcd members as control plane Machines.
-func (m *Management) TargetClusterEtcdIsHealthy(ctx context.Context, clusterKey client.ObjectKey, controlPlaneName string) error {
-	cluster, err := m.GetWorkloadCluster(ctx, clusterKey)
+func (m *Management) TargetClusterEtcdIsHealthy(ctx context.Context, controlPlaneName string) error {
+	cluster, err := m.GetWorkloadCluster(ctx)
 	if err != nil {
 		return err
 	}
-	return m.healthCheck(ctx, cluster.EtcdIsHealthy, clusterKey, controlPlaneName)
+	return m.healthCheck(ctx, cluster.EtcdIsHealthy, controlPlaneName)
 }


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**: This cleans up the management cluster a little bit. Every function needed the cluster key in the parameter list so it makes more sense as a field on the struct.

Also this fixes a possible NPE that i'll point out in comments

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #2702 
