### PR TITLE
🏃fix e2e test timeout

### DIFF
--- a/test/e2e/config/docker-ci.yaml
+++ b/test/e2e/config/docker-ci.yaml
@@ -74,4 +74,4 @@ intervals:
   default/wait-control-plane: ["5m", "10s"]
   default/wait-worker-nodes: ["3m", "10s"]
   default/wait-delete-cluster: ["3m", "10s"]
-  default/wait-machine-upgrade: ["15m", "1m"]
+  default/wait-machine-upgrade: ["15m", "10s"]

--- a/test/e2e/config/docker-dev.yaml
+++ b/test/e2e/config/docker-dev.yaml
@@ -105,4 +105,4 @@ intervals:
   default/wait-control-plane: ["3m", "10s"]
   default/wait-worker-nodes: ["3m", "10s"]
   default/wait-delete-cluster: ["3m", "10s"]
-  default/wait-machine-upgrade: ["15m", "1m"]
+  default/wait-machine-upgrade: ["15m", "10s"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes two timeouts in the test/e2e configuration files

/area testing
/assing @sedefsavas 