### PR TITLE
🐛Fix output of clusterctl config provider

### DIFF
--- a/cmd/clusterctl/cmd/config_provider.go
+++ b/cmd/clusterctl/cmd/config_provider.go
@@ -19,6 +19,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -151,10 +153,15 @@ func runGetComponents() error {
 func printComponents(c client.Components, output string) error {
 	switch output {
 	case ComponentsOutputText:
+		dir, file := filepath.Split(c.URL())
+		// Remove the version suffix from the URL since we already display it
+		// separately.
+		baseURL, _ := filepath.Split(strings.TrimSuffix(dir, "/"))
 		fmt.Printf("Name:               %s\n", c.Name())
 		fmt.Printf("Type:               %s\n", c.Type())
-		fmt.Printf("URL:                %s\n", c.URL())
+		fmt.Printf("URL:                %s\n", baseURL)
 		fmt.Printf("Version:            %s\n", c.Version())
+		fmt.Printf("File:               %s\n", file)
 		fmt.Printf("TargetNamespace:    %s\n", c.TargetNamespace())
 		fmt.Printf("WatchingNamespace:  %s\n", c.WatchingNamespace())
 		if len(c.Variables()) > 0 {


### PR DESCRIPTION
Split the file name from the URL.
Remove the version from the URL since we already have a separate field
for it.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR keeps the output of `clusterctl config provider -i aws` for example, similar to the output of `clusterctl config repositories`.
Ref https://github.com/kubernetes-sigs/cluster-api/issues/2830

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2171 
