### PR TITLE
🏃[e2e]: improve management cluster interface

### DIFF
--- a/test/framework/exec/kubectl.go
+++ b/test/framework/exec/kubectl.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+)
+
+// TODO: Remove this usage of kubectl and replace with a function from apply.go using the controller-runtime client.
+func KubectlApply(ctx context.Context, kubeconfigPath string, resources []byte) error {
+	rbytes := bytes.NewReader(resources)
+	applyCmd := NewCommand(
+		WithCommand("kubectl"),
+		WithArgs("apply", "--kubeconfig", kubeconfigPath, "-f", "-"),
+		WithStdin(rbytes),
+	)
+	stdout, stderr, err := applyCmd.Run(ctx)
+	if err != nil {
+		fmt.Println(string(stderr))
+		return err
+	}
+	fmt.Println(string(stdout))
+	return nil
+}
+
+func KubectlWait(ctx context.Context, kubeconfigPath string, args ...string) error {
+	wargs := append([]string{"wait", "--kubeconfig", kubeconfigPath}, args...)
+	wait := NewCommand(
+		WithCommand("kubectl"),
+		WithArgs(wargs...),
+	)
+	_, stderr, err := wait.Run(ctx)
+	if err != nil {
+		fmt.Println(string(stderr))
+		return err
+	}
+	return nil
+}

--- a/test/framework/interfaces.go
+++ b/test/framework/interfaces.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -60,10 +61,16 @@ type ManagementCluster interface {
 	Teardown(context.Context)
 	// GetName returns the name of the cluster.
 	GetName() string
+	// GetKubeconfigPath returns the path to the kubeconfig file for the cluster.
+	GetKubeconfigPath() string
+	// GetScheme returns the scheme defining the types hosted in the cluster.
+	GetScheme() *runtime.Scheme
 	// GetClient returns a client to the Management cluster.
 	GetClient() (client.Client, error)
 	// GetClientSet returns a clientset to the management cluster.
 	GetClientSet() (*kubernetes.Clientset, error)
 	// GetWorkdloadClient returns a client to the specified workload cluster.
 	GetWorkloadClient(ctx context.Context, namespace, name string) (client.Client, error)
+	// GetWorkerKubeconfigPath returns the path to the kubeconfig file for the specified workload cluster.
+	GetWorkerKubeconfigPath(ctx context.Context, namespace, name string) (string, error)
 }

--- a/test/framework/management/kind/mgmt.go
+++ b/test/framework/management/kind/mgmt.go
@@ -107,6 +107,16 @@ func (c *Cluster) GetName() string {
 	return c.Name
 }
 
+// GetKubeconfigPath returns the path to the kubeconfig file for the cluster.
+func (c Cluster) GetKubeconfigPath() string {
+	return c.KubeconfigPath
+}
+
+// GetScheme returns the scheme defining the types hosted in the cluster.
+func (c Cluster) GetScheme() *runtime.Scheme {
+	return c.Scheme
+}
+
 // LoadImage will put a local image onto the kind node
 func (c *Cluster) LoadImage(ctx context.Context, image string) error {
 	provider := cluster.NewProvider(
@@ -181,36 +191,13 @@ func (c *Cluster) ImageExists(ctx context.Context, image string) bool {
 // TODO: Considier a Kubectl function and then wrap it at the next level up.
 
 // Apply wraps `kubectl apply` and prints the output so we can see what gets applied to the cluster.
-// TODO: Remove this usage of kubectl and replace with a function from apply.go using the controller-runtime client.
 func (c *Cluster) Apply(ctx context.Context, resources []byte) error {
-	rbytes := bytes.NewReader(resources)
-	applyCmd := exec.NewCommand(
-		exec.WithCommand("kubectl"),
-		exec.WithArgs("apply", "--kubeconfig", c.KubeconfigPath, "-f", "-"),
-		exec.WithStdin(rbytes),
-	)
-	stdout, stderr, err := applyCmd.Run(ctx)
-	if err != nil {
-		fmt.Println(string(stderr))
-		return err
-	}
-	fmt.Println(string(stdout))
-	return nil
+	return exec.KubectlApply(ctx, c.KubeconfigPath, resources)
 }
 
 // Wait wraps `kubectl wait`.
 func (c *Cluster) Wait(ctx context.Context, args ...string) error {
-	wargs := append([]string{"wait", "--kubeconfig", c.KubeconfigPath}, args...)
-	wait := exec.NewCommand(
-		exec.WithCommand("kubectl"),
-		exec.WithArgs(wargs...),
-	)
-	_, stderr, err := wait.Run(ctx)
-	if err != nil {
-		fmt.Println(string(stderr))
-		return err
-	}
-	return nil
+	return exec.KubectlWait(ctx, c.KubeconfigPath, args...)
 }
 
 // Teardown deletes all the tmp files and cleans up the kind cluster.
@@ -266,11 +253,25 @@ func (c *Cluster) GetClient() (client.Client, error) {
 }
 
 // GetWorkloadClient returns a controller-runtime client for the workload cluster.
-// TODO Use remote package once it returns a controller runtime client
 func (c *Cluster) GetWorkloadClient(ctx context.Context, namespace, name string) (client.Client, error) {
-	mgmtClient, err := c.GetClient()
+	kubeconfigPath, err := c.GetWorkerKubeconfigPath(ctx, namespace, name)
 	if err != nil {
 		return nil, err
+	}
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return c.ClientFromRestConfig(restConfig)
+}
+
+// GetWorkerKubeconfigPath returns the path to the kubeconfig file for the specified workload cluster.
+func (c *Cluster) GetWorkerKubeconfigPath(ctx context.Context, namespace, name string) (string, error) {
+	mgmtClient, err := c.GetClient()
+	if err != nil {
+		return "", err
 	}
 	config := &v1.Secret{}
 	key := client.ObjectKey{
@@ -278,24 +279,19 @@ func (c *Cluster) GetWorkloadClient(ctx context.Context, namespace, name string)
 		Namespace: namespace,
 	}
 	if err := mgmtClient.Get(ctx, key, config); err != nil {
-		return nil, err
+		return "", err
 	}
 
 	f, err := ioutil.TempFile("", "worker-kubeconfig")
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return "", errors.WithStack(err)
 	}
 	data := config.Data["value"]
 	if _, err := f.Write(data); err != nil {
-		return nil, errors.WithStack(err)
+		return "", errors.WithStack(err)
 	}
 	// TODO: remove the tmpfile and pass the secret in to clientcmd
 	c.WorkloadClusterKubeconfigs[namespace+"-"+name] = f.Name()
 
-	restConfig, err := clientcmd.BuildConfigFromFlags("", f.Name())
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	return c.ClientFromRestConfig(restConfig)
+	return f.Name(), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces small improvements to the management cluster interface, so all the internal properties are now accessible without casting the interface back to the underlying implementation, like e.g.

https://github.com/kubernetes-sigs/cluster-api/blob/efe6b709f680f26c1ebe474492ebbd98d4328c0c/test/infrastructure/docker/e2e/docker_suite_test.go#L109-L110

**Which issue(s) this PR fixes**:
xref #2753
xref #2637
xref #2636

/assign @vincepri
/assign @sedefsavas