### PR TITLE
:warning: MachineHealthCheck Spec.Selector field cannot be empty

### DIFF
--- a/api/v1alpha3/machinehealthcheck_webhook.go
+++ b/api/v1alpha3/machinehealthcheck_webhook.go
@@ -90,11 +90,19 @@ func (m *MachineHealthCheck) validate(old *MachineHealthCheck) error {
 	var allErrs field.ErrorList
 
 	// Validate selector parses as Selector
-	_, err := metav1.LabelSelectorAsSelector(&m.Spec.Selector)
+	selector, err := metav1.LabelSelectorAsSelector(&m.Spec.Selector)
 	if err != nil {
 		allErrs = append(
 			allErrs,
 			field.Invalid(field.NewPath("spec", "selector"), m.Spec.Selector, err.Error()),
+		)
+	}
+
+	// Validate that the selector isn't empty.
+	if selector != nil && selector.Empty() {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec", "selector"), m.Spec.Selector, "selector must not be empty"),
 		)
 	}
 

--- a/api/v1alpha3/machinehealthcheck_webhook_test.go
+++ b/api/v1alpha3/machinehealthcheck_webhook_test.go
@@ -105,11 +105,21 @@ func TestMachineHealthCheckClusterNameImmutable(t *testing.T) {
 			newMHC := &MachineHealthCheck{
 				Spec: MachineHealthCheckSpec{
 					ClusterName: tt.newClusterName,
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "test",
+						},
+					},
 				},
 			}
 			oldMHC := &MachineHealthCheck{
 				Spec: MachineHealthCheckSpec{
 					ClusterName: tt.oldClusterName,
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "test",
+						},
+					},
 				},
 			}
 
@@ -172,6 +182,11 @@ func TestMachineHealthCheckNodeStartupTimeout(t *testing.T) {
 		mhc := &MachineHealthCheck{
 			Spec: MachineHealthCheckSpec{
 				NodeStartupTimeout: tt.timeout,
+				Selector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"test": "test",
+					},
+				},
 			},
 		}
 
@@ -220,6 +235,11 @@ func TestMachineHealthCheckMaxUnhealthy(t *testing.T) {
 		mhc := &MachineHealthCheck{
 			Spec: MachineHealthCheckSpec{
 				MaxUnhealthy: &maxUnhealthy,
+				Selector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"test": "test",
+					},
+				},
 			},
 		}
 
@@ -231,4 +251,12 @@ func TestMachineHealthCheckMaxUnhealthy(t *testing.T) {
 			g.Expect(mhc.ValidateUpdate(mhc)).To(Succeed())
 		}
 	}
+}
+
+func TestMachineHealthCheckSelectorValidation(t *testing.T) {
+	g := NewWithT(t)
+	mhc := &MachineHealthCheck{}
+	err := mhc.validate(nil)
+	g.Expect(err).ToNot(BeNil())
+	g.Expect(err.Error()).To(ContainSubstring("selector must not be empty"))
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3006
