### PR TITLE
🏃 remove one annotation and make the function calls idempotent instead

### DIFF
--- a/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
+++ b/controlplane/kubeadm/controllers/kubeadm_control_plane_controller_test.go
@@ -1685,7 +1685,7 @@ func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.
 		Machines: machines,
 	}
 
-	_, err := r.scaleDownControlPlane(context.Background(), cluster, kcp, machines, machines, controlPlane)
+	_, err := r.scaleDownControlPlane(context.Background(), controlPlane)
 	g.Expect(err).ToNot(HaveOccurred())
 }
 
@@ -1730,14 +1730,4 @@ func TestKubeadmControlPlaneReconciler_upgradeControlPlane(t *testing.T) {
 	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
 	g.Expect(machineList.Items).NotTo(BeEmpty())
 	g.Expect(machineList.Items).To(HaveLen(1))
-
-	machineCollection := internal.NewFilterableMachineCollection(&machineList.Items[0])
-	result, err = r.upgradeControlPlane(context.Background(), cluster, kcp, machineCollection, machineCollection, controlPlane)
-
-	g.Expect(machineList.Items[0].Annotations).To(HaveKey(controlplanev1.SelectedForUpgradeAnnotation))
-
-	// TODO flesh out the rest of this test - this is currently least-effort to confirm a fix for an NPE when updating
-	// the etcd version
-	g.Expect(result).To(Equal(ctrl.Result{}))
-	g.Expect(err).To(Equal(&capierrors.RequeueAfterError{RequeueAfter: HealthCheckFailedRequeueAfter}))
 }

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api/util"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -278,10 +279,16 @@ func (f *fakeClient) Patch(_ context.Context, _ runtime.Object, _ client.Patch, 
 	return nil
 }
 
-func (f *fakeClient) Update(_ context.Context, _ runtime.Object, _ ...client.UpdateOption) error {
+func (f *fakeClient) Update(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
 	f.updateCalled = true
 	if f.updateErr != nil {
 		return f.updateErr
+	}
+	switch item := obj.(type) {
+	case *corev1.ConfigMap:
+		f.get[util.ObjectKey(item).String()] = obj.DeepCopyObject()
+	default:
+		return fmt.Errorf("unknown type: %s", item)
 	}
 	return nil
 }

--- a/controlplane/kubeadm/internal/kubeadm_config_map.go
+++ b/controlplane/kubeadm/internal/kubeadm_config_map.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	clusterStatusKey        = "ClusterStatus"
+	ClusterStatusKey        = "ClusterStatus"
 	clusterConfigurationKey = "ClusterConfiguration"
 	statusAPIEndpointsKey   = "apiEndpoints"
 	configVersionKey        = "kubernetesVersion"
@@ -42,9 +42,9 @@ type kubeadmConfig struct {
 
 // RemoveAPIEndpoint removes an APIEndpoint fromt he kubeadm config cluster status config map
 func (k *kubeadmConfig) RemoveAPIEndpoint(endpoint string) error {
-	data, ok := k.ConfigMap.Data[clusterStatusKey]
+	data, ok := k.ConfigMap.Data[ClusterStatusKey]
 	if !ok {
-		return errors.Errorf("could not find key %q in kubeadm config", clusterStatusKey)
+		return errors.Errorf("could not find key %q in kubeadm config", ClusterStatusKey)
 	}
 	status, err := yamlToUnstructured([]byte(data))
 	if err != nil {
@@ -62,7 +62,7 @@ func (k *kubeadmConfig) RemoveAPIEndpoint(endpoint string) error {
 	if err != nil {
 		return errors.Wrap(err, "error encoding kubeadm ClusterStatus object")
 	}
-	k.ConfigMap.Data[clusterStatusKey] = string(updated)
+	k.ConfigMap.Data[ClusterStatusKey] = string(updated)
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What this PR does / why we need it**:
This PR removes an internal annotation and replaces it with an idempotent function instead. This should help some failure cases when the action is complete but marking the node fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #2702 

/cc @vincepri 
/assign @sedefsavas @fabriziopandini 
