### PR TITLE
🌱 Clusterctl init ignore pre releases

### DIFF
--- a/cmd/clusterctl/client/cluster/upgrader_info.go
+++ b/cmd/clusterctl/client/cluster/upgrader_info.go
@@ -72,6 +72,7 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse available version for the %s provider", provider.InstanceName())
 		}
+
 		if latestVersion == nil || latestVersion.LessThan(availableSemVersion) {
 			latestVersion = availableSemVersion
 		}
@@ -92,7 +93,9 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 		return nil, errors.Errorf("invalid provider metadata: version %s (the current version) for the provider %s does not match any release series", provider.Version, provider.InstanceName())
 	}
 
-	// Filters the versions to be considered for upgrading the provider (next versions) and checks if the releaseSeries defined in metadata includes all of them.
+	// Filters the versions to be considered for upgrading the provider (next
+	// versions) and checks if the releaseSeries defined in metadata includes
+	// all of them.
 	nextVersions := []version.Version{}
 	for _, repositoryVersion := range repositoryVersions {
 		// we are ignoring the conversion error here because a first check already passed above
@@ -170,8 +173,11 @@ func (i *upgradeInfo) getLatestNextVersion(contract string) *version.Version {
 		for j := range i.nextVersions {
 			nextVersion := &i.nextVersions[j]
 
-			// Drop the nextVersion version if not linked with the current release series
-			if nextVersion.Major() != releaseSeries.Major || nextVersion.Minor() != releaseSeries.Minor {
+			// Drop the nextVersion version if not linked with the current
+			// release series or if it is a pre-release.
+			if nextVersion.Major() != releaseSeries.Major ||
+				nextVersion.Minor() != releaseSeries.Minor ||
+				nextVersion.PreRelease() != "" {
 				continue
 			}
 

--- a/cmd/clusterctl/client/repository/repository_github.go
+++ b/cmd/clusterctl/client/repository/repository_github.go
@@ -243,6 +243,12 @@ func (g *gitHubRepository) getLatestRelease() (string, error) {
 			// discard releases with tags that are not a valid semantic versions (the user can point explicitly to such releases)
 			continue
 		}
+
+		// ignore pre-releases when getting latest release
+		if sv.PreRelease() != "" {
+			continue
+		}
+
 		if latestReleaseVersion == nil || latestReleaseVersion.LessThan(sv) {
 			latestTag = v
 			latestReleaseVersion = sv

--- a/cmd/clusterctl/client/repository/repository_github_test.go
+++ b/cmd/clusterctl/client/repository/repository_github_test.go
@@ -316,11 +316,11 @@ func Test_gitHubRepository_getLatestRelease(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Get release v0.4.1",
+			name: "Get latest release, ignores pre-release version",
 			field: field{
-				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/v0.4.1/path", clusterctlv1.CoreProviderType),
+				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/latest/path", clusterctlv1.CoreProviderType),
 			},
-			want:    "v0.4.3-alpha", // prerelease/build releaese are considered as well
+			want:    "v0.4.2",
 			wantErr: false,
 		},
 		{
@@ -347,8 +347,8 @@ func Test_gitHubRepository_getLatestRelease(t *testing.T) {
 				return
 			}
 			g.Expect(err).NotTo(HaveOccurred())
-
 			g.Expect(got).To(Equal(tt.want))
+			g.Expect(gRepo.defaultVersion).To(Equal(tt.want))
 		})
 	}
 }

--- a/cmd/clusterctl/client/repository/repository_local.go
+++ b/cmd/clusterctl/client/repository/repository_local.go
@@ -209,6 +209,10 @@ func (r *localRepository) getLatestRelease() (string, error) {
 		if err != nil {
 			continue
 		}
+		// ignore pre-releases when getting latest release
+		if sv.PreRelease() != "" {
+			continue
+		}
 		if latestReleaseVersion == nil || latestReleaseVersion.LessThan(sv) {
 			latestTag = v
 			latestReleaseVersion = sv

--- a/cmd/clusterctl/client/repository/repository_local_test.go
+++ b/cmd/clusterctl/client/repository/repository_local_test.go
@@ -153,6 +153,7 @@ func Test_localRepository_newLocalRepository_Latest(t *testing.T) {
 	// Create several release directories
 	createLocalTestProviderFile(t, tmpDir, "bootstrap-foo/v1.0.0/bootstrap-components.yaml", "foo: bar")
 	createLocalTestProviderFile(t, tmpDir, "bootstrap-foo/v1.0.1/bootstrap-components.yaml", "foo: bar")
+	createLocalTestProviderFile(t, tmpDir, "bootstrap-foo/v2.0.0-alpha.0/bootstrap-components.yaml", "foo: bar")
 	createLocalTestProviderFile(t, tmpDir, "bootstrap-foo/Foo.Bar/bootstrap-components.yaml", "foo: bar")
 	createLocalTestProviderFile(t, tmpDir, "bootstrap-foo/foo.file", "foo: bar")
 
@@ -182,6 +183,7 @@ func Test_localRepository_GetFile(t *testing.T) {
 	// Provider 2: URL is for the latest release
 	createLocalTestProviderFile(t, tmpDir, "bootstrap-bar/v1.0.0/bootstrap-components.yaml", "version: v1.0.0")
 	createLocalTestProviderFile(t, tmpDir, "bootstrap-bar/v1.0.1/bootstrap-components.yaml", "version: v1.0.1")
+	createLocalTestProviderFile(t, tmpDir, "bootstrap-bar/v2.0.0-alpha.0/bootstrap-components.yaml", "version: v2.0.0-alpha.0")
 	createLocalTestProviderFile(t, tmpDir, "bootstrap-bar/Foo.Bar/bootstrap-components.yaml", "version: Foo.Bar")
 	createLocalTestProviderFile(t, tmpDir, "bootstrap-bar/foo.file", "foo: bar")
 	p2URLLatest := "bootstrap-bar/latest/bootstrap-components.yaml"
@@ -248,6 +250,21 @@ func Test_localRepository_GetFile(t *testing.T) {
 			},
 			want: want{
 				contents: "version: v1.0.1", // We use the file contents to determine data was read from latest release
+			},
+			wantErr: false,
+		},
+		{
+			name: "Get file from pre-release version release directory",
+			fields: fields{
+				provider:              p2,
+				configVariablesClient: test.NewFakeVariableClient(),
+			},
+			args: args{
+				version:  "v2.0.0-alpha.0",
+				fileName: "bootstrap-components.yaml",
+			},
+			want: want{
+				contents: "version: v2.0.0-alpha.0", // We use the file contents to determine data was read from latest release
 			},
 			wantErr: false,
 		},

--- a/cmd/clusterctl/internal/test/fake_github.go
+++ b/cmd/clusterctl/internal/test/fake_github.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"testing"
 
 	"github.com/google/go-github/github"
 )
@@ -47,10 +46,4 @@ func NewFakeGitHub() (client *github.Client, mux *http.ServeMux, teardown func()
 	client.UploadURL = url
 
 	return client, mux, server.Close
-}
-
-func TestMethod(t *testing.T, r *http.Request, want string) {
-	if got := r.Method; got != want {
-		t.Errorf("Request method: %v, want %v", got, want)
-	}
 }

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -53,13 +53,27 @@ Note it is not possible to skip automatic installation of the `cluster-api` core
 
 #### Provider version
 
-The `clusterctl init` command by default installs the latest version available for each selected provider.
+The `clusterctl init` command by default installs the latest version available
+for each selected provider.
 
 <aside class="note">
 
 <h1> Is it possible to install a specific version of a provider? </h1>
 
 You can specify the provider version by appending a version tag to the provider name, e.g. `aws:v0.4.1`.
+
+</aside>
+
+<aside class="note">
+
+<h1> Pre-release provider versions </h1>
+
+`clusterctl init` does not install pre-release versions by default. For
+example, if a provider has releases `v0.7.0-alpha.0` and `v0.6.6`, the latest
+release installed will be `v0.6.6`.
+
+You can specify the provider version by appending a version tag to the
+provider name, e.g. `vsphere:v0.7.0-alpha.0`.
 
 </aside>
 

--- a/docs/book/src/clusterctl/commands/upgrade.md
+++ b/docs/book/src/clusterctl/commands/upgrade.md
@@ -11,7 +11,7 @@ API Version of Cluster API (contract), e.g. the v1alpha 3 Cluster API contract.
 A management group is a group of providers composed by a CoreProvider and a set of Bootstrap/ControlPlane/Infrastructure
 providers watching objects in the same namespace.
 
-Usually, in a management cluster there is only a management group, but in case of [n-core multi tenancy](init.md#multi-tenancy) 
+Usually, in a management cluster there is only a management group, but in case of [n-core multi tenancy](init.md#multi-tenancy)
 there can be more than one.
 
 # upgrade plan
@@ -45,21 +45,35 @@ You can now apply the upgrade by executing the following command:
 The output contains the latest release available for each management group in the cluster/for each API Version of Cluster API (contract)
 available at the moment.
 
+<aside class="note">
+
+<h1> Pre-release provider versions </h1>
+
+`clusterctl upgrade plan` does not display pre-release versions by default. For
+example, if a provider has releases `v0.7.0-alpha.0` and `v0.6.6` available, the latest
+release availble for upgrade will be `v0.6.6`.
+
+</aside>
+
 # upgrade apply
 
-After choosing the desired option for the upgrade, you can run the provided command.
+After choosing the desired option for the upgrade, you can run the following
+command to upgrade all the providers in the management group. This upgrades
+all the providers to the latest stable releases.
 
 ```shell
-clusterctl upgrade apply --management-group capi-system/cluster-api  --cluster-api-version v1alpha3
+clusterctl upgrade apply \
+  --management-group capi-system/cluster-api  \
+  --contract v1alpha3
 ```
 
 The upgrade process is composed by two steps:
 
-* Delete the current version of the provider components, while preserving the namespace where the provider components 
+* Delete the current version of the provider components, while preserving the namespace where the provider components
   are hosted and the provider's CRDs.
 * Install the new version of the provider components.
 
-Please note that clusterctl does not upgrade Cluster API objects (Clusters, MachineDeployments, Machine etc.); upgrading 
+Please note that clusterctl does not upgrade Cluster API objects (Clusters, MachineDeployments, Machine etc.); upgrading
 such objects are the responsibility of the provider's controllers.
 
 <aside class="note warning">
@@ -73,6 +87,24 @@ User is required to re-apply flag values after the upgrade completes.
 
 </aside>
 
+<aside class="note warning">
+
+<h1> Upgrading to pre-release provider versions </h1>
+
+In order to upgrade to a provider's pre-release version, we can do
+the following:
+
+```shell
+clusterctl upgrade apply --management-group capi-system/cluster-api \
+    --core capi-system/cluster-api:v0.3.1 \
+    --bootstrap capi-kubeadm-bootstrap-system/kubeadm:v0.3.1 \
+    --control-plane capi-kubeadm-control-plane-system/kubeadm:v0.3.1 \
+    --infrastructure capv-system/vsphere:v0.7.0-alpha.0
+```
+
+In this case, all the provider's versions must be explicitly stated.
+
+</aside>
 
 ## Upgrading a Multi-tenancy management cluster
 
@@ -82,47 +114,47 @@ different environment variables for customizing the provider instances.
 
 In order to upgrade a multi-tenancy management cluster, and preserve the instance specific settings, you should do
 the same during upgrades and execute multiple calls to `clusterctl upgrade apply`, each one with different environment
-variables. 
+variables.
 
 For instance, in case of a management cluster with n>1 instances of an infrastructure provider, and only one instance
 of Cluster API core provider, bootstrap provider and control plane provider, you should:
 
-Run once `clusterctl upgrade apply` for the core provider, the bootstrap provider and the control plane provider; 
-this can be achieved by using the `--core`, `--bootstrap` and `--control-plane` flags followed by the upgrade target 
+Run once `clusterctl upgrade apply` for the core provider, the bootstrap provider and the control plane provider;
+this can be achieved by using the `--core`, `--bootstrap` and `--control-plane` flags followed by the upgrade target
 for each one of those providers, e.g.
-  
+
 ```shell
 clusterctl upgrade apply --management-group capi-system/cluster-api \
     --core capi-system/cluster-api:v0.3.1 \
     --bootstrap capi-kubeadm-bootstrap-system/kubeadm:v0.3.1 \
-    --control-plane capi-kubeadm-control-plane-system/kubeadm:v0.3.1 
+    --control-plane capi-kubeadm-control-plane-system/kubeadm:v0.3.1
 ```
 
-Run `clusterctl upgrade apply` for each infrastructure provider instance, using the `--infrastructure` flag, 
+Run `clusterctl upgrade apply` for each infrastructure provider instance, using the `--infrastructure` flag,
 taking care to provide different environment variables for each call (as in the initial setup), e.g.
-  
+
 Set the environment variables for instance 1 and then run:
 
 ```shell
 clusterctl upgrade apply --management-group capi-system/cluster-api \
-    --infrastructure instance1/docker:v0.3.1  
+    --infrastructure instance1/docker:v0.3.1
 ```
-  
+
 Afterwards, set the environment variables for instance 2 and then run:
-  
+
 ```shell
 clusterctl upgrade apply --management-group capi-system/cluster-api \
-    --infrastructure instance2/docker:v0.3.1  
+    --infrastructure instance2/docker:v0.3.1
 ```
-  
+
 etc.
 
 <aside class="note warning">
 
 <h1>tips</h1>
 
-As alternative of using multiple set of env variables it is possible to use 
-multiple config files and pass them to the different `clusterctl upgrade apply` calls 
+As alternative of using multiple set of env variables it is possible to use
+multiple config files and pass them to the different `clusterctl upgrade apply` calls
 using the `--config` flag.
 
 </aside>


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR skips pre-releases during a `clusterctl init` and during `clusterctl upgrade <plan|apply>`. That is, we ignore pre-releases except if explicitly declared.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3435 
