### PR TITLE
 ⚠️  Use cache tracker to get a client for remote clusters

### DIFF
--- a/controllers/machinehealthcheck_targets.go
+++ b/controllers/machinehealthcheck_targets.go
@@ -159,7 +159,7 @@ func (t *healthCheckTarget) needsRemediation(logger logr.Logger, timeoutForMachi
 
 // getTargetsFromMHC uses the MachineHealthCheck's selector to fetch machines
 // and their nodes targeted by the health check, ready for health checking.
-func (r *MachineHealthCheckReconciler) getTargetsFromMHC(clusterClient client.Client, mhc *clusterv1.MachineHealthCheck) ([]healthCheckTarget, error) {
+func (r *MachineHealthCheckReconciler) getTargetsFromMHC(clusterClient client.Reader, mhc *clusterv1.MachineHealthCheck) ([]healthCheckTarget, error) {
 	machines, err := r.getMachinesFromMHC(mhc)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting machines from MachineHealthCheck")
@@ -215,7 +215,7 @@ func (r *MachineHealthCheckReconciler) getMachinesFromMHC(mhc *clusterv1.Machine
 
 // getNodeFromMachine fetches the node from a local or remote cluster for a
 // given machine.
-func (r *MachineHealthCheckReconciler) getNodeFromMachine(clusterClient client.Client, machine *clusterv1.Machine) (*corev1.Node, error) {
+func (r *MachineHealthCheckReconciler) getNodeFromMachine(clusterClient client.Reader, machine *clusterv1.Machine) (*corev1.Node, error) {
 	if machine.Status.NodeRef == nil {
 		return nil, nil
 	}

--- a/controllers/machinehealthcheck_targets_test.go
+++ b/controllers/machinehealthcheck_targets_test.go
@@ -364,9 +364,11 @@ func newTestMachine(name, namespace, clusterName, nodeName string, labels map[st
 			},
 		},
 		Status: clusterv1.MachineStatus{
+			InfrastructureReady: true,
+			BootstrapReady:      true,
+			Phase:               string(clusterv1.MachinePhaseRunning),
 			NodeRef: &corev1.ObjectReference{
-				Name:      nodeName,
-				Namespace: namespace,
+				Name: nodeName,
 			},
 		},
 	}

--- a/controllers/remote/cluster_cache_healthcheck_test.go
+++ b/controllers/remote/cluster_cache_healthcheck_test.go
@@ -84,6 +84,9 @@ var _ = Describe("ClusterCache HealthCheck suite", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
+			testCluster.Status.ControlPlaneInitialized = true
+			testCluster.Status.InfrastructureReady = true
+			Expect(k8sClient.Status().Update(ctx, testCluster)).To(Succeed())
 
 			By("Creating a test cluster kubeconfig")
 			Expect(kubeconfig.CreateEnvTestSecret(k8sClient, testEnv.Config, testCluster)).To(Succeed())
@@ -131,7 +134,7 @@ var _ = Describe("ClusterCache HealthCheck suite", func() {
 			config := rest.CopyConfig(testEnv.Config)
 			go cct.healthCheckCluster(&healthCheckInput{ctx.Done(), testClusterKey, config, testPollInterval, testPollTimeout, testUnhealthyThreshold, "/foo"})
 
-			// This should succeed after 3 consecutive failed requests
+			// This should succeed after N consecutive failed requests.
 			Eventually(func() *clusterCache {
 				cct.clusterCachesLock.RLock()
 				defer cct.clusterCachesLock.RUnlock()
@@ -159,7 +162,7 @@ var _ = Describe("ClusterCache HealthCheck suite", func() {
 
 			go cct.healthCheckCluster(&healthCheckInput{ctx.Done(), testClusterKey, config, testPollInterval, testPollTimeout, testUnhealthyThreshold, "/"})
 
-			// This should succeed after 3 consecutive failed requests
+			// This should succeed after N consecutive failed requests.
 			Eventually(func() *clusterCache {
 				cct.clusterCachesLock.RLock()
 				defer cct.clusterCachesLock.RUnlock()

--- a/controllers/remote/cluster_cache_reconciler_test.go
+++ b/controllers/remote/cluster_cache_reconciler_test.go
@@ -29,7 +29,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -85,7 +84,6 @@ var _ = Describe("ClusterCache Reconciler suite", func() {
 				Cluster:      testClusterKey,
 				Watcher:      watcher,
 				Kind:         kind,
-				CacheOptions: cache.Options{},
 				EventHandler: eventHandler,
 				Predicates: []predicate.Predicate{
 					&predicate.ResourceVersionChangedPredicate{},

--- a/controllers/remote/cluster_cache_tracker_test.go
+++ b/controllers/remote/cluster_cache_tracker_test.go
@@ -30,7 +30,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -152,6 +151,9 @@ var _ = Describe("ClusterCache Tracker suite", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
+			testCluster.Status.ControlPlaneInitialized = true
+			testCluster.Status.InfrastructureReady = true
+			Expect(k8sClient.Status().Update(ctx, testCluster)).To(Succeed())
 
 			By("Creating a test cluster kubeconfig")
 			Expect(kubeconfig.CreateEnvTestSecret(k8sClient, testEnv.Config, testCluster)).To(Succeed())
@@ -180,7 +182,6 @@ var _ = Describe("ClusterCache Tracker suite", func() {
 				Cluster:      input.clusterKey,
 				Watcher:      input.watcher,
 				Kind:         input.kind,
-				CacheOptions: cache.Options{},
 				EventHandler: input.eventHandler,
 				Predicates:   input.predicates,
 			})).To(Succeed())
@@ -206,7 +207,6 @@ var _ = Describe("ClusterCache Tracker suite", func() {
 					Cluster:      input.clusterKey,
 					Watcher:      input.watcher,
 					Kind:         input.kind,
-					CacheOptions: cache.Options{},
 					EventHandler: input.eventHandler,
 					Predicates:   input.predicates,
 				})).To(Succeed())
@@ -226,7 +226,6 @@ var _ = Describe("ClusterCache Tracker suite", func() {
 					Cluster:      input.clusterKey,
 					Watcher:      input.watcher,
 					Kind:         input.kind,
-					CacheOptions: cache.Options{},
 					EventHandler: input.eventHandler,
 					Predicates:   input.predicates,
 				})).To(Succeed())
@@ -247,7 +246,6 @@ var _ = Describe("ClusterCache Tracker suite", func() {
 					Cluster:      input.clusterKey,
 					Watcher:      input.watcher,
 					Kind:         input.kind,
-					CacheOptions: cache.Options{},
 					EventHandler: input.eventHandler,
 					Predicates:   input.predicates,
 				})).To(Succeed())
@@ -266,7 +264,6 @@ var _ = Describe("ClusterCache Tracker suite", func() {
 					Cluster:      input.clusterKey,
 					Watcher:      input.watcher,
 					Kind:         input.kind,
-					CacheOptions: cache.Options{},
 					EventHandler: input.eventHandler,
 					Predicates:   input.predicates,
 				})).To(Succeed())
@@ -323,7 +320,6 @@ var _ = Describe("ClusterCache Tracker suite", func() {
 					Cluster:      differentClusterInput.clusterKey,
 					Watcher:      differentClusterInput.watcher,
 					Kind:         differentClusterInput.kind,
-					CacheOptions: cache.Options{},
 					EventHandler: differentClusterInput.eventHandler,
 					Predicates:   differentClusterInput.predicates,
 				})).To(Succeed())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -81,11 +81,13 @@ var _ = BeforeSuite(func(done Done) {
 	Expect((&MachineReconciler{
 		Client:   testEnv,
 		Log:      log.Log,
+		Tracker:  tracker,
 		recorder: testEnv.GetEventRecorderFor("machine-controller"),
 	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 	Expect((&MachineSetReconciler{
 		Client:   testEnv,
 		Log:      log.Log,
+		Tracker:  tracker,
 		recorder: testEnv.GetEventRecorderFor("machineset-controller"),
 	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 	Expect((&MachineDeploymentReconciler{

--- a/main.go
+++ b/main.go
@@ -222,15 +222,17 @@ func setupReconcilers(mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 	if err := (&controllers.MachineReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Machine"),
+		Client:  mgr.GetClient(),
+		Log:     ctrl.Log.WithName("controllers").WithName("Machine"),
+		Tracker: tracker,
 	}).SetupWithManager(mgr, concurrency(machineConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Machine")
 		os.Exit(1)
 	}
 	if err := (&controllers.MachineSetReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("MachineSet"),
+		Client:  mgr.GetClient(),
+		Log:     ctrl.Log.WithName("controllers").WithName("MachineSet"),
+		Tracker: tracker,
 	}).SetupWithManager(mgr, concurrency(machineSetConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MachineSet")
 		os.Exit(1)

--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -263,8 +263,8 @@ var _ = Describe("Patch Helper", func() {
 				Expect(patcher.Patch(ctx, obj)).To(Succeed())
 
 				By("Validating the object has been updated")
+				objAfter := obj.DeepCopy()
 				Eventually(func() bool {
-					objAfter := obj.DeepCopy()
 					if err := testEnv.Get(ctx, key, objAfter); err != nil {
 						return false
 					}
@@ -279,7 +279,7 @@ var _ = Describe("Patch Helper", func() {
 						obj.Spec.Paused == objAfter.Spec.Paused &&
 						obj.Spec.ControlPlaneEndpoint == objAfter.Spec.ControlPlaneEndpoint &&
 						obj.Status.Phase == objAfter.Status.Phase
-				}, timeout).Should(BeTrue())
+				}, timeout).Should(BeTrue(), cmp.Diff(obj, objAfter))
 			})
 
 			Specify("should return an error if there is an unresolvable conflict", func() {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR's main goal is to improve the re-usability of the remote clusters caches, and exposing a method to get a new delegating client from it.

After an afternoon debugging test flakes in CI and locally, I've tracked down the main slowdown in tests to the `remote.NewClusterClient` function. This function creates a new client backed by a new cache every time is called, which is a heavy-weight and highly unoptimized way to get a client to a workload cluster. Moreover, the client it creates, although backed by a cache, isn't a delegating one.

With this PR, we're finally able to share not only the cache between different controllers but also the underlying delegating client, initializing it only once.

Marking this as ⚠️ due to the removal of `WatchInput.CacheOptions` for `ClusterCacheTracker`.

Related to #2993 