### PR TITLE
🐛 Include machines in deleting status when calculate machineset replicas

### DIFF
--- a/controllers/machineset_controller_test.go
+++ b/controllers/machineset_controller_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/util"
@@ -577,15 +576,14 @@ func TestShouldExcludeMachine(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 	}
 
-	logger := klogr.New()
 	for _, tc := range testCases {
 		g := NewWithT(t)
 
-		got := shouldExcludeMachine(&tc.machineSet, &tc.machine, logger)
+		got := shouldExcludeMachine(&tc.machineSet, &tc.machine)
 
 		g.Expect(got).To(Equal(tc.expected))
 	}

--- a/controllers/mdutil/util.go
+++ b/controllers/mdutil/util.go
@@ -472,6 +472,22 @@ func GetActualReplicaCountForMachineSets(machineSets []*clusterv1.MachineSet) in
 	return totalActualReplicas
 }
 
+// TotalMachineSetsReplicaSum returns sum of max(ms.Spec.Replicas, ms.Status.Replicas) across all the machine sets.
+//
+// This is used to guarantee that the total number of machines will not exceed md.Spec.Replicas + maxSurge.
+// Use max(spec.Replicas,status.Replicas) to cover the cases that:
+// 1. Scale up, where spec.Replicas increased but no machine created yet, so spec.Replicas > status.Replicas
+// 2. Scale down, where spec.Replicas decreased but machine not deleted yet, so spec.Replicas < status.Replicas
+func TotalMachineSetsReplicaSum(machineSets []*clusterv1.MachineSet) int32 {
+	totalReplicas := int32(0)
+	for _, ms := range machineSets {
+		if ms != nil {
+			totalReplicas += integer.Int32Max(*(ms.Spec.Replicas), ms.Status.Replicas)
+		}
+	}
+	return totalReplicas
+}
+
 // GetReadyReplicaCountForMachineSets returns the number of ready machines corresponding to the given machine sets.
 func GetReadyReplicaCountForMachineSets(machineSets []*clusterv1.MachineSet) int32 {
 	totalReadyReplicas := int32(0)
@@ -521,7 +537,7 @@ func NewMSNewReplicas(deployment *clusterv1.MachineDeployment, allMSs []*cluster
 			return 0, err
 		}
 		// Find the total number of machines
-		currentMachineCount := GetReplicaCountForMachineSets(allMSs)
+		currentMachineCount := TotalMachineSetsReplicaSum(allMSs)
 		maxTotalMachines := *(deployment.Spec.Replicas) + int32(maxSurge)
 		if currentMachineCount >= maxTotalMachines {
 			// Cannot scale up.
@@ -533,24 +549,7 @@ func NewMSNewReplicas(deployment *clusterv1.MachineDeployment, allMSs []*cluster
 		scaleUpCount = integer.Int32Min(scaleUpCount, *(deployment.Spec.Replicas)-*(newMS.Spec.Replicas))
 		return *(newMS.Spec.Replicas) + scaleUpCount, nil
 	default:
-		// Check if we can scale up.
-		maxSurge, err := intstrutil.GetValueFromIntOrPercent(deployment.Spec.Strategy.RollingUpdate.MaxSurge, int(*(deployment.Spec.Replicas)), true)
-		if err != nil {
-			return 0, err
-		}
-		// Find the total number of machines
-		currentMachineCount := GetReplicaCountForMachineSets(allMSs)
-		maxTotalMachines := *(deployment.Spec.Replicas) + int32(maxSurge)
-		if currentMachineCount >= maxTotalMachines {
-			// Cannot scale up.
-			return *(newMS.Spec.Replicas), nil
-		}
-		// Scale up.
-		scaleUpCount := maxTotalMachines - currentMachineCount
-		// Do not exceed the number of desired replicas.
-		scaleUpCount = integer.Int32Min(scaleUpCount, *(deployment.Spec.Replicas)-*(newMS.Spec.Replicas))
-		return *(newMS.Spec.Replicas) + scaleUpCount, nil
-		// -- return 0, errors.Errorf("deployment type %v isn't supported", deployment.Spec.Strategy.Type)
+		return 0, fmt.Errorf("deployment strategy %v isn't supported", deployment.Spec.Strategy.Type)
 	}
 }
 

--- a/controllers/mdutil/util_test.go
+++ b/controllers/mdutil/util_test.go
@@ -411,7 +411,7 @@ func TestGetReplicaCountForMachineSets(t *testing.T) {
 	*(ms1.Spec.Replicas) = 1
 	ms1.Status.Replicas = 2
 	ms2 := generateMS(generateDeployment("bar"))
-	*(ms2.Spec.Replicas) = 2
+	*(ms2.Spec.Replicas) = 5
 	ms2.Status.Replicas = 3
 
 	tests := []struct {
@@ -419,18 +419,21 @@ func TestGetReplicaCountForMachineSets(t *testing.T) {
 		Sets           []*clusterv1.MachineSet
 		ExpectedCount  int32
 		ExpectedActual int32
+		ExpectedTotal  int32
 	}{
 		{
 			Name:           "1:2 Replicas",
 			Sets:           []*clusterv1.MachineSet{&ms1},
 			ExpectedCount:  1,
 			ExpectedActual: 2,
+			ExpectedTotal:  2,
 		},
 		{
-			Name:           "3:5 Replicas",
+			Name:           "6:5 Replicas",
 			Sets:           []*clusterv1.MachineSet{&ms1, &ms2},
-			ExpectedCount:  3,
+			ExpectedCount:  6,
 			ExpectedActual: 5,
+			ExpectedTotal:  7,
 		},
 	}
 
@@ -440,6 +443,7 @@ func TestGetReplicaCountForMachineSets(t *testing.T) {
 
 			g.Expect(GetReplicaCountForMachineSets(test.Sets)).To(Equal(test.ExpectedCount))
 			g.Expect(GetActualReplicaCountForMachineSets(test.Sets)).To(Equal(test.ExpectedActual))
+			g.Expect(TotalMachineSetsReplicaSum(test.Sets)).To(Equal(test.ExpectedTotal))
 		})
 	}
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR fix the issue that MachineDeployment RollingUpdate may launch machines more than (MD.Spec.Replicas + maxSurge). It include machines in deleting status when calculate MachineSet status replicas. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3417 
