### PR TITLE
:seedling: Add deprecation notice for RequeueAfterError

### DIFF
--- a/errors/controllers.go
+++ b/errors/controllers.go
@@ -26,6 +26,13 @@ import (
 // HasRequeueAfterError represents that an actuator managed object should
 // be requeued for further processing after the given RequeueAfter time has
 // passed.
+//
+// DEPRECATED: This error is deprecated and should not be used for new code.
+// See https://github.com/kubernetes-sigs/cluster-api/issues/3370 for more information.
+//
+// Users should switch their methods and functions to return a (ctrl.Result, error) pair,
+// instead of relying on this error. Controller runtime exposes a Result.IsZero() (from 0.5.9, and 0.6.2)
+// which can be used from callers to see if reconciliation should be stopped or continue.
 type HasRequeueAfterError interface {
 	// GetRequeueAfter gets the duration to wait until the managed object is
 	// requeued for further processing.
@@ -35,6 +42,13 @@ type HasRequeueAfterError interface {
 // RequeueAfterError represents that an actuator managed object should be
 // requeued for further processing after the given RequeueAfter time has
 // passed.
+//
+// DEPRECATED: This error is deprecated and should not be used for new code.
+// See https://github.com/kubernetes-sigs/cluster-api/issues/3370 for more information.
+//
+// Users should switch their methods and functions to return a (ctrl.Result, error) pair,
+// instead of relying on this error. Controller runtime exposes a Result.IsZero() (from 0.5.9, and 0.6.2)
+// which can be used from callers to see if reconciliation should be stopped or continue.
 type RequeueAfterError struct {
 	RequeueAfter time.Duration
 }
@@ -51,6 +65,13 @@ func (e *RequeueAfterError) GetRequeueAfter() time.Duration {
 }
 
 // IsRequeueAfter returns true if the error satisfies the interface HasRequeueAfterError.
+//
+// DEPRECATED: This error is deprecated and should not be used for new code.
+// See https://github.com/kubernetes-sigs/cluster-api/issues/3370 for more information.
+//
+// Users should switch their methods and functions to return a (ctrl.Result, error) pair,
+// instead of relying on this error. Controller runtime exposes a Result.IsZero() (from 0.5.9, and 0.6.2)
+// which can be used from callers to see if reconciliation should be stopped or continue.
 func IsRequeueAfter(err error) bool {
 	_, ok := errors.Cause(err).(HasRequeueAfterError)
 	return ok


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Related to the effort outlined in #3370, this PR adds a deprecation notice for the struct and helper functions.

/milestone v0.3.8
/assign @ncdc @detiber 
