### PR TITLE
🏃 Seed the random number generator

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -109,6 +110,8 @@ func InitFlags(fs *pflag.FlagSet) {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	InitFlags(pflag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()

--- a/cmd/example-provider/main.go
+++ b/cmd/example-provider/main.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"flag"
+	"math/rand"
 	"os"
+	"time"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog"
@@ -30,6 +32,8 @@ import (
 )
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	klog.InitFlags(nil)
 	var enableLeaderElection bool
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -101,6 +102,8 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Webhook Server port, disabled by default. When enabled, the manager will only work as webhook server, no reconcilers are installed.")
 }
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	InitFlags(pflag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"math/rand"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -131,6 +132,8 @@ func InitFlags(fs *pflag.FlagSet) {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	InitFlags(pflag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"math/rand"
 	"os"
 	"time"
 
@@ -55,6 +56,8 @@ func init() {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
+
 	klog.InitFlags(nil)
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.IntVar(&concurrency, "concurrency", 10, "The number of docker machines to process simultaneously")


### PR DESCRIPTION
**What this PR does / why we need it**:
Seed the random number generator, as (at least) controller-runtime uses
it to add jitter to shared informer resync periods.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
