### PR TITLE
🐛 Test suites should create proper machines

### DIFF
--- a/controllers/external/testing.go
+++ b/controllers/external/testing.go
@@ -104,6 +104,10 @@ var (
 									Type:                   "object",
 									XPreserveUnknownFields: pointer.BoolPtr(true),
 								},
+								"status": {
+									Type:                   "object",
+									XPreserveUnknownFields: pointer.BoolPtr(true),
+								},
 							},
 						},
 					},
@@ -146,6 +150,10 @@ var (
 									Type:                   "object",
 									XPreserveUnknownFields: pointer.BoolPtr(true),
 								},
+								"status": {
+									Type:                   "object",
+									XPreserveUnknownFields: pointer.BoolPtr(true),
+								},
 							},
 						},
 					},
@@ -185,6 +193,10 @@ var (
 							Type: "object",
 							Properties: map[string]apiextensionsv1.JSONSchemaProps{
 								"spec": {
+									Type:                   "object",
+									XPreserveUnknownFields: pointer.BoolPtr(true),
+								},
+								"status": {
 									Type:                   "object",
 									XPreserveUnknownFields: pointer.BoolPtr(true),
 								},

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -275,7 +275,7 @@ func (r *MachineReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 	if err != nil {
 		switch err {
 		case errNoControlPlaneNodes, errLastControlPlaneNode, errNilNodeRef, errClusterIsBeingDeleted:
-			logger.Info("Deleting Kubernetes Node associated with Machine is not allowed", "node", m.Status.NodeRef, "cause", err)
+			logger.Info("Deleting Kubernetes Node associated with Machine is not allowed", "node", m.Status.NodeRef, "cause", err.Error())
 		default:
 			return ctrl.Result{}, errors.Wrapf(err, "failed to check if Kubernetes Node deletion is allowed")
 		}

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -268,7 +268,7 @@ func (r *MachineDeploymentReconciler) getMachineDeploymentsForMachineSet(ms *clu
 	logger := r.Log.WithValues("machineset", ms.Name, "namespace", ms.Namespace)
 
 	if len(ms.Labels) == 0 {
-		logger.Info("No MachineDeployments found for MachineSet because it has no labels", "machineset", ms.Name)
+		logger.V(2).Info("No MachineDeployments found for MachineSet because it has no labels", "machineset", ms.Name)
 		return nil
 	}
 

--- a/controllers/machinedeployment_controller_test.go
+++ b/controllers/machinedeployment_controller_test.go
@@ -122,8 +122,7 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
 			"metadata":   map[string]interface{}{},
 			"spec": map[string]interface{}{
-				"size":       "3xlarge",
-				"providerID": "test:////id",
+				"size": "3xlarge",
 			},
 		}
 		infraTmpl := &unstructured.Unstructured{
@@ -296,8 +295,8 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 				if !metav1.IsControlledBy(&m, thirdMachineSet) {
 					continue
 				}
-				fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource)
-				fakeMachineNodeRef(&m)
+				providerID := fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource)
+				fakeMachineNodeRef(&m, providerID)
 			}
 
 			if err := testEnv.List(ctx, machineSets, msListOpts...); err != nil {
@@ -351,8 +350,8 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 				if !metav1.IsControlledBy(&m, &newms) {
 					continue
 				}
-				fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource)
-				fakeMachineNodeRef(&m)
+				providerID := fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource)
+				fakeMachineNodeRef(&m, providerID)
 			}
 
 			listOpts := client.MatchingLabels(newLabels)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -46,6 +46,8 @@ var (
 )
 
 func TestAPIs(t *testing.T) {
+	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
+	SetDefaultEventuallyTimeout(30 * time.Second)
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,


### PR DESCRIPTION
This PR makes sure that machines created during MHC tests
have proper node references, infrastructure refs, and status fields.

In the future, we need to make all of these fake utilities available
in a separate package for folks to use, given that they're really
important for integration tests.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
/assign @gab-satchi 
