### PR TITLE
Add helper wrapping envtest

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -40,7 +40,6 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capierrors "sigs.k8s.io/cluster-api/errors"
-	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
@@ -56,16 +55,16 @@ var _ = Describe("Cluster Reconciler", func() {
 		}
 
 		// Create the Cluster object and expect the Reconcile and Deployment to be created
-		Expect(k8sClient.Create(ctx, instance)).ToNot(HaveOccurred())
+		Expect(testEnv.Create(ctx, instance)).ToNot(HaveOccurred())
 		key := client.ObjectKey{Namespace: instance.Namespace, Name: instance.Name}
 		defer func() {
-			err := k8sClient.Delete(ctx, instance)
+			err := testEnv.Delete(ctx, instance)
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
 		// Make sure the Cluster exists.
 		Eventually(func() bool {
-			if err := k8sClient.Get(ctx, key, instance); err != nil {
+			if err := testEnv.Get(ctx, key, instance); err != nil {
 				return false
 			}
 			return len(instance.Finalizers) > 0
@@ -80,16 +79,16 @@ var _ = Describe("Cluster Reconciler", func() {
 				Namespace:    "default",
 			},
 		}
-		Expect(k8sClient.Create(ctx, cluster)).To(BeNil())
+		Expect(testEnv.Create(ctx, cluster)).To(BeNil())
 		key := client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}
 		defer func() {
-			err := k8sClient.Delete(ctx, cluster)
+			err := testEnv.Delete(ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
 		// Wait for reconciliation to happen.
 		Eventually(func() bool {
-			if err := k8sClient.Get(ctx, key, cluster); err != nil {
+			if err := testEnv.Get(ctx, key, cluster); err != nil {
 				return false
 			}
 			return len(cluster.Finalizers) > 0
@@ -97,7 +96,7 @@ var _ = Describe("Cluster Reconciler", func() {
 
 		// Patch
 		Eventually(func() bool {
-			ph, err := patch.NewHelper(cluster, k8sClient)
+			ph, err := patch.NewHelper(cluster, testEnv)
 			Expect(err).ShouldNot(HaveOccurred())
 			cluster.Spec.InfrastructureRef = &v1.ObjectReference{Name: "test"}
 			cluster.Spec.ControlPlaneRef = &v1.ObjectReference{Name: "test-too"}
@@ -108,7 +107,7 @@ var _ = Describe("Cluster Reconciler", func() {
 		// Assertions
 		Eventually(func() bool {
 			instance := &clusterv1.Cluster{}
-			if err := k8sClient.Get(ctx, key, instance); err != nil {
+			if err := testEnv.Get(ctx, key, instance); err != nil {
 				return false
 			}
 			return instance.Spec.InfrastructureRef != nil &&
@@ -124,16 +123,16 @@ var _ = Describe("Cluster Reconciler", func() {
 				Namespace:    "default",
 			},
 		}
-		Expect(k8sClient.Create(ctx, cluster)).To(BeNil())
+		Expect(testEnv.Create(ctx, cluster)).To(BeNil())
 		key := client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}
 		defer func() {
-			err := k8sClient.Delete(ctx, cluster)
+			err := testEnv.Delete(ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
 		// Wait for reconciliation to happen.
 		Eventually(func() bool {
-			if err := k8sClient.Get(ctx, key, cluster); err != nil {
+			if err := testEnv.Get(ctx, key, cluster); err != nil {
 				return false
 			}
 			return len(cluster.Finalizers) > 0
@@ -141,7 +140,7 @@ var _ = Describe("Cluster Reconciler", func() {
 
 		// Patch
 		Eventually(func() bool {
-			ph, err := patch.NewHelper(cluster, k8sClient)
+			ph, err := patch.NewHelper(cluster, testEnv)
 			Expect(err).ShouldNot(HaveOccurred())
 			cluster.Status.InfrastructureReady = true
 			Expect(ph.Patch(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -151,7 +150,7 @@ var _ = Describe("Cluster Reconciler", func() {
 		// Assertions
 		Eventually(func() bool {
 			instance := &clusterv1.Cluster{}
-			if err := k8sClient.Get(ctx, key, instance); err != nil {
+			if err := testEnv.Get(ctx, key, instance); err != nil {
 				return false
 			}
 			return instance.Status.InfrastructureReady
@@ -166,16 +165,16 @@ var _ = Describe("Cluster Reconciler", func() {
 				Namespace:    "default",
 			},
 		}
-		Expect(k8sClient.Create(ctx, cluster)).To(BeNil())
+		Expect(testEnv.Create(ctx, cluster)).To(BeNil())
 		key := client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}
 		defer func() {
-			err := k8sClient.Delete(ctx, cluster)
+			err := testEnv.Delete(ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
 		// Wait for reconciliation to happen.
 		Eventually(func() bool {
-			if err := k8sClient.Get(ctx, key, cluster); err != nil {
+			if err := testEnv.Get(ctx, key, cluster); err != nil {
 				return false
 			}
 			return len(cluster.Finalizers) > 0
@@ -183,7 +182,7 @@ var _ = Describe("Cluster Reconciler", func() {
 
 		// Patch
 		Eventually(func() bool {
-			ph, err := patch.NewHelper(cluster, k8sClient)
+			ph, err := patch.NewHelper(cluster, testEnv)
 			Expect(err).ShouldNot(HaveOccurred())
 			cluster.Status.InfrastructureReady = true
 			cluster.Spec.InfrastructureRef = &v1.ObjectReference{Name: "test"}
@@ -194,7 +193,7 @@ var _ = Describe("Cluster Reconciler", func() {
 		// Assertions
 		Eventually(func() bool {
 			instance := &clusterv1.Cluster{}
-			if err := k8sClient.Get(ctx, key, instance); err != nil {
+			if err := testEnv.Get(ctx, key, instance); err != nil {
 				return false
 			}
 			return instance.Status.InfrastructureReady &&
@@ -211,16 +210,16 @@ var _ = Describe("Cluster Reconciler", func() {
 				Namespace:    "default",
 			},
 		}
-		Expect(k8sClient.Create(ctx, cluster)).To(BeNil())
+		Expect(testEnv.Create(ctx, cluster)).To(BeNil())
 		key := client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}
 		defer func() {
-			err := k8sClient.Delete(ctx, cluster)
+			err := testEnv.Delete(ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
 		// Wait for reconciliation to happen.
 		Eventually(func() bool {
-			if err := k8sClient.Get(ctx, key, cluster); err != nil {
+			if err := testEnv.Get(ctx, key, cluster); err != nil {
 				return false
 			}
 			return len(cluster.Finalizers) > 0
@@ -228,7 +227,7 @@ var _ = Describe("Cluster Reconciler", func() {
 
 		// Patch
 		Eventually(func() bool {
-			ph, err := patch.NewHelper(cluster, k8sClient)
+			ph, err := patch.NewHelper(cluster, testEnv)
 			Expect(err).ShouldNot(HaveOccurred())
 			cluster.SetFinalizers([]string{})
 			Expect(ph.Patch(ctx, cluster)).ShouldNot(HaveOccurred())
@@ -240,7 +239,7 @@ var _ = Describe("Cluster Reconciler", func() {
 		// Assertions
 		Eventually(func() []string {
 			instance := &clusterv1.Cluster{}
-			if err := k8sClient.Get(ctx, key, instance); err != nil {
+			if err := testEnv.Get(ctx, key, instance); err != nil {
 				return []string{"not-empty"}
 			}
 			return instance.Finalizers
@@ -255,17 +254,17 @@ var _ = Describe("Cluster Reconciler", func() {
 			},
 		}
 
-		Expect(k8sClient.Create(ctx, cluster)).To(BeNil())
+		Expect(testEnv.Create(ctx, cluster)).To(BeNil())
 		key := client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}
 		defer func() {
-			err := k8sClient.Delete(ctx, cluster)
+			err := testEnv.Delete(ctx, cluster)
 			Expect(err).NotTo(HaveOccurred())
 		}()
-		Expect(kubeconfig.CreateEnvTestSecret(k8sClient, cfg, cluster)).To(Succeed())
+		Expect(testEnv.CreateKubeconfigSecret(cluster)).To(Succeed())
 
 		// Wait for reconciliation to happen.
 		Eventually(func() bool {
-			if err := k8sClient.Get(ctx, key, cluster); err != nil {
+			if err := testEnv.Get(ctx, key, cluster); err != nil {
 				return false
 			}
 			return len(cluster.Finalizers) > 0
@@ -282,7 +281,7 @@ var _ = Describe("Cluster Reconciler", func() {
 			},
 		}
 
-		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		Expect(testEnv.Create(ctx, node)).To(Succeed())
 
 		machine := &clusterv1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
@@ -301,10 +300,10 @@ var _ = Describe("Cluster Reconciler", func() {
 			},
 		}
 
-		Expect(k8sClient.Create(ctx, machine)).To(BeNil())
+		Expect(testEnv.Create(ctx, machine)).To(BeNil())
 		key = client.ObjectKey{Name: machine.Name, Namespace: machine.Namespace}
 		defer func() {
-			err := k8sClient.Delete(ctx, machine)
+			err := testEnv.Delete(ctx, machine)
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
@@ -316,7 +315,7 @@ var _ = Describe("Cluster Reconciler", func() {
 		// we continue to see test timeouts here, that will likely point to something else being the problem, but
 		// I've yet to determine any other possibility for the test flakes.
 		Eventually(func() bool {
-			if err := k8sClient.Get(ctx, key, machine); err != nil {
+			if err := testEnv.Get(ctx, key, machine); err != nil {
 				return false
 			}
 			return len(machine.Finalizers) > 0
@@ -325,7 +324,7 @@ var _ = Describe("Cluster Reconciler", func() {
 		// Assertion
 		key = client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}
 		Eventually(func() bool {
-			if err := k8sClient.Get(ctx, key, cluster); err != nil {
+			if err := testEnv.Get(ctx, key, cluster); err != nil {
 				return false
 			}
 			return cluster.Status.ControlPlaneInitialized

--- a/controllers/machine_controller_phases_test.go
+++ b/controllers/machine_controller_phases_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Reconcile Machine Phases", func() {
 	}
 
 	BeforeEach(func() {
-		defaultKubeconfigSecret = kubeconfig.GenerateSecret(defaultCluster, kubeconfig.FromEnvTestConfig(cfg, defaultCluster))
+		defaultKubeconfigSecret = kubeconfig.GenerateSecret(defaultCluster, kubeconfig.FromEnvTestConfig(testEnv.Config, defaultCluster))
 	})
 
 	It("Should set OwnerReference and cluster name label on external objects", func() {

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"path"
+	"path/filepath"
+	goruntime "runtime"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	"sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type TestEnvironment struct {
+	*envtest.Environment
+	manager.Manager
+	client.Client
+
+	Config  *rest.Config
+	scheme  *runtime.Scheme
+	doneMgr chan struct{}
+}
+
+func newTestEnvironment() *TestEnvironment {
+	scheme := scheme.Scheme
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(clusterv1.AddToScheme(scheme))
+	utilruntime.Must(bootstrapv1.AddToScheme(scheme))
+
+	_, filename, _, _ := goruntime.Caller(0) //nolint
+	root := path.Join(path.Dir(filename), "..", "..")
+
+	return &TestEnvironment{
+		Environment: &envtest.Environment{
+			ErrorIfCRDPathMissing: true,
+			CRDDirectoryPaths: []string{
+				filepath.Join(root, "config", "crd", "bases"),
+				filepath.Join(root, "controlplane", "kubeadm", "config", "crd", "bases"),
+				filepath.Join(root, "bootstrap", "kubeadm", "config", "crd", "bases"),
+			},
+			CRDs: []runtime.Object{
+				external.TestGenericBootstrapCRD,
+				external.TestGenericBootstrapTemplateCRD,
+				external.TestGenericInfrastructureCRD,
+				external.TestGenericInfrastructureTemplateCRD,
+			},
+		},
+		scheme:  scheme,
+		doneMgr: make(chan struct{}),
+	}
+}
+
+func NewTestEnvironment() (*TestEnvironment, error) {
+	env := newTestEnvironment()
+
+	cfg, err := env.Environment.Start()
+	if err != nil {
+		return env, err
+	}
+
+	mgr, err := manager.New(cfg, manager.Options{
+		Scheme:             env.scheme,
+		MetricsBindAddress: "0",
+		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+			syncPeriod := 1 * time.Second
+			opts.Resync = &syncPeriod
+			return cache.New(config, opts)
+		},
+	})
+	if err != nil {
+		if stopErr := env.Stop(); err != nil {
+			return nil, kerrors.NewAggregate([]error{err, stopErr})
+		}
+		return env, err
+	}
+
+	env.Config = cfg
+	env.Manager = mgr
+	env.Client = mgr.GetClient()
+
+	return env, nil
+}
+
+func (t *TestEnvironment) StartManager() error {
+	return t.Manager.Start(t.doneMgr)
+}
+
+func (t *TestEnvironment) Stop() error {
+	close(t.doneMgr)
+	return t.Environment.Stop()
+}
+
+func (t *TestEnvironment) CreateKubeconfigSecret(cluster *clusterv1.Cluster) error {
+	return kubeconfig.CreateEnvTestSecret(t.Client, t.Config, cluster)
+}

--- a/util/kubeconfig/testing.go
+++ b/util/kubeconfig/testing.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// Deprecated: use test/helpers/envtest
 func CreateEnvTestSecret(client client.Client, cfg *rest.Config, cluster *clusterv1.Cluster) error {
 	return client.Create(context.TODO(), GenerateSecret(cluster, FromEnvTestConfig(cfg, cluster)))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Trying to make envtest it a simpler API, less copypasta. I think we should be able to keep it up to date with the full set of our CRDs.

I only updated the `controllers` package tests, but others can be updated as needed.

Split out from #2975