### PR TITLE
🐛 Fix CRS move test flakes

### DIFF
--- a/cmd/clusterctl/internal/test/fake_objects.go
+++ b/cmd/clusterctl/internal/test/fake_objects.go
@@ -1104,7 +1104,12 @@ func SelectClusterObj(objs []runtime.Object, namespace, name string) *clusterv1.
 		}
 
 		if accessor.GetName() == name && accessor.GetNamespace() == namespace {
-			cluster := &clusterv1.Cluster{}
+			cluster := &clusterv1.Cluster{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "Cluster",
+				},
+			}
 			if err := FakeScheme.Convert(o, cluster, nil); err != nil {
 				panic(fmt.Sprintf("failed to convert %s to cluster: %v", o.GetObjectKind(), err))
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes some flakes we are observing in ClusterResourceSet move tests, see e.g. https://github.com/kubernetes-sigs/cluster-api/pull/3337#issuecomment-669173651