### PR TITLE
🌱  MHC mapper tests shouldn't create new test environments

### DIFF
--- a/controllers/machinehealthcheck_targets_test.go
+++ b/controllers/machinehealthcheck_targets_test.go
@@ -645,6 +645,7 @@ func newTestMachine(name, namespace, clusterName, nodeName string, labels map[st
 	for k, v := range labels {
 		l[k] = v
 	}
+	l[clusterv1.ClusterLabelName] = clusterName
 
 	bootstrap := "bootstrap"
 	return &clusterv1.Machine{


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR removes the need to create new envtest environments in multiple tests (this should be discouraged in general). Envtest is meant to be used globally at a package level, and shouldn't generally be created in each individual test.

The affected tests in this PR are testing private methods, for this the fake client is a better choice. 

This PR also removes the need for cluster-name index on MHC, which isn't needed because a label is already present to filter objects that way.

/assign @fabriziopandini 
