### PR TITLE
🌱 MachinePool now has `status.observedGeneration`

### DIFF
--- a/config/crd/bases/exp.cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/exp.cluster.x-k8s.io_machinepools.yaml
@@ -439,6 +439,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
               phase:
                 description: Phase represents the current phase of cluster actuation.
                   E.g. Pending, Running, Terminating, Failed etc.

--- a/exp/api/v1alpha3/machinepool_types.go
+++ b/exp/api/v1alpha3/machinepool_types.go
@@ -116,6 +116,10 @@ type MachinePoolStatus struct {
 	// InfrastructureReady is the state of the infrastructure provider.
 	// +optional
 	InfrastructureReady bool `json:"infrastructureReady"`
+
+	// ObservedGeneration is the latest generation observed by the controller.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // ANCHOR_END: MachinePoolStatus

--- a/exp/controllers/machinepool_controller.go
+++ b/exp/controllers/machinepool_controller.go
@@ -137,7 +137,12 @@ func (r *MachinePoolReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, rete
 		// TODO(jpang): add support for metrics.
 
 		// Always attempt to patch the object and status after each reconciliation.
-		if err := patchHelper.Patch(ctx, mp); err != nil {
+		// Patch ObservedGeneration only if the reconciliation completed successfully
+		patchOpts := []patch.Option{}
+		if reterr == nil {
+			patchOpts = append(patchOpts, patch.WithStatusObservedGeneration{})
+		}
+		if err := patchHelper.Patch(ctx, mp, patchOpts...); err != nil {
 			reterr = kerrors.NewAggregate([]error{reterr, err})
 		}
 	}()

--- a/exp/controllers/machinepool_controller_test.go
+++ b/exp/controllers/machinepool_controller_test.go
@@ -337,6 +337,7 @@ func TestReconcileMachinePoolRequest(t *testing.T) {
 					NodeRefs: []corev1.ObjectReference{
 						{Name: "test"},
 					},
+					ObservedGeneration: 1,
 				},
 			},
 			expected: expected{
@@ -372,6 +373,7 @@ func TestReconcileMachinePoolRequest(t *testing.T) {
 					NodeRefs: []corev1.ObjectReference{
 						{Name: "test"},
 					},
+					ObservedGeneration: 1,
 				},
 			},
 			expected: expected{


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the status ObserverGeneration into the machinepool controller
**Which issue(s) this PR fixes**:
Fixes #3078
