### PR TITLE
🐛clusterctl: fix replace variables

### DIFF
--- a/cmd/clusterctl/client/repository/components.go
+++ b/cmd/clusterctl/client/repository/components.go
@@ -347,8 +347,8 @@ func replaceVariables(yaml []byte, variables []string, configVariablesClient con
 			missingVariables = append(missingVariables, key)
 			continue
 		}
-		exp := regexp.MustCompile(`\$\{\s*` + key + `\s*\}`)
-		tmp = exp.ReplaceAllString(tmp, val)
+		exp := regexp.MustCompile(`\$\{\s*` + regexp.QuoteMeta(key) + `\s*\}`)
+		tmp = exp.ReplaceAllLiteralString(tmp, val)
 	}
 	if len(missingVariables) > 0 {
 		return nil, errors.Errorf("value for variables [%s] is not set. Please set the value using os environment variables or the clusterctl config file", strings.Join(missingVariables, ", "))

--- a/cmd/clusterctl/client/repository/components_test.go
+++ b/cmd/clusterctl/client/repository/components_test.go
@@ -93,6 +93,28 @@ func Test_replaceVariables(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "pass and replaces variables when variable name contains regex metacharacters",
+			args: args{
+				yaml:      []byte("foo ${ BA$R }"),
+				variables: []string{"BA$R"},
+				configVariablesClient: test.NewFakeVariableClient().
+					WithVar("BA$R", "bar"),
+			},
+			want:    []byte("foo bar"),
+			wantErr: false,
+		},
+		{
+			name: "pass and replaces variables when variable value contains regex metacharacters",
+			args: args{
+				yaml:      []byte("foo ${ BAR }"),
+				variables: []string{"BAR"},
+				configVariablesClient: test.NewFakeVariableClient().
+					WithVar("BAR", "ba$r"),
+			},
+			want:    []byte("foo ba$r"),
+			wantErr: false,
+		},
+		{
 			name: "fails for missing variables",
 			args: args{
 				yaml:                  []byte("foo ${ BAR } ${ BAZ }"),


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes a problem in clusterctl replace variable when the value contains $

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes-sigs/cluster-api/issues/2857
