### PR TITLE
🌱 Controllers should now populate `status.observedGeneration`

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -206,8 +206,12 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 			),
 			conditions.WithStepCounter(),
 		)
-
-		if err := patchHelper.Patch(ctx, config); err != nil {
+		// Patch ObservedGeneration only if the reconciliation completed successfully
+		patchOpts := []patch.Option{}
+		if rerr == nil {
+			patchOpts = append(patchOpts, patch.WithStatusObservedGeneration{})
+		}
+		if err := patchHelper.Patch(ctx, config, patchOpts...); err != nil {
 			log.Error(rerr, "Failed to patch config")
 			if rerr == nil {
 				rerr = err

--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
@@ -467,6 +467,7 @@ func TestKubeadmConfigReconciler_Reconcile_GenerateCloudConfigData(t *testing.T)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(cfg.Status.Ready).To(BeTrue())
 	g.Expect(cfg.Status.DataSecretName).NotTo(BeNil())
+	g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
 	assertHasTrueCondition(g, myclient, request, bootstrapv1.CertificatesAvailableCondition)
 	assertHasTrueCondition(g, myclient, request, bootstrapv1.DataSecretAvailableCondition)
 
@@ -631,6 +632,7 @@ func TestReconcileIfJoinNodesAndControlPlaneIsReady(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cfg.Status.Ready).To(BeTrue())
 			g.Expect(cfg.Status.DataSecretName).NotTo(BeNil())
+			g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
 			assertHasTrueCondition(g, myclient, request, bootstrapv1.DataSecretAvailableCondition)
 
 			l := &corev1.SecretList{}
@@ -708,6 +710,7 @@ func TestReconcileIfJoinNodePoolsAndControlPlaneIsReady(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(cfg.Status.Ready).To(BeTrue())
 			g.Expect(cfg.Status.DataSecretName).NotTo(BeNil())
+			g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
 
 			l := &corev1.SecretList{}
 			err = myclient.List(context.Background(), l, client.ListOption(client.InNamespace(metav1.NamespaceSystem)))
@@ -788,6 +791,7 @@ func TestKubeadmConfigSecretCreatedStatusNotPatched(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(cfg.Status.Ready).To(BeTrue())
 	g.Expect(cfg.Status.DataSecretName).NotTo(BeNil())
+	g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
 }
 
 func TestBootstrapTokenTTLExtension(t *testing.T) {
@@ -835,6 +839,7 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(cfg.Status.Ready).To(BeTrue())
 	g.Expect(cfg.Status.DataSecretName).NotTo(BeNil())
+	g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
 
 	request = ctrl.Request{
 		NamespacedName: client.ObjectKey{
@@ -851,6 +856,7 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(cfg.Status.Ready).To(BeTrue())
 	g.Expect(cfg.Status.DataSecretName).NotTo(BeNil())
+	g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
 
 	l := &corev1.SecretList{}
 	err = myclient.List(context.Background(), l, client.ListOption(client.InNamespace(metav1.NamespaceSystem)))
@@ -1468,6 +1474,7 @@ func TestKubeadmConfigReconciler_Reconcile_PatchWhenErrorOccurred(t *testing.T) 
 	g.Expect(err).NotTo(HaveOccurred())
 	// check if the kubeadm config has been patched
 	g.Expect(cfg.Spec.InitConfiguration).ToNot(BeNil())
+	g.Expect(cfg.Status.ObservedGeneration).NotTo(BeNil())
 }
 
 // test utils

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -138,7 +138,12 @@ func (r *ClusterReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr e
 		r.reconcileMetrics(ctx, cluster)
 
 		// Always attempt to Patch the Cluster object and status after each reconciliation.
-		if err := patchHelper.Patch(ctx, cluster); err != nil {
+		// Patch ObservedGeneration only if the reconciliation completed successfully
+		patchOpts := []patch.Option{}
+		if reterr == nil {
+			patchOpts = append(patchOpts, patch.WithStatusObservedGeneration{})
+		}
+		if err := patchHelper.Patch(ctx, cluster, patchOpts...); err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()

--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Cluster Reconciler", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			cluster.Spec.InfrastructureRef = &v1.ObjectReference{Name: "test"}
 			cluster.Spec.ControlPlaneRef = &v1.ObjectReference{Name: "test-too"}
-			Expect(ph.Patch(ctx, cluster)).ShouldNot(HaveOccurred())
+			Expect(ph.Patch(ctx, cluster, patch.WithStatusObservedGeneration{})).ShouldNot(HaveOccurred())
 			return true
 		}, timeout).Should(BeTrue())
 
@@ -143,7 +143,7 @@ var _ = Describe("Cluster Reconciler", func() {
 			ph, err := patch.NewHelper(cluster, testEnv)
 			Expect(err).ShouldNot(HaveOccurred())
 			cluster.Status.InfrastructureReady = true
-			Expect(ph.Patch(ctx, cluster)).ShouldNot(HaveOccurred())
+			Expect(ph.Patch(ctx, cluster, patch.WithStatusObservedGeneration{})).ShouldNot(HaveOccurred())
 			return true
 		}, timeout).Should(BeTrue())
 
@@ -186,7 +186,7 @@ var _ = Describe("Cluster Reconciler", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			cluster.Status.InfrastructureReady = true
 			cluster.Spec.InfrastructureRef = &v1.ObjectReference{Name: "test"}
-			Expect(ph.Patch(ctx, cluster)).ShouldNot(HaveOccurred())
+			Expect(ph.Patch(ctx, cluster, patch.WithStatusObservedGeneration{})).ShouldNot(HaveOccurred())
 			return true
 		}, timeout).Should(BeTrue())
 
@@ -230,7 +230,7 @@ var _ = Describe("Cluster Reconciler", func() {
 			ph, err := patch.NewHelper(cluster, testEnv)
 			Expect(err).ShouldNot(HaveOccurred())
 			cluster.SetFinalizers([]string{})
-			Expect(ph.Patch(ctx, cluster)).ShouldNot(HaveOccurred())
+			Expect(ph.Patch(ctx, cluster, patch.WithStatusObservedGeneration{})).ShouldNot(HaveOccurred())
 			return true
 		}, timeout).Should(BeTrue())
 

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -185,7 +185,12 @@ func (r *MachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr e
 		r.reconcileMetrics(ctx, m)
 
 		// Always attempt to patch the object and status after each reconciliation.
-		if err := patchHelper.Patch(ctx, m); err != nil {
+		// Patch ObservedGeneration only if the reconciliation completed successfully
+		patchOpts := []patch.Option{}
+		if reterr == nil {
+			patchOpts = append(patchOpts, patch.WithStatusObservedGeneration{})
+		}
+		if err := patchHelper.Patch(ctx, m, patchOpts...); err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -362,6 +362,7 @@ func TestReconcileRequest(t *testing.T) {
 					NodeRef: &corev1.ObjectReference{
 						Name: "test",
 					},
+					ObservedGeneration: 1,
 				},
 			},
 			expected: expected{
@@ -389,6 +390,7 @@ func TestReconcileRequest(t *testing.T) {
 					NodeRef: &corev1.ObjectReference{
 						Name: "test",
 					},
+					ObservedGeneration: 1,
 				},
 			},
 			expected: expected{

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -151,7 +151,12 @@ func (r *MachineHealthCheckReconciler) Reconcile(req ctrl.Request) (_ ctrl.Resul
 
 	defer func() {
 		// Always attempt to patch the object and status after each reconciliation.
-		if err := patchHelper.Patch(ctx, m); err != nil {
+		// Patch ObservedGeneration only if the reconciliation completed successfully
+		patchOpts := []patch.Option{}
+		if reterr == nil {
+			patchOpts = append(patchOpts, patch.WithStatusObservedGeneration{})
+		}
+		if err := patchHelper.Patch(ctx, m, patchOpts...); err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()

--- a/controllers/machinehealthcheck_controller_test.go
+++ b/controllers/machinehealthcheck_controller_test.go
@@ -77,6 +77,7 @@ var _ = Describe("MachineHealthCheck", func() {
 						InfrastructureReady: true,
 						BootstrapReady:      true,
 						Phase:               string(clusterv1.MachinePhaseRunning),
+						ObservedGeneration:  1,
 					},
 				}
 
@@ -313,10 +314,11 @@ var _ = Describe("MachineHealthCheck", func() {
 						return nil
 					}
 					return &mhc.Status
-				}).Should(Equal(&clusterv1.MachineHealthCheckStatus{
-					ExpectedMachines: 2,
-					CurrentHealthy:   2,
-					Targets:          targetMachines},
+				}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
+					ExpectedMachines:   2,
+					CurrentHealthy:     2,
+					ObservedGeneration: 1,
+					Targets:            targetMachines},
 				))
 			})
 
@@ -341,9 +343,10 @@ var _ = Describe("MachineHealthCheck", func() {
 					}
 					return &mhc.Status
 				}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-					ExpectedMachines: 3,
-					CurrentHealthy:   2,
-					Targets:          targetMachines,
+					ExpectedMachines:   3,
+					CurrentHealthy:     2,
+					ObservedGeneration: 1,
+					Targets:            targetMachines,
 				}))
 			})
 
@@ -370,9 +373,10 @@ var _ = Describe("MachineHealthCheck", func() {
 					}
 					return &mhc.Status
 				}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-					ExpectedMachines: 3,
-					CurrentHealthy:   1,
-					Targets:          targetMachines},
+					ExpectedMachines:   3,
+					CurrentHealthy:     1,
+					ObservedGeneration: 1,
+					Targets:            targetMachines},
 				))
 
 				// Calculate how many Machines have health check succeeded = false.
@@ -434,9 +438,10 @@ var _ = Describe("MachineHealthCheck", func() {
 				}
 				return &mhc.Status
 			}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-				ExpectedMachines: 3,
-				CurrentHealthy:   2,
-				Targets:          targetMachines},
+				ExpectedMachines:   3,
+				CurrentHealthy:     2,
+				ObservedGeneration: 1,
+				Targets:            targetMachines},
 			))
 
 			// Calculate how many Machines have health check succeeded = false.
@@ -498,9 +503,10 @@ var _ = Describe("MachineHealthCheck", func() {
 				}
 				return &mhc.Status
 			}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-				ExpectedMachines: 3,
-				CurrentHealthy:   2,
-				Targets:          targetMachines},
+				ExpectedMachines:   3,
+				CurrentHealthy:     2,
+				ObservedGeneration: 1,
+				Targets:            targetMachines},
 			))
 
 			// Calculate how many Machines have health check succeeded = false.
@@ -568,9 +574,10 @@ var _ = Describe("MachineHealthCheck", func() {
 				}
 				return &mhc.Status
 			}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-				ExpectedMachines: 3,
-				CurrentHealthy:   2,
-				Targets:          targetMachines},
+				ExpectedMachines:   3,
+				CurrentHealthy:     2,
+				ObservedGeneration: 1,
+				Targets:            targetMachines},
 			))
 
 			// Calculate how many Machines have health check succeeded = false.
@@ -629,9 +636,10 @@ var _ = Describe("MachineHealthCheck", func() {
 				}
 				return &mhc.Status
 			}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-				ExpectedMachines: 1,
-				CurrentHealthy:   1,
-				Targets:          targetMachines},
+				ExpectedMachines:   1,
+				CurrentHealthy:     1,
+				ObservedGeneration: 1,
+				Targets:            targetMachines},
 			))
 
 			// Transition the node to unhealthy.
@@ -654,9 +662,10 @@ var _ = Describe("MachineHealthCheck", func() {
 				}
 				return &mhc.Status
 			}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-				ExpectedMachines: 1,
-				CurrentHealthy:   0,
-				Targets:          targetMachines},
+				ExpectedMachines:   1,
+				CurrentHealthy:     0,
+				ObservedGeneration: 1,
+				Targets:            targetMachines},
 			))
 
 			// Calculate how many Machines have health check succeeded = false.
@@ -1223,11 +1232,12 @@ func TestIndexMachineByNodeName(t *testing.T) {
 
 func TestIsAllowedRemediation(t *testing.T) {
 	testCases := []struct {
-		name             string
-		maxUnhealthy     *intstr.IntOrString
-		expectedMachines int32
-		currentHealthy   int32
-		allowed          bool
+		name               string
+		maxUnhealthy       *intstr.IntOrString
+		expectedMachines   int32
+		currentHealthy     int32
+		allowed            bool
+		observedGeneration int64
 	}{
 		{
 			name:             "when maxUnhealthy is not set",
@@ -1296,8 +1306,9 @@ func TestIsAllowedRemediation(t *testing.T) {
 					MaxUnhealthy: tc.maxUnhealthy,
 				},
 				Status: clusterv1.MachineHealthCheckStatus{
-					ExpectedMachines: tc.expectedMachines,
-					CurrentHealthy:   tc.currentHealthy,
+					ExpectedMachines:   tc.expectedMachines,
+					CurrentHealthy:     tc.currentHealthy,
+					ObservedGeneration: tc.observedGeneration,
 				},
 			}
 

--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -160,7 +160,12 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(req ctrl.Request) (res ctrl.Re
 
 		// patch and return right away instead of reusing the main defer,
 		// because the main defer may take too much time to get cluster status
-		if err := patchHelper.Patch(ctx, kcp); err != nil {
+		// Patch ObservedGeneration only if the reconciliation completed successfully
+		patchOpts := []patch.Option{}
+		if reterr == nil {
+			patchOpts = append(patchOpts, patch.WithStatusObservedGeneration{})
+		}
+		if err := patchHelper.Patch(ctx, kcp, patchOpts...); err != nil {
 			logger.Error(err, "Failed to patch KubeadmControlPlane to add finalizer")
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the observedGeneration object in the status

**Which issue(s) this PR fixes**:
Fixes #3078