### PR TITLE
:book: Fix references to spec.kubernetesVersion for the Machine object to spec.Version

### DIFF
--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -282,7 +282,7 @@ spec:
                     type: string
                   kubernetesVersion:
                     description: 'KubernetesVersion is the target version of the control
-                      plane. NB: This value defaults to the Machine object spec.Version'
+                      plane. NB: This value defaults to the Machine object spec.version'
                     type: string
                   networking:
                     description: 'Networking holds configuration for the networking
@@ -1088,7 +1088,7 @@ spec:
                     type: string
                   kubernetesVersion:
                     description: 'KubernetesVersion is the target version of the control
-                      plane. NB: This value defaults to the Machine object spec.Version'
+                      plane. NB: This value defaults to the Machine object spec.version'
                     type: string
                   networking:
                     description: 'Networking holds configuration for the networking

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -282,7 +282,7 @@ spec:
                     type: string
                   kubernetesVersion:
                     description: 'KubernetesVersion is the target version of the control
-                      plane. NB: This value defaults to the Machine object spec.kubernetesVersion'
+                      plane. NB: This value defaults to the Machine object spec.Version'
                     type: string
                   networking:
                     description: 'Networking holds configuration for the networking
@@ -1088,7 +1088,7 @@ spec:
                     type: string
                   kubernetesVersion:
                     description: 'KubernetesVersion is the target version of the control
-                      plane. NB: This value defaults to the Machine object spec.kubernetesVersion'
+                      plane. NB: This value defaults to the Machine object spec.Version'
                     type: string
                   networking:
                     description: 'Networking holds configuration for the networking

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -303,7 +303,7 @@ spec:
                           kubernetesVersion:
                             description: 'KubernetesVersion is the target version
                               of the control plane. NB: This value defaults to the
-                              Machine object spec.Version'
+                              Machine object spec.version'
                             type: string
                           networking:
                             description: 'Networking holds configuration for the networking
@@ -1141,7 +1141,7 @@ spec:
                           kubernetesVersion:
                             description: 'KubernetesVersion is the target version
                               of the control plane. NB: This value defaults to the
-                              Machine object spec.Version'
+                              Machine object spec.version'
                             type: string
                           networking:
                             description: 'Networking holds configuration for the networking

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -303,7 +303,7 @@ spec:
                           kubernetesVersion:
                             description: 'KubernetesVersion is the target version
                               of the control plane. NB: This value defaults to the
-                              Machine object spec.kubernetesVersion'
+                              Machine object spec.Version'
                             type: string
                           networking:
                             description: 'Networking holds configuration for the networking
@@ -1141,7 +1141,7 @@ spec:
                           kubernetesVersion:
                             description: 'KubernetesVersion is the target version
                               of the control plane. NB: This value defaults to the
-                              Machine object spec.kubernetesVersion'
+                              Machine object spec.Version'
                             type: string
                           networking:
                             description: 'Networking holds configuration for the networking

--- a/bootstrap/kubeadm/types/v1beta1/types.go
+++ b/bootstrap/kubeadm/types/v1beta1/types.go
@@ -64,7 +64,7 @@ type ClusterConfiguration struct {
 	Networking Networking `json:"networking,omitempty"`
 
 	// KubernetesVersion is the target version of the control plane.
-	// NB: This value defaults to the Machine object spec.Version
+	// NB: This value defaults to the Machine object spec.version
 	// +optional
 	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
 

--- a/bootstrap/kubeadm/types/v1beta1/types.go
+++ b/bootstrap/kubeadm/types/v1beta1/types.go
@@ -64,7 +64,7 @@ type ClusterConfiguration struct {
 	Networking Networking `json:"networking,omitempty"`
 
 	// KubernetesVersion is the target version of the control plane.
-	// NB: This value defaults to the Machine object spec.kubernetesVersion
+	// NB: This value defaults to the Machine object spec.Version
 	// +optional
 	KubernetesVersion string `json:"kubernetesVersion,omitempty"`
 

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -358,7 +358,7 @@ spec:
                       kubernetesVersion:
                         description: 'KubernetesVersion is the target version of the
                           control plane. NB: This value defaults to the Machine object
-                          spec.kubernetesVersion'
+                          spec.version'
                         type: string
                       networking:
                         description: 'Networking holds configuration for the networking


### PR DESCRIPTION
**What this PR does / why we need it**:
Change reference from "spec.kubernetesVersion" to "spec.Version" for the Machine object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3257
