### PR TITLE
 🏃[KCP] reorganize unit tests

### DIFF
--- a/controlplane/kubeadm/controllers/helpers_test.go
+++ b/controlplane/kubeadm/controllers/helpers_test.go
@@ -1,0 +1,403 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	utilpointer "k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
+	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/hash"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/cluster-api/util/secret"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestReconcileKubeconfigEmptyAPIEndpoints(t *testing.T) {
+	g := NewWithT(t)
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			Version: "v1.16.6",
+		},
+	}
+	clusterName := client.ObjectKey{Namespace: "test", Name: "foo"}
+
+	fakeClient := newFakeClient(g, kcp.DeepCopy())
+	r := &KubeadmControlPlaneReconciler{
+		Client:   fakeClient,
+		Log:      log.Log,
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, clusterv1.APIEndpoint{}, kcp)).To(Succeed())
+
+	kubeconfigSecret := &corev1.Secret{}
+	secretName := client.ObjectKey{
+		Namespace: "test",
+		Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
+	}
+	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(MatchError(ContainSubstring("not found")))
+}
+
+func TestReconcileKubeconfigMissingCACertificate(t *testing.T) {
+	g := NewWithT(t)
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			Version: "v1.16.6",
+		},
+	}
+	clusterName := client.ObjectKey{Namespace: "test", Name: "foo"}
+	endpoint := clusterv1.APIEndpoint{Host: "test.local", Port: 8443}
+
+	fakeClient := newFakeClient(g, kcp.DeepCopy())
+	r := &KubeadmControlPlaneReconciler{
+		Client:   fakeClient,
+		Log:      log.Log,
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, endpoint, kcp)).NotTo(Succeed())
+
+	kubeconfigSecret := &corev1.Secret{}
+	secretName := client.ObjectKey{
+		Namespace: "test",
+		Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
+	}
+	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(MatchError(ContainSubstring("not found")))
+}
+
+func TestReconcileKubeconfigSecretAlreadyExists(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+		},
+	}
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			Version: "v1.16.6",
+		},
+	}
+	clusterName := util.ObjectKey(cluster)
+	endpoint := clusterv1.APIEndpoint{Host: "test.local", Port: 8443}
+
+	existingKubeconfigSecret := kubeconfig.GenerateSecretWithOwner(
+		client.ObjectKey{Name: "foo", Namespace: "test"},
+		[]byte{},
+		*metav1.NewControllerRef(cluster, clusterv1.GroupVersion.WithKind("Cluster")),
+	)
+
+	fakeClient := newFakeClient(g, kcp.DeepCopy(), existingKubeconfigSecret.DeepCopy())
+	r := &KubeadmControlPlaneReconciler{
+		Client:   fakeClient,
+		Log:      log.Log,
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, endpoint, kcp)).To(Succeed())
+
+	kubeconfigSecret := &corev1.Secret{}
+	secretName := client.ObjectKey{
+		Namespace: "test",
+		Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
+	}
+	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(Succeed())
+	g.Expect(kubeconfigSecret.Labels).To(Equal(existingKubeconfigSecret.Labels))
+	g.Expect(kubeconfigSecret.Data).To(Equal(existingKubeconfigSecret.Data))
+	g.Expect(kubeconfigSecret.OwnerReferences).NotTo(ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
+
+}
+
+func TestKubeadmControlPlaneReconciler_reconcileKubeconfig(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+		},
+	}
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			Version: "v1.16.6",
+		},
+	}
+	clusterName := util.ObjectKey(cluster)
+	endpoint := clusterv1.APIEndpoint{Host: "test.local", Port: 8443}
+
+	clusterCerts := secret.NewCertificatesForInitialControlPlane(&kubeadmv1.ClusterConfiguration{})
+	g.Expect(clusterCerts.Generate()).To(Succeed())
+	caCert := clusterCerts.GetByPurpose(secret.ClusterCA)
+	existingCACertSecret := caCert.AsSecret(
+		client.ObjectKey{Namespace: "test", Name: "foo"},
+		*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane")),
+	)
+
+	fakeClient := newFakeClient(g, kcp.DeepCopy(), existingCACertSecret.DeepCopy())
+	r := &KubeadmControlPlaneReconciler{
+		Client:   fakeClient,
+		Log:      log.Log,
+		recorder: record.NewFakeRecorder(32),
+	}
+	g.Expect(r.reconcileKubeconfig(context.Background(), clusterName, endpoint, kcp)).To(Succeed())
+
+	kubeconfigSecret := &corev1.Secret{}
+	secretName := client.ObjectKey{
+		Namespace: "test",
+		Name:      secret.Name(clusterName.Name, secret.Kubeconfig),
+	}
+	g.Expect(r.Client.Get(context.Background(), secretName, kubeconfigSecret)).To(Succeed())
+	g.Expect(kubeconfigSecret.OwnerReferences).NotTo(BeEmpty())
+	g.Expect(kubeconfigSecret.OwnerReferences).To(ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
+	g.Expect(kubeconfigSecret.Labels).To(HaveKeyWithValue(clusterv1.ClusterLabelName, clusterName.Name))
+}
+
+func TestCloneConfigsAndGenerateMachine(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+		},
+	}
+
+	genericMachineTemplate := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "GenericMachineTemplate",
+			"apiVersion": "generic.io/v1",
+			"metadata": map[string]interface{}{
+				"name":      "infra-foo",
+				"namespace": cluster.Namespace,
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"hello": "world",
+					},
+				},
+			},
+		},
+	}
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kcp-foo",
+			Namespace: cluster.Namespace,
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			InfrastructureTemplate: corev1.ObjectReference{
+				Kind:       genericMachineTemplate.GetKind(),
+				APIVersion: genericMachineTemplate.GetAPIVersion(),
+				Name:       genericMachineTemplate.GetName(),
+				Namespace:  cluster.Namespace,
+			},
+			Version: "v1.16.6",
+		},
+	}
+
+	fakeClient := newFakeClient(g, cluster.DeepCopy(), kcp.DeepCopy(), genericMachineTemplate.DeepCopy())
+
+	r := &KubeadmControlPlaneReconciler{
+		Client:   fakeClient,
+		Log:      log.Log,
+		recorder: record.NewFakeRecorder(32),
+		scheme:   scheme.Scheme,
+	}
+
+	bootstrapSpec := &bootstrapv1.KubeadmConfigSpec{
+		JoinConfiguration: &kubeadmv1.JoinConfiguration{},
+	}
+	g.Expect(r.cloneConfigsAndGenerateMachine(context.Background(), cluster, kcp, bootstrapSpec, nil)).To(Succeed())
+
+	machineList := &clusterv1.MachineList{}
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(machineList.Items).To(HaveLen(1))
+
+	for _, m := range machineList.Items {
+		g.Expect(m.Namespace).To(Equal(cluster.Namespace))
+		g.Expect(m.Name).NotTo(BeEmpty())
+		g.Expect(m.Name).To(HavePrefix(kcp.Name))
+
+		g.Expect(m.Spec.InfrastructureRef.Namespace).To(Equal(cluster.Namespace))
+		g.Expect(m.Spec.InfrastructureRef.Name).To(HavePrefix(genericMachineTemplate.GetName()))
+		g.Expect(m.Spec.InfrastructureRef.APIVersion).To(Equal(genericMachineTemplate.GetAPIVersion()))
+		g.Expect(m.Spec.InfrastructureRef.Kind).To(Equal("GenericMachine"))
+
+		g.Expect(m.Spec.Bootstrap.ConfigRef.Namespace).To(Equal(cluster.Namespace))
+		g.Expect(m.Spec.Bootstrap.ConfigRef.Name).To(HavePrefix(kcp.Name))
+		g.Expect(m.Spec.Bootstrap.ConfigRef.APIVersion).To(Equal(bootstrapv1.GroupVersion.String()))
+		g.Expect(m.Spec.Bootstrap.ConfigRef.Kind).To(Equal("KubeadmConfig"))
+	}
+}
+
+func TestKubeadmControlPlaneReconciler_generateMachine(t *testing.T) {
+	g := NewWithT(t)
+	fakeClient := newFakeClient(g)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testCluster",
+			Namespace: "test",
+		},
+	}
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testControlPlane",
+			Namespace: cluster.Namespace,
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			Version: "v1.16.6",
+		},
+	}
+
+	infraRef := &corev1.ObjectReference{
+		Kind:       "InfraKind",
+		APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+		Name:       "infra",
+		Namespace:  cluster.Namespace,
+	}
+	bootstrapRef := &corev1.ObjectReference{
+		Kind:       "BootstrapKind",
+		APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+		Name:       "bootstrap",
+		Namespace:  cluster.Namespace,
+	}
+	expectedMachineSpec := clusterv1.MachineSpec{
+		ClusterName: cluster.Name,
+		Version:     utilpointer.StringPtr(kcp.Spec.Version),
+		Bootstrap: clusterv1.Bootstrap{
+			ConfigRef: bootstrapRef.DeepCopy(),
+		},
+		InfrastructureRef: *infraRef.DeepCopy(),
+	}
+	r := &KubeadmControlPlaneReconciler{
+		Client:            fakeClient,
+		Log:               log.Log,
+		managementCluster: &internal.Management{Client: fakeClient},
+		recorder:          record.NewFakeRecorder(32),
+	}
+	g.Expect(r.generateMachine(context.Background(), kcp, cluster, infraRef, bootstrapRef, nil)).To(Succeed())
+
+	machineList := &clusterv1.MachineList{}
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(machineList.Items).NotTo(BeEmpty())
+	g.Expect(machineList.Items).To(HaveLen(1))
+	machine := machineList.Items[0]
+	g.Expect(machine.Name).To(HavePrefix(kcp.Name))
+	g.Expect(machine.Namespace).To(Equal(kcp.Namespace))
+	g.Expect(machine.Labels).To(Equal(internal.ControlPlaneLabelsForClusterWithHash(cluster.Name, hash.Compute(&kcp.Spec))))
+	g.Expect(machine.OwnerReferences).To(HaveLen(1))
+	g.Expect(machine.OwnerReferences).To(ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
+	g.Expect(machine.Spec).To(Equal(expectedMachineSpec))
+}
+
+func TestKubeadmControlPlaneReconciler_generateKubeadmConfig(t *testing.T) {
+	g := NewWithT(t)
+	fakeClient := newFakeClient(g)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testCluster",
+			Namespace: "test",
+		},
+	}
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testControlPlane",
+			Namespace: cluster.Namespace,
+		},
+	}
+
+	spec := bootstrapv1.KubeadmConfigSpec{}
+	expectedReferenceKind := "KubeadmConfig"
+	expectedReferenceAPIVersion := bootstrapv1.GroupVersion.String()
+	expectedOwner := metav1.OwnerReference{
+		Kind:       "KubeadmControlPlane",
+		APIVersion: controlplanev1.GroupVersion.String(),
+		Name:       kcp.Name,
+	}
+
+	r := &KubeadmControlPlaneReconciler{
+		Client:   fakeClient,
+		Log:      log.Log,
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	got, err := r.generateKubeadmConfig(context.Background(), kcp, cluster, spec.DeepCopy())
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Name).To(HavePrefix(kcp.Name))
+	g.Expect(got.Namespace).To(Equal(kcp.Namespace))
+	g.Expect(got.Kind).To(Equal(expectedReferenceKind))
+	g.Expect(got.APIVersion).To(Equal(expectedReferenceAPIVersion))
+
+	bootstrapConfig := &bootstrapv1.KubeadmConfig{}
+	key := client.ObjectKey{Name: got.Name, Namespace: got.Namespace}
+	g.Expect(fakeClient.Get(context.Background(), key, bootstrapConfig)).To(Succeed())
+	g.Expect(bootstrapConfig.Labels).To(Equal(internal.ControlPlaneLabelsForClusterWithHash(cluster.Name, hash.Compute(&kcp.Spec))))
+	g.Expect(bootstrapConfig.OwnerReferences).To(HaveLen(1))
+	g.Expect(bootstrapConfig.OwnerReferences).To(ContainElement(expectedOwner))
+	g.Expect(bootstrapConfig.Spec).To(Equal(spec))
+}
+
+// TODO
+func TestReconcileExternalReference(t *testing.T) {}
+
+// TODO
+func TestCleanupFromGeneration(t *testing.T) {}
+
+// TODO
+func TestMarkWithAnnotationKey(t *testing.T) {}

--- a/controlplane/kubeadm/controllers/scale_test.go
+++ b/controlplane/kubeadm/controllers/scale_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestKubeadmControlPlaneReconciler_initializeControlPlane(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster, kcp, genericMachineTemplate := createClusterWithControlPlane()
+
+	fakeClient := newFakeClient(g, cluster.DeepCopy(), kcp.DeepCopy(), genericMachineTemplate.DeepCopy())
+
+	r := &KubeadmControlPlaneReconciler{
+		Client:   fakeClient,
+		Log:      log.Log,
+		recorder: record.NewFakeRecorder(32),
+	}
+	controlPlane := &internal.ControlPlane{
+		Cluster: cluster,
+		KCP:     kcp,
+	}
+
+	result, err := r.initializeControlPlane(context.Background(), cluster, kcp, controlPlane)
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	machineList := &clusterv1.MachineList{}
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(machineList.Items).NotTo(BeEmpty())
+	g.Expect(machineList.Items).To(HaveLen(1))
+
+	g.Expect(machineList.Items[0].Namespace).To(Equal(cluster.Namespace))
+	g.Expect(machineList.Items[0].Name).To(HavePrefix(kcp.Name))
+
+	g.Expect(machineList.Items[0].Spec.InfrastructureRef.Namespace).To(Equal(cluster.Namespace))
+	g.Expect(machineList.Items[0].Spec.InfrastructureRef.Name).To(HavePrefix(genericMachineTemplate.GetName()))
+	g.Expect(machineList.Items[0].Spec.InfrastructureRef.APIVersion).To(Equal(genericMachineTemplate.GetAPIVersion()))
+	g.Expect(machineList.Items[0].Spec.InfrastructureRef.Kind).To(Equal("GenericMachine"))
+
+	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.Namespace).To(Equal(cluster.Namespace))
+	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.Name).To(HavePrefix(kcp.Name))
+	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.APIVersion).To(Equal(bootstrapv1.GroupVersion.String()))
+	g.Expect(machineList.Items[0].Spec.Bootstrap.ConfigRef.Kind).To(Equal("KubeadmConfig"))
+}
+
+func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
+	t.Run("creates a control plane Machine if health checks pass", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cluster, kcp, genericMachineTemplate := createClusterWithControlPlane()
+		initObjs := []runtime.Object{cluster.DeepCopy(), kcp.DeepCopy(), genericMachineTemplate.DeepCopy()}
+
+		fmc := &fakeManagementCluster{
+			Machines:            internal.NewFilterableMachineCollection(),
+			ControlPlaneHealthy: true,
+			EtcdHealthy:         true,
+		}
+
+		for i := 0; i < 2; i++ {
+			m, _ := createMachineNodePair(fmt.Sprintf("test-%d", i), cluster, kcp, true)
+			fmc.Machines = fmc.Machines.Insert(m)
+			initObjs = append(initObjs, m.DeepCopy())
+		}
+
+		fakeClient := newFakeClient(g, initObjs...)
+
+		r := &KubeadmControlPlaneReconciler{
+			Client:            fakeClient,
+			managementCluster: fmc,
+			Log:               log.Log,
+			recorder:          record.NewFakeRecorder(32),
+		}
+		controlPlane := &internal.ControlPlane{
+			KCP:      kcp,
+			Cluster:  cluster,
+			Machines: fmc.Machines,
+		}
+
+		result, err := r.scaleUpControlPlane(context.Background(), cluster, kcp, fmc.Machines.DeepCopy(), controlPlane)
+		g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		controlPlaneMachines := clusterv1.MachineList{}
+		g.Expect(fakeClient.List(context.Background(), &controlPlaneMachines)).To(Succeed())
+		g.Expect(controlPlaneMachines.Items).To(HaveLen(3))
+	})
+	t.Run("does not create a control plane Machine if health checks fail", func(t *testing.T) {
+		cluster, kcp, genericMachineTemplate := createClusterWithControlPlane()
+		initObjs := []runtime.Object{cluster.DeepCopy(), kcp.DeepCopy(), genericMachineTemplate.DeepCopy()}
+
+		beforeMachines := internal.NewFilterableMachineCollection()
+		for i := 0; i < 2; i++ {
+			m, _ := createMachineNodePair(fmt.Sprintf("test-%d", i), cluster.DeepCopy(), kcp.DeepCopy(), true)
+			beforeMachines = beforeMachines.Insert(m)
+			initObjs = append(initObjs, m.DeepCopy())
+		}
+
+		testCases := []struct {
+			name                  string
+			etcdUnHealthy         bool
+			controlPlaneUnHealthy bool
+		}{
+			{
+				name:          "etcd health check fails",
+				etcdUnHealthy: true,
+			},
+			{
+				name:                  "controlplane component health check fails",
+				controlPlaneUnHealthy: true,
+			},
+		}
+		for _, tc := range testCases {
+			g := NewWithT(t)
+
+			fakeClient := newFakeClient(g, initObjs...)
+			fmc := &fakeManagementCluster{
+				Machines:            beforeMachines.DeepCopy(),
+				ControlPlaneHealthy: !tc.controlPlaneUnHealthy,
+				EtcdHealthy:         !tc.etcdUnHealthy,
+			}
+
+			r := &KubeadmControlPlaneReconciler{
+				Client:            fakeClient,
+				managementCluster: fmc,
+				Log:               log.Log,
+				recorder:          record.NewFakeRecorder(32),
+			}
+			controlPlane := &internal.ControlPlane{
+				KCP:      kcp,
+				Cluster:  cluster,
+				Machines: beforeMachines,
+			}
+
+			ownedMachines := fmc.Machines.DeepCopy()
+			_, err := r.scaleUpControlPlane(context.Background(), cluster.DeepCopy(), kcp.DeepCopy(), ownedMachines, controlPlane)
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err).To(MatchError(&capierrors.RequeueAfterError{RequeueAfter: healthCheckFailedRequeueAfter}))
+
+			controlPlaneMachines := &clusterv1.MachineList{}
+			g.Expect(fakeClient.List(context.Background(), controlPlaneMachines)).To(Succeed())
+			g.Expect(controlPlaneMachines.Items).To(HaveLen(len(beforeMachines)))
+
+			endMachines := internal.NewFilterableMachineCollectionFromMachineList(controlPlaneMachines)
+			for _, m := range endMachines {
+				bm, ok := beforeMachines[m.Name]
+				g.Expect(ok).To(BeTrue())
+				g.Expect(m).To(Equal(bm))
+			}
+		}
+	})
+}
+
+func TestKubeadmControlPlaneReconciler_scaleDownControlPlane_NoError(t *testing.T) {
+	g := NewWithT(t)
+
+	machines := map[string]*clusterv1.Machine{
+		"one": machine("one"),
+	}
+
+	r := &KubeadmControlPlaneReconciler{
+		Log:      log.Log,
+		recorder: record.NewFakeRecorder(32),
+		Client:   newFakeClient(g, machines["one"]),
+		managementCluster: &fakeManagementCluster{
+			EtcdHealthy:         true,
+			ControlPlaneHealthy: true,
+		},
+	}
+	cluster := &clusterv1.Cluster{}
+	kcp := &controlplanev1.KubeadmControlPlane{}
+	controlPlane := &internal.ControlPlane{
+		KCP:      kcp,
+		Cluster:  cluster,
+		Machines: machines,
+	}
+
+	_, err := r.scaleDownControlPlane(context.Background(), cluster, kcp, machines, machines, controlPlane)
+	g.Expect(err).ToNot(HaveOccurred())
+}
+
+func machine(name string) *clusterv1.Machine {
+	return &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+	}
+}

--- a/controlplane/kubeadm/controllers/status_test.go
+++ b/controlplane/kubeadm/controllers/status_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/klogr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestKubeadmControlPlaneReconciler_updateStatusNoMachines(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+		},
+	}
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Namespace,
+			Name:      "foo",
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			Version: "v1.16.6",
+		},
+	}
+	kcp.Default()
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
+
+	fakeClient := newFakeClient(g, kcp.DeepCopy(), cluster.DeepCopy())
+	log.SetLogger(klogr.New())
+
+	r := &KubeadmControlPlaneReconciler{
+		Client: fakeClient,
+		Log:    log.Log,
+		scheme: scheme.Scheme,
+		managementCluster: &fakeManagementCluster{
+			Machines: map[string]*clusterv1.Machine{},
+			Workload: fakeWorkloadCluster{},
+		},
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
+	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(0))
+	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(0))
+	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(0))
+	g.Expect(kcp.Status.Initialized).To(BeFalse())
+	g.Expect(kcp.Status.Ready).To(BeFalse())
+	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
+	g.Expect(kcp.Status.FailureMessage).To(BeNil())
+	g.Expect(kcp.Status.FailureReason).To(BeEquivalentTo(""))
+}
+
+func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesNotReady(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+		},
+	}
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Namespace,
+			Name:      "foo",
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			Version: "v1.16.6",
+		},
+	}
+	kcp.Default()
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
+
+	machines := map[string]*clusterv1.Machine{}
+	objs := []runtime.Object{cluster.DeepCopy(), kcp.DeepCopy()}
+	for i := 0; i < 3; i++ {
+		name := fmt.Sprintf("test-%d", i)
+		m, n := createMachineNodePair(name, cluster, kcp, false)
+		objs = append(objs, n)
+		machines[m.Name] = m
+	}
+
+	fakeClient := newFakeClient(g, objs...)
+	log.SetLogger(klogr.New())
+
+	r := &KubeadmControlPlaneReconciler{
+		Client: fakeClient,
+		Log:    log.Log,
+		scheme: scheme.Scheme,
+		managementCluster: &fakeManagementCluster{
+			Machines: machines,
+			Workload: fakeWorkloadCluster{},
+		},
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
+	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(3))
+	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(0))
+	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(3))
+	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
+	g.Expect(kcp.Status.FailureMessage).To(BeNil())
+	g.Expect(kcp.Status.FailureReason).To(BeEquivalentTo(""))
+	g.Expect(kcp.Status.Initialized).To(BeFalse())
+	g.Expect(kcp.Status.Ready).To(BeFalse())
+}
+
+func TestKubeadmControlPlaneReconciler_updateStatusAllMachinesReady(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "foo",
+		},
+	}
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Namespace,
+			Name:      "foo",
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			Version: "v1.16.6",
+		},
+	}
+	kcp.Default()
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
+
+	objs := []runtime.Object{cluster.DeepCopy(), kcp.DeepCopy(), kubeadmConfigMap()}
+	machines := map[string]*clusterv1.Machine{}
+	for i := 0; i < 3; i++ {
+		name := fmt.Sprintf("test-%d", i)
+		m, n := createMachineNodePair(name, cluster, kcp, true)
+		objs = append(objs, n)
+		machines[m.Name] = m
+	}
+
+	fakeClient := newFakeClient(g, objs...)
+	log.SetLogger(klogr.New())
+
+	r := &KubeadmControlPlaneReconciler{
+		Client: fakeClient,
+		Log:    log.Log,
+		scheme: scheme.Scheme,
+		managementCluster: &fakeManagementCluster{
+			Machines: machines,
+			Workload: fakeWorkloadCluster{
+				Status: internal.ClusterStatus{
+					Nodes:            3,
+					ReadyNodes:       3,
+					HasKubeadmConfig: true,
+				},
+			},
+		},
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
+	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(3))
+	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(3))
+	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(0))
+	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
+	g.Expect(kcp.Status.FailureMessage).To(BeNil())
+	g.Expect(kcp.Status.FailureReason).To(BeEquivalentTo(""))
+	g.Expect(kcp.Status.Initialized).To(BeTrue())
+	g.Expect(kcp.Status.Ready).To(BeTrue())
+}
+
+func TestKubeadmControlPlaneReconciler_updateStatusMachinesReadyMixed(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "test",
+		},
+	}
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Namespace,
+			Name:      "foo",
+		},
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			Version: "v1.16.6",
+		},
+	}
+	kcp.Default()
+	g.Expect(kcp.ValidateCreate()).To(Succeed())
+	machines := map[string]*clusterv1.Machine{}
+	objs := []runtime.Object{cluster.DeepCopy(), kcp.DeepCopy()}
+	for i := 0; i < 4; i++ {
+		name := fmt.Sprintf("test-%d", i)
+		m, n := createMachineNodePair(name, cluster, kcp, false)
+		machines[m.Name] = m
+		objs = append(objs, n)
+	}
+	m, n := createMachineNodePair("testReady", cluster, kcp, true)
+	objs = append(objs, n, kubeadmConfigMap())
+	machines[m.Name] = m
+	fakeClient := newFakeClient(g, objs...)
+	log.SetLogger(klogr.New())
+
+	r := &KubeadmControlPlaneReconciler{
+		Client: fakeClient,
+		Log:    log.Log,
+		scheme: scheme.Scheme,
+		managementCluster: &fakeManagementCluster{
+			Machines: machines,
+			Workload: fakeWorkloadCluster{
+				Status: internal.ClusterStatus{
+					Nodes:            5,
+					ReadyNodes:       1,
+					HasKubeadmConfig: true,
+				},
+			},
+		},
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	g.Expect(r.updateStatus(context.Background(), kcp, cluster)).To(Succeed())
+	g.Expect(kcp.Status.Replicas).To(BeEquivalentTo(5))
+	g.Expect(kcp.Status.ReadyReplicas).To(BeEquivalentTo(1))
+	g.Expect(kcp.Status.UnavailableReplicas).To(BeEquivalentTo(4))
+	g.Expect(kcp.Status.Selector).NotTo(BeEmpty())
+	g.Expect(kcp.Status.FailureMessage).To(BeNil())
+	g.Expect(kcp.Status.FailureReason).To(BeEquivalentTo(""))
+	g.Expect(kcp.Status.Initialized).To(BeTrue())
+	g.Expect(kcp.Status.Ready).To(BeTrue())
+}
+
+func kubeadmConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubeadm-config",
+			Namespace: metav1.NamespaceSystem,
+		},
+	}
+}

--- a/controlplane/kubeadm/controllers/upgrade_test.go
+++ b/controlplane/kubeadm/controllers/upgrade_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/tools/record"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestKubeadmControlPlaneReconciler_upgradeControlPlane(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster, kcp, genericMachineTemplate := createClusterWithControlPlane()
+	kcp.Spec.Version = "v1.17.3"
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration = nil
+
+	fakeClient := newFakeClient(g, cluster.DeepCopy(), kcp.DeepCopy(), genericMachineTemplate.DeepCopy())
+
+	r := &KubeadmControlPlaneReconciler{
+		Client:   fakeClient,
+		Log:      log.Log,
+		recorder: record.NewFakeRecorder(32),
+		managementCluster: &fakeManagementCluster{
+			Management: &internal.Management{Client: fakeClient},
+			Workload:   fakeWorkloadCluster{},
+		},
+	}
+	controlPlane := &internal.ControlPlane{
+		KCP:      kcp,
+		Cluster:  cluster,
+		Machines: nil,
+	}
+
+	result, err := r.initializeControlPlane(context.Background(), cluster, kcp, controlPlane)
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+	g.Expect(err).NotTo(HaveOccurred())
+
+	machineList := &clusterv1.MachineList{}
+	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(machineList.Items).NotTo(BeEmpty())
+	g.Expect(machineList.Items).To(HaveLen(1))
+
+	machineCollection := internal.NewFilterableMachineCollection(&machineList.Items[0])
+	result, err = r.upgradeControlPlane(context.Background(), cluster, kcp, machineCollection, machineCollection, controlPlane)
+
+	g.Expect(machineList.Items[0].Annotations).To(HaveKey(controlplanev1.SelectedForUpgradeAnnotation))
+
+	// TODO flesh out the rest of this test - this is currently least-effort to confirm a fix for an NPE when updating
+	// the etcd version
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(err).To(Equal(&capierrors.RequeueAfterError{RequeueAfter: healthCheckFailedRequeueAfter}))
+}
+
+// TODO
+func TestSelectMachineForUpgrade(t *testing.T) {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Following https://github.com/kubernetes-sigs/cluster-api/pull/2767, this PR reorganize KCP unite tests.

No issue is created for this.
