### PR TITLE
🏃Disable failure domains in e2e tests

### DIFF
--- a/test/framework/control_plane.go
+++ b/test/framework/control_plane.go
@@ -314,6 +314,9 @@ func DeleteCluster(ctx context.Context, input DeleteClusterInput) {
 	if options.SkipResourceCleanup {
 		return
 	}
+	if input.Cluster == nil {
+		return
+	}
 	By(fmt.Sprintf("deleting cluster %s", input.Cluster.GetName()))
 	Expect(input.Deleter.Delete(ctx, input.Cluster)).To(Succeed())
 }

--- a/test/infrastructure/docker/e2e/docker_suite_test.go
+++ b/test/infrastructure/docker/e2e/docker_suite_test.go
@@ -39,10 +39,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/framework"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestDocker(t *testing.T) {
@@ -58,6 +60,8 @@ func TestDocker(t *testing.T) {
 
 var (
 	mgmt          *CAPDCluster
+	mgmtClient    ctrlclient.Client
+	cluster       *clusterv1.Cluster
 	ctx           = context.Background()
 	config        *framework.Config
 	configPath    string

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -41,21 +41,14 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var mgmtClient ctrlclient.Client
-var cluster *clusterv1.Cluster
-
 var _ = Describe("Docker", func() {
 	Describe("Cluster Creation", func() {
 		var (
-			namespace  string
+			namespace  = "default"
 			clusterGen = &ClusterGenerator{}
 		)
-		SetDefaultEventuallyTimeout(3 * time.Minute)
+		SetDefaultEventuallyTimeout(5 * time.Minute)
 		SetDefaultEventuallyPollingInterval(10 * time.Second)
-
-		BeforeEach(func() {
-			namespace = "default"
-		})
 
 		AfterEach(func() {
 			// Dump cluster API and docker related resources to artifacts before deleting them.
@@ -71,7 +64,8 @@ var _ = Describe("Docker", func() {
 		Describe("Multi-node controlplane cluster", func() {
 			var controlPlane *controlplanev1.KubeadmControlPlane
 
-			Specify("Basic create", func() {
+			BeforeEach(func() {
+				// Create a multi-node cluster with failure domains config
 				replicas := 3
 				var (
 					infraCluster *infrav1.DockerCluster
@@ -79,13 +73,16 @@ var _ = Describe("Docker", func() {
 					err          error
 				)
 				cluster, infraCluster, controlPlane, template = clusterGen.GenerateCluster(namespace, int32(replicas))
+
+				// TODO: Temporarily disabling failure domains to get
+				// full-upgrade test to work.
 				// Set failure domains here
-				infraCluster.Spec.FailureDomains = clusterv1.FailureDomains{
-					"domain-one":   {ControlPlane: true},
-					"domain-two":   {ControlPlane: true},
-					"domain-three": {ControlPlane: true},
-					"domain-four":  {ControlPlane: false},
-				}
+				// infraCluster.Spec.FailureDomains = clusterv1.FailureDomains{
+				// 	"domain-one":   {ControlPlane: true},
+				// 	"domain-two":   {ControlPlane: true},
+				// 	"domain-three": {ControlPlane: true},
+				// 	"domain-four":  {ControlPlane: false},
+				// }
 
 				md, infraTemplate, bootstrapTemplate := GenerateMachineDeployment(cluster, 1)
 
@@ -166,7 +163,10 @@ var _ = Describe("Docker", func() {
 					ControlPlane: controlPlane,
 				}
 				framework.WaitForControlPlaneToBeReady(ctx, waitForControlPlaneToBeReadyInput)
+			})
 
+			// TODO: Activate once we can verify it working.
+			XSpecify("failure domains are correct", func() {
 				// Assert failure domain is working as expected
 				assertControlPlaneFailureDomainInput := framework.AssertControlPlaneFailureDomainsInput{
 					GetLister:  mgmtClient,
@@ -179,10 +179,9 @@ var _ = Describe("Docker", func() {
 					},
 				}
 				framework.AssertControlPlaneFailureDomains(ctx, assertControlPlaneFailureDomainInput)
-
 			})
 
-			Specify("Full upgrade", func() {
+			Specify("Full upgrade - Kubernetes, kube-proxy, etcd, coredns", func() {
 				By("upgrading the control plane object to a new version")
 				patchHelper, err := patch.NewHelper(controlPlane, mgmtClient)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Removing the failure domains setup and disabling the failure domains
assertions so that we can get the `Full Upgrade` test to pass
consistently.
Also did some refactoring by moving the multi-node cluster setup into a
BeforeEach block so that the `Full Upgrade` test can be run without
running the failure domain assertion.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref #2764 
Ref #2753