### PR TITLE
✨ Allowing mutability for the PreKubeadmCommands, PostKubeadmCommands and Files

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
@@ -74,6 +74,9 @@ const (
 	spec                 = "spec"
 	kubeadmConfigSpec    = "kubeadmConfigSpec"
 	clusterConfiguration = "clusterConfiguration"
+	preKubeadmCommands   = "preKubeadmCommands"
+	postKubeadmCommands  = "postKubeadmCommands"
+	files                = "files"
 )
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -87,6 +90,9 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageRepository"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageTag"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "imageRepository"},
+		{spec, kubeadmConfigSpec, preKubeadmCommands},
+		{spec, kubeadmConfigSpec, postKubeadmCommands},
+		{spec, kubeadmConfigSpec, files},
 		{spec, "infrastructureTemplate", "name"},
 		{spec, "replicas"},
 		{spec, "version"},

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
@@ -188,6 +188,17 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 						Name: "test",
 					},
 				},
+				PreKubeadmCommands: []string{
+					"test", "foo",
+				},
+				PostKubeadmCommands: []string{
+					"test", "foo",
+				},
+				Files: []bootstrapv1.File{
+					{
+						Path: "test",
+					},
+				},
 			},
 			Version: "v1.16.6",
 		},
@@ -204,6 +215,16 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 
 	validUpdate := before.DeepCopy()
 	validUpdate.Labels = map[string]string{"blue": "green"}
+	validUpdate.Spec.KubeadmConfigSpec.PreKubeadmCommands = []string{"ab", "abc"}
+	validUpdate.Spec.KubeadmConfigSpec.PostKubeadmCommands = []string{"ab", "abc"}
+	validUpdate.Spec.KubeadmConfigSpec.Files = []bootstrapv1.File{
+		{
+			Path: "ab",
+		},
+		{
+			Path: "abc",
+		},
+	}
 	validUpdate.Spec.Version = "v1.16.6"
 	validUpdate.Spec.InfrastructureTemplate.Name = "orange"
 	validUpdate.Spec.Replicas = pointer.Int32Ptr(5)


### PR DESCRIPTION
What this PR does / why we need it:
Allows to modify preKubeadmCommands, postKubeadmCommands and files in KCP

Which issue(s) this PR fixes:
Fixes #3014