### PR TITLE
:bug: [0.2] Exclude conversion-data annotation when MD reconciles

### DIFF
--- a/controllers/mdutil/util.go
+++ b/controllers/mdutil/util.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/klog"
 	"k8s.io/utils/integer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	"sigs.k8s.io/cluster-api/util/conversion"
 )
 
 const (
@@ -156,6 +157,13 @@ var annotationsToSkip = map[string]bool{
 	RevisionHistoryAnnotation:      true,
 	DesiredReplicasAnnotation:      true,
 	MaxReplicasAnnotation:          true,
+
+	// Exclude the conversion annotation, to avoid infinite loops between the conversion webhook
+	// and the MachineDeployment controller syncing the annotations between a MachineDeployment
+	// and its linked MachineSets.
+	//
+	// See https://github.com/kubernetes-sigs/cluster-api/pull/3010#issue-413767831 for more details.
+	conversion.DataAnnotation: true,
 }
 
 // skipCopyAnnotation returns true if we should skip copying the annotation with the given annotation key

--- a/util/conversion/conversion.go
+++ b/util/conversion/conversion.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversion
+
+const (
+	DataAnnotation = "cluster.x-k8s.io/conversion-data"
+)


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR fixes an issue that was causing controller to fight with each other when a management cluster had both v1alpha2 and v1alpha3 running.

The MachineDeployment controller has has logic to sync annotations from a MachineDeployment to its linked MachineSets as seen in: https://github.com/kubernetes-sigs/cluster-api/blob/a799265e225b8f0e47b4642c8211a9213d0aea9a/controllers/machinedeployment_sync.go#L112

The `SetNewMachineSetAnnotations` (regardless of what the names says) actually syncs up annotations on a new MachineSet or an existing one, in particular when this function is called https://github.com/kubernetes-sigs/cluster-api/blob/a799265e225b8f0e47b4642c8211a9213d0aea9a/controllers/mdutil/util.go#L202 annotation are copied, and if there has been changes it returns true and the MachineSet is ultimately patched.

All annotations are usually copied, with the exception for some listed in https://github.com/kubernetes-sigs/cluster-api/blob/a799265e225b8f0e47b4642c8211a9213d0aea9a/controllers/mdutil/util.go#L141-L147.

With the release of v1alpha3, we added the `conversion-data` annotation that is used internally to restore fields that would otherwise be lost during the conversion to an older version. This annotation caused the MD to always think that a change needs to be made:

1. MachineDeployment sees that the MachineSet has the wrong `conversion-data` value (because it's set from the conversion webhook)
2. MachineDeployment copies its own `conversion-data` (as shown above), increases the revision history https://github.com/kubernetes-sigs/cluster-api/blob/a799265e225b8f0e47b4642c8211a9213d0aea9a/controllers/mdutil/util.go#L241, and issues a patch.
3. Webhook conversion kicks in, but removes the `conversion-data` field https://github.com/kubernetes-sigs/cluster-api/blob/a799265e225b8f0e47b4642c8211a9213d0aea9a/util/conversion/conversion.go#L125
3. Webhook saves the updated object in etcd.
4. Webhook conversion kicks in and converts the object from v1alpha3 to v1alpha2, overwriting the `conversion-data` field.
5. Go to step 1