### PR TITLE
✨  Set MachinePool phase to scaling when infra is scaling

### DIFF
--- a/exp/api/v1alpha3/machinepool_types.go
+++ b/exp/api/v1alpha3/machinepool_types.go
@@ -153,6 +153,14 @@ const (
 	// have become Kubernetes Nodes in the Ready state.
 	MachinePoolPhaseRunning = MachinePoolPhase("Running")
 
+	// MachinePoolPhaseRunning is the MachinePool state when the
+	// MachinePool infrastructure is scaling up.
+	MachinePoolPhaseScalingUp = MachinePoolPhase("ScalingUp")
+
+	// MachinePoolPhaseRunning is the MachinePool state when the
+	// MachinePool infrastructure is scaling down.
+	MachinePoolPhaseScalingDown = MachinePoolPhase("ScalingDown")
+
 	// MachinePoolPhaseDeleting is the MachinePool state when a delete
 	// request has been sent to the API Server,
 	// but its infrastructure has not yet been fully deleted.
@@ -180,6 +188,8 @@ func (m *MachinePoolStatus) GetTypedPhase() MachinePoolPhase {
 		MachinePoolPhaseProvisioning,
 		MachinePoolPhaseProvisioned,
 		MachinePoolPhaseRunning,
+		MachinePoolPhaseScalingUp,
+		MachinePoolPhaseScalingDown,
 		MachinePoolPhaseDeleting,
 		MachinePoolPhaseFailed:
 		return phase

--- a/exp/controllers/machinepool_controller_noderef.go
+++ b/exp/controllers/machinepool_controller_noderef.go
@@ -99,7 +99,7 @@ func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, cluster *
 
 	if mp.Status.Replicas != mp.Status.ReadyReplicas || len(nodeRefsResult.references) != int(mp.Status.ReadyReplicas) {
 		return errors.Wrapf(&capierrors.RequeueAfterError{RequeueAfter: 30 * time.Second},
-			"NodeRefs != ReadyReplicas [%q != %q] for MachinePool %q in namespace %q", len(nodeRefsResult.references), mp.Status.ReadyReplicas, mp.Name, mp.Namespace)
+			"NodeRefs != ReadyReplicas [%d != %d] for MachinePool %q in namespace %q", len(nodeRefsResult.references), mp.Status.ReadyReplicas, mp.Name, mp.Namespace)
 	}
 	return nil
 }

--- a/exp/controllers/machinepool_controller_phases.go
+++ b/exp/controllers/machinepool_controller_phases.go
@@ -60,9 +60,19 @@ func (r *MachinePoolReconciler) reconcilePhase(mp *expv1.MachinePool) {
 		mp.Status.SetTypedPhase(expv1.MachinePoolPhaseProvisioned)
 	}
 
-	// Set the phase to "running" if there is a NodeRef field.
-	if mp.Status.InfrastructureReady && len(mp.Status.NodeRefs) == int(mp.Status.ReadyReplicas) {
+	// Set the phase to "running" if the number of ready replicas is equal to desired replicas.
+	if mp.Status.InfrastructureReady && *mp.Spec.Replicas == mp.Status.ReadyReplicas {
 		mp.Status.SetTypedPhase(expv1.MachinePoolPhaseRunning)
+	}
+
+	// Set the phase to "scalingUp" if the infrastructure is scaling up.
+	if mp.Status.InfrastructureReady && *mp.Spec.Replicas > mp.Status.ReadyReplicas {
+		mp.Status.SetTypedPhase(expv1.MachinePoolPhaseScalingUp)
+	}
+
+	// Set the phase to "scalingDown" if the infrastructure is scaling down.
+	if mp.Status.InfrastructureReady && *mp.Spec.Replicas < mp.Status.ReadyReplicas {
+		mp.Status.SetTypedPhase(expv1.MachinePoolPhaseScalingDown)
 	}
 
 	// Set the phase to "failed" if any of Status.FailureReason or Status.FailureMessage is not-nil.

--- a/exp/controllers/machinepool_controller_test.go
+++ b/exp/controllers/machinepool_controller_test.go
@@ -56,7 +56,7 @@ func TestMachinePoolFinalizer(t *testing.T) {
 			Template: clusterv1.MachineTemplateSpec{
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						Data: &bootstrapData,
+						DataSecretName: &bootstrapData,
 					},
 				},
 			},
@@ -75,7 +75,7 @@ func TestMachinePoolFinalizer(t *testing.T) {
 			Template: clusterv1.MachineTemplateSpec{
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						Data: &bootstrapData,
+						DataSecretName: &bootstrapData,
 					},
 				},
 			},
@@ -152,6 +152,7 @@ func TestMachinePoolOwnerReference(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: expv1.MachinePoolSpec{
+			Replicas:    pointer.Int32Ptr(1),
 			ClusterName: "invalid",
 		},
 	}
@@ -162,10 +163,11 @@ func TestMachinePoolOwnerReference(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: expv1.MachinePoolSpec{
+			Replicas: pointer.Int32Ptr(1),
 			Template: clusterv1.MachineTemplateSpec{
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						Data: &bootstrapData,
+						DataSecretName: &bootstrapData,
 					},
 				},
 			},
@@ -182,10 +184,11 @@ func TestMachinePoolOwnerReference(t *testing.T) {
 			},
 		},
 		Spec: expv1.MachinePoolSpec{
+			Replicas: pointer.Int32Ptr(1),
 			Template: clusterv1.MachineTemplateSpec{
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
-						Data: &bootstrapData,
+						DataSecretName: &bootstrapData,
 					},
 				},
 			},
@@ -327,7 +330,7 @@ func TestReconcileMachinePoolRequest(t *testing.T) {
 								Kind:       "InfrastructureConfig",
 								Name:       "infra-config1",
 							},
-							Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+							Bootstrap: clusterv1.Bootstrap{DataSecretName: pointer.StringPtr("data")},
 						},
 					},
 				},
@@ -363,7 +366,7 @@ func TestReconcileMachinePoolRequest(t *testing.T) {
 								Kind:       "InfrastructureConfig",
 								Name:       "infra-config1",
 							},
-							Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+							Bootstrap: clusterv1.Bootstrap{DataSecretName: pointer.StringPtr("data")},
 						},
 					},
 				},
@@ -402,7 +405,7 @@ func TestReconcileMachinePoolRequest(t *testing.T) {
 								Kind:       "InfrastructureConfig",
 								Name:       "infra-config1",
 							},
-							Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+							Bootstrap: clusterv1.Bootstrap{DataSecretName: pointer.StringPtr("data")},
 						},
 					},
 				},
@@ -598,7 +601,7 @@ func TestRemoveMachinePoolFinalizerAfterDeleteReconcile(t *testing.T) {
 						Kind:       "InfrastructureConfig",
 						Name:       "infra-config1",
 					},
-					Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+					Bootstrap: clusterv1.Bootstrap{DataSecretName: pointer.StringPtr("data")},
 				},
 			},
 		},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Adds a `ScalingUp` and a `ScalingDown` phase for MachinePool, to indicate when the MachinePool replica count is being increased and when it is being decreased. 

Eg:
```
$ k get mp                                       
NAME         REPLICAS   PHASE
vmss2-mp-0   2          Running

$ k scale mp vmss2-mp-0 --replicas 4        
machinepool.exp.cluster.x-k8s.io/vmss2-mp-0 scaled

$ k get mp   
NAME         REPLICAS   PHASE
vmss2-mp-0   2          ScalingUp

 $ k scale mp vmss2-mp-0 --replicas 1
machinepool.exp.cluster.x-k8s.io/vmss2-mp-0 scaled

$ k get mp
NAME         REPLICAS   PHASE
vmss2-mp-0   2          ScalingDown
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
