### PR TITLE
🌱  Add CAPD control plane toleration

### DIFF
--- a/test/infrastructure/docker/config/manager/manager.yaml
+++ b/test/infrastructure/docker/config/manager/manager.yaml
@@ -38,6 +38,9 @@ spec:
         securityContext:
           privileged: true
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
       volumes:
         - name: dockersock
           hostPath:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a toleration to the CAPD manager deployment so that it can run on control plane nodes. I was trying to self-host a cluster with CAPD and was surprised to see that this deployment's pods were unable to be scheduled because it doesn't tolerate running on the control plane nodes.