### PR TITLE
🏃Remove unused TemplateOptions struct

### DIFF
--- a/cmd/clusterctl/client/repository/template_client.go
+++ b/cmd/clusterctl/client/repository/template_client.go
@@ -24,18 +24,6 @@ import (
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
-// TemplateOptions defines a set of well-know variables that all the cluster templates are expected to manage;
-// this set of variables defines a simple, day1 experience that will be made accessible via flags in the clusterctl CLI.
-// Please note that each provider/each template is allowed to add more variables, but additional variables are exposed
-// only via environment variables or the clusterctl configuration file.
-type TemplateOptions struct {
-	ClusterName       string
-	Namespace         string
-	KubernetesVersion string
-	ControlplaneCount int
-	WorkerCount       int
-}
-
 // TemplateClient has methods to work with cluster templates hosted on a provider repository.
 // Templates are yaml files to be used for creating a guest cluster.
 type TemplateClient interface {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This is some cleanup. I noticed we had this struct but it wasn't being used anywhere in the code base. Everything builds and all tests pass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A
