### PR TITLE
🌱 Cleanup machinesNeedingRollout in KCP

### DIFF
--- a/controlplane/kubeadm/internal/machinefilters/machine_filters.go
+++ b/controlplane/kubeadm/internal/machinefilters/machine_filters.go
@@ -166,11 +166,15 @@ func IsReady() Func {
 	}
 }
 
-// OlderThan returns a filter to find all machines
-// that have a CreationTimestamp earlier than the given time.
-func OlderThan(t *metav1.Time) Func {
+// ShouldRolloutAfter returns a filter to find all machines
+// that should rollout after the given time.
+func ShouldRolloutAfter(t *metav1.Time) Func {
+	now := metav1.Now()
 	return func(machine *clusterv1.Machine) bool {
 		if machine == nil {
+			return false
+		}
+		if t == nil || !t.Before(&now) {
 			return false
 		}
 		return machine.CreationTimestamp.Before(t)


### PR DESCRIPTION
**What this PR does / why we need it**:
As per #3234 (comment) there is room for cleaning up the machinesNeedingRollout func in KCP

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3276
