### PR TITLE
🐛[KCP] fix for machine selection logic during scale down

### DIFF
--- a/controlplane/kubeadm/controllers/scale.go
+++ b/controlplane/kubeadm/controllers/scale.go
@@ -99,7 +99,7 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 
 	markedForDeletion := selectedMachines.Filter(machinefilters.HasAnnotationKey(controlplanev1.DeleteForScaleDownAnnotation))
 	if len(markedForDeletion) == 0 {
-		fd := controlPlane.FailureDomainWithMostMachines()
+		fd := controlPlane.FailureDomainWithMostMachines(selectedMachines)
 		machinesInFailureDomain := selectedMachines.Filter(machinefilters.InFailureDomains(fd))
 		machineToMark := machinesInFailureDomain.Oldest()
 		if machineToMark == nil {

--- a/controlplane/kubeadm/controllers/upgrade.go
+++ b/controlplane/kubeadm/controllers/upgrade.go
@@ -105,7 +105,7 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 }
 
 func (r *KubeadmControlPlaneReconciler) selectMachineForUpgrade(ctx context.Context, _ *clusterv1.Cluster, requireUpgrade internal.FilterableMachineCollection, controlPlane *internal.ControlPlane) (*clusterv1.Machine, error) {
-	failureDomain := controlPlane.FailureDomainWithMostMachines()
+	failureDomain := controlPlane.FailureDomainWithMostMachines(requireUpgrade)
 
 	inFailureDomain := requireUpgrade.Filter(machinefilters.InFailureDomains(failureDomain))
 	selected := inFailureDomain.Oldest()

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -109,9 +109,9 @@ func (c *ControlPlane) MachinesNeedingUpgrade() FilterableMachineCollection {
 
 // FailureDomainWithMostMachines returns the failure domain with the most number of machines.
 // Used when scaling down.
-func (c *ControlPlane) FailureDomainWithMostMachines() *string {
+func (c *ControlPlane) FailureDomainWithMostMachines(machines FilterableMachineCollection) *string {
 	// See if there are any Machines that are not in currently defined failure domains first.
-	notInFailureDomains := c.Machines.Filter(
+	notInFailureDomains := machines.Filter(
 		machinefilters.Not(machinefilters.InFailureDomains(c.FailureDomains().FilterControlPlane().GetIDs()...)),
 	)
 	if len(notInFailureDomains) > 0 {
@@ -122,7 +122,7 @@ func (c *ControlPlane) FailureDomainWithMostMachines() *string {
 	}
 
 	// Otherwise pick the currently known failure domain with the most Machines
-	return PickMost(c.Cluster.Status.FailureDomains.FilterControlPlane(), c.Machines)
+	return PickMost(c.Cluster.Status.FailureDomains.FilterControlPlane(), machines)
 }
 
 // FailureDomainWithFewestMachines returns the failure domain with the fewest number of machines.

--- a/controlplane/kubeadm/internal/control_plane_test.go
+++ b/controlplane/kubeadm/internal/control_plane_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Control Plane", func() {
 		Describe("With most machines", func() {
 			Context("With all machines in known failure domains", func() {
 				It("should return the failure domain that has the most number of machines", func() {
-					Expect(*controlPlane.FailureDomainWithMostMachines()).To(Equal("two"))
+					Expect(*controlPlane.FailureDomainWithMostMachines(controlPlane.Machines)).To(Equal("two"))
 				})
 			})
 			Context("With some machines in non-defined failure domains", func() {
@@ -67,7 +67,7 @@ var _ = Describe("Control Plane", func() {
 					controlPlane.Machines.Insert(machine("machine-5", withFailureDomain("unknown")))
 				})
 				It("should return machines in non-defined failure domains first", func() {
-					Expect(*controlPlane.FailureDomainWithMostMachines()).To(Equal("unknown"))
+					Expect(*controlPlane.FailureDomainWithMostMachines(controlPlane.Machines)).To(Equal("unknown"))
 				})
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Select the failure domain with most machines in a smaller set of machines instead of all controlplane machines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2760
