### PR TITLE
🏃clusterctl: cache GitHub API calls

### DIFF
--- a/cmd/clusterctl/client/repository/repository_github_test.go
+++ b/cmd/clusterctl/client/repository/repository_github_test.go
@@ -437,7 +437,7 @@ func Test_gitHubRepository_downloadFilesFromRelease(t *testing.T) {
 
 	var id1 int64 = 1
 	var id2 int64 = 2
-	tagName := "file.yaml"
+	tagName := "vO.3.3"
 	file := "file.yaml"
 
 	type args struct {
@@ -495,7 +495,7 @@ func Test_gitHubRepository_downloadFilesFromRelease(t *testing.T) {
 						},
 					},
 				},
-				fileName: file,
+				fileName: "another file",
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
As per https://github.com/kubernetes-sigs/cluster-api/issues/2450#issuecomment-607854874 this PR implements caching for GitHub API calls, thus reducing the number or call for `clusterctl init` from 20 to 8

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2450

/area clusterctl
