### PR TITLE
🐛Remove ClusterResourceSet from bindings on deletion

### DIFF
--- a/exp/addons/api/v1alpha3/clusterresourceset_types.go
+++ b/exp/addons/api/v1alpha3/clusterresourceset_types.go
@@ -25,6 +25,9 @@ import (
 const (
 	// ClusterResourceSetSecretType is the only accepted type of secret in resources
 	ClusterResourceSetSecretType corev1.SecretType = "addons.cluster.x-k8s.io/resource-set" //nolint:gosec
+
+	// ClusterResourceSetFinalizer is added to the ClusterResourceSet object for additional cleanup logic on deletion.
+	ClusterResourceSetFinalizer = "addons.cluster.x-k8s.io"
 )
 
 // ANCHOR: ClusterResourceSetSpec

--- a/exp/addons/api/v1alpha3/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1alpha3/clusterresourcesetbinding_types.go
@@ -89,6 +89,17 @@ func (c *ClusterResourceSetBinding) GetOrCreateBinding(clusterResourceSet *Clust
 	return binding
 }
 
+// DeleteBinding removes the ClusterResourceSet from the ClusterResourceSetBinding Bindings list
+func (c *ClusterResourceSetBinding) DeleteBinding(clusterResourceSet *ClusterResourceSet) {
+	for i, binding := range c.Spec.Bindings {
+		if binding.ClusterResourceSetName == clusterResourceSet.Name {
+			copy(c.Spec.Bindings[i:], c.Spec.Bindings[i+1:])
+			c.Spec.Bindings = c.Spec.Bindings[:len(c.Spec.Bindings)-1]
+			break
+		}
+	}
+}
+
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=clusterresourcesetbindings,scope=Namespaced,categories=cluster-api
 // +kubebuilder:subresource:status

--- a/exp/addons/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/controllers/clusterresourceset_controller_test.go
@@ -41,6 +41,10 @@ var _ = Describe("ClusterResourceSet Reconciler", func() {
 
 	var testCluster *clusterv1.Cluster
 	var clusterName string
+
+	var configmapName = "test-configmap"
+	var configmap2Name = "test-configmap2"
+
 	BeforeEach(func() {
 		clusterName = fmt.Sprintf("cluster-%s", util.RandomString(6))
 		testCluster = &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: defaultNamespaceName}}
@@ -49,6 +53,38 @@ var _ = Describe("ClusterResourceSet Reconciler", func() {
 		Expect(testEnv.Create(ctx, testCluster)).To(Succeed())
 		By("Creating the remote Cluster kubeconfig")
 		Expect(testEnv.CreateKubeconfigSecret(testCluster)).To(Succeed())
+
+		testConfigmap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configmapName,
+				Namespace: defaultNamespaceName,
+			},
+			Data: map[string]string{
+				"cm": `metadata:
+ name: resource-configmap
+ namespace: default
+kind: ConfigMap
+apiVersion: v1`,
+			},
+		}
+
+		testConfigmap2 := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configmap2Name,
+				Namespace: defaultNamespaceName,
+			},
+			Data: map[string]string{
+				"cm": `metadata:
+kind: ConfigMap
+apiVersion: v1
+metadata:
+ name: resource-configmap
+ namespace: default`,
+			},
+		}
+		By("Creating 2 ConfigMaps with ConfigMap in their data field")
+		testEnv.Create(ctx, testConfigmap)
+		testEnv.Create(ctx, testConfigmap2)
 	})
 	AfterEach(func() {
 		By("Deleting the Kubeconfigsecret")
@@ -59,43 +95,31 @@ var _ = Describe("ClusterResourceSet Reconciler", func() {
 			},
 		}
 		Expect(testEnv.Delete(ctx, secret)).To(Succeed())
-	})
 
-	It("Should reconcile a ClusterResourceSet when a cluster with matching label exists", func() {
-		By("Creating the resource configmap")
-		var configmapName = "test-configmap"
-		testConfigmap := &corev1.ConfigMap{
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      configmapName,
+				Name:      "test-clusterresourceset",
 				Namespace: defaultNamespaceName,
 			},
-			Data: map[string]string{
-				"cm": `metadata:
-name: resource-configmap
-namespace: default
-kind: ConfigMap
-apiVersion: v1
----
-metadata:
-name: resource-configmap2
-namespace: default
-kind: ConfigMap
-apiVersion: v1`,
-				"cm2": `metadata:
-name: resource-configmap3
-namespace: default
-kind: ConfigMap
-apiVersion: v1
----
-metadata:
-name: resource-configmap4
-namespace: default
-kind: ConfigMap
-apiVersion: v1`,
-			},
 		}
-		Expect(testEnv.Create(ctx, testConfigmap)).To(Succeed())
 
+		err := testEnv.Get(ctx, client.ObjectKey{Namespace: clusterResourceSetInstance.Namespace, Name: clusterResourceSetInstance.Name}, clusterResourceSetInstance)
+		if err == nil {
+			Expect(testEnv.Delete(ctx, clusterResourceSetInstance)).To(Succeed())
+		}
+
+		Eventually(func() bool {
+			crsKey := client.ObjectKey{
+				Namespace: clusterResourceSetInstance.Namespace,
+				Name:      clusterResourceSetInstance.Name,
+			}
+			crs := &addonsv1.ClusterResourceSet{}
+			err := testEnv.Get(ctx, crsKey, crs)
+			return err != nil
+		}, timeout).Should(BeTrue())
+	})
+
+	It("Should reconcile a ClusterResourceSet with multiple resources when a cluster with matching label exists", func() {
 		By("Updating the cluster with labels")
 		labels := map[string]string{"foo": "bar"}
 		testCluster.SetLabels(labels)
@@ -111,14 +135,11 @@ apiVersion: v1`,
 				ClusterSelector: metav1.LabelSelector{
 					MatchLabels: labels,
 				},
-				Resources: []addonsv1.ResourceRef{{Name: configmapName, Kind: "ConfigMap"}},
+				Resources: []addonsv1.ResourceRef{{Name: configmapName, Kind: "ConfigMap"}, {Name: configmap2Name, Kind: "ConfigMap"}},
 			},
 		}
 		// Create the ClusterResourceSet.
 		Expect(testEnv.Create(ctx, clusterResourceSetInstance)).To(Succeed())
-		defer func() {
-			Expect(testEnv.Delete(ctx, clusterResourceSetInstance)).To(Succeed())
-		}()
 
 		By("Verifying ClusterResourceSetBinding is created with cluster owner reference")
 		Eventually(func() bool {
@@ -135,7 +156,11 @@ apiVersion: v1`,
 			if len(binding.Spec.Bindings) != 1 {
 				return false
 			}
-			if len(binding.Spec.Bindings[0].Resources) != 1 {
+			if len(binding.Spec.Bindings[0].Resources) != 2 {
+				return false
+			}
+
+			if binding.Spec.Bindings[0].Resources[0].Applied != true || binding.Spec.Bindings[0].Resources[1].Applied != true {
 				return false
 			}
 
@@ -149,7 +174,6 @@ apiVersion: v1`,
 		By("Deleting the Cluster")
 		Expect(testEnv.Delete(ctx, testCluster)).To(Succeed())
 	})
-
 	It("Should reconcile a cluster when its labels are changed to match a ClusterResourceSet's selector", func() {
 
 		labels := map[string]string{"foo": "bar"}
@@ -167,9 +191,6 @@ apiVersion: v1`,
 		}
 		// Create the ClusterResourceSet.
 		Expect(testEnv.Create(ctx, clusterResourceSetInstance)).To(Succeed())
-		defer func() {
-			Expect(testEnv.Delete(ctx, clusterResourceSetInstance)).To(Succeed())
-		}()
 
 		testCluster.SetLabels(labels)
 		Expect(testEnv.Update(ctx, testCluster)).To(Succeed())
@@ -211,16 +232,13 @@ apiVersion: v1`,
 
 		Eventually(func() bool {
 			binding := &addonsv1.ClusterResourceSetBinding{}
-
 			err := testEnv.Get(ctx, clusterResourceSetBindingKey, binding)
-
 			return apierrors.IsNotFound(err)
 		}, timeout).Should(BeTrue())
 	})
 	It("Should reconcile a ClusterResourceSet when a resource is created that is part of ClusterResourceSet resources", func() {
-
 		labels := map[string]string{"foo2": "bar2"}
-		newCMName := "test-configmap2"
+		newCMName := "test-configmap3"
 
 		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -236,9 +254,6 @@ apiVersion: v1`,
 		}
 		// Create the ClusterResourceSet.
 		Expect(testEnv.Create(ctx, clusterResourceSetInstance)).To(Succeed())
-		defer func() {
-			Expect(testEnv.Delete(ctx, clusterResourceSetInstance)).To(Succeed())
-		}()
 
 		testCluster.SetLabels(labels)
 		Expect(testEnv.Update(ctx, testCluster)).To(Succeed())
@@ -256,7 +271,7 @@ apiVersion: v1`,
 			return err == nil
 		}, timeout).Should(BeTrue())
 
-		// Initially ConfiMap is missing, so no resources in the binding.
+		// Initially ConfigMap is missing, so no resources in the binding.
 		Eventually(func() bool {
 			binding := &addonsv1.ClusterResourceSetBinding{}
 
@@ -291,5 +306,114 @@ apiVersion: v1`,
 			return false
 		}, timeout).Should(BeTrue())
 		Expect(testEnv.Delete(ctx, testConfigmap)).To(Succeed())
+	})
+	It("Should delete ClusterResourceSet from the bindings list when ClusterResourceSet is deleted", func() {
+		By("Updating the cluster with labels")
+		labels := map[string]string{"foo": "bar"}
+		testCluster.SetLabels(labels)
+		Expect(testEnv.Update(ctx, testCluster)).To(Succeed())
+
+		By("Creating a ClusterResourceSet instance that has same labels as selector")
+		clusterResourceSetInstance2 := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-clusterresourceset",
+				Namespace: defaultNamespaceName,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Resources: []addonsv1.ResourceRef{{Name: configmapName, Kind: "ConfigMap"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		Expect(testEnv.Create(ctx, clusterResourceSetInstance2)).To(Succeed())
+
+		By("Creating a second ClusterResourceSet instance that has same labels as selector")
+		clusterResourceSetInstance3 := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-clusterresourceset2",
+				Namespace: defaultNamespaceName,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Resources: []addonsv1.ResourceRef{{Name: configmapName, Kind: "ConfigMap"}, {Name: configmap2Name, Kind: "ConfigMap"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		Expect(testEnv.Create(ctx, clusterResourceSetInstance3)).To(Succeed())
+
+		By("Verifying ClusterResourceSetBinding is created with 2 ClusterResourceSets")
+		Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			clusterResourceSetBindingKey := client.ObjectKey{
+				Namespace: testCluster.Namespace,
+				Name:      testCluster.Name,
+			}
+			err := testEnv.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+			return len(binding.Spec.Bindings) == 2
+		}, timeout).Should(BeTrue())
+
+		By("Verifying deleted CRS is deleted from ClusterResourceSetBinding")
+		// Delete one of the CRS instances and wait until it is removed from the binding list.
+		Expect(testEnv.Delete(ctx, clusterResourceSetInstance2)).To(Succeed())
+		Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			clusterResourceSetBindingKey := client.ObjectKey{
+				Namespace: testCluster.Namespace,
+				Name:      testCluster.Name,
+			}
+			err := testEnv.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+			return len(binding.Spec.Bindings) == 1
+		}, timeout).Should(BeTrue())
+
+		By("Verifying ClusterResourceSetBinding  is deleted after deleting all matching CRS objects")
+		// Delete one of the CRS instances and wait until it is removed from the binding list.
+		Expect(testEnv.Delete(ctx, clusterResourceSetInstance3)).To(Succeed())
+		Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			clusterResourceSetBindingKey := client.ObjectKey{
+				Namespace: testCluster.Namespace,
+				Name:      testCluster.Name,
+			}
+			return testEnv.Get(ctx, clusterResourceSetBindingKey, binding) != nil
+		}, timeout).Should(BeTrue())
+
+		By("Deleting the Cluster")
+		Expect(testEnv.Delete(ctx, testCluster)).To(Succeed())
+	})
+	It("Should add finalizer after reconcile", func() {
+		dt := metav1.Now()
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-clusterresourceset",
+				Namespace:         defaultNamespaceName,
+				Finalizers:        []string{addonsv1.ClusterResourceSetFinalizer},
+				DeletionTimestamp: &dt,
+			},
+		}
+		// Create the ClusterResourceSet.
+		Expect(testEnv.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+		Eventually(func() bool {
+			crsKey := client.ObjectKey{
+				Namespace: clusterResourceSetInstance.Namespace,
+				Name:      clusterResourceSetInstance.Name,
+			}
+			crs := &addonsv1.ClusterResourceSet{}
+
+			err := testEnv.Get(ctx, crsKey, crs)
+			if err == nil {
+				return len(crs.Finalizers) > 0
+			}
+			return false
+		}, timeout).Should(BeTrue())
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes CRS from the CRSBinding `bindings` after CRS is deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3453
