### PR TITLE
🐛 Return error if clusterctl config doesn't exist

### DIFF
--- a/cmd/clusterctl/client/config/reader_viper.go
+++ b/cmd/clusterctl/client/config/reader_viper.go
@@ -61,11 +61,10 @@ func (v *viperReader) Init(path string) error {
 	viper.AllowEmptyEnv(true)
 	viper.AutomaticEnv()
 
-	// If a path file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		log.V(5).Info("Reading configuration", "File", viper.ConfigFileUsed())
+	if err := viper.ReadInConfig(); err != nil {
+		return err
 	}
-
+	log.V(5).Info("Reading configuration", "File", viper.ConfigFileUsed())
 	return nil
 }
 

--- a/cmd/clusterctl/client/config/reader_viper_test.go
+++ b/cmd/clusterctl/client/config/reader_viper_test.go
@@ -25,6 +25,45 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+func Test_viperReader_Init(t *testing.T) {
+
+	g := NewWithT(t)
+	dir, err := ioutil.TempDir("", "clusterctl")
+	g.Expect(err).NotTo(HaveOccurred())
+	defer os.RemoveAll(dir)
+
+	configFile := filepath.Join(dir, ".clusterctl.yaml")
+	g.Expect(ioutil.WriteFile(configFile, []byte("bar: bar"), 0640)).To(Succeed())
+	tests := []struct {
+		name      string
+		cfgPath   string
+		expectErr bool
+	}{
+		{
+			name:      "reads in config successfully",
+			cfgPath:   configFile,
+			expectErr: false,
+		},
+		{
+			name:      "returns error for invalid config file path",
+			cfgPath:   "do-not-exist.yaml",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gg := NewWithT(t)
+			v := &viperReader{}
+			if tt.expectErr {
+				gg.Expect(v.Init(tt.cfgPath)).ToNot(Succeed())
+				return
+			}
+			gg.Expect(v.Init(tt.cfgPath)).To(Succeed())
+
+		})
+	}
+}
 func Test_viperReader_Get(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
See issue details but essentially we are returning an error if clusterctl cannot find the specified config file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2897
