### PR TITLE
:running: Update kind to v0.7.0 in integration tests

### DIFF
--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -21,7 +21,7 @@ set -o pipefail
 set -x
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KIND_VERSION=v0.6.1
+MINIMUM_KIND_VERSION=v0.7.0
 
 # Ensure the kind tool exists and is a viable version, or installs it
 verify_kind_version() {

--- a/scripts/ci-integration.sh
+++ b/scripts/ci-integration.sh
@@ -23,7 +23,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${REPO_ROOT}/hack/ensure-go.sh"
 
 MAKE="make"
-KIND_VERSION="v0.6.1"
+KIND_VERSION="v0.7.0"
 KUBECTL_VERSION="v1.16.7"
 KUSTOMIZE_VERSION="3.1.0"
 CRD_YAML="crd.yaml"
@@ -82,8 +82,6 @@ prepare_crd_yaml() {
 
 create_bootstrap() {
    kind create cluster --name "${BOOTSTRAP_CLUSTER_NAME}"
-   KUBECONFIG="$(kind get kubeconfig-path --name="${BOOTSTRAP_CLUSTER_NAME}")"
-   export KUBECONFIG
 
    kind load docker-image "${CONTROLLER_IMG}-${GOARCH}:${VERSION}" --name "${BOOTSTRAP_CLUSTER_NAME}"
    kind load docker-image "${KUBEADM_BOOTSTRAP_CONTROLLER_IMG}-${GOARCH}:${VERSION}" --name "${BOOTSTRAP_CLUSTER_NAME}"

--- a/test/integration/cluster/cluster_test.go
+++ b/test/integration/cluster/cluster_test.go
@@ -20,7 +20,6 @@ package cluster
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -65,8 +64,10 @@ var _ = Describe("Cluster-Controller", func() {
 
 	BeforeEach(func() {
 		// Load configuration
-		kubeconfig := os.Getenv("KUBECONFIG")
-		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+		configOverrides := &clientcmd.ConfigOverrides{}
+		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+		config, err := kubeConfig.ClientConfig()
 		Expect(err).ShouldNot(HaveOccurred())
 
 		// Create kubernetes client


### PR DESCRIPTION
**What this PR does / why we need it**:
Update kind binary to v0.7.0 for CI. That's the version required by CAPD, and used by the e2e test framework.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
