### PR TITLE
🐛[clusterctl] accept cluster names with dots

### DIFF
--- a/cmd/clusterctl/client/common.go
+++ b/cmd/clusterctl/client/common.go
@@ -92,3 +92,11 @@ func validateDNS1123Label(label string) error {
 	}
 	return nil
 }
+
+func validateDNS1123Domanin(subdomain string) error {
+	errs := validation.IsDNS1123Subdomain(subdomain)
+	if len(errs) != 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -299,7 +299,7 @@ func (c *clusterctlClient) templateOptionsToVariables(options GetClusterTemplate
 	c.configClient.Variables().Set("NAMESPACE", options.TargetNamespace)
 
 	// the ClusterName, if valid, can be used in templates using the ${ CLUSTER_NAME } variable.
-	if err := validateDNS1123Label(options.ClusterName); err != nil {
+	if err := validateDNS1123Domanin(options.ClusterName); err != nil {
 		return errors.Wrapf(err, "invalid cluster name")
 	}
 	c.configClient.Variables().Set("CLUSTER_NAME", options.ClusterName)

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -290,6 +290,16 @@ func Test_clusterctlClient_templateOptionsToVariables(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "tolerates subdomains as cluster Name",
+			args: args{
+				options: GetClusterTemplateOptions{
+					ClusterName:     "foo.bar",
+					TargetNamespace: "baz",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "fails for invalid namespace Name",
 			args: args{
 				options: GetClusterTemplateOptions{


### PR DESCRIPTION
**What this PR does / why we need it**:
The cluster-name parameter is used for object names and labels, so it should accept valid DNS1123 subdomains values including the dot character

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3049