### PR TITLE
✨Support specific kubeconfig context in clusterctl

### DIFF
--- a/cmd/clusterctl/client/alias.go
+++ b/cmd/clusterctl/client/alias.go
@@ -36,3 +36,6 @@ type Template repository.Template
 
 // UpgradePlan defines a list of possible upgrade targets for a management group.
 type UpgradePlan cluster.UpgradePlan
+
+// Kubeconfig is a type that specifies inputs related to the actual kubeconfig.
+type Kubeconfig cluster.Kubeconfig

--- a/cmd/clusterctl/client/cluster/proxy_test.go
+++ b/cmd/clusterctl/client/cluster/proxy_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
+	"sigs.k8s.io/cluster-api/cmd/version"
+)
+
+var _ Proxy = &test.FakeProxy{}
+
+func TestProxyGetConfig(t *testing.T) {
+	t.Run("GetConfig", func(t *testing.T) {
+		tests := []struct {
+			name               string
+			context            string
+			kubeconfigContents string
+			expectedHost       string
+			expectErr          bool
+		}{
+			{
+				name:               "defaults to the currentContext if none is specified",
+				kubeconfigContents: kubeconfig("management", "default"),
+				expectedHost:       "https://management-server:1234",
+				expectErr:          false,
+			},
+			{
+				name:               "returns host of cluster associated with the specified context even if currentContext is different",
+				kubeconfigContents: kubeconfig("management", "default"),
+				context:            "workload",
+				expectedHost:       "https://kind-server:38790",
+				expectErr:          false,
+			},
+			{
+				name:               "returns error if cannot load the kubeconfig file",
+				expectErr:          true,
+				kubeconfigContents: "bad contents",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				g := NewWithT(t)
+				dir, err := ioutil.TempDir("", "clusterctl")
+				g.Expect(err).NotTo(HaveOccurred())
+				defer os.RemoveAll(dir)
+				configFile := filepath.Join(dir, ".test-kubeconfig.yaml")
+				g.Expect(ioutil.WriteFile(configFile, []byte(tt.kubeconfigContents), 0640)).To(Succeed())
+
+				proxy := newProxy(Kubeconfig{Path: configFile, Context: tt.context})
+				conf, err := proxy.GetConfig()
+				if tt.expectErr {
+					g.Expect(err).To(HaveOccurred())
+					return
+				}
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(conf).ToNot(BeNil())
+				// asserting on the host of the cluster associated with the
+				// context
+				g.Expect(conf.Host).To(Equal(tt.expectedHost))
+				g.Expect(conf.UserAgent).To(Equal(fmt.Sprintf("clusterctl/%s (%s)", version.Get().GitVersion, version.Get().Platform)))
+				g.Expect(conf.QPS).To(BeEquivalentTo(20))
+				g.Expect(conf.Burst).To(BeEquivalentTo(100))
+				g.Expect(conf.Timeout.String()).To(Equal("30s"))
+			})
+		}
+	})
+
+	t.Run("configure timeout", func(t *testing.T) {
+		g := NewWithT(t)
+		dir, err := ioutil.TempDir("", "clusterctl")
+		g.Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(dir)
+		configFile := filepath.Join(dir, ".test-kubeconfig.yaml")
+		g.Expect(ioutil.WriteFile(configFile, []byte(kubeconfig("management", "default")), 0640)).To(Succeed())
+
+		proxy := newProxy(Kubeconfig{Path: configFile, Context: "management"}, InjectProxyTimeout(23*time.Second))
+		conf, err := proxy.GetConfig()
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(conf.Timeout.String()).To(Equal("23s"))
+	})
+}
+
+func TestProxyCurrentNamespace(t *testing.T) {
+	tests := []struct {
+		name               string
+		kubeconfigPath     string
+		kubeconfigContents string
+		kubeconfigContext  string
+		expectErr          bool
+		expectedNamespace  string
+	}{
+		{
+			name:           "return error for invalid kubeconfig path",
+			kubeconfigPath: "do-not-exist",
+			expectErr:      true,
+		},
+		{
+			name:               "return error for bad kubeconfig contents",
+			kubeconfigContents: "management",
+			expectErr:          true,
+		},
+		{
+			name:               "return default namespace if unspecified",
+			kubeconfigContents: kubeconfig("workload", ""),
+			expectErr:          false,
+			expectedNamespace:  "default",
+		},
+		{
+			name:               "return error when current-context is empty",
+			kubeconfigContents: kubeconfig("", ""),
+			expectErr:          true,
+		},
+		{
+			name:               "return error when current-context is incorrect or does not exist",
+			kubeconfigContents: kubeconfig("does-not-exist", ""),
+			expectErr:          true,
+		},
+		{
+			name:               "return specified namespace for the current context",
+			kubeconfigContents: kubeconfig("workload", "mykindns"),
+			expectErr:          false,
+			expectedNamespace:  "mykindns",
+		},
+		{
+			name:               "return the namespace of the specified context which is different from current context",
+			kubeconfigContents: kubeconfig("management", "workload-ns"),
+			expectErr:          false,
+			kubeconfigContext:  "workload",
+			expectedNamespace:  "workload-ns",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			var configFile string
+			if len(tt.kubeconfigPath) != 0 {
+				configFile = tt.kubeconfigPath
+			} else {
+				dir, err := ioutil.TempDir("", "clusterctl")
+				g.Expect(err).NotTo(HaveOccurred())
+				defer os.RemoveAll(dir)
+				configFile = filepath.Join(dir, ".test-kubeconfig.yaml")
+				g.Expect(ioutil.WriteFile(configFile, []byte(tt.kubeconfigContents), 0640)).To(Succeed())
+			}
+
+			proxy := newProxy(Kubeconfig{Path: configFile, Context: tt.kubeconfigContext})
+			ns, err := proxy.CurrentNamespace()
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(ns).To(Equal(tt.expectedNamespace))
+		})
+	}
+}
+
+func kubeconfig(currentContext, namespace string) string {
+	return fmt.Sprintf(`---
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://management-server:1234
+  name: management
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://kind-server:38790
+  name: workload
+contexts:
+- context:
+    cluster: management
+    user: management
+    namespace: management-ns
+  name: management
+- context:
+    cluster: workload
+    user: workload
+    namespace: %s
+  name: workload
+current-context: %s
+kind: Config
+preferences: {}
+users:
+- name: management
+  user:
+    client-certificate-data: c3R1ZmYK
+    client-key-data: c3R1ZmYK
+- name: workload
+  user:
+    client-certificate-data: c3R1ZmYK
+    client-key-data: c3R1ZmYK
+`, namespace, currentContext)
+
+}

--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -17,8 +17,9 @@ limitations under the License.
 package client
 
 import (
-	"k8s.io/utils/pointer"
 	"strconv"
+
+	"k8s.io/utils/pointer"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -51,8 +52,9 @@ func (c *clusterctlClient) GetProviderComponents(provider string, providerType c
 
 // GetClusterTemplateOptions carries the options supported by GetClusterTemplate.
 type GetClusterTemplateOptions struct {
-	// Kubeconfig file to use for accessing the management cluster. If empty, default discovery rules apply.
-	Kubeconfig string
+	// Kubeconfig defines the kubeconfig to use for accessing the management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	Kubeconfig Kubeconfig
 
 	// ProviderRepositorySource to be used for reading the workload cluster template from a provider repository;
 	// only one template source can be used at time; if not other source will be set, a ProviderRepositorySource

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -19,16 +19,18 @@ package client
 import (
 	"fmt"
 	"io/ioutil"
-	"k8s.io/utils/pointer"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 )
 
@@ -391,7 +393,7 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 		WithDefaultVersion("v3.0.0").
 		WithFile("v3.0.0", "cluster-template.yaml", rawTemplate)
 
-	cluster1 := newFakeCluster("kubeconfig", config1).
+	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1).
 		WithProviderInventory(infraProviderConfig.Name(), infraProviderConfig.Type(), "v3.0.0", "foo", "bar").
 		WithObjs(configMap)
 
@@ -419,7 +421,7 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 			name: "repository source - pass",
 			args: args{
 				options: GetClusterTemplateOptions{
-					Kubeconfig: "kubeconfig",
+					Kubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					ProviderRepositorySource: &ProviderRepositorySourceOptions{
 						InfrastructureProvider: "infra:v3.0.0",
 						Flavor:                 "",
@@ -439,7 +441,7 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 			name: "repository source - detects provider name/version if missing",
 			args: args{
 				options: GetClusterTemplateOptions{
-					Kubeconfig: "kubeconfig",
+					Kubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					ProviderRepositorySource: &ProviderRepositorySourceOptions{
 						InfrastructureProvider: "", // empty triggers auto-detection of the provider name/version
 						Flavor:                 "",
@@ -459,7 +461,7 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 			name: "repository source - use current namespace if targetNamespace is missing",
 			args: args{
 				options: GetClusterTemplateOptions{
-					Kubeconfig: "kubeconfig",
+					Kubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					ProviderRepositorySource: &ProviderRepositorySourceOptions{
 						InfrastructureProvider: "infra:v3.0.0",
 						Flavor:                 "",
@@ -479,7 +481,7 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 			name: "URL source - pass",
 			args: args{
 				options: GetClusterTemplateOptions{
-					Kubeconfig: "kubeconfig",
+					Kubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					URLSource: &URLSourceOptions{
 						URL: path,
 					},
@@ -498,7 +500,7 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 			name: "ConfigMap source - pass",
 			args: args{
 				options: GetClusterTemplateOptions{
-					Kubeconfig: "kubeconfig",
+					Kubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					ConfigMapSource: &ConfigMapSourceOptions{
 						Namespace: "ns1",
 						Name:      "my-template",

--- a/cmd/clusterctl/client/delete.go
+++ b/cmd/clusterctl/client/delete.go
@@ -25,8 +25,9 @@ import (
 
 // DeleteOptions carries the options supported by Delete.
 type DeleteOptions struct {
-	// Kubeconfig file to use for accessing the management cluster. If empty, default discovery rules apply.
-	Kubeconfig string
+	// Kubeconfig defines the kubeconfig to use for accessing the management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	Kubeconfig Kubeconfig
 
 	// Namespace where the provider to be deleted lives. If unspecified, the namespace name will be inferred
 	// from the current configuration.

--- a/cmd/clusterctl/client/delete_test.go
+++ b/cmd/clusterctl/client/delete_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 )
 
 func Test_clusterctlClient_Delete(t *testing.T) {
@@ -47,7 +48,7 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 			},
 			args: args{
 				options: DeleteOptions{
-					Kubeconfig:              "kubeconfig",
+					Kubeconfig:              Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					IncludeNamespace:        false,
 					IncludeCRDs:             false,
 					Namespace:               "",
@@ -68,7 +69,7 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 			},
 			args: args{
 				options: DeleteOptions{
-					Kubeconfig:              "kubeconfig",
+					Kubeconfig:              Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					IncludeNamespace:        false,
 					IncludeCRDs:             false,
 					Namespace:               "capbpk-system",
@@ -89,7 +90,7 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 			},
 			args: args{
 				options: DeleteOptions{
-					Kubeconfig:              "kubeconfig",
+					Kubeconfig:              Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					IncludeNamespace:        false,
 					IncludeCRDs:             false,
 					Namespace:               "", // empty namespace triggers namespace auto detection
@@ -115,7 +116,8 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 			}
 			g.Expect(err).NotTo(HaveOccurred())
 
-			proxy := tt.fields.client.clusters["kubeconfig"].Proxy()
+			input := cluster.Kubeconfig(tt.args.options.Kubeconfig)
+			proxy := tt.fields.client.clusters[input].Proxy()
 			gotProviders := &clusterctlv1.ProviderList{}
 
 			c, err := proxy.NewClient()
@@ -150,7 +152,7 @@ func fakeClusterForDelete() *fakeClient {
 		WithFile("v2.0.0", "components.yaml", componentsYAML("ns2")).
 		WithFile("v2.1.0", "components.yaml", componentsYAML("ns2"))
 
-	cluster1 := newFakeCluster("kubeconfig", config1)
+	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1)
 	cluster1.fakeProxy.WithProviderInventory(capiProviderConfig.Name(), capiProviderConfig.Type(), "v1.0.0", "capi-system", "")
 	cluster1.fakeProxy.WithProviderInventory(bootstrapProviderConfig.Name(), bootstrapProviderConfig.Type(), "v1.0.0", "capbpk-system", "")
 

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -28,6 +28,39 @@ import (
 
 const NoopProvider = "-"
 
+// InitOptions carries the options supported by Init.
+type InitOptions struct {
+	// Kubeconfig defines the kubeconfig to use for accessing the management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	Kubeconfig Kubeconfig
+
+	// CoreProvider version (e.g. cluster-api:v0.3.0) to add to the management cluster. If unspecified, the
+	// cluster-api core provider's latest release is used.
+	CoreProvider string
+
+	// BootstrapProviders and versions (e.g. kubeadm:v0.3.0) to add to the management cluster.
+	// If unspecified, the kubeadm bootstrap provider's latest release is used.
+	BootstrapProviders []string
+
+	// InfrastructureProviders and versions (e.g. aws:v0.5.0) to add to the management cluster.
+	InfrastructureProviders []string
+
+	// ControlPlaneProviders and versions (e.g. kubeadm:v0.3.0) to add to the management cluster.
+	// If unspecified, the kubeadm control plane provider latest release is used.
+	ControlPlaneProviders []string
+
+	// TargetNamespace defines the namespace where the providers should be deployed. If unspecified, each provider
+	// will be installed in a provider's default namespace.
+	TargetNamespace string
+
+	// WatchingNamespace defines the namespace the providers should watch to reconcile Cluster API objects.
+	// If unspecified, the providers watches for Cluster API objects across all namespaces.
+	WatchingNamespace string
+
+	// LogUsageInstructions instructs the init command to print the usage instructions in case of first run.
+	LogUsageInstructions bool
+}
+
 // Init initializes a management cluster by adding the requested list of providers.
 func (c *clusterctlClient) Init(options InitOptions) ([]Components, error) {
 	log := logf.Log

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -16,6 +16,21 @@ limitations under the License.
 
 package client
 
+// MoveOptions carries the options supported by move.
+type MoveOptions struct {
+	// FromKubeconfig defines the kubeconfig to use for accessing the source management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	FromKubeconfig Kubeconfig
+
+	// ToKubeconfig defines the kubeconfig to use for accessing the target management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	ToKubeconfig Kubeconfig
+
+	// Namespace where the objects describing the workload cluster exists. If unspecified, the current
+	// namespace will be used.
+	Namespace string
+}
+
 func (c *clusterctlClient) Move(options MoveOptions) error {
 	// Get the client for interacting with the source management cluster.
 	fromCluster, err := c.clusterClientFactory(options.FromKubeconfig)

--- a/cmd/clusterctl/client/move_test.go
+++ b/cmd/clusterctl/client/move_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+)
+
+func Test_clusterctlClient_Move(t *testing.T) {
+	type fields struct {
+		client *fakeClient
+	}
+	type args struct {
+		options MoveOptions
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "does not return error if cluster client is found",
+			fields: fields{
+				client: fakeClientForMove(), // core v1.0.0 (v1.0.1 available), infra v2.0.0 (v2.0.1 available)
+			},
+			args: args{
+				options: MoveOptions{
+					FromKubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
+					ToKubeconfig:   Kubeconfig{Path: "kubeconfig", Context: "worker-context"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns an error if from cluster client is not found",
+			fields: fields{
+				client: fakeClientForMove(), // core v1.0.0 (v1.0.1 available), infra v2.0.0 (v2.0.1 available)
+			},
+			args: args{
+				options: MoveOptions{
+					FromKubeconfig: Kubeconfig{Path: "kubeconfig", Context: "does-not-exist"},
+					ToKubeconfig:   Kubeconfig{Path: "kubeconfig", Context: "worker-context"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "returns an error if to cluster client is not found",
+			fields: fields{
+				client: fakeClientForMove(), // core v1.0.0 (v1.0.1 available), infra v2.0.0 (v2.0.1 available)
+			},
+			args: args{
+				options: MoveOptions{
+					FromKubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
+					ToKubeconfig:   Kubeconfig{Path: "kubeconfig", Context: "does-not-exist"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			err := tt.fields.client.Move(tt.args.options)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+}
+
+func fakeClientForMove() *fakeClient {
+	core := config.NewProvider("cluster-api", "https://somewhere.com", clusterctlv1.CoreProviderType)
+	infra := config.NewProvider("infra", "https://somewhere.com", clusterctlv1.InfrastructureProviderType)
+
+	config1 := newFakeConfig().
+		WithProvider(core).
+		WithProvider(infra)
+
+	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1).
+		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "").
+		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "").
+		WithObjectMover(&fakeObjectMover{})
+
+	// Creating this cluster for move_test
+	cluster2 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "worker-context"}, config1).
+		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "").
+		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "")
+
+	client := newFakeClient(config1).
+		WithCluster(cluster1).
+		WithCluster(cluster2)
+
+	return client
+}
+
+type fakeObjectMover struct {
+	moveErr error
+}
+
+func (f *fakeObjectMover) Move(namespace string, toCluster cluster.Client) error {
+	return f.moveErr
+}

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -27,8 +27,8 @@ import (
 
 // PlanUpgradeOptions carries the options supported by upgrade plan.
 type PlanUpgradeOptions struct {
-	// Kubeconfig file to use for accessing the management cluster. If empty, default discovery rules apply.
-	Kubeconfig string
+	// Kubeconfig defines the kubeconfig to use for accessing the management cluster. If empty, default discovery rules apply.
+	Kubeconfig Kubeconfig
 }
 
 func (c *clusterctlClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePlan, error) {
@@ -43,14 +43,14 @@ func (c *clusterctlClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePla
 		return nil, err
 	}
 
-	upgradePlan, err := cluster.ProviderUpgrader().Plan()
+	upgradePlans, err := cluster.ProviderUpgrader().Plan()
 	if err != nil {
 		return nil, err
 	}
 
 	// UpgradePlan is an alias for cluster.UpgradePlan; this makes the conversion
-	aliasUpgradePlan := make([]UpgradePlan, len(upgradePlan))
-	for i, plan := range upgradePlan {
+	aliasUpgradePlan := make([]UpgradePlan, len(upgradePlans))
+	for i, plan := range upgradePlans {
 		aliasUpgradePlan[i] = UpgradePlan{
 			Contract:     plan.Contract,
 			CoreProvider: plan.CoreProvider,
@@ -63,8 +63,8 @@ func (c *clusterctlClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePla
 
 // ApplyUpgradeOptions carries the options supported by upgrade apply.
 type ApplyUpgradeOptions struct {
-	// Kubeconfig file to use for accessing the management cluster. If empty, default discovery rules apply.
-	Kubeconfig string
+	// Kubeconfig to use for accessing the management cluster. If empty, default discovery rules apply.
+	Kubeconfig Kubeconfig
 
 	// ManagementGroup that should be upgraded (e.g. capi-system/cluster-api).
 	ManagementGroup string

--- a/cmd/clusterctl/cmd/config_cluster.go
+++ b/cmd/clusterctl/cmd/config_cluster.go
@@ -27,6 +27,7 @@ import (
 
 type configClusterOptions struct {
 	kubeconfig             string
+	kubeconfigContext      string
 	flavor                 string
 	infrastructureProvider string
 
@@ -94,6 +95,8 @@ var configClusterClusterCmd = &cobra.Command{
 func init() {
 	configClusterClusterCmd.Flags().StringVar(&cc.kubeconfig, "kubeconfig", "",
 		"Path to a kubeconfig file to use for the management cluster. If empty, default discovery rules apply.")
+	configClusterClusterCmd.Flags().StringVar(&cc.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
 
 	// flags for the template variables
 	configClusterClusterCmd.Flags().StringVarP(&cc.targetNamespace, "target-namespace", "n", "",
@@ -137,7 +140,7 @@ func runGetClusterTemplate(cmd *cobra.Command, name string) error {
 	}
 
 	templateOptions := client.GetClusterTemplateOptions{
-		Kubeconfig:        cc.kubeconfig,
+		Kubeconfig:        client.Kubeconfig{Path: cc.kubeconfig, Context: cc.kubeconfigContext},
 		ClusterName:       name,
 		TargetNamespace:   cc.targetNamespace,
 		KubernetesVersion: cc.kubernetesVersion,

--- a/cmd/clusterctl/cmd/delete.go
+++ b/cmd/clusterctl/cmd/delete.go
@@ -24,6 +24,7 @@ import (
 
 type deleteOptions struct {
 	kubeconfig              string
+	kubeconfigContext       string
 	targetNamespace         string
 	coreProvider            string
 	bootstrapProviders      []string
@@ -84,6 +85,8 @@ var deleteCmd = &cobra.Command{
 func init() {
 	deleteCmd.Flags().StringVar(&dd.kubeconfig, "kubeconfig", "",
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
+	deleteCmd.Flags().StringVar(&dd.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
 	deleteCmd.Flags().StringVar(&dd.targetNamespace, "namespace", "", "The namespace where the provider to be deleted lives. If unspecified, the namespace name will be inferred from the current configuration")
 
 	deleteCmd.Flags().BoolVar(&dd.includeNamespace, "include-namespace", false,
@@ -126,7 +129,7 @@ func runDelete() error {
 	}
 
 	if err := c.Delete(client.DeleteOptions{
-		Kubeconfig:              dd.kubeconfig,
+		Kubeconfig:              client.Kubeconfig{Path: dd.kubeconfig, Context: dd.kubeconfigContext},
 		IncludeNamespace:        dd.includeNamespace,
 		IncludeCRDs:             dd.includeCRDs,
 		Namespace:               dd.targetNamespace,

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -25,6 +25,7 @@ import (
 
 type initOptions struct {
 	kubeconfig              string
+	kubeconfigContext       string
 	coreProvider            string
 	bootstrapProviders      []string
 	controlPlaneProviders   []string
@@ -91,6 +92,8 @@ var initCmd = &cobra.Command{
 func init() {
 	initCmd.Flags().StringVar(&io.kubeconfig, "kubeconfig", "",
 		"Path to the kubeconfig for the management cluster. If unspecified, default discovery rules apply.")
+	initCmd.Flags().StringVar(&io.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
 	initCmd.Flags().StringVar(&io.coreProvider, "core", "",
 		"Core provider version (e.g. cluster-api:v0.3.0) to add to the management cluster. If unspecified, Cluster API's latest release is used.")
 	initCmd.Flags().StringSliceVarP(&io.infrastructureProviders, "infrastructure", "i", nil,
@@ -118,7 +121,7 @@ func runInit() error {
 	}
 
 	options := client.InitOptions{
-		Kubeconfig:              io.kubeconfig,
+		Kubeconfig:              client.Kubeconfig{Path: io.kubeconfig, Context: io.kubeconfigContext},
 		CoreProvider:            io.coreProvider,
 		BootstrapProviders:      io.bootstrapProviders,
 		ControlPlaneProviders:   io.controlPlaneProviders,

--- a/cmd/clusterctl/cmd/move.go
+++ b/cmd/clusterctl/cmd/move.go
@@ -23,9 +23,11 @@ import (
 )
 
 type moveOptions struct {
-	fromKubeconfig string
-	namespace      string
-	toKubeconfig   string
+	fromKubeconfig        string
+	fromKubeconfigContext string
+	toKubeconfig          string
+	toKubeconfigContext   string
+	namespace             string
 }
 
 var mo = &moveOptions{}
@@ -52,6 +54,10 @@ func init() {
 		"Path to the kubeconfig file for the source management cluster. If unspecified, default discovery rules apply.")
 	moveCmd.Flags().StringVar(&mo.toKubeconfig, "to-kubeconfig", "",
 		"Path to the kubeconfig file to use for the destination management cluster.")
+	moveCmd.Flags().StringVar(&mo.fromKubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file for the source management cluster. If empty, current context will be used.")
+	moveCmd.Flags().StringVar(&mo.toKubeconfigContext, "to-kubeconfig-context", "",
+		"Context to be used within the kubeconfig file for the destination management cluster. If empty, current context will be used.")
 	moveCmd.Flags().StringVarP(&mo.namespace, "namespace", "n", "",
 		"The namespace where the workload cluster is hosted. If unspecified, the current context's namespace is used.")
 
@@ -69,8 +75,8 @@ func runMove() error {
 	}
 
 	if err := c.Move(client.MoveOptions{
-		FromKubeconfig: mo.fromKubeconfig,
-		ToKubeconfig:   mo.toKubeconfig,
+		FromKubeconfig: client.Kubeconfig{Path: mo.fromKubeconfig, Context: mo.fromKubeconfigContext},
+		ToKubeconfig:   client.Kubeconfig{Path: mo.toKubeconfig, Context: mo.toKubeconfigContext},
 		Namespace:      mo.namespace,
 	}); err != nil {
 		return err

--- a/cmd/clusterctl/cmd/upgrade_apply.go
+++ b/cmd/clusterctl/cmd/upgrade_apply.go
@@ -25,6 +25,7 @@ import (
 
 type upgradeApplyOptions struct {
 	kubeconfig              string
+	kubeconfigContext       string
 	managementGroup         string
 	contract                string
 	coreProvider            string
@@ -60,6 +61,8 @@ var upgradeApplyCmd = &cobra.Command{
 func init() {
 	upgradeApplyCmd.Flags().StringVar(&ua.kubeconfig, "kubeconfig", "",
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
+	upgradeApplyCmd.Flags().StringVar(&ua.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
 	upgradeApplyCmd.Flags().StringVar(&ua.managementGroup, "management-group", "",
 		"The management group that should be upgraded (e.g. capi-system/cluster-api)")
 	upgradeApplyCmd.Flags().StringVar(&ua.contract, "contract", "",
@@ -91,7 +94,7 @@ func runUpgradeApply() error {
 	}
 
 	if err := c.ApplyUpgrade(client.ApplyUpgradeOptions{
-		Kubeconfig:              ua.kubeconfig,
+		Kubeconfig:              client.Kubeconfig{Path: ua.kubeconfig, Context: ua.kubeconfigContext},
 		ManagementGroup:         ua.managementGroup,
 		Contract:                ua.contract,
 		CoreProvider:            ua.coreProvider,

--- a/cmd/clusterctl/cmd/upgrade_plan.go
+++ b/cmd/clusterctl/cmd/upgrade_plan.go
@@ -26,7 +26,8 @@ import (
 )
 
 type upgradePlanOptions struct {
-	kubeconfig string
+	kubeconfig        string
+	kubeconfigContext string
 }
 
 var up = &upgradePlanOptions{}
@@ -56,6 +57,8 @@ var upgradePlanCmd = &cobra.Command{
 func init() {
 	upgradePlanCmd.Flags().StringVar(&up.kubeconfig, "kubeconfig", "",
 		"Path to the kubeconfig file to use for accessing the management cluster. If empty, default discovery rules apply.")
+	upgradePlanCmd.Flags().StringVar(&up.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
 }
 
 func runUpgradePlan() error {
@@ -65,7 +68,7 @@ func runUpgradePlan() error {
 	}
 
 	upgradePlans, err := c.PlanUpgrade(client.PlanUpgradeOptions{
-		Kubeconfig: up.kubeconfig,
+		Kubeconfig: client.Kubeconfig{Path: up.kubeconfig, Context: up.kubeconfigContext},
 	})
 	if err != nil {
 		return err

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	fakebootstrap "sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test/providers/bootstrap"
@@ -59,6 +60,10 @@ func (f *FakeProxy) CurrentNamespace() (string, error) {
 
 func (f *FakeProxy) ValidateKubernetesVersion() error {
 	return nil
+}
+
+func (f *FakeProxy) GetConfig() (*rest.Config, error) {
+	return nil, nil
 }
 
 func (f *FakeProxy) NewClient() (client.Client, error) {

--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -45,7 +45,7 @@ const (
 type InitInput struct {
 	LogFolder               string
 	ClusterctlConfigPath    string
-	KubeconfigPath          string
+	Kubeconfig              clusterctlclient.Kubeconfig
 	CoreProvider            string
 	BootstrapProviders      []string
 	ControlPlaneProviders   []string
@@ -62,7 +62,7 @@ func Init(ctx context.Context, input InitInput) {
 	)
 
 	initOpt := clusterctlclient.InitOptions{
-		Kubeconfig:              input.KubeconfigPath,
+		Kubeconfig:              input.Kubeconfig,
 		CoreProvider:            input.CoreProvider,
 		BootstrapProviders:      input.BootstrapProviders,
 		ControlPlaneProviders:   input.ControlPlaneProviders,
@@ -81,7 +81,7 @@ func Init(ctx context.Context, input InitInput) {
 type ConfigClusterInput struct {
 	LogFolder                string
 	ClusterctlConfigPath     string
-	KubeconfigPath           string
+	Kubeconfig               clusterctlclient.Kubeconfig
 	InfrastructureProvider   string
 	Namespace                string
 	ClusterName              string
@@ -103,7 +103,7 @@ func ConfigCluster(ctx context.Context, input ConfigClusterInput) []byte {
 	)
 
 	templateOptions := clusterctlclient.GetClusterTemplateOptions{
-		Kubeconfig: input.KubeconfigPath,
+		Kubeconfig: input.Kubeconfig,
 		ProviderRepositorySource: &clusterctlclient.ProviderRepositorySourceOptions{
 			InfrastructureProvider: input.InfrastructureProvider,
 			Flavor:                 input.Flavor,
@@ -133,8 +133,8 @@ func ConfigCluster(ctx context.Context, input ConfigClusterInput) []byte {
 type MoveInput struct {
 	LogFolder            string
 	ClusterctlConfigPath string
-	FromKubeconfigPath   string
-	ToKubeconfigPath     string
+	FromKubeconfig       clusterctlclient.Kubeconfig
+	ToKubeconfig         clusterctlclient.Kubeconfig
 	Namespace            string
 }
 
@@ -146,8 +146,8 @@ func Move(ctx context.Context, input MoveInput) {
 	defer log.Close()
 
 	options := clusterctlclient.MoveOptions{
-		FromKubeconfig: input.FromKubeconfigPath,
-		ToKubeconfig:   input.ToKubeconfigPath,
+		FromKubeconfig: input.FromKubeconfig,
+		ToKubeconfig:   input.ToKubeconfig,
 		Namespace:      input.Namespace,
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds support to specify the context within a kubeconfig file. It affects all the commands that provide `--kubeconfig` flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2659 
Fixes #2854

**Release Notes:**
- 🐛  Fixes bug in `proxy.CurrentNamespace` to return error if it cannot find
context in the kubeconfig.
- ➕ Adds GetConfig to Proxy interface
- ➕ Adds alias client.Kubeconfig to cluster.Kubeconfig to continue separation
of concerns between client libraries.
- ➕ ClusterClientFactory takes a new input called client.Kubeconfig
which contains kubeconfig Path and Context.
- ⚠️ Replaces KubeconfigPath() method on cluster.Client interface with Kubeconfig().
  - This method returns cluster.Kubeconfig which contains the various kubeconfig properties that are supported.
- ➕ Adds `--kubeconfig-context` flag to `move` command.
  - Replace FromKubeconfigPath in client.MoveOptions to FromKubeconfig.
- ➕ Adds `--to-kubeconfig-context` flag to `move` command.
  - Replace ToKubeconfigPath in client.MoveOptions to ToKubeconfig.
- ➕ Adds `--kubeconfig-context` flag to `config cluster` command.
  - Replace KubeconfigPath in client.GetClusterTemplateOptions to Kubeconfig.
- ➕ Adds `--kubeconfig-context` flag to `delete` command.
  - Replace KubeconfigPath in client.DeleteOptions to Kubeconfig.
- ➕ Adds `--kubeconfig-context` flag to `init` command.
  - Replace KubeconfigPath in client.InitOptions to Kubeconfig.
- ➕ Adds `--kubeconfig-context` flag to `upgrade` command.
  - Replace KubeconfigPath in client.PlanUpgradeOptions to Kubeconfig.
  - Replace KubeconfigPath in client.ApplyUpgradeOptions to Kubeconfig.
- Override timeout in proxy client
  - Defaults to a 30s timeout. This can be overridden via the InjectProxyTimeout ProxyOption.