### PR TITLE
:bug: fix error from duplicate bootstrap data secret

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -718,8 +718,13 @@ func (r *KubeadmConfigReconciler) storeBootstrapData(ctx context.Context, scope 
 		Type: clusterv1.ClusterSecretType,
 	}
 
+	// as secret creation and scope.Config status patch are not atomic operations
+	// it is possible that secret creation happens but the config.Status patches are not applied
 	if err := r.Client.Create(ctx, secret); err != nil {
-		return errors.Wrapf(err, "failed to create bootstrap data secret for KubeadmConfig %s/%s", scope.Config.Namespace, scope.Config.Name)
+		if !apierrors.IsAlreadyExists(err) {
+			return errors.Wrapf(err, "failed to create bootstrap data secret for KubeadmConfig %s/%s", scope.Config.Namespace, scope.Config.Name)
+		}
+		r.Log.Info("bootstrap data secret for KubeadmConfig already exists", "secret", secret.Name, "KubeadmConfig", scope.Config.Name)
 	}
 
 	scope.Config.Status.DataSecretName = pointer.StringPtr(secret.Name)


### PR DESCRIPTION
What this PR does / why we need it:
This PR skips the creation of boostrap data secret for KubeadmConfig if it already exists.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2970
