### PR TITLE
🏃 Improve Cluster.Spec.Paused watchers and provide utils

### DIFF
--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -58,7 +58,7 @@ type MachineDeploymentReconciler struct {
 }
 
 func (r *MachineDeploymentReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
-	err := ctrl.NewControllerManagedBy(mgr).
+	controller, err := ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.MachineDeployment{}).
 		Owns(&clusterv1.MachineSet{}).
 		Watches(
@@ -66,10 +66,19 @@ func (r *MachineDeploymentReconciler) SetupWithManager(mgr ctrl.Manager, options
 			&handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(r.MachineSetToDeployments)},
 		).
 		WithOptions(options).
-		Complete(r)
+		Build(r)
 
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+
+	// Add a watch on clusterv1.Cluster object for paused notifications.
+	clusterToMachineDeployments, err := util.ClusterToObjectsMapper(mgr.GetClient(), &clusterv1.MachineDeploymentList{}, mgr.GetScheme())
+	if err != nil {
+		return err
+	}
+	if err := util.WatchOnClusterPaused(controller, clusterToMachineDeployments); err != nil {
+		return err
 	}
 
 	r.recorder = mgr.GetEventRecorderFor("machinedeployment-controller")

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -549,4 +550,100 @@ func TestEnsureOwnerRef(t *testing.T) {
 		g.Expect(obj.OwnerReferences).Should(ContainElement(ref))
 		g.Expect(obj.OwnerReferences).Should(HaveLen(1))
 	})
+}
+
+func TestClusterToObjectsMapper(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	scheme := runtime.NewScheme()
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test1",
+		},
+	}
+
+	table := []struct {
+		name        string
+		objects     []runtime.Object
+		input       runtime.Object
+		output      []ctrl.Request
+		expectError bool
+	}{
+		{
+			name:  "should return a list of requests with labelled machines",
+			input: &clusterv1.MachineList{},
+			objects: []runtime.Object{
+				&clusterv1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machine1",
+						Labels: map[string]string{
+							clusterv1.ClusterLabelName: "test1",
+						},
+					},
+				},
+				&clusterv1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "machine2",
+						Labels: map[string]string{
+							clusterv1.ClusterLabelName: "test1",
+						},
+					},
+				},
+			},
+			output: []ctrl.Request{
+				{NamespacedName: client.ObjectKey{Name: "machine1"}},
+				{NamespacedName: client.ObjectKey{Name: "machine2"}},
+			},
+		},
+		{
+			name:  "should return a list of requests with labelled MachineDeployments",
+			input: &clusterv1.MachineDeploymentList{},
+			objects: []runtime.Object{
+				&clusterv1.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "md1",
+						Labels: map[string]string{
+							clusterv1.ClusterLabelName: "test1",
+						},
+					},
+				},
+				&clusterv1.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "md2",
+						Labels: map[string]string{
+							clusterv1.ClusterLabelName: "test2",
+						},
+					},
+				},
+				&clusterv1.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "md3",
+						Labels: map[string]string{
+							clusterv1.ClusterLabelName: "test1",
+						},
+					},
+				},
+				&clusterv1.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "md4",
+					},
+				},
+			},
+			output: []ctrl.Request{
+				{NamespacedName: client.ObjectKey{Name: "md1"}},
+				{NamespacedName: client.ObjectKey{Name: "md3"}},
+			},
+		},
+	}
+
+	for _, tc := range table {
+		tc.objects = append(tc.objects, cluster)
+		client := fake.NewFakeClientWithScheme(scheme, tc.objects...)
+
+		f, err := ClusterToObjectsMapper(client, tc.input, scheme)
+		g.Expect(err != nil, err).To(Equal(tc.expectError))
+		g.Expect(f.Map(handler.MapObject{Object: cluster})).To(ConsistOf(tc.output))
+	}
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
In an effort to standardize ways to get notifications when a `Cluster.Spec.Paused` flips, we now provide a util function to add a predicate-based watcher, and a generic function that maps a Cluster to a list of objects.

/assign @ncdc @nader-ziada 
/cc @frapposelli @fabriziopandini @wfernandes @yastij @CecileRobertMichon @detiber 
/milestone v0.3.3
