### PR TITLE
🐛 fix push images for CAPD

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -65,7 +65,7 @@ providers = {
     },
     "docker": {
         "context": "test/infrastructure/docker",
-        "image": "gcr.io/k8s-staging-capi-docker/capd-manager",
+        "image": "gcr.io/k8s-staging-cluster-api/capd-manager",
         "live_reload_deps": [
             "main.go",
             "go.mod",

--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -102,10 +102,10 @@ The Docker provider is not designed for production use and is intended for devel
 
 Before running the local-overrides hack:
 
-- Run `make -C test/infrastructure/docker docker-build REGISTRY=gcr.io/k8s-staging-capi-docker` to build the docker provider image
+- Run `make -C test/infrastructure/docker docker-build REGISTRY=gcr.io/k8s-staging-cluster-api` to build the docker provider image
   using a specific REGISTRY (you can choose your own).
 
-- Run `make -C test/infrastructure/docker generate-manifests REGISTRY=gcr.io/k8s-staging-capi-docker` to generate
+- Run `make -C test/infrastructure/docker generate-manifests REGISTRY=gcr.io/k8s-staging-cluster-api` to generate
   the docker provider manifest using the above registry/Image.
 
 Run the local-overrides hack and save the `clusterctl init` command provided in the command output to be used later.
@@ -138,7 +138,7 @@ EOF
 
 - Run `kind create cluster --config kind-cluster-with-extramounts.yaml` to create the management cluster using the above file
 
-- Run `kind load docker-image gcr.io/k8s-staging-capi-docker/capd-manager-amd64:dev` to make the docker provider image available
+- Run `kind load docker-image gcr.io/k8s-staging-cluster-api/capd-manager-amd64:dev` to make the docker provider image available
   for the kubelet in the management cluster.
 
 - Run `clusterctl init` command provided as output of the local-overrides hack.

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -44,8 +44,7 @@ GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 
 # Define Docker related variables. Releases should modify and double check these vars.
 REGISTRY ?= gcr.io/$(shell gcloud config get-value project)
-STAGING_REGISTRY := gcr.io/k8s-staging-capi-docker
-PROD_REGISTRY := us.gcr.io/k8s-artifacts-prod/capi-docker
+STAGING_REGISTRY := gcr.io/k8s-staging-cluster-api
 IMAGE_NAME ?= capd-manager
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 TAG ?= dev
@@ -200,8 +199,8 @@ release: clean-release ## Builds and push container images using the latest git 
 	# Push the release image to the staging bucket first.
 	REGISTRY=$(STAGING_REGISTRY) TAG=$(RELEASE_TAG) \
 		$(MAKE) docker-build-all docker-push-all
-	# Set the manifest image to the production bucket.
-	MANIFEST_IMG=$(PROD_REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(RELEASE_TAG) \
+	# Set the manifest image to the staging bucket.
+	MANIFEST_IMG=$(STAGING_REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(RELEASE_TAG) \
 		$(MAKE) set-manifest-image
 	PULL_POLICY=IfNotPresent $(MAKE) set-manifest-pull-policy
 	$(MAKE) release-manifests

--- a/test/infrastructure/docker/config/manager/manager_image_patch.yaml
+++ b/test/infrastructure/docker/config/manager/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/k8s-staging-capi-docker/capd-manager:dev
+      - image: gcr.io/k8s-staging-cluster-api/capd-manager:dev
         name: manager


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes failures in post-cluster-api-push-images due to CAPD trying to post images in the old repository.

/assign @vincepri 

Fixed #3182