### PR TITLE
🐛 Fix support for dual-stack network ranges

### DIFF
--- a/api/v1alpha3/cluster_types.go
+++ b/api/v1alpha3/cluster_types.go
@@ -95,7 +95,7 @@ func (n *NetworkRanges) String() string {
 	if n == nil {
 		return ""
 	}
-	return strings.Join(n.CIDRBlocks, "")
+	return strings.Join(n.CIDRBlocks, ",")
 }
 
 // ANCHOR_END: NetworkRanges

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -296,13 +296,14 @@ spec:
                       podSubnet:
                         description: PodSubnet is the subnet used by pods. If unset,
                           the API server will not allocate CIDR ranges for every node.
-                          Defaults to the first element of the Cluster object's spec.clusterNetwork.services.cidrBlocks
-                          if that is set
+                          Defaults to a comma-delimited string of the Cluster object's
+                          spec.clusterNetwork.services.cidrBlocks if that is set
                         type: string
                       serviceSubnet:
                         description: ServiceSubnet is the subnet used by k8s services.
-                          Defaults to the first element of the Cluster object's spec.clusterNetwork.pods.cidrBlocks
-                          field, or to "10.96.0.0/12" if that's unset.
+                          Defaults to a comma-delimited string of the Cluster object's
+                          spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12"
+                          if that's unset.
                         type: string
                     type: object
                   scheduler:
@@ -1101,13 +1102,14 @@ spec:
                       podSubnet:
                         description: PodSubnet is the subnet used by pods. If unset,
                           the API server will not allocate CIDR ranges for every node.
-                          Defaults to the first element of the Cluster object's spec.clusterNetwork.services.cidrBlocks
-                          if that is set
+                          Defaults to a comma-delimited string of the Cluster object's
+                          spec.clusterNetwork.services.cidrBlocks if that is set
                         type: string
                       serviceSubnet:
                         description: ServiceSubnet is the subnet used by k8s services.
-                          Defaults to the first element of the Cluster object's spec.clusterNetwork.pods.cidrBlocks
-                          field, or to "10.96.0.0/12" if that's unset.
+                          Defaults to a comma-delimited string of the Cluster object's
+                          spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12"
+                          if that's unset.
                         type: string
                     type: object
                   scheduler:

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -317,14 +317,14 @@ spec:
                               podSubnet:
                                 description: PodSubnet is the subnet used by pods.
                                   If unset, the API server will not allocate CIDR
-                                  ranges for every node. Defaults to the first element
-                                  of the Cluster object's spec.clusterNetwork.services.cidrBlocks
+                                  ranges for every node. Defaults to a comma-delimited
+                                  string of the Cluster object's spec.clusterNetwork.services.cidrBlocks
                                   if that is set
                                 type: string
                               serviceSubnet:
                                 description: ServiceSubnet is the subnet used by k8s
-                                  services. Defaults to the first element of the Cluster
-                                  object's spec.clusterNetwork.pods.cidrBlocks field,
+                                  services. Defaults to a comma-delimited string of
+                                  the Cluster object's spec.clusterNetwork.pods.cidrBlocks,
                                   or to "10.96.0.0/12" if that's unset.
                                 type: string
                             type: object
@@ -1155,14 +1155,14 @@ spec:
                               podSubnet:
                                 description: PodSubnet is the subnet used by pods.
                                   If unset, the API server will not allocate CIDR
-                                  ranges for every node. Defaults to the first element
-                                  of the Cluster object's spec.clusterNetwork.services.cidrBlocks
+                                  ranges for every node. Defaults to a comma-delimited
+                                  string of the Cluster object's spec.clusterNetwork.services.cidrBlocks
                                   if that is set
                                 type: string
                               serviceSubnet:
                                 description: ServiceSubnet is the subnet used by k8s
-                                  services. Defaults to the first element of the Cluster
-                                  object's spec.clusterNetwork.pods.cidrBlocks field,
+                                  services. Defaults to a comma-delimited string of
+                                  the Cluster object's spec.clusterNetwork.pods.cidrBlocks,
                                   or to "10.96.0.0/12" if that's unset.
                                 type: string
                             type: object

--- a/bootstrap/kubeadm/types/v1beta1/types.go
+++ b/bootstrap/kubeadm/types/v1beta1/types.go
@@ -232,13 +232,13 @@ type NodeRegistrationOptions struct {
 // Networking contains elements describing cluster's networking configuration
 type Networking struct {
 	// ServiceSubnet is the subnet used by k8s services.
-	// Defaults to the first element of the Cluster object's spec.clusterNetwork.pods.cidrBlocks field, or
+	// Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
 	// to "10.96.0.0/12" if that's unset.
 	// +optional
 	ServiceSubnet string `json:"serviceSubnet,omitempty"`
 	// PodSubnet is the subnet used by pods.
 	// If unset, the API server will not allocate CIDR ranges for every node.
-	// Defaults to the first element of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+	// Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
 	// +optional
 	PodSubnet string `json:"podSubnet,omitempty"`
 	// DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -372,15 +372,15 @@ spec:
                           podSubnet:
                             description: PodSubnet is the subnet used by pods. If
                               unset, the API server will not allocate CIDR ranges
-                              for every node. Defaults to the first element of the
-                              Cluster object's spec.clusterNetwork.services.cidrBlocks
+                              for every node. Defaults to a comma-delimited string
+                              of the Cluster object's spec.clusterNetwork.services.cidrBlocks
                               if that is set
                             type: string
                           serviceSubnet:
                             description: ServiceSubnet is the subnet used by k8s services.
-                              Defaults to the first element of the Cluster object's
-                              spec.clusterNetwork.pods.cidrBlocks field, or to "10.96.0.0/12"
-                              if that's unset.
+                              Defaults to a comma-delimited string of the Cluster
+                              object's spec.clusterNetwork.pods.cidrBlocks, or to
+                              "10.96.0.0/12" if that's unset.
                             type: string
                         type: object
                       scheduler:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes support for dual-stack network ranges. Users can provide more than one pod and/or service CIDR block on their [ClusterSpec's ClusterNetwork struct](https://github.com/benmoss/cluster-api/blob/2aeb53299285a86cc9ccaa13365ca58d0b61c8ac/api/v1alpha3/cluster_types.go#L65-L84) which then is used to populate the [KubeadmConfig Networking struct](https://github.com/benmoss/cluster-api/blob/2aeb53299285a86cc9ccaa13365ca58d0b61c8ac/bootstrap/kubeadm/types/v1beta1/types.go#L232-L247).

**Which issue(s) this PR fixes**
Fixes #3149