### PR TITLE
🏃Remove annotations on upgradeControlPlane

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -25,12 +25,8 @@ import (
 )
 
 const (
-	KubeadmControlPlaneFinalizer             = "kubeadm.controlplane.cluster.x-k8s.io"
-	KubeadmControlPlaneHashLabelKey          = "kubeadm.controlplane.cluster.x-k8s.io/hash"
-	SelectedForUpgradeAnnotation             = "kubeadm.controlplane.cluster.x-k8s.io/selected-for-upgrade"
-	UpgradeReplacementCreatedAnnotation      = "kubeadm.controlplane.cluster.x-k8s.io/upgrade-replacement-created"
-	DeleteForScaleDownAnnotation             = "kubeadm.controlplane.cluster.x-k8s.io/delete-for-scale-down"
-	ScaleDownConfigMapEntryRemovedAnnotation = "kubeadm.controlplane.cluster.x-k8s.io/scale-down-configmap-entry-removed"
+	KubeadmControlPlaneFinalizer    = "kubeadm.controlplane.cluster.x-k8s.io"
+	KubeadmControlPlaneHashLabelKey = "kubeadm.controlplane.cluster.x-k8s.io/hash"
 )
 
 // KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.

--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -223,7 +223,7 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, cluster *
 	// Upgrade takes precedence over other operations
 	if len(requireUpgrade) > 0 {
 		logger.Info("Upgrading Control Plane")
-		return r.upgradeControlPlane(ctx, cluster, kcp, ownedMachines, requireUpgrade, controlPlane)
+		return r.upgradeControlPlane(ctx, cluster, kcp, controlPlane)
 	}
 
 	// If we've made it this far, we can assume that all ownedMachines are up to date
@@ -240,11 +240,11 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, cluster *
 	case numMachines < desiredReplicas && numMachines > 0:
 		// Create a new Machine w/ join
 		logger.Info("Scaling up control plane", "Desired", desiredReplicas, "Existing", numMachines)
-		return r.scaleUpControlPlane(ctx, cluster, kcp, ownedMachines, controlPlane)
+		return r.scaleUpControlPlane(ctx, cluster, kcp, controlPlane)
 	// We are scaling down
 	case numMachines > desiredReplicas:
 		logger.Info("Scaling down control plane", "Desired", desiredReplicas, "Existing", numMachines)
-		return r.scaleDownControlPlane(ctx, cluster, kcp, ownedMachines, ownedMachines, controlPlane)
+		return r.scaleDownControlPlane(ctx, cluster, kcp, controlPlane)
 	}
 
 	// Get the workload cluster client.

--- a/controlplane/kubeadm/controllers/helpers.go
+++ b/controlplane/kubeadm/controllers/helpers.go
@@ -229,23 +229,3 @@ func (r *KubeadmControlPlaneReconciler) generateMachine(ctx context.Context, kcp
 	}
 	return nil
 }
-
-func (r *KubeadmControlPlaneReconciler) markWithAnnotationKey(ctx context.Context, machine *clusterv1.Machine, annotationKey string) error {
-	if machine == nil {
-		return errors.New("expected machine not nil")
-	}
-	patchHelper, err := patch.NewHelper(machine, r.Client)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create patch helper for machine %s", machine.Name)
-	}
-
-	if machine.Annotations == nil {
-		machine.Annotations = make(map[string]string)
-	}
-	machine.Annotations[annotationKey] = ""
-
-	if err := patchHelper.Patch(ctx, machine); err != nil {
-		return errors.Wrapf(err, "failed to patch machine %s selected for upgrade", machine.Name)
-	}
-	return nil
-}

--- a/controlplane/kubeadm/controllers/upgrade_test.go
+++ b/controlplane/kubeadm/controllers/upgrade_test.go
@@ -19,15 +19,13 @@ package controllers
 import (
 	"context"
 	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
-	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -41,6 +39,7 @@ func TestKubeadmControlPlaneReconciler_upgradeControlPlane(t *testing.T) {
 	cluster, kcp, genericMachineTemplate := createClusterWithControlPlane()
 	kcp.Spec.Version = "v1.17.3"
 	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration = nil
+	kcp.Spec.Replicas = pointer.Int32Ptr(1)
 
 	fakeClient := newFakeClient(g, cluster.DeepCopy(), kcp.DeepCopy(), genericMachineTemplate.DeepCopy())
 
@@ -49,8 +48,10 @@ func TestKubeadmControlPlaneReconciler_upgradeControlPlane(t *testing.T) {
 		Log:      log.Log,
 		recorder: record.NewFakeRecorder(32),
 		managementCluster: &fakeManagementCluster{
-			Management: &internal.Management{Client: fakeClient},
-			Workload:   fakeWorkloadCluster{},
+			Management:          &internal.Management{Client: fakeClient},
+			Workload:            fakeWorkloadCluster{Status: internal.ClusterStatus{Nodes: 1}},
+			ControlPlaneHealthy: true,
+			EtcdHealthy:         true,
 		},
 	}
 	controlPlane := &internal.ControlPlane{
@@ -63,157 +64,51 @@ func TestKubeadmControlPlaneReconciler_upgradeControlPlane(t *testing.T) {
 	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
 	g.Expect(err).NotTo(HaveOccurred())
 
-	machineList := &clusterv1.MachineList{}
-	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
-	g.Expect(machineList.Items).NotTo(BeEmpty())
-	g.Expect(machineList.Items).To(HaveLen(1))
+	// initial setup
+	initialMachine := &clusterv1.MachineList{}
+	g.Expect(fakeClient.List(context.Background(), initialMachine, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(initialMachine.Items).To(HaveLen(1))
 
-	machineCollection := internal.NewFilterableMachineCollection(&machineList.Items[0])
-	result, err = r.upgradeControlPlane(context.Background(), cluster, kcp, machineCollection, machineCollection, controlPlane)
+	// change the KCP spec so the machine becomes outdated
+	kcp.Spec.Version = "v1.17.4"
 
-	g.Expect(machineList.Items[0].Annotations).To(HaveKey(controlplanev1.SelectedForUpgradeAnnotation))
+	// run upgrade the first time, expect we scale up
+	needingUpgrade := internal.NewFilterableMachineCollectionFromMachineList(initialMachine)
+	controlPlane.Machines = needingUpgrade
+	result, err = r.upgradeControlPlane(context.Background(), cluster, kcp, controlPlane)
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+	g.Expect(err).To(BeNil())
+	bothMachines := &clusterv1.MachineList{}
+	g.Expect(fakeClient.List(context.Background(), bothMachines, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(bothMachines.Items).To(HaveLen(2))
 
-	// TODO flesh out the rest of this test - this is currently least-effort to confirm a fix for an NPE when updating
-	// the etcd version
-	g.Expect(result).To(Equal(ctrl.Result{}))
+	// run upgrade a second time, simulate that the node has not appeared yet but the machine exists
+	r.managementCluster.(*fakeManagementCluster).ControlPlaneHealthy = false
+	_, err = r.upgradeControlPlane(context.Background(), cluster, kcp, controlPlane)
 	g.Expect(err).To(Equal(&capierrors.RequeueAfterError{RequeueAfter: healthCheckFailedRequeueAfter}))
-}
+	g.Expect(fakeClient.List(context.Background(), bothMachines, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(bothMachines.Items).To(HaveLen(2))
 
-func TestSelectMachineForUpgrade(t *testing.T) {
-	g := NewWithT(t)
+	controlPlane.Machines = internal.NewFilterableMachineCollectionFromMachineList(bothMachines)
 
-	cluster, kcp, genericMachineTemplate := createClusterWithControlPlane()
-	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration = nil
+	// manually increase number of nodes, make control plane healthy again
+	r.managementCluster.(*fakeManagementCluster).Workload.Status.Nodes++
+	r.managementCluster.(*fakeManagementCluster).ControlPlaneHealthy = true
 
-	m1 := machine("machine-1", withFailureDomain("one"), withTimestamp(metav1.Time{Time: time.Date(1, 0, 0, 0, 0, 0, 0, time.UTC)}))
-	m2 := machine("machine-2", withFailureDomain("two"), withTimestamp(metav1.Time{Time: time.Date(2, 0, 0, 0, 0, 0, 0, time.UTC)}))
-	m3 := machine("machine-3", withFailureDomain("two"), withTimestamp(metav1.Time{Time: time.Date(3, 0, 0, 0, 0, 0, 0, time.UTC)}))
-	m4 := machine("machine-4", withFailureDomain("four"))
+	// run upgrade the second time, expect we scale down
+	result, err = r.upgradeControlPlane(context.Background(), cluster, kcp, controlPlane)
+	g.Expect(err).To(BeNil())
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: true}))
+	finalMachine := &clusterv1.MachineList{}
+	g.Expect(fakeClient.List(context.Background(), finalMachine, client.InNamespace(cluster.Namespace))).To(Succeed())
+	g.Expect(finalMachine.Items).To(HaveLen(1))
 
-	mc1 := internal.FilterableMachineCollection{"machine-1": m1}
-	mc2 := internal.FilterableMachineCollection{
-		"machine-1": m1,
-		"machine-2": m2,
-	}
-	mc3 := internal.FilterableMachineCollection{
-		"machine-1": m1,
-		"machine-2": m2,
-		"machine-3": m3,
-	}
-	fd := clusterv1.FailureDomains{
-		"one":   failureDomain(true),
-		"two":   failureDomain(true),
-		"three": failureDomain(false),
-	}
-
-	controlPlane3Machines := &internal.ControlPlane{
-		KCP:      &controlplanev1.KubeadmControlPlane{},
-		Cluster:  &clusterv1.Cluster{Status: clusterv1.ClusterStatus{FailureDomains: fd}},
-		Machines: mc3,
-	}
-
-	fakeClient := newFakeClient(
-		g,
-		cluster.DeepCopy(),
-		kcp.DeepCopy(),
-		genericMachineTemplate.DeepCopy(),
-		m1.DeepCopy(),
-		m2.DeepCopy(),
-		m4.DeepCopy(),
-	)
-
-	r := &KubeadmControlPlaneReconciler{
-		Client:   fakeClient,
-		Log:      log.Log,
-		recorder: record.NewFakeRecorder(32),
-		managementCluster: &fakeManagementCluster{
-			Management: &internal.Management{Client: fakeClient},
-			Workload:   fakeWorkloadCluster{},
-		},
-	}
-
-	testCases := []struct {
-		name            string
-		upgradeMachines internal.FilterableMachineCollection
-		cp              *internal.ControlPlane
-		expectErr       bool
-		expectedMachine clusterv1.Machine
-	}{
-		{
-			name:            "When controlplane and upgrade machines are same, picks the oldest failure domain with most machines ",
-			upgradeMachines: mc3,
-			cp:              controlPlane3Machines,
-			expectErr:       false,
-			expectedMachine: clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-2"}},
-		},
-		{
-			name:            "Picks the upgrade machine even if it does not belong to the fd with most machines",
-			upgradeMachines: mc1,
-			cp:              controlPlane3Machines,
-			expectErr:       false,
-			expectedMachine: clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-1"}},
-		},
-		{
-			name:            "Picks the upgrade machine that belongs to the fd with most machines",
-			upgradeMachines: mc2,
-			cp:              controlPlane3Machines,
-			expectErr:       false,
-			expectedMachine: clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-2"}},
-		},
-		{
-			name:            "Picks the upgrade machine that is not in existing failure domains",
-			upgradeMachines: internal.FilterableMachineCollection{"machine-4": m4},
-			cp:              controlPlane3Machines,
-			expectErr:       false,
-			expectedMachine: clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "machine-4"}},
-		},
-		{
-			name:            "Marking machine with annotation fails",
-			upgradeMachines: internal.FilterableMachineCollection{"machine-3": m3},
-			cp:              controlPlane3Machines,
-			expectErr:       true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewWithT(t)
-
-			g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
-
-			selectedMachine, err := r.selectAndMarkMachine(context.Background(), tc.upgradeMachines, controlplanev1.SelectedForUpgradeAnnotation, tc.cp)
-
-			if tc.expectErr {
-				g.Expect(err).To(HaveOccurred())
-				return
-			}
-
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(selectedMachine.Name).To(Equal(tc.expectedMachine.Name))
-		})
-	}
-
-}
-
-func failureDomain(controlPlane bool) clusterv1.FailureDomainSpec {
-	return clusterv1.FailureDomainSpec{
-		ControlPlane: controlPlane,
-	}
+	// assert that the deleted machine is the oldest, initial machine
+	g.Expect(finalMachine.Items[0].Name).ToNot(Equal(initialMachine.Items[0].Name))
+	g.Expect(finalMachine.Items[0].CreationTimestamp.Time).To(BeTemporally(">", initialMachine.Items[0].CreationTimestamp.Time))
 }
 
 type machineOpt func(*clusterv1.Machine)
-
-func withFailureDomain(fd string) machineOpt {
-	return func(m *clusterv1.Machine) {
-		m.Spec.FailureDomain = &fd
-	}
-}
-
-func withTimestamp(t metav1.Time) machineOpt {
-	return func(m *clusterv1.Machine) {
-		m.CreationTimestamp = t
-	}
-}
 
 func machine(name string, opts ...machineOpt) *clusterv1.Machine {
 	m := &clusterv1.Machine{

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -48,7 +48,7 @@ func NewControlPlane(cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmCont
 
 // Logger returns a logger with useful context.
 func (c *ControlPlane) Logger() logr.Logger {
-	return Log.WithValues("namespace", c.KCP.Namespace, "name", c.KCP.Name, "cluster-nanme", c.Cluster.Name)
+	return Log.WithValues("namespace", c.KCP.Namespace, "name", c.KCP.Name, "cluster-name", c.Cluster.Name)
 }
 
 // FailureDomains returns a slice of failure domain objects synced from the infrastructure provider into Cluster.Status.


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes use of annotations in upgrade logic. We were duplicating the logic of selecting the machine in the scale down code, and it also causes bugs like #2430 where the cached state stored in the annotation gets out of sync with the world.

This logic working is dependent on the fact that `scaleUp` / `TargetClusterControlPlaneIsHealthy` ensures there's a 1:1 correspondence of nodes and machines so we don't continue scaling up while new machines are still joining the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2702 
