### PR TITLE
🐛 Scope MHC machines to the cluster matching their clusterName

### DIFF
--- a/api/v1alpha3/machinehealthcheck_webhook.go
+++ b/api/v1alpha3/machinehealthcheck_webhook.go
@@ -106,6 +106,12 @@ func (m *MachineHealthCheck) validate(old *MachineHealthCheck) error {
 		)
 	}
 
+	if clusterName, ok := m.Spec.Selector.MatchLabels[ClusterLabelName]; ok && clusterName != m.Spec.ClusterName {
+		allErrs = append(
+			allErrs,
+			field.Invalid(field.NewPath("spec", "selector"), m.Spec.Selector, "cannot specify a cluster selector other than the one specified by ClusterName"))
+	}
+
 	if old != nil && old.Spec.ClusterName != m.Spec.ClusterName {
 		allErrs = append(
 			allErrs,

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -373,7 +373,7 @@ func (r *MachineHealthCheckReconciler) getMachineFromNode(nodeName string) (*clu
 		}
 	}
 	if len(items) != 1 {
-		return nil, errors.Errorf("expecting one machine for node %v, got %v", nodeName, items)
+		return nil, errors.Errorf("expecting one machine for node %v, got %v", nodeName, machineNames(items))
 	}
 	return items[0], nil
 }
@@ -423,4 +423,12 @@ func isAllowedRemediation(mhc *clusterv1.MachineHealthCheck) bool {
 	// If unhealthy is above maxUnhealthy, short circuit any further remediation
 	unhealthy := mhc.Status.ExpectedMachines - mhc.Status.CurrentHealthy
 	return int(unhealthy) <= maxUnhealthy
+}
+
+func machineNames(machines []*clusterv1.Machine) []string {
+	result := make([]string, 0, len(machines))
+	for _, m := range machines {
+		result = append(result, m.Name)
+	}
+	return result
 }

--- a/controllers/machinehealthcheck_targets_test.go
+++ b/controllers/machinehealthcheck_targets_test.go
@@ -48,6 +48,7 @@ func TestGetTargetsFromMHC(t *testing.T) {
 			Namespace: namespace,
 		},
 		Spec: clusterv1.MachineHealthCheckSpec{
+			ClusterName: clusterName,
 			Selector: metav1.LabelSelector{
 				MatchLabels: mhcSelector,
 			},
@@ -72,7 +73,7 @@ func TestGetTargetsFromMHC(t *testing.T) {
 	testNode3 := newTestNode("node3")
 	testMachine3 := newTestMachine("machine3", namespace, clusterName, testNode3.Name, mhcSelector)
 	testNode4 := newTestNode("node4")
-	testMachine4 := newTestMachine("machine4", namespace, clusterName, testNode4.Name, mhcSelector)
+	testMachine4 := newTestMachine("machine4", namespace, "other-cluster", testNode4.Name, mhcSelector)
 
 	testCases := []struct {
 		desc            string
@@ -97,7 +98,7 @@ func TestGetTargetsFromMHC(t *testing.T) {
 			},
 		},
 		{
-			desc:     "when a machine's labels do not match",
+			desc:     "when a machine's labels do not match the selector",
 			toCreate: append(baseObjects, testMachine1, testMachine2, testNode1),
 			expectedTargets: []healthCheckTarget{
 				{
@@ -120,11 +121,6 @@ func TestGetTargetsFromMHC(t *testing.T) {
 					Machine: testMachine3,
 					MHC:     testMHC,
 					Node:    testNode3,
-				},
-				{
-					Machine: testMachine4,
-					MHC:     testMHC,
-					Node:    testNode4,
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix MHC so that it will only target machines that have the label marking them as being a part of the cluster specified by the MHC's `ClusterName`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3202

I fixed the `errors.Errorf` call since I noticed it was logging memory addresses rather than machine names, but not really related to this PR.
