### PR TITLE
🌱Add infraref annotation to KCP machines

### DIFF
--- a/api/v1alpha3/common_types.go
+++ b/api/v1alpha3/common_types.go
@@ -38,6 +38,14 @@ const (
 	// on the reconciled object.
 	PausedAnnotation = "cluster.x-k8s.io/paused"
 
+	// TemplateClonedFromNameAnnotation is the infrastructure machine annotation that stores the name of the infrastructure template resource
+	// that was cloned for the machine.
+	TemplateClonedFromNameAnnotation = "cluster.x-k8s.io/cloned-from-name"
+
+	// TemplateClonedFromGroupKindAnnotation is the infrastructure machine annotation that stores the group-kind of the infrastructure template resource
+	// that was cloned for the machine.
+	TemplateClonedFromGroupKindAnnotation = "cluster.x-k8s.io/cloned-from-groupkind"
+
 	// ClusterSecretType defines the type of secret created by core components
 	ClusterSecretType corev1.SecretType = "cluster.x-k8s.io/secret" //nolint:gosec
 )

--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -83,6 +83,7 @@ func CloneTemplate(ctx context.Context, in *CloneTemplateInput) (*corev1.ObjectR
 	}
 	generateTemplateInput := &GenerateTemplateInput{
 		Template:    from,
+		TemplateRef: in.TemplateRef,
 		Namespace:   in.Namespace,
 		ClusterName: in.ClusterName,
 		OwnerRef:    in.OwnerRef,
@@ -106,6 +107,10 @@ type GenerateTemplateInput struct {
 	// Template is the TemplateRef turned into an unstructured.
 	// +required
 	Template *unstructured.Unstructured
+
+	// TemplateRef is a reference to the template that needs to be cloned.
+	// +required
+	TemplateRef *corev1.ObjectReference
 
 	// Namespace is the Kuberentes namespace the cloned object should be created into.
 	// +required
@@ -140,6 +145,14 @@ func GenerateTemplate(in *GenerateTemplateInput) (*unstructured.Unstructured, er
 	to.SetSelfLink("")
 	to.SetName(names.SimpleNameGenerator.GenerateName(in.Template.GetName() + "-"))
 	to.SetNamespace(in.Namespace)
+
+	if to.GetAnnotations() == nil {
+		to.SetAnnotations(map[string]string{})
+	}
+	annotations := to.GetAnnotations()
+	annotations[clusterv1.TemplateClonedFromNameAnnotation] = in.TemplateRef.Name
+	annotations[clusterv1.TemplateClonedFromGroupKindAnnotation] = in.TemplateRef.GroupVersionKind().GroupKind().String()
+	to.SetAnnotations(annotations)
 
 	// Set labels.
 	labels := to.GetLabels()

--- a/controllers/external/util_test.go
+++ b/controllers/external/util_test.go
@@ -200,6 +200,9 @@ func TestCloneTemplateResourceFound(t *testing.T) {
 
 	cloneAnnotations := clone.GetAnnotations()
 	g.Expect(cloneAnnotations).To(HaveKeyWithValue("test", "annotations"))
+
+	g.Expect(cloneAnnotations).To(HaveKeyWithValue(clusterv1.TemplateClonedFromNameAnnotation, templateRef.Name))
+	g.Expect(cloneAnnotations).To(HaveKeyWithValue(clusterv1.TemplateClonedFromGroupKindAnnotation, templateRef.GroupVersionKind().GroupKind().String()))
 }
 
 func TestCloneTemplateResourceFoundNoOwner(t *testing.T) {

--- a/controlplane/kubeadm/controllers/scale_test.go
+++ b/controlplane/kubeadm/controllers/scale_test.go
@@ -66,7 +66,6 @@ func TestKubeadmControlPlaneReconciler_initializeControlPlane(t *testing.T) {
 
 	machineList := &clusterv1.MachineList{}
 	g.Expect(fakeClient.List(context.Background(), machineList, client.InNamespace(cluster.Namespace))).To(Succeed())
-	g.Expect(machineList.Items).NotTo(BeEmpty())
 	g.Expect(machineList.Items).To(HaveLen(1))
 
 	g.Expect(machineList.Items[0].Namespace).To(Equal(cluster.Namespace))

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -32,6 +32,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controllers/external"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
@@ -57,6 +58,7 @@ func init() {
 	utilruntime.Must(clusterv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(bootstrapv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(expv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(controlplanev1.AddToScheme(scheme.Scheme))
 
 	// Get the root of the current file to use in CRD paths.
 	_, filename, _, _ := goruntime.Caller(0) //nolint


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds infrastructure template that is cloned to create a machine as annotation to the machine object.
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3020
