### PR TITLE
🐛 Removes abs path for url providers

### DIFF
--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -154,7 +154,7 @@ func (c *E2EConfig) AbsPaths(basePath string) {
 		provider := &c.Providers[i]
 		for j := range provider.Versions {
 			version := &provider.Versions[j]
-			if version.Value != "" {
+			if version.Type != framework.URLSource && version.Value != "" {
 				if !filepath.IsAbs(version.Value) {
 					version.Value = filepath.Join(basePath, version.Value)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
e2e config can specify providers both local and remote. When providing a remote provider with type set to URL, the e2e config still tries to determine an `absolute` path to the remote URL. This change omits url based providers from  being modified into absolute paths.

/assign @fabriziopandini 

