### PR TITLE
🌱  Build & push CAPD images to staging registry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,6 +12,15 @@ steps:
     - PULL_BASE_REF=$_PULL_BASE_REF
     args:
     - release-staging
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+    dir: 'test/infrastructure/docker'
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - TAG=$_GIT_TAG
+    - PULL_BASE_REF=$_PULL_BASE_REF
+    args:
+    - release-staging
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
**Goal:** onboarding new developers to the ClusterAPI project requires going through the [developers.html](https://cluster-api.sigs.k8s.io/clusterctl/developers.html) steps, including a `docker build`. By pushing a `capd-manager` to [the staging registry](https://console.cloud.google.com/gcr/images/k8s-staging-capi-docker/GLOBAL/capd-manager) (new staging registry is [here](https://console.cloud.google.com/gcr/images/k8s-staging-cluster-api/GLOBAL/capd-manager?gcrImageListsize=30)), we simplify the onboarding (I hope).

Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3101

I'm not sure editing `cloudbuild.yaml` is enough; what should I do now?