### PR TITLE
🏃Clusterctl config small improvements

### DIFF
--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -49,7 +49,7 @@ func (c *clusterctlClient) GetProviderComponents(provider string, providerType c
 		Version:           options.Version,
 		TargetNamespace:   options.TargetNamespace,
 		WatchingNamespace: options.WatchingNamespace,
-		SkipVariables:     true,
+		SkipVariables:     options.SkipVariables,
 	}
 	components, err := c.getComponentsByName(provider, providerType, inputOptions)
 	if err != nil {

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -204,6 +204,7 @@ func Test_getComponentsByName_withEmptyVariables(t *testing.T) {
 	options := ComponentsOptions{
 		TargetNamespace:   "ns1",
 		WatchingNamespace: "",
+		SkipVariables:     true,
 	}
 	components, err := client.GetProviderComponents(repository1Config.Name(), repository1Config.Type(), options)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/cmd/clusterctl/client/repository/template.go
+++ b/cmd/clusterctl/client/repository/template.go
@@ -80,7 +80,7 @@ func NewTemplate(rawYaml []byte, configVariablesClient config.VariablesClient, t
 		}, nil
 	}
 
-	yaml, err := replaceVariables(rawYaml, variables, configVariablesClient)
+	yaml, err := replaceVariables(rawYaml, variables, configVariablesClient, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to perform variable substitution")
 	}

--- a/cmd/clusterctl/cmd/config_provider.go
+++ b/cmd/clusterctl/cmd/config_provider.go
@@ -139,6 +139,7 @@ func runGetComponents() error {
 	options := client.ComponentsOptions{
 		TargetNamespace:   cpo.targetNamespace,
 		WatchingNamespace: cpo.watchingNamespace,
+		SkipVariables:     true,
 	}
 	components, err := c.GetProviderComponents(providerName, providerType, options)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR is a follow up of the https://github.com/kubernetes-sigs/cluster-api/pull/2905#discussion_r410313987

Also, the PR contains a second commits to support "if variables are available use them, but tolerate missing variables" as discussed in https://github.com/kubernetes-sigs/cluster-api/issues/2876#issuecomment-613909426

/area clusterctl
/assign @nader-ziada 
/assign @wfernandes 