### PR TITLE
🐛 Removing lint fast=true target as its failing to lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ help:  ## Display this help
 ## --------------------------------------
 
 .PHONY: test
-test: generate lint ## Run tests
+test: generate lint-full ## Run tests
 	go test -v ./...
 
 .PHONY: test-integration
@@ -104,10 +104,7 @@ $(CONVERSION_GEN): $(TOOLS_DIR)/go.mod
 ## Linting
 ## --------------------------------------
 
-.PHONY: lint
-lint: $(GOLANGCI_LINT) ## Lint codebase
-	$(GOLANGCI_LINT) run -v
-
+.PHONY: lint-full
 lint-full: $(GOLANGCI_LINT) ## Run slower linters to detect possible issues
 	$(GOLANGCI_LINT) run -v --fast=false
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
An old version of `Golint-cli` is being used which causes lint errors when run as `fast=true` mode. It exits with non success code but no error. Running `lint-full` solves this problem.
Removing the `lint` target.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3304 
