### PR TITLE
✨ add condition merge utils

### DIFF
--- a/util/conditions/merge.go
+++ b/util/conditions/merge.go
@@ -72,9 +72,7 @@ func merge(conditions []localizedCondition, targetCondition clusterv1.ConditionT
 func getConditionGroups(conditions []localizedCondition) conditionGroups {
 	groups := conditionGroups{}
 
-	for i := range conditions {
-		condition := conditions[i]
-
+	for _, condition := range conditions {
 		if condition.Condition == nil {
 			continue
 		}

--- a/util/conditions/merge.go
+++ b/util/conditions/merge.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+// localizedCondition defines a condition with the information of the object the conditions
+// was originated from.
+type localizedCondition struct {
+	*clusterv1.Condition
+	Getter
+}
+
+// merge a list of condition into a single one.
+// This operation is designed to ensure visibility of the most relevant conditions for defining the
+// operational state of a component. E.g. If there is one error in the condition list, this one takes
+// priority over the other conditions and it is should be reflected in the target condition.
+//
+// More specifically:
+// 1. Conditions are grouped by status, severity
+// 2. The resulting condition groups are sorted according to the following priority:
+//   - P0 - Status=False, Severity=Error
+//   - P1 - Status=False, Severity=Warning
+//   - P2 - Status=False, Severity=Info
+//   - P3 - Status=True
+//   - P4 - Status=Unknown
+// 3. The group with highest priority is used to determine status, severity and other info of the target condition.
+//
+// Please note that the last operation includes also the task of computing the Reason and the Message for the target
+// condition; in order to complete such task some trade-off should be made, because there is no a golden rule
+// for summarizing many Reason/Message into single Reason/Message.
+// mergeOptions allows the user to adapt this process to the specific needs by exposing a set of merge strategies.
+func merge(conditions []localizedCondition, targetCondition clusterv1.ConditionType, options *mergeOptions) *clusterv1.Condition {
+	g := getConditionGroups(conditions)
+	if len(g) == 0 {
+		return nil
+	}
+
+	if g.TopGroup().status == corev1.ConditionTrue {
+		return TrueCondition(targetCondition)
+	}
+
+	targetReason := getReason(g, options)
+	targetMessage := getMessage(g, options)
+	if g.TopGroup().status == corev1.ConditionFalse {
+		return FalseCondition(targetCondition, targetReason, g.TopGroup().severity, targetMessage)
+	}
+	return UnknownCondition(targetCondition, targetReason, targetMessage)
+}
+
+// getConditionGroups groups a list of conditions according to status, severity values.
+// Additionally, the resulting groups are sorted by mergePriority.
+func getConditionGroups(conditions []localizedCondition) conditionGroups {
+	groups := conditionGroups{}
+
+	for i := range conditions {
+		condition := conditions[i]
+
+		if condition.Condition == nil {
+			continue
+		}
+
+		added := false
+		for i := range groups {
+			if groups[i].status == condition.Status && groups[i].severity == condition.Severity {
+				groups[i].conditions = append(groups[i].conditions, condition)
+				added = true
+				break
+			}
+		}
+		if !added {
+			groups = append(groups, conditionGroup{
+				conditions: []localizedCondition{condition},
+				status:     condition.Status,
+				severity:   condition.Severity,
+			})
+		}
+	}
+
+	// sort groups by priority
+	sort.Sort(groups)
+
+	// sorts conditions in the TopGroup so we ensure predictable result for merge strategies.
+	// condition are sorted using the same lexicographic order used by Set; in case two conditions
+	// have the same type, condition are sorted using according to the alphabetical order of the source object name.
+	if len(groups) > 0 {
+		sort.Slice(groups[0].conditions, func(i, j int) bool {
+			a := groups[0].conditions[i]
+			b := groups[0].conditions[j]
+			if a.Type != b.Type {
+				return lexicographicLess(a.Condition, b.Condition)
+			}
+			return a.GetName() < b.GetName()
+		})
+	}
+
+	return groups
+}
+
+// conditionGroups provides supports for grouping a list of conditions to be
+// merged into a single condition. ConditionGroups can be sorted by mergePriority.
+type conditionGroups []conditionGroup
+
+func (g conditionGroups) Len() int {
+	return len(g)
+}
+
+func (g conditionGroups) Less(i, j int) bool {
+	return g[i].mergePriority() < g[j].mergePriority()
+}
+
+func (g conditionGroups) Swap(i, j int) {
+	g[i], g[j] = g[j], g[i]
+}
+
+// TopGroup returns the the condition group with the highest mergePriority.
+func (g conditionGroups) TopGroup() *conditionGroup {
+	if len(g) == 0 {
+		return nil
+	}
+	return &g[0]
+}
+
+// TrueGroup returns the the condition group with status True, if any.
+func (g conditionGroups) TrueGroup() *conditionGroup {
+	return g.getByStatusAndSeverity(corev1.ConditionTrue, clusterv1.ConditionSeverityNone)
+}
+
+// ErrorGroup returns the the condition group with status False and severity Error, if any.
+func (g conditionGroups) ErrorGroup() *conditionGroup {
+	return g.getByStatusAndSeverity(corev1.ConditionFalse, clusterv1.ConditionSeverityError)
+}
+
+// WarningGroup returns the the condition group with status False and severity Warning, if any.
+func (g conditionGroups) WarningGroup() *conditionGroup {
+	return g.getByStatusAndSeverity(corev1.ConditionFalse, clusterv1.ConditionSeverityWarning)
+}
+
+func (g conditionGroups) getByStatusAndSeverity(status corev1.ConditionStatus, severity clusterv1.ConditionSeverity) *conditionGroup {
+	if len(g) == 0 {
+		return nil
+	}
+	for _, group := range g {
+		if group.status == status && group.severity == severity {
+			return &group
+		}
+	}
+	return nil
+}
+
+// conditionGroup define a group of conditions with the same status and severity,
+// and thus with the same priority when merging into a Ready condition.
+type conditionGroup struct {
+	status     corev1.ConditionStatus
+	severity   clusterv1.ConditionSeverity
+	conditions []localizedCondition
+}
+
+// mergePriority provides a priority value for the status and severity tuple that identifies this
+// condition group. The mergePriority value allows an easier sorting of conditions groups.
+func (g conditionGroup) mergePriority() int {
+	switch g.status {
+	case corev1.ConditionFalse:
+		switch g.severity {
+		case clusterv1.ConditionSeverityError:
+			return 0
+		case clusterv1.ConditionSeverityWarning:
+			return 1
+		case clusterv1.ConditionSeverityInfo:
+			return 2
+		}
+	case corev1.ConditionTrue:
+		return 3
+	case corev1.ConditionUnknown:
+		return 4
+	}
+
+	// this should never happen
+	return 99
+}

--- a/util/conditions/merge_strategies.go
+++ b/util/conditions/merge_strategies.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"fmt"
+	"strings"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+// mergeOptions allows to set strategies for merging a set of conditions into a single condition,
+// and more specifically for computing the target Reason and the target Message.
+type mergeOptions struct {
+	conditionOrder []clusterv1.ConditionType
+	addSourceRef   bool
+	stepCounter    int
+}
+
+// MergeOption defines an option for computing a summary of conditions.
+type MergeOption func(*mergeOptions)
+
+// WithConditionOrder instructs merge about the condition order to be used when
+// merging conditions Reason and Message into the Target Condition.
+// The remaining conditions (not included in this list) will be sorted by type, and in case of
+// two conditions with the same type, by the source object name.
+func WithConditionOrder(t ...clusterv1.ConditionType) MergeOption {
+	return func(c *mergeOptions) {
+		c.conditionOrder = t
+	}
+}
+
+// WithStepCounter instructs merge to add a "x of y completed" string to the message,
+// where x is the number of conditions with Status=true and y is the number passed to this method.
+func WithStepCounter(to int) MergeOption {
+	return func(c *mergeOptions) {
+		c.stepCounter = to
+	}
+}
+
+// AddSourceRef instructs merge to add info about the originating object to the target Reason.
+func AddSourceRef() MergeOption {
+	return func(c *mergeOptions) {
+		c.addSourceRef = true
+	}
+}
+
+// getReason returns the reason to be applied to the condition resulting by merging a set of condition groups.
+// The reason is computed according to the given mergeOptions.
+func getReason(groups conditionGroups, options *mergeOptions) string {
+	return getFirstReason(groups, options.conditionOrder, options.addSourceRef)
+}
+
+// getFirstReason returns the first reason from the ordered list of conditions in the top group.
+// If required, the reason gets
+func getFirstReason(g conditionGroups, order []clusterv1.ConditionType, addSourceRef bool) string {
+	if condition := getFirstCondition(g, order); condition != nil {
+		reason := condition.Reason
+		if addSourceRef {
+			return localizeReason(reason, condition.Getter)
+		}
+		return reason
+	}
+	return ""
+}
+
+// localizeReason adds info about the originating object to the target Reason.
+func localizeReason(reason string, from Getter) string {
+	if strings.Contains(reason, "@") {
+		return reason
+	}
+	return fmt.Sprintf("%s@%s/%s", reason, from.GetObjectKind().GroupVersionKind().Kind, from.GetName())
+}
+
+// getMessage returns the message to be applied to the condition resulting by merging a set of condition groups.
+// The message is computed according to the given mergeOptions, but in case of errors or warning a
+// summary of existing errors is automatically added.
+func getMessage(groups conditionGroups, options *mergeOptions) string {
+	errorAndWarningSummary := getErrorAndWarningSummary(groups)
+	if options.stepCounter > 0 {
+		counter := getStepCounterMessage(groups, options.stepCounter)
+		if errorAndWarningSummary != "" {
+			return fmt.Sprintf("%s, %s", counter, errorAndWarningSummary)
+		}
+		return counter
+
+	}
+
+	firstMessage := getFirstMessage(groups, options.conditionOrder)
+	if errorAndWarningSummary != "" {
+		return fmt.Sprintf("%s (%s)", firstMessage, errorAndWarningSummary)
+	}
+	return firstMessage
+}
+
+func getErrorAndWarningSummary(groups conditionGroups) string {
+	msgs := []string{}
+	if errorGroup := groups.ErrorGroup(); errorGroup != nil {
+		switch l := len(errorGroup.conditions); l {
+		case 1:
+			msgs = append(msgs, "1 error")
+		default:
+			msgs = append(msgs, fmt.Sprintf("%d errors", len(errorGroup.conditions)))
+		}
+	}
+	if warningGroup := groups.WarningGroup(); warningGroup != nil {
+		switch l := len(warningGroup.conditions); l {
+		case 1:
+			msgs = append(msgs, "1 warning")
+		default:
+			msgs = append(msgs, fmt.Sprintf("%d warnings", len(warningGroup.conditions)))
+		}
+	}
+	if len(msgs) > 0 {
+		return strings.Join(msgs, ", ")
+	}
+	return ""
+}
+
+// getStepCounterMessage returns a message "x of y completed", where x is the number of conditions
+// with Status=true and y is the number passed to this method.
+func getStepCounterMessage(groups conditionGroups, to int) string {
+	ct := 0
+	if trueGroup := groups.TrueGroup(); trueGroup != nil {
+		ct = len(trueGroup.conditions)
+	}
+	return fmt.Sprintf("%d of %d completed", ct, to)
+}
+
+// getFirstMessage returns the message from the ordered list of conditions in the top group.
+func getFirstMessage(groups conditionGroups, order []clusterv1.ConditionType) string {
+	if condition := getFirstCondition(groups, order); condition != nil {
+		return condition.Message
+	}
+	return ""
+}
+
+// getFirstCondition returns a first condition from the ordered list of conditions in the top group.
+func getFirstCondition(g conditionGroups, priority []clusterv1.ConditionType) *localizedCondition {
+	topGroup := g.TopGroup()
+	if topGroup == nil {
+		return nil
+	}
+
+	switch len(topGroup.conditions) {
+	case 0:
+		return nil
+	case 1:
+		return &topGroup.conditions[0]
+	default:
+		for _, p := range priority {
+			for _, c := range topGroup.conditions {
+				if c.Type == p {
+					return &c
+				}
+			}
+		}
+		return &topGroup.conditions[0]
+	}
+}

--- a/util/conditions/merge_strategies.go
+++ b/util/conditions/merge_strategies.go
@@ -66,7 +66,7 @@ func getReason(groups conditionGroups, options *mergeOptions) string {
 }
 
 // getFirstReason returns the first reason from the ordered list of conditions in the top group.
-// If required, the reason gets
+// If required, the reason gets localized with the source object reference.
 func getFirstReason(g conditionGroups, order []clusterv1.ConditionType, addSourceRef bool) string {
 	if condition := getFirstCondition(g, order); condition != nil {
 		reason := condition.Reason

--- a/util/conditions/merge_strategies_test.go
+++ b/util/conditions/merge_strategies_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+func TestGetStepCounterMessage(t *testing.T) {
+	g := NewWithT(t)
+
+	groups := getConditionGroups(conditionsWithSource(&clusterv1.Cluster{},
+		nil1,
+		true1, true1,
+		falseInfo1,
+		falseWarning1, falseWarning1,
+		falseError1,
+		unknown1,
+	))
+
+	got := getStepCounterMessage(groups, 8)
+
+	// step count message should report n° if true conditions over to number
+	g.Expect(got).To(Equal("2 of 8 completed"))
+}
+
+func TestLocalizeReason(t *testing.T) {
+	g := NewWithT(t)
+
+	getter := &clusterv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Cluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cluster",
+		},
+	}
+
+	// localize should reason location
+	got := localizeReason("foo", getter)
+	g.Expect(got).To(Equal("foo@Cluster/test-cluster"))
+
+	// localize should not alter existing location
+	got = localizeReason("foo@SomeKind/some-name", getter)
+	g.Expect(got).To(Equal("foo@SomeKind/some-name"))
+}
+
+func TestGetFirstReasonAndMessage(t *testing.T) {
+	g := NewWithT(t)
+
+	foo := FalseCondition("foo", "falseFoo", clusterv1.ConditionSeverityInfo, "message falseFoo")
+	bar := FalseCondition("bar", "falseBar", clusterv1.ConditionSeverityInfo, "message falseBar")
+
+	getter := &clusterv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Cluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cluster",
+		},
+	}
+
+	groups := getConditionGroups(conditionsWithSource(getter, foo, bar))
+
+	// getFirst should report first condition in lexicografical order if no order is specified
+	gotReason := getFirstReason(groups, nil, false)
+	g.Expect(gotReason).To(Equal("falseBar"))
+	gotMessage := getFirstMessage(groups, nil)
+	g.Expect(gotMessage).To(Equal("message falseBar"))
+
+	// getFirst should report should respect order
+	gotReason = getFirstReason(groups, []clusterv1.ConditionType{"foo", "bar"}, false)
+	g.Expect(gotReason).To(Equal("falseFoo"))
+	gotMessage = getFirstMessage(groups, []clusterv1.ConditionType{"foo", "bar"})
+	g.Expect(gotMessage).To(Equal("message falseFoo"))
+
+	// getFirst should report should respect order in case of missing conditions
+	gotReason = getFirstReason(groups, []clusterv1.ConditionType{"missingBaz", "foo", "bar"}, false)
+	g.Expect(gotReason).To(Equal("falseFoo"))
+	gotMessage = getFirstMessage(groups, []clusterv1.ConditionType{"missingBaz", "foo", "bar"})
+	g.Expect(gotMessage).To(Equal("message falseFoo"))
+
+	// getFirst should fallback to first condition if none of the conditions in the list exists
+	gotReason = getFirstReason(groups, []clusterv1.ConditionType{"missingBaz"}, false)
+	g.Expect(gotReason).To(Equal("falseBar"))
+	gotMessage = getFirstMessage(groups, []clusterv1.ConditionType{"missingBaz"})
+	g.Expect(gotMessage).To(Equal("message falseBar"))
+
+	// getFirstReason should localize reason if required
+	gotReason = getFirstReason(groups, nil, true)
+	g.Expect(gotReason).To(Equal("falseBar@Cluster/test-cluster"))
+}
+
+func TestHighLights(t *testing.T) {
+	tests := []struct {
+		name   string
+		groups conditionGroups
+		want   string
+	}{
+		{
+			name:   "return empty highlight if there are no error and warning",
+			groups: getConditionGroups(conditionsWithSource(&clusterv1.Cluster{}, true1, falseInfo1, unknown1)),
+			want:   "",
+		},
+		{
+			name:   "1 errors",
+			groups: getConditionGroups(conditionsWithSource(&clusterv1.Cluster{}, true1, falseInfo1, unknown1, falseError1)),
+			want:   "1 error",
+		},
+		{
+			name:   "n>1 errors",
+			groups: getConditionGroups(conditionsWithSource(&clusterv1.Cluster{}, true1, falseInfo1, unknown1, falseError1, falseError1)),
+			want:   "2 errors",
+		},
+		{
+			name:   "1 warning",
+			groups: getConditionGroups(conditionsWithSource(&clusterv1.Cluster{}, true1, falseInfo1, unknown1, falseWarning1)),
+			want:   "1 warning",
+		},
+		{
+			name:   "n>1 warning",
+			groups: getConditionGroups(conditionsWithSource(&clusterv1.Cluster{}, true1, falseInfo1, unknown1, falseWarning1, falseWarning1)),
+			want:   "2 warnings",
+		},
+		{
+			name:   "errors and warning",
+			groups: getConditionGroups(conditionsWithSource(&clusterv1.Cluster{}, true1, falseInfo1, unknown1, falseError1, falseError1, falseWarning1)),
+			want:   "2 errors, 1 warning",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got := getErrorAndWarningSummary(tt.groups)
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}

--- a/util/conditions/merge_test.go
+++ b/util/conditions/merge_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+func TestNewConditionsGroup(t *testing.T) {
+	g := NewWithT(t)
+
+	conditions := []*clusterv1.Condition{nil1, true1, true1, falseInfo1, falseWarning1, falseWarning1, falseError1, unknown1}
+
+	got := getConditionGroups(conditionsWithSource(&clusterv1.Cluster{}, conditions...))
+
+	g.Expect(got).ToNot(BeNil())
+	g.Expect(got).To(HaveLen(5))
+
+	// The top group should be False/Error and it should have one condition
+	g.Expect(got.TopGroup().status).To(Equal(corev1.ConditionFalse))
+	g.Expect(got.TopGroup().severity).To(Equal(clusterv1.ConditionSeverityError))
+	g.Expect(got.TopGroup().conditions).To(HaveLen(1))
+
+	// The true group should be true and it should have two conditions
+	g.Expect(got.TrueGroup().status).To(Equal(corev1.ConditionTrue))
+	g.Expect(got.TrueGroup().severity).To(Equal(clusterv1.ConditionSeverityNone))
+	g.Expect(got.TrueGroup().conditions).To(HaveLen(2))
+
+	// The error group should be False/Error and it should have one condition
+	g.Expect(got.ErrorGroup().status).To(Equal(corev1.ConditionFalse))
+	g.Expect(got.ErrorGroup().severity).To(Equal(clusterv1.ConditionSeverityError))
+	g.Expect(got.ErrorGroup().conditions).To(HaveLen(1))
+
+	// The warning group should be False/Warning and it should have two conditions
+	g.Expect(got.WarningGroup().status).To(Equal(corev1.ConditionFalse))
+	g.Expect(got.WarningGroup().severity).To(Equal(clusterv1.ConditionSeverityWarning))
+	g.Expect(got.WarningGroup().conditions).To(HaveLen(2))
+
+	// got[0] should be False/Error and it should have one condition
+	g.Expect(got[0].status).To(Equal(corev1.ConditionFalse))
+	g.Expect(got[0].severity).To(Equal(clusterv1.ConditionSeverityError))
+	g.Expect(got[0].conditions).To(HaveLen(1))
+
+	// got[1] should be False/Warning and it should have two conditions
+	g.Expect(got[1].status).To(Equal(corev1.ConditionFalse))
+	g.Expect(got[1].severity).To(Equal(clusterv1.ConditionSeverityWarning))
+	g.Expect(got[1].conditions).To(HaveLen(2))
+
+	// got[2] should be False/Info and it should have one condition
+	g.Expect(got[2].status).To(Equal(corev1.ConditionFalse))
+	g.Expect(got[2].severity).To(Equal(clusterv1.ConditionSeverityInfo))
+	g.Expect(got[2].conditions).To(HaveLen(1))
+
+	// got[3] should be True and it should have two conditions
+	g.Expect(got[3].status).To(Equal(corev1.ConditionTrue))
+	g.Expect(got[3].severity).To(Equal(clusterv1.ConditionSeverityNone))
+	g.Expect(got[3].conditions).To(HaveLen(2))
+
+	// got[4] should be Unknown and it should have one condition
+	g.Expect(got[4].status).To(Equal(corev1.ConditionUnknown))
+	g.Expect(got[4].severity).To(Equal(clusterv1.ConditionSeverityNone))
+	g.Expect(got[4].conditions).To(HaveLen(1))
+
+	// nil conditions are ignored
+}
+
+func TestMergeRespectPriority(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []*clusterv1.Condition
+		want       *clusterv1.Condition
+	}{
+		{
+			name:       "Aggregate nil list return nil",
+			conditions: nil,
+			want:       nil,
+		},
+		{
+			name:       "Aggregate empty list return nil",
+			conditions: []*clusterv1.Condition{},
+			want:       nil,
+		},
+		{
+			name:       "When there is false/error it returns false/error",
+			conditions: []*clusterv1.Condition{falseError1, falseWarning1, falseInfo1, unknown1, true1},
+			want:       FalseCondition("foo", "reason falseError1", clusterv1.ConditionSeverityError, "message falseError1 (1 error, 1 warning)"),
+		},
+		{
+			name:       "When there is false/warning and no false/error, it returns false/warning",
+			conditions: []*clusterv1.Condition{falseWarning1, falseInfo1, unknown1, true1},
+			want:       FalseCondition("foo", "reason falseWarning1", clusterv1.ConditionSeverityWarning, "message falseWarning1 (1 warning)"),
+		},
+		{
+			name:       "When there is false/info and no false/error or false/warning, it returns false/info",
+			conditions: []*clusterv1.Condition{falseInfo1, unknown1, true1},
+			want:       FalseCondition("foo", "reason falseInfo1", clusterv1.ConditionSeverityInfo, "message falseInfo1"),
+		},
+		{
+			name:       "When there is true and no false/*, it returns info",
+			conditions: []*clusterv1.Condition{unknown1, true1},
+			want:       TrueCondition("foo"),
+		},
+		{
+			name:       "When there is unknown and no true or false/*, it returns unknown",
+			conditions: []*clusterv1.Condition{unknown1},
+			want:       UnknownCondition("foo", "reason unknown1", "message unknown1"),
+		},
+		{
+			name:       "nil conditions are ignored",
+			conditions: []*clusterv1.Condition{nil1, nil1, nil1},
+			want:       nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got := merge(conditionsWithSource(&clusterv1.Cluster{}, tt.conditions...), "foo", &mergeOptions{})
+
+			if tt.want == nil {
+				g.Expect(got).To(BeNil())
+				return
+			}
+			g.Expect(got).To(haveSameStateOf(tt.want))
+		})
+	}
+}
+
+func conditionsWithSource(obj Setter, conditions ...*clusterv1.Condition) []localizedCondition {
+	obj.SetConditions(conditionList(conditions...))
+
+	ret := []localizedCondition{}
+	for i := range conditions {
+		ret = append(ret, localizedCondition{
+			Condition: conditions[i],
+			Getter:    obj,
+		})
+	}
+
+	return ret
+}

--- a/util/conditions/setter.go
+++ b/util/conditions/setter.go
@@ -112,6 +112,26 @@ func MarkFalse(to Setter, t clusterv1.ConditionType, reason string, severity clu
 	Set(to, FalseCondition(t, reason, severity, messageFormat, messageArgs...))
 }
 
+// SetSummary sets a Ready condition with the summary of all the conditions existing
+// on an object. If the object does not have other conditions, no summary condition is generated.
+func SetSummary(to Setter, options ...MergeOption) {
+	Set(to, Summary(to, options...))
+}
+
+// SetMirrorCondition creates a new condition by mirroring the the Ready condition from a dependent object;
+// if the Ready condition does not exists in the source object, no target conditions is generated.
+func SetMirrorCondition(to Setter, targetCondition clusterv1.ConditionType, from Getter) {
+	Set(to, Mirror(from, targetCondition))
+}
+
+// SetAggregateCondition creates a new condition with the aggregation of all the the Ready condition
+// from a list of dependent objects; if the Ready condition does not exists in one of the source object,
+// the object is excluded from the aggregation; if none of the source object have ready condition,
+// no target conditions is generated.
+func SetAggregateCondition(to Setter, targetCondition clusterv1.ConditionType, from []Getter, options ...MergeOption) {
+	Set(to, Aggregate(from, targetCondition, options...))
+}
+
 // Delete deletes the condition with the given type.
 func Delete(to Setter, t clusterv1.ConditionType) {
 	if to == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a utils for handling conditions according to the design patterns introduced by the [condition CAEP](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/20200506-conditions.md) (Mirror, Aggregate, Summarize)

/cc @gab-satchi 
