### PR TITLE
🏃 Remove MachineSet controller Update fallback

### DIFF
--- a/api/v1alpha3/machineset_types.go
+++ b/api/v1alpha3/machineset_types.go
@@ -115,7 +115,8 @@ type MachineSetStatus struct {
 	Selector string `json:"selector,omitempty"`
 
 	// Replicas is the most recently observed number of replicas.
-	Replicas int32 `json:"replicas"`
+	// +optional
+	Replicas int32 `json:"replicas,omitempty"`
 
 	// The number of replicas that have labels matching the labels of the machine template of the MachineSet.
 	// +optional

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -910,8 +910,6 @@ spec:
                   be in the same format as the query-param syntax. More info about
                   label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
                 type: string
-            required:
-            - replicas
             type: object
         type: object
     served: true

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -671,17 +671,7 @@ func (r *MachineSetReconciler) patchMachineSetStatus(ctx context.Context, ms *cl
 
 	newStatus.DeepCopyInto(&ms.Status)
 	if err := r.Client.Status().Patch(ctx, ms, patch); err != nil {
-		// TODO(vincepri): Try to fix this once we upgrade to CRDv1.
-		// Our Status.Replicas field is a required non-pointer integer, Go defaults this field to "0" value when decoding
-		// the data from the API server. For this reason, when we try to write the value "0", the patch is going to think
-		// the value is already there and shouldn't be patched, making it fail validation.
-		// Fallback to Update.
-		if !apierrors.IsInvalid(err) {
-			return nil, err
-		}
-		if err := r.Client.Status().Update(ctx, ms); err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	return ms, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes some somewhat crufty logic around falling back to using `Update` when `Patch` fails on MachineSets due to validations. It seems that the patch that is constructed will never contain `replicas: 0`, so it fails validation because it was a required field.

By marking it as optional and omitempty it won't be submitted to the server, we can just rely on it having a default of 0 by virtue of being a Go value type.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1945

/assign @vincepri 