### PR TITLE
Clarify comment for UpgradeAfter

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -55,8 +55,7 @@ type KubeadmControlPlaneSpec struct {
 	KubeadmConfigSpec cabpkv1.KubeadmConfigSpec `json:"kubeadmConfigSpec"`
 
 	// UpgradeAfter is a field to indicate an upgrade should be performed
-	// after the specified time even if no changes have been made to the
-	// KubeadmControlPlane
+	// only after the specified time for machines with an outdated spec.
 	// +optional
 	UpgradeAfter *metav1.Time `json:"upgradeAfter,omitempty"`
 }

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -915,8 +915,8 @@ spec:
                 type: integer
               upgradeAfter:
                 description: UpgradeAfter is a field to indicate an upgrade should
-                  be performed after the specified time even if no changes have been
-                  made to the KubeadmControlPlane
+                  be performed only after the specified time for machines with an
+                  outdated spec.
                 format: date-time
                 type: string
               version:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This comment “an upgrade should be performed after the specified time even if no changes have been made to the KubeadmControlPlane” makes me think an upgrade will take place even though no changes has been made at all and the spec is up to date, i.e a renewal policy. However we are still filtering out by up to date spec https://github.com/kubernetes-sigs/cluster-api/blob/master/controlplane/kubeadm/internal/control_plane.go#L100

This tries to clarify the behaviour in the comment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
