### PR TITLE
🏃 Move MHC remediations to MachineSet controller

### DIFF
--- a/api/v1alpha3/machine_types.go
+++ b/api/v1alpha3/machine_types.go
@@ -29,6 +29,10 @@ const (
 	// MachineControlPlaneLabelName is the label set on machines or related objects that are part of a control plane.
 	MachineControlPlaneLabelName = "cluster.x-k8s.io/control-plane"
 
+	// MachineUnhealthy is set on machines determined unhealthy by the Machine Health Check controller.
+	// It is expected that the controller that maintains this machine will remediate this machine by deleting it.
+	MachineUnhealthy = "cluster.x-k8s.io/unhealthy"
+
 	// ExcludeNodeDrainingAnnotation annotation explicitly skips node draining if set
 	ExcludeNodeDrainingAnnotation = "machine.cluster.x-k8s.io/exclude-node-draining"
 

--- a/controllers/machinehealthcheck_targets_test.go
+++ b/controllers/machinehealthcheck_targets_test.go
@@ -18,22 +18,18 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
-	gtypes "github.com/onsi/gomega/types"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
-	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -43,9 +39,8 @@ func TestGetTargetsFromMHC(t *testing.T) {
 	clusterName := "test-cluster"
 	mhcSelector := map[string]string{"cluster": clusterName, "machine-group": "foo"}
 
-	// Create a namespace and cluster for the tests
+	// Create a namespace for the tests
 	testNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "mhc-test"}}
-	testCluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: clusterName}}
 
 	// Create a test MHC
 	testMHC := &clusterv1.MachineHealthCheck{
@@ -57,7 +52,6 @@ func TestGetTargetsFromMHC(t *testing.T) {
 			Selector: metav1.LabelSelector{
 				MatchLabels: mhcSelector,
 			},
-			ClusterName: testCluster.ObjectMeta.Name,
 			UnhealthyConditions: []clusterv1.UnhealthyCondition{
 				{
 					Type:    corev1.NodeReady,
@@ -68,7 +62,7 @@ func TestGetTargetsFromMHC(t *testing.T) {
 		},
 	}
 
-	baseObjects := []runtime.Object{testNS, testCluster, testMHC}
+	baseObjects := []runtime.Object{testNS, testMHC}
 
 	// Initialise some test machines and nodes for use in the test cases
 
@@ -151,7 +145,7 @@ func TestGetTargetsFromMHC(t *testing.T) {
 				scheme: scheme.Scheme,
 			}
 
-			targets, err := reconciler.getTargetsFromMHC(k8sClient, testCluster, testMHC)
+			targets, err := reconciler.getTargetsFromMHC(k8sClient, testMHC)
 			gs.Expect(err).ToNot(HaveOccurred())
 
 			gs.Expect(targets).To(ConsistOf(tc.expectedTargets))
@@ -334,71 +328,35 @@ func TestHealthCheckTargets(t *testing.T) {
 	}
 }
 
-func TestRemediate(t *testing.T) {
+func TestAnnotate(t *testing.T) {
 	namespace := "test-mhc"
 	clusterName := "test-cluster"
-	labels := map[string]string{"cluster": clusterName, "machine-group": "foo"}
-
-	machineSetORs := []metav1.OwnerReference{{APIVersion: clusterv1.GroupVersion.String(), Kind: "MachineSet"}}
-	kubeadmControlPlaneORs := []metav1.OwnerReference{{APIVersion: controlplanev1.GroupVersion.String(), Kind: "KubeadmControlPlane"}}
 
 	workerNode := newTestNode("worker-node")
-	workerMachine := newTestMachine("worker-machine", namespace, clusterName, workerNode.Name, labels)
-	workerMachine.SetOwnerReferences(machineSetORs)
-	workerMachineUnowned := newTestMachine("worker-machine", namespace, clusterName, workerNode.Name, labels)
-
-	controlPlaneNode := newTestNode("control-plane-node")
-	if controlPlaneNode.Labels == nil {
-		controlPlaneNode.Labels = make(map[string]string)
-	}
-	controlPlaneNode.Labels[nodeControlPlaneLabel] = ""
-
-	controlPlaneMachine := newTestMachine("control-plane-machine", namespace, clusterName, controlPlaneNode.Name, labels)
-	controlPlaneMachine.SetOwnerReferences(kubeadmControlPlaneORs)
-	if controlPlaneMachine.Labels == nil {
-		controlPlaneMachine.Labels = make(map[string]string)
-	}
-	controlPlaneMachine.Labels[clusterv1.MachineControlPlaneLabelName] = ""
+	workerMachine := newTestMachine("worker-machine", namespace, clusterName, workerNode.Name, nil)
+	alreadyAnnotated := workerMachine.DeepCopy()
+	alreadyAnnotated.Annotations = map[string]string{clusterv1.MachineUnhealthy: ""}
 
 	testCases := []struct {
-		name          string
-		node          *corev1.Node
-		machine       *clusterv1.Machine
-		expectErr     bool
-		expectDeleted bool
-		expectEvents  []string
+		name            string
+		node            *corev1.Node
+		machine         *clusterv1.Machine
+		expectErr       bool
+		expectAnnotated bool
 	}{
 		{
-			name:          "when the machine is not owned by a machineset",
-			node:          workerNode,
-			machine:       workerMachineUnowned,
-			expectErr:     false,
-			expectDeleted: false,
-			expectEvents:  []string{},
+			name:            "it annotates the machine with the unhealthy annotation",
+			node:            workerNode,
+			machine:         workerMachine,
+			expectErr:       false,
+			expectAnnotated: true,
 		},
 		{
-			name:          "when the node is a worker with a machine owned by a machineset",
-			node:          workerNode,
-			machine:       workerMachine,
-			expectErr:     false,
-			expectDeleted: true,
-			expectEvents:  []string{EventMachineDeleted},
-		},
-		{
-			name:          "when the node is a control plane node",
-			node:          controlPlaneNode,
-			machine:       controlPlaneMachine,
-			expectErr:     false,
-			expectDeleted: false,
-			expectEvents:  []string{},
-		},
-		{
-			name:          "when the machine is a control plane machine",
-			node:          nil,
-			machine:       controlPlaneMachine,
-			expectErr:     false,
-			expectDeleted: false,
-			expectEvents:  []string{},
+			name:            "it leaves the annotation on already-annotated machines",
+			node:            workerNode,
+			machine:         alreadyAnnotated,
+			expectErr:       false,
+			expectAnnotated: true,
 		},
 	}
 
@@ -409,7 +367,7 @@ func TestRemediate(t *testing.T) {
 			target := &healthCheckTarget{
 				Node:    tc.node,
 				Machine: tc.machine,
-				MHC:     newTestMachineHealthCheck("mhc", namespace, clusterName, labels),
+				MHC:     newTestMachineHealthCheck("mhc", namespace, clusterName, nil),
 			}
 
 			fakeRecorder := record.NewFakeRecorder(2)
@@ -420,221 +378,18 @@ func TestRemediate(t *testing.T) {
 			}
 
 			// Run rememdiation
-			err := target.remediate(context.Background(), log.Log, k8sClient, fakeRecorder)
+			err := target.annotate(context.Background(), log.Log, k8sClient, fakeRecorder)
 			gs.Expect(err != nil).To(Equal(tc.expectErr))
 
 			machine := &clusterv1.Machine{}
 			key := types.NamespacedName{Namespace: tc.machine.Namespace, Name: tc.machine.Name}
-			err = k8sClient.Get(context.Background(), key, machine)
+			gs.Expect(k8sClient.Get(context.Background(), key, machine)).To(Succeed())
 
-			// Check if the machine was deleted or not
-			if tc.expectDeleted {
-				gs.Expect(errors.IsNotFound(err)).To(BeTrue())
+			if tc.expectAnnotated {
+				gs.Expect(machine.GetAnnotations()).To(HaveKeyWithValue(clusterv1.MachineUnhealthy, ""))
 			} else {
-				gs.Expect(err).ToNot(HaveOccurred())
-				gs.Expect(machine).To(Equal(target.Machine))
+				gs.Expect(machine.GetAnnotations()).NotTo(HaveKey(clusterv1.MachineUnhealthy))
 			}
-
-			// Check which event types were sent
-			gs.Expect(fakeRecorder.Events).To(HaveLen(len(tc.expectEvents)))
-			receivedEvents := []string{}
-			eventMatchers := []gtypes.GomegaMatcher{}
-			for _, ev := range tc.expectEvents {
-				receivedEvents = append(receivedEvents, <-fakeRecorder.Events)
-				eventMatchers = append(eventMatchers, ContainSubstring(fmt.Sprintf(" %s ", ev)))
-			}
-			gs.Expect(receivedEvents).To(ConsistOf(eventMatchers))
-		})
-	}
-}
-
-func TestHasMachineSetOwner(t *testing.T) {
-	machineSetOR := metav1.OwnerReference{
-		Kind:       "MachineSet",
-		APIVersion: clusterv1.GroupVersion.String(),
-	}
-
-	machineDeploymentOR := metav1.OwnerReference{
-		Kind:       "MachineDeployment",
-		APIVersion: clusterv1.GroupVersion.String(),
-	}
-
-	differentGroupOR := metav1.OwnerReference{
-		Kind:       "MachineSet",
-		APIVersion: "different-group/v1",
-	}
-
-	invalidGroupOR := metav1.OwnerReference{
-		Kind:       "MachineSet",
-		APIVersion: "invalid/group/",
-	}
-
-	testCases := []struct {
-		name            string
-		ownerReferences []metav1.OwnerReference
-		hasOwner        bool
-		expectErr       bool
-	}{
-		{
-			name:            "with no owner references",
-			ownerReferences: []metav1.OwnerReference{},
-			hasOwner:        false,
-			expectErr:       false,
-		},
-		{
-			name:            "with a MachineDeployment owner reference",
-			ownerReferences: []metav1.OwnerReference{machineDeploymentOR},
-			hasOwner:        false,
-			expectErr:       false,
-		},
-		{
-			name:            "with a MachineSet owner reference",
-			ownerReferences: []metav1.OwnerReference{machineSetOR},
-			hasOwner:        true,
-			expectErr:       false,
-		},
-		{
-			name:            "with a MachineSet and MachineDeployment owner reference",
-			ownerReferences: []metav1.OwnerReference{machineSetOR, machineDeploymentOR},
-			hasOwner:        true,
-			expectErr:       false,
-		},
-		{
-			name:            "with a MachineSet owner reference from a different API Group",
-			ownerReferences: []metav1.OwnerReference{differentGroupOR},
-			hasOwner:        false,
-			expectErr:       false,
-		},
-		{
-			name:            "with a MachineSet owner reference from an invalid API Group",
-			ownerReferences: []metav1.OwnerReference{invalidGroupOR},
-			hasOwner:        false,
-			expectErr:       true,
-		},
-		{
-			name:            "with MachineSet owner references from two API Groups",
-			ownerReferences: []metav1.OwnerReference{differentGroupOR, machineSetOR},
-			hasOwner:        true,
-			expectErr:       false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			gs := NewGomegaWithT(t)
-
-			machine := newTestMachine("machine", "test-mhc", "test-cluster", "node", map[string]string{})
-			machine.SetOwnerReferences(tc.ownerReferences)
-
-			target := &healthCheckTarget{
-				Machine: machine,
-			}
-
-			hasOwner, err := target.hasMachineSetOwner()
-			gs.Expect(err != nil).To(Equal(tc.expectErr))
-			gs.Expect(hasOwner).To(Equal(tc.hasOwner))
-		})
-	}
-}
-
-func TestIsControlPlane(t *testing.T) {
-	namespace := "test-mhc"
-	clusterName := "test-cluster"
-	labels := map[string]string{"cluster": clusterName, "machine-group": "foo"}
-
-	workerNode := newTestNode("worker-node")
-	workerMachine := newTestMachine("worker-machine", namespace, clusterName, workerNode.Name, labels)
-
-	controlPlaneNode1 := newTestNode("control-plane-node")
-	if controlPlaneNode1.Labels == nil {
-		controlPlaneNode1.Labels = make(map[string]string)
-	}
-	controlPlaneNode1.Labels[nodeControlPlaneLabel] = ""
-
-	controlPlaneMachine1 := newTestMachine("control-plane-machine", namespace, clusterName, controlPlaneNode1.Name, labels)
-	if controlPlaneMachine1.Labels == nil {
-		controlPlaneMachine1.Labels = make(map[string]string)
-	}
-	controlPlaneMachine1.Labels[clusterv1.MachineControlPlaneLabelName] = ""
-
-	controlPlaneNode2 := newTestNode("control-plane-node")
-	if controlPlaneNode2.Labels == nil {
-		controlPlaneNode2.Labels = make(map[string]string)
-	}
-	controlPlaneNode2.Labels[nodeControlPlaneLabel] = "abcdef"
-
-	controlPlaneMachine2 := newTestMachine("control-plane-machine", namespace, clusterName, controlPlaneNode2.Name, labels)
-	if controlPlaneMachine2.Labels == nil {
-		controlPlaneMachine2.Labels = make(map[string]string)
-	}
-	controlPlaneMachine2.Labels[clusterv1.MachineControlPlaneLabelName] = "abcdef"
-
-	testCases := []struct {
-		name           string
-		node           *corev1.Node
-		machine        *clusterv1.Machine
-		isControlPlane bool
-	}{
-		{
-			name:           "when the node and machine are nil",
-			node:           nil,
-			machine:        nil,
-			isControlPlane: false,
-		},
-		{
-			name:           "when the node is not a control plane node",
-			node:           workerNode,
-			machine:        workerMachine,
-			isControlPlane: false,
-		},
-		{
-			name:           "when the node is missing and the machine is not a control plane machine",
-			node:           nil,
-			machine:        workerMachine,
-			isControlPlane: false,
-		},
-		{
-			name:           "when the node is a control plane node",
-			node:           controlPlaneNode1,
-			machine:        controlPlaneMachine1,
-			isControlPlane: true,
-		},
-		{
-			name:           "when the node is missing and the machine is a control plane machine",
-			node:           nil,
-			machine:        controlPlaneMachine1,
-			isControlPlane: true,
-		},
-		{
-			name:           "when the node control plane label has a value",
-			node:           controlPlaneNode2,
-			machine:        controlPlaneMachine2,
-			isControlPlane: true,
-		},
-		{
-			name:           "when the machine control plane label has a value",
-			node:           nil,
-			machine:        controlPlaneMachine2,
-			isControlPlane: true,
-		},
-		{
-			name:           "when the node is not a control plane node, but the machine is a control plane machine",
-			node:           workerNode,
-			machine:        controlPlaneMachine1,
-			isControlPlane: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			gs := NewGomegaWithT(t)
-
-			target := &healthCheckTarget{
-				Node:    tc.node,
-				Machine: tc.machine,
-			}
-
-			gs.Expect(target.isControlPlane()).To(Equal(tc.isControlPlane))
 		})
 	}
 }

--- a/test/integration/mhc_test.go
+++ b/test/integration/mhc_test.go
@@ -1,0 +1,240 @@
+// +build integration
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"flag"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controllers"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+	"sigs.k8s.io/cluster-api/test/helpers"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+func TestMachineSetsWithMachineHealthCheck(t *testing.T) {
+	g := NewWithT(t)
+	testEnv, err := helpers.NewTestEnvironment()
+	g.Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		g.Expect(testEnv.Stop()).To(Succeed())
+	}()
+
+	klog.InitFlags(nil)
+	g.Expect(flag.Set("v", "4")).To(Succeed())
+	g.Expect(flag.Set("logtostderr", "false")).To(Succeed())
+
+	logger := klogr.New()
+
+	g.Expect((&controllers.MachineSetReconciler{
+		Client: testEnv,
+		Log:    logger,
+	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
+	g.Expect((&controllers.MachineHealthCheckReconciler{
+		Client: testEnv,
+		Log:    logger,
+	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
+
+	go func() {
+		g.Expect(testEnv.StartManager()).To(Succeed())
+	}()
+
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "mhc-test"}}
+	g.Expect(testEnv.Create(context.Background(), namespace)).To(Succeed())
+	defer cleanup(g, testEnv, namespace)
+
+	cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: namespace.Name, Name: "test-cluster"}}
+	g.Expect(testEnv.Create(context.Background(), cluster)).To(Succeed())
+
+	g.Expect(testEnv.CreateKubeconfigSecret(cluster)).To(Succeed())
+
+	bootstrapTmpl := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "BootstrapMachineTemplate",
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+			"metadata": map[string]interface{}{
+				"name":      "ms-template",
+				"namespace": namespace.Name,
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"kind":       "BootstrapMachine",
+					"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+					"metadata":   map[string]interface{}{},
+				},
+			},
+		},
+	}
+	g.Expect(testEnv.Create(context.Background(), bootstrapTmpl)).To(Succeed())
+
+	infraTmpl := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "InfrastructureMachineTemplate",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+			"metadata": map[string]interface{}{
+				"name":      "ms-template",
+				"namespace": namespace.Name,
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"kind":       "InfrastructureMachine",
+					"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+					"metadata":   map[string]interface{}{},
+					"spec": map[string]interface{}{
+						"size":       "3xlarge",
+						"providerID": "test:////id",
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testEnv.Create(context.Background(), infraTmpl)).To(Succeed())
+
+	instance := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "ms-",
+			Namespace:    namespace.Name,
+		},
+		Spec: clusterv1.MachineSetSpec{
+			ClusterName: cluster.Name,
+			Replicas:    pointer.Int32Ptr(1),
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"label-1": "true",
+				},
+			},
+			Template: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: map[string]string{
+						"label-1": "true",
+					},
+				},
+				Spec: clusterv1.MachineSpec{
+					ClusterName: cluster.Name,
+					Version:     pointer.StringPtr("1.0.0"),
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+							Kind:       "BootstrapMachineTemplate",
+							Name:       bootstrapTmpl.GetName(),
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+						Kind:       "InfrastructureMachineTemplate",
+						Name:       infraTmpl.GetName(),
+					},
+				},
+			},
+		},
+	}
+	g.Expect(testEnv.Create(context.Background(), instance)).To(Succeed())
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+		},
+	}
+	g.Expect(testEnv.Create(context.Background(), node)).To(Succeed())
+	defer cleanup(g, testEnv, node)
+
+	mhc := &clusterv1.MachineHealthCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mhc",
+			Namespace: namespace.Name,
+		},
+		Spec: clusterv1.MachineHealthCheckSpec{
+			ClusterName: cluster.Name,
+			UnhealthyConditions: []clusterv1.UnhealthyCondition{
+				{
+					Type:    corev1.NodeReady,
+					Status:  corev1.ConditionUnknown,
+					Timeout: metav1.Duration{Duration: 5 * time.Minute},
+				},
+			},
+		},
+	}
+	mhc.Default()
+	g.Expect(testEnv.Create(context.Background(), mhc)).To(Succeed())
+
+	var nodes corev1.NodeList
+	g.Expect(testEnv.List(context.Background(), &nodes)).To(Succeed())
+
+	var found bool
+	for i := range nodes.Items {
+		n := nodes.Items[i]
+		if n.Name == node.Name {
+			found = true
+			node = &n
+		}
+	}
+	g.Expect(found).To(BeTrue())
+
+	var machines clusterv1.MachineList
+	g.Eventually(func() ([]clusterv1.Machine, error) {
+		if err := testEnv.List(context.Background(), &machines); err != nil {
+			return nil, err
+		}
+
+		return machines.Items, nil
+	}, 10*time.Second).Should(HaveLen(1))
+
+	machine := &machines.Items[0]
+	machine.Status.NodeRef = &corev1.ObjectReference{
+		APIVersion: node.APIVersion,
+		Kind:       node.Kind,
+		Name:       node.Name,
+		UID:        node.UID,
+	}
+	failureReason := capierrors.MachineStatusError("foo")
+	machine.Status.FailureReason = &failureReason
+	g.Expect(testEnv.Status().Update(context.Background(), machine)).To(Succeed())
+
+	machine.ObjectMeta.Finalizers = []string{"whatever"}
+	g.Expect(testEnv.Update(context.Background(), machine)).To(Succeed())
+
+	g.Eventually(func() (*metav1.Time, error) {
+		if err := testEnv.Get(context.Background(), util.ObjectKey(machine), machine); err != nil {
+			return nil, err
+		}
+
+		return machine.DeletionTimestamp, nil
+	}, 10*time.Second).Should(Not(BeNil()))
+
+	// release finalizer so machine can be deleted
+	machine.SetFinalizers(nil)
+	g.Expect(testEnv.Update(context.Background(), machine)).To(Succeed())
+}
+
+func cleanup(g *WithT, client client.Client, obj runtime.Object) {
+	g.Expect(client.Delete(context.Background(), obj)).To(Succeed())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Changes the MachineHealthCheck controller to only annotate unhealthy machines with the new annotation
- Changes the MachineSet controller to now remediate machines with this annotation by deleting them

Follow up from #2920 