### PR TITLE
✨Allow KCP users to mutate node registration options

### DIFF
--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -483,7 +483,9 @@ spec:
                     type: object
                   nodeRegistration:
                     description: NodeRegistration holds fields that relate to registering
-                      the new control-plane node to the cluster
+                      the new control-plane node to the cluster. When used in the
+                      context of control plane nodes, NodeRegistration should remain
+                      consistent across both InitConfiguration and JoinConfiguration
                     properties:
                       criSocket:
                         description: CRISocket is used to retrieve container runtime
@@ -662,7 +664,9 @@ spec:
                     type: string
                   nodeRegistration:
                     description: NodeRegistration holds fields that relate to registering
-                      the new control-plane node to the cluster
+                      the new control-plane node to the cluster. When used in the
+                      context of control plane nodes, NodeRegistration should remain
+                      consistent across both InitConfiguration and JoinConfiguration
                     properties:
                       criSocket:
                         description: CRISocket is used to retrieve container runtime
@@ -1391,7 +1395,9 @@ spec:
                     type: object
                   nodeRegistration:
                     description: NodeRegistration holds fields that relate to registering
-                      the new control-plane node to the cluster
+                      the new control-plane node to the cluster. When used in the
+                      context of control plane nodes, NodeRegistration should remain
+                      consistent across both InitConfiguration and JoinConfiguration
                     properties:
                       criSocket:
                         description: CRISocket is used to retrieve container runtime
@@ -1570,7 +1576,9 @@ spec:
                     type: string
                   nodeRegistration:
                     description: NodeRegistration holds fields that relate to registering
-                      the new control-plane node to the cluster
+                      the new control-plane node to the cluster. When used in the
+                      context of control plane nodes, NodeRegistration should remain
+                      consistent across both InitConfiguration and JoinConfiguration
                     properties:
                       criSocket:
                         description: CRISocket is used to retrieve container runtime

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -514,7 +514,10 @@ spec:
                             type: object
                           nodeRegistration:
                             description: NodeRegistration holds fields that relate
-                              to registering the new control-plane node to the cluster
+                              to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration
+                              should remain consistent across both InitConfiguration
+                              and JoinConfiguration
                             properties:
                               criSocket:
                                 description: CRISocket is used to retrieve container
@@ -703,7 +706,10 @@ spec:
                             type: string
                           nodeRegistration:
                             description: NodeRegistration holds fields that relate
-                              to registering the new control-plane node to the cluster
+                              to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration
+                              should remain consistent across both InitConfiguration
+                              and JoinConfiguration
                             properties:
                               criSocket:
                                 description: CRISocket is used to retrieve container
@@ -1461,7 +1467,10 @@ spec:
                             type: object
                           nodeRegistration:
                             description: NodeRegistration holds fields that relate
-                              to registering the new control-plane node to the cluster
+                              to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration
+                              should remain consistent across both InitConfiguration
+                              and JoinConfiguration
                             properties:
                               criSocket:
                                 description: CRISocket is used to retrieve container
@@ -1650,7 +1659,10 @@ spec:
                             type: string
                           nodeRegistration:
                             description: NodeRegistration holds fields that relate
-                              to registering the new control-plane node to the cluster
+                              to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration
+                              should remain consistent across both InitConfiguration
+                              and JoinConfiguration
                             properties:
                               criSocket:
                                 description: CRISocket is used to retrieve container

--- a/bootstrap/kubeadm/types/v1beta1/types.go
+++ b/bootstrap/kubeadm/types/v1beta1/types.go
@@ -33,7 +33,9 @@ type InitConfiguration struct {
 	// +optional
 	BootstrapTokens []BootstrapToken `json:"bootstrapTokens,omitempty"`
 
-	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster
+	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+	// When used in the context of control plane nodes, NodeRegistration should remain consistent
+	// across both InitConfiguration and JoinConfiguration
 	// +optional
 	NodeRegistration NodeRegistrationOptions `json:"nodeRegistration,omitempty"`
 
@@ -325,7 +327,9 @@ type ExternalEtcd struct {
 type JoinConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster
+	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+	// When used in the context of control plane nodes, NodeRegistration should remain consistent
+	// across both InitConfiguration and JoinConfiguration
 	// +optional
 	NodeRegistration NodeRegistrationOptions `json:"nodeRegistration,omitempty"`
 

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook.go
@@ -80,6 +80,9 @@ const (
 	spec                 = "spec"
 	kubeadmConfigSpec    = "kubeadmConfigSpec"
 	clusterConfiguration = "clusterConfiguration"
+	initConfiguration    = "initConfiguration"
+	joinConfiguration    = "joinConfiguration"
+	nodeRegistration     = "nodeRegistration"
 	preKubeadmCommands   = "preKubeadmCommands"
 	postKubeadmCommands  = "postKubeadmCommands"
 	files                = "files"
@@ -96,6 +99,8 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageRepository"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageTag"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "imageRepository"},
+		{spec, kubeadmConfigSpec, initConfiguration, nodeRegistration, "*"},
+		{spec, kubeadmConfigSpec, joinConfiguration, nodeRegistration, "*"},
 		{spec, kubeadmConfigSpec, preKubeadmCommands},
 		{spec, kubeadmConfigSpec, postKubeadmCommands},
 		{spec, kubeadmConfigSpec, files},

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -671,7 +671,10 @@ spec:
                         type: object
                       nodeRegistration:
                         description: NodeRegistration holds fields that relate to
-                          registering the new control-plane node to the cluster
+                          registering the new control-plane node to the cluster. When
+                          used in the context of control plane nodes, NodeRegistration
+                          should remain consistent across both InitConfiguration and
+                          JoinConfiguration
                         properties:
                           criSocket:
                             description: CRISocket is used to retrieve container runtime
@@ -855,7 +858,10 @@ spec:
                         type: string
                       nodeRegistration:
                         description: NodeRegistration holds fields that relate to
-                          registering the new control-plane node to the cluster
+                          registering the new control-plane node to the cluster. When
+                          used in the context of control plane nodes, NodeRegistration
+                          should remain consistent across both InitConfiguration and
+                          JoinConfiguration
                         properties:
                           criSocket:
                             description: CRISocket is used to retrieve container runtime


### PR DESCRIPTION
**What this PR does / why we need it**:
Opens up the KCP validating webhook to allow for mutation to `.spec.kubeadmConfigSpec.initConfiguration.nodeRegistration` and `.spec.kubeadmConfigSpec.joinConfiguration.nodeRegistration`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3323
