### PR TITLE
🐛 Add kubernetes server validation on clusterctl

### DIFF
--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -30,6 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	minimumKubernetesVersion = "v1.16.0"
+)
+
 var (
 	ctx = context.TODO()
 )
@@ -186,6 +190,9 @@ func newClusterClient(kubeconfig string, configClient config.Client, options ...
 type Proxy interface {
 	// CurrentNamespace returns the namespace from the current context in the kubeconfig file
 	CurrentNamespace() (string, error)
+
+	// ValidateKubernetesVersion returns an error if management cluster version less than minimumKubernetesVersion
+	ValidateKubernetesVersion() error
 
 	// NewClient returns a new controller runtime Client object for working on the management cluster
 	NewClient() (client.Client, error)

--- a/cmd/clusterctl/client/cluster/inventory.go
+++ b/cmd/clusterctl/client/cluster/inventory.go
@@ -91,6 +91,10 @@ func newInventoryClient(proxy Proxy, pollImmediateWaiter PollImmediateWaiter) *i
 func (p *inventoryClient) EnsureCustomResourceDefinitions() error {
 	log := logf.Log
 
+	if err := p.proxy.ValidateKubernetesVersion(); err != nil {
+		return err
+	}
+
 	// Being this the first connection of many clusterctl operations, we want to fail fast if there is no
 	// connectivity to the cluster, so we try to get a client as a first thing.
 	// NB. NewClient has an internal retry loop that should mitigate temporary connection glitch; here we are

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -57,6 +57,10 @@ func (f *FakeProxy) CurrentNamespace() (string, error) {
 	return "default", nil
 }
 
+func (f *FakeProxy) ValidateKubernetesVersion() error {
+	return nil
+}
+
 func (f *FakeProxy) NewClient() (client.Client, error) {
 	if f.cs != nil {
 		return f.cs, nil


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR adds clusterctl Kubernetes server validation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2837

