### PR TITLE
 🐛Add DeleteMachineAnnotation for MachineSet Delete Policy

### DIFF
--- a/controllers/machineset_delete_policy.go
+++ b/controllers/machineset_delete_policy.go
@@ -33,7 +33,11 @@ type (
 const (
 	// DeleteNodeAnnotation marks nodes that will be given priority for deletion
 	// when a machineset scales down. This annotation is given top priority on all delete policies.
+	// Deprecated: Please use DeleteMachineAnnotation instead.
 	DeleteNodeAnnotation = "cluster.k8s.io/delete-machine"
+	// DeleteMachineAnnotation marks nodes that will be given priority for deletion
+	// when a machineset scales down. This annotation is given top priority on all delete policies.
+	DeleteMachineAnnotation = "cluster.x-k8s.io/delete-machine"
 
 	mustDelete    deletePriority = 100.0
 	betterDelete  deletePriority = 50.0
@@ -49,6 +53,9 @@ func oldestDeletePriority(machine *clusterv1.Machine) deletePriority {
 		return mustDelete
 	}
 	if machine.ObjectMeta.Annotations != nil && machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" {
+		return mustDelete
+	}
+	if _, ok := machine.ObjectMeta.Annotations[DeleteMachineAnnotation]; ok {
 		return mustDelete
 	}
 	if machine.Status.FailureReason != nil || machine.Status.FailureMessage != nil {
@@ -71,6 +78,9 @@ func newestDeletePriority(machine *clusterv1.Machine) deletePriority {
 	if machine.ObjectMeta.Annotations != nil && machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" {
 		return mustDelete
 	}
+	if _, ok := machine.ObjectMeta.Annotations[DeleteMachineAnnotation]; ok {
+		return mustDelete
+	}
 	if machine.Status.FailureReason != nil || machine.Status.FailureMessage != nil {
 		return mustDelete
 	}
@@ -82,6 +92,9 @@ func randomDeletePolicy(machine *clusterv1.Machine) deletePriority {
 		return mustDelete
 	}
 	if machine.ObjectMeta.Annotations != nil && machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" {
+		return betterDelete
+	}
+	if _, ok := machine.ObjectMeta.Annotations[DeleteMachineAnnotation]; ok {
 		return betterDelete
 	}
 	if machine.Status.FailureReason != nil || machine.Status.FailureMessage != nil {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR adds another annotation called `DeleteMachineAnnotation=cluster.x-k8s.io/delete-machine` to the MachineSet Delete Policy because that annotation is the one that is documented.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2912 

**Release Notes**
- ➕ Add `controllers.DeleteMachineAnnotation` with value `cluster.x-k8s.io/delete-machine`. Please use this annotation moving forward as the other annotation `DeleteNodeAnnotation` is planned for removal in the next CAPI release.