### PR TITLE
🌱 Improve conditions summary

### DIFF
--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -167,11 +167,17 @@ func (r *MachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr e
 	}
 
 	defer func() {
-		// always update the readyCondition with the summary of the machine conditions.
+		// Always update the readyCondition with the summary of the machine conditions.
 		conditions.SetSummary(m,
-			// we want to surface infrastructure problems first, then the others.
-			conditions.WithConditionOrder(clusterv1.InfrastructureReadyCondition),
-			conditions.WithStepCounter(clusterv1.MachineSummaryConditionsCount),
+			conditions.WithConditions(
+				clusterv1.BootstrapReadyCondition,
+				clusterv1.InfrastructureReadyCondition,
+				// TODO: add MHC conditions here
+			),
+			conditions.WithStepCounterIfOnly(
+				clusterv1.BootstrapReadyCondition,
+				clusterv1.InfrastructureReadyCondition,
+			),
 		)
 
 		r.reconcilePhase(ctx, m)

--- a/test/infrastructure/docker/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/controllers/dockercluster_controller.go
@@ -91,7 +91,12 @@ func (r *DockerClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	// Always attempt to Patch the DockerCluster object and status after each reconciliation.
 	defer func() {
 		// always update the readyCondition; the summary is represented using the "1 of x completed" notation.
-		conditions.SetSummary(dockerCluster, conditions.WithStepCounter(1))
+		conditions.SetSummary(dockerCluster,
+			conditions.WithConditions(
+				infrav1.LoadBalancerAvailableCondition,
+			),
+			conditions.WithStepCounter(),
+		)
 
 		if err := patchHelper.Patch(ctx, dockerCluster); err != nil {
 			log.Error(err, "failed to patch DockerCluster")

--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
@@ -117,7 +117,13 @@ func (r *DockerMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 	// Always attempt to Patch the DockerMachine object and status after each reconciliation.
 	defer func() {
 		// always update the readyCondition; the summary is represented using the "1 of x completed" notation.
-		conditions.SetSummary(dockerMachine, conditions.WithStepCounter(infrav1.ConditionsCount))
+		conditions.SetSummary(dockerMachine,
+			conditions.WithConditions(
+				infrav1.ContainerProvisionedCondition,
+				infrav1.BootstrapExecSucceededCondition,
+			),
+			conditions.WithStepCounter(),
+		)
 
 		if err := patchHelper.Patch(ctx, dockerMachine); err != nil {
 			log.Error(err, "failed to patch DockerMachine")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR 
1. Makes it possible to specify a list of conditions to be used for generating a summary, so we can control how the semantic for the Ready conditions change over time (before it was automatically changing whenever a new condition was added)
2. Makes the step x of y notation to use the above list of conditions to determine the y value
3. Makes it possible to use the step x of y notation during the provisioning of a machine, but then it switches backs to the default notation when other conditions appear (e.g MHC conditions)

All the existing summary conditions are then updated to use the new merge options.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3151
