### PR TITLE
📖 Improve implementers guide

### DIFF
--- a/docs/book/src/developer/providers/implementers-guide/generate_crds.md
+++ b/docs/book/src/developer/providers/implementers-guide/generate_crds.md
@@ -79,6 +79,14 @@ make manifests
 [rbac]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#customresourcesubresources-v1beta1-apiextensions-k8s-io
 [kbstatus]: https://book.kubebuilder.io/reference/generating-crd.html?highlight=status#status
 
+### Apply further customizations
+The cluster API CRDs should be further customized:
+
+- [Apply the contract version label to support conversions](https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#apply-the-contract-version-label-clusterx-k8sioversion-version1_version2_version3-to-your-crds) 
+- [Upgrade to CRD v1](https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#upgrade-to-crd-v1)
+- [Set “matchPolicy=Equivalent” kubebuilder marker for webhooks](https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#add-matchpolicyequivalent-kubebuilder-marker-in-webhooks)
+- [Refactor the kustomize config folder to support multi-tenancy](https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#refactor-kustomize-config-folder-to-support-multi-tenancy-when-using-webhooks)
+- [Ensure you are compliant with the clusterctl provider contract](https://cluster-api.sigs.k8s.io/clusterctl/provider-contract.html#components-yaml)
 
 ### Commit your changes
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the provider implementers guide documenting that it is required to apply the contract version label and some other customizations to the scaffolding generated by kubebuilder


**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3039
