### PR TITLE
⚠️ util.{Machine,Cluster}ToInfrastructureMapFunc should exclude version when parsing object references

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -267,10 +267,10 @@ func ClusterToInfrastructureMapFunc(gvk schema.GroupVersionKind) handler.ToReque
 		if c.Spec.InfrastructureRef == nil {
 			return nil
 		}
-
-		// Return early if the GroupVersionKind doesn't match what we expect.
-		infraGVK := c.Spec.InfrastructureRef.GroupVersionKind()
-		if gvk != infraGVK {
+		gk := gvk.GroupKind()
+		// Return early if the GroupKind doesn't match what we expect.
+		infraGK := c.Spec.InfrastructureRef.GroupVersionKind().GroupKind()
+		if gk != infraGK {
 			return nil
 		}
 
@@ -314,9 +314,10 @@ func MachineToInfrastructureMapFunc(gvk schema.GroupVersionKind) handler.ToReque
 			return nil
 		}
 
-		// Return early if the GroupVersionKind doesn't match what we expect.
-		infraGVK := m.Spec.InfrastructureRef.GroupVersionKind()
-		if gvk != infraGVK {
+		gk := gvk.GroupKind()
+		// Return early if the GroupKind doesn't match what we expect.
+		infraGK := m.Spec.InfrastructureRef.GroupVersionKind().GroupKind()
+		if gk != infraGK {
 			return nil
 		}
 


### PR DESCRIPTION
This bugfix will fix the matching issue discussed in [2775](https://github.com/kubernetes-sigs/cluster-api/issues/2775) using match on group kind and not version in. 