### PR TITLE
🌱 Allow incremental condition patch

### DIFF
--- a/util/conditions/patch.go
+++ b/util/conditions/patch.go
@@ -28,8 +28,8 @@ type Patch []PatchOperation
 
 // PatchOperation define an operation that changes a single condition.
 type PatchOperation struct {
-	Target *clusterv1.Condition
-	Base   *clusterv1.Condition
+	After  *clusterv1.Condition
+	Before *clusterv1.Condition
 	Op     PatchOperationType
 }
 
@@ -57,12 +57,12 @@ func NewPatch(before Getter, after Getter) Patch {
 		targetCondition := targetConditions[i]
 		currentCondition := Get(before, targetCondition.Type)
 		if currentCondition == nil {
-			patch = append(patch, PatchOperation{Op: AddConditionPatch, Target: &targetCondition})
+			patch = append(patch, PatchOperation{Op: AddConditionPatch, After: &targetCondition})
 			continue
 		}
 
 		if !reflect.DeepEqual(&targetCondition, currentCondition) {
-			patch = append(patch, PatchOperation{Op: ChangeConditionPatch, Target: &targetCondition, Base: currentCondition})
+			patch = append(patch, PatchOperation{Op: ChangeConditionPatch, After: &targetCondition, Before: currentCondition})
 		}
 	}
 
@@ -72,67 +72,114 @@ func NewPatch(before Getter, after Getter) Patch {
 		baseCondition := baseConditions[i]
 		targetCondition := Get(after, baseCondition.Type)
 		if targetCondition == nil {
-			patch = append(patch, PatchOperation{Op: RemoveConditionPatch, Base: &baseCondition})
+			patch = append(patch, PatchOperation{Op: RemoveConditionPatch, Before: &baseCondition})
 		}
 	}
 	return patch
 }
 
+// applyOptions allows to set strategies for patch apply.
+type applyOptions struct {
+	ownedConditions []clusterv1.ConditionType
+}
+
+func (o *applyOptions) isOwnedCondition(t clusterv1.ConditionType) bool {
+	for _, i := range o.ownedConditions {
+		if i == t {
+			return true
+		}
+	}
+	return false
+}
+
+// ApplyOption defines an option for applying a condition patch.
+type ApplyOption func(*applyOptions)
+
+// WithOwnedConditions allows to define condition types owned by the controller.
+// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+func WithOwnedConditions(t ...clusterv1.ConditionType) ApplyOption {
+	return func(c *applyOptions) {
+		c.ownedConditions = t
+	}
+}
+
 // Apply executes a three-way merge of a list of Patch.
 // When merge conflicts are detected (latest deviated from before in an incompatible way), an error is returned.
-func (p Patch) Apply(latest Setter) error {
+func (p Patch) Apply(latest Setter, options ...ApplyOption) error {
 	if len(p) == 0 {
 		return nil
+	}
+
+	applyOpt := &applyOptions{}
+	for _, o := range options {
+		o(applyOpt)
 	}
 
 	for _, conditionPatch := range p {
 		switch conditionPatch.Op {
 		case AddConditionPatch:
+			// If the conditions is owned, always keep the after value.
+			if applyOpt.isOwnedCondition(conditionPatch.After.Type) {
+				Set(latest, conditionPatch.After)
+				continue
+			}
+
 			// If the condition is already on latest, check if latest and after agree on the change; if not, this is a conflict.
-			if sourceCondition := Get(latest, conditionPatch.Target.Type); sourceCondition != nil {
+			if latestCondition := Get(latest, conditionPatch.After.Type); latestCondition != nil {
 				// If latest and after agree on the change, then it is a conflict.
-				if !hasSameState(sourceCondition, conditionPatch.Target) {
-					return errors.Errorf("error patching conditions: The condition %q on was modified by a different process and this caused a merge/AddCondition conflict", conditionPatch.Target.Type)
+				if !hasSameState(latestCondition, conditionPatch.After) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/AddCondition conflict", conditionPatch.After.Type)
 				}
 				// otherwise, the latest is already as intended.
 				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
 				continue
 			}
 			// If the condition does not exists on the latest, add the new after condition.
-			Set(latest, conditionPatch.Target)
+			Set(latest, conditionPatch.After)
 
 		case ChangeConditionPatch:
-			sourceCondition := Get(latest, conditionPatch.Target.Type)
+			// If the conditions is owned, always keep the after value.
+			if applyOpt.isOwnedCondition(conditionPatch.After.Type) {
+				Set(latest, conditionPatch.After)
+				continue
+			}
+
+			latestCondition := Get(latest, conditionPatch.After.Type)
 
 			// If the condition does not exist anymore on the latest, this is a conflict.
-			if sourceCondition == nil {
-				return errors.Errorf("error patching conditions: The condition %q on was deleted by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.Target.Type)
+			if latestCondition == nil {
+				return errors.Errorf("error patching conditions: The condition %q was deleted by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.After.Type)
 			}
 
 			// If the condition on the latest is different from the base condition, check if
-			// the after state corresponds to the desired value. If not this is a conflict.
-			if !reflect.DeepEqual(sourceCondition, conditionPatch.Base) {
-				if !hasSameState(sourceCondition, conditionPatch.Target) {
-					return errors.Errorf("error patching conditions: The condition %q on was modified by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.Target.Type)
+			// the after state corresponds to the desired value. If not this is a conflict (unless we should ignore conflicts for this condition type).
+			if !reflect.DeepEqual(latestCondition, conditionPatch.Before) {
+				if !hasSameState(latestCondition, conditionPatch.After) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/ChangeCondition conflict", conditionPatch.After.Type)
 				}
 				// Otherwise the latest is already as intended.
 				// NOTE: We are preserving LastTransitionTime from the latest in order to avoid altering the existing value.
 				continue
 			}
-
 			// Otherwise apply the new after condition.
-			Set(latest, conditionPatch.Target)
+			Set(latest, conditionPatch.After)
 
 		case RemoveConditionPatch:
+			// If the conditions is owned, always keep the after value (condition should be deleted).
+			if applyOpt.isOwnedCondition(conditionPatch.Before.Type) {
+				Delete(latest, conditionPatch.Before.Type)
+				continue
+			}
+
 			// If the condition is still on the latest, check if it is changed in the meantime;
 			// if so then this is a conflict.
-			if sourceCondition := Get(latest, conditionPatch.Base.Type); sourceCondition != nil {
-				if !hasSameState(sourceCondition, conditionPatch.Base) {
-					return errors.Errorf("error patching conditions: The condition %q on was modified by a different process and this caused a merge/RemoveCondition conflict", conditionPatch.Base.Type)
+			if latestCondition := Get(latest, conditionPatch.Before.Type); latestCondition != nil {
+				if !hasSameState(latestCondition, conditionPatch.Before) {
+					return errors.Errorf("error patching conditions: The condition %q was modified by a different process and this caused a merge/RemoveCondition conflict", conditionPatch.Before.Type)
 				}
 			}
 			// Otherwise the latest and after agreed on the delete operation, so there's nothing to change.
-			Delete(latest, conditionPatch.Base.Type)
+			Delete(latest, conditionPatch.Before.Type)
 		}
 	}
 	return nil

--- a/util/patch/options.go
+++ b/util/patch/options.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package patch
 
+import clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
 // Option is some configuration that modifies options for a patch request.
 type Option interface {
 	// ApplyToHelper applies this configuration to the given Helper options.
@@ -27,13 +29,28 @@ type HelperOptions struct {
 	// IncludeStatusObservedGeneration sets the status.observedGeneration field
 	// on the incoming object to match metadata.generation, only if there is a change.
 	IncludeStatusObservedGeneration bool
+
+	// OwnedConditions defines condition types owned by the controller.
+	// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+	OwnedConditions []clusterv1.ConditionType
 }
 
 // WithStatusObservedGeneration sets the status.observedGeneration field
 // on the incoming object to match metadata.generation, only if there is a change.
 type WithStatusObservedGeneration struct{}
 
-// ApplyToHelper applies this configuration to the given an List options.
+// ApplyToHelper applies this configuration to the given HelperOptions.
 func (w WithStatusObservedGeneration) ApplyToHelper(in *HelperOptions) {
 	in.IncludeStatusObservedGeneration = true
+}
+
+// WithOwnedConditions allows to define condition types owned by the controller.
+// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+type WithOwnedConditions struct {
+	Conditions []clusterv1.ConditionType
+}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithOwnedConditions) ApplyToHelper(in *HelperOptions) {
+	in.OwnedConditions = w.Conditions
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows incremental condition patching within the same controller.

In order to do so, in the final defer patch, it is required to declare the list of conditions the controller owns, and for which, a conflict between after and latest value of the condition should not generate errors (after value should always be used instead)

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3260

/assign @vincepri 
/assign @gab-satchi 