### PR TITLE
✨ Provide a way to disable kube-proxy management in KCP via annotations

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -34,6 +34,9 @@ const (
 	// SkipCoreDNSAnnotation annotation explicitly skips reconciling CoreDNS if set
 	SkipCoreDNSAnnotation = "controlplane.cluster.x-k8s.io/skip-coredns"
 
+	// SkipKubeProxyAnnotation annotation explicitly skips reconciling kube-proxy if set
+	SkipKubeProxyAnnotation = "controlplane.cluster.x-k8s.io/skip-kube-proxy"
+
 	// KubeadmClusterConfigurationAnnotation is a machine annotation that stores the json-marshalled string of KCP ClusterConfiguration.
 	// This annotation is used to detect any changes in ClusterConfiguration and trigger machine rollout in KCP.
 	KubeadmClusterConfigurationAnnotation = "controlplane.cluster.x-k8s.io/kubeadm-cluster-configuration"

--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -371,6 +371,11 @@ func checkNodeNoExecuteCondition(node corev1.Node) error {
 
 // UpdateKubeProxyImageInfo updates kube-proxy image in the kube-proxy DaemonSet.
 func (w *Workload) UpdateKubeProxyImageInfo(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane) error {
+	// Return early if we've been asked to skip kube-proxy upgrades entirely.
+	if _, ok := kcp.Annotations[controlplanev1.SkipKubeProxyAnnotation]; ok {
+		return nil
+	}
+
 	ds := &appsv1.DaemonSet{}
 
 	if err := w.Client.Get(ctx, ctrlclient.ObjectKey{Name: kubeProxyKey, Namespace: metav1.NamespaceSystem}, ds); err != nil {

--- a/controlplane/kubeadm/internal/workload_cluster_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_test.go
@@ -123,6 +123,21 @@ func TestUpdateKubeProxyImageInfo(t *testing.T) {
 					},
 				}},
 		},
+		{
+			name:        "does not update image repository when no kube-proxy update is requested",
+			ds:          newKubeProxyDSWithImage(""), // Using the same image name that would otherwise lead to an error
+			expectErr:   false,
+			expectImage: "",
+			KCP: &v1alpha3.KubeadmControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1alpha3.SkipKubeProxyAnnotation: "",
+					},
+				},
+				Spec: v1alpha3.KubeadmControlPlaneSpec{
+					Version: "v1.16.3",
+				}},
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
**What this PR does / why we need it**:
For air-gapped systems that cannot pull container images, the rolling
update of add-ons needs to be coordinated in a more particular fashion.
This allows users of the KCP to opt out of kube-proxy management with a
similar mechanism to how they would opt out of CoreDNS management (#3023)

Similarly to #3023 we also see error messages when parsing the kube-proxy image name (`"vmware/kube-proxy:v1.16.7_vmware.1"`):
```
E0709 13:17:09.235042       1 controller.go:346] controllers/KubeadmControlPlane "msg"="failed to update kube-proxy daemonset" "error"="failed to parse image name: couldn't parse image name: repository name must be canonical" "cluster"="tkc3" "kubeadmControlPlane"="tkc3-control-plane" "namespace"="default"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3318
