### PR TITLE
📖 Add known bug warning for clusterctl delete

### DIFF
--- a/cmd/clusterctl/cmd/delete.go
+++ b/cmd/clusterctl/cmd/delete.go
@@ -53,6 +53,14 @@ var deleteCmd = &cobra.Command{
 		# Please note, if there are multiple instances of the AWS provider installed in the cluster,
 		# global/shared resources (e.g. ClusterRoles), are not deleted in order to preserve
 		# the functioning of the remaining instances.
+		#
+		# WARNING: There is a known bug where deleting an infrastructure component from a namespace that share
+		# the same prefix with other namespaces (e.g. 'foo' and 'foo-bar') will result
+		# in erroneous deletion of cluster scoped objects such as 'ClusterRole' and
+		# 'ClusterRoleBindings' that share the same namespace prefix.
+		# This is true if the prefix before a dash '-' is same. That is, namespaces such
+		# as 'foo' and 'foobar' are fine however namespaces such as 'foo' and 'foo-bar'
+		# are not. See CAPI issue 3119 for more details.
 		clusterctl delete --infrastructure aws --namespace=foo
 
 		# Deletes all the providers

--- a/docs/book/src/clusterctl/commands/delete.md
+++ b/docs/book/src/clusterctl/commands/delete.md
@@ -31,10 +31,44 @@ you can use the `--include-crd` flag.
 Be aware that this operation deletes all the object of Kind defined in the provider's CRDs, e.g. when deleting
 the aws provider, it deletes all the `AWSCluster`, `AWSMachine` etc.
 
-</aside> 
+</aside>
+
+<aside class="note warning">
+
+<h1>Warning</h1>
+
+KNOWN BUG:
+
+Deleting an infrastructure component from a namespace _that share
+the same prefix_ with other namespaces (e.g. `foo` and `foo-bar`) will result
+in erroneous deletion of cluster scoped objects such as `ClusterRole` and
+`ClusterRoleBindings` that share the same namespace prefix.
+
+This is true if the prefix before a dash `-` is same. That is, namespaces such
+as `foo` and `foobar` are fine however namespaces such as `foo` and `foo-bar`
+are not.
+
+For example,
+
+1. Init an infrastructure provider in namespace `foo` and `foo-bar`.
+    ```
+    clusterctl init --infrastructure aws --watching-namespace foo --target-namespace foo
+    clusterctl init --infrastructure aws --watching-namespace foo-bar --target-namespace foo-bar
+    ```
+1. Delete infrastructure components from namespace `foo`
+    ```
+    clusterctl delete --infrastructure aws --namespace foo
+    ```
+
+ClusterRole and ClusterRoleBindings for both the namespaces are deleted.
+
+See [issue 3119] for more details.
+
+</aside>
 
 If you want to delete all the providers in a single operation , you can use the `--all` flag.
 
 ```shell
 clusterctl delete --all
 ```
+[issue 3119]: https://github.com/kubernetes-sigs/cluster-api/issues/3119


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds a documentation warning for the `clusterctl delete` section in the CAPI book to surface the bug #3119.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref https://github.com/kubernetes-sigs/cluster-api/issues/3119
