### PR TITLE
🏃 rewrite kubeadm control plane logs for consistency

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -110,7 +110,7 @@ func (r *ClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr e
 
 	// Return early if the object or Cluster is paused.
 	if util.IsPaused(cluster, cluster) {
-		logger.V(3).Info("reconciliation is paused for this object")
+		logger.Info("Reconciliation is paused for this object")
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -143,7 +143,7 @@ func (r *MachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr e
 
 	// Return early if the object or Cluster is paused.
 	if util.IsPaused(cluster, m) {
-		logger.V(3).Info("reconciliation is paused for this object")
+		logger.Info("Reconciliation is paused for this object")
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -108,7 +108,7 @@ func (r *MachineDeploymentReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result
 
 	// Return early if the object or Cluster is paused.
 	if util.IsPaused(cluster, deployment) {
-		logger.V(3).Info("reconciliation is paused for this object")
+		logger.Info("Reconciliation is paused for this object")
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -141,7 +141,7 @@ func (r *MachineHealthCheckReconciler) Reconcile(req ctrl.Request) (_ ctrl.Resul
 
 	// Return early if the object or Cluster is paused.
 	if util.IsPaused(cluster, m) {
-		logger.V(3).Info("reconciliation is paused for this object")
+		logger.Info("Reconciliation is paused for this object")
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -125,7 +125,7 @@ func (r *MachineSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 
 	// Return early if the object or Cluster is paused.
 	if util.IsPaused(cluster, machineSet) {
-		logger.V(3).Info("reconciliation is paused for this object")
+		logger.Info("Reconciliation is paused for this object")
 		return ctrl.Result{}, nil
 	}
 

--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -45,7 +45,8 @@ import (
 )
 
 const (
-	kubeProxyKey = "kube-proxy"
+	kubeProxyKey        = "kube-proxy"
+	labelNodeRoleMaster = "node-role.kubernetes.io/master"
 )
 
 var (
@@ -58,13 +59,12 @@ type etcdClientFor interface {
 
 // WorkloadCluster defines all behaviors necessary to upgrade kubernetes on a workload cluster
 type WorkloadCluster interface {
-	// Basic health and status behaviors
-
+	// Basic health and status checks.
 	ClusterStatus(ctx context.Context) (ClusterStatus, error)
 	ControlPlaneIsHealthy(ctx context.Context) (HealthCheckResult, error)
 	EtcdIsHealthy(ctx context.Context) (HealthCheckResult, error)
 
-	// Behaviors necessary for upgrade
+	// Upgrade related tasks.
 	ReconcileKubeletRBACBinding(ctx context.Context, version semver.Version) error
 	ReconcileKubeletRBACRole(ctx context.Context, version semver.Version) error
 	UpdateKubernetesVersionInKubeadmConfigMap(ctx context.Context, version semver.Version) error
@@ -87,7 +87,7 @@ type Workload struct {
 func (w *Workload) getControlPlaneNodes(ctx context.Context) (*corev1.NodeList, error) {
 	nodes := &corev1.NodeList{}
 	labels := map[string]string{
-		"node-role.kubernetes.io/master": "",
+		labelNodeRoleMaster: "",
 	}
 
 	if err := w.Client.List(ctx, nodes, ctrlclient.MatchingLabels(labels)); err != nil {

--- a/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md
@@ -157,7 +157,7 @@ outside of the existing module.
   ```go
   // Return early if the object or Cluster is paused.
   if util.IsPaused(cluster, <object>) {
-    logger.V(3).Info("reconciliation is paused for this object")
+    logger.Info("Reconciliation is paused for this object")
     return ctrl.Result{}, nil
   }
   ```

--- a/exp/controllers/machinepool_controller.go
+++ b/exp/controllers/machinepool_controller.go
@@ -101,7 +101,7 @@ func (r *MachinePoolReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, rete
 
 	// Return early if the object or Cluster is paused.
 	if util.IsPaused(cluster, mp) {
-		logger.V(3).Info("reconciliation is paused for this object")
+		logger.Info("Reconciliation is paused for this object")
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or  🏃(:running:, other) -->

**What this PR does / why we need it**:
/assign @sedefsavas 
