### PR TITLE
🐛 clusterctl to show config provider without setting env vars

### DIFF
--- a/cmd/clusterctl/client/alias.go
+++ b/cmd/clusterctl/client/alias.go
@@ -31,6 +31,9 @@ type Provider config.Provider
 // Components wraps a YAML file that defines the provider's components (CRDs, controller, RBAC rules etc.).
 type Components repository.Components
 
+// ComponentsOptions wraps inputs to get provider's components
+type ComponentsOptions repository.ComponentsOptions
+
 // Template wraps a YAML file that defines the cluster objects (Cluster, Machines etc.).
 type Template repository.Template
 

--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -28,8 +28,8 @@ type Client interface {
 	// GetProvidersConfig returns the list of providers configured for this instance of clusterctl.
 	GetProvidersConfig() ([]Provider, error)
 
-	// GetProviderComponents returns the provider components for a given provider, targetNamespace, watchingNamespace.
-	GetProviderComponents(provider string, providerType clusterctlv1.ProviderType, targetNameSpace, watchingNamespace string) (Components, error)
+	// GetProviderComponents returns the provider components for a given provider with options including targetNamespace, watchingNamespace.
+	GetProviderComponents(provider string, providerType clusterctlv1.ProviderType, options ComponentsOptions) (Components, error)
 
 	// Init initializes a management cluster by adding the requested list of providers.
 	Init(options InitOptions) ([]Components, error)

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -72,8 +72,8 @@ func (f fakeClient) GetProvidersConfig() ([]Provider, error) {
 	return f.internalClient.GetProvidersConfig()
 }
 
-func (f fakeClient) GetProviderComponents(provider string, providerType clusterctlv1.ProviderType, targetNameSpace, watchingNamespace string) (Components, error) {
-	return f.internalClient.GetProviderComponents(provider, providerType, targetNameSpace, watchingNamespace)
+func (f fakeClient) GetProviderComponents(provider string, providerType clusterctlv1.ProviderType, options ComponentsOptions) (Components, error) {
+	return f.internalClient.GetProviderComponents(provider, providerType, options)
 }
 
 func (f fakeClient) GetClusterTemplate(options GetClusterTemplateOptions) (Template, error) {
@@ -443,16 +443,16 @@ type fakeComponentClient struct {
 	configClient   config.Client
 }
 
-func (f *fakeComponentClient) Get(version, targetNamespace, watchingNamespace string) (repository.Components, error) {
-	if version == "" {
-		version = f.fakeRepository.DefaultVersion()
+func (f *fakeComponentClient) Get(options repository.ComponentsOptions) (repository.Components, error) {
+	if options.Version == "" {
+		options.Version = f.fakeRepository.DefaultVersion()
 	}
 	path := f.fakeRepository.ComponentsPath()
 
-	content, err := f.fakeRepository.GetFile(version, path)
+	content, err := f.fakeRepository.GetFile(options.Version, path)
 	if err != nil {
 		return nil, err
 	}
 
-	return repository.NewComponents(f.provider, version, content, f.configClient, targetNamespace, watchingNamespace)
+	return repository.NewComponents(f.provider, f.configClient, content, options)
 }

--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -325,7 +325,12 @@ func (u *providerUpgrader) getUpgradeComponents(provider UpgradeItem) (repositor
 		return nil, err
 	}
 
-	components, err := providerRepository.Components().Get(provider.NextVersion, provider.Namespace, provider.WatchedNamespace)
+	options := repository.ComponentsOptions{
+		Version:           provider.NextVersion,
+		TargetNamespace:   provider.Namespace,
+		WatchingNamespace: provider.WatchedNamespace,
+	}
+	components, err := providerRepository.Components().Get(options)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/common.go
+++ b/cmd/clusterctl/client/common.go
@@ -25,31 +25,33 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
 )
 
-// getComponentsByName is a utility method that returns components for a given provider, targetNamespace, and watchingNamespace.
-func (c *clusterctlClient) getComponentsByName(provider string, providerType clusterctlv1.ProviderType, targetNamespace string, watchingNamespace string) (repository.Components, error) {
+// getComponentsByName is a utility method that returns components
+// for a given provider with options including targetNamespace, and watchingNamespace.
+func (c *clusterctlClient) getComponentsByName(provider string, providerType clusterctlv1.ProviderType, options repository.ComponentsOptions) (repository.Components, error) {
 
-	// parse the abbreviated syntax for name[:version]
+	// Parse the abbreviated syntax for name[:version]
 	name, version, err := parseProviderName(provider)
 	if err != nil {
 		return nil, err
 	}
+	options.Version = version
 
-	// gets the provider configuration (that includes the location of the provider repository)
+	// Gets the provider configuration (that includes the location of the provider repository)
 	providerConfig, err := c.configClient.Providers().Get(name, providerType)
 	if err != nil {
 		return nil, err
 	}
 
-	// get a client for the provider repository and read the provider components;
+	// Get a client for the provider repository and read the provider components;
 	// during the process, provider components will be processed performing variable substitution, customization of target
 	// and watching namespace etc.
 
-	repository, err := c.repositoryClientFactory(providerConfig)
+	repositoryClientFactory, err := c.repositoryClientFactory(providerConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	components, err := repository.Components().Get(version, targetNamespace, watchingNamespace)
+	components, err := repositoryClientFactory.Components().Get(options)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
 )
 
 func (c *clusterctlClient) GetProvidersConfig() ([]Provider, error) {
@@ -42,8 +43,15 @@ func (c *clusterctlClient) GetProvidersConfig() ([]Provider, error) {
 	return rr, nil
 }
 
-func (c *clusterctlClient) GetProviderComponents(provider string, providerType clusterctlv1.ProviderType, targetNameSpace, watchingNamespace string) (Components, error) {
-	components, err := c.getComponentsByName(provider, providerType, targetNameSpace, watchingNamespace)
+func (c *clusterctlClient) GetProviderComponents(provider string, providerType clusterctlv1.ProviderType, options ComponentsOptions) (Components, error) {
+	// ComponentsOptions is an alias for repository.ComponentsOptions; this makes the conversion
+	inputOptions := repository.ComponentsOptions{
+		Version:           options.Version,
+		TargetNamespace:   options.TargetNamespace,
+		WatchingNamespace: options.WatchingNamespace,
+		SkipVariables:     true,
+	}
+	components, err := c.getComponentsByName(provider, providerType, inputOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -23,6 +23,7 @@ import (
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
@@ -231,8 +232,11 @@ func (c *clusterctlClient) addToInstaller(options addToInstallerOptions, provide
 			}
 			continue
 		}
-
-		components, err := c.getComponentsByName(provider, providerType, options.targetNamespace, options.watchingNamespace)
+		componentsOptions := repository.ComponentsOptions{
+			TargetNamespace:   options.targetNamespace,
+			WatchingNamespace: options.watchingNamespace,
+		}
+		components, err := c.getComponentsByName(provider, providerType, componentsOptions)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get provider components for the %q provider", provider)
 		}

--- a/cmd/clusterctl/client/repository/components_client_test.go
+++ b/cmd/clusterctl/client/repository/components_client_test.go
@@ -233,8 +233,13 @@ func Test_componentsClient_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gs := NewWithT(t)
 
+			options := ComponentsOptions{
+				Version:           tt.args.version,
+				TargetNamespace:   tt.args.targetNamespace,
+				WatchingNamespace: tt.args.watchingNamespace,
+			}
 			f := newComponentsClient(tt.fields.provider, tt.fields.repository, configClient)
-			got, err := f.Get(tt.args.version, tt.args.targetNamespace, tt.args.watchingNamespace)
+			got, err := f.Get(options)
 			if tt.wantErr {
 				gs.Expect(err).To(HaveOccurred())
 				return

--- a/cmd/clusterctl/cmd/config_provider.go
+++ b/cmd/clusterctl/cmd/config_provider.go
@@ -136,7 +136,11 @@ func runGetComponents() error {
 		return err
 	}
 
-	components, err := c.GetProviderComponents(providerName, providerType, cpo.targetNamespace, cpo.watchingNamespace)
+	options := client.ComponentsOptions{
+		TargetNamespace:   cpo.targetNamespace,
+		WatchingNamespace: cpo.watchingNamespace,
+	}
+	components, err := c.GetProviderComponents(providerName, providerType, options)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- the clusterctl config provider now can show the configuration without any env vars being set
- change the code path so we don't have to replace variables as part of this informational command 

**Which issue(s) this PR fixes** 
Fixes #2876 

**Release Notes:**
 - ⚠️ ComponentsClient.Get method definition changed from `func(string, string, string) (Components, error)` to `func(ComponentsOptions) (Components, error)`
 - ⚠️ NewComponents method definition changed from `func(sigs.k8s.io/cluster-api/cmd/clusterctl/client/config.Provider, string, []byte, sigs.k8s.io/cluster-api/cmd/clusterctl/client/config.Client, string, string) (*components, error)` to `func(sigs.k8s.io/cluster-api/cmd/clusterctl/client/config.Provider, sigs.k8s.io/cluster-api/cmd/clusterctl/client/config.Client, []byte, ComponentsOptions) (*components, error)`