### PR TITLE
:warning: Let MHC to remediate any machine owned by a controller

### DIFF
--- a/controllers/machinehealthcheck_targets.go
+++ b/controllers/machinehealthcheck_targets.go
@@ -26,25 +26,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	ownerControllerKind   = "MachineSet"
 	nodeControlPlaneLabel = "node-role.kubernetes.io/master"
 
 	// Event types
 
-	// EventSkippedControlPlane is emitted in case an unhealthy node (or a machine
-	// associated with the node) has the `master` role
-	EventSkippedControlPlane string = "SkippedControlPlane"
-	// EventMachineDeletionFailed is emitted in case remediation of a machine
-	// is required but deletion of its Machine object failed
 	EventMachineDeletionFailed string = "MachineDeletionFailed"
 	// EventMachineDeleted is emitted when machine was successfully remediated
 	// by deleting its Machine object
@@ -274,31 +268,18 @@ func minDuration(durations []time.Duration) time.Duration {
 	return minDuration
 }
 
-// remediate deletes the Machine if it is owned by a MachineSet and is not part of the cluster's control plane
+// remediate deletes the Machine if it is owned by a controller
 func (t *healthCheckTarget) remediate(ctx context.Context, logger logr.Logger, c client.Client, r record.EventRecorder) error {
 	logger = logger.WithValues("target", t.string())
 	logger.Info("Starting remediation for target")
 
-	// If the machine is not owned by a MachineSet, it should be skipped
-	hasOwner, err := t.hasMachineSetOwner()
+	// If the machine is not owned by a controller, it should be skipped
+	hasControllerOwner, err := t.hasControllerOwner()
 	if err != nil {
 		return fmt.Errorf("%s: unable to determine Machine owners: %v", t.string(), err)
 	}
-	if !hasOwner {
-		logger.Info("Target has no machineset owner, skipping remediation")
-		return nil
-	}
-
-	// If the machine is a control plane node, it should be skipped
-	if t.isControlPlane() {
-		r.Eventf(
-			t.Machine,
-			corev1.EventTypeNormal,
-			EventSkippedControlPlane,
-			"Machine %v is a control plane node, skipping remediation",
-			t.string(),
-		)
-		logger.Info("Target is a control plane node, skipping remediation")
+	if !hasControllerOwner {
+		logger.Info("Target has no controller owner, skipping remediation")
 		return nil
 	}
 
@@ -325,35 +306,20 @@ func (t *healthCheckTarget) remediate(ctx context.Context, logger logr.Logger, c
 	return nil
 }
 
-// hasMachineSetOwner checks whether the target's Machine is owned by a MachineSet
-func (t *healthCheckTarget) hasMachineSetOwner() (bool, error) {
+// hasControllerOwner checks whether the target's Machine is owned by a controller
+func (t *healthCheckTarget) hasControllerOwner() (bool, error) {
 	ownerRefs := t.Machine.ObjectMeta.GetOwnerReferences()
 	for _, or := range ownerRefs {
-		if or.Kind == ownerControllerKind {
-			// The Kind matches so check the Group matches as well
-			gv, err := schema.ParseGroupVersion(or.APIVersion)
-			if err != nil {
-				return false, err
-			}
-			if gv.Group == clusterv1.GroupVersion.Group {
+		gv, err := schema.ParseGroupVersion(or.APIVersion)
+		if err != nil {
+			return false, err
+		}
+
+		if gv.Group == clusterv1.GroupVersion.Group || gv.Group == controlplanev1.GroupVersion.Group {
+			if or.Controller != nil && *or.Controller {
 				return true, nil
 			}
 		}
 	}
 	return false, nil
-}
-
-// isControlPlane checks whether the target refers to a machine that is part of the
-// cluster's control plane
-func (t *healthCheckTarget) isControlPlane() bool {
-	if t.Node != nil && labels.Set(t.Node.Labels).Has(nodeControlPlaneLabel) {
-		return true
-	}
-
-	// if the node is not found, fallback to checking the machine
-	if t.Machine != nil && labels.Set(t.Machine.Labels).Has(clusterv1.MachineControlPlaneLabelName) {
-		return true
-	}
-
-	return false
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
We want to relax the hard dependency on machineSets and let remediation to happen for machines that are owned by any controller in the known groups.
This will enable a possible integration for a self healing control plane.

Needs https://github.com/kubernetes-sigs/cluster-api/issues/2818
/hold

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2836
