### PR TITLE
 📖 Add note to top of MHC docs

### DIFF
--- a/docs/book/src/tasks/healthcheck.md
+++ b/docs/book/src/tasks/healthcheck.md
@@ -4,6 +4,16 @@
 
 Before attempting to configure a MachineHealthCheck, you should have a working [management cluster] with at least one MachineDeployment or MachineSet deployed.
 
+<aside class="note warn">
+
+<h1> Important </h1>
+
+Please note that MachineHealthChecks currently **only** support Machines that are owned by a MachineSet.
+Please review the [Limitations and Caveats of a MachineHealthCheck](#limitations-and-caveats-of-a-machinehealthcheck)
+at the bottom of this page for full details of MachineHealthCheck limitations.
+
+</aside>
+
 ## What is a MachineHealthCheck?
 
 A MachineHealthCheck is a resource within the Cluster API which allows users to define conditions under which Machine's within a Cluster should be considered unhealthy.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This adds a note to the top of the MHC documentation highlighting that MHC currently only supports Machines owned by a MachineSet. This has tripped a few people up so this is an effort to try and make the limitations more obvious to users.

Fixes #2861