### PR TITLE
:bug: Properly adopt cluster secrets on upgrade

### DIFF
--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -554,7 +554,7 @@ func (r *KubeadmControlPlaneReconciler) adoptOwnedSecrets(ctx context.Context, k
 
 	for i := range secrets.Items {
 		s := secrets.Items[i]
-		if !util.IsControlledBy(&s, currentOwner) {
+		if !util.IsOwnedByObject(&s, currentOwner) {
 			continue
 		}
 		// avoid taking ownership of the bootstrap data secret

--- a/docs/book/src/tasks/kubeadm-control-plane.md
+++ b/docs/book/src/tasks/kubeadm-control-plane.md
@@ -39,8 +39,8 @@ but is the final step in fully upgrading a Cluster API managed cluster.
 
 It is recommended to manage workload machines with one or more `MachineDeployment`s. `MachineDeployment`s will
 transparently manage `MachineSet`s and `Machine`s to allow for a seamless scaling experience. A modification to the
-`MachineDeployment`s spec will begin a rolling update of the workload machines. Follow 
-[these instructions](./change-machine-template.md) for changing the 
+`MachineDeployment`s spec will begin a rolling update of the workload machines. Follow
+[these instructions](./change-machine-template.md) for changing the
 template for an existing `MachineDeployment`.
 
 For a more in-depth look at how `MachineDeployments` manage scaling events, take a look at the [`MachineDeployment`
@@ -48,6 +48,8 @@ controller documentation](../developer/architecture/controllers/machine-deployme
 documentation](../developer/architecture/controllers/machine-set.md).
 
 ### Adopting existing machines into KubeadmControlPlane management
+
+WARNING: If you are adopting Machines that were created on a v1alpha2 cluster, you must use a version with the fix for [#3144](https://github.com/kubernetes-sigs/cluster-api/issues/3144) to perform the adoption or your cluster will be broken.
 
 If your cluster has existing machines labeled with `cluster.x-k8s.io/control-plane`, you may opt in to management of those machines by creating a new KubeadmControlPlane object and updating the associated Cluster object's `controlPlaneRef` like so:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Cluster-scoped secrets in v1alpha2 were generated an owner ref that lacked the "controller=true" property.

That means that checking for a controller reference will fail to adopt any v1a2 secrets, and cause the cluster to enter a broken state on adoption post-upgrade.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3144
