### PR TITLE
🏃[e2e] increase timeout for HA upgrade test

### DIFF
--- a/test/e2e/config/docker-ci.yaml
+++ b/test/e2e/config/docker-ci.yaml
@@ -75,7 +75,7 @@ variables:
 intervals:
   default/wait-controllers: ["3m", "10s"]
   default/wait-cluster: ["3m", "10s"]
-  default/wait-control-plane: ["5m", "10s"]
+  default/wait-control-plane: ["10m", "10s"]
   default/wait-worker-nodes: ["5m", "10s"]
   default/wait-delete-cluster: ["3m", "10s"]
   default/wait-machine-upgrade: ["20m", "10s"]


### PR DESCRIPTION
**What this PR does / why we need it**:
After observing some failures both in periodic and pre pull jobs when starting an HA control plane, I'm increasing an e2e timeout  

/area testing
/assign @vincepri 
/assign @sedefsavas 