### PR TITLE
🏃 Cleanup some internal MachineSet bits

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -545,4 +546,14 @@ func ClusterToObjectsMapper(c client.Client, ro runtime.Object, scheme *runtime.
 		return results
 
 	}), nil
+}
+
+// ObjectReferenceToUnstructured converts an object reference to an unstructured object.
+func ObjectReferenceToUnstructured(in corev1.ObjectReference) *unstructured.Unstructured {
+	out := &unstructured.Unstructured{}
+	out.SetKind(in.Kind)
+	out.SetAPIVersion(in.APIVersion)
+	out.SetNamespace(in.Namespace)
+	out.SetName(in.Name)
+	return out
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Just a minor cleanup to the MachineSet internal code.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2989 

/assign @detiber 
/milestone v0.3.7