### PR TITLE
🐛[e2e] add workaround for panic in high level helpers

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -56,9 +56,12 @@ func dumpSpecResourcesAndCleanup(ctx context.Context, specName string, clusterPr
 
 	if !skipCleanup {
 		Byf("Deleting cluster %s/%s", cluster.Namespace, cluster.Name)
-		framework.DeleteClusterAndWait(ctx, framework.DeleteClusterAndWaitInput{
-			Client:  clusterProxy.GetClient(),
-			Cluster: cluster,
+		// While https://github.com/kubernetes-sigs/cluster-api/issues/2955 is addressed in future iterations, there is a chance
+		// that cluster variable is not set even if the cluster exists, so we are calling DeleteAllClustersAndWait
+		// instead of DeleteClusterAndWait
+		framework.DeleteAllClustersAndWait(ctx, framework.DeleteAllClustersAndWaitInput{
+			Client:    clusterProxy.GetClient(),
+			Namespace: namespace.Name,
 		}, intervalsGetter(specName, "wait-delete-cluster")...)
 
 		Byf("Deleting namespace used for hosting the %q test spec", specName)


### PR DESCRIPTION
**What this PR does / why we need it**:
As per comment https://github.com/kubernetes-sigs/cluster-api/issues/2955#issuecomment-618916750 adding a workaround for high-level helpers panicking without returning values.

**Which issue(s) this PR fixes** :
xref https://github.com/kubernetes-sigs/cluster-api/issues/2955
