### PR TITLE
🏃[KCP]: Re-queue until Ready

### DIFF
--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -153,6 +154,14 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(req ctrl.Request) (res ctrl.Re
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 
+		// TODO: remove this as soon as we have a proper remote cluster cache in place.
+		// Make KCP to requeue in case status is not ready, so we can check for node status without waiting for a full resync (by default 10 minutes).
+		// Only requeue if we are not going in exponential backoff due to error, or if we are not already re-queueing, or if the object has a deletion timestamp.
+		if reterr == nil && !res.Requeue && !(res.RequeueAfter > 0) && kcp.ObjectMeta.DeletionTimestamp.IsZero() {
+			if !kcp.Status.Ready {
+				res = ctrl.Result{RequeueAfter: 20 * time.Second}
+			}
+		}
 	}()
 
 	if !kcp.ObjectMeta.DeletionTimestamp.IsZero() {

--- a/controlplane/kubeadm/controllers/controller_test.go
+++ b/controlplane/kubeadm/controllers/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -379,7 +380,8 @@ func TestReconcileClusterNoEndpoints(t *testing.T) {
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(result).To(Equal(ctrl.Result{}))
+	// TODO: this should stop to re-queue as soon as we have a proper remote cluster cache in place.
+	g.Expect(result).To(Equal(ctrl.Result{Requeue: false, RequeueAfter: 20 * time.Second}))
 	g.Expect(r.Client.Get(context.Background(), util.ObjectKey(kcp), kcp)).To(Succeed())
 
 	// Always expect that the Finalizer is set on the passed in resource


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a temporary workaround in KCP making the controller to continuously re-queue until the Ready state is reached

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2906
The issue will be closed when there will be the final solution in place
