### PR TITLE
OWNERS_ALIASES: add fabriziopandini to leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,6 +5,7 @@ aliases:
   - neolit123
   - justinsb
   - timothysc
+  - fabriziopandini
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for Cluster API


### PR DESCRIPTION
add @fabriziopandini to the owner aliases file under leads.

for matching:
https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle#leadership
also as @detiber commented here:
https://github.com/kubernetes-sigs/cluster-api/pull/2498#discussion_r386487064

/assign @detiber @vincepri 

we have the responsibility to self-`/hold` and not `/approve` without agreement, etc..
