### PR TITLE
🌱 Integrate shared remote cluster watching into MHC

### DIFF
--- a/controllers/remote/cluster_cache_reconciler_test.go
+++ b/controllers/remote/cluster_cache_reconciler_test.go
@@ -129,13 +129,12 @@ var _ = Describe("ClusterCache Reconciler suite", func() {
 			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
 
 			By("Starting the ClusterCacheReconciler")
-			r, err := NewClusterCacheReconciler(
-				&log.NullLogger{},
-				mgr,
-				controller.Options{},
-				cct,
-			)
-			Expect(err).ToNot(HaveOccurred())
+			r := &ClusterCacheReconciler{
+				Log:     &log.NullLogger{},
+				Client:  mgr.GetClient(),
+				Tracker: cct,
+			}
+			Expect(r.SetupWithManager(mgr, controller.Options{})).To(Succeed())
 
 			By("Creating clusters to test with")
 			clusterRequest1, clusterCache1 = createAndWatchCluster("cluster-1")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

This PR sets up a ClusterCacheTracker and reconciler in the main and passes the tracker to the MHC so that it can use that to track remote Nodes rather than doing it itself

I've also added a test which is meant to check the remote tracking functionality, but I hit a bump, with the normal timeout, it passes whether the tracker is there or not because we do a full resync every second. So I've set it with a very short timeout (500ms), I'm concerned this may flake in CI. 

Does anyone happen to know why the tests set up this way so that there's a full sync every second? What are the implications of possible extending that? 