### PR TITLE
:running: Follow-up to condition patch utils

### DIFF
--- a/util/conditions/patch.go
+++ b/util/conditions/patch.go
@@ -98,7 +98,6 @@ func (p Patch) Apply(source Setter) error {
 				}
 				// otherwise, the source is already as intended.
 				// NOTE: We are preserving LastTransitionTime from the source in order to avoid altering the existing value.
-				// XXX Set(source, sourceCondition)
 				continue
 			}
 			// If the condition does not exists on the source, add the new target condition.
@@ -120,7 +119,6 @@ func (p Patch) Apply(source Setter) error {
 				}
 				// Otherwise the source is already as intended.
 				// NOTE: We are preserving LastTransitionTime from the source in order to avoid altering the existing value.
-				// XXX Set(source, sourceCondition)
 				continue
 			}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
/assign @fabriziopandini 