### PR TITLE
🐛 KCP should update Kubeadm config map when setting `imageRepository`

### DIFF
--- a/controlplane/kubeadm/controllers/upgrade.go
+++ b/controlplane/kubeadm/controllers/upgrade.go
@@ -48,7 +48,6 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 	}
 
 	parsedVersion, err := semver.ParseTolerant(kcp.Spec.Version)
-	parsedImageRepository := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ImageRepository
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to parse kubernetes version %q", kcp.Spec.Version)
 	}
@@ -65,8 +64,11 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 		return ctrl.Result{}, errors.Wrap(err, "failed to update the kubernetes version in the kubeadm config map")
 	}
 
-	if err := workloadCluster.UpdateImageRepositoryInKubeadmConfigMap(ctx, parsedImageRepository); err != nil {
-		return ctrl.Result{}, errors.Wrap(err, "failed to update the kubernetes version in the kubeadm config map")
+	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration != nil {
+		imageRepository := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ImageRepository
+		if err := workloadCluster.UpdateImageRepositoryInKubeadmConfigMap(ctx, imageRepository); err != nil {
+			return ctrl.Result{}, errors.Wrap(err, "failed to update the image repository in the kubeadm config map")
+		}
 	}
 
 	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration != nil && kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local != nil {

--- a/controlplane/kubeadm/controllers/upgrade.go
+++ b/controlplane/kubeadm/controllers/upgrade.go
@@ -48,6 +48,7 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 	}
 
 	parsedVersion, err := semver.ParseTolerant(kcp.Spec.Version)
+	parsedImageRepository := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ImageRepository
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to parse kubernetes version %q", kcp.Spec.Version)
 	}
@@ -61,6 +62,10 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 	}
 
 	if err := workloadCluster.UpdateKubernetesVersionInKubeadmConfigMap(ctx, parsedVersion); err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to update the kubernetes version in the kubeadm config map")
+	}
+
+	if err := workloadCluster.UpdateImageRepositoryInKubeadmConfigMap(ctx, parsedImageRepository); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to update the kubernetes version in the kubeadm config map")
 	}
 

--- a/controlplane/kubeadm/internal/kubeadm_config_map.go
+++ b/controlplane/kubeadm/internal/kubeadm_config_map.go
@@ -90,8 +90,11 @@ func (k *kubeadmConfig) UpdateKubernetesVersion(version string) error {
 	return nil
 }
 
-// UpdateImageRepository changes the kubernetes version found in the kubeadm config map
+// UpdateImageRepository changes the image repository found in the kubeadm config map
 func (k *kubeadmConfig) UpdateImageRepository(imageRepository string) error {
+	if imageRepository == "" {
+		return nil
+	}
 	data, ok := k.ConfigMap.Data[clusterConfigurationKey]
 	if !ok {
 		return errors.Errorf("unable to find %q key in kubeadm ConfigMap", clusterConfigurationKey)
@@ -101,7 +104,7 @@ func (k *kubeadmConfig) UpdateImageRepository(imageRepository string) error {
 		return errors.Wrapf(err, "unable to decode kubeadm ConfigMap's %q to Unstructured object", clusterConfigurationKey)
 	}
 	if err := unstructured.SetNestedField(configuration.UnstructuredContent(), imageRepository, configImageRepositoryKey); err != nil {
-		return errors.Wrapf(err, "unable to update %q on kubeadm ConfigMap's %q", configVersionKey, clusterConfigurationKey)
+		return errors.Wrapf(err, "unable to update %q on kubeadm ConfigMap's %q", imageRepository, clusterConfigurationKey)
 	}
 	updated, err := yaml.Marshal(configuration)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes issues arising when a user specifies a global `imageRegistry` in their `clusterConfiguration`. We weren't updating the kubeadm configmap and so when we spun up new nodes kubeadm would still pull from the default registry.

**Which issue(s) this PR fixes**
Fixes #2805

