### PR TITLE
🌱 Add test reconcile etcd members

### DIFF
--- a/controlplane/kubeadm/internal/etcd/fake/client.go
+++ b/controlplane/kubeadm/internal/etcd/fake/client.go
@@ -32,6 +32,7 @@ type FakeEtcdClient struct {
 	StatusResponse       *clientv3.StatusResponse
 	ErrorResponse        error
 	MovedLeader          uint64
+	RemovedMember        uint64
 }
 
 func (c *FakeEtcdClient) Endpoints() []string {
@@ -54,7 +55,8 @@ func (c *FakeEtcdClient) AlarmList(_ context.Context) (*clientv3.AlarmResponse, 
 func (c *FakeEtcdClient) MemberList(_ context.Context) (*clientv3.MemberListResponse, error) {
 	return c.MemberListResponse, c.ErrorResponse
 }
-func (c *FakeEtcdClient) MemberRemove(_ context.Context, _ uint64) (*clientv3.MemberRemoveResponse, error) {
+func (c *FakeEtcdClient) MemberRemove(_ context.Context, i uint64) (*clientv3.MemberRemoveResponse, error) {
+	c.RemovedMember = i
 	return c.MemberRemoveResponse, c.ErrorResponse
 }
 func (c *FakeEtcdClient) MemberUpdate(_ context.Context, _ uint64, _ []string) (*clientv3.MemberUpdateResponse, error) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR builds on top of the work done in https://github.com/kubernetes-sigs/cluster-api/pull/3350. It adds tests for ReconcileEtcdMembers using envtest. 

**PR #3350 should be merged in before this one.**

Look at the last commit of this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3526 
