### PR TITLE
📖 Mgmt cluster version req

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -21,7 +21,7 @@ Choose one of the options below:
 
 1. **Existing Management Cluster**
 
-For production use-cases a "real" Kubernetes cluster should be used with appropriate backup and DR policies and procedures in place.
+For production use-cases a "real" Kubernetes cluster should be used with appropriate backup and DR policies and procedures in place. The Kubernetes cluster must be at least v1.16+. 
 
 ```bash
 export KUBECONFIG=<...>


### PR DESCRIPTION
This PR adds a required version for your management cluster if a user chooses to bring their own. 
The guidance is v1.16+ for your k8s management cluster. 