### PR TITLE
:seedling: Allow Patch to specify options as well

### DIFF
--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -530,14 +530,14 @@ var _ = Describe("Patch Helper", func() {
 			}()
 
 			By("Creating a new patch helper")
-			patcher, err := NewHelper(obj, testEnv, WithStatusObservedGeneration{})
+			patcher, err := NewHelper(obj, testEnv)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Updating the object spec")
 			obj.Spec.Replicas = pointer.Int32Ptr(10)
 
 			By("Patching the object")
-			Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			Expect(patcher.Patch(ctx, obj, WithStatusObservedGeneration{})).To(Succeed())
 
 			By("Validating the object has been updated")
 			Eventually(func() bool {
@@ -562,7 +562,7 @@ var _ = Describe("Patch Helper", func() {
 			}()
 
 			By("Creating a new patch helper")
-			patcher, err := NewHelper(obj, testEnv, WithStatusObservedGeneration{})
+			patcher, err := NewHelper(obj, testEnv)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Updating the object spec")
@@ -578,7 +578,7 @@ var _ = Describe("Patch Helper", func() {
 			}
 
 			By("Patching the object")
-			Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			Expect(patcher.Patch(ctx, obj, WithStatusObservedGeneration{})).To(Succeed())
 
 			By("Validating the object has been updated")
 			Eventually(func() bool {
@@ -607,11 +607,11 @@ var _ = Describe("Patch Helper", func() {
 			Expect(testEnv.Status().Update(ctx, obj))
 
 			By("Creating a new patch helper")
-			patcher, err := NewHelper(obj, testEnv, WithStatusObservedGeneration{})
+			patcher, err := NewHelper(obj, testEnv)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Patching the object")
-			Expect(patcher.Patch(ctx, obj)).To(Succeed())
+			Expect(patcher.Patch(ctx, obj, WithStatusObservedGeneration{})).To(Succeed())
 
 			By("Validating the object has been updated")
 			Eventually(func() bool {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds ability to add options when invoking `Patch`, this PR is related to an issue reported by @detiber that wouldn't allow us to only patch observed generation when needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #3256 
