### PR TITLE
🌱 Document docker version requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN go mod download
 # Copy the sources
 COPY ./ ./
 
-# Cache the go build
+# Cache the go build into the the Go’s compiler cache folder so we take benefits of compiler caching across docker build calls
 RUN --mount=type=cache,target=/root/.cache/go-build \
     go build .
 
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 ARG package=.
 ARG ARCH
 
-# Do not force rebuild of up-to-date packages (do not use -a)
+# Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
     go build -ldflags '-extldflags "-static"' \

--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -4,7 +4,7 @@ This document describes how to use `clusterctl` during the development workflow.
 
 ## Prerequisites
 
-* A Cluster API development setup (go, git, etc.)
+* A Cluster API development setup (go, git, kind v0.7 or newer, Docker v19.03 or newer etc.)
 * A local clone of the Cluster API GitHub repository
 * A local clone of the GitHub repositories for the providers you want to install
 

--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -20,14 +20,14 @@ Other providers may have additional steps you need to follow to get up and runni
 ### Docker
 
 Iterating on the cluster API involves repeatedly building Docker containers.
-You'll need the [docker daemon][docker] available.
+You'll need the [docker daemon][docker] v19.03 or newer available.
 
 [docker]: https://docs.docker.com/install/
 
 ### A Cluster
 
 You'll likely want an existing cluster as your [management cluster][mcluster].
-The easiest way to do this is with [kind], as explained in the quick start.
+The easiest way to do this is with [kind] v0.7 or newer, as explained in the quick start.
 
 Make sure your cluster is set as the default for `kubectl`.
 If it's not, you will need to modify subsequent `kubectl` commands below.

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -7,8 +7,8 @@ workflow that offers easy deployments and rapid iterative builds.
 
 ## Prerequisites
 
-1. [Docker](https://docs.docker.com/install/)
-1. [kind](https://kind.sigs.k8s.io) v0.6 or newer
+1. [Docker](https://docs.docker.com/install/) v19.03 or newer
+1. [kind](https://kind.sigs.k8s.io) v0.7 or newer
    (other clusters can be used if `preload_images_for_kind` is set to false)
 1. [kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md) standalone
    (`kubectl kustomize` does not work because it is missing some features of kustomize v3)

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -42,7 +42,7 @@ COPY . .
 # Essentially, change directories into CAPD
 WORKDIR /workspace/test/infrastructure/docker
 
-# Build the CAPD manager
+# Build the CAPD manager using the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /workspace/manager main.go
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As per https://github.com/kubernetes-sigs/cluster-api/pull/3210#issuecomment-646053557, documenting docker version requirements and the usage of `--mount=type=cache,target=/root/.cache/go-build`

/assign @vincepri 