### PR TITLE
✨ Make clusterctl cert-manager timeout configurable

### DIFF
--- a/cmd/clusterctl/client/cluster/cert_manager_test.go
+++ b/cmd/clusterctl/client/cluster/cert_manager_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
+)
+
+func Test_GetTimeout(t *testing.T) {
+
+	pollImmediateWaiter := func(interval, timeout time.Duration, condition wait.ConditionFunc) error {
+		return nil
+	}
+
+	tests := []struct {
+		name    string
+		timeout string
+		want    time.Duration
+	}{
+		{
+			name:    "no custom value set for timeout",
+			timeout: "",
+			want:    10 * time.Minute,
+		},
+		{
+			name:    "a custom value of timeout is set",
+			timeout: "5m",
+			want:    5 * time.Minute,
+		},
+		{
+			name:    "invalid custom value of timeout is set",
+			timeout: "5",
+			want:    10 * time.Minute,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			fakeConfigClient := newFakeConfig(tt.timeout)
+
+			cm := newCertMangerClient(fakeConfigClient, nil, pollImmediateWaiter)
+			tm := cm.getWaitTimeout()
+
+			g.Expect(tm).To(Equal(tt.want))
+		})
+	}
+
+}
+
+func newFakeConfig(timeout string) fakeConfigClient {
+	fakeReader := test.NewFakeReader().WithVar("cert-manager-timeout", timeout)
+
+	client, _ := config.New("fake-config", config.InjectReader(fakeReader))
+	return fakeConfigClient{
+		fakeReader:         fakeReader,
+		internalclient:     client,
+		certManagerTimeout: timeout,
+	}
+}
+
+type fakeConfigClient struct {
+	fakeReader         *test.FakeReader
+	internalclient     config.Client
+	certManagerTimeout string
+}
+
+var _ config.Client = &fakeConfigClient{}
+
+func (f fakeConfigClient) Providers() config.ProvidersClient {
+	return f.internalclient.Providers()
+}
+
+func (f fakeConfigClient) Variables() config.VariablesClient {
+	return f.internalclient.Variables()
+}
+
+func (f fakeConfigClient) ImageMeta() config.ImageMetaClient {
+	return f.internalclient.ImageMeta()
+}
+
+func (f *fakeConfigClient) WithVar(key, value string) *fakeConfigClient {
+	f.fakeReader.WithVar(key, value)
+	return f
+}
+
+func (f *fakeConfigClient) WithProvider(provider config.Provider) *fakeConfigClient {
+	f.fakeReader.WithProvider(provider.Name(), provider.Type(), provider.URL())
+	return f
+}

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -154,3 +154,15 @@ images:
 
 In this example we are overriding the image repository for all the components and the image tag for
 all the images in the cert-manager component.
+
+## Cert-Manager timeout override
+
+For situations when resources are limited or the network is slow, the cert-manager wait time to be running can be customized by adding a field to the clusterctl config file, for example:
+
+```yaml
+  cert-manager-timeout: 15m 
+```
+
+The value string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+If no value is specified or the format is invalid, the default value of 10 minutes will be used.


### PR DESCRIPTION

**What this PR does / why we need it**:
- cert-manager-timeout can be set in config file
- default of 10 minutes if no value is set

**Which issue(s) this PR fixes
Fixes #2822
