### PR TITLE
🏃increase test e2e timeout

### DIFF
--- a/test/e2e/config/docker-ci.yaml
+++ b/test/e2e/config/docker-ci.yaml
@@ -71,7 +71,7 @@ variables:
 intervals:
   default/wait-controllers: ["3m", "10s"]
   default/wait-cluster: ["3m", "10s"]
-  default/wait-control-plane: ["3m", "10s"]
+  default/wait-control-plane: ["5m", "10s"]
   default/wait-worker-nodes: ["3m", "10s"]
   default/wait-delete-cluster: ["3m", "10s"]
   default/wait-machine-upgrade: ["15m", "1m"]


### PR DESCRIPTION
**What this PR does / why we need it**:
tuning test e2e timeouts to reduce flakes

/assign @sedefsavas 
/area testing
