### PR TITLE
🐛  Default MachinePool replicas and MinReadySeconds

### DIFF
--- a/exp/api/v1alpha3/machinepool_webhook.go
+++ b/exp/api/v1alpha3/machinepool_webhook.go
@@ -18,6 +18,7 @@ package v1alpha3
 
 import (
 	"fmt"
+	"k8s.io/utils/pointer"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -45,6 +46,14 @@ func (m *MachinePool) Default() {
 		m.Labels = make(map[string]string)
 	}
 	m.Labels[clusterv1.ClusterLabelName] = m.Spec.ClusterName
+
+	if m.Spec.Replicas == nil {
+		m.Spec.Replicas = pointer.Int32Ptr(1)
+	}
+
+	if m.Spec.MinReadySeconds == nil {
+		m.Spec.MinReadySeconds = pointer.Int32Ptr(0)
+	}
 
 	if m.Spec.Template.Spec.Bootstrap.ConfigRef != nil && len(m.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace) == 0 {
 		m.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace = m.Namespace

--- a/exp/api/v1alpha3/machinepool_webhook_test.go
+++ b/exp/api/v1alpha3/machinepool_webhook_test.go
@@ -46,6 +46,8 @@ func TestMachinePoolDefault(t *testing.T) {
 	m.Default()
 
 	g.Expect(m.Labels[clusterv1.ClusterLabelName]).To(Equal(m.Spec.ClusterName))
+	g.Expect(m.Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
+	g.Expect(m.Spec.MinReadySeconds).To(Equal(pointer.Int32Ptr(0)))
 	g.Expect(m.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace).To(Equal(m.Namespace))
 	g.Expect(m.Spec.Template.Spec.InfrastructureRef.Namespace).To(Equal(m.Namespace))
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: These two fields are [documented as being defaulted](https://github.com/kubernetes-sigs/cluster-api/blob/master/exp/api/v1alpha3/machinepool_types.go#L39) but in reality, there were no defaults in place. Note: the default values match the machine deployment ones.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
