### PR TITLE
✨ Add observed generation to all relevant objects

### DIFF
--- a/api/v1alpha2/conversion.go
+++ b/api/v1alpha2/conversion.go
@@ -52,6 +52,7 @@ func (src *Cluster) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Status.FailureDomains = restored.Status.FailureDomains
 	dst.Spec.Paused = restored.Spec.Paused
 	dst.Status.Conditions = restored.Status.Conditions
+	dst.Status.ObservedGeneration = restored.Status.ObservedGeneration
 
 	return nil
 }
@@ -116,6 +117,7 @@ func (src *Machine) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 	restoreMachineSpec(&restored.Spec, &dst.Spec)
+	dst.Status.ObservedGeneration = restored.Status.ObservedGeneration
 
 	return nil
 }

--- a/api/v1alpha2/zz_generated.conversion.go
+++ b/api/v1alpha2/zz_generated.conversion.go
@@ -465,6 +465,7 @@ func autoConvert_v1alpha3_ClusterStatus_To_v1alpha2_ClusterStatus(in *v1alpha3.C
 	out.ControlPlaneInitialized = in.ControlPlaneInitialized
 	// WARNING: in.ControlPlaneReady requires manual conversion: does not exist in peer-type
 	// WARNING: in.Conditions requires manual conversion: does not exist in peer-type
+	// WARNING: in.ObservedGeneration requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -916,6 +917,7 @@ func autoConvert_v1alpha3_MachineStatus_To_v1alpha2_MachineStatus(in *v1alpha3.M
 	out.Phase = in.Phase
 	out.BootstrapReady = in.BootstrapReady
 	out.InfrastructureReady = in.InfrastructureReady
+	// WARNING: in.ObservedGeneration requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha3/cluster_types.go
+++ b/api/v1alpha3/cluster_types.go
@@ -138,6 +138,10 @@ type ClusterStatus struct {
 	// Conditions defines current service state of the cluster.
 	// +optional
 	Conditions Conditions `json:"conditions,omitempty"`
+
+	// ObservedGeneration is the latest generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // ANCHOR_END: ClusterStatus

--- a/api/v1alpha3/machine_types.go
+++ b/api/v1alpha3/machine_types.go
@@ -155,6 +155,10 @@ type MachineStatus struct {
 	// InfrastructureReady is the state of the infrastructure provider.
 	// +optional
 	InfrastructureReady bool `json:"infrastructureReady"`
+
+	// ObservedGeneration is the latest generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // ANCHOR_END: MachineStatus

--- a/api/v1alpha3/machinehealthcheck_types.go
+++ b/api/v1alpha3/machinehealthcheck_types.go
@@ -83,6 +83,10 @@ type MachineHealthCheckStatus struct {
 	// total number of healthy machines counted by this machine health check
 	// +kubebuilder:validation:Minimum=0
 	CurrentHealthy int32 `json:"currentHealthy,omitempty"`
+
+	// ObservedGeneration is the latest generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // ANCHOR_END: MachineHealthCheckStatus

--- a/bootstrap/kubeadm/api/v1alpha2/conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha2/conversion.go
@@ -37,6 +37,7 @@ func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	dst.Status.DataSecretName = restored.Status.DataSecretName
+	dst.Status.ObservedGeneration = restored.Status.ObservedGeneration
 	dst.Spec.Verbosity = restored.Spec.Verbosity
 	dst.Spec.UseExperimentalRetryJoin = restored.Spec.UseExperimentalRetryJoin
 	dst.Spec.Files = restored.Spec.Files

--- a/bootstrap/kubeadm/api/v1alpha2/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha2/zz_generated.conversion.go
@@ -309,6 +309,7 @@ func autoConvert_v1alpha3_KubeadmConfigStatus_To_v1alpha2_KubeadmConfigStatus(in
 	out.BootstrapData = *(*[]byte)(unsafe.Pointer(&in.BootstrapData))
 	// WARNING: in.FailureReason requires manual conversion: does not exist in peer-type
 	// WARNING: in.FailureMessage requires manual conversion: does not exist in peer-type
+	// WARNING: in.ObservedGeneration requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/bootstrap/kubeadm/api/v1alpha3/kubeadmbootstrapconfig_types.go
+++ b/bootstrap/kubeadm/api/v1alpha3/kubeadmbootstrapconfig_types.go
@@ -112,6 +112,10 @@ type KubeadmConfigStatus struct {
 	// FailureMessage will be set on non-retryable errors
 	// +optional
 	FailureMessage string `json:"failureMessage,omitempty"`
+
+	// ObservedGeneration is the latest generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -1660,6 +1660,11 @@ spec:
               failureReason:
                 description: FailureReason will be set on non-retryable errors
                 type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
               ready:
                 description: Ready indicates the BootstrapData field is ready to be
                   consumed

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -403,6 +403,11 @@ spec:
                 description: InfrastructureReady is the state of the infrastructure
                   provider.
                 type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
               phase:
                 description: Phase represents the current phase of cluster actuation.
                   E.g. Pending, Running, Terminating, Failed etc.

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -162,6 +162,11 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -635,6 +635,11 @@ spec:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
               phase:
                 description: Phase represents the current phase of machine actuation.
                   E.g. Pending, Running, Terminating, Failed etc.

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -112,6 +112,10 @@ type KubeadmControlPlaneStatus struct {
 	// state, and will be set to a descriptive error message.
 	// +optional
 	FailureMessage *string `json:"failureMessage,omitempty"`
+
+	// ObservedGeneration is the latest generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -967,6 +967,11 @@ spec:
                 description: Initialized denotes whether or not the control plane
                   has the uploaded kubeadm-config configmap.
                 type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
               ready:
                 description: Ready denotes that the KubeadmControlPlane API Server
                   is ready to receive requests.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an `ObservedGeneration` field to all objects that have a Status. My understanding of the semantics of `ObservedGeneration` is that it's only supposed to be updated when reconciliation is *complete* for the given version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3078