### PR TITLE
[WIP][e2e] improve docker build performance

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,0 +1,37 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Prepare for building the manager
+FROM golang:1.13.8 as builder
+WORKDIR /workspace
+
+# Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy
+ARG goproxy=https://proxy.golang.org
+# Run this with docker build --build_arg package=./controlplane/kubeadm or --build_arg package=./bootstrap/kubeadm
+ENV GOPROXY=$goproxy
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the sources
+COPY ./ ./
+
+# Cache the go build
+RUN go build .
+

--- a/Dockerfile-manager
+++ b/Dockerfile-manager
@@ -1,0 +1,30 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the manager
+FROM cluster-api/builder:dev as builder
+ARG package=.
+ARG ARCH
+
+# Do not force rebuild of up-to-date packages (do not use -a)
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
+    go build -ldflags '-extldflags "-static"' \
+    -o manager ${package}
+
+# Production image
+FROM gcr.io/distroless/static:latest
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER nobody
+ENTRYPOINT ["/manager"]

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -36,10 +36,10 @@ export ARCH=amd64
 export PULL_POLICY=IfNotPresent
 
 ## Rebuild all Cluster API provider images
-time make docker-build
+time make docker-build-ci
 
 ## Rebuild CAPD provider images
-time make -C test/infrastructure/docker docker-build
+time make -C test/infrastructure/docker docker-build-ci
 
 ## Pulling cert manager images so we can pre-load in kind nodes
 time docker pull quay.io/jetstack/cert-manager-cainjector:v0.11.0

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -48,7 +48,7 @@ time docker pull quay.io/jetstack/cert-manager-controller:v0.11.0
 
 # Configure e2e tests
 export GINKGO_FOCUS=
-export GINKGO_NODES=2
+export GINKGO_NODES=3
 export GINKGO_NOCOLOR=true
 export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/docker-ci.yaml"
 export ARTIFACTS="${ARTIFACTS:-${REPO_ROOT}/_artifacts}"

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -36,15 +36,15 @@ export ARCH=amd64
 export PULL_POLICY=IfNotPresent
 
 ## Rebuild all Cluster API provider images
-make docker-build
+time make docker-build
 
 ## Rebuild CAPD provider images
-make -C test/infrastructure/docker docker-build
+time make -C test/infrastructure/docker docker-build
 
 ## Pulling cert manager images so we can pre-load in kind nodes
-docker pull quay.io/jetstack/cert-manager-cainjector:v0.11.0
-docker pull quay.io/jetstack/cert-manager-webhook:v0.11.0
-docker pull quay.io/jetstack/cert-manager-controller:v0.11.0
+time docker pull quay.io/jetstack/cert-manager-cainjector:v0.11.0
+time docker pull quay.io/jetstack/cert-manager-webhook:v0.11.0
+time docker pull quay.io/jetstack/cert-manager-controller:v0.11.0
 
 # Configure e2e tests
 export GINKGO_FOCUS=
@@ -57,4 +57,4 @@ export USE_EXISTING_CLUSTER=false
 
 # Run e2e tests
 mkdir -p "$ARTIFACTS"
-make -C test/e2e/ run
+time make -C test/e2e/ run

--- a/test/infrastructure/docker/Dockerfile-manager
+++ b/test/infrastructure/docker/Dockerfile-manager
@@ -1,0 +1,52 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the manager
+FROM cluster-api/builder:dev as builder
+
+# Essentially, change directories into CAPD
+WORKDIR /workspace/test/infrastructure/docker
+
+# Copy the Go Modules manifests
+COPY test/infrastructure/docker/go.mod go.mod
+COPY test/infrastructure/docker/go.sum go.sum
+
+# Cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Build the CAPD manager
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /workspace/manager main.go
+
+# Use alpine:latest as minimal base image to package the manager binary and its dependencies
+FROM alpine:latest
+
+# install a couple of dependencies
+WORKDIR /tmp
+RUN apk add --update \
+    curl \
+    && rm -rf /var/cache/apk/*
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl
+
+RUN curl -LO https://download.docker.com/linux/static/stable/x86_64/docker-19.03.1.tgz && \
+    tar zxvf docker-19.03.1.tgz --strip 1 -C /usr/bin docker/docker && \
+    rm docker-19.03.1.tgz
+
+WORKDIR /
+COPY --from=builder /workspace/manager .
+
+ENTRYPOINT ["/manager"]

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -159,6 +159,12 @@ modules: ## Runs go mod to ensure modules are up to date.
 ## Docker
 ## --------------------------------------
 
+.PHONY: docker-build-ci
+docker-build-ci: ## Build the docker image for controller-manager
+	docker build --build-arg ARCH=$(ARCH) ../../.. -t $(CONTROLLER_IMG)-$(ARCH):$(TAG) -f Dockerfile-manager
+	MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
+	$(MAKE) set-manifest-pull-policy
+
 .PHONY: docker-build
 docker-build: ## Build the docker image for controller-manager
 	docker build --pull --build-arg ARCH=$(ARCH) ../../.. -t $(CONTROLLER_IMG)-$(ARCH):$(TAG) --file Dockerfile


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is an experiment on improving docker build time on ci (and possibly also locally)

Baseline:
make docker-build: `6m9.495s`
make -C test/infrastructure/docker docker-build: `3m47.634s`

Actual
make docker-build: `3m16.611s`
make -C test/infrastructure/docker docker-build: `1m12.619s`

**Which issue(s) this PR fixes**:
 Fixes #
