### PR TITLE
🐛 fix CAPBK conversion bug

### DIFF
--- a/bootstrap/kubeadm/api/v1alpha2/conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha2/conversion.go
@@ -50,16 +50,20 @@ func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 	// lookup.
 	dstPaths := make(map[string]*kubeadmbootstrapv1alpha3.File, len(dst.Spec.Files))
 	for i := range dst.Spec.Files {
-		file := dst.Spec.Files[i]
-		dstPaths[file.Path] = &file
+		path := dst.Spec.Files[i].Path
+		dstPaths[path] = &dst.Spec.Files[i]
 	}
 
 	// If we find a restored file matching the file path of a v1alpha2
 	// file with no content, we should restore contentFrom to that file.
-	for _, restoredFile := range restored.Spec.Files {
+	for i := range restored.Spec.Files {
+		restoredFile := restored.Spec.Files[i]
 		dstFile, exists := dstPaths[restoredFile.Path]
 		if exists && dstFile.Content == "" {
-			dstFile.ContentFrom = restoredFile.ContentFrom
+			if dstFile.ContentFrom == nil {
+				dstFile.ContentFrom = new(kubeadmbootstrapv1alpha3.FileSource)
+			}
+			*dstFile.ContentFrom = *restoredFile.ContentFrom
 		}
 	}
 

--- a/bootstrap/kubeadm/api/v1alpha2/conversion_test.go
+++ b/bootstrap/kubeadm/api/v1alpha2/conversion_test.go
@@ -35,8 +35,7 @@ func TestConvertKubeadmConfig(t *testing.T) {
 
 			src := &v1alpha3.KubeadmConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "hub",
-					Annotations: map[string]string{},
+					Name: "hub",
 				},
 				Spec: v1alpha3.KubeadmConfigSpec{
 					Files: []v1alpha3.File{

--- a/util/conversion/conversion.go
+++ b/util/conversion/conversion.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	fuzz "github.com/google/gofuzz"
 	"github.com/onsi/gomega"
 
@@ -35,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/json"
-	"k8s.io/utils/diff"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -159,7 +159,7 @@ func FuzzTestFunc(scheme *runtime.Scheme, hub conversion.Hub, dst conversion.Con
 			g.Expect(dstCopy.ConvertTo(after)).To(gomega.Succeed())
 
 			// Make sure that the hub before the conversions and after are the same, include a diff if not.
-			g.Expect(apiequality.Semantic.DeepEqual(hubCopy, after)).To(gomega.BeTrue(), diff.ObjectDiff(hubCopy, after))
+			g.Expect(apiequality.Semantic.DeepEqual(hubCopy, after)).To(gomega.BeTrue(), cmp.Diff(hubCopy, after))
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
One more follow up to https://github.com/kubernetes-sigs/cluster-api/pull/3100

Fixes a bug in the conversion logic @CecileRobertMichon caught as we were working on capz conversions.

Adds pretty printing for object diffs in conversion utils. The current output is dense and not very human readable.

/assign @vincepri @CecileRobertMichon 
