### PR TITLE
🏃‍♂️ Provide a way in KCP to disable CoreDNS management via annotations

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -27,6 +27,9 @@ import (
 const (
 	KubeadmControlPlaneFinalizer    = "kubeadm.controlplane.cluster.x-k8s.io"
 	KubeadmControlPlaneHashLabelKey = "kubeadm.controlplane.cluster.x-k8s.io/hash"
+
+	// SkipCoreDNSAnnotation annotation explicitly skips reconciling CoreDNS if set
+	SkipCoreDNSAnnotation = "controlplane.cluster.x-k8s.io/skip-coredns"
 )
 
 // KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.

--- a/controlplane/kubeadm/internal/workload_cluster_coredns.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns.go
@@ -68,10 +68,16 @@ type coreDNSInfo struct {
 // UpdateCoreDNS updates the kubeadm configmap, coredns corefile and coredns
 // deployment.
 func (w *Workload) UpdateCoreDNS(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane) error {
+	// Return early if we've been asked to skip CoreDNS upgrades entirely.
+	if _, ok := kcp.Annotations[controlplanev1.SkipCoreDNSAnnotation]; ok {
+		return nil
+	}
+
 	// Return early if the configuration is nil.
 	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
 		return nil
 	}
+
 	clusterConfig := kcp.Spec.KubeadmConfigSpec.ClusterConfiguration
 	// Return early if the type is anything other than empty (default), or CoreDNS.
 	if clusterConfig.DNS.Type != "" && clusterConfig.DNS.Type != kubeadmv1.CoreDNS {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

We're seeing a lot of these log lines in our cluster(s):

```
E0506 19:19:39.493104       1 controller.go:258] controller-runtime/controller "msg"="Reconciler error" "error"="failed to update CoreDNS deployment: failed to validate CoreDNS: toVersion \"1.6.2\" must be greater than fromVersion \"1.6.2\""  "controller"="kubeadmcontrolplane" "request"={"Namespace":"md1a","Name":"md1a-controlplane"}
```

It looks like CoreDNS is being reconciled even though we haven't set up any of the DNS properties to opt in to that behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
