### PR TITLE
WIP: 🏃Use role aggregation label in docker provider e2e tests

### DIFF
--- a/test/infrastructure/docker/config/local-e2e/capi-kubeadm-control-plane/capi-kubeadm-control-plane-docker-cluster-role.yaml
+++ b/test/infrastructure/docker/config/local-e2e/capi-kubeadm-control-plane/capi-kubeadm-control-plane-docker-cluster-role.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capi-kubeadm-control-plane-docker
+  labels:
+    kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockerclusters
+  - dockermachines
+  - dockermachinetemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/test/infrastructure/docker/config/local-e2e/capi-kubeadm-control-plane/kustomization.yaml
+++ b/test/infrastructure/docker/config/local-e2e/capi-kubeadm-control-plane/kustomization.yaml
@@ -1,0 +1,14 @@
+bases:
+- ../../../../../../controlplane/kubeadm/config
+resources:
+- capi-kubeadm-control-plane-docker-cluster-role.yaml
+patchesJSON6902:
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: capi-kubeadm-control-plane-manager-role
+  patch: |-
+    - op: replace
+      path: /rules/0/apiGroups
+      value: ["bootstrap.cluster.x-k8s.io", "controlplane.cluster.x-k8s.io"]

--- a/test/infrastructure/docker/config/local-e2e/capi/capi-manager-docker-cluster-role.yaml
+++ b/test/infrastructure/docker/config/local-e2e/capi/capi-manager-docker-cluster-role.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capi-manager-docker
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: "true"
+rules:
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockerclusters
+  - dockermachines
+  - dockermachinetemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/test/infrastructure/docker/config/local-e2e/capi/kustomization.yaml
+++ b/test/infrastructure/docker/config/local-e2e/capi/kustomization.yaml
@@ -1,0 +1,17 @@
+bases:
+- ../../../../../../config
+resources:
+- capi-manager-docker-cluster-role.yaml
+patchesJSON6902:
+- target:
+    group: rbac.authorization.k8s.io
+    version: v1
+    kind: ClusterRole
+    name: capi-manager-role
+  patch: |-
+    - op: replace
+      path: /rules/1/apiGroups
+      value: ["bootstrap.cluster.x-k8s.io", "controlplane.cluster.x-k8s.io"]
+    - op: replace
+      path: /rules/2/apiGroups
+      value: ["bootstrap.cluster.x-k8s.io"]

--- a/test/infrastructure/docker/e2e/local-e2e.conf
+++ b/test/infrastructure/docker/e2e/local-e2e.conf
@@ -34,7 +34,7 @@ components:
 # Load CAPI core and wait for its pods to become available.
 - name:    capi
   sources:
-  - value: ../../../../config
+  - value: ../config/local-e2e/capi
     replacements:
     - old: "imagePullPolicy: Always"
       new: "imagePullPolicy: IfNotPresent"
@@ -58,7 +58,7 @@ components:
 # Load the CAPI kubeadm control plane and wait for its pods to become available.
 - name:    capi-kubeadm-control-plane
   sources:
-  - value: ../../../../controlplane/kubeadm/config
+  - value: ../config/local-e2e/capi-kubeadm-control-plane
     replacements:
     - old: "imagePullPolicy: Always"
       new: "imagePullPolicy: IfNotPresent"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**: Modifies docker infrastructure provider e2e tests to use the aggregation labels introduced in the following PRs:
- https://github.com/kubernetes-sigs/cluster-api/pull/1980
- https://github.com/kubernetes-sigs/cluster-api/pull/2685

This is meant to start testing the case of a non-SIG sponsored infrastructure provider integrating with cluster-api by providing RBAC for the capi manager and capi kubeadm control plane manager.

Since the capi and kubeadm control plane manager roles have full access to the `infrastructure.cluster.x-k8s.io` group by default, this access is patched out of the roles so that a docker specific role can be aggregated to test this functionality. This patch is fragile to changes due to the hardcoded indexes so potentially there is a better way of doing this.

This PR is WIP pending merge of https://github.com/kubernetes-sigs/cluster-api/pull/2685 and feedback on whether this is actually what/how we want to test this (can also make similar changes to ci-e2e at that point).