### PR TITLE
🐛 Apply conditions patch should preserve LastTransitionTime

### DIFF
--- a/util/conditions/setter_test.go
+++ b/util/conditions/setter_test.go
@@ -148,11 +148,19 @@ func TestSetLastTransitionTime(t *testing.T) {
 		LastTransitionTimeCheck func(*WithT, metav1.Time)
 	}{
 		{
-			name: "Set a condition that dos not exists should set the last transition time",
+			name: "Set a condition that does not exists should set the last transition time if not defined",
 			to:   setterWithConditions(),
 			new:  foo,
 			LastTransitionTimeCheck: func(g *WithT, lastTransitionTime metav1.Time) {
 				g.Expect(lastTransitionTime).ToNot(BeZero())
+			},
+		},
+		{
+			name: "Set a condition that does not exists should preserve the last transition time if defined",
+			to:   setterWithConditions(),
+			new:  fooWithLastTransitionTime,
+			LastTransitionTimeCheck: func(g *WithT, lastTransitionTime metav1.Time) {
+				g.Expect(lastTransitionTime).To(Equal(x))
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a nasty bug when applying a condition patch with and add operation with the path happening on a different second than the one where the condition was set on the target object.

The PR also align the variable names used for the objects involved in the three-way merge with the one used by the patch helper (before, after, latest), so there will be less confusion were looking at the code

**Which issue(s) this PR fixes**
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3178
