### PR TITLE
📖 Fix typos for CABPK

### DIFF
--- a/docs/book/src/developer/architecture/controllers/bootstrap.md
+++ b/docs/book/src/developer/architecture/controllers/bootstrap.md
@@ -5,7 +5,7 @@ Bootstrapping is the process in which:
 1. A cluster is bootstrapped
 1. A machine is bootstrapped and takes on a role within a cluster
 
-[CAPBK](https://github.com/kubernetes-sigs/cluster-api/tree/master/bootstrap/kubeadm) is the reference bootstrap provider and is based on `kubeadm`. CAPBK codifies the steps for [creating a cluster](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/) in multiple configurations.
+[CABPK](https://github.com/kubernetes-sigs/cluster-api/tree/master/bootstrap/kubeadm) is the reference bootstrap provider and is based on `kubeadm`. CABPK codifies the steps for [creating a cluster](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/) in multiple configurations.
 
 ![](../../../images/bootstrap-controller.png)
 

--- a/docs/book/src/tasks/certs/using-custom-certificates.md
+++ b/docs/book/src/tasks/certs/using-custom-certificates.md
@@ -1,6 +1,6 @@
 ## Using Custom Certificates
 
-Cluster API expects certificates and keys used for bootstrapping to follow the below convention. CAPBK generates new certificates using this convention if they do not already exist.
+Cluster API expects certificates and keys used for bootstrapping to follow the below convention. CABPK generates new certificates using this convention if they do not already exist.
 
 Each certificate must be stored in a single secret named one of:
 


### PR DESCRIPTION
Fix typos, by replacing CAPBK with CABPK, `Cluster API Bootstrap Provider Kubeadm`.
