### PR TITLE
🌱 Add tests for ensureNamespace

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -394,7 +394,8 @@ func (o *objectMover) ensureNamespace(toProxy Proxy, namespace string) error {
 		Name: namespace,
 	}
 
-	if err := cs.Get(ctx, key, ns); err == nil {
+	err = cs.Get(ctx, key, ns)
+	if err == nil {
 		return nil
 	}
 	if apierrors.IsForbidden(err) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
#2252 requires a test for `ensureNamespaces`. This PR includes a test for `ensureNamespace` (which is called inside `ensureNamespaces`) and also I think a bug fix regarding the scope of an `err`.

In writing new tests for `ensureNamespaces`, I've found some odd behavior there which needs addressing. A test for that function is not in this PR.

Edit: this is in relation to my previous PR https://github.com/kubernetes-sigs/cluster-api/pull/2984