### PR TITLE
🌱 Add generate yaml subcommand to clusterctl

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -55,6 +55,20 @@ type Client interface {
 
 	// ApplyUpgrade executes an upgrade plan.
 	ApplyUpgrade(options ApplyUpgradeOptions) error
+
+	// ProcessYAML provides a direct way to process a yaml and inspect its
+	// variables.
+	ProcessYAML(options ProcessYAMLOptions) (YamlPrinter, error)
+}
+
+// YamlPrinter exposes methods that prints the processed template and
+// variables.
+type YamlPrinter interface {
+	// Variables required by the template.
+	Variables() []string
+
+	// Yaml returns yaml defining all the cluster template objects as a byte array.
+	Yaml() ([]byte, error)
 }
 
 // clusterctlClient implements Client.

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -105,6 +105,10 @@ func (f fakeClient) ApplyUpgrade(options ApplyUpgradeOptions) error {
 	return f.internalClient.ApplyUpgrade(options)
 }
 
+func (f fakeClient) ProcessYAML(options ProcessYAMLOptions) (YamlPrinter, error) {
+	return f.internalClient.ProcessYAML(options)
+}
+
 // newFakeClient returns a clusterctl client that allows to execute tests on a set of fake config, fake repositories and fake clusters.
 // you can use WithCluster and WithRepository to prepare for the test case.
 func newFakeClient(configClient config.Client) *fakeClient {

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -21,9 +21,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -597,4 +599,115 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 			gs.Expect(gotYaml).To(Equal(tt.want.yaml))
 		})
 	}
+}
+
+func Test_clusterctlClient_ProcessYAML(t *testing.T) {
+	g := NewWithT(t)
+	template := `v1: ${VAR1:=default1}
+v2: ${VAR2=default2}
+v3: ${VAR3:-default3}`
+	dir, err := ioutil.TempDir("", "clusterctl")
+	g.Expect(err).NotTo(HaveOccurred())
+	defer os.RemoveAll(dir)
+
+	templateFile := filepath.Join(dir, "template.yaml")
+	g.Expect(ioutil.WriteFile(templateFile, []byte(template), 0600)).To(Succeed())
+
+	inputReader := strings.NewReader(template)
+
+	tests := []struct {
+		name         string
+		options      ProcessYAMLOptions
+		expectErr    bool
+		expectedYaml string
+		expectedVars []string
+	}{
+		{
+			name: "returns the expected yaml and variables",
+			options: ProcessYAMLOptions{
+				URLSource: &URLSourceOptions{
+					URL: templateFile,
+				},
+				ListVariablesOnly: false,
+			},
+			expectErr: false,
+			expectedYaml: `v1: default1
+v2: default2
+v3: default3`,
+			expectedVars: []string{"VAR1", "VAR2", "VAR3"},
+		},
+		{
+			name: "returns the expected variables only if ListVariablesOnly is set",
+			options: ProcessYAMLOptions{
+				URLSource: &URLSourceOptions{
+					URL: templateFile,
+				},
+				ListVariablesOnly: true,
+			},
+			expectErr:    false,
+			expectedYaml: ``,
+			expectedVars: []string{"VAR1", "VAR2", "VAR3"},
+		},
+		{
+			name:      "returns error if no source was specified",
+			options:   ProcessYAMLOptions{},
+			expectErr: true,
+		},
+		{
+			name: "processes yaml from specified reader",
+			options: ProcessYAMLOptions{
+				ReaderSource: &ReaderSourceOptions{
+					Reader: inputReader,
+				},
+				ListVariablesOnly: false,
+			},
+			expectErr: false,
+			expectedYaml: `v1: default1
+v2: default2
+v3: default3`,
+			expectedVars: []string{"VAR1", "VAR2", "VAR3"},
+		},
+		{
+			name: "returns error if unable to read from reader",
+			options: ProcessYAMLOptions{
+				ReaderSource: &ReaderSourceOptions{
+					Reader: &errReader{},
+				},
+				ListVariablesOnly: false,
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config1 := newFakeConfig().
+				WithProvider(infraProviderConfig)
+			cluster1 := newFakeCluster(cluster.Kubeconfig{}, config1)
+
+			client := newFakeClient(config1).WithCluster(cluster1)
+
+			printer, err := client.ProcessYAML(tt.options)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			expectedYaml, err := printer.Yaml()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(string(expectedYaml)).To(Equal(tt.expectedYaml))
+
+			expectedVars := printer.Variables()
+			g.Expect(expectedVars).To(ConsistOf(tt.expectedVars))
+
+		})
+	}
+
+}
+
+// errReader returns a non-EOF error on the first read.
+type errReader struct{}
+
+func (e *errReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("read error")
 }

--- a/cmd/clusterctl/cmd/generate.go
+++ b/cmd/clusterctl/cmd/generate.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate yaml using clusterctl yaml processor.",
+	Long:  `Generate yaml using clusterctl yaml processor.`,
+}
+
+func init() {
+	RootCmd.AddCommand(generateCmd)
+}

--- a/cmd/clusterctl/cmd/generate_yaml.go
+++ b/cmd/clusterctl/cmd/generate_yaml.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+type generateYAMLOptions struct {
+	url           string
+	listVariables bool
+}
+
+var gyOpts = &generateYAMLOptions{}
+
+var generateYamlCmd = &cobra.Command{
+	Use:   "yaml",
+	Short: "Process yaml using clusterctl's yaml processor",
+	Long: LongDesc(`
+		Process yaml using clusterctl's yaml processor.
+
+		clusterctl ships with a simple yaml processor that performs variable
+		substitution that takes into account of default values.
+
+		Variable values are either sourced from the clusterctl config file or
+		from environment variables`),
+
+	Example: Examples(`
+		# Generates a configuration file with variable values using
+		a template from a specific URL.
+		clusterctl generate yaml --from https://github.com/foo-org/foo-repository/blob/master/cluster-template.yaml
+
+		# Generates a configuration file with variable values using
+		a template stored locally.
+		clusterctl generate yaml --from ~/workspace/cluster-template.yaml
+
+		# Prints list of variables used in the local template
+		clusterctl generate yaml --from ~/workspace/cluster-template.yaml --list-variables
+
+		# Prints list of variables from template passed in via stdin
+		cat ~/workspace/cluster-template.yaml | clusterctl generate yaml --list-variables
+`),
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return generateYAML(os.Stdin, os.Stdout)
+	},
+}
+
+func init() {
+	// flags for the url source
+	generateYamlCmd.Flags().StringVar(&gyOpts.url, "from", "-",
+		"The URL to read the template from. It defaults to '-' which reads from stdin.")
+
+	// other flags
+	generateYamlCmd.Flags().BoolVar(&gyOpts.listVariables, "list-variables", false,
+		"Returns the list of variables expected by the template instead of the template yaml")
+
+	generateCmd.AddCommand(generateYamlCmd)
+}
+
+func generateYAML(r io.Reader, w io.Writer) error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+	options := client.ProcessYAMLOptions{
+		ListVariablesOnly: gyOpts.listVariables,
+	}
+	if gyOpts.url != "" {
+		if gyOpts.url == "-" {
+			options.ReaderSource = &client.ReaderSourceOptions{
+				Reader: r,
+			}
+		} else {
+			options.URLSource = &client.URLSourceOptions{
+				URL: gyOpts.url,
+			}
+		}
+	}
+	printer, err := c.ProcessYAML(options)
+	if err != nil {
+		return err
+	}
+	if gyOpts.listVariables {
+		if len(printer.Variables()) > 0 {
+			fmt.Fprintln(w, "Variables:")
+			for _, v := range printer.Variables() {
+				fmt.Fprintf(w, "  - %s\n", v)
+			}
+		} else {
+			fmt.Fprintln(w)
+		}
+		return nil
+	}
+	out, err := printer.Yaml()
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(out))
+	return err
+}

--- a/cmd/clusterctl/cmd/generate_yaml_test.go
+++ b/cmd/clusterctl/cmd/generate_yaml_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_generateYAML(t *testing.T) {
+	g := NewWithT(t)
+	// create a local template
+	contents := `v1: ${VAR1:=default1}
+v2: ${VAR2=default2}
+v3: ${VAR3:-default3}`
+	template, cleanup1 := createTempFile(g, contents)
+	defer cleanup1()
+
+	templateWithoutVars, cleanup2 := createTempFile(g, `v1: foobar
+v2: bazfoo`)
+	defer cleanup2()
+
+	inputReader := strings.NewReader(contents)
+
+	tests := []struct {
+		name           string
+		options        *generateYAMLOptions
+		inputReader    io.Reader
+		expectErr      bool
+		expectedOutput string
+	}{
+		{
+			name:      "prints processed yaml using --from flag",
+			options:   &generateYAMLOptions{url: template},
+			expectErr: false,
+			expectedOutput: `v1: default1
+v2: default2
+v3: default3
+`,
+		},
+		{
+			name:      "prints variables using --list-variables flag",
+			options:   &generateYAMLOptions{url: template, listVariables: true},
+			expectErr: false,
+			expectedOutput: `Variables:
+  - VAR1
+  - VAR2
+  - VAR3
+`,
+		},
+		{
+			name:      "returns error for bad templateFile path",
+			options:   &generateYAMLOptions{url: "/tmp/do-not-exist", listVariables: true},
+			expectErr: true,
+		},
+		{
+			name:      "returns error if no options were specified",
+			options:   &generateYAMLOptions{},
+			expectErr: true,
+		},
+		{
+			name:           "prints nothing if there are no variables in the template",
+			options:        &generateYAMLOptions{url: templateWithoutVars, listVariables: true},
+			expectErr:      false,
+			expectedOutput: "\n",
+		},
+		{
+			name:        "prints processed yaml using specified reader when '--from=-'",
+			options:     &generateYAMLOptions{url: "-", listVariables: false},
+			inputReader: inputReader,
+			expectErr:   false,
+			expectedOutput: `v1: default1
+v2: default2
+v3: default3
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			gyOpts = tt.options
+			buf := bytes.NewBufferString("")
+			err := generateYAML(inputReader, buf)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			output, err := ioutil.ReadAll(buf)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(string(output)).To(Equal(tt.expectedOutput))
+		})
+	}
+
+}
+
+// createTempFile creates a temporary yaml file inside a temp dir. It returns
+// the filepath and a cleanup function for the temp directory.
+func createTempFile(g *WithT, contents string) (string, func()) {
+	dir, err := ioutil.TempDir("", "clusterctl")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	templateFile := filepath.Join(dir, "templ.yaml")
+	g.Expect(ioutil.WriteFile(templateFile, []byte(contents), 0600)).To(Succeed())
+
+	return templateFile, func() {
+		os.RemoveAll(dir)
+	}
+}

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
     - [clusterctl Commands](clusterctl/commands/commands.md)
         - [init](clusterctl/commands/init.md)
         - [config cluster](clusterctl/commands/config-cluster.md)
+        - [generate yaml](clusterctl/commands/generate-yaml.md)
         - [move](./clusterctl/commands/move.md)
         - [upgrade](clusterctl/commands/upgrade.md)
         - [delete](clusterctl/commands/delete.md)

--- a/docs/book/src/clusterctl/commands/commands.md
+++ b/docs/book/src/clusterctl/commands/commands.md
@@ -2,9 +2,7 @@
 
 * [`clusterctl init`](init.md)
 * [`clusterctl config cluster`](config-cluster.md)
+* [`clusterctl generate yaml`](generate-yaml.md)
 * [`clusterctl move`](move.md)
 * [`clusterctl upgrade`](upgrade.md)
 * [`clusterctl delete`](delete.md)
-
-
-

--- a/docs/book/src/clusterctl/commands/generate-yaml.md
+++ b/docs/book/src/clusterctl/commands/generate-yaml.md
@@ -1,0 +1,42 @@
+# clusterctl generate yaml
+
+The `clusterctl generate yaml` command processes yaml using clusterct's yaml
+processor.
+
+The intent of this command is to allow users who may have specific templates
+to leverage clusterctl's yaml processor for variable substitution. For
+example, this command can be leveraged in local and CI scripts or for
+development purposes.
+
+clusterctl ships with a simple yaml processor that performs variable
+substitution that takes into account of default values.
+Under the hood, clusterctl's yaml processor uses
+[drone/envsubst][drone-envsusbt] to replace variables and uses the defaults if
+necessary.
+
+Variable values are either sourced from the clusterctl config file or
+from environment variables.
+
+Current usage of the command is as follows:
+```bash
+# Generates a configuration file with variable values using a template from a
+# specific URL.
+clusterctl generate yaml --from https://github.com/foo-org/foo-repository/blob/master/cluster-template.yaml
+
+# Generates a configuration file with variable values using
+# a template stored locally.
+clusterctl generate yaml  --from ~/workspace/cluster-template.yaml
+
+# Prints list of variables used in the local template
+clusterctl generate yaml --from ~/workspace/cluster-template.yaml --list-variables
+
+# Prints list of variables from template passed in via stdin
+cat ~/workspace/cluster-template.yaml | clusterctl generate yaml --from - --list-variables
+
+# Default behavior for this sub-command is to read from stdin.
+# Generate configuration from stdin
+cat ~/workspace/cluster-template.yaml | clusterctl generate yaml
+```
+
+<!-- Links -->
+[drone-envsusbt]: https://github.com/drone/envsusbt

--- a/docs/book/src/clusterctl/overview.md
+++ b/docs/book/src/clusterctl/overview.md
@@ -5,7 +5,7 @@ The `clusterctl` CLI tool handles the lifecycle of a Cluster API [management clu
 The `clusterctl` command line interface is specifically designed for providing a simple "day 1 experience" and a
 quick start with Cluster API; it automates fetching the YAML files defining [provider components] and installing them.
 
-Additionally it encodes a set of best practices in managing providers, that helps the user in avoiding 
+Additionally it encodes a set of best practices in managing providers, that helps the user in avoiding
 mis-configurations or in managing day 2 operations such as upgrades.
 
 * use [`clusterctl init`](commands/init.md) to install Cluster API providers
@@ -13,6 +13,8 @@ mis-configurations or in managing day 2 operations such as upgrades.
 * use [`clusterctl delete`](commands/delete.md) to delete Cluster API providers
 
 * use [`clusterctl config cluster`](commands/config-cluster.md) to spec out workload clusters
+* use [`clusterctl generate yaml`](commands/generate-yaml.md) to process yaml
+  using clusterctl's internal yaml processor.
 * use [`clusterctl move`](commands/move.md) to migrate objects defining a workload clusters (e.g. Cluster, Machines) from a management cluster to another management cluster
 
 <!-- links -->


### PR DESCRIPTION
Currently, this only works with --from flag since that is the most generic and can be used for any template.
It also provides the --list-variables flag to list variables present in the template

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds the `generate yaml` subcommand. It works as follows:
```bash
# Print out the processed yaml with variables substituted.
clusterctl generate yaml --from <file-path>
# Prints out the list of variables available in the template.
clusterctl generate yaml --from <file-path> --list-variables
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3379 
