### PR TITLE
🏃[e2e] Add deprecated tag to e2e framework.config

### DIFF
--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -161,6 +161,7 @@ type ComponentConfig struct {
 }
 
 // Config is the input used to configure the e2e test environment.
+// Deprecated. Please use clusterctl.E2EConfig instead.
 type Config struct {
 	// Name is the name of the Kind management cluster.
 	// Defaults to DefaultManagementClusterName.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR deprecates e2e framework.config. New config to be used is clusterctl.E2EConfig.

/assign @fabriziopandini 