### PR TITLE
🌱Add watch for ClusterResourceSet resources

### DIFF
--- a/exp/addons/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/controllers/clusterresourceset_controller_test.go
@@ -217,4 +217,79 @@ apiVersion: v1`,
 			return apierrors.IsNotFound(err)
 		}, timeout).Should(BeTrue())
 	})
+	It("Should reconcile a ClusterResourceSet when a resource is created that is part of ClusterResourceSet resources", func() {
+
+		labels := map[string]string{"foo2": "bar2"}
+		newCMName := "test-configmap2"
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-clusterresourceset",
+				Namespace: defaultNamespaceName,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Resources: []addonsv1.ResourceRef{{Name: newCMName, Kind: "ConfigMap"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		Expect(testEnv.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+		defer func() {
+			Expect(testEnv.Delete(ctx, clusterResourceSetInstance)).To(Succeed())
+		}()
+
+		testCluster.SetLabels(labels)
+		Expect(testEnv.Update(ctx, testCluster)).To(Succeed())
+
+		By("Verifying ClusterResourceSetBinding is created with cluster owner reference")
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+		Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+
+			err := testEnv.Get(ctx, clusterResourceSetBindingKey, binding)
+			return err == nil
+		}, timeout).Should(BeTrue())
+
+		// Initially ConfiMap is missing, so no resources in the binding.
+		Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+
+			err := testEnv.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err == nil {
+				if len(binding.Spec.Bindings) > 0 && len(binding.Spec.Bindings[0].Resources) == 0 {
+					return true
+				}
+			}
+			return false
+		}, timeout).Should(BeTrue())
+
+		testConfigmap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      newCMName,
+				Namespace: defaultNamespaceName,
+			},
+			Data: map[string]string{},
+		}
+		Expect(testEnv.Create(ctx, testConfigmap)).To(Succeed())
+
+		// When the ConfigMap resource is created, CRS should get reconciled immediately.
+		Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+
+			err := testEnv.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err == nil {
+				if len(binding.Spec.Bindings[0].Resources) > 0 && binding.Spec.Bindings[0].Resources[0].Name == newCMName {
+					return true
+				}
+			}
+			return false
+		}, timeout).Should(BeTrue())
+		Expect(testEnv.Delete(ctx, testConfigmap)).To(Succeed())
+	})
 })

--- a/exp/addons/controllers/predicates/resource_predicates.go
+++ b/exp/addons/controllers/predicates/resource_predicates.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ResourceCreate returns a predicate that returns true for a create event
+func ResourceCreate(logger logr.Logger) predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+}
+
+// AddonsSecretCreate returns a predicate that returns true for a Secret create event if in addons Secret type
+func AddonsSecretCreate(logger logr.Logger) predicate.Funcs {
+	log := logger.WithValues("predicate", "SecretCreateOrUpdate")
+
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			log = log.WithValues("eventType", "create")
+			s, ok := e.Object.(*corev1.Secret)
+			if !ok {
+				log.V(4).Info("Expected Secret", "secret", e.Object.GetObjectKind().GroupVersionKind().String())
+				return false
+			}
+			if string(s.Type) != string(addonsv1.ClusterResourceSetSecretType) {
+				log.V(4).Info("Expected Secret Type", "type", addonsv1.SecretClusterResourceSetResourceKind,
+					"got", string(s.Type))
+				return false
+			}
+			return true
+		},
+		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds watch on ClusterResourceSet resources (ConfigMaps/Secrets), so that for the resources that is missing during `Apply` will be reconciled on creation or update of resources.

One down side of this is everytime a resource is created/updated, all CRS objects in the same namespace will be reconciled. Although CRS is added as owner of the resources during CRS creation since newly created resources were not there, they will not have owner refs and we cannot use owner references to get only the CRSs that has the created resource.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3397
