### PR TITLE
🏃 tests: move NewWithT(t) to inside the t.Run where applicable

### DIFF
--- a/api/v1alpha2/conversion_test.go
+++ b/api/v1alpha2/conversion_test.go
@@ -42,10 +42,10 @@ func TestFuzzyConversion(t *testing.T) {
 }
 
 func TestConvertCluster(t *testing.T) {
-	g := NewWithT(t)
-
 	t.Run("to hub", func(t *testing.T) {
 		t.Run("should convert the first value in Status.APIEndpoints to Spec.ControlPlaneEndpoint", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &Cluster{
 				Status: ClusterStatus{
 					APIEndpoints: []APIEndpoint{
@@ -66,6 +66,8 @@ func TestConvertCluster(t *testing.T) {
 
 	t.Run("from hub", func(t *testing.T) {
 		t.Run("preserves fields from hub version", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &v1alpha3.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "hub",
@@ -92,6 +94,8 @@ func TestConvertCluster(t *testing.T) {
 		})
 
 		t.Run("should convert Spec.ControlPlaneEndpoint to Status.APIEndpoints[0]", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &v1alpha3.Cluster{
 				Spec: v1alpha3.ClusterSpec{
 					ControlPlaneEndpoint: v1alpha3.APIEndpoint{
@@ -110,10 +114,10 @@ func TestConvertCluster(t *testing.T) {
 }
 
 func TestConvertMachine(t *testing.T) {
-	g := NewWithT(t)
-
 	t.Run("to hub", func(t *testing.T) {
 		t.Run("should convert the Spec.ClusterName from label", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -130,6 +134,8 @@ func TestConvertMachine(t *testing.T) {
 
 	t.Run("from hub", func(t *testing.T) {
 		t.Run("preserves fields from hub version", func(t *testing.T) {
+			g := NewWithT(t)
+
 			failureDomain := "my failure domain"
 			src := &v1alpha3.Machine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -159,10 +165,10 @@ func TestConvertMachine(t *testing.T) {
 }
 
 func TestConvertMachineSet(t *testing.T) {
-	g := NewWithT(t)
-
 	t.Run("to hub", func(t *testing.T) {
 		t.Run("should convert the Spec.ClusterName from label", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &MachineSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -180,6 +186,8 @@ func TestConvertMachineSet(t *testing.T) {
 
 	t.Run("from hub", func(t *testing.T) {
 		t.Run("preserves field from hub version", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &v1alpha3.MachineSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "hub",
@@ -208,10 +216,10 @@ func TestConvertMachineSet(t *testing.T) {
 }
 
 func TestConvertMachineDeployment(t *testing.T) {
-	g := NewWithT(t)
-
 	t.Run("to hub", func(t *testing.T) {
 		t.Run("should convert the Spec.ClusterName from label", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &MachineDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -227,6 +235,8 @@ func TestConvertMachineDeployment(t *testing.T) {
 		})
 
 		t.Run("should convert the annotations", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &MachineDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -249,6 +259,8 @@ func TestConvertMachineDeployment(t *testing.T) {
 
 	t.Run("from hub", func(t *testing.T) {
 		t.Run("preserves fields from hub version", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &v1alpha3.MachineDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "hub",
@@ -278,6 +290,8 @@ func TestConvertMachineDeployment(t *testing.T) {
 		})
 
 		t.Run("should convert the annotations", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &v1alpha3.MachineDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{

--- a/bootstrap/kubeadm/api/v1alpha2/conversion_test.go
+++ b/bootstrap/kubeadm/api/v1alpha2/conversion_test.go
@@ -27,10 +27,10 @@ import (
 )
 
 func TestConvertKubeadmConfig(t *testing.T) {
-	g := NewWithT(t)
-
 	t.Run("from hub", func(t *testing.T) {
 		t.Run("preserves fields from hub version", func(t *testing.T) {
+			g := NewWithT(t)
+
 			src := &v1alpha3.KubeadmConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "hub",
@@ -52,6 +52,5 @@ func TestConvertKubeadmConfig(t *testing.T) {
 			g.Expect(restored.Status.Ready).To(Equal(src.Status.Ready))
 			g.Expect(restored.Status.DataSecretName).To(Equal(src.Status.DataSecretName))
 		})
-
 	})
 }

--- a/bootstrap/kubeadm/internal/cloudinit/controlplane_test.go
+++ b/bootstrap/kubeadm/internal/cloudinit/controlplane_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestTemplateYAMLIndent(t *testing.T) {
-	g := NewWithT(t)
-
 	testcases := []struct {
 		name     string
 		input    string
@@ -48,6 +46,8 @@ func TestTemplateYAMLIndent(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(templateYAMLIndent(tc.indent, tc.input)).To(Equal(tc.expected))
 		})
 	}

--- a/bootstrap/kubeadm/internal/locking/control_plane_init_mutex_test.go
+++ b/bootstrap/kubeadm/internal/locking/control_plane_init_mutex_test.go
@@ -110,6 +110,8 @@ func TestControlPlaneInitMutex_Lock(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
 			l := &ControlPlaneInitMutex{
 				log:    log.Log,
 				client: tc.client,
@@ -128,7 +130,7 @@ func TestControlPlaneInitMutex_Lock(t *testing.T) {
 				},
 			}
 
-			g.Expect(l.Lock(context.Background(), cluster, machine)).To(Equal(tc.shouldAcquire))
+			gs.Expect(l.Lock(context.Background(), cluster, machine)).To(Equal(tc.shouldAcquire))
 		})
 	}
 }
@@ -192,6 +194,8 @@ func TestControlPlaneInitMutex_UnLock(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
 			l := &ControlPlaneInitMutex{
 				log:    log.Log,
 				client: tc.client,
@@ -205,7 +209,7 @@ func TestControlPlaneInitMutex_UnLock(t *testing.T) {
 				},
 			}
 
-			g.Expect(l.Unlock(context.Background(), cluster)).To(Equal(tc.shouldRelease))
+			gs.Expect(l.Unlock(context.Background(), cluster)).To(Equal(tc.shouldRelease))
 		})
 	}
 }

--- a/bootstrap/kubeadm/types/v1beta1/bootstraptokenstring_test.go
+++ b/bootstrap/kubeadm/types/v1beta1/bootstraptokenstring_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestMarshalJSON(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		bts      BootstrapTokenString
 		expected string
@@ -39,6 +37,8 @@ func TestMarshalJSON(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.bts.ID, func(t *testing.T) {
+			g := NewWithT(t)
+
 			b, err := json.Marshal(rt.bts)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(b).To(BeEquivalentTo(rt.expected))
@@ -47,8 +47,6 @@ func TestMarshalJSON(t *testing.T) {
 }
 
 func TestUnmarshalJSON(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		input         string
 		bts           *BootstrapTokenString
@@ -65,6 +63,8 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.input, func(t *testing.T) {
+			g := NewWithT(t)
+
 			newbts := &BootstrapTokenString{}
 			err := json.Unmarshal([]byte(rt.input), newbts)
 			if rt.expectedError {
@@ -78,8 +78,6 @@ func TestUnmarshalJSON(t *testing.T) {
 }
 
 func TestJSONRoundtrip(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		input string
 		bts   *BootstrapTokenString
@@ -89,6 +87,8 @@ func TestJSONRoundtrip(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.input, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(roundtrip(rt.input, rt.bts)).To(Succeed())
 		})
 	}
@@ -132,8 +132,6 @@ func roundtrip(input string, bts *BootstrapTokenString) error {
 }
 
 func TestTokenFromIDAndSecret(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		bts      BootstrapTokenString
 		expected string
@@ -144,14 +142,14 @@ func TestTokenFromIDAndSecret(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.bts.ID, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(rt.bts.String()).To(Equal(rt.expected))
 		})
 	}
 }
 
 func TestNewBootstrapTokenString(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		token         string
 		expectedError bool
@@ -176,6 +174,8 @@ func TestNewBootstrapTokenString(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.token, func(t *testing.T) {
+			g := NewWithT(t)
+
 			actual, err := NewBootstrapTokenString(rt.token)
 			if rt.expectedError {
 				g.Expect(err).To(HaveOccurred())
@@ -189,8 +189,6 @@ func TestNewBootstrapTokenString(t *testing.T) {
 }
 
 func TestNewBootstrapTokenStringFromIDAndSecret(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		id, secret    string
 		expectedError bool
@@ -212,6 +210,8 @@ func TestNewBootstrapTokenStringFromIDAndSecret(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.id, func(t *testing.T) {
+			g := NewWithT(t)
+
 			actual, err := NewBootstrapTokenStringFromIDAndSecret(rt.id, rt.secret)
 			if rt.expectedError {
 				g.Expect(err).To(HaveOccurred())

--- a/bootstrap/kubeadm/types/v1beta2/bootstraptokenstring_test.go
+++ b/bootstrap/kubeadm/types/v1beta2/bootstraptokenstring_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestMarshalJSON(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		bts      BootstrapTokenString
 		expected string
@@ -39,6 +37,8 @@ func TestMarshalJSON(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.bts.ID, func(t *testing.T) {
+			g := NewWithT(t)
+
 			b, err := json.Marshal(rt.bts)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(string(b)).To(Equal(rt.expected))
@@ -47,8 +47,6 @@ func TestMarshalJSON(t *testing.T) {
 }
 
 func TestUnmarshalJSON(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		input         string
 		bts           *BootstrapTokenString
@@ -65,6 +63,8 @@ func TestUnmarshalJSON(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.input, func(t *testing.T) {
+			g := NewWithT(t)
+
 			newbts := &BootstrapTokenString{}
 			err := json.Unmarshal([]byte(rt.input), newbts)
 			if rt.expectedError {
@@ -78,8 +78,6 @@ func TestUnmarshalJSON(t *testing.T) {
 }
 
 func TestJSONRoundtrip(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		input string
 		bts   *BootstrapTokenString
@@ -89,6 +87,8 @@ func TestJSONRoundtrip(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.input, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(roundtrip(rt.input, rt.bts)).To(Succeed())
 		})
 	}
@@ -132,8 +132,6 @@ func roundtrip(input string, bts *BootstrapTokenString) error {
 }
 
 func TestTokenFromIDAndSecret(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		bts      BootstrapTokenString
 		expected string
@@ -144,14 +142,14 @@ func TestTokenFromIDAndSecret(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.bts.ID, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(rt.bts.String()).To(Equal(rt.expected))
 		})
 	}
 }
 
 func TestNewBootstrapTokenString(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		token         string
 		expectedError bool
@@ -176,6 +174,8 @@ func TestNewBootstrapTokenString(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.token, func(t *testing.T) {
+			g := NewWithT(t)
+
 			actual, err := NewBootstrapTokenString(rt.token)
 			if rt.expectedError {
 				g.Expect(err).To(HaveOccurred())
@@ -188,8 +188,6 @@ func TestNewBootstrapTokenString(t *testing.T) {
 }
 
 func TestNewBootstrapTokenStringFromIDAndSecret(t *testing.T) {
-	g := NewWithT(t)
-
 	var tests = []struct {
 		id, secret    string
 		expectedError bool
@@ -211,6 +209,8 @@ func TestNewBootstrapTokenStringFromIDAndSecret(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.id, func(t *testing.T) {
+			g := NewWithT(t)
+
 			actual, err := NewBootstrapTokenStringFromIDAndSecret(rt.id, rt.secret)
 			if rt.expectedError {
 				g.Expect(err).To(HaveOccurred())

--- a/cmd/clusterctl/api/v1alpha3/provider_type_test.go
+++ b/cmd/clusterctl/api/v1alpha3/provider_type_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func Test_Provider_ManifestLabel(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		provider     string
 		providerType ProviderType
@@ -85,6 +83,8 @@ func Test_Provider_ManifestLabel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			p := &Provider{
 				ProviderName: tt.fields.provider,
 				Type:         string(tt.fields.providerType),

--- a/cmd/clusterctl/client/cluster/components_test.go
+++ b/cmd/clusterctl/client/cluster/components_test.go
@@ -35,8 +35,6 @@ import (
 )
 
 func Test_providerComponents_Delete(t *testing.T) {
-	g := NewWithT(t)
-
 	labels := map[string]string{
 		clusterv1.ProviderLabelName: "infrastructure-infra",
 	}
@@ -250,6 +248,8 @@ func Test_providerComponents_Delete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			proxy := test.NewFakeProxy().WithObjs(initObjs...)
 			c := newComponentsClient(proxy)
 			err := c.Delete(DeleteOptions{

--- a/cmd/clusterctl/client/cluster/installer_test.go
+++ b/cmd/clusterctl/client/cluster/installer_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func Test_providerInstaller_Validate(t *testing.T) {
-	g := NewWithT(t)
-
 	fakeReader := test.NewFakeReader().
 		WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 		WithProvider("infra1", clusterctlv1.InfrastructureProviderType, "https://somewhere.com").
@@ -196,6 +194,8 @@ func Test_providerInstaller_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			configClient, _ := config.New("", config.InjectReader(fakeReader))
 
 			i := &providerInstaller{
@@ -268,8 +268,6 @@ func newFakeComponents(name string, providerType clusterctlv1.ProviderType, vers
 }
 
 func Test_shouldInstallSharedComponents(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		providerList *clusterctlv1.ProviderList
 		provider     clusterctlv1.Provider
@@ -325,6 +323,8 @@ func Test_shouldInstallSharedComponents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := shouldInstallSharedComponents(tt.args.providerList, tt.args.provider)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/cmd/clusterctl/client/cluster/inventory_managementgroup_test.go
+++ b/cmd/clusterctl/client/cluster/inventory_managementgroup_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func Test_inventoryClient_GetManagementGroups(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		proxy Proxy
 	}
@@ -146,6 +144,8 @@ func Test_inventoryClient_GetManagementGroups(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			p := &inventoryClient{
 				proxy: tt.fields.proxy,
 			}

--- a/cmd/clusterctl/client/cluster/inventory_test.go
+++ b/cmd/clusterctl/client/cluster/inventory_test.go
@@ -34,8 +34,6 @@ func fakePollImmediateWaiter(interval, timeout time.Duration, condition wait.Con
 }
 
 func Test_inventoryClient_EnsureCustomResourceDefinitions(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		alreadyHasCRD bool
 	}
@@ -61,6 +59,8 @@ func Test_inventoryClient_EnsureCustomResourceDefinitions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			p := newInventoryClient(test.NewFakeProxy(), fakePollImmediateWaiter)
 			if tt.fields.alreadyHasCRD {
 				//forcing creation of metadata before test
@@ -80,8 +80,6 @@ func Test_inventoryClient_EnsureCustomResourceDefinitions(t *testing.T) {
 var fooProvider = clusterctlv1.Provider{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "ns1"}}
 
 func Test_inventoryClient_List(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		initObjs []runtime.Object
 	}
@@ -106,6 +104,8 @@ func Test_inventoryClient_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			p := newInventoryClient(test.NewFakeProxy().WithObjs(tt.fields.initObjs...), fakePollImmediateWaiter)
 			got, err := p.List()
 			if tt.wantErr {
@@ -120,8 +120,6 @@ func Test_inventoryClient_List(t *testing.T) {
 }
 
 func Test_inventoryClient_Create(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		proxy Proxy
 	}
@@ -167,6 +165,8 @@ func Test_inventoryClient_Create(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			p := &inventoryClient{
 				proxy: tt.fields.proxy,
 			}

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -359,10 +359,11 @@ var moveTests = []struct {
 }
 
 func Test_getMoveSequence(t *testing.T) {
-	g := NewWithT(t)
 	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
 	for _, tt := range moveTests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			// Create an objectGraph bound a source cluster with all the CRDs for the types involved in the test.
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
@@ -390,10 +391,11 @@ func Test_getMoveSequence(t *testing.T) {
 }
 
 func Test_objectMover_move(t *testing.T) {
-	g := NewWithT(t)
 	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
 	for _, tt := range moveTests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			// Create an objectGraph bound a source cluster with all the CRDs for the types involved in the test.
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
@@ -463,8 +465,6 @@ func Test_objectMover_move(t *testing.T) {
 }
 
 func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		objs []runtime.Object
 	}
@@ -634,6 +634,8 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			// Create an objectGraph bound a source cluster with all the CRDs for the types involved in the test.
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
@@ -658,8 +660,6 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 }
 
 func Test_objectsMoverService_checkTargetProviders(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		fromProxy Proxy
 	}
@@ -774,6 +774,8 @@ func Test_objectsMoverService_checkTargetProviders(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			o := &objectMover{
 				fromProviderInventory: newInventoryClient(tt.fields.fromProxy, nil),
 			}

--- a/cmd/clusterctl/client/cluster/objectgraph_test.go
+++ b/cmd/clusterctl/client/cluster/objectgraph_test.go
@@ -33,8 +33,6 @@ import (
 )
 
 func TestObjectGraph_getDiscoveryTypeMetaList(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		proxy Proxy
 	}
@@ -64,6 +62,8 @@ func TestObjectGraph_getDiscoveryTypeMetaList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			graph := newObjectGraph(tt.fields.proxy)
 			got, err := graph.getDiscoveryTypes()
 			if tt.wantErr {
@@ -867,10 +867,11 @@ func getDetachedObjectGraphWihObjs(objs []runtime.Object) (*objectGraph, error) 
 }
 
 func TestObjectGraph_addObj_WithFakeObjects(t *testing.T) {
-	g := NewWithT(t)
 	// NB. we are testing the graph is properly built starting from objects (this test) or from the same objects read from the cluster (TestGraphBuilder_Discovery)
 	for _, tt := range objectGraphsTests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			graph, err := getDetachedObjectGraphWihObjs(tt.args.objs)
 			g.Expect(err).NotTo(HaveOccurred())
 
@@ -914,10 +915,11 @@ func getFakeDiscoveryTypes(graph *objectGraph) ([]metav1.TypeMeta, error) {
 }
 
 func TestObjectGraph_Discovery(t *testing.T) {
-	g := NewWithT(t)
 	// NB. we are testing the graph is properly built starting from objects (TestGraphBuilder_addObj_WithFakeObjects) or from the same objects read from the cluster (this test).
 	for _, tt := range objectGraphsTests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			// Create an objectGraph bound to a source cluster with all the CRDs for the types involved in the test.
 			graph := getObjectGraphWithObjs(tt.args.objs)
 
@@ -939,8 +941,6 @@ func TestObjectGraph_Discovery(t *testing.T) {
 }
 
 func TestObjectGraph_DiscoveryByNamespace(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		namespace string
 		objs      []runtime.Object
@@ -1035,6 +1035,8 @@ func TestObjectGraph_DiscoveryByNamespace(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			// Create an objectGraph bound to a source cluster with all the CRDs for the types involved in the test.
 			graph := getObjectGraphWithObjs(tt.args.objs)
 
@@ -1056,8 +1058,6 @@ func TestObjectGraph_DiscoveryByNamespace(t *testing.T) {
 }
 
 func Test_objectGraph_setSoftOwnership(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		objs []runtime.Object
 	}
@@ -1081,6 +1081,8 @@ func Test_objectGraph_setSoftOwnership(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			graph, err := getDetachedObjectGraphWihObjs(tt.fields.objs)
 			g.Expect(err).NotTo(HaveOccurred())
 
@@ -1105,8 +1107,6 @@ func Test_objectGraph_setSoftOwnership(t *testing.T) {
 }
 
 func Test_objectGraph_setClusterTenants(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		objs []runtime.Object
 	}
@@ -1236,6 +1236,8 @@ func Test_objectGraph_setClusterTenants(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			gb, err := getDetachedObjectGraphWihObjs(tt.fields.objs)
 			g.Expect(err).NotTo(HaveOccurred())
 

--- a/cmd/clusterctl/client/cluster/template_test.go
+++ b/cmd/clusterctl/client/cluster/template_test.go
@@ -131,6 +131,8 @@ func Test_templateClient_GetFromConfigMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			tc := &templateClient{
 				proxy:        tt.fields.proxy,
 				configClient: tt.fields.configClient,
@@ -199,6 +201,8 @@ func Test_templateClient_getGitHubFileContent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			c := &templateClient{
 				configClient: configClient,
 				gitHubClientFactory: func(configVariablesClient config.VariablesClient) (*github.Client, error) {
@@ -256,6 +260,8 @@ func Test_templateClient_getLocalFileContent(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			c := &templateClient{}
 			got, err := c.getLocalFileContent(tt.args.rURL)
 			if tt.wantErr {
@@ -332,6 +338,8 @@ func Test_templateClient_GetFromURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			c := &templateClient{
 				configClient: configClient,
 				gitHubClientFactory: func(configVariablesClient config.VariablesClient) (*github.Client, error) {

--- a/cmd/clusterctl/client/cluster/upgrader_info_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_info_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		reader     config.Reader
 		repository repository.Repository
@@ -151,6 +149,8 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			configClient, _ := config.New("", config.InjectReader(tt.fields.reader))
 
 			u := &providerUpgrader{
@@ -171,8 +171,6 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 }
 
 func Test_upgradeInfo_getContractsForUpgrade(t *testing.T) {
-	g := NewWithT(t)
-
 	type field struct {
 		currentVersion string
 		metadata       *clusterctlv1.Metadata
@@ -233,6 +231,8 @@ func Test_upgradeInfo_getContractsForUpgrade(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			upgradeInfo := newUpgradeInfo(tt.field.metadata, version.MustParseSemantic(tt.field.currentVersion), nil)
 
 			got := upgradeInfo.getContractsForUpgrade()
@@ -242,8 +242,6 @@ func Test_upgradeInfo_getContractsForUpgrade(t *testing.T) {
 }
 
 func Test_upgradeInfo_getLatestNextVersion(t *testing.T) {
-	g := NewWithT(t)
-
 	type field struct {
 		currentVersion string
 		nextVersions   []string
@@ -329,6 +327,8 @@ func Test_upgradeInfo_getLatestNextVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			upgradeInfo := newUpgradeInfo(tt.field.metadata, version.MustParseSemantic(tt.field.currentVersion), toSemanticVersions(tt.field.nextVersions))
 
 			got := upgradeInfo.getLatestNextVersion(tt.args.contract)

--- a/cmd/clusterctl/client/cluster/upgrader_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func Test_providerUpgrader_Plan(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		reader     config.Reader
 		repository map[string]repository.Repository
@@ -483,6 +481,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			configClient, _ := config.New("", config.InjectReader(tt.fields.reader))
 
 			u := &providerUpgrader{
@@ -505,8 +505,6 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 }
 
 func Test_providerUpgrader_createCustomPlan(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		reader     config.Reader
 		repository map[string]repository.Repository
@@ -772,6 +770,8 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			configClient, _ := config.New("", config.InjectReader(tt.fields.reader))
 
 			u := &providerUpgrader{

--- a/cmd/clusterctl/client/common_test.go
+++ b/cmd/clusterctl/client/common_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func Test_parseProviderName(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		provider string
 	}
@@ -56,6 +54,8 @@ func Test_parseProviderName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			gotName, gotVersion, err := parseProviderName(tt.args.provider)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/cmd/clusterctl/client/config/imagemeta_client_test.go
+++ b/cmd/clusterctl/client/config/imagemeta_client_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func Test_imageMetaClient_AlterImage(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		reader Reader
 	}
@@ -132,6 +130,8 @@ func Test_imageMetaClient_AlterImage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			p := newImageMetaClient(tt.fields.reader)
 
 			got, err := p.AlterImage(tt.args.component, tt.args.image)

--- a/cmd/clusterctl/client/config/providers_client_test.go
+++ b/cmd/clusterctl/client/config/providers_client_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func Test_providers_List(t *testing.T) {
-	g := NewWithT(t)
-
 	reader := test.NewFakeReader()
 
 	p := &providersClient{
@@ -120,6 +118,8 @@ func Test_providers_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			p := &providersClient{
 				reader: tt.fields.configGetter,
 			}
@@ -136,8 +136,6 @@ func Test_providers_List(t *testing.T) {
 }
 
 func Test_validateProvider(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		r Provider
 	}
@@ -219,6 +217,8 @@ func Test_validateProvider(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			err := validateProvider(tt.args.r)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -249,8 +249,6 @@ func Test_providers_Defaults(t *testing.T) {
 }
 
 func Test_providers_Get(t *testing.T) {
-	g := NewWithT(t)
-
 	reader := test.NewFakeReader()
 
 	p := &providersClient{
@@ -317,6 +315,8 @@ func Test_providers_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			p := &providersClient{
 				reader: reader,
 			}

--- a/cmd/clusterctl/client/config/reader_viper_test.go
+++ b/cmd/clusterctl/client/config/reader_viper_test.go
@@ -73,18 +73,20 @@ func Test_viperReader_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
 			v := &viperReader{}
 
-			g.Expect(v.Init(configFile)).To(Succeed())
+			gs.Expect(v.Init(configFile)).To(Succeed())
 
 			got, err := v.Get(tt.args.key)
 			if tt.wantErr {
-				g.Expect(err).To(HaveOccurred())
+				gs.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(got).To(Equal(tt.want))
+			gs.Expect(err).NotTo(HaveOccurred())
+			gs.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -122,15 +124,17 @@ func Test_viperReader_Set(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
 			v := &viperReader{}
 
-			g.Expect(v.Init(configFile)).To(Succeed())
+			gs.Expect(v.Init(configFile)).To(Succeed())
 
 			v.Set(tt.args.key, tt.args.value)
 
 			got, err := v.Get(tt.args.key)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(got).To(Equal(tt.want))
+			gs.Expect(err).NotTo(HaveOccurred())
+			gs.Expect(got).To(Equal(tt.want))
 		})
 	}
 }

--- a/cmd/clusterctl/client/config/variables_client_test.go
+++ b/cmd/clusterctl/client/config/variables_client_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func Test_variables_Get(t *testing.T) {
-	g := NewWithT(t)
-
 	reader := test.NewFakeReader().WithVar("foo", "bar")
 
 	type args struct {
@@ -56,6 +54,8 @@ func Test_variables_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			p := &variablesClient{
 				reader: reader,
 			}

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
-	g := NewWithT(t)
-
 	customProviderConfig := config.NewProvider("custom", "url", clusterctlv1.BootstrapProviderType)
 
 	type field struct {
@@ -83,6 +81,8 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := tt.field.client.GetProvidersConfig()
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -101,8 +101,6 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 }
 
 func Test_clusterctlClient_GetProviderComponents(t *testing.T) {
-	g := NewWithT(t)
-
 	config1 := newFakeConfig().
 		WithProvider(capiProviderConfig)
 
@@ -154,6 +152,8 @@ func Test_clusterctlClient_GetProviderComponents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := client.GetProviderComponents(tt.args.provider, capiProviderConfig.Type(), tt.args.targetNameSpace, tt.args.watchingNamespace)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -168,8 +168,6 @@ func Test_clusterctlClient_GetProviderComponents(t *testing.T) {
 }
 
 func Test_clusterctlClient_templateOptionsToVariables(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		options GetClusterTemplateOptions
 	}
@@ -277,6 +275,8 @@ func Test_clusterctlClient_templateOptionsToVariables(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			config := newFakeConfig().
 				WithVar("KUBERNETES_VERSION", "v3.4.5") // with this line we are simulating an env var
 
@@ -462,19 +462,21 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
 			got, err := client.GetClusterTemplate(tt.args.options)
 			if tt.wantErr {
-				g.Expect(err).To(HaveOccurred())
+				gs.Expect(err).To(HaveOccurred())
 				return
 			}
-			g.Expect(err).NotTo(HaveOccurred())
+			gs.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(got.Variables()).To(Equal(tt.want.variables))
-			g.Expect(got.TargetNamespace()).To(Equal(tt.want.targetNamespace))
+			gs.Expect(got.Variables()).To(Equal(tt.want.variables))
+			gs.Expect(got.TargetNamespace()).To(Equal(tt.want.targetNamespace))
 
 			gotYaml, err := got.Yaml()
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(gotYaml).To(Equal(tt.want.yaml))
+			gs.Expect(err).NotTo(HaveOccurred())
+			gs.Expect(gotYaml).To(Equal(tt.want.yaml))
 		})
 	}
 }

--- a/cmd/clusterctl/client/delete_test.go
+++ b/cmd/clusterctl/client/delete_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func Test_clusterctlClient_Delete(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		client *fakeClient
 	}
@@ -108,6 +106,8 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			err := tt.fields.client.Delete(tt.args.options)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/cmd/clusterctl/client/init_test.go
+++ b/cmd/clusterctl/client/init_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func Test_clusterctlClient_Init(t *testing.T) {
-	g := NewWithT(t)
-
 	type field struct {
 		client *fakeClient
 		hasCRD bool
@@ -325,6 +323,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 
 			if tt.field.hasCRD {
 				g.Expect(tt.field.client.clusters["kubeconfig"].ProviderInventory().EnsureCustomResourceDefinitions()).To(Succeed())

--- a/cmd/clusterctl/client/repository/client_test.go
+++ b/cmd/clusterctl/client/repository/client_test.go
@@ -61,11 +61,13 @@ func Test_newRepositoryClient_LocalFileSystemRepository(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
 			repoClient, err := newRepositoryClient(tt.fields.provider, configClient)
-			g.Expect(err).NotTo(HaveOccurred())
+			gs.Expect(err).NotTo(HaveOccurred())
 
 			var expected *localRepository
-			g.Expect(repoClient.repository).To(BeAssignableToTypeOf(expected))
+			gs.Expect(repoClient.repository).To(BeAssignableToTypeOf(expected))
 		})
 	}
 }

--- a/cmd/clusterctl/client/repository/components_client_test.go
+++ b/cmd/clusterctl/client/repository/components_client_test.go
@@ -231,20 +231,22 @@ func Test_componentsClient_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
 			f := newComponentsClient(tt.fields.provider, tt.fields.repository, configClient)
 			got, err := f.Get(tt.args.version, tt.args.targetNamespace, tt.args.watchingNamespace)
 			if tt.wantErr {
-				g.Expect(err).To(HaveOccurred())
+				gs.Expect(err).To(HaveOccurred())
 				return
 			}
-			g.Expect(err).NotTo(HaveOccurred())
+			gs.Expect(err).NotTo(HaveOccurred())
 
-			g.Expect(got.Name()).To(Equal(tt.want.provider.Name()))
-			g.Expect(got.Type()).To(Equal(tt.want.provider.Type()))
-			g.Expect(got.Version()).To(Equal(tt.want.version))
-			g.Expect(got.TargetNamespace()).To(Equal(tt.want.targetNamespace))
-			g.Expect(got.WatchingNamespace()).To(Equal(tt.want.watchingNamespace))
-			g.Expect(got.Variables()).To(Equal(tt.want.variables))
+			gs.Expect(got.Name()).To(Equal(tt.want.provider.Name()))
+			gs.Expect(got.Type()).To(Equal(tt.want.provider.Type()))
+			gs.Expect(got.Version()).To(Equal(tt.want.version))
+			gs.Expect(got.TargetNamespace()).To(Equal(tt.want.targetNamespace))
+			gs.Expect(got.WatchingNamespace()).To(Equal(tt.want.watchingNamespace))
+			gs.Expect(got.Variables()).To(Equal(tt.want.variables))
 
 			yaml, err := got.Yaml()
 			if err != nil {
@@ -253,18 +255,18 @@ func Test_componentsClient_Get(t *testing.T) {
 			}
 
 			if len(tt.want.variables) > 0 {
-				g.Expect(yaml).To(ContainSubstring(variableValue))
+				gs.Expect(yaml).To(ContainSubstring(variableValue))
 			}
 
 			for _, o := range got.InstanceObjs() {
 				for _, v := range []string{clusterctlv1.ClusterctlLabelName, clusterv1.ProviderLabelName} {
-					g.Expect(o.GetLabels()).To(HaveKey(v))
+					gs.Expect(o.GetLabels()).To(HaveKey(v))
 				}
 			}
 
 			for _, o := range got.SharedObjs() {
 				for _, v := range []string{clusterctlv1.ClusterctlLabelName, clusterv1.ProviderLabelName, clusterctlv1.ClusterctlResourceLifecyleLabelName} {
-					g.Expect(o.GetLabels()).To(HaveKey(v))
+					gs.Expect(o.GetLabels()).To(HaveKey(v))
 				}
 			}
 		})

--- a/cmd/clusterctl/client/repository/components_test.go
+++ b/cmd/clusterctl/client/repository/components_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func Test_inspectVariables(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		data string
 	}
@@ -64,14 +62,14 @@ func Test_inspectVariables(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(inspectVariables([]byte(tt.args.data))).To(Equal(tt.want))
 		})
 	}
 }
 
 func Test_replaceVariables(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		yaml                  []byte
 		variables             []string
@@ -107,6 +105,8 @@ func Test_replaceVariables(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := replaceVariables(tt.args.yaml, tt.args.variables, tt.args.configVariablesClient)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -120,8 +120,6 @@ func Test_replaceVariables(t *testing.T) {
 }
 
 func Test_inspectTargetNamespace(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		objs []unstructured.Unstructured
 	}
@@ -182,6 +180,8 @@ func Test_inspectTargetNamespace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := inspectTargetNamespace(tt.args.objs)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -195,8 +195,6 @@ func Test_inspectTargetNamespace(t *testing.T) {
 }
 
 func Test_fixTargetNamespace(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		objs            []unstructured.Unstructured
 		targetNamespace string
@@ -279,6 +277,8 @@ func Test_fixTargetNamespace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got := fixTargetNamespace(tt.args.objs, tt.args.targetNamespace)
 			g.Expect(got).To(ContainElements(tt.want)) //skipping from test the automatically added namespace Object
 		})
@@ -286,8 +286,6 @@ func Test_fixTargetNamespace(t *testing.T) {
 }
 
 func Test_addNamespaceIfMissing(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		objs            []unstructured.Unstructured
 		targetNamespace string
@@ -322,6 +320,8 @@ func Test_addNamespaceIfMissing(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got := addNamespaceIfMissing(tt.args.objs, tt.args.targetNamespace)
 
 			wgot, err := inspectTargetNamespace(got)
@@ -332,8 +332,6 @@ func Test_addNamespaceIfMissing(t *testing.T) {
 }
 
 func Test_fixRBAC(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		objs            []unstructured.Unstructured
 		targetNamespace string
@@ -582,6 +580,8 @@ func Test_fixRBAC(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := fixRBAC(tt.args.objs, tt.args.targetNamespace)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -620,8 +620,6 @@ func fakeDeployment(watchNamespace string) unstructured.Unstructured {
 }
 
 func Test_inspectWatchNamespace(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		objs []unstructured.Unstructured
 	}
@@ -671,6 +669,8 @@ func Test_inspectWatchNamespace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := inspectWatchNamespace(tt.args.objs)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -684,8 +684,6 @@ func Test_inspectWatchNamespace(t *testing.T) {
 }
 
 func Test_fixWatchNamespace(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		objs              []unstructured.Unstructured
 		watchingNamespace string
@@ -728,6 +726,8 @@ func Test_fixWatchNamespace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := fixWatchNamespace(tt.args.objs, tt.args.watchingNamespace)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -743,8 +743,6 @@ func Test_fixWatchNamespace(t *testing.T) {
 }
 
 func Test_addCommonLabels(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		objs         []unstructured.Unstructured
 		name         string
@@ -785,6 +783,8 @@ func Test_addCommonLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got := addCommonLabels(tt.args.objs, config.NewProvider(tt.args.name, "", tt.args.providerType))
 			g.Expect(got).To(Equal(tt.want))
 		})
@@ -792,8 +792,6 @@ func Test_addCommonLabels(t *testing.T) {
 }
 
 func Test_splitInstanceAndSharedResources(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		objs []unstructured.Unstructured
 	}
@@ -935,6 +933,8 @@ func Test_splitInstanceAndSharedResources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			gotInstanceObjs, gotWebHookObjs := splitInstanceAndSharedResources(tt.args.objs)
 			g.Expect(gotInstanceObjs).To(ConsistOf(tt.wantInstanceObjs))
 			g.Expect(gotWebHookObjs).To(ConsistOf(tt.wantSharedObjs))

--- a/cmd/clusterctl/client/repository/metadata_client_test.go
+++ b/cmd/clusterctl/client/repository/metadata_client_test.go
@@ -36,8 +36,6 @@ var metadataYaml = []byte("apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3\n" +
 	"")
 
 func Test_metadataClient_Get(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		provider   config.Provider
 		version    string
@@ -136,6 +134,8 @@ func Test_metadataClient_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			f := &metadataClient{
 				configVarClient: test.NewFakeVariableClient(),
 				provider:        tt.fields.provider,

--- a/cmd/clusterctl/client/repository/repository_local_test.go
+++ b/cmd/clusterctl/client/repository/repository_local_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func Test_localRepository_newLocalRepository(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		provider              config.Provider
 		configVariablesClient config.VariablesClient
@@ -109,6 +107,8 @@ func Test_localRepository_newLocalRepository(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := newLocalRepository(tt.fields.provider, tt.fields.configVariablesClient)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -172,8 +172,6 @@ func Test_localRepository_newLocalRepository_Latest(t *testing.T) {
 }
 
 func Test_localRepository_GetFile(t *testing.T) {
-	g := NewWithT(t)
-
 	tmpDir := createTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
@@ -256,6 +254,8 @@ func Test_localRepository_GetFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			r, err := newLocalRepository(tt.fields.provider, tt.fields.configVariablesClient)
 			g.Expect(err).NotTo(HaveOccurred())
 
@@ -272,8 +272,6 @@ func Test_localRepository_GetFile(t *testing.T) {
 }
 
 func Test_localRepository_GetVersions(t *testing.T) {
-	g := NewWithT(t)
-
 	tmpDir := createTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
@@ -331,6 +329,8 @@ func Test_localRepository_GetVersions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			r, err := newLocalRepository(tt.fields.provider, tt.fields.configVariablesClient)
 			g.Expect(err).NotTo(HaveOccurred())
 

--- a/cmd/clusterctl/client/repository/template_client_test.go
+++ b/cmd/clusterctl/client/repository/template_client_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func Test_templates_Get(t *testing.T) {
-	g := NewWithT(t)
-
 	p1 := config.NewProvider("p1", "", clusterctlv1.BootstrapProviderType)
 
 	type fields struct {
@@ -158,6 +156,8 @@ func Test_templates_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			f := newTemplateClient(tt.fields.provider, tt.fields.version, tt.fields.repository, tt.fields.configVariablesClient)
 			got, err := f.Get(tt.args.flavor, tt.args.targetNamespace, tt.args.listVariablesOnly)
 			if tt.wantErr {

--- a/cmd/clusterctl/client/repository/template_test.go
+++ b/cmd/clusterctl/client/repository/template_test.go
@@ -36,8 +36,6 @@ var templateMapYaml = []byte("apiVersion: v1\n" +
 	"  name: manager")
 
 func Test_newTemplate(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		rawYaml               []byte
 		configVariablesClient config.VariablesClient
@@ -85,6 +83,8 @@ func Test_newTemplate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := NewTemplate(tt.args.rawYaml, tt.args.configVariablesClient, tt.args.targetNamespace, tt.args.listVariablesOnly)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/cmd/clusterctl/client/upgrade_test.go
+++ b/cmd/clusterctl/client/upgrade_test.go
@@ -31,8 +31,6 @@ import (
 )
 
 func Test_clusterctlClient_ApplyUpgrade(t *testing.T) {
-	g := NewWithT(t)
-
 	type fields struct {
 		client *fakeClient
 	}
@@ -165,6 +163,8 @@ func Test_clusterctlClient_ApplyUpgrade(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			err := tt.fields.client.ApplyUpgrade(tt.args.options)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -260,8 +260,6 @@ func fakeProvider(name string, providerType clusterctlv1.ProviderType, version, 
 }
 
 func Test_parseUpgradeItem(t *testing.T) {
-	g := NewWithT(t)
-
 	type args struct {
 		provider string
 	}
@@ -326,6 +324,8 @@ func Test_parseUpgradeItem(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := parseUpgradeItem(tt.args.provider, clusterctlv1.CoreProviderType)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())

--- a/cmd/clusterctl/internal/util/objs_test.go
+++ b/cmd/clusterctl/internal/util/objs_test.go
@@ -18,8 +18,9 @@ package util
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -128,17 +129,16 @@ func Test_inspectImages(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := InspectImages(tt.args.objs)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }
@@ -191,22 +191,19 @@ func TestFixImages(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := FixImages(tt.args.objs, tt.args.alterImageFunc)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
-			}
 			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
 				return
 			}
 
-			gotImages, err := InspectImages(got)
-			if err != nil {
-				t.Fatal(err)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
 
-			if !reflect.DeepEqual(gotImages, tt.want) {
-				t.Errorf("got = %v, want %v", got, tt.want)
-			}
+			gotImages, err := InspectImages(got)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(gotImages).To(Equal(tt.want))
 		})
 	}
 }

--- a/cmd/clusterctl/log/logger_test.go
+++ b/cmd/clusterctl/log/logger_test.go
@@ -19,6 +19,8 @@ package log
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/pkg/errors"
 )
 
@@ -91,18 +93,15 @@ func TestFlatten(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			got, err := flatten(logEntry{
 				Prefix: tt.args.prefix,
 				Level:  0,
 				Values: tt.args.kvList,
 			})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if got != tt.want {
-				t.Errorf("Flatten() = %v, want %v", got, tt.want)
-			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
 		})
 	}
 }

--- a/controllers/machinedeployment_sync_test.go
+++ b/controllers/machinedeployment_sync_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestMachineDeploymentSyncStatus(t *testing.T) {
-	g := NewWithT(t)
-
 	msStatusError := capierrors.MachineSetStatusError("some failure")
 
 	var tests = map[string]struct {
@@ -215,6 +213,8 @@ func TestMachineDeploymentSyncStatus(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			actualStatus := calculateStatus(test.machineSets, test.newMachineSet, test.deployment)
 			g.Expect(actualStatus).To(Equal(test.expectedStatus))
 		})

--- a/controllers/machineset_controller_test.go
+++ b/controllers/machineset_controller_test.go
@@ -511,8 +511,10 @@ func TestMachineSetToMachines(t *testing.T) {
 
 	for _, tc := range testsCases {
 		t.Run(tc.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
 			got := r.MachineToMachineSets(tc.mapObject)
-			g.Expect(got).To(Equal(tc.expected))
+			gs.Expect(got).To(Equal(tc.expected))
 		})
 	}
 }

--- a/controllers/mdutil/util_test.go
+++ b/controllers/mdutil/util_test.go
@@ -100,8 +100,6 @@ func generateMachineTemplateSpec(name string, annotations, labels map[string]str
 }
 
 func TestEqualMachineTemplate(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		Name           string
 		Former, Latter clusterv1.MachineTemplateSpec
@@ -253,6 +251,8 @@ func TestEqualMachineTemplate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			runTest := func(t1, t2 *clusterv1.MachineTemplateSpec, reversed bool) {
 				// Run
 				equal := EqualMachineTemplate(t1, t2)
@@ -269,8 +269,6 @@ func TestEqualMachineTemplate(t *testing.T) {
 }
 
 func TestFindNewMachineSet(t *testing.T) {
-	g := NewWithT(t)
-
 	now := metav1.Now()
 	later := metav1.Time{Time: now.Add(time.Minute)}
 
@@ -316,6 +314,8 @@ func TestFindNewMachineSet(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			ms := FindNewMachineSet(&test.deployment, test.msList)
 			g.Expect(ms).To(Equal(test.expected))
 		})
@@ -323,8 +323,6 @@ func TestFindNewMachineSet(t *testing.T) {
 }
 
 func TestFindOldMachineSets(t *testing.T) {
-	g := NewWithT(t)
-
 	now := metav1.Now()
 	later := metav1.Time{Time: now.Add(time.Minute)}
 	before := metav1.Time{Time: now.Add(-time.Minute)}
@@ -398,6 +396,8 @@ func TestFindOldMachineSets(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			requireMS, allMS := FindOldMachineSets(&test.deployment, test.msList)
 			g.Expect(allMS).To(ConsistOf(test.expected))
 			// MSs are getting filtered correctly by ms.spec.replicas
@@ -407,8 +407,6 @@ func TestFindOldMachineSets(t *testing.T) {
 }
 
 func TestGetReplicaCountForMachineSets(t *testing.T) {
-	g := NewWithT(t)
-
 	ms1 := generateMS(generateDeployment("foo"))
 	*(ms1.Spec.Replicas) = 1
 	ms1.Status.Replicas = 2
@@ -438,6 +436,8 @@ func TestGetReplicaCountForMachineSets(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(GetReplicaCountForMachineSets(test.Sets)).To(Equal(test.ExpectedCount))
 			g.Expect(GetActualReplicaCountForMachineSets(test.Sets)).To(Equal(test.ExpectedActual))
 		})
@@ -445,8 +445,6 @@ func TestGetReplicaCountForMachineSets(t *testing.T) {
 }
 
 func TestResolveFenceposts(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		maxSurge          string
 		maxUnavailable    string
@@ -491,6 +489,8 @@ func TestResolveFenceposts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("maxSurge="+test.maxSurge, func(t *testing.T) {
+			g := NewWithT(t)
+
 			maxSurge := intstr.FromString(test.maxSurge)
 			maxUnavail := intstr.FromString(test.maxUnavailable)
 			surge, unavail, err := ResolveFenceposts(&maxSurge, &maxUnavail, test.desired)
@@ -506,8 +506,6 @@ func TestResolveFenceposts(t *testing.T) {
 }
 
 func TestNewMSNewReplicas(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		Name          string
 		strategyType  clusterv1.MachineDeploymentStrategyType
@@ -534,6 +532,8 @@ func TestNewMSNewReplicas(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			*(newDeployment.Spec.Replicas) = test.depReplicas
 			newDeployment.Spec.Strategy = &clusterv1.MachineDeploymentStrategy{Type: test.strategyType}
 			newDeployment.Spec.Strategy.RollingUpdate = &clusterv1.MachineRollingUpdateDeployment{
@@ -555,8 +555,6 @@ func TestNewMSNewReplicas(t *testing.T) {
 }
 
 func TestDeploymentComplete(t *testing.T) {
-	g := NewWithT(t)
-
 	deployment := func(desired, current, updated, available, maxUnavailable, maxSurge int32) *clusterv1.MachineDeployment {
 		return &clusterv1.MachineDeployment{
 			Spec: clusterv1.MachineDeploymentSpec{
@@ -626,14 +624,14 @@ func TestDeploymentComplete(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(DeploymentComplete(test.d, &test.d.Status)).To(Equal(test.expected))
 		})
 	}
 }
 
 func TestMaxUnavailable(t *testing.T) {
-	g := NewWithT(t)
-
 	deployment := func(replicas int32, maxUnavailable intstr.IntOrString) clusterv1.MachineDeployment {
 		return clusterv1.MachineDeployment{
 			Spec: clusterv1.MachineDeploymentSpec{
@@ -692,6 +690,8 @@ func TestMaxUnavailable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(MaxUnavailable(test.deployment)).To(Equal(test.expected))
 		})
 	}
@@ -699,8 +699,6 @@ func TestMaxUnavailable(t *testing.T) {
 
 //Set of simple tests for annotation related util functions
 func TestAnnotationUtils(t *testing.T) {
-	g := NewWithT(t)
-
 	//Setup
 	tDeployment := generateDeployment("nginx")
 	tMS := generateMS(tDeployment)
@@ -709,6 +707,8 @@ func TestAnnotationUtils(t *testing.T) {
 
 	//Test Case 1: Check if anotations are copied properly from deployment to MS
 	t.Run("SetNewMachineSetAnnotations", func(t *testing.T) {
+		g := NewWithT(t)
+
 		//Try to set the increment revision from 1 through 20
 		for i := 0; i < 20; i++ {
 
@@ -721,6 +721,8 @@ func TestAnnotationUtils(t *testing.T) {
 
 	//Test Case 2:  Check if annotations are set properly
 	t.Run("SetReplicasAnnotations", func(t *testing.T) {
+		g := NewWithT(t)
+
 		g.Expect(SetReplicasAnnotations(&tMS, 10, 11)).To(BeTrue())
 		g.Expect(tMS.Annotations).To(HaveKeyWithValue(clusterv1.DesiredReplicasAnnotation, "10"))
 		g.Expect(tMS.Annotations).To(HaveKeyWithValue(clusterv1.MaxReplicasAnnotation, "11"))
@@ -733,14 +735,14 @@ func TestAnnotationUtils(t *testing.T) {
 	*tMS.Spec.Replicas = 1
 
 	t.Run("IsSaturated", func(t *testing.T) {
+		g := NewWithT(t)
+
 		g.Expect(IsSaturated(&tDeployment, &tMS)).To(BeTrue())
 	})
 	//Tear Down
 }
 
 func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
-	g := NewWithT(t)
-
 	desiredReplicas := fmt.Sprintf("%d", int32(10))
 	maxReplicas := fmt.Sprintf("%d", int32(20))
 
@@ -805,6 +807,8 @@ func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(ReplicasAnnotationsNeedUpdate(test.machineSet, 10, 20)).To(Equal(test.expected))
 		})
 	}

--- a/controllers/noderefutil/providerid_test.go
+++ b/controllers/noderefutil/providerid_test.go
@@ -25,8 +25,6 @@ import (
 const aws = "aws"
 
 func TestNewProviderID(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name       string
 		input      string
@@ -56,6 +54,8 @@ func TestNewProviderID(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			id, err := NewProviderID(tc.input)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(id.CloudProvider()).To(Equal(aws))
@@ -65,8 +65,6 @@ func TestNewProviderID(t *testing.T) {
 }
 
 func TestInvalidProviderID(t *testing.T) {
-	g := NewWithT(t)
-
 	testCases := []struct {
 		name  string
 		input string
@@ -106,6 +104,8 @@ func TestInvalidProviderID(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			_, err := NewProviderID(test.input)
 			g.Expect(err).To(MatchError(test.err))
 		})

--- a/controllers/noderefutil/util_test.go
+++ b/controllers/noderefutil/util_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestIsNodeAvaialble(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name              string
 		node              *corev1.Node
@@ -143,14 +141,14 @@ func TestIsNodeAvaialble(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(IsNodeAvailable(test.node, test.minReadySeconds, metav1.Now())).To(Equal(test.expectedAvailable))
 		})
 	}
 }
 
 func TestGetReadyCondition(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name              string
 		nodeStatus        *corev1.NodeStatus
@@ -223,14 +221,14 @@ func TestGetReadyCondition(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(GetReadyCondition(test.nodeStatus)).To(Equal(test.expectedCondition))
 		})
 	}
 }
 
 func TestIsNodeReady(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name          string
 		node          *corev1.Node
@@ -302,6 +300,8 @@ func TestIsNodeReady(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			g.Expect(IsNodeReady(test.node)).To(Equal(test.expectedReady))
 		})
 	}

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -94,28 +94,33 @@ func TestNewClusterClient(t *testing.T) {
 	g.Expect(scheme.AddToScheme(testScheme)).To(Succeed())
 	ctx := context.Background()
 	t.Run("cluster with valid kubeconfig", func(t *testing.T) {
+		gs := NewWithT(t)
+
 		client := fake.NewFakeClientWithScheme(testScheme, validSecret)
 		_, err := NewClusterClient(ctx, client, clusterWithValidKubeConfig, testScheme)
 		// Since we do not have a remote server to connect to, we should expect to get
 		// an error to that effect for the purpose of this test.
-		g.Expect(err).To(MatchError(ContainSubstring("no such host")))
+		gs.Expect(err).To(MatchError(ContainSubstring("no such host")))
 
 		restConfig, err := RESTConfig(ctx, client, clusterWithValidKubeConfig)
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(restConfig.Host).To(Equal("https://test-cluster-api:6443"))
+		gs.Expect(err).NotTo(HaveOccurred())
+		gs.Expect(restConfig.Host).To(Equal("https://test-cluster-api:6443"))
 	})
 
 	t.Run("cluster with no kubeconfig", func(t *testing.T) {
+		gs := NewWithT(t)
+
 		client := fake.NewFakeClientWithScheme(testScheme)
 		_, err := NewClusterClient(ctx, client, clusterWithNoKubeConfig, testScheme)
-		g.Expect(err).To(MatchError(ContainSubstring("not found")))
+		gs.Expect(err).To(MatchError(ContainSubstring("not found")))
 	})
 
 	t.Run("cluster with invalid kubeconfig", func(t *testing.T) {
+		gs := NewWithT(t)
+
 		client := fake.NewFakeClientWithScheme(testScheme, invalidSecret)
 		_, err := NewClusterClient(ctx, client, clusterWithInvalidKubeConfig, testScheme)
-		g.Expect(err).To(HaveOccurred())
-		g.Expect(apierrors.IsNotFound(err)).To(BeFalse())
+		gs.Expect(err).To(HaveOccurred())
+		gs.Expect(apierrors.IsNotFound(err)).To(BeFalse())
 	})
-
 }

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -49,8 +49,6 @@ type checkStaticPodReadyConditionTest struct {
 }
 
 func TestCheckStaticPodReadyCondition(t *testing.T) {
-	g := NewWithT(t)
-
 	table := []checkStaticPodReadyConditionTest{
 		{
 			name:       "pod is ready",
@@ -59,6 +57,8 @@ func TestCheckStaticPodReadyCondition(t *testing.T) {
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			pod := corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-pod",
@@ -72,8 +72,6 @@ func TestCheckStaticPodReadyCondition(t *testing.T) {
 }
 
 func TestCheckStaticPodNotReadyCondition(t *testing.T) {
-	g := NewWithT(t)
-
 	table := []checkStaticPodReadyConditionTest{
 		{
 			name: "no pod status",
@@ -85,6 +83,8 @@ func TestCheckStaticPodNotReadyCondition(t *testing.T) {
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			pod := corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-pod",
@@ -287,8 +287,6 @@ func (f *fakeClient) Update(_ context.Context, _ runtime.Object, _ ...client.Upd
 }
 
 func TestManagementCluster_healthCheck_NoError(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name             string
 		machineList      *clusterv1.MachineList
@@ -318,6 +316,8 @@ func TestManagementCluster_healthCheck_NoError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			ctx := context.Background()
 			m := &Management{
 				Client: &fakeClient{list: tt.machineList},
@@ -328,8 +328,6 @@ func TestManagementCluster_healthCheck_NoError(t *testing.T) {
 }
 
 func TestManagementCluster_healthCheck_Errors(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name             string
 		machineList      *clusterv1.MachineList
@@ -426,6 +424,8 @@ func TestManagementCluster_healthCheck_Errors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			ctx := context.Background()
 			clusterKey := client.ObjectKey{Namespace: "default", Name: "cluster-name"}
 			controlPlaneName := "control-plane-name"
@@ -472,9 +472,9 @@ func nilNodeRef(machine clusterv1.Machine) clusterv1.Machine {
 }
 
 func TestRemoveMemberForNode_ErrControlPlaneMinNodes(t *testing.T) {
-	g := NewWithT(t)
-
 	t.Run("do not remove the etcd member if the cluster has fewer than 2 control plane nodes", func(t *testing.T) {
+		g := NewWithT(t)
+
 		expectedErr := ErrControlPlaneMinNodes
 
 		workloadCluster := &Workload{

--- a/controlplane/kubeadm/internal/failure_domain_test.go
+++ b/controlplane/kubeadm/internal/failure_domain_test.go
@@ -84,8 +84,9 @@ func TestNewFailureDomainPicker(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		g := NewWithT(t)
 		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			fd := PickFewest(tc.fds, tc.machines)
 			if tc.expected == nil {
 				g.Expect(fd).To(BeNil())

--- a/controlplane/kubeadm/internal/workload_cluster_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_test.go
@@ -43,8 +43,6 @@ import (
 )
 
 func TestCluster_ReconcileKubeletRBACBinding_NoError(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name   string
 		client ctrlclient.Client
@@ -73,6 +71,8 @@ func TestCluster_ReconcileKubeletRBACBinding_NoError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			c := &Workload{
 				Client: tt.client,
 			}
@@ -83,8 +83,6 @@ func TestCluster_ReconcileKubeletRBACBinding_NoError(t *testing.T) {
 }
 
 func TestCluster_ReconcileKubeletRBACBinding_Error(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name   string
 		client ctrlclient.Client
@@ -106,6 +104,8 @@ func TestCluster_ReconcileKubeletRBACBinding_Error(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			c := &Workload{
 				Client: tt.client,
 			}
@@ -146,9 +146,7 @@ func TestUpdateKubeProxyImageInfo(t *testing.T) {
 	g := NewWithT(t)
 
 	scheme := runtime.NewScheme()
-	if err := appsv1.AddToScheme(scheme); err != nil {
-		t.Fatalf("unable to setup scheme: %s", err)
-	}
+	g.Expect(appsv1.AddToScheme(scheme)).To(Succeed())
 
 	tests := []struct {
 		name        string
@@ -236,6 +234,8 @@ func TestUpdateKubeProxyImageInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
 			objects := []runtime.Object{
 				&tt.ds,
 			}
@@ -245,15 +245,15 @@ func TestUpdateKubeProxyImageInfo(t *testing.T) {
 			}
 			err := w.UpdateKubeProxyImageInfo(ctx, tt.KCP)
 			if tt.expectErr {
-				g.Expect(err).To(HaveOccurred())
+				gs.Expect(err).To(HaveOccurred())
 			} else {
-				g.Expect(err).NotTo(HaveOccurred())
+				gs.Expect(err).NotTo(HaveOccurred())
 			}
 
 			proxyImage, err := getProxyImageInfo(ctx, w.Client)
-			g.Expect(err).NotTo(HaveOccurred())
+			gs.Expect(err).NotTo(HaveOccurred())
 			if tt.expectImage != "" {
-				g.Expect(proxyImage).To(Equal(tt.expectImage))
+				gs.Expect(proxyImage).To(Equal(tt.expectImage))
 			}
 		})
 	}

--- a/test/infrastructure/docker/cloudinit/runcmd_test.go
+++ b/test/infrastructure/docker/cloudinit/runcmd_test.go
@@ -42,8 +42,6 @@ runcmd:
 }
 
 func TestRunCmdRun(t *testing.T) {
-	g := NewWithT(t)
-
 	var useCases = []struct {
 		name         string
 		r            runCmd
@@ -77,6 +75,8 @@ func TestRunCmdRun(t *testing.T) {
 
 	for _, rt := range useCases {
 		t.Run(rt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			commands, err := rt.r.Commands()
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(rt.expectedCmds).To(Equal(commands))

--- a/test/infrastructure/docker/cloudinit/writefiles_test.go
+++ b/test/infrastructure/docker/cloudinit/writefiles_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestWriteFiles(t *testing.T) {
-	g := NewWithT(t)
-
 	var useCases = []struct {
 		name         string
 		w            writeFilesAction
@@ -89,6 +87,8 @@ func TestWriteFiles(t *testing.T) {
 
 	for _, rt := range useCases {
 		t.Run(rt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			cmds, err := rt.w.Commands()
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(rt.expectedCmds).To(Equal(cmds))
@@ -97,8 +97,6 @@ func TestWriteFiles(t *testing.T) {
 }
 
 func TestFixContent(t *testing.T) {
-	g := NewWithT(t)
-
 	v := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	gv, _ := gZipData([]byte(v))
 	var useCases = []struct {
@@ -129,6 +127,8 @@ func TestFixContent(t *testing.T) {
 
 	for _, rt := range useCases {
 		t.Run(rt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
 			encoding := fixEncoding(rt.encoding)
 			c, err := fixContent(rt.content, encoding)
 			if rt.expectedError {


### PR DESCRIPTION
**What this PR does / why we need it**:
move NewWithT(t) to inside the t.Run where applicable

/kind cleanup

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
 - Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2798


cc @wfernandes @fabriziopandini 