### PR TITLE
🐛 Include watching namespace for custom provider upgrades

### DIFF
--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -269,6 +269,10 @@ func (u *providerUpgrader) createCustomPlan(coreProvider clusterctlv1.Provider, 
 			return nil, errors.Errorf("unable to complete that upgrade: the target version for the provider %s supports the %s API Version of Cluster API (contract), while the management group is using %s", upgradeItem.InstanceName(), contract, targetContract)
 		}
 
+		// Migrate the additional provider attributes to the upgrade item
+		// such as watching namespace.
+		upgradeItem.WatchedNamespace = provider.WatchedNamespace
+
 		upgradePlan.Providers = append(upgradePlan.Providers, upgradeItem)
 		upgradeInstanceNames.Insert(upgradeItem.InstanceName())
 	}

--- a/cmd/clusterctl/client/config/provider.go
+++ b/cmd/clusterctl/client/config/provider.go
@@ -48,7 +48,7 @@ type Provider interface {
 	Less(other Provider) bool
 }
 
-// provider implements provider
+// provider implements Provider
 type provider struct {
 	name         string
 	url          string

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -191,6 +191,9 @@ func parseUpgradeItem(ref string, providerType clusterctlv1.ProviderType) (*clus
 			},
 			ProviderName: name,
 			Type:         string(providerType),
+			// The value for the following fields will be retrieved while
+			// creating the custom upgrade plan.
+			WatchedNamespace: "",
 		},
 		NextVersion: version,
 	}, nil

--- a/cmd/clusterctl/client/upgrade_test.go
+++ b/cmd/clusterctl/client/upgrade_test.go
@@ -206,7 +206,7 @@ func Test_clusterctlClient_ApplyUpgrade(t *testing.T) {
 					Kind:       "ProviderList",
 				},
 				ListMeta: metav1.ListMeta{},
-				Items: []clusterctlv1.Provider{ // only one provider should be upgraded
+				Items: []clusterctlv1.Provider{
 					fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.1", "cluster-api-system"),
 					fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.1", "infra-system"),
 				},
@@ -281,8 +281,8 @@ func fakeClientForUpgrade() *fakeClient {
 	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1).
 		WithRepository(repository1).
 		WithRepository(repository2).
-		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "").
-		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "")
+		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "watchingNS").
+		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "watchingNS")
 
 	client := newFakeClient(config1).
 		WithRepository(repository1).
@@ -310,7 +310,7 @@ func fakeProvider(name string, providerType clusterctlv1.ProviderType, version, 
 		ProviderName:     name,
 		Type:             string(providerType),
 		Version:          version,
-		WatchedNamespace: "",
+		WatchedNamespace: "watchingNS",
 	}
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR ensures that the Watching Namespace for a provider is preserved when upgrading that provider via a custom plan. That is, if we do something like `clusterctl upgrade apply --management-group=foo/cluster-api --infrastructure foo/aws:v0.5.5`. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3413 
