### PR TITLE
:seedling: add v0.7 to the embedded metadata

### DIFF
--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -263,6 +263,7 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 				},
 				ReleaseSeries: []clusterctlv1.ReleaseSeries{
 					// v1alpha3 release series
+					{Major: 0, Minor: 7, Contract: "v1alpha3"},
 					{Major: 0, Minor: 6, Contract: "v1alpha3"},
 					// v1alpha2 release series are supported only for upgrades
 					{Major: 0, Minor: 5, Contract: "v1alpha2"},


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What this PR does / why we need it**: This PR bumps the embedded metadata of CAPV to include 0.7

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/assign @vincepri 