### PR TITLE
✨ Enable kubectl scale on MachinePool

### DIFF
--- a/config/crd/bases/exp.cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/exp.cluster.x-k8s.io_machinepools.yaml
@@ -21,6 +21,10 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
     - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
         etc
       jsonPath: .status.phase
@@ -457,6 +461,9 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}
 status:
   acceptedNames:

--- a/exp/api/v1alpha3/machinepool_types.go
+++ b/exp/api/v1alpha3/machinepool_types.go
@@ -184,7 +184,9 @@ func (m *MachinePoolStatus) GetTypedPhase() MachinePoolPhase {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=machinepools,shortName=mp,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="Replicas",type="string",JSONPath=".status.replicas",description="MachinePool replicas count"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="MachinePool status such as Terminating/Pending/Provisioning/Running/Failed etc"
 // +k8s:conversion-gen=false
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Enables the "/scale" subresource on MachinePools. Note that this does not define a `selectorpath` as `MachinePool` replicas are not represented by individual objects and instead map directly to the infrastructure set replica count.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3158 
