### PR TITLE
🐛 Delete ClusterResourceSetBinding when cluster is deleted.

### DIFF
--- a/exp/addons/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/controllers/clusterresourcesetbinding_controller.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/predicates"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// +kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
+
+// ClusterResourceSetBindingReconciler reconciles a ClusterResourceSetBinding object
+type ClusterResourceSetBindingReconciler struct {
+	Client client.Client
+	Log    logr.Logger
+}
+
+func (r *ClusterResourceSetBindingReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
+	_, err := ctrl.NewControllerManagedBy(mgr).
+		For(&addonsv1.ClusterResourceSetBinding{}).
+		Watches(
+			&source.Kind{Type: &clusterv1.Cluster{}},
+			&handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(r.clusterToClusterResourceSetBinding)},
+		).
+		WithOptions(options).
+		WithEventFilter(predicates.ResourceNotPaused(r.Log)).
+		Build(r)
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+
+	return nil
+}
+
+func (r *ClusterResourceSetBindingReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reterr error) {
+	ctx := context.Background()
+	log := r.Log.WithValues("clusterresourcesetbinding", req.NamespacedName)
+
+	// Fetch the ClusterResourceSetBinding instance.
+	binding := &addonsv1.ClusterResourceSetBinding{}
+	if err := r.Client.Get(ctx, req.NamespacedName, binding); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
+	}
+
+	cluster, err := util.GetOwnerCluster(ctx, r.Client, binding.ObjectMeta)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	// If the owner cluster is already deleted or in deletion process, delete its ClusterResourceSetBinding
+	if apierrors.IsNotFound(err) || !cluster.DeletionTimestamp.IsZero() {
+		log.Info("deleting ClusterResourceSetBinding because the owner Cluster no longer exists")
+		err := r.Client.Delete(ctx, binding)
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// clusterToClusterResourceSetBinding is mapper function that maps clusters to ClusterResourceSetBinding
+func (r *ClusterResourceSetBindingReconciler) clusterToClusterResourceSetBinding(o handler.MapObject) []ctrl.Request {
+	return []reconcile.Request{
+		{
+			NamespacedName: client.ObjectKey{
+				Namespace: o.Meta.GetNamespace(),
+				Name:      o.Meta.GetName(),
+			},
+		},
+	}
+}

--- a/exp/addons/controllers/suite_test.go
+++ b/exp/addons/controllers/suite_test.go
@@ -23,9 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/cluster-api/controllers/remote"
-	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/helpers"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
@@ -35,10 +33,6 @@ import (
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
-func init() {
-	_ = addonsv1.AddToScheme(scheme.Scheme)
-}
 
 var (
 	testEnv *helpers.TestEnvironment
@@ -62,6 +56,10 @@ var _ = BeforeSuite(func(done Done) {
 		Client:  testEnv,
 		Log:     log.Log,
 		Tracker: trckr,
+	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
+	Expect((&ClusterResourceSetBindingReconciler{
+		Client: testEnv,
+		Log:    log.Log,
 	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 
 	By("starting the manager")

--- a/main.go
+++ b/main.go
@@ -271,6 +271,13 @@ func setupReconcilers(mgr ctrl.Manager) {
 			setupLog.Error(err, "unable to create controller", "controller", "ClusterResourceSet")
 			os.Exit(1)
 		}
+		if err := (&addonscontrollers.ClusterResourceSetBindingReconciler{
+			Client: mgr.GetClient(),
+			Log:    ctrl.Log.WithName("controllers").WithName("ClusterResourceSetBinding"),
+		}).SetupWithManager(mgr, concurrency(clusterResourceSetConcurrency)); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ClusterResourceSetBinding")
+			os.Exit(1)
+		}
 	}
 
 	if err := (&controllers.MachineHealthCheckReconciler{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR deletes ClusterResourceSetBinding when the owner cluster is deleted.
This is not garbage collected because both Cluster and ClusterResourceSet are the owners of ClusterResourceSetBinding but when any of them is deleted, ClusterResourceSetBinding should also be deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3357
