### PR TITLE
🌱  Log when and why a machine is marked for remediation

### DIFF
--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -250,7 +250,8 @@ func (r *MachineHealthCheckReconciler) reconcile(ctx context.Context, logger log
 	// mark for remediation
 	errList := []error{}
 	for _, t := range unhealthy {
-		logger.V(3).Info("Target meets unhealthy criteria, triggers remediation", "target", t.string())
+		condition := conditions.Get(t.Machine, clusterv1.MachineHealthCheckSuccededCondition)
+		logger.Info("Target has failed health check, marking for remediation", "target", t.string(), "reason", condition.Reason, "message", condition.Message)
 
 		conditions.MarkFalse(t.Machine, clusterv1.MachineOwnerRemediatedCondition, clusterv1.WaitingForRemediation, clusterv1.ConditionSeverityWarning, "MachineHealthCheck failed")
 		if err := t.patchHelper.Patch(ctx, t.Machine); err != nil {
@@ -265,7 +266,6 @@ func (r *MachineHealthCheckReconciler) reconcile(ctx context.Context, logger log
 		)
 	}
 	for _, t := range healthy {
-		logger.V(3).Info("patching machine", "machine", t.Machine.GetName())
 		if err := t.patchHelper.Patch(ctx, t.Machine); err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "Failed to patch healthy machine status for machine %q", t.Machine.Name)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now MHC logs almost nothing on the `-v=0` log level. This adds a new message when a machine fails a health check and we are marking it for remediation. We [store information](https://github.com/benmoss/cluster-api/blob/c510161e2c2639a4c5e8a1683c34a016a1d236ac/controllers/machinehealthcheck_targets.go#L94-L158) about why the health check fails on the condition, so we can use that to surface the failure now. 

Also removes the "patching machine" log line from healthy machines, this is almost always useless in my experience.