### PR TITLE
🏃Add build e2e flag to docker e2e file

### DIFF
--- a/test/infrastructure/docker/e2e/custom_management.go
+++ b/test/infrastructure/docker/e2e/custom_management.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2019 The Kubernetes Authors.
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Not sure why this file is the only file in `test/infrastructure/docker/e2e` to not have the build flag. It seems incorrect. Unless there is some other reason to not have this build flag.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A
