### PR TITLE
🌱 Add get workload cluster test

### DIFF
--- a/controlplane/kubeadm/internal/suite_test.go
+++ b/controlplane/kubeadm/internal/suite_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"sigs.k8s.io/cluster-api/test/helpers"
+)
+
+var (
+	testEnv *helpers.TestEnvironment
+	ctx     context.Context
+)
+
+func TestMain(m *testing.M) {
+	testEnv = helpers.NewTestEnvironment()
+	go func() {
+		if err := testEnv.StartManager(); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+
+	code := m.Run()
+
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
+	}
+
+	os.Exit(code)
+}

--- a/util/certs/certs.go
+++ b/util/certs/certs.go
@@ -70,7 +70,7 @@ func EncodePublicKeyPEM(key *rsa.PublicKey) ([]byte, error) {
 func DecodeCertPEM(encoded []byte) (*x509.Certificate, error) {
 	block, _ := pem.Decode(encoded)
 	if block == nil {
-		return nil, nil
+		return nil, errors.New("unable to decode PEM data")
 	}
 
 	return x509.ParseCertificate(block.Bytes)
@@ -81,7 +81,7 @@ func DecodeCertPEM(encoded []byte) (*x509.Certificate, error) {
 func DecodePrivateKeyPEM(encoded []byte) (crypto.Signer, error) {
 	block, _ := pem.Decode(encoded)
 	if block == nil {
-		return nil, nil
+		return nil, errors.New("unable to decode PEM data")
 	}
 
 	errs := []error{}

--- a/util/certs/certs_test.go
+++ b/util/certs/certs_test.go
@@ -23,16 +23,16 @@ import (
 )
 
 type decodeTest struct {
+	name        string
 	key         []byte
 	expectError bool
 }
 
 func TestDecodePrivateKeyPEM(t *testing.T) {
-	g := NewWithT(t)
 
 	cases := []decodeTest{
-		// PKCS1 private key
 		{
+			name: "successfully processes PKCS1 private key",
 			key: []byte(`
 -----BEGIN RSA PRIVATE KEY-----
 MIICXAIBAAKBgQCgcTrC6rTj6KV5GeUyEODguAY+RMxX0ZzskOZBUFuUn1ADj7qK
@@ -51,8 +51,8 @@ I8eun6k9HNyEieJTVaB9AVnykoZ78UbCQaipm9W7i4Q=
 -----END RSA PRIVATE KEY-----
 			`),
 		},
-		// PKCS8 private key
 		{
+			name: "successfully processes PKCS8 private key",
 			key: []byte(`
 -----BEGIN PRIVATE KEY-----
 MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAKBxOsLqtOPopXkZ
@@ -72,8 +72,8 @@ RsJBqKmb1buLhA==
 -----END PRIVATE KEY-----
 			`),
 		},
-		// EC private key
 		{
+			name: "successfully processes EC private key",
 			key: []byte(`
 -----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIOsVFUX30MNP7e+MFRTbdknxaC3q3S8fYvmXtrM9tPJJoAoGCCqGSM49
@@ -82,8 +82,8 @@ X9ZN2FCDgn06wSq/cZvLOl2tGPRt5wSMug==
 -----END EC PRIVATE KEY-----
 			`),
 		},
-		// Bad format private key
 		{
+			name: "return error for bad format private key",
 			key: []byte(`
 -----BEGIN RSA PRIVATE KEY-----
 sxcvMIICXAIBAAKBgQCgcTrC6rTj6KV5GeUyEODguAY+RMxX0ZzskOZBUFuUn1ADj7qK
@@ -103,14 +103,45 @@ I8eun6k9HNyEieJTVaB9AVnykoZ78UbCQaipm9W7i4Q=
 			`),
 			expectError: true,
 		},
+		{
+			name:        "return error for un-decodeable key",
+			key:         []byte("un-decodeable"),
+			expectError: true,
+		},
 	}
 
 	for _, tc := range cases {
-		_, err := DecodePrivateKeyPEM(tc.key)
-		if tc.expectError {
-			g.Expect(err).To(HaveOccurred())
-		} else {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			_, err := DecodePrivateKeyPEM(tc.key)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
 			g.Expect(err).NotTo(HaveOccurred())
-		}
+		})
 	}
+}
+
+func TestDecodeCertPEM(t *testing.T) {
+	cases := []decodeTest{
+		{
+			name:        "return error for un-decodeable cert",
+			key:         []byte("un-decodeable"),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		g := NewWithT(t)
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DecodeCertPEM(tc.key)
+			if tc.expectError {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds a test for GetWorkloadCluster method. It uses **envtest** since we are trying to move away from using `fakeClient`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3525
