### PR TITLE
🐛 Removes MachineSet Controller owner for existing Machines

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -389,6 +389,14 @@ func ReplaceOwnerRef(ownerReferences []metav1.OwnerReference, source metav1.Obje
 	return ownerReferences
 }
 
+// RemoveOwnerRef returns the slice of owner references after removing the supplied owner ref
+func RemoveOwnerRef(ownerReferences []metav1.OwnerReference, inputRef metav1.OwnerReference) []metav1.OwnerReference {
+	if index := indexOwnerRef(ownerReferences, inputRef); index != -1 {
+		return append(ownerReferences[:index], ownerReferences[index+1:]...)
+	}
+	return ownerReferences
+}
+
 // indexOwnerRef returns the index of the owner reference in the slice if found, or -1.
 func indexOwnerRef(ownerReferences []metav1.OwnerReference, ref metav1.OwnerReference) int {
 	for index, r := range ownerReferences {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -823,3 +823,47 @@ func TestIsSupportedVersionSkew(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveOwnerRef(t *testing.T) {
+	g := NewWithT(t)
+	ownerRefs := []metav1.OwnerReference{
+		{
+			APIVersion: "dazzlings.info/v1",
+			Kind:       "Twilight",
+			Name:       "m4g1c",
+		},
+		{
+			APIVersion: "bar.cluster.x-k8s.io/v1alpha3",
+			Kind:       "TestCluster",
+			Name:       "bar-1",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		toBeRemoved metav1.OwnerReference
+	}{
+		{
+			name: "owner reference present",
+			toBeRemoved: metav1.OwnerReference{
+				APIVersion: "dazzlings.info/v1",
+				Kind:       "Twilight",
+				Name:       "m4g1c",
+			},
+		},
+		{
+			name: "owner reference not present",
+			toBeRemoved: metav1.OwnerReference{
+				APIVersion: "dazzlings.info/v1",
+				Kind:       "Twilight",
+				Name:       "abcdef",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newOwnerRefs := RemoveOwnerRef(ownerRefs, tt.toBeRemoved)
+			g.Expect(HasOwnerRef(newOwnerRefs, tt.toBeRemoved)).NotTo(BeTrue())
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks if any existing machines have the MachineSet controllers as the owner and removes them in the reconcile phase since the Machine controller should be the owner

**Which issue(s) this PR fixes**:
Fixes #3145 
