### PR TITLE
🐛 Make KCP supporting external etcd

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -505,7 +505,7 @@ func (r *KubeadmConfigReconciler) joinControlplane(ctx context.Context, scope *S
 		scope.Config.Spec.JoinConfiguration.ControlPlane = &kubeadmv1beta1.JoinControlPlane{}
 	}
 
-	certificates := secret.NewCertificatesForJoiningControlPlane()
+	certificates := secret.NewControlPlaneJoinCerts(scope.Config.Spec.ClusterConfiguration)
 	err := certificates.Lookup(
 		ctx,
 		r.Client,

--- a/controlplane/kubeadm/controllers/scale.go
+++ b/controlplane/kubeadm/controllers/scale.go
@@ -110,15 +110,17 @@ func (r *KubeadmControlPlaneReconciler) scaleDownControlPlane(
 		return ctrl.Result{}, errors.New("failed to pick control plane Machine to delete")
 	}
 
-	// If etcd leadership is on machine that is about to be deleted, move it to the newest member available.
-	etcdLeaderCandidate := controlPlane.Machines.Newest()
-	if err := workloadCluster.ForwardEtcdLeadership(ctx, machineToDelete, etcdLeaderCandidate); err != nil {
-		logger.Error(err, "Failed to move leadership to candidate machine", "candidate", etcdLeaderCandidate.Name)
-		return ctrl.Result{}, err
-	}
-	if err := workloadCluster.RemoveEtcdMemberForMachine(ctx, machineToDelete); err != nil {
-		logger.Error(err, "Failed to remove etcd member for machine")
-		return ctrl.Result{}, err
+	// If KCP should manage etcd, If etcd leadership is on machine that is about to be deleted, move it to the newest member available.
+	if controlPlane.IsEtcdManaged() {
+		etcdLeaderCandidate := controlPlane.Machines.Newest()
+		if err := workloadCluster.ForwardEtcdLeadership(ctx, machineToDelete, etcdLeaderCandidate); err != nil {
+			logger.Error(err, "Failed to move leadership to candidate machine", "candidate", etcdLeaderCandidate.Name)
+			return ctrl.Result{}, err
+		}
+		if err := workloadCluster.RemoveEtcdMemberForMachine(ctx, machineToDelete); err != nil {
+			logger.Error(err, "Failed to remove etcd member for machine")
+			return ctrl.Result{}, err
+		}
 	}
 
 	if err := r.managementCluster.TargetClusterControlPlaneIsHealthy(ctx, util.ObjectKey(cluster)); err != nil {

--- a/util/secret/certificates_test.go
+++ b/util/secret/certificates_test.go
@@ -25,15 +25,22 @@ import (
 	"sigs.k8s.io/cluster-api/util/secret"
 )
 
-func TestNewCertificatesForControlPlane_Stacked(t *testing.T) {
+func TestNewCertificatesForJoiningControlPlane_Stacked(t *testing.T) {
 	g := NewWithT(t)
 
-	config := &v1beta1.ClusterConfiguration{}
-	certs := secret.NewCertificatesForInitialControlPlane(config)
+	certs := secret.NewCertificatesForJoiningControlPlane()
 	g.Expect(certs.GetByPurpose(secret.EtcdCA).KeyFile).NotTo(BeEmpty())
 }
 
-func TestNewCertificatesForControlPlane_External(t *testing.T) {
+func TesNewControlPlaneJoinCerts_Stacked(t *testing.T) {
+	g := NewWithT(t)
+
+	config := &v1beta1.ClusterConfiguration{}
+	certs := secret.NewControlPlaneJoinCerts(config)
+	g.Expect(certs.GetByPurpose(secret.EtcdCA).KeyFile).NotTo(BeEmpty())
+}
+
+func TestNewControlPlaneJoinCerts_External(t *testing.T) {
 	g := NewWithT(t)
 
 	config := &v1beta1.ClusterConfiguration{
@@ -42,6 +49,6 @@ func TestNewCertificatesForControlPlane_External(t *testing.T) {
 		},
 	}
 
-	certs := secret.NewCertificatesForInitialControlPlane(config)
+	certs := secret.NewControlPlaneJoinCerts(config)
 	g.Expect(certs.GetByPurpose(secret.EtcdCA).KeyFile).To(BeEmpty())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes KCP supporting external etcd. While investigating this issue I discovered that the CAPBK support for external etcd is broken for joining control-planes ([original PR](https://github.com/kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm/pull/260)) because we are not managing a flexible list of certificates [here](https://github.com/kubernetes-sigs/cluster-api/blob/5f0a49e0fcf2a1cb90b54553e7836600e571aae6/util/secret/certificates.go#L115-L138).

Now this should be fixed, but in order to get this working we are preserving the ClusterConfiguration in all the KubeadmConfig generated by KCP, and this is a kind of duplicate of the machine annotation recently added.
I'm opening an issue to sort out a common approach. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3242
