### PR TITLE
🏃clusterctl: add retries to clustectl move

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -117,7 +117,7 @@ func (cm *certManagerClient) EnsureWebhook() error {
 	}
 
 	// installs the web-hook
-	createCertManagerBackoff := newBackoff()
+	createCertManagerBackoff := newWriteBackoff()
 	objs = sortResourcesForCreate(objs)
 	for i := range objs {
 		o := objs[i]

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -205,7 +205,7 @@ func retryWithExponentialBackoff(opts wait.Backoff, operation func() error) erro
 		i++
 		if err := operation(); err != nil {
 			if i < opts.Steps {
-				log.V(5).Info("Operation failed, retry", "Error", err)
+				log.V(5).Info("Operation failed, retrying with backoff", "Cause", err.Error())
 				return false, nil
 			}
 			return false, err
@@ -218,8 +218,8 @@ func retryWithExponentialBackoff(opts wait.Backoff, operation func() error) erro
 	return nil
 }
 
-// newBackoff creates a new API Machinery backoff parameter set suitable for use with clusterctl operations.
-func newBackoff() wait.Backoff {
+// newWriteBackoff creates a new API Machinery backoff parameter set suitable for use with clusterctl write operations.
+func newWriteBackoff() wait.Backoff {
 	// Return a exponential backoff configuration which returns durations for a total time of ~40s.
 	// Example: 0, .5s, 1.2s, 2.3s, 4s, 6s, 10s, 16s, 24s, 37s
 	// Jitter is added as a random fraction of the duration multiplied by the jitter factor.
@@ -228,5 +228,31 @@ func newBackoff() wait.Backoff {
 		Factor:   1.5,
 		Steps:    10,
 		Jitter:   0.4,
+	}
+}
+
+// newConnectBackoff creates a new API Machinery backoff parameter set suitable for use when clusterctl connect to a cluster.
+func newConnectBackoff() wait.Backoff {
+	// Return a exponential backoff configuration which returns durations for a total time of ~15s.
+	// Example: 0, .25s, .6s, 1.2, 2.1s, 3.4s, 5.5s, 8s, 12s
+	// Jitter is added as a random fraction of the duration multiplied by the jitter factor.
+	return wait.Backoff{
+		Duration: 250 * time.Millisecond,
+		Factor:   1.5,
+		Steps:    9,
+		Jitter:   0.1,
+	}
+}
+
+// newReadBackoff creates a new API Machinery backoff parameter set suitable for use with clusterctl read operations.
+func newReadBackoff() wait.Backoff {
+	// Return a exponential backoff configuration which returns durations for a total time of ~15s.
+	// Example: 0, .25s, .6s, 1.2, 2.1s, 3.4s, 5.5s, 8s, 12s
+	// Jitter is added as a random fraction of the duration multiplied by the jitter factor.
+	return wait.Backoff{
+		Duration: 250 * time.Millisecond,
+		Factor:   1.5,
+		Steps:    9,
+		Jitter:   0.1,
 	}
 }

--- a/cmd/clusterctl/client/cluster/components.go
+++ b/cmd/clusterctl/client/cluster/components.go
@@ -57,7 +57,7 @@ type providerComponents struct {
 }
 
 func (p *providerComponents) Create(objs []unstructured.Unstructured) error {
-	createComponentObjectBackoff := newBackoff()
+	createComponentObjectBackoff := newWriteBackoff()
 	for i := range objs {
 		obj := objs[i]
 

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/clusterctl/client/cluster/objectgraph.go
+++ b/cmd/clusterctl/client/cluster/objectgraph.go
@@ -171,14 +171,12 @@ func (o *objectGraph) objToNode(obj *unstructured.Unstructured) *node {
 func (o *objectGraph) getDiscoveryTypes() ([]metav1.TypeMeta, error) {
 	discoveredTypes := []metav1.TypeMeta{}
 
-	c, err := o.proxy.NewClient()
-	if err != nil {
-		return nil, err
-	}
-
 	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
-	if err := c.List(ctx, crdList, client.MatchingLabels{clusterctlv1.ClusterctlLabelName: ""}); err != nil {
-		return nil, errors.Wrap(err, "failed to get the list of CRDs required for the move discovery phase")
+	getDiscoveryTypesBackoff := newReadBackoff()
+	if err := retryWithExponentialBackoff(getDiscoveryTypesBackoff, func() error {
+		return getCRDList(o.proxy, crdList)
+	}); err != nil {
+		return nil, err
 	}
 
 	for _, crd := range crdList.Items {
@@ -203,32 +201,42 @@ func (o *objectGraph) getDiscoveryTypes() ([]metav1.TypeMeta, error) {
 	return discoveredTypes, nil
 }
 
+func getCRDList(proxy Proxy, crdList *apiextensionsv1.CustomResourceDefinitionList) error {
+	c, err := proxy.NewClient()
+	if err != nil {
+		return err
+	}
+
+	if err := c.List(ctx, crdList, client.HasLabels{clusterctlv1.ClusterctlLabelName}); err != nil {
+		return errors.Wrap(err, "failed to get the list of CRDs required for the move discovery phase")
+	}
+	return nil
+}
+
 // Discovery reads all the Kubernetes objects existing in a namespace (or in all namespaces if empty) for the types received in input, and then adds
 // everything to the objects graph.
 func (o *objectGraph) Discovery(namespace string, types []metav1.TypeMeta) error {
 	log := logf.Log
 	log.Info("Discovering Cluster API objects")
 
-	c, err := o.proxy.NewClient()
-	if err != nil {
-		return err
-	}
-
 	selectors := []client.ListOption{}
 	if namespace != "" {
 		selectors = append(selectors, client.InNamespace(namespace))
 	}
 
-	for _, typeMeta := range types {
+	discoveryBackoff := newReadBackoff()
+	for i := range types {
+		typeMeta := types[i]
 		objList := new(unstructured.UnstructuredList)
-		objList.SetAPIVersion(typeMeta.APIVersion)
-		objList.SetKind(typeMeta.Kind)
 
-		if err := c.List(ctx, objList, selectors...); err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			return errors.Wrapf(err, "failed to list %q resources", objList.GroupVersionKind())
+		if err := retryWithExponentialBackoff(discoveryBackoff, func() error {
+			return getObjList(o.proxy, typeMeta, selectors, objList)
+		}); err != nil {
+			return err
+		}
+
+		if len(objList.Items) == 0 {
+			continue
 		}
 
 		log.V(5).Info(typeMeta.Kind, "Count", len(objList.Items))
@@ -247,6 +255,24 @@ func (o *objectGraph) Discovery(namespace string, types []metav1.TypeMeta) error
 	// Completes the graph by setting for each node the list of Clusters the node belong to.
 	o.setClusterTenants()
 
+	return nil
+}
+
+func getObjList(proxy Proxy, typeMeta metav1.TypeMeta, selectors []client.ListOption, objList *unstructured.UnstructuredList) error {
+	c, err := proxy.NewClient()
+	if err != nil {
+		return err
+	}
+
+	objList.SetAPIVersion(typeMeta.APIVersion)
+	objList.SetKind(typeMeta.Kind)
+
+	if err := c.List(ctx, objList, selectors...); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list %q resources", objList.GroupVersionKind())
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add some more retries to clusterctl. More specifically
- adds retries for handling temporary connection problems with clusters
- adds retries for all the read/write operations triggered clusterctl move

/assign @vincepri 
/assign @wfernandes 