### PR TITLE
🐛 Convert MachineSet annotations from v1alpha2

### DIFF
--- a/api/v1alpha2/conversion.go
+++ b/api/v1alpha2/conversion.go
@@ -172,6 +172,11 @@ func (src *MachineSet) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.Template.Spec.ClusterName = name
 	}
 
+	// Manually convert annotations
+	for i := range v2Annotations {
+		convertAnnotations(v2Annotations[i], v3Annotations[i], dst.Annotations)
+	}
+
 	// Manually restore data.
 	restored := &v1alpha3.MachineSet{}
 	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
@@ -190,6 +195,11 @@ func (dst *MachineSet) ConvertFrom(srcRaw conversion.Hub) error {
 	src := srcRaw.(*v1alpha3.MachineSet)
 	if err := Convert_v1alpha3_MachineSet_To_v1alpha2_MachineSet(src, dst, nil); err != nil {
 		return err
+	}
+
+	// Manually convert annotations
+	for i := range v3Annotations {
+		convertAnnotations(v3Annotations[i], v2Annotations[i], dst.Annotations)
 	}
 
 	// Preserve Hub data on down-conversion except for metadata


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
We were previously only converting MachineDeployment annotations from v1alpha2 to their v1alpha3 version, we need to do the same for MachineSet, given that the MachineDeployment controller is the one that annotates MachineSets.

/milestone v0.3.6
/assign @ncdc 
