### PR TITLE
 📖 Update Azure spot types to use string instead of float

### DIFF
--- a/docs/proposals/20200330-spot-instances.md
+++ b/docs/proposals/20200330-spot-instances.md
@@ -214,7 +214,8 @@ when the instance is created:
   (Delete is supported for VMs as part of VMSS only).
 
 - BillingProfile (default: -1) : This is a struct containing a single field, `MaxPrice`.
-  This is a float representation of the maximum price the user wishes to pay for their VM.
+  This is a string representation of the maximum price the user wishes to pay for their VM.
+  Uses a string representation because [floats are disallowed](https://github.com/kubernetes-sigs/controller-tools/issues/245#issuecomment-518465214) in Kubernetes APIs.
   This defaults to -1 which makes the maximum price the On-Demand price for the instance type.
   This also means the instance will never be evicted for price reasons as Azure caps Spot Market prices at the On-Demand price.
   (Note instances may still be evicted based on resource pressure within a region).
@@ -224,7 +225,7 @@ Similar to AWS, we can make an optional struct for SpotVMOptions, which, if pres
 
 ```
 type SpotVMOptions struct {
-  MaxPrice *float64 `json:”maxPrice,omitempty”`
+  MaxPrice *string `json:”maxPrice,omitempty”`
 }
 
 type AzureMachineSpec struct {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Update the Spot instances proposal to clarify that the Azure types should use string instead of float as originally noted.
It was noticed during implementation (https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/559/files#r424579944) that floats are not allowed by the controller-tools crd generator tool

Ref: https://github.com/kubernetes-sigs/controller-tools/issues/245

The alternative to this is to use a `resource.Quantity` which is allowed, but I'm not sure if that adds much benefit over using a string

CC @CecileRobertMichon 
