### PR TITLE
✨clusterctl: add CLUSTERCTL_LOG_LEVEL environment variable

### DIFF
--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -18,15 +18,21 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
-var cfgFile string
+var (
+	cfgFile   string
+	verbosity *int
+)
 
 var RootCmd = &cobra.Command{
 	Use:          "clusterctl",
@@ -48,12 +54,33 @@ func Execute() {
 func init() {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
-	verbosity := flag.CommandLine.Int("v", 0, "Set the log level verbosity.")
-	logf.SetLogger(logf.NewLogger(logf.WithThreshold(verbosity)))
+	verbosity = flag.CommandLine.Int("v", 0, "Set the log level verbosity. This overrides the CLUSTERCTL_LOG_LEVEL environment variable.")
 
 	RootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
 		"Path to clusterctl configuration (default is `$HOME/.cluster-api/clusterctl.yaml`)")
+
+	cobra.OnInitialize(initConfig)
+}
+
+func initConfig() {
+	// check if the CLUSTERCTL_LOG_LEVEL was set via env var or in the config file
+	if *verbosity == 0 {
+		configClient, err := config.New(cfgFile)
+		if err == nil {
+			v, err := configClient.Variables().Get("CLUSTERCTL_LOG_LEVEL")
+			if err == nil && v != "" {
+				verbosityFromEnv, err := strconv.Atoi(v)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Failed to convert CLUSTERCTL_LOG_LEVEL string to an int. err=%s\n", err.Error())
+					os.Exit(1)
+				}
+				verbosity = &verbosityFromEnv
+			}
+		}
+	}
+
+	logf.SetLogger(logf.NewLogger(logf.WithThreshold(verbosity)))
 }
 
 const Indentation = `  `

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -160,9 +160,16 @@ all the images in the cert-manager component.
 For situations when resources are limited or the network is slow, the cert-manager wait time to be running can be customized by adding a field to the clusterctl config file, for example:
 
 ```yaml
-  cert-manager-timeout: 15m 
+  cert-manager-timeout: 15m
 ```
 
 The value string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 If no value is specified or the format is invalid, the default value of 10 minutes will be used.
+
+
+## Debugging/Logging
+
+To have more verbose logs you can use the `-v` flag when running the `clusterctl` and set the level of the logging verbose with a positive integer number, ie. `-v 3`.
+
+If you do not want to use the flag every time you issue a command you can set the environment variable `CLUSTERCTL_LOG_LEVEL` or set the variable in the `clusterctl` config file which is located by default at `$HOME/.cluster-api/clusterctl.yaml`.


### PR DESCRIPTION
**What this PR does / why we need it**:
add a `CLUSTERCTL_LOG_LEVEL` environment variable to be used instead of the `-v`.
if `CLUSTERCTL_LOG_LEVEL` is set it will override the flag `-v`

example, I did not have any running cluster, then I added some log output to make the example.
UPDATED with the new behavior
```
$ export CLUSTERCTL_LOG_LEVEL=5
$  ./bin/clusterctl config cluster my -v3
Info
info level 0
info level 1
info level 2
info level 3
Error: failed to identify the default infrastructure provider. Please specify an infrastructure provider: unsupported management cluster server version: v1.14.6 - minimum required version is v1.16.0

$ export CLUSTERCTL_LOG_LEVEL=5
$  ./bin/clusterctl config cluster my
Info
info level 0
info level 1
info level 2
info level 3
info level 4
info level 5
Error: failed to identify the default infrastructure provider. Please specify an infrastructure provider: unsupported management cluster server version: v1.14.6 - minimum required version is v1.16.0
```

and

```
$ unset CLUSTERCTL_LOG_LEVEL
$  ./bin/clusterctl config cluster my -v3
Info
info level 0
info level 1
info level 2
info level 3
Error: failed to identify the default infrastructure provider. Please specify an infrastructure provider: unsupported management cluster server version: v1.14.6 - minimum required version is v1.16.0
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
 - Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/2957

/kind feature
cc @wfernandes 
