### PR TITLE
🏃[KCP] Recover from a manual machine deletion

### DIFF
--- a/controlplane/kubeadm/controllers/fakes_test.go
+++ b/controlplane/kubeadm/controllers/fakes_test.go
@@ -70,6 +70,10 @@ func (f fakeWorkloadCluster) ForwardEtcdLeadership(_ context.Context, _ *cluster
 	return nil
 }
 
+func (f fakeWorkloadCluster) ReconcileEtcdMembers(ctx context.Context) error {
+	return nil
+}
+
 func (f fakeWorkloadCluster) ClusterStatus(_ context.Context) (internal.ClusterStatus, error) {
 	return f.Status, nil
 }

--- a/controlplane/kubeadm/controllers/scale.go
+++ b/controlplane/kubeadm/controllers/scale.go
@@ -49,15 +49,7 @@ func (r *KubeadmControlPlaneReconciler) initializeControlPlane(ctx context.Conte
 func (r *KubeadmControlPlaneReconciler) scaleUpControlPlane(ctx context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, _ internal.FilterableMachineCollection, controlPlane *internal.ControlPlane) (ctrl.Result, error) {
 	logger := controlPlane.Logger()
 
-	if err := r.managementCluster.TargetClusterControlPlaneIsHealthy(ctx, util.ObjectKey(cluster), kcp.Name); err != nil {
-		logger.V(2).Info("Waiting for control plane to pass control plane health check before adding an additional control plane machine", "cause", err)
-		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "ControlPlaneUnhealthy", "Waiting for control plane to pass control plane health check before adding additional control plane machine: %v", err)
-		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: healthCheckFailedRequeueAfter}
-	}
-
-	if err := r.managementCluster.TargetClusterEtcdIsHealthy(ctx, util.ObjectKey(cluster), kcp.Name); err != nil {
-		logger.V(2).Info("Waiting for control plane to pass etcd health check before adding an additional control plane machine", "cause", err)
-		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "ControlPlaneUnhealthy", "Waiting for control plane to pass etcd health check before adding additional control plane machine: %v", err)
+	if err := r.reconcileHealth(ctx, cluster, kcp, controlPlane); err != nil {
 		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: healthCheckFailedRequeueAfter}
 	}
 
@@ -90,11 +82,13 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 		return ctrl.Result{}, errors.Wrapf(err, "failed to create client to workload cluster")
 	}
 
-	// We don't want to health check at the beginning of this method to avoid blocking re-entrancy
-
 	// Wait for any delete in progress to complete before deleting another Machine
 	if controlPlane.HasDeletingMachine() {
 		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: deleteRequeueAfter}
+	}
+
+	if err := r.reconcileHealth(ctx, cluster, kcp, controlPlane); err != nil {
+		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: healthCheckFailedRequeueAfter}
 	}
 
 	// If there is not already a Machine that is marked for scale down, find one and mark it
@@ -113,13 +107,6 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 		return ctrl.Result{}, errors.New("failed to pick control plane Machine to delete")
 	}
 
-	// Ensure etcd is healthy prior to attempting to remove the member
-	if err := r.managementCluster.TargetClusterEtcdIsHealthy(ctx, util.ObjectKey(cluster), kcp.Name); err != nil {
-		logger.V(2).Info("Waiting for control plane to pass etcd health check before removing a control plane machine", "cause", err)
-		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "ControlPlaneUnhealthy",
-			"Waiting for control plane to pass etcd health check before removing a control plane machine: %v", err)
-		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: healthCheckFailedRequeueAfter}
-	}
 	// If etcd leadership is on machine that is about to be deleted, move it to the newest member available.
 	etcdLeaderCandidate := ownedMachines.Newest()
 	if err := workloadCluster.ForwardEtcdLeadership(ctx, machineToDelete, etcdLeaderCandidate); err != nil {
@@ -148,13 +135,6 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 		}
 	}
 
-	// Do a final health check of the Control Plane components prior to actually deleting the machine
-	if err := r.managementCluster.TargetClusterControlPlaneIsHealthy(ctx, util.ObjectKey(cluster), kcp.Name); err != nil {
-		logger.V(2).Info("Waiting for control plane to pass control plane health check before removing a control plane machine", "cause", err)
-		r.recorder.Eventf(kcp, corev1.EventTypeWarning, "ControlPlaneUnhealthy",
-			"Waiting for control plane to pass control plane health check before removing a control plane machine: %v", err)
-		return ctrl.Result{}, &capierrors.RequeueAfterError{RequeueAfter: healthCheckFailedRequeueAfter}
-	}
 	logger = logger.WithValues("machine", machineToDelete)
 	if err := r.Client.Delete(ctx, machineToDelete); err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "Failed to delete control plane machine")

--- a/controlplane/kubeadm/controllers/scale_test.go
+++ b/controlplane/kubeadm/controllers/scale_test.go
@@ -164,6 +164,7 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 			}
 
 			ownedMachines := fmc.Machines.DeepCopy()
+
 			_, err := r.scaleUpControlPlane(context.Background(), cluster.DeepCopy(), kcp.DeepCopy(), ownedMachines, controlPlane)
 			g.Expect(err).To(HaveOccurred())
 			g.Expect(err).To(MatchError(&capierrors.RequeueAfterError{RequeueAfter: healthCheckFailedRequeueAfter}))

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -194,6 +194,42 @@ var _ = Describe("Docker Create", func() {
 			},
 		}
 		framework.AssertControlPlaneFailureDomains(ctx, assertControlPlaneFailureDomainInput)
+
+		Describe("Docker recover from manual workload machine deletion", func() {
+			By("cleaning up etcd members and kubeadm configMap")
+			inClustersNamespaceListOption := ctrlclient.InNamespace(cluster.Namespace)
+			// ControlPlane labels
+			matchClusterListOption := ctrlclient.MatchingLabels{
+				clusterv1.MachineControlPlaneLabelName: "",
+				clusterv1.ClusterLabelName:             cluster.Name,
+			}
+
+			machineList := &clusterv1.MachineList{}
+			err = mgmtClient.List(ctx, machineList, inClustersNamespaceListOption, matchClusterListOption)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(machineList.Items).To(HaveLen(int(*controlPlane.Spec.Replicas)))
+
+			Expect(mgmtClient.Delete(ctx, &machineList.Items[0])).To(Succeed())
+
+			Eventually(func() (int, error) {
+				machineList := &clusterv1.MachineList{}
+				if err := mgmtClient.List(ctx, machineList, inClustersNamespaceListOption, matchClusterListOption); err != nil {
+					fmt.Println(err)
+					return 0, err
+				}
+				return len(machineList.Items), nil
+			}, "10m", "5s").Should(Equal(int(*controlPlane.Spec.Replicas) - 1))
+
+			By("ensuring a replacement machine is created")
+			Eventually(func() (int, error) {
+				machineList := &clusterv1.MachineList{}
+				if err := mgmtClient.List(ctx, machineList, inClustersNamespaceListOption, matchClusterListOption); err != nil {
+					fmt.Println(err)
+					return 0, err
+				}
+				return len(machineList.Items), nil
+			}, "10m", "30s").Should(Equal(int(*controlPlane.Spec.Replicas)))
+		})
 	})
 
 })

--- a/test/infrastructure/docker/e2e/docker_test.go
+++ b/test/infrastructure/docker/e2e/docker_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Docker Create", func() {
 		mgmtClient ctrlclient.Client
 		cluster    *clusterv1.Cluster
 	)
-	SetDefaultEventuallyTimeout(10 * time.Minute)
+	SetDefaultEventuallyTimeout(15 * time.Minute)
 	SetDefaultEventuallyPollingInterval(10 * time.Second)
 
 	AfterEach(func() {
@@ -137,7 +137,7 @@ var _ = Describe("Docker Create", func() {
 			Cluster:      cluster,
 			ControlPlane: controlPlane,
 		}
-		framework.WaitForOneKubeadmControlPlaneMachineToExist(ctx, waitForOneKubeadmControlPlaneMachineToExistInput, "5m")
+		framework.WaitForOneKubeadmControlPlaneMachineToExist(ctx, waitForOneKubeadmControlPlaneMachineToExistInput, "15m")
 
 		// Insatll a networking solution on the workload cluster
 		workloadClient, err := mgmt.GetWorkloadClient(ctx, cluster.Namespace, cluster.Name)
@@ -218,7 +218,7 @@ var _ = Describe("Docker Create", func() {
 					return 0, err
 				}
 				return len(machineList.Items), nil
-			}, "10m", "5s").Should(Equal(int(*controlPlane.Spec.Replicas) - 1))
+			}, "15m", "5s").Should(Equal(int(*controlPlane.Spec.Replicas) - 1))
 
 			By("ensuring a replacement machine is created")
 			Eventually(func() (int, error) {
@@ -228,7 +228,7 @@ var _ = Describe("Docker Create", func() {
 					return 0, err
 				}
 				return len(machineList.Items), nil
-			}, "10m", "30s").Should(Equal(int(*controlPlane.Spec.Replicas)))
+			}, "15m", "30s").Should(Equal(int(*controlPlane.Spec.Replicas)))
 		})
 	})
 

--- a/test/infrastructure/docker/e2e/docker_upgrade_test.go
+++ b/test/infrastructure/docker/e2e/docker_upgrade_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Docker Upgrade", func() {
 		cluster      *clusterv1.Cluster
 		controlPlane *controlplanev1.KubeadmControlPlane
 	)
-	SetDefaultEventuallyTimeout(10 * time.Minute)
+	SetDefaultEventuallyTimeout(15 * time.Minute)
 	SetDefaultEventuallyPollingInterval(10 * time.Second)
 
 	BeforeEach(func() {
@@ -97,7 +97,7 @@ var _ = Describe("Docker Upgrade", func() {
 			Cluster:      cluster,
 			ControlPlane: controlPlane,
 		}
-		framework.WaitForOneKubeadmControlPlaneMachineToExist(ctx, waitForOneKubeadmControlPlaneMachineToExistInput, "5m")
+		framework.WaitForOneKubeadmControlPlaneMachineToExist(ctx, waitForOneKubeadmControlPlaneMachineToExistInput, "15m")
 
 		// Insatll a networking solution on the workload cluster
 		workloadClient, err := mgmt.GetWorkloadClient(ctx, cluster.Namespace, cluster.Name)
@@ -116,7 +116,7 @@ var _ = Describe("Docker Upgrade", func() {
 			Cluster:      cluster,
 			ControlPlane: controlPlane,
 		}
-		framework.WaitForKubeadmControlPlaneMachinesToExist(ctx, assertKubeadmControlPlaneNodesExistInput, "10m", "10s")
+		framework.WaitForKubeadmControlPlaneMachinesToExist(ctx, assertKubeadmControlPlaneNodesExistInput, "15m", "10s")
 
 		// Create the workload nodes
 		createMachineDeploymentinput := framework.CreateMachineDeploymentInput{
@@ -228,7 +228,7 @@ var _ = Describe("Docker Upgrade", func() {
 				return 0, errors.New("old nodes remain")
 			}
 			return upgraded, nil
-		}, "10m", "30s").Should(Equal(int(*controlPlane.Spec.Replicas)))
+		}, "15m", "30s").Should(Equal(int(*controlPlane.Spec.Replicas)))
 
 		workloadClient, err := mgmt.GetWorkloadClient(ctx, cluster.Namespace, cluster.Name)
 		Expect(err).ToNot(HaveOccurred())
@@ -245,7 +245,7 @@ var _ = Describe("Docker Upgrade", func() {
 			}
 
 			return false, nil
-		}, "10m", "30s").Should(BeTrue())
+		}, "15m", "30s").Should(BeTrue())
 
 		By("ensuring CoreDNS has the correct image")
 		Eventually(func() (bool, error) {
@@ -259,7 +259,7 @@ var _ = Describe("Docker Upgrade", func() {
 			}
 
 			return false, nil
-		}, "10m", "30s").Should(BeTrue())
+		}, "15m", "30s").Should(BeTrue())
 
 		// Before patching ensure all pods are ready in workload cluster
 		// Might not need this step any more.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds KCP logic to recover from a manual machine deletion. When an ETCD member with missing machine is detected, delete it from the ETCD members and from Kubeadm configmap.

**Which issue(s) this PR fixes** 
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2818

