### PR TITLE
:running: Work around DNS interception

### DIFF
--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -52,7 +52,7 @@ var (
 	validKubeConfig = `
 clusters:
 - cluster:
-    server: https://test-cluster-api:6443
+    server: https://test-cluster-api.nodomain.example.com:6443
   name: test-cluster-api
 contexts:
 - context:
@@ -104,7 +104,7 @@ func TestNewClusterClient(t *testing.T) {
 
 		restConfig, err := RESTConfig(ctx, client, clusterWithValidKubeConfig)
 		gs.Expect(err).NotTo(HaveOccurred())
-		gs.Expect(restConfig.Host).To(Equal("https://test-cluster-api:6443"))
+		gs.Expect(restConfig.Host).To(Equal("https://test-cluster-api.nodomain.example.com:6443"))
 	})
 
 	t.Run("cluster with no kubeconfig", func(t *testing.T) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

CenturyLink's DNS servers helpfully suggest that `test-cluster-api` lives on their "web helper" servers, and so instead of seeing a "no such host" error, I see a timeout trying to connect to a `https://` endpoint that couldn't exist.

They're willing to resolve this domain as `NXDOMAIN`, which both speeds up the test and makes it pass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
