### PR TITLE
📖 Document how to upgrade a multi-tenant cluster

### DIFF
--- a/docs/book/src/clusterctl/commands/upgrade.md
+++ b/docs/book/src/clusterctl/commands/upgrade.md
@@ -116,3 +116,13 @@ clusterctl upgrade apply --management-group capi-system/cluster-api \
 ```
   
 etc.
+
+<aside class="note warning">
+
+<h1>tips</h1>
+
+As alternative of using multiple set of env variables it is possible to use 
+multiple config files and pass them to the different `clusterctl upgrade apply` calls 
+using the `--config` flag.
+
+</aside>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the clusterctl upgrade docs by documenting how to upgrade a multi-tenant cluster where each provider instance was installed with different env variables

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2997

/cc @MaxRink