### PR TITLE
📖 Update references to proper CAPBK location

### DIFF
--- a/docs/book/src/developer/architecture/controllers/bootstrap.md
+++ b/docs/book/src/developer/architecture/controllers/bootstrap.md
@@ -5,7 +5,7 @@ Bootstrapping is the process in which:
 1. A cluster is bootstrapped
 1. A machine is bootstrapped and takes on a role within a cluster
 
-[CAPBK](https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm) is the reference bootstrap provider and is based on `kubeadm`. CAPBK codifies the steps for [creating a cluster](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/) in multiple configurations.
+[CAPBK](https://github.com/kubernetes-sigs/cluster-api/tree/master/bootstrap/kubeadm) is the reference bootstrap provider and is based on `kubeadm`. CAPBK codifies the steps for [creating a cluster](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/) in multiple configurations.
 
 ![](../../../images/bootstrap-controller.png)
 
@@ -13,4 +13,4 @@ See [proposal](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/p
 
 ### Implementations
 
-* [Kubeadm](https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm) (Reference Implementation)
+* [Kubeadm](https://github.com/kubernetes-sigs/cluster-api/tree/master/bootstrap/kubeadm) (Reference Implementation)

--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -6,7 +6,7 @@ are also sponsored by SIG Cluster Lifecycle. Providers marked in bold are known 
 support v1alpha3 API types.
 
 ## Bootstrap
-- [**Kubeadm**](https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm)
+- [**Kubeadm**](https://github.com/kubernetes-sigs/cluster-api/tree/master/bootstrap/kubeadm)
 - [**Talos**](https://github.com/talos-systems/cluster-api-bootstrap-provider-talos)
 
 

--- a/test/infrastructure/docker/README.md
+++ b/test/infrastructure/docker/README.md
@@ -4,7 +4,7 @@ CAPD is a reference implementation of an infrastructure provider for the Cluster
 
 This is one out of three components needed to run a Cluster API management cluster.
 
-For a complete overview, please refer to the documentation available [here](https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm#cluster-api-bootstrap-provider-kubeadm) which uses CAPD as an example infrastructure provider.
+For a complete overview, please refer to the documentation available [here](https://github.com/kubernetes-sigs/cluster-api/tree/master/bootstrap/kubeadm#cluster-api-bootstrap-provider-kubeadm) which uses CAPD as an example infrastructure provider.
 
 ## CAPD Goals
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes all instances of https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm
to the new location, https://github.com/kubernetes-sigs/cluster-api/tree/master/bootstrap/kubeadm in
the documentation.

This corresponds to the deprecation described in https://github.com/kubernetes-sigs/cluster-api/pull/1634

