### PR TITLE
🏃‍♂️ Switch clusterctl logging to stderr

### DIFF
--- a/cmd/clusterctl/client/repository/components_client.go
+++ b/cmd/clusterctl/client/repository/components_client.go
@@ -77,7 +77,7 @@ func (f *componentsClient) Get(options ComponentsOptions) (Components, error) {
 			return nil, errors.Wrapf(err, "failed to read %q from provider's repository %q", path, f.provider.ManifestLabel())
 		}
 	} else {
-		log.V(1).Info("Using", "Override", path, "Provider", f.provider.ManifestLabel(), "Version", options.Version)
+		log.Info("Using", "Override", path, "Provider", f.provider.ManifestLabel(), "Version", options.Version)
 	}
 
 	return NewComponents(f.provider, f.configClient, file, options)

--- a/cmd/clusterctl/log/logger.go
+++ b/cmd/clusterctl/log/logger.go
@@ -19,6 +19,7 @@ package log
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -126,7 +127,7 @@ func (l *logger) write(values []interface{}) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(f)
+	fmt.Fprintln(os.Stderr, f)
 }
 
 func (l *logger) clone() *logger {


### PR DESCRIPTION
**What this PR does / why we need it**:
This lets us log warnings like when overrides are being used without interfering with the ability to pipe to `kubectl`.

Before you'd get:
```
clusterctl config cluster bmo --kubernetes-version v1.17.3 --control-plane-machine-count=1 -v 5  | k apply -f-
error: error parsing STDIN: error converting YAML to JSON: yaml: line 2: mapping values are not allowed in this context
```

Now you get:
```
bin/clusterctl config cluster bmo --kubernetes-version v1.17.3 --control-plane-machine-count=1 -v 5  | k apply -f-
No default config file available
Fetching File="cluster-template.yaml" Provider="infrastructure-aws" Version="v0.5.3"
cluster.cluster.x-k8s.io/bmo created
awscluster.infrastructure.cluster.x-k8s.io/bmo created
kubeadmcontrolplane.controlplane.cluster.x-k8s.io/bmo-control-plane created
awsmachinetemplate.infrastructure.cluster.x-k8s.io/bmo-control-plane unchanged
machinedeployment.cluster.x-k8s.io/bmo-md-0 created
awsmachinetemplate.infrastructure.cluster.x-k8s.io/bmo-md-0 created
kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/bmo-md-0 unchanged
```

**Which issue(s) this PR fixes**
Fixes #2713