### PR TITLE
🐛Modify the output of config repositories

### DIFF
--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_runGetRepositories(t *testing.T) {
+	t.Run("prints output", func(t *testing.T) {
+		g := NewWithT(t)
+
+		tmpDir, err := ioutil.TempDir("", "cc")
+		g.Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		path := filepath.Join(tmpDir, "clusterctl.yaml")
+		g.Expect(ioutil.WriteFile(path, []byte(template), 0644)).To(Succeed())
+
+		buf := bytes.NewBufferString("")
+		g.Expect(runGetRepositories(path, buf)).To(Succeed())
+
+		out, err := ioutil.ReadAll(buf)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(string(out)).To(Equal(expectedOutput))
+	})
+
+	t.Run("returns error for bad cfgFile path", func(t *testing.T) {
+		g := NewWithT(t)
+		buf := bytes.NewBufferString("")
+		g.Expect(runGetRepositories("do-not-exist", buf)).ToNot(Succeed())
+	})
+
+	t.Run("returns error for nil writer", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(runGetRepositories("do-exist", nil)).ToNot(Succeed())
+	})
+
+	t.Run("returns error for bad template", func(t *testing.T) {
+		g := NewWithT(t)
+
+		tmpDir, err := ioutil.TempDir("", "cc")
+		g.Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		path := filepath.Join(tmpDir, "clusterctl.yaml")
+		g.Expect(ioutil.WriteFile(path, []byte("providers: foobar"), 0644)).To(Succeed())
+
+		buf := bytes.NewBufferString("")
+		g.Expect(runGetRepositories(path, buf)).ToNot(Succeed())
+	})
+}
+
+var template = `---
+providers:
+  # add a custom provider
+  - name: "my-infra-provider"
+    url: "/home/.cluster-api/overrides/infrastructure-docker/latest/infrastructure-components.yaml"
+    type: "InfrastructureProvider"
+  # add a custom provider
+  - name: "another-provider"
+    url: "./bootstrap-components.yaml"
+    type: "BootstrapProvider"
+  # bad url
+  - name: "aws"
+    url: "my-aws-infrastructure-components.yaml"
+    type: "InfrastructureProvider"
+  # override a pre-defined provider
+  - name: "cluster-api"
+    url: "https://github.com/myorg/myforkofclusterapi/releases/latest/core_components.yaml"
+    type: "CoreProvider"
+`
+
+var expectedOutput = `NAME                TYPE                     URL                                                                                  FILE
+cluster-api         CoreProvider             https://github.com/myorg/myforkofclusterapi/releases/latest/                         core_components.yaml
+another-provider    BootstrapProvider        ./                                                                                   bootstrap-components.yaml
+kubeadm             BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api/releases/latest/                      bootstrap-components.yaml
+kubeadm             ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api/releases/latest/                      control-plane-components.yaml
+aws                 InfrastructureProvider                                                                                        my-aws-infrastructure-components.yaml
+azure               InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/latest/       infrastructure-components.yaml
+metal3              InfrastructureProvider   https://github.com/metal3-io/cluster-api-provider-metal3/releases/latest/            infrastructure-components.yaml
+my-infra-provider   InfrastructureProvider   /home/.cluster-api/overrides/infrastructure-docker/latest/                           infrastructure-components.yaml
+openstack           InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/latest/   infrastructure-components.yaml
+vsphere             InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/latest/     infrastructure-components.yaml
+`

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -35,7 +35,7 @@ type initOptions struct {
 	listImages              bool
 }
 
-var io = &initOptions{}
+var initOpts = &initOptions{}
 
 var initCmd = &cobra.Command{
 	Use:   "init",
@@ -90,25 +90,25 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
-	initCmd.Flags().StringVar(&io.kubeconfig, "kubeconfig", "",
+	initCmd.Flags().StringVar(&initOpts.kubeconfig, "kubeconfig", "",
 		"Path to the kubeconfig for the management cluster. If unspecified, default discovery rules apply.")
-	initCmd.Flags().StringVar(&io.kubeconfigContext, "kubeconfig-context", "",
+	initCmd.Flags().StringVar(&initOpts.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
-	initCmd.Flags().StringVar(&io.coreProvider, "core", "",
+	initCmd.Flags().StringVar(&initOpts.coreProvider, "core", "",
 		"Core provider version (e.g. cluster-api:v0.3.0) to add to the management cluster. If unspecified, Cluster API's latest release is used.")
-	initCmd.Flags().StringSliceVarP(&io.infrastructureProviders, "infrastructure", "i", nil,
+	initCmd.Flags().StringSliceVarP(&initOpts.infrastructureProviders, "infrastructure", "i", nil,
 		"Infrastructure providers and versions (e.g. aws:v0.5.0) to add to the management cluster.")
-	initCmd.Flags().StringSliceVarP(&io.bootstrapProviders, "bootstrap", "b", nil,
+	initCmd.Flags().StringSliceVarP(&initOpts.bootstrapProviders, "bootstrap", "b", nil,
 		"Bootstrap providers and versions (e.g. kubeadm:v0.3.0) to add to the management cluster. If unspecified, Kubeadm bootstrap provider's latest release is used.")
-	initCmd.Flags().StringSliceVarP(&io.controlPlaneProviders, "control-plane", "c", nil,
+	initCmd.Flags().StringSliceVarP(&initOpts.controlPlaneProviders, "control-plane", "c", nil,
 		"Control plane providers and versions (e.g. kubeadm:v0.3.0) to add to the management cluster. If unspecified, the Kubeadm control plane provider's latest release is used.")
-	initCmd.Flags().StringVar(&io.targetNamespace, "target-namespace", "",
+	initCmd.Flags().StringVar(&initOpts.targetNamespace, "target-namespace", "",
 		"The target namespace where the providers should be deployed. If unspecified, the provider components' default namespace is used.")
-	initCmd.Flags().StringVar(&io.watchingNamespace, "watching-namespace", "",
+	initCmd.Flags().StringVar(&initOpts.watchingNamespace, "watching-namespace", "",
 		"Namespace the providers should watch when reconciling objects. If unspecified, all namespaces are watched.")
 
 	// TODO: Move this to a sub-command or similar, it shouldn't really be a flag.
-	initCmd.Flags().BoolVar(&io.listImages, "list-images", false,
+	initCmd.Flags().BoolVar(&initOpts.listImages, "list-images", false,
 		"Lists the container images required for initializing the management cluster (without actually installing the providers)")
 
 	RootCmd.AddCommand(initCmd)
@@ -121,17 +121,17 @@ func runInit() error {
 	}
 
 	options := client.InitOptions{
-		Kubeconfig:              client.Kubeconfig{Path: io.kubeconfig, Context: io.kubeconfigContext},
-		CoreProvider:            io.coreProvider,
-		BootstrapProviders:      io.bootstrapProviders,
-		ControlPlaneProviders:   io.controlPlaneProviders,
-		InfrastructureProviders: io.infrastructureProviders,
-		TargetNamespace:         io.targetNamespace,
-		WatchingNamespace:       io.watchingNamespace,
+		Kubeconfig:              client.Kubeconfig{Path: initOpts.kubeconfig, Context: initOpts.kubeconfigContext},
+		CoreProvider:            initOpts.coreProvider,
+		BootstrapProviders:      initOpts.bootstrapProviders,
+		ControlPlaneProviders:   initOpts.controlPlaneProviders,
+		InfrastructureProviders: initOpts.infrastructureProviders,
+		TargetNamespace:         initOpts.targetNamespace,
+		WatchingNamespace:       initOpts.watchingNamespace,
 		LogUsageInstructions:    true,
 	}
 
-	if io.listImages {
+	if initOpts.listImages {
 		images, err := c.InitImages(options)
 		if err != nil {
 			return err


### PR DESCRIPTION
- URL column points to the latest release for the provider.
- FILE column specifies the file within the release.
- Changes var io to initOpts to avoid pkg io conflict

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes the output of `clusterctl config repositories`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2830
