### PR TITLE
🌱 Prints command help on validation error

### DIFF
--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -57,7 +57,9 @@ func Execute() {
 				}
 			}
 		}
-		// TODO: print cmd help if validation error
+		if RootCmd.CalledAs() != "clusterctl" {
+			RootCmd.Help()
+		}
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This commit removes a TODO in place of displaying the command help
message before exiting.

If the command `$ clusterctl` is issued, we skip printing the help at
this stage as it is already printed.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
It removes a TODO and provides help to the user upon a validation error for the `clusterctl` command.
