### PR TITLE
✨ Support modifying spec.kubeadmConfigSpec.clusterConfiguration.imageRepository

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
@@ -19,9 +19,10 @@ package v1alpha3
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/coredns/corefile-migration/migration"
 	kubeadmv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
-	"strings"
 
 	"github.com/blang/semver"
 	jsonpatch "github.com/evanphx/json-patch"
@@ -84,6 +85,7 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, clusterConfiguration, "etcd", "local", "imageTag"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageRepository"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageTag"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, "imageRepository"},
 		{spec, "infrastructureTemplate", "name"},
 		{spec, "replicas"},
 		{spec, "version"},

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
@@ -546,7 +546,7 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 		},
 		{
 			name:      "should fail when making a change to the cluster config's imageRepository",
-			expectErr: true,
+			expectErr: false,
 			before:    before,
 			kcp:       imageRepository,
 		},

--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -678,6 +678,13 @@ func (w *Workload) UpdateKubeProxyImageInfo(ctx context.Context, kcp *controlpla
 	if err != nil {
 		return err
 	}
+	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration != nil &&
+		kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ImageRepository != "" {
+		newImageName, err = util.ModifyImageRepository(newImageName, kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ImageRepository)
+		if err != nil {
+			return err
+		}
+	}
 
 	if container.Image != newImageName {
 		helper, err := patch.NewHelper(ds, w.Client)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -19,11 +19,13 @@ package util
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/blang/semver"
 	. "github.com/onsi/gomega"
 
+	"github.com/docker/distribution/reference"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -487,6 +489,40 @@ func TestModifyImageTag(t *testing.T) {
 		res, err := ModifyImageTag(image, testTag)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(res).To(Equal("example.com/image:v1.17.4_build1"))
+	})
+}
+
+func TestModifyImageRepository(t *testing.T) {
+	const testRepository = "example.com/new"
+	g := NewGomegaWithT(t)
+	t.Run("updates the repository of the image", func(t *testing.T) {
+		image := "example.com/subpaths/are/okay/image:1.17.3"
+		res, err := ModifyImageRepository(image, testRepository)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res).To(Equal("example.com/new/image:1.17.3"))
+	})
+
+	t.Run("errors if the repository name is too long", func(t *testing.T) {
+		testRepository := strings.Repeat("a", 255)
+		image := "example.com/image:1.17.3"
+		_, err := ModifyImageRepository(image, testRepository)
+		g.Expect(err).To(MatchError(ContainSubstring(reference.ErrNameTooLong.Error())))
+	})
+
+	t.Run("errors if the image name is not canonical", func(t *testing.T) {
+		image := "image:1.17.3"
+		_, err := ModifyImageRepository(image, testRepository)
+		g.Expect(err).To(MatchError(ContainSubstring(reference.ErrNameNotCanonical.Error())))
+	})
+	t.Run("errors if the image name is not tagged", func(t *testing.T) {
+		image := "example.com/image"
+		_, err := ModifyImageRepository(image, testRepository)
+		g.Expect(err).To(MatchError(ContainSubstring("image must be tagged")))
+	})
+	t.Run("errors if the image name is not valid", func(t *testing.T) {
+		image := "example.com/image:$@$(*"
+		_, err := ModifyImageRepository(image, testRepository)
+		g.Expect(err).To(MatchError(ContainSubstring("failed to parse image name")))
 	})
 }
 


### PR DESCRIPTION
- Update kube-proxy and coreDNS images
- Allow modification in webhook

**What this PR does / why we need it**:
Allows users to update the global image registry after having created a cluster.

**Which issue(s) this PR fixes**
Fixes #2777

/assign @vincepri 
