### PR TITLE
🐛 Wrap error so as to not lose context

### DIFF
--- a/cmd/clusterctl/client/repository/repository_local.go
+++ b/cmd/clusterctl/client/repository/repository_local.go
@@ -97,7 +97,7 @@ func (r *localRepository) GetFile(version, fileName string) ([]byte, error) {
 
 	f, err := os.Stat(absolutePath)
 	if err != nil {
-		return nil, errors.Errorf("failed to read file %q from local release %s", absolutePath, version)
+		return nil, errors.Wrapf(err, "failed to read file %q from local release %s", absolutePath, version)
 	}
 	if f.IsDir() {
 		return nil, errors.Errorf("invalid path: file %q is actually a directory %q", fileName, absolutePath)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR wraps the error from `os.Stat` when trying to read a file locally. This can be used to improve debugging and troubleshooting. We do this a few lines below for `ioutil.ReadFile`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A
