### PR TITLE
🏃CAPD automatically re-create a machine if there is an error during provisioning

### DIFF
--- a/test/infrastructure/docker/docker/machine.go
+++ b/test/infrastructure/docker/docker/machine.go
@@ -142,7 +142,7 @@ func (m *Machine) Create(ctx context.Context, role string, version *string, moun
 		}
 		// After creating a node we need to wait a small amount of time until crictl does not return an error.
 		// This fixes an issue where we try to kubeadm init too quickly after creating the container.
-		err = wait.PollImmediate(500*time.Millisecond, 2*time.Second, func() (bool, error) {
+		err = wait.PollImmediate(500*time.Millisecond, 4*time.Second, func() (bool, error) {
 			ps := m.container.Commander.Command("crictl", "ps")
 			return ps.Run(ctx) == nil, nil
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes CAPD recover from conditions when the docker provider creates a container for a machine, but for some reason, the container is not fully operational/does not completes all the provisioning steps.

More specifically, given that the CAPD provisioning time is small, the PR cleanups containers with provisioning errors and re-provision from scratch

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2999
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2341

/assing @vincepri 
/assing @sedefsavas 