### PR TITLE
📖 Remove extra mention of clusterawsadm in context where it is not needed

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -301,8 +301,6 @@ before configuring a cluster with Cluster API.
 {{#tabs name:"tab-configuration-infrastructure" tabs:"AWS,Azure,Docker,GCP,vSphere,OpenStack,Metal3"}}
 {{#tab AWS}}
 
-Download the latest binary of `clusterawsadm` from the [AWS provider releases] and make sure to place it in your path.
-
 ```bash
 export AWS_REGION=us-east-1
 export AWS_SSH_KEY_NAME=default


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes the second mention of needing to install `clusterawsadm` for a step where `clusterawsadm` is not relevant.

It's likely just a copy and paste artifact from the earlier step, when `clusterawsadm` is required for generating the CloudFormation IAM assets.
