### PR TITLE
[WIP] Add conformance testing to clusterctl framework

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -21,13 +21,12 @@ import (
 	"fmt"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
-
 	"github.com/blang/semver"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 	"sigs.k8s.io/cluster-api/util"
 )
 
@@ -42,8 +41,9 @@ const (
 	CoreDNSVersionUpgradeTo      = "COREDNS_VERSION_UPGRADE_TO"
 )
 
+// Byf is deprecated. Use "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions" as dot import instead.
 func Byf(format string, a ...interface{}) {
-	By(fmt.Sprintf(format, a...))
+	ginkgoextensions.Byf(format, a...)
 }
 
 func setupSpecNamespace(ctx context.Context, specName string, clusterProxy framework.ClusterProxy, artifactFolder string) (*corev1.Namespace, context.CancelFunc) {

--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
-	"sigs.k8s.io/cluster-api/test/e2e/internal/log"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
@@ -137,7 +136,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 			Namespace:            namespace.Name,
 		})
 
-		log.Logf("Waiting for the cluster infrastructure to be provisioned")
+		By("Waiting for the cluster infrastructure to be provisioned")
 		selfHostedCluster = framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
 			Getter:    selfHostedClusterProxy.GetClient(),
 			Namespace: selfHostedNamespace.Name,
@@ -174,7 +173,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 				Namespace:            selfHostedNamespace.Name,
 			})
 
-			log.Logf("Waiting for the cluster infrastructure to be provisioned")
+			By("Waiting for the cluster infrastructure to be provisioned")
 			cluster = framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{
 				Getter:    input.BootstrapClusterProxy.GetClient(),
 				Namespace: namespace.Name,

--- a/test/framework/alltypes_helpers.go
+++ b/test/framework/alltypes_helpers.go
@@ -22,11 +22,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 
+	"github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -181,4 +184,17 @@ func PrettyPrint(v interface{}) string {
 		return err.Error()
 	}
 	return string(b)
+}
+
+// CompleteCommand prints a command before running it. Acts as a helper function.
+// privateArgs when true will not print arguments.
+func CompleteCommand(cmd *exec.Cmd, desc string, privateArgs bool) *exec.Cmd {
+	cmd.Stderr = ginkgo.GinkgoWriter
+	cmd.Stdout = ginkgo.GinkgoWriter
+	if privateArgs {
+		Byf("%s: dir=%s, command=%s", desc, cmd.Dir, cmd)
+	} else {
+		Byf("%s: dir=%s, command=%s", desc, cmd.Dir, cmd.String())
+	}
+	return cmd
 }

--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -385,9 +385,18 @@ func (c *E2EConfig) GetIntervals(spec, key string) []interface{} {
 
 // GetVariable returns a variable from the e2e config file.
 func (c *E2EConfig) GetVariable(varName string) string {
-	version, ok := c.Variables[varName]
+	variable, ok := c.Variables[varName]
 	Expect(ok).NotTo(BeFalse())
-	return version
+	return variable
+}
+
+// GetStringVariableWithDefault returns a variable from the e2e config file, but can return a default string.
+func (c *E2EConfig) GetStringVariableWithDefault(varName string, defaultValue string) string {
+	variable, ok := c.Variables[varName]
+	if !ok {
+		return defaultValue
+	}
+	return variable
 }
 
 // GetVariable returns an Int64Ptr variable from the e2e config file.

--- a/test/framework/config.go
+++ b/test/framework/config.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"path"
 	"regexp"
 
 	"github.com/pkg/errors"
@@ -362,4 +364,16 @@ func (g componentSourceGenerator) GetName() string {
 // Manifests return the YAML bundle.
 func (g componentSourceGenerator) Manifests(ctx context.Context) ([]byte, error) {
 	return YAMLForComponentSource(ctx, g.ComponentSource)
+}
+
+// DumpToFile will dump the running e2e config to a file
+func (c *Config) DumpToFile(filename string) error {
+	yaml, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(path.Dir(filename), 0o700); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filename, yaml, 0o600)
 }

--- a/test/framework/ginkgoextensions/output.go
+++ b/test/framework/ginkgoextensions/output.go
@@ -14,14 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package log
+package ginkgoextensions
 
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
+	"github.com/go-logr/logr"
+	"github.com/onsi/ginkgo"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
 )
 
-func Logf(format string, a ...interface{}) {
-	fmt.Fprintf(GinkgoWriter, "INFO: "+format+"\n", a...)
+var Log logr.Logger
+
+func init() {
+	klog.InitFlags(nil)
+	Log = klogr.New()
+	klog.SetOutput(ginkgo.GinkgoWriter)
+}
+
+func Byf(format string, a ...interface{}) {
+	ginkgo.By(fmt.Sprintf(format, a...))
 }

--- a/test/framework/kubetest/setup.go
+++ b/test/framework/kubetest/setup.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubetest
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const (
+	ciVersionURL = "https://dl.k8s.io/ci/latest.txt"
+)
+
+// FetchKubernetesCIVersion fetches the latest main branch Kubernetes version
+func FetchKubernetesCIVersion() (string, error) {
+	resp, err := http.Get(ciVersionURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/test/framework/kubetest/test.go
+++ b/test/framework/kubetest/test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubetest
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/test/framework"
+)
+
+const (
+	standardImage   = "gcr.io/k8s-artifacts-prod/conformance"
+	ciArtifactImage = "gcr.io/kubernetes-ci-images/conformance"
+)
+
+const (
+	DefaultGinkgoNodes            = 1
+	DefaultGinkoSlowSpecThreshold = 120
+)
+
+type RunInput struct {
+	// ClusterProxy is a clusterctl test framework proxy for the workload cluster
+	// for which to run kubetest against
+	ClusterProxy framework.ClusterProxy
+	// NumberOfNodes is the number of cluster nodes that exist for kubetest
+	// to be aware of
+	NumberOfNodes int
+	// UseCIArtifacts will fetch the latest build from the main branch of kubernetes/kubernetes
+	UseCIArtifacts bool `json:"useCIArtifacts,omitempty"`
+	// ArtifactsDirectory is where conformance suite output will go
+	ArtifactsDirectory string `json:"artifactsDirectory,omitempty"`
+	// Path to the kubetest e2e config file
+	ConfigFilePath string `json:"configFilePath,omitempty"`
+	// GinkgoNodes is the number of Ginkgo nodes to use
+	GinkgoNodes int `json:"ginkgoNodes,omitempty"`
+	// GinkgoSlowSpecThreshold is time in s before spec is marked as slow
+	GinkgoSlowSpecThreshold int `json:"ginkgoSlowSpecThreshold,omitempty"`
+	// KubernetesVersion is the version of Kubernetes to test
+	KubernetesVersion string
+	// ConformanceImage is an optional field to specify an exact conformance image
+	ConformanceImage string
+}
+
+// Run executes kube-test given an artifact directory, and sets settings
+// required for kubetest to work with Cluster API. JUnit files are
+// also gathered for inclusion in Prow.
+func Run(input RunInput) error {
+	if input.GinkgoNodes == 0 {
+		input.GinkgoNodes = DefaultGinkgoNodes
+	}
+	if input.GinkgoSlowSpecThreshold == 0 {
+		input.GinkgoSlowSpecThreshold = 120
+	}
+	if input.NumberOfNodes == 0 {
+		numNodes, err := countClusterNodes(input.ClusterProxy)
+		if err != nil {
+			return err
+		}
+		input.NumberOfNodes = numNodes
+	}
+	if input.ArtifactsDirectory == "" {
+		if dir, ok := os.LookupEnv("ARTIFACTS"); ok {
+			input.ArtifactsDirectory = dir
+		}
+		input.ArtifactsDirectory = "_artifacts"
+	}
+	reportDir := path.Join(input.ArtifactsDirectory, "kubetest")
+	outputDir := path.Join(reportDir, "e2e-output")
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
+		return err
+	}
+	ginkgoVars := map[string]string{
+		"nodes":             strconv.Itoa(input.GinkgoNodes),
+		"slowSpecThreshold": strconv.Itoa(input.GinkgoSlowSpecThreshold),
+	}
+	e2eVars := map[string]string{
+		"kubeconfig":           "/tmp/kubeconfig",
+		"provider":             "skeleton",
+		"report-dir":           "/output",
+		"e2e-output-dir":       "/output/e2e-output",
+		"dump-logs-on-failure": "false",
+		"report-prefix":        "kubetest.",
+		"num-nodes":            strconv.FormatInt(int64(input.NumberOfNodes), 10),
+		"viper-config":         "/tmp/viper-config.yaml",
+	}
+	ginkgoArgs := buildArgs(ginkgoVars, "-")
+	e2eArgs := buildArgs(e2eVars, "--")
+	if input.ConformanceImage == "" {
+		input.ConformanceImage = versionToConformanceImage(input.KubernetesVersion, input.UseCIArtifacts)
+	}
+	kubeConfigVolumeMount := volumeArg(input.ClusterProxy.GetKubeconfigPath(), "/tmp/kubeconfig")
+	outputVolumeMount := volumeArg(reportDir, "/output")
+	viperVolumeMount := volumeArg(input.ConfigFilePath, "/tmp/viper-config.yaml")
+	user, err := user.Current()
+	if err != nil {
+		return errors.Wrap(err, "unable to determine current user")
+	}
+	userArg := user.Uid + ":" + user.Gid
+	e2eCmd := exec.Command("docker", "run", "--user", userArg, kubeConfigVolumeMount, outputVolumeMount, viperVolumeMount, "-t", input.ConformanceImage)
+	e2eCmd.Args = append(e2eCmd.Args, "/usr/local/bin/ginkgo")
+	e2eCmd.Args = append(e2eCmd.Args, ginkgoArgs...)
+	e2eCmd.Args = append(e2eCmd.Args, "/usr/local/bin/e2e.test")
+	e2eCmd.Args = append(e2eCmd.Args, "--")
+	e2eCmd.Args = append(e2eCmd.Args, e2eArgs...)
+	e2eCmd = framework.CompleteCommand(e2eCmd, "Running e2e test", false)
+	if err := e2eCmd.Run(); err != nil {
+		return errors.Wrap(err, "Unable to run conformance tests")
+	}
+	if err := framework.GatherJUnitReports(reportDir, input.ArtifactsDirectory); err != nil {
+		return err
+	}
+	return nil
+}
+
+func countClusterNodes(proxy framework.ClusterProxy) (int, error) {
+	nodeList, err := proxy.GetClientSet().CoreV1().Nodes().List(corev1.ListOptions{})
+	if err != nil {
+		return 0, errors.Wrap(err, "Unable to count nodes")
+	}
+	return len(nodeList.Items), nil
+}
+
+func isSELinuxEnforcing() bool {
+	dat, err := ioutil.ReadFile("/sys/fs/selinux/enforce")
+	if err != nil {
+		return false
+	}
+	return string(dat) == "1"
+}
+
+func volumeArg(src, dest string) string {
+	volumeArg := "-v" + src + ":" + dest
+	if isSELinuxEnforcing() {
+		return volumeArg + ":z"
+	}
+	return volumeArg
+}
+
+func versionToConformanceImage(kubernetesVersion string, usingCIArtifacts bool) string {
+	k8sVersion := strings.ReplaceAll(kubernetesVersion, "+", "_")
+	if usingCIArtifacts {
+		return ciArtifactImage + ":" + k8sVersion
+	}
+	return standardImage + ":" + k8sVersion
+}
+
+// buildArgs converts a string map to the format --key=value
+func buildArgs(kv map[string]string, flagMarker string) []string {
+	args := make([]string, len(kv))
+	i := 0
+	for k, v := range kv {
+		args[i] = flagMarker + k + "=" + v
+		i++
+	}
+	return args
+}

--- a/test/framework/suite_helpers.go
+++ b/test/framework/suite_helpers.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+func GatherJUnitReports(srcDir string, destDir string) error {
+	if err := os.MkdirAll(srcDir, 0o700); err != nil {
+		return err
+	}
+	return filepath.Walk(srcDir, func(p string, info os.FileInfo, err error) error {
+		if info.IsDir() && p != srcDir {
+			return filepath.SkipDir
+		}
+		if filepath.Ext(p) != ".xml" {
+			return nil
+		}
+		base := filepath.Base(p)
+		if strings.HasPrefix(base, "junit") {
+			newName := strings.ReplaceAll(base, "_", ".")
+			if err := os.Rename(p, path.Join(destDir, newName)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- Helpers for running kubetest (for e2e or conformance) against a cluster provisioned using the clusterctl
  test framework
- Adds mechanism to set a Kubernetes version based on the latest CI artifacts
- Can run kubetest from the latest CI artifacts using Docker against a workload proxy

Based on port with additional cleanup of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1760:


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2141 
Fixes #3569  
