### PR TITLE
🐛fix a clusterctl error when moving cluster with user provided certs

### DIFF
--- a/cmd/clusterctl/client/cluster/objectgraph_test.go
+++ b/cmd/clusterctl/client/cluster/objectgraph_test.go
@@ -1078,6 +1078,18 @@ func Test_objectGraph_setSoftOwnership(t *testing.T) {
 				"/v1, Kind=Secret, ns1/foo-kubeconfig": {}, // the kubeconfig secret has explicit OwnerRef to the cluster, so it should NOT be identified as a soft ownership
 			},
 		},
+		{
+			name: "A cluster with a soft owned secret (cluster name with - in the middle)",
+			fields: fields{
+				objs: test.NewFakeCluster("ns1", "foo-bar").Objs(),
+			},
+			wantSecrets: map[string][]string{ // wantSecrets is a map[node UID] --> list of soft owner UIDs
+				"/v1, Kind=Secret, ns1/foo-bar-ca": { // the ca secret has no explicit OwnerRef to the cluster, so it should be identified as a soft ownership
+					"cluster.x-k8s.io/v1alpha3, Kind=Cluster, ns1/foo-bar",
+				},
+				"/v1, Kind=Secret, ns1/foo-bar-kubeconfig": {}, // the kubeconfig secret has explicit OwnerRef to the cluster, so it should NOT be identified as a soft ownership
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/util/secret/consts.go
+++ b/util/secret/consts.go
@@ -47,3 +47,8 @@ const (
 	// APIServerEtcdClient is the secret name of user-supplied secret containing the apiserver-etcd-client key/cert
 	APIServerEtcdClient Purpose = "apiserver-etcd-client"
 )
+
+var (
+	// allSecretPurposes defines a lists with all the secret suffix used by Cluster API
+	allSecretPurposes = []Purpose{Kubeconfig, ClusterCA, EtcdCA, ServiceAccount, FrontProxyCA, APIServerEtcdClient}
+)

--- a/util/secret/secret_test.go
+++ b/util/secret/secret_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestParseSecretName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   Purpose
+		wantErr bool
+	}{
+		{
+			name: "A secret for the test cluster",
+			args: args{
+				name: "test-kubeconfig",
+			},
+			want:    "test",
+			want1:   Kubeconfig,
+			wantErr: false,
+		},
+		{
+			name: "A secret for the test-capa cluster (cluster name with - in the middle)",
+			args: args{
+				name: "test-capa-ca",
+			},
+			want:    "test-capa",
+			want1:   ClusterCA,
+			wantErr: false,
+		},
+		{
+			name: "Not a Cluster API secret",
+			args: args{
+				name: "foo",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Not a Cluster API secret (secret name with - in the middle)",
+			args: args{
+				name: "foo-bar",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got, got1, err := ParseSecretName(tt.args.name)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(got).To(Equal(tt.want))
+			g.Expect(got1).To(Equal(tt.want1))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue in clusterctl when moving clusters with a hyphen in the name and user provider cluster secrets

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2964

/assign @vincepri 
/assign @wfernandes 
/cc @Arvinderpal 
