### PR TITLE
Add packet to list of default providers ✨

### DIFF
--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -35,6 +35,7 @@ const (
 	Metal3ProviderName              = "metal3"
 	OpenStackProviderName           = "openstack"
 	VSphereProviderName             = "vsphere"
+	PacketProviderName              = "packet"
 	ProvidersConfigKey              = "providers"
 )
 
@@ -87,6 +88,11 @@ func (p *providersClient) defaults() []Provider {
 		&provider{
 			name:         AzureProviderName,
 			url:          "https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/latest/infrastructure-components.yaml",
+			providerType: clusterctlv1.InfrastructureProviderType,
+		},
+		&provider{
+			name:         PacketProviderName,
+			url:          "https://github.com/packethost/cluster-api-provider-packet/releases/latest/infrastructure-components.yaml",
 			providerType: clusterctlv1.InfrastructureProviderType,
 		},
 		&provider{

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -50,6 +50,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 			field: field{
 				client: newFakeClient(newFakeConfig()),
 			},
+			// note: these will be sorted by name by the Providers() call, so be sure they are in alphabetical order here too
 			wantProviders: []string{
 				config.ClusterAPIProviderName,
 				config.KubeadmBootstrapProviderName,
@@ -58,6 +59,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 				config.AzureProviderName,
 				config.Metal3ProviderName,
 				config.OpenStackProviderName,
+				config.PacketProviderName,
 				config.VSphereProviderName,
 			},
 			wantErr: false,
@@ -67,6 +69,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 			field: field{
 				client: newFakeClient(newFakeConfig().WithProvider(customProviderConfig)),
 			},
+			// note: these will be sorted by name by the Providers() call, so be sure they are in alphabetical order here too
 			wantProviders: []string{
 				config.ClusterAPIProviderName,
 				customProviderConfig.Name(),
@@ -76,6 +79,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 				config.AzureProviderName,
 				config.Metal3ProviderName,
 				config.OpenStackProviderName,
+				config.PacketProviderName,
 				config.VSphereProviderName,
 			},
 			wantErr: false,

--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -206,6 +206,18 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 					// older version are not supported by clusterctl
 				},
 			}
+		case config.PacketProviderName:
+			return &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "Metadata",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					// v1alpha3 release series
+					{Major: 0, Minor: 3, Contract: "v1alpha3"},
+					// older version are not supported by clusterctl
+				},
+			}
 		case config.OpenStackProviderName:
 			return &clusterctlv1.Metadata{
 				TypeMeta: metav1.TypeMeta{

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -108,6 +108,7 @@ azure               InfrastructureProvider   https://github.com/kubernetes-sigs/
 metal3              InfrastructureProvider   https://github.com/metal3-io/cluster-api-provider-metal3/releases/latest/            infrastructure-components.yaml
 my-infra-provider   InfrastructureProvider   /home/.cluster-api/overrides/infrastructure-docker/latest/                           infrastructure-components.yaml
 openstack           InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/latest/   infrastructure-components.yaml
+packet              InfrastructureProvider   https://github.com/packethost/cluster-api-provider-packet/releases/latest/           infrastructure-components.yaml
 vsphere             InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/latest/     infrastructure-components.yaml
 `
 
@@ -147,6 +148,10 @@ var expectedOutputYaml = `- File: core_components.yaml
   Name: openstack
   ProviderType: InfrastructureProvider
   URL: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/latest/
+- File: infrastructure-components.yaml
+  Name: packet
+  ProviderType: InfrastructureProvider
+  URL: https://github.com/packethost/cluster-api-provider-packet/releases/latest/
 - File: infrastructure-components.yaml
   Name: vsphere
   ProviderType: InfrastructureProvider


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

Adds Packet's cluster-api provider (CAPP) to the default supported repositories

Packet just completed a run of converting its v1alpha1 provider to v1alpha3, and is ready to incorporate it.

Follow-on PR will add it to the book where the default ones are listed.

Packet decided - in discussion with some of the cluster-api folks on a call last week (and slack with @timothysc ) to donate its cluster-api provider to Kubernetes-sigs, so it could live under https://github.com/kubernetes-sigs/cluster-api-provider-packet . That is a separate process which we will go through to prepare it, and raise in a future cluster-api meeting.

cc @gianarb 