### PR TITLE
 🏃[e2e] enable all docker e2e tests for CI

### DIFF
--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -91,9 +91,8 @@ test-e2e: ## Run the end-to-end tests
 
 E2E_CONF_FILE ?= e2e/local-e2e.conf
 SKIP_RESOURCE_CLEANUP ?= false
-FOCUS ?= Basic
 run-e2e:
-	go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath $(E2E_CONF_FILE))" -skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) -ginkgo.focus='$(FOCUS)'
+	go test ./e2e -v -ginkgo.v -ginkgo.trace -count=1 -timeout=20m -tags=e2e -e2e.config="$(abspath $(E2E_CONF_FILE))" -skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP)
 
 ## --------------------------------------
 ## Binaries

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Docker", func() {
 			namespace  string
 			clusterGen = &ClusterGenerator{}
 		)
-		SetDefaultEventuallyTimeout(3 * time.Minute)
+		SetDefaultEventuallyTimeout(10 * time.Minute)
 		SetDefaultEventuallyPollingInterval(10 * time.Second)
 
 		BeforeEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables an existing e2e test that does KCP upgrade for CI.
Also, timeout is increased as it takes longer than 3 minutes in local setups.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2654
