### PR TITLE
🏃 e2e: replace fmt.Println with writes to ginko's writer

### DIFF
--- a/test/e2e/internal/log/log.go
+++ b/test/e2e/internal/log/log.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+)
+
+func Logf(format string, a ...interface{}) {
+	fmt.Fprintf(GinkgoWriter, "INFO: "+format+"\n", a...)
+}

--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/test/e2e/internal/log"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
@@ -138,7 +139,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 			Namespace:            namespace.Name,
 		})
 
-		fmt.Fprintf(GinkgoWriter, "Waiting for the cluster infrastructure to be provisioned\n")
+		log.Logf("Waiting for the cluster infrastructure to be provisioned")
 		selfHostedCluster = framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
 			Getter:    selfHostedClusterProxy.GetClient(),
 			Namespace: selfHostedNamespace.Name,
@@ -175,7 +176,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 				Namespace:            selfHostedNamespace.Name,
 			})
 
-			fmt.Fprintf(GinkgoWriter, "Waiting for the cluster infrastructure to be provisioned\n")
+			log.Logf("Waiting for the cluster infrastructure to be provisioned")
 			cluster = framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
 				Getter:    input.BootstrapClusterProxy.GetClient(),
 				Namespace: namespace.Name,

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -18,13 +18,12 @@ package bootstrap
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	kindv1 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	kind "sigs.k8s.io/kind/pkg/cluster"
 )
@@ -130,9 +129,9 @@ func (k *kindClusterProvider) Dispose(ctx context.Context) {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for Dispose")
 
 	if err := kind.NewProvider().Delete(k.name, k.kubeconfigPath); err != nil {
-		fmt.Fprintf(GinkgoWriter, "Deleting the kind cluster %q failed. You may need to remove this by hand.\n", k.name)
+		log.Logf("Deleting the kind cluster %q failed. You may need to remove this by hand.", k.name)
 	}
 	if err := os.Remove(k.kubeconfigPath); err != nil {
-		fmt.Fprintf(GinkgoWriter, "Deleting the kubeconfig file %q file. You may need to remove this by hand.\n", k.kubeconfigPath)
+		log.Logf("Deleting the kubeconfig file %q file. You may need to remove this by hand.", k.kubeconfigPath)
 	}
 }

--- a/test/framework/bootstrap/kind_util.go
+++ b/test/framework/bootstrap/kind_util.go
@@ -18,17 +18,16 @@ package bootstrap
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/exec"
+	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	kind "sigs.k8s.io/kind/pkg/cluster"
 	kindnodes "sigs.k8s.io/kind/pkg/cluster/nodes"
 	kindnodesutils "sigs.k8s.io/kind/pkg/cluster/nodeutils"
@@ -51,7 +50,7 @@ func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKi
 	Expect(ctx).NotTo(BeNil(), "ctx is required for CreateKindBootstrapClusterAndLoadImages")
 	Expect(input.Name).ToNot(BeEmpty(), "Invalid argument. Name can't be empty when calling CreateKindBootstrapClusterAndLoadImages")
 
-	fmt.Fprintf(GinkgoWriter, "Creating a kind cluster with name %q\n", input.Name)
+	log.Logf("Creating a kind cluster with name %q", input.Name)
 
 	options := []KindClusterOption{}
 	if input.RequiresDockerSock {
@@ -86,14 +85,14 @@ func LoadImagesToKindCluster(ctx context.Context, input LoadImagesToKindClusterI
 	Expect(input.Name).ToNot(BeEmpty(), "Invalid argument. Name can't be empty when calling LoadImagesToKindCluster")
 
 	for _, image := range input.Images {
-		fmt.Fprintf(GinkgoWriter, "Loading image: %q\n", image.Name)
+		log.Logf("Loading image: %q", image.Name)
 		err := loadImage(ctx, input.Name, image.Name)
 		switch image.LoadBehavior {
 		case framework.MustLoadImage:
 			Expect(err).ToNot(HaveOccurred(), "Failed to load image %q into the kind cluster %q", image.Name, input.Name)
 		case framework.TryLoadImage:
 			if err != nil {
-				fmt.Fprintf(GinkgoWriter, "[WARNING] Unable to load image %q into the kind cluster %q: %v \n", image.Name, input.Name, err)
+				log.Logf("[WARNING] Unable to load image %q into the kind cluster %q: %v", image.Name, input.Name, err)
 			}
 		}
 	}

--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -25,7 +25,6 @@ import (
 	goruntime "runtime"
 	"strings"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/framework/exec"
+	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -246,7 +246,7 @@ func (p *clusterProxy) Dispose(ctx context.Context) {
 
 	if p.shouldCleanupKubeconfig {
 		if err := os.Remove(p.kubeconfigPath); err != nil {
-			fmt.Fprintf(GinkgoWriter, "Deleting the kubeconfig file %q file. You may need to remove this by hand.\n", p.kubeconfigPath)
+			log.Logf("Deleting the kubeconfig file %q file. You may need to remove this by hand.", p.kubeconfigPath)
 		}
 	}
 }

--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -28,6 +28,7 @@ import (
 	clusterctlclient "sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 	clusterctllog "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl/logger"
+	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 )
 
 // Provide E2E friendly wrappers for the clusterctl client library.
@@ -55,7 +56,7 @@ type InitInput struct {
 
 // Init calls clusterctl init with the list of providers defined in the local repository
 func Init(ctx context.Context, input InitInput) {
-	fmt.Fprintf(GinkgoWriter, "clusterctl init --core %s --bootstrap %s --control-plane %s --infrastructure %s\n",
+	log.Logf("clusterctl init --core %s --bootstrap %s --control-plane %s --infrastructure %s",
 		input.CoreProvider,
 		strings.Join(input.BootstrapProviders, ", "),
 		strings.Join(input.ControlPlaneProviders, ", "),
@@ -97,7 +98,7 @@ type ConfigClusterInput struct {
 
 // ConfigCluster gets a workload cluster based on a template.
 func ConfigCluster(ctx context.Context, input ConfigClusterInput) []byte {
-	fmt.Fprintf(GinkgoWriter, "clusterctl config cluster %s --infrastructure %s --kubernetes-version %s --control-plane-machine-count %d --worker-machine-count %d --flavor %s\n",
+	log.Logf("clusterctl config cluster %s --infrastructure %s --kubernetes-version %s --control-plane-machine-count %d --worker-machine-count %d --flavor %s",
 		input.ClusterName,
 		valueOrDefault(input.InfrastructureProvider),
 		input.KubernetesVersion,

--- a/test/framework/internal/log/log.go
+++ b/test/framework/internal/log/log.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+)
+
+func Logf(format string, a ...interface{}) {
+	fmt.Fprintf(GinkgoWriter, "INFO: "+format+"\n", a...)
+}

--- a/test/framework/machine_helpers.go
+++ b/test/framework/machine_helpers.go
@@ -18,8 +18,6 @@ package framework
 
 import (
 	"context"
-	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -28,7 +26,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetMachinesByMachineDeploymentsInput is the input for GetMachinesByMachineDeployments.
@@ -65,7 +65,7 @@ type GetMachinesByMachineHealthCheckInput struct {
 	MachineHealthCheck *clusterv1.MachineHealthCheck
 }
 
-// GetMachinesByMachineHealthCheckInput returns Machine objects for a cluster that match with MachineHealthCheck selector.
+// GetMachinesByMachineHealthCheck returns Machine objects for a cluster that match with MachineHealthCheck selector.
 func GetMachinesByMachineHealthCheck(ctx context.Context, input GetMachinesByMachineHealthCheckInput) []clusterv1.Machine {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for GetMachinesByMachineDeployments")
 	Expect(input.Lister).ToNot(BeNil(), "Invalid argument. input.Lister can't be nil when calling GetMachinesByMachineHealthCheck")
@@ -121,7 +121,7 @@ func WaitForControlPlaneMachinesToBeUpgraded(ctx context.Context, input WaitForC
 	Expect(input.MachineCount).To(BeNumerically(">", 0), "Invalid argument. input.MachineCount can't be smaller than 1 when calling WaitForControlPlaneMachinesToBeUpgraded")
 
 	By("ensuring all machines have upgraded kubernetes version")
-	fmt.Fprintf(GinkgoWriter, "Ensuring all MachineDeployment Machines have upgraded kubernetes version %s\n", input.KubernetesUpgradeVersion)
+	log.Logf("Ensuring all MachineDeployment Machines have upgraded kubernetes version %s", input.KubernetesUpgradeVersion)
 
 	Eventually(func() (int, error) {
 		machines := GetControlPlaneMachinesByCluster(ctx, GetControlPlaneMachinesByClusterInput{
@@ -161,7 +161,7 @@ func WaitForMachineDeploymentMachinesToBeUpgraded(ctx context.Context, input Wai
 	Expect(input.MachineDeployment).ToNot(BeNil(), "Invalid argument. input.MachineDeployment can't be nil when calling WaitForMachineDeploymentMachinesToBeUpgraded")
 	Expect(input.MachineCount).To(BeNumerically(">", 0), "Invalid argument. input.MachineCount can't be smaller than 1 when calling WaitForMachineDeploymentMachinesToBeUpgraded")
 
-	fmt.Fprintf(GinkgoWriter, "Ensuring all MachineDeployment Machines have upgraded kubernetes version %s\n", input.KubernetesUpgradeVersion)
+	log.Logf("Ensuring all MachineDeployment Machines have upgraded kubernetes version %s", input.KubernetesUpgradeVersion)
 	Eventually(func() (int, error) {
 		machines := GetMachinesByMachineDeployments(ctx, GetMachinesByMachineDeploymentsInput{
 			Lister:            input.Lister,
@@ -199,7 +199,7 @@ func PatchNodeCondition(ctx context.Context, input PatchNodeConditionInput) {
 	Expect(input.NodeCondition).ToNot(BeNil(), "Invalid argument. input.NodeCondition can't be nil when calling PatchNodeConditions")
 	Expect(input.Machine).ToNot(BeNil(), "Invalid argument. input.Machine can't be nil when calling PatchNodeConditions")
 
-	fmt.Fprintf(GinkgoWriter, "Patching the node condition to the node\n")
+	log.Logf("Patching the node condition to the node")
 	Expect(input.Machine.Status.NodeRef).ToNot(BeNil())
 	node := &corev1.Node{}
 	Expect(input.ClusterProxy.GetWorkloadCluster(ctx, input.Cluster.Namespace, input.Cluster.Name).GetClient().Get(ctx, types.NamespacedName{Name: input.Machine.Status.NodeRef.Name, Namespace: input.Machine.Status.NodeRef.Namespace}, node)).To(Succeed())

--- a/test/framework/namespace_helpers.go
+++ b/test/framework/namespace_helpers.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -57,7 +58,7 @@ func CreateNamespace(ctx context.Context, input CreateNamespaceInput, intervals 
 			Name: input.Name,
 		},
 	}
-	fmt.Fprintf(GinkgoWriter, "Creating namespace %s\n", input.Name)
+	log.Logf("Creating namespace %s", input.Name)
 	Eventually(func() error {
 		return input.Creator.Create(context.TODO(), ns)
 	}, intervals...).Should(Succeed())
@@ -98,7 +99,7 @@ func DeleteNamespace(ctx context.Context, input DeleteNamespaceInput, intervals 
 			Name: input.Name,
 		},
 	}
-	fmt.Fprintf(GinkgoWriter, "Deleting namespace %s\n", input.Name)
+	log.Logf("Deleting namespace %s", input.Name)
 	Eventually(func() error {
 		return input.Deleter.Delete(context.TODO(), ns)
 	}, intervals...).Should(Succeed())
@@ -181,7 +182,7 @@ func CreateNamespaceAndWatchEvents(ctx context.Context, input CreateNamespaceAnd
 	namespace := CreateNamespace(ctx, CreateNamespaceInput{Creator: input.Creator, Name: input.Name}, "40s", "10s")
 	Expect(namespace).ToNot(BeNil(), "Failed to create namespace %q", input.Name)
 
-	fmt.Fprintf(GinkgoWriter, "Creating event watcher for namespace %q\n", input.Name)
+	log.Logf("Creating event watcher for namespace %q", input.Name)
 	watchesCtx, cancelWatches := context.WithCancel(ctx)
 	go func() {
 		defer GinkgoRecover()

--- a/test/framework/pod_helpers.go
+++ b/test/framework/pod_helpers.go
@@ -18,7 +18,6 @@ package framework
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -52,8 +52,7 @@ func WaitForPodListCondition(ctx context.Context, input WaitForPodListConditionI
 		// all pods in the list should satisfy the condition
 		err := input.Condition(podList)
 		if err != nil {
-			// DEBUG:
-			fmt.Println(err.Error())
+			log.Logf("Failed to get the conditions for the pod list: %+v", err)
 			return false, err
 		}
 		return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
replace fmt.Println with writes to ginko's writer

Let me know if this is what you want :)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
 - Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/2514

/cc @chuckha 
