### PR TITLE
🐛 KCP: fix problem in rollout detection logic when ClusterConfiguration is nil

### DIFF
--- a/controlplane/kubeadm/internal/machinefilters/util_test.go
+++ b/controlplane/kubeadm/internal/machinefilters/util_test.go
@@ -90,6 +90,22 @@ func TestMatchClusterConfiguration(t *testing.T) {
 		}
 		g.Expect(matchClusterConfiguration(kcp, m)).To(gomega.BeFalse())
 	})
+	t.Run("Return true if cluster configuration is nil (special case)", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		kcp := &controlplanev1.KubeadmControlPlane{
+			Spec: controlplanev1.KubeadmControlPlaneSpec{
+				KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{},
+			},
+		}
+		m := &clusterv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					controlplanev1.KubeadmClusterConfigurationAnnotation: "null",
+				},
+			},
+		}
+		g.Expect(matchClusterConfiguration(kcp, m)).To(gomega.BeTrue())
+	})
 }
 
 func TestGetAdjustedKcpConfig(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a problem that arises when KCP does not have a clusterConfiguration set, because we do a comparison of a cached version of the clusterConfiguration stored in a Machine annotation with the current clusterConfiguration. 
In this case the Machine has "null" as the value of the annotation, since the clusterConfiguration was nil. When this gets unmarshaled and compared with nil it returns false :-(

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3353
