### PR TITLE
🐛 listDescendents fetch MachinePools

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -391,7 +391,7 @@ func (r *ClusterReconciler) listDescendants(ctx context.Context, cluster *cluste
 
 	if feature.Gates.Enabled(feature.MachinePool) {
 		if err := r.Client.List(ctx, &descendants.machinePools, listOptions...); err != nil {
-			return descendants, errors.Wrapf(err, "failed to list MachineSets for the cluster %s/%s", cluster.Namespace, cluster.Name)
+			return descendants, errors.Wrapf(err, "failed to list MachinePools for the cluster %s/%s", cluster.Namespace, cluster.Name)
 		}
 	}
 	var machines clusterv1.MachineList


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR makes sure`listDescendents` function fetches MachinePools object too. This enables MachinePools to be deleted as well when cluster is deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2952 
