### PR TITLE
✨ Add remote cluster cache manager

### DIFF
--- a/controllers/remote/cluster_cache.go
+++ b/controllers/remote/cluster_cache.go
@@ -1,0 +1,435 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	healthCheckPollInterval       = 10 * time.Second
+	healthCheckRequestTimeout     = 5 * time.Second
+	healthCheckUnhealthyThreshold = 3
+)
+
+// clusterCache embeds cache.Cache and combines it with a stop channel.
+type clusterCache struct {
+	cache.Cache
+
+	lock    sync.Mutex
+	stopped bool
+	stop    chan struct{}
+}
+
+// Stop closes the cache.Cache's stop channel if it has not already been stopped.
+func (cc *clusterCache) Stop() {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+
+	if cc.stopped {
+		return
+	}
+
+	cc.stopped = true
+	close(cc.stop)
+}
+
+// ClusterCacheTracker manages client caches for workload clusters.
+type ClusterCacheTracker struct {
+	log    logr.Logger
+	client client.Client
+
+	clusterCachesLock sync.RWMutex
+	clusterCaches     map[client.ObjectKey]*clusterCache
+
+	watchesLock sync.RWMutex
+	watches     map[client.ObjectKey]map[watchInfo]struct{}
+}
+
+// NewClusterCacheTracker creates a new ClusterCacheTracker.
+func NewClusterCacheTracker(log logr.Logger, manager ctrl.Manager) (*ClusterCacheTracker, error) {
+	m := &ClusterCacheTracker{
+		log:           log,
+		client:        manager.GetClient(),
+		clusterCaches: make(map[client.ObjectKey]*clusterCache),
+		watches:       make(map[client.ObjectKey]map[watchInfo]struct{}),
+	}
+
+	return m, nil
+}
+
+// Watcher is a scoped-down interface from Controller that only knows how to watch.
+type Watcher interface {
+	// Watch watches src for changes, sending events to eventHandler if they pass predicates.
+	Watch(src source.Source, eventHandler handler.EventHandler, predicates ...predicate.Predicate) error
+}
+
+// watchInfo is used as a map key to uniquely identify a watch. Because predicates is a slice, it cannot be included.
+type watchInfo struct {
+	watcher      Watcher
+	kind         runtime.Object
+	eventHandler handler.EventHandler
+}
+
+// watchExists returns true if watch has already been established. This does NOT hold any lock.
+func (m *ClusterCacheTracker) watchExists(cluster client.ObjectKey, watch watchInfo) bool {
+	watchesForCluster, clusterFound := m.watches[cluster]
+	if !clusterFound {
+		return false
+	}
+
+	_, watchFound := watchesForCluster[watch]
+	return watchFound
+}
+
+// deleteWatchesForCluster removes the watches for cluster from the tracker.
+func (m *ClusterCacheTracker) deleteWatchesForCluster(cluster client.ObjectKey) {
+	m.watchesLock.Lock()
+	defer m.watchesLock.Unlock()
+
+	delete(m.watches, cluster)
+}
+
+// WatchInput specifies the parameters used to establish a new watch for a remote cluster.
+type WatchInput struct {
+	// Cluster is the key for the remote cluster.
+	Cluster client.ObjectKey
+
+	// Watcher is the watcher (controller) whose Reconcile() function will be called for events.
+	Watcher Watcher
+
+	// Kind is the type of resource to watch.
+	Kind runtime.Object
+
+	// CacheOptions are used to specify options for the remote cache, such as the Scheme to use.
+	CacheOptions cache.Options
+
+	// EventHandler contains the event handlers to invoke for resource events.
+	EventHandler handler.EventHandler
+
+	// Predicates is used to filter resource events.
+	Predicates []predicate.Predicate
+}
+
+// Watch watches a remote cluster for resource events. If the watch already exists based on cluster, watcher,
+// kind, and eventHandler, then this is a no-op.
+func (m *ClusterCacheTracker) Watch(ctx context.Context, input WatchInput) error {
+	wi := watchInfo{
+		watcher:      input.Watcher,
+		kind:         input.Kind,
+		eventHandler: input.EventHandler,
+	}
+
+	// First, check if the watch already exists
+	var exists bool
+	m.watchesLock.RLock()
+	exists = m.watchExists(input.Cluster, wi)
+	m.watchesLock.RUnlock()
+
+	if exists {
+		m.log.V(4).Info("Watch already exists", "namespace", input.Cluster.Namespace, "cluster", input.Cluster.Name, "kind", fmt.Sprintf("%T", input.Kind))
+		return nil
+	}
+
+	// Doesn't exist - grab the write lock
+	m.watchesLock.Lock()
+	defer m.watchesLock.Unlock()
+
+	// Need to check if another goroutine created the watch while this one was waiting for the lock
+	if m.watchExists(input.Cluster, wi) {
+		m.log.V(4).Info("Watch already exists", "namespace", input.Cluster.Namespace, "cluster", input.Cluster.Name, "kind", fmt.Sprintf("%T", input.Kind))
+		return nil
+	}
+
+	// Need to create the watch
+	watchesForCluster, found := m.watches[input.Cluster]
+	if !found {
+		watchesForCluster = make(map[watchInfo]struct{})
+		m.watches[input.Cluster] = watchesForCluster
+	}
+
+	cache, err := m.getOrCreateClusterCache(ctx, input.Cluster, input.CacheOptions)
+	if err != nil {
+		return err
+	}
+
+	if err := input.Watcher.Watch(source.NewKindWithCache(input.Kind, cache), input.EventHandler, input.Predicates...); err != nil {
+		return errors.Wrap(err, "error creating watch")
+	}
+
+	watchesForCluster[wi] = struct{}{}
+
+	return nil
+}
+
+// getOrCreateClusterCache returns the clusterCache for cluster, creating a new ClusterCache if needed.
+func (m *ClusterCacheTracker) getOrCreateClusterCache(ctx context.Context, cluster client.ObjectKey, cacheOptions cache.Options) (*clusterCache, error) {
+	cache := m.getClusterCache(cluster)
+	if cache != nil {
+		return cache, nil
+	}
+
+	return m.newClusterCache(ctx, cluster, cacheOptions)
+}
+
+// getClusterCache returns the clusterCache for cluster, or nil if it does not exist.
+func (m *ClusterCacheTracker) getClusterCache(cluster client.ObjectKey) *clusterCache {
+	m.clusterCachesLock.RLock()
+	defer m.clusterCachesLock.RUnlock()
+
+	return m.clusterCaches[cluster]
+}
+
+// newClusterCache creates and starts a new clusterCache for cluster.
+func (m *ClusterCacheTracker) newClusterCache(ctx context.Context, cluster client.ObjectKey, cacheOptions cache.Options) (*clusterCache, error) {
+	m.clusterCachesLock.Lock()
+	defer m.clusterCachesLock.Unlock()
+
+	// If another goroutine created the cache while this one was waiting to acquire the write lock, return that
+	// instead of overwriting it.
+	if c, exists := m.clusterCaches[cluster]; exists {
+		return c, nil
+	}
+
+	config, err := RESTConfig(ctx, m.client, cluster)
+	if err != nil {
+		return nil, errors.Wrap(err, "error fetching REST client config for remote cluster")
+	}
+
+	remoteCache, err := cache.New(config, cacheOptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating cache for remote cluster")
+	}
+	stop := make(chan struct{})
+
+	cc := &clusterCache{
+		Cache: remoteCache,
+		stop:  stop,
+	}
+	m.clusterCaches[cluster] = cc
+
+	// Start the cache!!!
+	go remoteCache.Start(cc.stop)
+	// Start cluster healthcheck!!!
+	go m.healthCheckCluster(&healthCheckInput{
+		stop:    cc.stop,
+		cluster: cluster,
+		cfg:     config,
+	})
+
+	return cc, nil
+}
+
+func (m *ClusterCacheTracker) deleteClusterCache(cluster client.ObjectKey) {
+	m.clusterCachesLock.Lock()
+	defer m.clusterCachesLock.Unlock()
+
+	delete(m.clusterCaches, cluster)
+}
+
+// healthCheckInput provides the input for the healthCheckCluster method
+type healthCheckInput struct {
+	stop               <-chan struct{}
+	cluster            client.ObjectKey
+	cfg                *rest.Config
+	interval           time.Duration
+	requestTimeout     time.Duration
+	unhealthyThreshold int
+	path               string
+}
+
+// validate sets default values if optional parameters are not set
+func (h *healthCheckInput) validate() {
+	if h.interval == 0 {
+		h.interval = healthCheckPollInterval
+	}
+	if h.requestTimeout == 0 {
+		h.requestTimeout = healthCheckRequestTimeout
+	}
+	if h.unhealthyThreshold == 0 {
+		h.unhealthyThreshold = healthCheckUnhealthyThreshold
+	}
+	if h.path == "" {
+		h.path = "/"
+	}
+}
+
+// healthCheckCluster will poll the cluster's API at the path given and, if there are
+// `unhealthyThreshold` consecutive failures, will deem the cluster unhealthy.
+// Once the cluster is deemed unhealthy, the cluster's cache is stopped and removed.
+func (m *ClusterCacheTracker) healthCheckCluster(in *healthCheckInput) {
+	// populate optional params for healthCheckInput
+	in.validate()
+
+	unhealthyCount := 0
+
+	runHealthCheckWithThreshold := func() (bool, error) {
+		remoteCache := m.getClusterCache(in.cluster)
+		if remoteCache == nil {
+			// Cache for this cluster has already been cleaned up.
+			// Nothing to do, so return true.
+			return true, nil
+		}
+
+		// healthCheckPath returning an error is considered a failed health check
+		// (Either an issue was encountered connecting or the API returned an error).
+		// If no error occurs, reset the unhealthy coutner.
+		err := healthCheckPath(in.cfg, in.requestTimeout, in.path)
+		if err != nil {
+			unhealthyCount++
+		} else {
+			unhealthyCount = 0
+		}
+
+		if unhealthyCount >= in.unhealthyThreshold {
+			// `healthCheckUnhealthyThreshold` (or more) consecutive failures.
+			// Cluster is now considered unhealthy.
+			// return last error from `doHealthCheck`
+			return false, err
+		}
+
+		return false, nil
+	}
+
+	err := wait.PollImmediateUntil(in.interval, runHealthCheckWithThreshold, in.stop)
+	// An error returned implies the health check has failed a sufficient number of
+	// times for the cluster to be considered unhealthy
+	if err != nil {
+		c := m.getClusterCache(in.cluster)
+		if c == nil {
+			return
+		}
+
+		// Stop the cache and clean up
+		c.Stop()
+		m.deleteClusterCache(in.cluster)
+		m.deleteWatchesForCluster(in.cluster)
+	}
+}
+
+// healthCheckPath attempts to request a given absolute path from the API server
+// defined in the rest.Config and returns any errors that occurred during the request.
+func healthCheckPath(sourceCfg *rest.Config, requestTimeout time.Duration, path string) error {
+	codec := runtime.NoopEncoder{Decoder: scheme.Codecs.UniversalDecoder()}
+	cfg := rest.CopyConfig(sourceCfg)
+	cfg.NegotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{Serializer: codec})
+
+	restClient, err := rest.UnversionedRESTClientFor(cfg)
+	if err != nil {
+		// Config is invalid, cannot perform health checks
+		return err
+	}
+
+	_, err = restClient.Get().AbsPath(path).Timeout(requestTimeout).Do().Get()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ClusterCacheReconciler is responsible for stopping remote cluster caches when
+// the cluster for the remote cache is being deleted.
+type ClusterCacheReconciler struct {
+	log     logr.Logger
+	client  client.Client
+	tracker *ClusterCacheTracker
+}
+
+func NewClusterCacheReconciler(
+	log logr.Logger,
+	mgr ctrl.Manager,
+	controllerOptions controller.Options,
+	cct *ClusterCacheTracker,
+) (*ClusterCacheReconciler, error) {
+	r := &ClusterCacheReconciler{
+		log:     log,
+		client:  mgr.GetClient(),
+		tracker: cct,
+	}
+
+	// Watch Clusters so we can stop and remove caches when Clusters are deleted.
+	_, err := ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.Cluster{}).
+		WithOptions(controllerOptions).
+		Build(r)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create cluster cache manager controller")
+	}
+
+	return r, nil
+}
+
+// Reconcile reconciles Clusters and removes ClusterCaches for any Cluster that cannot be retrieved from the
+// management cluster.
+func (r *ClusterCacheReconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	ctx := context.Background()
+
+	log := r.log.WithValues("namespace", req.Namespace, "name", req.Name)
+	log.V(4).Info("Reconciling")
+
+	var cluster clusterv1.Cluster
+
+	err := r.client.Get(ctx, req.NamespacedName, &cluster)
+	if err == nil {
+		log.V(4).Info("Cluster still exists")
+		return reconcile.Result{}, nil
+	} else if !kerrors.IsNotFound(err) {
+		log.Error(err, "Error retrieving cluster")
+		return reconcile.Result{}, err
+	}
+
+	log.V(4).Info("Cluster no longer exists")
+
+	c := r.tracker.getClusterCache(req.NamespacedName)
+	if c == nil {
+		log.V(4).Info("No current cluster cache exists - nothing to do")
+		return reconcile.Result{}, nil
+	}
+
+	log.V(4).Info("Stopping cluster cache")
+	c.Stop()
+
+	r.tracker.deleteClusterCache(req.NamespacedName)
+
+	log.V(4).Info("Deleting watches for cluster cache")
+	r.tracker.deleteWatchesForCluster(req.NamespacedName)
+
+	return reconcile.Result{}, nil
+}

--- a/controllers/remote/cluster_cache_healthcheck_test.go
+++ b/controllers/remote/cluster_cache_healthcheck_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ = Describe("ClusterCache HealthCheck suite", func() {
+	Context("when health checking clusters", func() {
+		var mgr manager.Manager
+		var doneMgr chan struct{}
+		var k8sClient client.Client
+
+		var testNamespace *corev1.Namespace
+		var testClusterKey client.ObjectKey
+		var cct *ClusterCacheTracker
+		var cc *clusterCache
+
+		var testPollInterval = 100 * time.Millisecond
+		var testPollTimeout = 50 * time.Millisecond
+		var testUnhealthyThreshold = 3
+
+		BeforeEach(func() {
+			By("Setting up a new manager")
+			var err error
+			mgr, err = manager.New(cfg, manager.Options{
+				Scheme:             scheme.Scheme,
+				MetricsBindAddress: "0",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			doneMgr = make(chan struct{})
+			By("Starting the manager")
+			go func() {
+				Expect(mgr.Start(doneMgr)).To(Succeed())
+			}()
+
+			k8sClient = mgr.GetClient()
+
+			By("Setting up a ClusterCacheTracker")
+			cct, err = NewClusterCacheTracker(log.NullLogger{}, mgr)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a namespace for the test")
+			testNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "cluster-cache-test-"}}
+			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+
+			By("Creating a test cluster")
+			testCluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: testNamespace.GetName(),
+				},
+			}
+			Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
+
+			By("Creating a test cluster kubeconfig")
+			Expect(kubeconfig.CreateEnvTestSecret(k8sClient, cfg, testCluster)).To(Succeed())
+
+			testClusterKey = util.ObjectKey(testCluster)
+
+			cc = &clusterCache{
+				stop: make(chan struct{}),
+			}
+			cct.clusterCaches[testClusterKey] = cc
+		})
+
+		AfterEach(func() {
+			By("Deleting any Secrets")
+			Expect(cleanupTestSecrets(ctx, k8sClient)).To(Succeed())
+			By("Deleting any Clusters")
+			Expect(cleanupTestClusters(ctx, k8sClient)).To(Succeed())
+			By("Stopping the manager")
+			close(doneMgr)
+		})
+
+		It("with a healthy cluster", func() {
+			// Ensure the context times out after the consistently below
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			config := rest.CopyConfig(cfg)
+			go cct.healthCheckCluster(&healthCheckInput{ctx.Done(), testClusterKey, config, testPollInterval, testPollTimeout, testUnhealthyThreshold, "/"})
+
+			// This should succed after 1 second, approx 10 requests to the API
+			Consistently(func() *clusterCache {
+				cct.clusterCachesLock.RLock()
+				defer cct.clusterCachesLock.RUnlock()
+				return cct.clusterCaches[testClusterKey]
+			}).ShouldNot(BeNil())
+			Expect(func() bool {
+				cc.lock.Lock()
+				defer cc.lock.Unlock()
+				return cc.stopped
+			}()).To(BeFalse())
+		})
+
+		It("with an invalid path", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			config := rest.CopyConfig(cfg)
+			go cct.healthCheckCluster(&healthCheckInput{ctx.Done(), testClusterKey, config, testPollInterval, testPollTimeout, testUnhealthyThreshold, "/foo"})
+
+			// This should succeed after 3 consecutive failed requests
+			Eventually(func() *clusterCache {
+				cct.clusterCachesLock.RLock()
+				defer cct.clusterCachesLock.RUnlock()
+				return cct.clusterCaches[testClusterKey]
+			}).Should(BeNil())
+			Expect(func() bool {
+				cc.lock.Lock()
+				defer cc.lock.Unlock()
+				return cc.stopped
+			}()).To(BeTrue())
+		})
+
+		It("with an invalid config", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			config := rest.CopyConfig(cfg)
+
+			// Set the host to a random free port on localhost
+			addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+			Expect(err).ToNot(HaveOccurred())
+			l, err := net.ListenTCP("tcp", addr)
+			Expect(err).ToNot(HaveOccurred())
+			l.Close()
+			config.Host = fmt.Sprintf("http://127.0.0.1:%d", l.Addr().(*net.TCPAddr).Port)
+
+			go cct.healthCheckCluster(&healthCheckInput{ctx.Done(), testClusterKey, config, testPollInterval, testPollTimeout, testUnhealthyThreshold, "/"})
+
+			// This should succeed after 3 consecutive failed requests
+			Eventually(func() *clusterCache {
+				cct.clusterCachesLock.RLock()
+				defer cct.clusterCachesLock.RUnlock()
+				return cct.clusterCaches[testClusterKey]
+			}).Should(BeNil())
+			Expect(func() bool {
+				cc.lock.Lock()
+				defer cc.lock.Unlock()
+				return cc.stopped
+			}()).To(BeTrue())
+		})
+	})
+})

--- a/controllers/remote/cluster_cache_reconciler_test.go
+++ b/controllers/remote/cluster_cache_reconciler_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	gtypes "github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("ClusterCache Reconciler suite", func() {
+	Context("When running the ClusterCacheReconciler", func() {
+		var mgr manager.Manager
+		var doneMgr chan struct{}
+		var cct *ClusterCacheTracker
+		var k8sClient client.Client
+
+		var testNamespace *corev1.Namespace
+		var clusterRequest1, clusterRequest2, clusterRequest3 reconcile.Request
+		var clusterCache1, clusterCache2, clusterCache3 *clusterCache
+
+		// createAndWatchCluster creates a new cluster and ensures the clusterCacheTracker is watching the cluster
+		createAndWatchCluster := func(clusterName string) (reconcile.Request, *clusterCache) {
+			By(fmt.Sprintf("Creating a cluster %q", clusterName))
+			testCluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: testNamespace.GetName(),
+				},
+			}
+			Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
+
+			// Check the cluster can be fetch from the API server
+			testClusterKey := util.ObjectKey(testCluster)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, testClusterKey, &clusterv1.Cluster{})
+			}, timeout).Should(Succeed())
+
+			By("Creating a test cluster kubeconfig")
+			Expect(kubeconfig.CreateEnvTestSecret(k8sClient, cfg, testCluster)).To(Succeed())
+			// Check the secret can be fetch from the API server
+			secretKey := client.ObjectKey{Namespace: testNamespace.GetName(), Name: fmt.Sprintf("%s-kubeconfig", testCluster.GetName())}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, secretKey, &corev1.Secret{})
+			}, timeout).Should(Succeed())
+
+			watcher, _ := newTestWatcher()
+			kind := &corev1.Node{}
+			eventHandler := &handler.Funcs{}
+
+			By("Calling watch on the test cluster")
+			// TODO: Make this test not rely on Watch doing its job?
+			Expect(cct.Watch(ctx, WatchInput{
+				Cluster:      testClusterKey,
+				Watcher:      watcher,
+				Kind:         kind,
+				CacheOptions: cache.Options{},
+				EventHandler: eventHandler,
+				Predicates: []predicate.Predicate{
+					&predicate.ResourceVersionChangedPredicate{},
+					&predicate.GenerationChangedPredicate{},
+				},
+			})).To(Succeed())
+
+			// Check that a cache was created for the cluster
+			cc := func() *clusterCache {
+				cct.clusterCachesLock.RLock()
+				defer cct.clusterCachesLock.RUnlock()
+				return cct.clusterCaches[testClusterKey]
+			}()
+			Expect(cc).ToNot(BeNil())
+			return reconcile.Request{NamespacedName: testClusterKey}, cc
+		}
+
+		BeforeEach(func() {
+			By("Setting up a new manager")
+			var err error
+			mgr, err = manager.New(cfg, manager.Options{
+				Scheme:             scheme.Scheme,
+				MetricsBindAddress: "0",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			doneMgr = make(chan struct{})
+			By("Starting the manager")
+			go func() {
+				Expect(mgr.Start(doneMgr)).To(Succeed())
+			}()
+
+			k8sClient = mgr.GetClient()
+
+			By("Setting up a ClusterCacheTracker")
+			cct, err = NewClusterCacheTracker(log.NullLogger{}, mgr)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a namespace for the test")
+			testNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "cluster-cache-test-"}}
+			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+
+			By("Starting the ClusterCacheReconciler")
+			r, err := NewClusterCacheReconciler(
+				&log.NullLogger{},
+				mgr,
+				controller.Options{},
+				cct,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating clusters to test with")
+			clusterRequest1, clusterCache1 = createAndWatchCluster("cluster-1")
+			clusterRequest2, clusterCache2 = createAndWatchCluster("cluster-2")
+			clusterRequest3, clusterCache3 = createAndWatchCluster("cluster-3")
+
+			// Manually call Reconcile to ensure the Reconcile is completed before assertions
+			_, err = r.Reconcile(clusterRequest1)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = r.Reconcile(clusterRequest2)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = r.Reconcile(clusterRequest3)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			By("Deleting any Secrets")
+			Expect(cleanupTestSecrets(ctx, k8sClient)).To(Succeed())
+			By("Deleting any Clusters")
+			Expect(cleanupTestClusters(ctx, k8sClient)).To(Succeed())
+			By("Stopping the manager")
+			close(doneMgr)
+		})
+
+		type clusterKeyAndCache struct {
+			key   client.ObjectKey
+			cache *clusterCache
+		}
+
+		type clusterDeletedInput struct {
+			stoppedClusters func() []clusterKeyAndCache
+			runningClusters func() []clusterKeyAndCache
+		}
+
+		DescribeTable("when clusters are deleted", func(in *clusterDeletedInput) {
+			for _, cluster := range in.stoppedClusters() {
+				By(fmt.Sprintf("Deleting cluster %q", cluster.key.Name))
+				obj := &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cluster.key.Name,
+						Namespace: cluster.key.Namespace,
+					},
+				}
+				Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
+			}
+
+			// Check the stopped clustser's caches eventually stop
+			for _, cluster := range in.stoppedClusters() {
+				By(fmt.Sprintf("Checking cluster %q's cache is stopped", cluster.key.Name))
+				cc := cluster.cache
+				Eventually(func() bool {
+					cc.lock.Lock()
+					defer cc.lock.Unlock()
+					return cc.stopped
+				}, timeout).Should(BeTrue())
+			}
+
+			// Check the running cluster's caches are still running
+			for _, cluster := range in.runningClusters() {
+				By(fmt.Sprintf("Checking cluster %q's cache is running", cluster.key.Name))
+				cc := cluster.cache
+				Consistently(func() bool {
+					cc.lock.Lock()
+					defer cc.lock.Unlock()
+					return cc.stopped
+				}).Should(BeFalse())
+			}
+
+			By("Checking deleted Cluster's Caches are removed", func() {
+				matchers := []gtypes.GomegaMatcher{}
+				for _, cluster := range in.stoppedClusters() {
+					matchers = append(matchers, Not(HaveKey(cluster.key)))
+				}
+				for _, cluster := range in.runningClusters() {
+					matchers = append(matchers, HaveKeyWithValue(cluster.key, cluster.cache))
+				}
+				matchers = append(matchers, HaveLen(len(in.runningClusters())))
+
+				Eventually(func() map[client.ObjectKey]*clusterCache {
+					cct.clusterCachesLock.RLock()
+					defer cct.clusterCachesLock.RUnlock()
+					return cct.clusterCaches
+				}, timeout).Should(SatisfyAll(matchers...))
+			})
+
+			By("Checking deleted Cluster's Watches are removed", func() {
+				matchers := []gtypes.GomegaMatcher{}
+				for _, cluster := range in.stoppedClusters() {
+					matchers = append(matchers, Not(HaveKey(cluster.key)))
+				}
+				for _, cluster := range in.runningClusters() {
+					matchers = append(matchers, HaveKeyWithValue(cluster.key, Not(BeEmpty())))
+				}
+				matchers = append(matchers, HaveLen(len(in.runningClusters())))
+
+				Eventually(func() map[client.ObjectKey]map[watchInfo]struct{} {
+					cct.watchesLock.RLock()
+					defer cct.watchesLock.RUnlock()
+					return cct.watches
+				}(), timeout).Should(SatisfyAll(matchers...))
+			})
+		},
+			Entry("when no clusters deleted", &clusterDeletedInput{
+				stoppedClusters: func() []clusterKeyAndCache {
+					return []clusterKeyAndCache{}
+				},
+				runningClusters: func() []clusterKeyAndCache {
+					return []clusterKeyAndCache{
+						{
+							key:   clusterRequest1.NamespacedName,
+							cache: clusterCache1,
+						},
+						{
+							key:   clusterRequest2.NamespacedName,
+							cache: clusterCache2,
+						},
+						{
+							key:   clusterRequest3.NamespacedName,
+							cache: clusterCache3,
+						},
+					}
+				},
+			}),
+			Entry("when test-cluster-1 is deleted", &clusterDeletedInput{
+				stoppedClusters: func() []clusterKeyAndCache {
+					return []clusterKeyAndCache{
+						{
+							key:   clusterRequest1.NamespacedName,
+							cache: clusterCache1,
+						},
+					}
+				},
+				runningClusters: func() []clusterKeyAndCache {
+					return []clusterKeyAndCache{
+						{
+							key:   clusterRequest2.NamespacedName,
+							cache: clusterCache2,
+						},
+						{
+							key:   clusterRequest3.NamespacedName,
+							cache: clusterCache3,
+						},
+					}
+				},
+			}),
+			Entry("when test-cluster-2 is deleted", &clusterDeletedInput{
+				stoppedClusters: func() []clusterKeyAndCache {
+					return []clusterKeyAndCache{
+						{
+							key:   clusterRequest2.NamespacedName,
+							cache: clusterCache2,
+						},
+					}
+				},
+				runningClusters: func() []clusterKeyAndCache {
+					return []clusterKeyAndCache{
+						{
+							key:   clusterRequest1.NamespacedName,
+							cache: clusterCache1,
+						},
+						{
+							key:   clusterRequest3.NamespacedName,
+							cache: clusterCache3,
+						},
+					}
+				},
+			}),
+			Entry("when test-cluster-1 and test-cluster-3 are deleted", &clusterDeletedInput{
+				stoppedClusters: func() []clusterKeyAndCache {
+					return []clusterKeyAndCache{
+						{
+							key:   clusterRequest1.NamespacedName,
+							cache: clusterCache1,
+						},
+						{
+							key:   clusterRequest3.NamespacedName,
+							cache: clusterCache3,
+						},
+					}
+				},
+				runningClusters: func() []clusterKeyAndCache {
+					return []clusterKeyAndCache{
+						{
+							key:   clusterRequest2.NamespacedName,
+							cache: clusterCache2,
+						},
+					}
+				},
+			}),
+		)
+	})
+})

--- a/controllers/remote/cluster_cache_tracker_test.go
+++ b/controllers/remote/cluster_cache_tracker_test.go
@@ -1,0 +1,413 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/util/workqueue"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var _ = Describe("ClusterCache Tracker suite", func() {
+	Context("When Watch is called for a cluster", func() {
+		type assertWatchInput struct {
+			tracker      *ClusterCacheTracker
+			clusterKey   client.ObjectKey
+			watcher      Watcher
+			kind         runtime.Object
+			eventHandler handler.EventHandler
+			predicates   []predicate.Predicate
+			watcherInfo  chan testWatcherInfo
+			watchCount   int
+		}
+
+		var assertWatch = func(i *assertWatchInput) {
+			It("should create a running cache for the cluster", func() {
+				cache, ok := func() (*clusterCache, bool) {
+					i.tracker.clusterCachesLock.RLock()
+					defer i.tracker.clusterCachesLock.RUnlock()
+					cc, ok := i.tracker.clusterCaches[i.clusterKey]
+					return cc, ok
+				}()
+				Expect(ok).To(BeTrue())
+				stop := make(chan struct{})
+				Expect(func() bool {
+					cache.lock.Lock()
+					defer cache.lock.Unlock()
+					return cache.stopped
+				}()).To(BeFalse())
+				Expect(func() chan struct{} {
+					cache.lock.Lock()
+					defer cache.lock.Unlock()
+					return cache.stop
+				}()).ToNot(BeNil())
+				// WaitForCacheSync returns false if Start was not called
+				Expect(cache.Cache.WaitForCacheSync(stop)).To(BeTrue())
+			})
+
+			It("should add a watchInfo for the watch", func() {
+				expectedInfo := watchInfo{
+					watcher:      i.watcher,
+					kind:         i.kind,
+					eventHandler: i.eventHandler,
+				}
+				Expect(func() map[watchInfo]struct{} {
+					i.tracker.watchesLock.RLock()
+					defer i.tracker.watchesLock.RUnlock()
+					return i.tracker.watches[i.clusterKey]
+				}()).To(HaveKey(Equal(expectedInfo)))
+			})
+
+			It("should call the Watcher with the correct values", func() {
+				infos := []testWatcherInfo{}
+
+				watcherInfoLen := len(i.watcherInfo)
+				for j := 0; j < watcherInfoLen; j++ {
+					infos = append(infos, <-i.watcherInfo)
+				}
+
+				Expect(infos).To(ContainElement(
+					Equal(testWatcherInfo{
+						handler:    i.eventHandler,
+						predicates: i.predicates,
+					}),
+				))
+			})
+
+			It("should call the Watcher the expected number of times", func() {
+				Expect(i.watcherInfo).Should(HaveLen(i.watchCount))
+			})
+		}
+
+		var mgr manager.Manager
+		var doneMgr chan struct{}
+		var cct *ClusterCacheTracker
+		var k8sClient client.Client
+
+		var testNamespace *corev1.Namespace
+		var input assertWatchInput
+
+		BeforeEach(func() {
+			By("Setting up a new manager")
+			var err error
+			mgr, err = manager.New(cfg, manager.Options{
+				Scheme:             scheme.Scheme,
+				MetricsBindAddress: "0",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			doneMgr = make(chan struct{})
+			By("Starting the manager")
+			go func() {
+				Expect(mgr.Start(doneMgr)).To(Succeed())
+			}()
+
+			k8sClient = mgr.GetClient()
+
+			By("Setting up a ClusterCacheTracker")
+			cct, err = NewClusterCacheTracker(log.NullLogger{}, mgr)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating a namespace for the test")
+			testNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "cluster-cache-test-"}}
+			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+
+			By("Creating a test cluster")
+			testCluster := &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: testNamespace.GetName(),
+				},
+			}
+			Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
+
+			By("Creating a test cluster kubeconfig")
+			Expect(kubeconfig.CreateEnvTestSecret(k8sClient, cfg, testCluster)).To(Succeed())
+
+			testClusterKey := util.ObjectKey(testCluster)
+			watcher, watcherInfo := newTestWatcher()
+			kind := &corev1.Node{}
+			eventHandler := &handler.Funcs{}
+
+			input = assertWatchInput{
+				cct,
+				testClusterKey,
+				watcher,
+				kind,
+				eventHandler,
+				[]predicate.Predicate{
+					&predicate.ResourceVersionChangedPredicate{},
+					&predicate.GenerationChangedPredicate{},
+				},
+				watcherInfo,
+				1,
+			}
+
+			By("Calling watch on the test cluster")
+			Expect(cct.Watch(ctx, WatchInput{
+				Cluster:      input.clusterKey,
+				Watcher:      input.watcher,
+				Kind:         input.kind,
+				CacheOptions: cache.Options{},
+				EventHandler: input.eventHandler,
+				Predicates:   input.predicates,
+			})).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("Deleting any Secrets")
+			Expect(cleanupTestSecrets(ctx, k8sClient)).To(Succeed())
+			By("Deleting any Clusters")
+			Expect(cleanupTestClusters(ctx, k8sClient)).To(Succeed())
+			By("Stopping the manager")
+			close(doneMgr)
+		})
+
+		Context("when watch is called for a cluster", func() {
+			assertWatch(&input)
+		})
+
+		Context("when Watch is called for a second time with the same input", func() {
+			BeforeEach(func() {
+				By("Calling watch on the test cluster")
+				Expect(cct.Watch(ctx, WatchInput{
+					Cluster:      input.clusterKey,
+					Watcher:      input.watcher,
+					Kind:         input.kind,
+					CacheOptions: cache.Options{},
+					EventHandler: input.eventHandler,
+					Predicates:   input.predicates,
+				})).To(Succeed())
+			})
+
+			assertWatch(&input)
+		})
+
+		Context("when watch is called with a different Kind", func() {
+			BeforeEach(func() {
+				configMapKind := &corev1.ConfigMap{}
+				input.kind = configMapKind
+				input.watchCount = 2
+
+				By("Calling watch on the test cluster")
+				Expect(cct.Watch(ctx, WatchInput{
+					Cluster:      input.clusterKey,
+					Watcher:      input.watcher,
+					Kind:         input.kind,
+					CacheOptions: cache.Options{},
+					EventHandler: input.eventHandler,
+					Predicates:   input.predicates,
+				})).To(Succeed())
+			})
+
+			assertWatch(&input)
+		})
+
+		Context("when watch is called with a different EventHandler", func() {
+			BeforeEach(func() {
+				input.eventHandler = &handler.Funcs{
+					CreateFunc: func(_ event.CreateEvent, _ workqueue.RateLimitingInterface) {},
+				}
+				input.watchCount = 2
+
+				By("Calling watch on the test cluster")
+				Expect(cct.Watch(ctx, WatchInput{
+					Cluster:      input.clusterKey,
+					Watcher:      input.watcher,
+					Kind:         input.kind,
+					CacheOptions: cache.Options{},
+					EventHandler: input.eventHandler,
+					Predicates:   input.predicates,
+				})).To(Succeed())
+			})
+
+			assertWatch(&input)
+		})
+
+		Context("when watch is called with different Predicates", func() {
+			BeforeEach(func() {
+				input.predicates = []predicate.Predicate{}
+				input.watchCount = 1
+
+				By("Calling watch on the test cluster")
+				Expect(cct.Watch(ctx, WatchInput{
+					Cluster:      input.clusterKey,
+					Watcher:      input.watcher,
+					Kind:         input.kind,
+					CacheOptions: cache.Options{},
+					EventHandler: input.eventHandler,
+					Predicates:   input.predicates,
+				})).To(Succeed())
+			})
+
+			It("does not call the Watcher a second time", func() {
+				Expect(input.watcherInfo).Should(HaveLen(1))
+			})
+		})
+
+		Context("when watch is called with different Cluster", func() {
+			var differentClusterInput assertWatchInput
+
+			BeforeEach(func() {
+				// Copy the input so we can check both clusters at once
+				differentClusterInput = assertWatchInput{
+					cct,
+					input.clusterKey,
+					input.watcher,
+					input.kind,
+					input.eventHandler,
+					[]predicate.Predicate{
+						&predicate.ResourceVersionChangedPredicate{},
+						&predicate.GenerationChangedPredicate{},
+					},
+					input.watcherInfo,
+					1,
+				}
+
+				By("Creating a different cluster")
+				testCluster := &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "different-cluster",
+						Namespace: testNamespace.GetName(),
+					},
+				}
+				Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
+
+				By("Creating a test cluster kubeconfig")
+				Expect(kubeconfig.CreateEnvTestSecret(k8sClient, cfg, testCluster)).To(Succeed())
+				// Check the secret can be fetch from the API server
+				secretKey := client.ObjectKey{Namespace: testNamespace.GetName(), Name: fmt.Sprintf("%s-kubeconfig", testCluster.GetName())}
+				Eventually(func() error {
+					return k8sClient.Get(ctx, secretKey, &corev1.Secret{})
+				}, timeout).Should(Succeed())
+
+				differentClusterInput.clusterKey = util.ObjectKey(testCluster)
+				differentClusterInput.watchCount = 2
+
+				input.watchCount = 2
+
+				By("Calling watch on the test cluster")
+				Expect(cct.Watch(ctx, WatchInput{
+					Cluster:      differentClusterInput.clusterKey,
+					Watcher:      differentClusterInput.watcher,
+					Kind:         differentClusterInput.kind,
+					CacheOptions: cache.Options{},
+					EventHandler: differentClusterInput.eventHandler,
+					Predicates:   differentClusterInput.predicates,
+				})).To(Succeed())
+			})
+
+			// Check conditions for both clusters are still satisfied
+			assertWatch(&input)
+			assertWatch(&differentClusterInput)
+
+			It("should have independent caches for each cluster", func() {
+				testClusterCache, ok := func() (*clusterCache, bool) {
+					cct.clusterCachesLock.RLock()
+					defer cct.clusterCachesLock.RUnlock()
+					cc, ok := cct.clusterCaches[input.clusterKey]
+					return cc, ok
+				}()
+				Expect(ok).To(BeTrue())
+				differentClusterCache, ok := func() (*clusterCache, bool) {
+					cct.clusterCachesLock.RLock()
+					defer cct.clusterCachesLock.RUnlock()
+					cc, ok := cct.clusterCaches[differentClusterInput.clusterKey]
+					return cc, ok
+				}()
+				Expect(ok).To(BeTrue())
+				// Check stop channels are different, so that they can be stopped independently
+				Expect(testClusterCache.stop).ToNot(Equal(differentClusterCache.stop))
+				// Caches should also be different as they were constructed for different clusters
+				// Check the memory locations to assert independence
+				Expect(fmt.Sprintf("%p", testClusterCache.Cache)).ToNot(Equal(fmt.Sprintf("%p", differentClusterCache.Cache)))
+			})
+		})
+	})
+})
+
+type testWatchFunc = func(source.Source, handler.EventHandler, ...predicate.Predicate) error
+
+type testWatcher struct {
+	watchInfo chan testWatcherInfo
+}
+
+type testWatcherInfo struct {
+	handler    handler.EventHandler
+	predicates []predicate.Predicate
+}
+
+func (t *testWatcher) Watch(s source.Source, h handler.EventHandler, ps ...predicate.Predicate) error {
+	t.watchInfo <- testWatcherInfo{
+		handler:    h,
+		predicates: ps,
+	}
+	return nil
+}
+
+func newTestWatcher() (Watcher, chan testWatcherInfo) {
+	watchInfo := make(chan testWatcherInfo, 5)
+	return &testWatcher{
+		watchInfo: watchInfo,
+	}, watchInfo
+}
+
+func cleanupTestSecrets(ctx context.Context, c client.Client) error {
+	secretList := &corev1.SecretList{}
+	if err := c.List(ctx, secretList); err != nil {
+		return err
+	}
+	for _, secret := range secretList.Items {
+		s := secret
+		if err := c.Delete(ctx, &s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cleanupTestClusters(ctx context.Context, c client.Client) error {
+	clusterList := &clusterv1.ClusterList{}
+	if err := c.List(ctx, clusterList); err != nil {
+		return err
+	}
+	for _, cluster := range clusterList.Items {
+		o := cluster
+		if err := c.Delete(ctx, &o); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/controllers/remote/suite_test.go
+++ b/controllers/remote/suite_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	"flag"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+func init() {
+	klog.InitFlags(nil)
+	logf.SetLogger(klogr.New())
+
+	// Register required object kinds with global scheme.
+	_ = clusterv1.AddToScheme(scheme.Scheme)
+}
+
+const (
+	timeout = time.Second * 10
+)
+
+var (
+	cfg     *rest.Config
+	testEnv *envtest.Environment
+	ctx     = context.Background()
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	Expect(flag.Set("logtostderr", "false")).To(Succeed())
+	flag.Parse()
+	klog.SetOutput(GinkgoWriter)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	Expect(testEnv.Stop()).To(Succeed())
+})


### PR DESCRIPTION
**What this PR does / why we need it:**
Add a remote cluster cache manager that owns the full lifecycle of
caches against workload clusters. Controllers that need to watch
resources in workload clusters should use this functionality.

This is the foundation for #2414 and #2577.

It does not currently check for connectivity failures to workload clusters. It only stops the workload cluster caches if there is an error retrieving the Cluster from the management cluster. If desired, I could add something that does a minimal "ping" to each workload cluster periodically, removing any caches that have connectivity issues. Or we could do that in a follow-up.

I have not updated MachineHealthCheck to use this. I could do that in this PR, or a follow-up.

I have not added anything for KubeadmControlPlane to use this. I could do that in this PR, or a follow-up (cc @detiber).

/priority important-soon

cc @vincepri @ncdc 

--
This replaces #2835. I've taken the code that @ncdc wrote, addressed some feedback from the previous PR and added a test suite for this code. I have not done anything regarding this comment https://github.com/kubernetes-sigs/cluster-api/pull/2835/files#r401783111 as I was not sure how to interpret the conversation

With the code as is, it is not actually being used anywhere. To be used, we need to create a `ClusterCacheTracker` and call `NewClusterCacheReconciler` within `main.go`, pass the `ClusterCacheTracker` into controllers that will need access to remote caches (eg MHC), and then, from within the controller, call `ClusterCacheTracker.Watch` when reconciling their object. Tracking which of the clusters have already been watched and deduplication is handled within the `ClusterCacheTracker`, so no tracking is needed within individual controllers.

The deduplication will not work properly however with a different set of predicates for each Watch, I'm not sure if that's a major problem or not, open to suggestions for rewrites if there's a good way to fix that if we think it's important