### PR TITLE
✨ Add `get kubeconfig` clusterctl sub-command

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -40,6 +40,9 @@ type Client interface {
 	// GetClusterTemplate returns a workload cluster template.
 	GetClusterTemplate(options GetClusterTemplateOptions) (Template, error)
 
+	// GetKubeconfig returns the kubeconfig of the workload cluster.
+	GetKubeconfig(options GetKubeconfigOptions) (string, error)
+
 	// Delete deletes providers from a management cluster.
 	Delete(options DeleteOptions) error
 

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -81,6 +81,10 @@ func (f fakeClient) GetClusterTemplate(options GetClusterTemplateOptions) (Templ
 	return f.internalClient.GetClusterTemplate(options)
 }
 
+func (f fakeClient) GetKubeconfig(options GetKubeconfigOptions) (string, error) {
+	return f.internalClient.GetKubeconfig(options)
+}
+
 func (f fakeClient) Init(options InitOptions) ([]Components, error) {
 	return f.internalClient.Init(options)
 }
@@ -260,6 +264,10 @@ func (f *fakeClusterClient) ProviderUpgrader() cluster.ProviderUpgrader {
 
 func (f *fakeClusterClient) Template() cluster.TemplateClient {
 	return f.internalclient.Template()
+}
+
+func (f *fakeClusterClient) WorkloadCluster() cluster.WorkloadCluster {
+	return f.internalclient.WorkloadCluster()
 }
 
 func (f *fakeClusterClient) WithObjs(objs ...runtime.Object) *fakeClusterClient {

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -86,6 +86,9 @@ type Client interface {
 
 	// Template has methods to work with templates stored in the cluster.
 	Template() TemplateClient
+
+	// WorkloadCluster has methods for fetching kubeconfig of workload cluster from management cluster.
+	WorkloadCluster() WorkloadCluster
 }
 
 // PollImmediateWaiter tries a condition func until it returns true, an error, or the timeout is reached.
@@ -140,6 +143,10 @@ func (c *clusterClient) ProviderUpgrader() ProviderUpgrader {
 
 func (c *clusterClient) Template() TemplateClient {
 	return newTemplateClient(TemplateClientInput{c.proxy, c.configClient, c.processor})
+}
+
+func (c *clusterClient) WorkloadCluster() WorkloadCluster {
+	return newWorkloadCluster(c.proxy)
 }
 
 // Option is a configuration option supplied to New

--- a/cmd/clusterctl/client/cluster/workload_cluster.go
+++ b/cmd/clusterctl/client/cluster/workload_cluster.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"github.com/pkg/errors"
+	utilkubeconfig "sigs.k8s.io/cluster-api/util/kubeconfig"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// WorkloadCluster has methods for fetching kubeconfig of workload cluster from management cluster.
+type WorkloadCluster interface {
+	// GetKubeconfig returns the kubeconfig of the workload cluster.
+	GetKubeconfig(workloadClusterName string, namespace string) (string, error)
+}
+
+// workloadCluster implements WorkloadCluster.
+type workloadCluster struct {
+	proxy Proxy
+}
+
+// newWorkloadCluster returns a workloadCluster.
+func newWorkloadCluster(proxy Proxy) *workloadCluster {
+	return &workloadCluster{
+		proxy: proxy,
+	}
+}
+
+func (p *workloadCluster) GetKubeconfig(workloadClusterName string, namespace string) (string, error) {
+	cs, err := p.proxy.NewClient()
+	if err != nil {
+		return "", err
+	}
+
+	obj := client.ObjectKey{
+		Namespace: namespace,
+		Name:      workloadClusterName,
+	}
+	dataBytes, err := utilkubeconfig.FromSecret(ctx, cs, obj)
+	if err != nil {
+		return "", errors.Wrapf(err, "\"%s-kubeconfig\" not found in namespace %q", workloadClusterName, namespace)
+	}
+	return string(dataBytes), nil
+}

--- a/cmd/clusterctl/client/cluster/workload_cluster_test.go
+++ b/cmd/clusterctl/client/cluster/workload_cluster_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
+	"sigs.k8s.io/cluster-api/util/secret"
+)
+
+func Test_WorkloadCluster_GetKubeconfig(t *testing.T) {
+
+	var (
+		validKubeConfig = `
+clusters:
+- cluster:
+    certificate-authority-data: stuff
+    server: https://test-cluster-api:6443
+  name: test1
+contexts:
+- context:
+    cluster: test1
+    user: test1-admin
+  name: test1-admin@test1
+current-context: test1-admin@test1
+kind: Config
+preferences: {}
+users:
+- name: test1-admin
+  user:
+    client-certificate-data: stuff-cert-data
+    client-key-data: stuff-key-data
+`
+
+		validSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test1-kubeconfig",
+				Namespace: "test",
+				Labels:    map[string]string{clusterv1.ClusterLabelName: "test1"},
+			},
+			Data: map[string][]byte{
+				secret.KubeconfigDataName: []byte(validKubeConfig),
+			},
+		}
+	)
+
+	tests := []struct {
+		name      string
+		expectErr bool
+		proxy     Proxy
+	}{
+		{
+			name:      "return secret data",
+			expectErr: false,
+			proxy:     test.NewFakeProxy().WithObjs(validSecret),
+		},
+		{
+			name:      "return error if cannot find secert",
+			expectErr: true,
+			proxy:     test.NewFakeProxy(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			wc := newWorkloadCluster(tt.proxy)
+			data, err := wc.GetKubeconfig("test1", "test")
+
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(data).To(Equal(string(validSecret.Data[secret.KubeconfigDataName])))
+		})
+	}
+
+}

--- a/cmd/clusterctl/client/get_kubeconfig.go
+++ b/cmd/clusterctl/client/get_kubeconfig.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import "github.com/pkg/errors"
+
+//GetKubeconfigOptions carries all the options supported by GetKubeconfig
+type GetKubeconfigOptions struct {
+	// Kubeconfig defines the kubeconfig to use for accessing the management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	Kubeconfig Kubeconfig
+
+	// Namespace is the namespace in which secret is placed.
+	Namespace string
+
+	// WorkloadClusterName is the name of the workload cluster.
+	WorkloadClusterName string
+}
+
+func (c *clusterctlClient) GetKubeconfig(options GetKubeconfigOptions) (string, error) {
+	// gets access to the management cluster
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})
+	if err != nil {
+		return "", err
+	}
+
+	if options.Namespace == "" {
+		currentNamespace, err := clusterClient.Proxy().CurrentNamespace()
+		if err != nil {
+			return "", err
+		}
+		if currentNamespace == "" {
+			return "", errors.New("failed to identify the current namespace. Please specify the namespace where the workload cluster exists")
+		}
+		options.Namespace = currentNamespace
+	}
+
+	return clusterClient.WorkloadCluster().GetKubeconfig(options.WorkloadClusterName, options.Namespace)
+
+}

--- a/cmd/clusterctl/client/get_kubeconfig_test.go
+++ b/cmd/clusterctl/client/get_kubeconfig_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
+)
+
+func Test_clusterctlClient_GetKubeconfig(t *testing.T) {
+
+	configClient := newFakeConfig()
+	kubeconfig := cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}
+	clusterClient := &fakeClusterClient{
+		kubeconfig: kubeconfig,
+	}
+	// create a clusterctl client where the proxy returns an empty namespace
+	clusterClient.fakeProxy = test.NewFakeProxy().WithNamespace("")
+	badClient := newFakeClient(configClient).WithCluster(clusterClient)
+
+	tests := []struct {
+		name      string
+		client    *fakeClient
+		options   GetKubeconfigOptions
+		expectErr bool
+	}{
+		{
+			name:      "returns error if unable to get client for mgmt cluster",
+			client:    fakeEmptyCluster(),
+			expectErr: true,
+		},
+		{
+			name:      "returns error if unable namespace is empty",
+			client:    badClient,
+			options:   GetKubeconfigOptions{Kubeconfig: Kubeconfig(kubeconfig)},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			config, err := tt.client.GetKubeconfig(tt.options)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(config).ToNot(BeEmpty())
+		})
+	}
+}

--- a/cmd/clusterctl/cmd/get.go
+++ b/cmd/clusterctl/cmd/get.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get info from a management or a workload cluster",
+	Long:  `Get info from a management or a workload cluster`,
+}
+
+func init() {
+	RootCmd.AddCommand(getCmd)
+}

--- a/cmd/clusterctl/cmd/get_kubeconfig.go
+++ b/cmd/clusterctl/cmd/get_kubeconfig.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+type getKubeconfigOptions struct {
+	kubeconfig        string
+	kubeconfigContext string
+	namespace         string
+}
+
+var gk = &getKubeconfigOptions{}
+
+var getKubeconfigCmd = &cobra.Command{
+	Use:   "kubeconfig",
+	Short: "Gets the kubeconfig file for accessing a workload cluster",
+	Long: LongDesc(`
+		Gets the kubeconfig file for accessing a workload cluster`),
+
+	Example: Examples(`
+		# Get the workload cluster's kubeconfig.
+		clusterctl get kubeconfig <name of workload cluster>
+
+		# Get the workload cluster's kubeconfig in a particular namespace.
+		clusterctl get kubeconfig <name of workload cluster> --namespace foo`),
+
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGetKubeconfig(args[0])
+	},
+}
+
+func init() {
+	getKubeconfigCmd.Flags().StringVarP(&gk.namespace, "namespace", "n", "",
+		"Namespace where the workload cluster exist.")
+	getKubeconfigCmd.Flags().StringVar(&gk.kubeconfig, "kubeconfig", "",
+		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
+	getKubeconfigCmd.Flags().StringVar(&gk.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
+	getCmd.AddCommand(getKubeconfigCmd)
+}
+
+func runGetKubeconfig(workloadClusterName string) error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	options := client.GetKubeconfigOptions{
+		Kubeconfig:          client.Kubeconfig{Path: gk.kubeconfig, Context: gk.kubeconfigContext},
+		WorkloadClusterName: workloadClusterName,
+		Namespace:           gk.namespace,
+	}
+
+	out, err := c.GetKubeconfig(options)
+	if err != nil {
+		return err
+	}
+	fmt.Println(out)
+	return nil
+}

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -35,8 +35,9 @@ import (
 )
 
 type FakeProxy struct {
-	cs   client.Client
-	objs []runtime.Object
+	cs        client.Client
+	namespace string
+	objs      []runtime.Object
 }
 
 var (
@@ -57,7 +58,7 @@ func init() {
 }
 
 func (f *FakeProxy) CurrentNamespace() (string, error) {
-	return "default", nil
+	return f.namespace, nil
 }
 
 func (f *FakeProxy) ValidateKubernetesVersion() error {
@@ -121,11 +122,18 @@ func (f *FakeProxy) ListResources(labels map[string]string, namespaces ...string
 }
 
 func NewFakeProxy() *FakeProxy {
-	return &FakeProxy{}
+	return &FakeProxy{
+		namespace: "default",
+	}
 }
 
 func (f *FakeProxy) WithObjs(objs ...runtime.Object) *FakeProxy {
 	f.objs = append(f.objs, objs...)
+	return f
+}
+
+func (f *FakeProxy) WithNamespace(n string) *FakeProxy {
+	f.namespace = n
 	return f
 }
 

--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -177,9 +177,7 @@ EOF
 The command for getting the kubeconfig file for connecting to a workload cluster is the following:
 
 ```bash
-kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o jsonpath={.data.value} \
-  | base64 --decode \
-  > ./capi-quickstart.kubeconfig
+clusterctl get kubeconfig capi-quickstart
 ```
 
 When using docker-for-mac MacOS, you will need to do a couple of additional

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -357,7 +357,7 @@ See the [AWS provider prerequisites] document for more details.
 {{#/tab }}
 {{#tab Azure}}
 
-NOTE: `CLUSTER_NAME` can only include letters, numbers, and hyphens and can't be longer than 44 characters to allow for cluster name 
+NOTE: `CLUSTER_NAME` can only include letters, numbers, and hyphens and can't be longer than 44 characters to allow for cluster name
 to be used as a prefix for VMs and other resources that have [Azure naming rules and restrictions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)
 
 ```bash
@@ -562,9 +562,7 @@ The control planes won't be `Ready` until we install a CNI in the next step.
 After the first control plane node is up and running, we can retrieve the [workload cluster] Kubeconfig:
 
 ```bash
-kubectl --namespace=default get secret/capi-quickstart-kubeconfig -o jsonpath={.data.value} \
-  | base64 --decode \
-  > ./capi-quickstart.kubeconfig
+clusterctl get kubeconfig capi-quickstart
 ```
 
 ### Deploy a CNI solution


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds onto https://github.com/kubernetes-sigs/cluster-api/pull/3293. It adds on some tests and other feedback provided on the original PR.
I squashed Prankul's commits into one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2542 
