### PR TITLE
:bug: KCP should check if it has machines being deleted before proceeding with scale up/down

### DIFF
--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -322,10 +322,6 @@ func (r *MachineReconciler) isDeleteNodeAllowed(ctx context.Context, cluster *cl
 		// Do not delete the NodeRef if there are no remaining members of
 		// the control plane.
 		return errNoControlPlaneNodes
-	case numControlPlaneMachines == 1 && util.IsControlPlaneMachine(machine):
-		// Do not delete the NodeRef if this is the last member of the
-		// control plane.
-		return errLastControlPlaneNode
 	default:
 		// Otherwise it is okay to delete the NodeRef.
 		return nil

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -836,7 +837,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			expectedError: errNoControlPlaneNodes,
 		},
 		{
-			name:    "is last control plane members",
+			name:    "is last control plane member",
 			cluster: &clusterv1.Cluster{},
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -846,7 +847,8 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 						clusterv1.ClusterLabelName:             "test",
 						clusterv1.MachineControlPlaneLabelName: "",
 					},
-					Finalizers: []string{clusterv1.MachineFinalizer, metav1.FinalizerDeleteDependents},
+					Finalizers:        []string{clusterv1.MachineFinalizer, metav1.FinalizerDeleteDependents},
+					DeletionTimestamp: &metav1.Time{Time: time.Now().UTC()},
 				},
 				Spec: clusterv1.MachineSpec{
 					ClusterName:       "test-cluster",
@@ -859,7 +861,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errLastControlPlaneNode,
+			expectedError: errNoControlPlaneNodes,
 		},
 		{
 			name:    "has nodeRef and control plane is healthy",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes two different issues I observe during  KCP single control plane upgrade.

1. machine_controller was not allowing machine deletion thinking that it is the last control plane machine.

2. Not having a check for machines that are in deletion process during MachinesNeedingUpgrade() was causing a second machine with the new version to come up. It was creating a machine with new version, adding a DeletionTimestamp for the old node, and at this point when it comes to reconcile, it thinks there is still 1 machine to be upgraded (the one with the deletion timestamp) and it scales up one more time. 
Besides of creating a second machine, this was causing ForwardLeaderElection to panic from time to time. 

                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2915
