### PR TITLE
✨ Connect to the etcd leader when possible

### DIFF
--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -471,27 +471,6 @@ func nilNodeRef(machine clusterv1.Machine) clusterv1.Machine {
 	return machine
 }
 
-func TestRemoveMemberForNode_ErrControlPlaneMinNodes(t *testing.T) {
-	t.Run("do not remove the etcd member if the cluster has fewer than 2 control plane nodes", func(t *testing.T) {
-		g := NewWithT(t)
-
-		expectedErr := ErrControlPlaneMinNodes
-
-		workloadCluster := &Workload{
-			Client: &fakeClient{
-				list: &corev1.NodeList{
-					Items: []corev1.Node{
-						nodeNamed("first-control-plane"),
-					},
-				},
-			},
-		}
-
-		err := workloadCluster.removeMemberForNode(context.Background(), "first-control-plane")
-		g.Expect(err).To(MatchError(expectedErr))
-	})
-}
-
 func TestPickFirstNodeNotMatching(t *testing.T) {
 	g := NewWithT(t)
 

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -223,6 +223,7 @@ type fakeClient struct {
 	getErr       error
 	patchErr     error
 	updateErr    error
+	listErr      error
 }
 
 func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj runtime.Object) error {
@@ -251,6 +252,9 @@ func (f *fakeClient) Get(_ context.Context, key client.ObjectKey, obj runtime.Ob
 }
 
 func (f *fakeClient) List(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+	if f.listErr != nil {
+		return f.listErr
+	}
 	switch l := f.list.(type) {
 	case *clusterv1.MachineList:
 		l.DeepCopyInto(list.(*clusterv1.MachineList))
@@ -469,13 +473,4 @@ func controlPlaneMachine(name string) clusterv1.Machine {
 func nilNodeRef(machine clusterv1.Machine) clusterv1.Machine {
 	machine.Status.NodeRef = nil
 	return machine
-}
-
-func TestPickFirstNodeNotMatching(t *testing.T) {
-	g := NewWithT(t)
-
-	name := "first-control-plane"
-	anotherNode := firstNodeNotMatchingName(name, nodeListForTestControlPlaneIsHealthy().Items)
-	g.Expect(anotherNode).NotTo(BeNil())
-	g.Expect(anotherNode.Name).NotTo(Equal(name))
 }

--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -435,15 +435,6 @@ func checkNodeNoExecuteCondition(node corev1.Node) error {
 	return nil
 }
 
-func firstNodeNotMatchingName(name string, nodes []corev1.Node) *corev1.Node {
-	for _, n := range nodes {
-		if n.Name != name {
-			return &n
-		}
-	}
-	return nil
-}
-
 // UpdateKubeProxyImageInfo updates kube-proxy image in the kube-proxy DaemonSet.
 func (w *Workload) UpdateKubeProxyImageInfo(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane) error {
 	ds := &appsv1.DaemonSet{}

--- a/controlplane/kubeadm/internal/workload_cluster_etcd.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd.go
@@ -164,11 +164,7 @@ func (w *Workload) RemoveEtcdMemberForMachine(ctx context.Context, machine *clus
 	if len(controlPlaneNodes.Items) < 2 {
 		return ErrControlPlaneMinNodes
 	}
-	anotherNode := firstNodeNotMatchingName(machine.Status.NodeRef.Name, controlPlaneNodes.Items)
-	if anotherNode == nil {
-		return errors.Errorf("failed to find a control plane node whose name is not %s", machine.Status.NodeRef.Name)
-	}
-	etcdClient, err := w.etcdClientGenerator.forNode(ctx, anotherNode.Name)
+	etcdClient, err := w.etcdClientGenerator.forLeader(ctx, controlPlaneNodes)
 	if err != nil {
 		return errors.Wrap(err, "failed to create etcd client")
 	}

--- a/controlplane/kubeadm/internal/workload_cluster_etcd.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd.go
@@ -30,6 +30,7 @@ import (
 
 type etcdClientFor interface {
 	forNode(ctx context.Context, name string) (*etcd.Client, error)
+	forLeader(ctx context.Context, nodes *corev1.NodeList) (*etcd.Client, error)
 }
 
 // EtcdIsHealthy runs checks for every etcd member in the cluster to satisfy our definition of healthy.

--- a/controlplane/kubeadm/internal/workload_cluster_etcd.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd.go
@@ -190,9 +190,13 @@ func (w *Workload) RemoveEtcdMemberForMachine(ctx context.Context, machine *clus
 
 // ForwardEtcdLeadership forwards etcd leadership to the first follower
 func (w *Workload) ForwardEtcdLeadership(ctx context.Context, machine *clusterv1.Machine, leaderCandidate *clusterv1.Machine) error {
-	if machine == nil || machine.Status.NodeRef == nil || leaderCandidate == nil {
+	if machine == nil || machine.Status.NodeRef == nil {
 		return nil
 	}
+	if leaderCandidate == nil {
+		return errors.New("leader candidate cannot be nil")
+	}
+
 	nodes, err := w.getControlPlaneNodes(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to list control plane nodes")

--- a/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
@@ -31,6 +31,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	fake2 "sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -169,7 +170,7 @@ kind: ClusterConfiguration
 	}
 }
 
-func TestRemoveEtcdMemberFromMachine(t *testing.T) {
+func TestRemoveEtcdMemberForMachine(t *testing.T) {
 	machine := &clusterv1.Machine{
 		Status: clusterv1.MachineStatus{
 			NodeRef: &corev1.ObjectReference{
@@ -311,44 +312,53 @@ func TestRemoveEtcdMemberFromMachine(t *testing.T) {
 
 func TestForwardEtcdLeadership(t *testing.T) {
 	t.Run("handles errors correctly", func(t *testing.T) {
-		machine := &clusterv1.Machine{
-			Status: clusterv1.MachineStatus{
-				NodeRef: &corev1.ObjectReference{
-					Name: "machine-node",
-				},
-			},
-		}
-		machineNoNode := machine.DeepCopy()
-		machineNoNode.Status.NodeRef.Name = "does-not-exist"
+
 		tests := []struct {
 			name                string
 			machine             *clusterv1.Machine
 			leaderCandidate     *clusterv1.Machine
 			etcdClientGenerator etcdClientFor
+			k8sClient           client.Client
 			expectErr           bool
 		}{
 			{
-				name:      "does not panic if machine is nil",
+				name:      "does nothing if the machine is nil",
+				machine:   nil,
 				expectErr: false,
 			},
 			{
-				name: "does not panic if machine noderef is nil",
-				machine: &clusterv1.Machine{
-					Status: clusterv1.MachineStatus{
-						NodeRef: nil,
-					},
-				},
+				name: "does nothing if machine's NodeRef is nil",
+				machine: defaultMachine(func(m *clusterv1.Machine) {
+					m.Status.NodeRef = nil
+				}),
 				expectErr: false,
 			},
 			{
-				name:                "returns error if cannot find etcdClient for node",
-				machine:             machineNoNode,
-				etcdClientGenerator: &fakeEtcdClientGenerator{forNodeErr: errors.New("no etcdClient")},
+				name:            "does nothing if the leader candidate is nil",
+				machine:         defaultMachine(),
+				leaderCandidate: nil,
+				expectErr:       false,
+			},
+			{
+				name:            "returns an error if it can't retrieve the list of control plane nodes",
+				machine:         defaultMachine(),
+				leaderCandidate: defaultMachine(),
+				k8sClient:       &fakeClient{listErr: errors.New("failed to list nodes")},
+				expectErr:       true,
+			},
+			{
+				name:                "returns an error if it can't create an etcd client",
+				machine:             defaultMachine(),
+				leaderCandidate:     defaultMachine(),
+				k8sClient:           &fakeClient{},
+				etcdClientGenerator: &fakeEtcdClientGenerator{forLeaderErr: errors.New("no etcdClient")},
 				expectErr:           true,
 			},
 			{
-				name:    "returns error if it failed to get etcd members",
-				machine: machine,
+				name:            "returns error if it fails to get etcd members",
+				machine:         defaultMachine(),
+				leaderCandidate: defaultMachine(),
+				k8sClient:       &fakeClient{},
 				etcdClientGenerator: &fakeEtcdClientGenerator{
 					forNodeClient: &etcd.Client{
 						EtcdClient: &fake2.FakeEtcdClient{
@@ -363,6 +373,7 @@ func TestForwardEtcdLeadership(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				g := NewWithT(t)
 				w := &Workload{
+					Client:              tt.k8sClient,
 					etcdClientGenerator: tt.etcdClientGenerator,
 				}
 				ctx := context.TODO()
@@ -376,20 +387,12 @@ func TestForwardEtcdLeadership(t *testing.T) {
 		}
 	})
 
-	t.Run("does noop if machine etcd member ID does not match etcdClient leader ID", func(t *testing.T) {
+	t.Run("does nothing if the machine is not the leader", func(t *testing.T) {
 		g := NewWithT(t)
-		machine := &clusterv1.Machine{
-			Status: clusterv1.MachineStatus{
-				NodeRef: &corev1.ObjectReference{
-					Name: "machine-node",
-				},
-			},
-		}
 		fakeEtcdClient := &fake2.FakeEtcdClient{
 			MemberListResponse: &clientv3.MemberListResponse{
 				Members: []*pb.Member{
 					{Name: "machine-node", ID: uint64(101)},
-					{Name: "other-node", ID: uint64(1034)},
 				},
 			},
 			AlarmResponse: &clientv3.AlarmResponse{
@@ -410,29 +413,13 @@ func TestForwardEtcdLeadership(t *testing.T) {
 			etcdClientGenerator: etcdClientGenerator,
 		}
 		ctx := context.TODO()
-		err := w.ForwardEtcdLeadership(ctx, machine, nil)
+		err := w.ForwardEtcdLeadership(ctx, defaultMachine(), nil)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(fakeEtcdClient.MovedLeader).To(BeEquivalentTo(0))
 
 	})
 
 	t.Run("move etcd leader", func(t *testing.T) {
-		machine := &clusterv1.Machine{
-			Status: clusterv1.MachineStatus{
-				NodeRef: &corev1.ObjectReference{
-					Name: "machine-node",
-				},
-			},
-		}
-		leaderCandidate := &clusterv1.Machine{
-			Status: clusterv1.MachineStatus{
-				NodeRef: &corev1.ObjectReference{
-					Name: "leader-node",
-				},
-			},
-		}
-		leaderCandidateBadNodeRef := leaderCandidate.DeepCopy()
-		leaderCandidateBadNodeRef.Status.NodeRef.Name = "does-not-exist"
 		tests := []struct {
 			name               string
 			leaderCandidate    *clusterv1.Machine
@@ -441,32 +428,32 @@ func TestForwardEtcdLeadership(t *testing.T) {
 			expectErr          bool
 		}{
 			{
-				name:               "to the next available member",
-				expectedMoveLeader: 1034,
+				name: "it moves the etcd leadership to the leader candidate",
+				leaderCandidate: defaultMachine(func(m *clusterv1.Machine) {
+					m.Status.NodeRef.Name = "candidate-node"
+				}),
+				expectedMoveLeader: 12345,
 			},
 			{
-				name:        "returns error if failed to move to the next available member",
+				name: "returns error if failed to move to the leader candidate",
+				leaderCandidate: defaultMachine(func(m *clusterv1.Machine) {
+					m.Status.NodeRef.Name = "candidate-node"
+				}),
 				etcdMoveErr: errors.New("move err"),
 				expectErr:   true,
 			},
 			{
-				name:               "to the leader candidate",
-				leaderCandidate:    leaderCandidate,
-				expectedMoveLeader: 12345,
-			},
-			{
-				name:            "returns error if failed to move to the leader candidate",
-				leaderCandidate: leaderCandidate,
-				etcdMoveErr:     errors.New("move err"),
-				expectErr:       true,
-			},
-			{
-				name:            "returns error if it cannot find the leader etcd member",
-				leaderCandidate: leaderCandidateBadNodeRef,
-				expectErr:       true,
+				name: "returns error if the leader candidate doesn't exist in etcd",
+				leaderCandidate: defaultMachine(func(m *clusterv1.Machine) {
+					m.Status.NodeRef.Name = "some other node"
+				}),
+				expectErr: true,
 			},
 		}
 
+		currentLeader := defaultMachine(func(m *clusterv1.Machine) {
+			m.Status.NodeRef.Name = "current-leader"
+		})
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				g := NewWithT(t)
@@ -474,9 +461,9 @@ func TestForwardEtcdLeadership(t *testing.T) {
 					ErrorResponse: tt.etcdMoveErr,
 					MemberListResponse: &clientv3.MemberListResponse{
 						Members: []*pb.Member{
-							{Name: "machine-node", ID: uint64(101)},
+							{Name: currentLeader.Status.NodeRef.Name, ID: uint64(101)},
 							{Name: "other-node", ID: uint64(1034)},
-							{Name: "leader-node", ID: uint64(12345)},
+							{Name: "candidate-node", ID: uint64(12345)},
 						},
 					},
 					AlarmResponse: &clientv3.AlarmResponse{
@@ -485,7 +472,7 @@ func TestForwardEtcdLeadership(t *testing.T) {
 				}
 
 				etcdClientGenerator := &fakeEtcdClientGenerator{
-					forNodeClient: &etcd.Client{
+					forLeaderClient: &etcd.Client{
 						EtcdClient: fakeEtcdClient,
 						// this etcdClient belongs to the machine-node
 						LeaderID: 101,
@@ -494,9 +481,12 @@ func TestForwardEtcdLeadership(t *testing.T) {
 
 				w := &Workload{
 					etcdClientGenerator: etcdClientGenerator,
+					Client: &fakeClient{list: &corev1.NodeList{
+						Items: []corev1.Node{nodeNamed("leader-node"), nodeNamed("other-node"), nodeNamed("candidate-node")},
+					}},
 				}
 				ctx := context.TODO()
-				err := w.ForwardEtcdLeadership(ctx, machine, tt.leaderCandidate)
+				err := w.ForwardEtcdLeadership(ctx, currentLeader, tt.leaderCandidate)
 				if tt.expectErr {
 					g.Expect(err).To(HaveOccurred())
 					return
@@ -550,4 +540,18 @@ func withProviderID(pi string) func(corev1.Node) corev1.Node {
 		node.Spec.ProviderID = pi
 		return node
 	}
+}
+
+func defaultMachine(transforms ...func(m *clusterv1.Machine)) *clusterv1.Machine {
+	m := &clusterv1.Machine{
+		Status: clusterv1.MachineStatus{
+			NodeRef: &corev1.ObjectReference{
+				Name: "machine-node",
+			},
+		},
+	}
+	for _, t := range transforms {
+		t(m)
+	}
+	return m
 }

--- a/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
@@ -204,11 +204,12 @@ func TestRemoveEtcdMemberFromMachine(t *testing.T) {
 		expectErr           bool
 	}{
 		{
-			name:      "does not panic if machine is nil",
+			name:      "does nothing if the machine is nil",
+			machine:   nil,
 			expectErr: false,
 		},
 		{
-			name: "does not panic if machine noderef is nil",
+			name: "does nothing if the machine has no node",
 			machine: &clusterv1.Machine{
 				Status: clusterv1.MachineStatus{
 					NodeRef: nil,
@@ -217,13 +218,13 @@ func TestRemoveEtcdMemberFromMachine(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:      "returns error if there are less than 2 control plane nodes",
+			name:      "returns an error if there are less than 2 control plane nodes",
 			machine:   machine,
 			objs:      []runtime.Object{cp1},
 			expectErr: true,
 		},
 		{
-			name: "returns error if nodes match node ref name",
+			name: "returns an error if it can't find a node with a different name",
 			machine: &clusterv1.Machine{
 				Status: clusterv1.MachineStatus{
 					NodeRef: &corev1.ObjectReference{
@@ -235,14 +236,14 @@ func TestRemoveEtcdMemberFromMachine(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:                "returns error if it failed to create etcdClient",
+			name:                "returns an error if it failed to create the etcd client",
 			machine:             machine,
 			objs:                []runtime.Object{cp1, cp2},
 			etcdClientGenerator: &fakeEtcdClientGenerator{err: errors.New("no client")},
 			expectErr:           true,
 		},
 		{
-			name:    "returns error if it failed to get etcd members",
+			name:    "returns an error if the client errors getting etcd members",
 			machine: machine,
 			objs:    []runtime.Object{cp1, cp2},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
@@ -255,7 +256,7 @@ func TestRemoveEtcdMemberFromMachine(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:    "returns error if it failed to remove etcd member",
+			name:    "returns an error if the client errors removing the etcd member",
 			machine: machine,
 			objs:    []runtime.Object{cp1, cp2},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
@@ -278,7 +279,7 @@ func TestRemoveEtcdMemberFromMachine(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:    "removes member from etcd",
+			name:    "removes the member from etcd",
 			machine: machine,
 			objs:    []runtime.Object{cp1, cp2},
 			etcdClientGenerator: &fakeEtcdClientGenerator{

--- a/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
@@ -224,22 +224,10 @@ func TestRemoveEtcdMemberFromMachine(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "returns an error if it can't find a node with a different name",
-			machine: &clusterv1.Machine{
-				Status: clusterv1.MachineStatus{
-					NodeRef: &corev1.ObjectReference{
-						Name: "cp1",
-					},
-				},
-			},
-			objs:      []runtime.Object{cp1, cp1DiffNS},
-			expectErr: true,
-		},
-		{
-			name:                "returns an error if it failed to create the etcd client",
+			name:                "returns an error if it fails to create the etcd client",
 			machine:             machine,
 			objs:                []runtime.Object{cp1, cp2},
-			etcdClientGenerator: &fakeEtcdClientGenerator{forNodeErr: errors.New("no client")},
+			etcdClientGenerator: &fakeEtcdClientGenerator{forLeaderErr: errors.New("no client")},
 			expectErr:           true,
 		},
 		{
@@ -247,7 +235,7 @@ func TestRemoveEtcdMemberFromMachine(t *testing.T) {
 			machine: machine,
 			objs:    []runtime.Object{cp1, cp2},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodeClient: &etcd.Client{
+				forLeaderClient: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						ErrorResponse: errors.New("cannot get etcd members"),
 					},
@@ -260,7 +248,7 @@ func TestRemoveEtcdMemberFromMachine(t *testing.T) {
 			machine: machine,
 			objs:    []runtime.Object{cp1, cp2},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodeClient: &etcd.Client{
+				forLeaderClient: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						ErrorResponse: errors.New("cannot remove etcd member"),
 						MemberListResponse: &clientv3.MemberListResponse{
@@ -283,7 +271,7 @@ func TestRemoveEtcdMemberFromMachine(t *testing.T) {
 			machine: machine,
 			objs:    []runtime.Object{cp1, cp2},
 			etcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodeClient: &etcd.Client{
+				forLeaderClient: &etcd.Client{
 					EtcdClient: &fake2.FakeEtcdClient{
 						MemberListResponse: &clientv3.MemberListResponse{
 							Members: []*pb.Member{


### PR DESCRIPTION
**What this PR does / why we need it**:
We will now connect directly to the etcd leader node when removing nodes from the cluster and when we are changing the current etcd leader.

Previously when removing nodes we would just connect to any node other than the node for removal. When we were changing the current leader we would connect to both the current leader and the "candidate" leader, so this is a simplification of that code.

**Which issue(s) this PR fixes**:
Fixes #2789
