### PR TITLE
:bug: KCP should bypass the controller cache when initializing

### DIFF
--- a/controllers/remote/cluster.go
+++ b/controllers/remote/cluster.go
@@ -40,12 +40,11 @@ func NewClusterClient(ctx context.Context, c client.Client, cluster client.Objec
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create client for Cluster %s/%s", cluster.Namespace, cluster.Name)
 	}
-
 	return ret, nil
 }
 
 // RESTConfig returns a configuration instance to be used with a Kubernetes client.
-func RESTConfig(ctx context.Context, c client.Client, cluster client.ObjectKey) (*restclient.Config, error) {
+func RESTConfig(ctx context.Context, c client.Reader, cluster client.ObjectKey) (*restclient.Config, error) {
 	kubeConfig, err := kcfg.FromSecret(ctx, c, cluster)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve kubeconfig secret for Cluster %s/%s", cluster.Namespace, cluster.Name)

--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -65,7 +65,8 @@ type KubeadmControlPlaneReconciler struct {
 	controller controller.Controller
 	recorder   record.EventRecorder
 
-	managementCluster internal.ManagementCluster
+	managementCluster         internal.ManagementCluster
+	managementClusterUncached internal.ManagementCluster
 }
 
 func (r *KubeadmControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
@@ -96,6 +97,9 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager, optio
 
 	if r.managementCluster == nil {
 		r.managementCluster = &internal.Management{Client: r.Client}
+	}
+	if r.managementClusterUncached == nil {
+		r.managementClusterUncached = &internal.Management{Client: mgr.GetAPIReader()}
 	}
 
 	return nil

--- a/controlplane/kubeadm/controllers/controller_test.go
+++ b/controlplane/kubeadm/controllers/controller_test.go
@@ -525,6 +525,15 @@ kubernetesVersion: metav1.16.1`,
 				Status: internal.ClusterStatus{},
 			},
 		},
+		managementClusterUncached: &fakeManagementCluster{
+			Management: &internal.Management{Client: fakeClient},
+			Workload: fakeWorkloadCluster{
+				Workload: &internal.Workload{
+					Client: fakeClient,
+				},
+				Status: internal.ClusterStatus{},
+			},
+		},
 	}
 
 	result, err := r.Reconcile(ctrl.Request{NamespacedName: util.ObjectKey(kcp)})

--- a/controlplane/kubeadm/controllers/scale_test.go
+++ b/controlplane/kubeadm/controllers/scale_test.go
@@ -50,6 +50,10 @@ func TestKubeadmControlPlaneReconciler_initializeControlPlane(t *testing.T) {
 		Client:   fakeClient,
 		Log:      log.Log,
 		recorder: record.NewFakeRecorder(32),
+		managementClusterUncached: &fakeManagementCluster{
+			Management: &internal.Management{Client: fakeClient},
+			Workload:   fakeWorkloadCluster{},
+		},
 	}
 	controlPlane := &internal.ControlPlane{
 		Cluster: cluster,
@@ -101,10 +105,11 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 		fakeClient := newFakeClient(g, initObjs...)
 
 		r := &KubeadmControlPlaneReconciler{
-			Client:            fakeClient,
-			managementCluster: fmc,
-			Log:               log.Log,
-			recorder:          record.NewFakeRecorder(32),
+			Client:                    fakeClient,
+			managementCluster:         fmc,
+			managementClusterUncached: fmc,
+			Log:                       log.Log,
+			recorder:                  record.NewFakeRecorder(32),
 		}
 		controlPlane := &internal.ControlPlane{
 			KCP:      kcp,
@@ -156,10 +161,11 @@ func TestKubeadmControlPlaneReconciler_scaleUpControlPlane(t *testing.T) {
 			}
 
 			r := &KubeadmControlPlaneReconciler{
-				Client:            fakeClient,
-				managementCluster: fmc,
-				Log:               log.Log,
-				recorder:          record.NewFakeRecorder(32),
+				Client:                    fakeClient,
+				managementCluster:         fmc,
+				managementClusterUncached: fmc,
+				Log:                       log.Log,
+				recorder:                  record.NewFakeRecorder(32),
 			}
 			controlPlane := &internal.ControlPlane{
 				KCP:      kcp,

--- a/controlplane/kubeadm/controllers/upgrade_test.go
+++ b/controlplane/kubeadm/controllers/upgrade_test.go
@@ -53,6 +53,12 @@ func TestKubeadmControlPlaneReconciler_upgradeControlPlane(t *testing.T) {
 			ControlPlaneHealthy: true,
 			EtcdHealthy:         true,
 		},
+		managementClusterUncached: &fakeManagementCluster{
+			Management:          &internal.Management{Client: fakeClient},
+			Workload:            fakeWorkloadCluster{Status: internal.ClusterStatus{Nodes: 1}},
+			ControlPlaneHealthy: true,
+			EtcdHealthy:         true,
+		},
 	}
 	controlPlane := &internal.ControlPlane{
 		KCP:      kcp,

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -46,7 +46,7 @@ type ManagementCluster interface {
 
 // Management holds operations on the management cluster.
 type Management struct {
-	Client ctrlclient.Client
+	Client ctrlclient.Reader
 }
 
 // GetMachinesForCluster returns a list of machines that can be filtered or not.

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -40,7 +40,7 @@ var (
 )
 
 // FromSecret fetches the Kubeconfig for a Cluster.
-func FromSecret(ctx context.Context, c client.Client, cluster client.ObjectKey) ([]byte, error) {
+func FromSecret(ctx context.Context, c client.Reader, cluster client.ObjectKey) ([]byte, error) {
 	out, err := secret.Get(ctx, c, cluster, secret.Kubeconfig)
 	if err != nil {
 		return nil, err

--- a/util/secret/secret.go
+++ b/util/secret/secret.go
@@ -28,13 +28,13 @@ import (
 
 // Get retrieves the specified Secret (if any) from the given
 // cluster name and namespace.
-func Get(ctx context.Context, c client.Client, cluster client.ObjectKey, purpose Purpose) (*corev1.Secret, error) {
+func Get(ctx context.Context, c client.Reader, cluster client.ObjectKey, purpose Purpose) (*corev1.Secret, error) {
 	return GetFromNamespacedName(ctx, c, cluster, purpose)
 }
 
 // GetFromNamespacedName retrieves the specified Secret (if any) from the given
 // cluster name and namespace.
-func GetFromNamespacedName(ctx context.Context, c client.Client, clusterName client.ObjectKey, purpose Purpose) (*corev1.Secret, error) {
+func GetFromNamespacedName(ctx context.Context, c client.Reader, clusterName client.ObjectKey, purpose Purpose) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	secretKey := client.ObjectKey{
 		Namespace: clusterName.Namespace,


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR adds an uncached client to the KCP reconciler that can be used to talk to the management cluster directly bypassing the internal controller cache.  This additional check is only done if the `initializeControlPlane` method.

In addition to the changes above, this PR also cleans some functions that were accepting `client.Client` instead of the smaller `client.Reader` while only doing read operations. This is a backward-compatible change given that the interface is smaller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3001 
