### PR TITLE
✨ Add command `clusterctl get kubeconfig`

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -40,6 +40,9 @@ type Client interface {
 	// GetClusterTemplate returns a workload cluster template.
 	GetClusterTemplate(options GetClusterTemplateOptions) (Template, error)
 
+	// GetKubeconfig returns the kubeconfig
+	GetKubeconfig(options GetKubeconfigOptions) error
+
 	// Delete deletes providers from a management cluster.
 	Delete(options DeleteOptions) error
 

--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -40,8 +40,8 @@ type Client interface {
 	// GetClusterTemplate returns a workload cluster template.
 	GetClusterTemplate(options GetClusterTemplateOptions) (Template, error)
 
-	// GetKubeconfig returns the kubeconfig
-	GetKubeconfig(options GetKubeconfigOptions) error
+	// GetKubeconfig returns the kubeconfig of the workload cluster.
+	GetKubeconfig(options GetKubeconfigOptions) (string, error)
 
 	// Delete deletes providers from a management cluster.
 	Delete(options DeleteOptions) error

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -81,6 +81,10 @@ func (f fakeClient) GetClusterTemplate(options GetClusterTemplateOptions) (Templ
 	return f.internalClient.GetClusterTemplate(options)
 }
 
+func (f fakeClient) GetKubeconfig(options GetKubeconfigOptions) error {
+	return f.internalClient.GetKubeconfig(options)
+}
+
 func (f fakeClient) Init(options InitOptions) ([]Components, error) {
 	return f.internalClient.Init(options)
 }
@@ -256,6 +260,10 @@ func (f *fakeClusterClient) ProviderUpgrader() cluster.ProviderUpgrader {
 
 func (f *fakeClusterClient) Template() cluster.TemplateClient {
 	return f.internalclient.Template()
+}
+
+func (f *fakeClusterClient) WorkloadCluster() cluster.WorkloadCluster {
+	return f.internalclient.WorkloadCluster()
 }
 
 func (f *fakeClusterClient) WithObjs(objs ...runtime.Object) *fakeClusterClient {

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -81,7 +81,7 @@ func (f fakeClient) GetClusterTemplate(options GetClusterTemplateOptions) (Templ
 	return f.internalClient.GetClusterTemplate(options)
 }
 
-func (f fakeClient) GetKubeconfig(options GetKubeconfigOptions) error {
+func (f fakeClient) GetKubeconfig(options GetKubeconfigOptions) (string, error) {
 	return f.internalClient.GetKubeconfig(options)
 }
 

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -86,6 +86,9 @@ type Client interface {
 
 	// Template has methods to work with templates stored in the cluster.
 	Template() TemplateClient
+
+	// WorkloadCluster has methods to make
+	WorkloadCluster() WorkloadCluster
 }
 
 // PollImmediateWaiter tries a condition func until it returns true, an error, or the timeout is reached.
@@ -140,6 +143,10 @@ func (c *clusterClient) ProviderUpgrader() ProviderUpgrader {
 
 func (c *clusterClient) Template() TemplateClient {
 	return newTemplateClient(TemplateClientInput{c.proxy, c.configClient, c.processor})
+}
+
+func (c *clusterClient) WorkloadCluster() WorkloadCluster {
+	return newWorkloadCluster(c.proxy)
 }
 
 // Option is a configuration option supplied to New

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -87,7 +87,7 @@ type Client interface {
 	// Template has methods to work with templates stored in the cluster.
 	Template() TemplateClient
 
-	// WorkloadCluster has methods to make
+	// WorkloadCluster has methods for fetching kubeconfig of workload cluster from management cluster.
 	WorkloadCluster() WorkloadCluster
 }
 

--- a/cmd/clusterctl/client/cluster/workload_cluster.go
+++ b/cmd/clusterctl/client/cluster/workload_cluster.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+
+	kc "sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// WorkloadCluster has methods for fetching kubeconfig of workload cluster from management cluster.
+type WorkloadCluster interface {
+	//Get workload cluster kubeconfig
+	GetKubeconfig(name string) error
+}
+
+// workloadCluster implements WorkloadCluster.
+type workloadCluster struct {
+	proxy Proxy
+}
+
+func (p *workloadCluster) GetKubeconfig(name string) error {
+	cs, err := p.proxy.NewClient()
+	if err != nil {
+		return err
+	}
+
+	obj := client.ObjectKey{
+		Namespace: "default",
+		Name:      name,
+	}
+	dataBytes, err := kc.FromSecret(ctx, cs, obj)
+
+	data := string(dataBytes)
+	fmt.Println(data)
+	return err
+}
+
+// newWorkloadCluster returns a workloadCluster.
+func newWorkloadCluster(proxy Proxy) *workloadCluster {
+	return &workloadCluster{
+		proxy: proxy,
+	}
+}

--- a/cmd/clusterctl/client/get_kubeconfig.go
+++ b/cmd/clusterctl/client/get_kubeconfig.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+//GetKubeconfigOptions carries all the options supported by GetKubeconfig
+type GetKubeconfigOptions struct {
+	// Kubeconfig defines the kubeconfig to use for accessing the management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	Kubeconfig Kubeconfig
+
+	// Name is the name of the workload cluster.
+	Name string
+}
+
+func (c *clusterctlClient) GetKubeconfig(options GetKubeconfigOptions) error {
+	// gets access to the management cluster
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})
+	if err != nil {
+		return err
+	}
+
+	return clusterClient.WorkloadCluster().GetKubeconfig(options.Name)
+}

--- a/cmd/clusterctl/cmd/get.go
+++ b/cmd/clusterctl/cmd/get.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get kubeconfig for a workload cluster",
+	Long:  `Get kubeconfig for a workload cluster`,
+}
+
+func init() {
+	RootCmd.AddCommand(getCmd)
+}

--- a/cmd/clusterctl/cmd/get_kubeconfig.go
+++ b/cmd/clusterctl/cmd/get_kubeconfig.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+var getKubeconfigCmd = &cobra.Command{
+	Use:   "kubeconfig",
+	Short: "Get kubeconfig for a workload cluster",
+	Long: LongDesc(`
+		Get kubeconfig for a workload cluster`),
+
+	Example: Examples(`
+		# Merge the workload cluster kubeconfig with management cluster kubeconfig
+		clusterctl get kubeconfig <name of workload cluster>`),
+
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGetKubeconfig(cmd, args[0])
+	},
+}
+
+func init() {
+	getCmd.AddCommand(getKubeconfigCmd)
+}
+
+func runGetKubeconfig(cmd *cobra.Command, name string) error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	options := client.GetKubeconfigOptions{
+		Kubeconfig: client.Kubeconfig{Path: initOpts.kubeconfig, Context: initOpts.kubeconfigContext},
+		Name:       name,
+	}
+
+	return c.GetKubeconfig(options)
+}

--- a/cmd/clusterctl/cmd/get_kubeconfig.go
+++ b/cmd/clusterctl/cmd/get_kubeconfig.go
@@ -17,9 +17,19 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 )
+
+type getKubeconfigOptions struct {
+	kubeconfig        string
+	kubeconfigContext string
+	namespace         string
+}
+
+var gk = &getKubeconfigOptions{}
 
 var getKubeconfigCmd = &cobra.Command{
 	Use:   "kubeconfig",
@@ -28,29 +38,44 @@ var getKubeconfigCmd = &cobra.Command{
 		Get kubeconfig for a workload cluster`),
 
 	Example: Examples(`
-		# Merge the workload cluster kubeconfig with management cluster kubeconfig
-		clusterctl get kubeconfig <name of workload cluster>`),
+		# Get the workload cluster's kubeconfig.
+		clusterctl get kubeconfig <name of workload cluster>
+		
+		# Get the workload cluster's kubeconfig from secret in a particular namespace.
+		clusterctl get kubeconfig <name of workload cluster> --namespace foo`),
 
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runGetKubeconfig(cmd, args[0])
+		return runGetKubeconfig(args[0])
 	},
 }
 
 func init() {
+	getKubeconfigCmd.Flags().StringVarP(&gk.namespace, "namespace", "n", "",
+		"Namespace where the workload cluster exist.")
+	getKubeconfigCmd.Flags().StringVar(&gk.kubeconfig, "kubeconfig", "",
+		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
+	getKubeconfigCmd.Flags().StringVar(&gk.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
 	getCmd.AddCommand(getKubeconfigCmd)
 }
 
-func runGetKubeconfig(cmd *cobra.Command, name string) error {
+func runGetKubeconfig(workloadClusterName string) error {
 	c, err := client.New(cfgFile)
 	if err != nil {
 		return err
 	}
 
 	options := client.GetKubeconfigOptions{
-		Kubeconfig: client.Kubeconfig{Path: initOpts.kubeconfig, Context: initOpts.kubeconfigContext},
-		Name:       name,
+		Kubeconfig:          client.Kubeconfig{Path: gk.kubeconfig, Context: gk.kubeconfigContext},
+		WorkloadClusterName: workloadClusterName,
+		Namespace:           gk.namespace,
 	}
 
-	return c.GetKubeconfig(options)
+	out, err := c.GetKubeconfig(options)
+	if err != nil {
+		return err
+	}
+	fmt.Println(out)
+	return nil
 }

--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -177,9 +177,7 @@ EOF
 The command for getting the kubeconfig file for connecting to a workload cluster is the following:
 
 ```bash
-kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o jsonpath={.data.value} \
-  | base64 --decode \
-  > ./capi-quickstart.kubeconfig
+clusterctl get kubeconfig capi-quickstart
 ```
 
 When using docker-for-mac MacOS, you will need to do a couple of additional

--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -177,7 +177,7 @@ EOF
 The command for getting the kubeconfig file for connecting to a workload cluster is the following:
 
 ```bash
-clusterctl get kubeconfig capi-quickstart
+clusterctl get kubeconfig capi-quickstart --namespace=default
 ```
 
 When using docker-for-mac MacOS, you will need to do a couple of additional

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -560,7 +560,7 @@ The control planes won't be `Ready` until we install a CNI in the next step.
 After the first control plane node is up and running, we can retrieve the [workload cluster] Kubeconfig:
 
 ```bash
-clusterctl get kubeconfig capi-quickstart
+clusterctl get kubeconfig capi-quickstart --namespace=default
 ```
 
 ### Deploy a CNI solution

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -560,9 +560,7 @@ The control planes won't be `Ready` until we install a CNI in the next step.
 After the first control plane node is up and running, we can retrieve the [workload cluster] Kubeconfig:
 
 ```bash
-kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o jsonpath={.data.value} \
-  | base64 --decode \
-  > ./capi-quickstart.kubeconfig
+clusterctl get kubeconfig capi-quickstart
 ```
 
 ### Deploy a CNI solution


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR is for enhancing the end-user experience. Using command `clusterctl get kubeconfig <cluster name>` user can fetch the kubeconfig of the workload cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2542 
