### PR TITLE
⚠️ clusterctl: log.Log is now exposed correctly as logr.Logger

### DIFF
--- a/cmd/clusterctl/log/log.go
+++ b/cmd/clusterctl/log/log.go
@@ -23,10 +23,10 @@ import (
 
 // SetLogger sets a concrete logging implementation for all deferred Loggers.
 func SetLogger(l logr.Logger) {
-	Log.Fulfill(l)
+	Log = l
 }
 
 // Log is the base logger used by kubebuilder.  It delegates
 // to another logr.Logger.  You *must* call SetLogger to
 // get any actual logging.
-var Log = log.NewDelegatingLogger(log.NullLogger{})
+var Log logr.Logger = log.NullLogger{}


### PR DESCRIPTION
**What this PR does / why we need it**:
While investigating some e2e test failures I noticed that all the clusterctl logs subsequent to the first one are empty.
This change tries to force a reset of the controller-runtime log library