### PR TITLE
🏃[clusterctl e2e] Add log streaming to clusterctl e2e

### DIFF
--- a/test/framework/interfaces.go
+++ b/test/framework/interfaces.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -61,6 +62,8 @@ type ManagementCluster interface {
 	GetName() string
 	// GetClient returns a client to the Management cluster.
 	GetClient() (client.Client, error)
+	// GetClientSet returns a clientset to the management cluster.
+	GetClientSet() (*kubernetes.Clientset, error)
 	// GetWorkdloadClient returns a client to the specified workload cluster.
 	GetWorkloadClient(ctx context.Context, namespace, name string) (client.Client, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds log streaming to clusterctl e2e by using the same log streaming function as[ CAPA e2e.](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/test/e2e/e2e_suite_test.go)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2860

Open question: Do we want to get logs from CAPI webhook controllers?
