### PR TITLE
🐛 fix cluster create not paused when paused log entry

### DIFF
--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -76,7 +76,7 @@ func ClusterCreateNotPaused(logger logr.Logger) predicate.Funcs {
 				return true
 			}
 
-			log.V(4).Info("Cluster is not paused, blocking further processing")
+			log.V(4).Info("Cluster is paused, blocking further processing")
 			return false
 		},
 		UpdateFunc:  func(e event.UpdateEvent) bool { return false },


### PR DESCRIPTION
**What this PR does / why we need it**:
The log entry for `ClusterCreateNotPaused` predicate when the cluster is paused reads that it is "not paused, blocking further processing". This PR simply removes the not.
