### PR TITLE
🌱  clusterctl move ClusterResourceSets

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -275,7 +275,7 @@ func getMoveSequence(graph *objectGraph) *moveSequence {
 		// NB. it is necessary to filter out nodes not belonging to a cluster because e.g. discovery reads all the secrets,
 		// but only few of them are related to Clusters/Machines etc.
 		moveGroup := moveGroup{}
-		for _, n := range graph.getNodesWithClusterTenants() {
+		for _, n := range graph.getNodesWithTenants() {
 			// If the node was already included in the moveSequence, skip it.
 			if moveSequence.hasNode(n) {
 				continue
@@ -360,7 +360,7 @@ func patchCluster(proxy Proxy, cluster *node, patch client.Patch) error {
 func (o *objectMover) ensureNamespaces(graph *objectGraph, toProxy Proxy) error {
 	ensureNamespaceBackoff := newWriteBackoff()
 	namespaces := sets.NewString()
-	for _, node := range graph.getNodesWithClusterTenants() {
+	for _, node := range graph.getNodesWithTenants() {
 		namespace := node.identity.Namespace
 
 		// If the namespace was already processed, skip it.

--- a/cmd/clusterctl/internal/scheme/scheme.go
+++ b/cmd/clusterctl/internal/scheme/scheme.go
@@ -22,6 +22,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	addonsv1alpha3 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
 )
 
 var (
@@ -34,4 +35,5 @@ func init() {
 	_ = clusterctlv1.AddToScheme(Scheme)
 	_ = clusterv1.AddToScheme(Scheme)
 	_ = apiextensionsv1.AddToScheme(Scheme)
+	_ = addonsv1alpha3.AddToScheme(Scheme)
 }

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -28,6 +28,7 @@ import (
 	fakebootstrap "sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test/providers/bootstrap"
 	fakecontrolplane "sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test/providers/controlplane"
 	fakeinfrastructure "sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test/providers/infrastructure"
+	addonsv1alpha3 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -47,6 +48,7 @@ func init() {
 	_ = clusterctlv1.AddToScheme(FakeScheme)
 	_ = clusterv1.AddToScheme(FakeScheme)
 	_ = expv1.AddToScheme(FakeScheme)
+	_ = addonsv1alpha3.AddToScheme(FakeScheme)
 	_ = apiextensionslv1.AddToScheme(FakeScheme)
 
 	_ = fakebootstrap.AddToScheme(FakeScheme)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends clusterctl move so it will manage to move the ClusterResourceSet objects defined in a namespace.

TL;DR of the changes: during the discovery phase that is executed before Move, we are identifying ClusterResourceSet and their descendants; those objects will be included in the move scope.

NB. 
this PR will remain WIP until https://github.com/kubernetes-sigs/cluster-api/pull/3107 merges

/assign @vincepri 
/assign @sedefsavas 

