### PR TITLE
🏃Finish the pending tests and clean up a few other tests

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -50,6 +50,13 @@ func (c *ControlPlane) Logger() logr.Logger {
 	return Log.WithValues("namespace", c.KCP.Namespace, "name", c.KCP.Name, "cluster-nanme", c.Cluster.Name)
 }
 
+func (c *ControlPlane) FailureDomains() clusterv1.FailureDomains {
+	if c.Cluster.Status.FailureDomains == nil {
+		return clusterv1.FailureDomains{}
+	}
+	return c.Cluster.Status.FailureDomains
+}
+
 // Version returns the KubeadmControlPlane's version.
 func (c *ControlPlane) Version() *string {
 	return &c.KCP.Spec.Version
@@ -106,7 +113,7 @@ func (c *ControlPlane) MachinesNeedingUpgrade() FilterableMachineCollection {
 func (c *ControlPlane) FailureDomainWithMost() *string {
 	// See if there are any Machines that are not in currently defined failure domains first.
 	notInFailureDomains := c.Machines.Filter(
-		machinefilters.Not(machinefilters.InFailureDomains(c.Cluster.Status.FailureDomains.FilterControlPlane().GetIDs()...)),
+		machinefilters.Not(machinefilters.InFailureDomains(c.FailureDomains().FilterControlPlane().GetIDs()...)),
 	)
 	if len(notInFailureDomains) > 0 {
 		// return the failure domain for the oldest Machine not in the current list of failure domains
@@ -125,7 +132,7 @@ func (c *ControlPlane) FailureDomainWithFewest() *string {
 	if len(c.Cluster.Status.FailureDomains.FilterControlPlane()) == 0 {
 		return nil
 	}
-	return PickFewest(c.Cluster.Status.FailureDomains.FilterControlPlane(), c.Machines)
+	return PickFewest(c.FailureDomains().FilterControlPlane(), c.Machines)
 }
 
 // InitialControlPlaneConfig returns a new KubeadmConfigSpec that is to be used for an initializing control plane.

--- a/controlplane/kubeadm/internal/control_plane_test.go
+++ b/controlplane/kubeadm/internal/control_plane_test.go
@@ -18,9 +18,12 @@ package internal
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 )
 
@@ -30,14 +33,56 @@ func TestControlPlane(t *testing.T) {
 }
 
 var _ = Describe("Control Plane", func() {
-	Describe("MachinesNeedingUpgrade", func() {
-		var controlPlane *ControlPlane
+	var controlPlane *ControlPlane
+	BeforeEach(func() {
+		controlPlane = &ControlPlane{
+			KCP:     &controlplanev1.KubeadmControlPlane{},
+			Cluster: &clusterv1.Cluster{},
+		}
+	})
+
+	Describe("Failure domains", func() {
 		BeforeEach(func() {
-			controlPlane = &ControlPlane{
-				KCP: &controlplanev1.KubeadmControlPlane{},
+			controlPlane.Machines = FilterableMachineCollection{
+				"machine-1": machine("machine-1", withFailureDomain("one")),
+				"machine-2": machine("machine-2", withFailureDomain("two")),
+				"machine-3": machine("machine-3", withFailureDomain("two")),
+			}
+			controlPlane.Cluster.Status.FailureDomains = clusterv1.FailureDomains{
+				"one":   failureDomain(true),
+				"two":   failureDomain(true),
+				"three": failureDomain(true),
+				"four":  failureDomain(false),
 			}
 		})
 
+		Describe("With most machines", func() {
+			Context("With all machines in known failure domains", func() {
+				It("should return the failure domain that has the most number of machines", func() {
+					Expect(*controlPlane.FailureDomainWithMostMachines()).To(Equal("two"))
+				})
+			})
+			Context("With some machines in non-defined failure domains", func() {
+				JustBeforeEach(func() {
+					controlPlane.Machines.Insert(machine("machine-5", withFailureDomain("unknown")))
+				})
+				It("should return machines in non-defined failure domains first", func() {
+					Expect(*controlPlane.FailureDomainWithMostMachines()).To(Equal("unknown"))
+				})
+			})
+		})
+
+		Describe("With fewest machines", func() {
+			Context("With machines all in the known failure domains", func() {
+				It("should return the failure domain that has the fewest number of machines", func() {
+					Expect(*controlPlane.FailureDomainWithFewestMachines()).To(Equal("three"))
+				})
+			})
+
+		})
+	})
+
+	Describe("MachinesNeedingUpgrade", func() {
 		Context("With no machines", func() {
 			It("should return no machines", func() {
 				Expect(controlPlane.MachinesNeedingUpgrade()).To(HaveLen(0))
@@ -46,37 +91,93 @@ var _ = Describe("Control Plane", func() {
 
 		Context("With machines", func() {
 			BeforeEach(func() {
+				controlPlane.KCP.Spec.Version = "2"
 				controlPlane.Machines = FilterableMachineCollection{
-					"machine-1": machine("machine-1"),
+					"machine-1": machine("machine-1", withHash(controlPlane.SpecHash())),
+					"machine-2": machine("machine-2", withHash(controlPlane.SpecHash())),
+					"machine-3": machine("machine-3", withHash(controlPlane.SpecHash())),
 				}
 			})
+
 			Context("That have an old configuration", func() {
+				JustBeforeEach(func() {
+					controlPlane.Machines.Insert(machine("machine-4", withHash(controlPlane.SpecHash()+"outdated")))
+				})
 				It("should return some machines", func() {
-					Expect(controlPlane.MachinesNeedingUpgrade()).ToNot(HaveLen(0))
+					Expect(controlPlane.MachinesNeedingUpgrade()).To(HaveLen(1))
 				})
 			})
 
 			Context("That have an up-to-date configuration", func() {
+				year := 2000
+				BeforeEach(func() {
+					controlPlane.Machines = FilterableMachineCollection{
+						"machine-1": machine("machine-1",
+							withCreationTimestamp(metav1.Time{Time: time.Date(year-1, 0, 0, 0, 0, 0, 0, time.UTC)}),
+							withHash(controlPlane.SpecHash())),
+						"machine-2": machine("machine-3",
+							withCreationTimestamp(metav1.Time{Time: time.Date(year, 0, 0, 0, 0, 0, 0, time.UTC)}),
+							withHash(controlPlane.SpecHash())),
+						"machine-3": machine("machine-3",
+							withCreationTimestamp(metav1.Time{Time: time.Date(year+1, 0, 0, 0, 0, 0, 0, time.UTC)}),
+							withHash(controlPlane.SpecHash())),
+					}
+				})
+
 				Context("That has no upgradeAfter value set", func() {
-					PIt("should return no machines", func() {})
+					It("should return no machines", func() {
+						Expect(controlPlane.MachinesNeedingUpgrade()).To(HaveLen(0))
+					})
 				})
 
 				Context("That has an upgradeAfter value set", func() {
 					Context("That is in the future", func() {
-						PIt("should return no machines", func() {})
+						BeforeEach(func() {
+							future := time.Date(year+1000, 0, 0, 0, 0, 0, 0, time.UTC)
+							controlPlane.KCP.Spec.UpgradeAfter = &metav1.Time{Time: future}
+						})
+						It("should return no machines", func() {
+							Expect(controlPlane.MachinesNeedingUpgrade()).To(HaveLen(0))
+						})
 					})
 
 					Context("That is in the past", func() {
 						Context("That is before machine creation time", func() {
-							PIt("should return no machines", func() {})
+							JustBeforeEach(func() {
+								controlPlane.KCP.Spec.UpgradeAfter = &metav1.Time{Time: time.Date(year-2, 0, 0, 0, 0, 0, 0, time.UTC)}
+							})
+							It("should return no machines", func() {
+								Expect(controlPlane.MachinesNeedingUpgrade()).To(HaveLen(0))
+							})
 						})
+
 						Context("That is after machine creation time", func() {
-							PIt("should return no machines", func() {})
+							JustBeforeEach(func() {
+								controlPlane.KCP.Spec.UpgradeAfter = &metav1.Time{Time: time.Date(year, 1, 0, 0, 0, 0, 0, time.UTC)}
+							})
+							It("should return all machines older than this date machines", func() {})
 						})
 					})
 				})
 			})
 		})
-
 	})
 })
+
+func failureDomain(controlPlane bool) clusterv1.FailureDomainSpec {
+	return clusterv1.FailureDomainSpec{
+		ControlPlane: controlPlane,
+	}
+}
+
+func withFailureDomain(fd string) machineOpt {
+	return func(m *clusterv1.Machine) {
+		m.Spec.FailureDomain = &fd
+	}
+}
+
+func withHash(hash string) machineOpt {
+	return func(m *clusterv1.Machine) {
+		m.SetLabels(map[string]string{controlplanev1.KubeadmControlPlaneHashLabelKey: hash})
+	}
+}

--- a/controlplane/kubeadm/internal/machinefilters/machine_filters_test.go
+++ b/controlplane/kubeadm/internal/machinefilters/machine_filters_test.go
@@ -29,11 +29,11 @@ import (
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/machinefilters"
 )
 
-func falseFilter(machine *clusterv1.Machine) bool {
+func falseFilter(_ *clusterv1.Machine) bool {
 	return false
 }
 
-func trueFilter(machine *clusterv1.Machine) bool {
+func trueFilter(_ *clusterv1.Machine) bool {
 	return true
 }
 
@@ -163,6 +163,10 @@ func TestHashAnnotationKey(t *testing.T) {
 }
 
 func TestInFailureDomain(t *testing.T) {
+	t.Run("nil machine returns false", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(machinefilters.InFailureDomains(pointer.StringPtr("test"))(nil)).To(BeFalse())
+	})
 	t.Run("machine with given failure domain returns true", func(t *testing.T) {
 		g := NewWithT(t)
 		m := &clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: pointer.StringPtr("test")}}
@@ -171,7 +175,12 @@ func TestInFailureDomain(t *testing.T) {
 	t.Run("machine with a different failure domain returns false", func(t *testing.T) {
 		g := NewWithT(t)
 		m := &clusterv1.Machine{Spec: clusterv1.MachineSpec{FailureDomain: pointer.StringPtr("notTest")}}
-		g.Expect(machinefilters.InFailureDomains(pointer.StringPtr("test"), pointer.StringPtr("foo"))(m)).To(BeFalse())
+		g.Expect(machinefilters.InFailureDomains(
+			pointer.StringPtr("test"),
+			pointer.StringPtr("test2"),
+			pointer.StringPtr("test3"),
+			nil,
+			pointer.StringPtr("foo"))(m)).To(BeFalse())
 	})
 	t.Run("machine without failure domain returns false", func(t *testing.T) {
 		g := NewWithT(t)


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>


**What this PR does / why we need it**:
This PR replaces the removed tests from #2734 and adds a few more tests for the control plane object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #2702 

Depends on #2734 merging first

/assign @sedefsavas 
