### PR TITLE
🐛 Init images skip variables

### DIFF
--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -353,7 +353,7 @@ func (f fakeRepositoryClient) Components() repository.ComponentsClient {
 }
 
 func (f fakeRepositoryClient) Templates(version string) repository.TemplateClient {
-	// use a fakeComponentClient (instead of the internal client used in other fake objects) we can de deterministic on what is returned (e.g. avoid interferences from overrides)
+	// use a fakeTemplateClient (instead of the internal client used in other fake objects) we can de deterministic on what is returned (e.g. avoid interferences from overrides)
 	return &fakeTemplateClient{
 		version:               version,
 		fakeRepository:        f.fakeRepository,
@@ -362,7 +362,7 @@ func (f fakeRepositoryClient) Templates(version string) repository.TemplateClien
 }
 
 func (f fakeRepositoryClient) Metadata(version string) repository.MetadataClient {
-	// use a fakeComponentClient (instead of the internal client used in other fake objects) we can de deterministic on what is returned (e.g. avoid interferences from overrides)
+	// use a fakeMetadataClient (instead of the internal client used in other fake objects) we can de deterministic on what is returned (e.g. avoid interferences from overrides)
 	return &fakeMetadataClient{
 		version:        version,
 		fakeRepository: f.fakeRepository,

--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -94,7 +94,7 @@ type GetClusterTemplateOptions struct {
 	// It can be set through the cli flag, WORKER_MACHINE_COUNT environment variable or will default to 0
 	WorkerMachineCount *int64
 
-	// listVariablesOnly sets the GetClusterTemplate method to return the list of variables expected by the template
+	// ListVariablesOnly sets the GetClusterTemplate method to return the list of variables expected by the template
 	// without executing any further processing.
 	ListVariablesOnly bool
 }

--- a/cmd/clusterctl/client/repository/components.go
+++ b/cmd/clusterctl/client/repository/components.go
@@ -179,7 +179,8 @@ type ComponentsOptions struct {
 	Version           string
 	TargetNamespace   string
 	WatchingNamespace string
-	SkipVariables     bool
+	// Allows for skipping variable replacement in the component YAML
+	SkipVariables bool
 }
 
 // NewComponents returns a new objects embedding a component YAML file


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This PR allows commands like `clusterctl init --list-images` to work without having to define variables values in the clusterctl config or environment. However, `clusterctl init` will still require variables to be defined.

I've broken the work up into separate commits which I will squash after review.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2516 
