### PR TITLE
🌱 Remove RequeueAfterError from cluster controller

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -659,6 +659,8 @@ func TestReconcileControlPlaneInitializedControlPlaneRef(t *testing.T) {
 	r := &ClusterReconciler{
 		Log: log.Log,
 	}
-	g.Expect(r.reconcileControlPlaneInitialized(context.Background(), c)).To(Succeed())
+	res, err := r.reconcileControlPlaneInitialized(context.Background(), c)
+	g.Expect(res.IsZero()).To(BeTrue())
+	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(c.Status.ControlPlaneInitialized).To(BeFalse())
 }

--- a/controllers/external/types.go
+++ b/controllers/external/types.go
@@ -17,12 +17,21 @@ limitations under the License.
 package external
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // ReconcileOutput is a return type of the external reconciliation
 // of referenced objects
 type ReconcileOutput struct {
+	// RequeueAfter if greater than 0, tells the Controller to requeue the reconcile key after the Duration.
+	// Implies that Requeue is true, there is no need to set Requeue to true at the same time as RequeueAfter.
+	//
+	// TODO(vincepri): Remove this field here and try to return a better struct that embeds ctrl.Result,
+	// we can't do that today because the field would conflict with the current `Result` field,
+	// which should probably be renamed to `Object` or something similar.
+	RequeueAfter time.Duration
 	// Details of the referenced external object.
 	// +optional
 	Result *unstructured.Unstructured

--- a/util/util.go
+++ b/util/util.go
@@ -659,3 +659,22 @@ func ManagerDelegatingClientFunc(cache cache.Cache, config *rest.Config, options
 		StatusClient: c,
 	}, nil
 }
+
+// LowestNonZeroResult compares two reconciliation results
+// and returns the one with lowest requeue time.
+func LowestNonZeroResult(i, j ctrl.Result) ctrl.Result {
+	switch {
+	case i.IsZero():
+		return j
+	case j.IsZero():
+		return i
+	case i.Requeue:
+		return i
+	case j.Requeue:
+		return j
+	case i.RequeueAfter < j.RequeueAfter:
+		return i
+	default:
+		return j
+	}
+}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR further cleans the use of RequeueAfterError from our controllers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #3370

/milestone v0.3.9