### PR TITLE
🐛 fix: KubeadmControlPlane controller crash if infra template is not found

### DIFF
--- a/bootstrap/kubeadm/api/v1alpha2/conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha2/conversion.go
@@ -119,7 +119,6 @@ func Convert_v1alpha3_KubeadmConfigStatus_To_v1alpha2_KubeadmConfigStatus(in *ku
 	return nil
 }
 
-
 // Convert_v1alpha2_KubeadmConfigSpec_To_v1alpha3_KubeadmConfigSpec converts this KubeadmConfigSpec to the Hub version (v1alpha3).
 func Convert_v1alpha2_KubeadmConfigSpec_To_v1alpha3_KubeadmConfigSpec(in *KubeadmConfigSpec, out *kubeadmbootstrapv1alpha3.KubeadmConfigSpec, s apiconversion.Scope) error {
 	return autoConvert_v1alpha2_KubeadmConfigSpec_To_v1alpha3_KubeadmConfigSpec(in, out, s)


### PR DESCRIPTION
**What this PR does / why we need it**:
KubeadmControlPlane controller should not crash if infra template is not found

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2751 

