### PR TITLE
🌱 Add variables for featuregates

### DIFF
--- a/config/ci/manager/manager_auth_proxy_patch.yaml
+++ b/config/ci/manager/manager_auth_proxy_patch.yaml
@@ -23,3 +23,4 @@ spec:
           args:
             - "--metrics-addr=127.0.0.1:8080"
             - "--enable-leader-election"
+            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURSE_SET:=false}"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
+        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURSE_SET:=false}
         image: controller:latest
         name: manager
         ports:

--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -23,3 +23,4 @@ spec:
           args:
             - "--metrics-addr=127.0.0.1:8080"
             - "--enable-leader-election"
+            - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURSE_SET:=false}"

--- a/config/webhook/manager_webhook_patch.yaml
+++ b/config/webhook/manager_webhook_patch.yaml
@@ -11,6 +11,7 @@ spec:
         args:
         - "--metrics-addr=127.0.0.1:8080"
         - "--webhook-port=9443"
+        - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURSE_SET:=false}"
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/test/e2e/config/docker-ci.yaml
+++ b/test/e2e/config/docker-ci.yaml
@@ -35,10 +35,6 @@ providers:
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
-    - old: "--enable-leader-election"
-      new: "--enable-leader-election=false\n        - --feature-gates=ClusterResourceSet=true"
-    - old: "--webhook-port=9443"
-      new: "--webhook-port=9443\n        - --feature-gates=ClusterResourceSet=true"
 
 - name: kubeadm
   type: BootstrapProvider
@@ -89,6 +85,7 @@ variables:
   # IMPORTANT! This values should match the one used by the CNI provider
   DOCKER_POD_CIDRS: "192.168.0.0/16"
   CNI: "./data/cni/kindnet/kindnet.yaml"
+  EXP_CLUSTER_RESOURSE_SET: "true"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/e2e/config/docker-dev.yaml
+++ b/test/e2e/config/docker-dev.yaml
@@ -47,9 +47,7 @@ providers:
     - old: "imagePullPolicy: Always"
       new: "imagePullPolicy: IfNotPresent"
     - old: "--enable-leader-election"
-      new: "--enable-leader-election=false\n        - --feature-gates=ClusterResourceSet=true"
-    - old: "--webhook-port=9443"
-      new: "--webhook-port=9443\n        - --feature-gates=ClusterResourceSet=true"
+      new: "--enable-leader-election=false"
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
 
@@ -114,6 +112,7 @@ variables:
   DOCKER_POD_CIDRS: "192.168.0.0/16"
   #CNI: "./data/cni/calico/calico.yaml"
   CNI: "./data/cni/kindnet/kindnet.yaml"
+  EXP_CLUSTER_RESOURSE_SET: "true"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow up of https://github.com/kubernetes-sigs/cluster-api/pull/3270#issuecomment-656349748
It introduces two optional variables in core-components.yaml that can be used to toggle CAPI feature gates for experimental features.

/assign @vincepri 
/assign @CecileRobertMichon 
/cc @sedefsavas 