### PR TITLE
⚠️  Cleanup kind cluster if it fails during e2e setup

### DIFF
--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -103,10 +103,10 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		// this approach because this allows to have a single source of truth for images, the e2e config
 		cluster := clusterResources.Cluster
 		if cluster.Spec.InfrastructureRef.Kind == "DockerCluster" {
-			bootstrap.LoadImagesToKindCluster(context.TODO(), bootstrap.LoadImagesToKindClusterInput{
+			Expect(bootstrap.LoadImagesToKindCluster(context.TODO(), bootstrap.LoadImagesToKindClusterInput{
 				Name:   cluster.Name,
 				Images: input.E2EConfig.Images,
-			})
+			})).To(Succeed())
 		}
 
 		// Get a ClusterBroker so we can interact with the workload cluster

--- a/test/framework/bootstrap/kind_util.go
+++ b/test/framework/bootstrap/kind_util.go
@@ -64,10 +64,14 @@ func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKi
 
 	log.Logf("The kubeconfig file for the kind cluster is %s", clusterProvider.kubeconfigPath)
 
-	LoadImagesToKindCluster(ctx, LoadImagesToKindClusterInput{
+	err := LoadImagesToKindCluster(ctx, LoadImagesToKindClusterInput{
 		Name:   input.Name,
 		Images: input.Images,
 	})
+	if err != nil {
+		clusterProvider.Dispose(ctx)
+		Expect(err).NotTo(HaveOccurred()) // re-surface the error to fail the test
+	}
 
 	return clusterProvider
 }
@@ -82,22 +86,26 @@ type LoadImagesToKindClusterInput struct {
 }
 
 // LoadImagesToKindCluster provides a utility for loading images into a kind cluster.
-func LoadImagesToKindCluster(ctx context.Context, input LoadImagesToKindClusterInput) {
-	Expect(ctx).NotTo(BeNil(), "ctx is required for LoadImagesToKindCluster")
-	Expect(input.Name).ToNot(BeEmpty(), "Invalid argument. Name can't be empty when calling LoadImagesToKindCluster")
+func LoadImagesToKindCluster(ctx context.Context, input LoadImagesToKindClusterInput) error {
+	if ctx == nil {
+		return errors.New("ctx is required for LoadImagesToKindCluster")
+	}
+	if input.Name == "" {
+		return errors.New("Invalid argument. Name can't be empty when calling LoadImagesToKindCluster")
+	}
 
 	for _, image := range input.Images {
 		log.Logf("Loading image: %q", image.Name)
-		err := loadImage(ctx, input.Name, image.Name)
-		switch image.LoadBehavior {
-		case framework.MustLoadImage:
-			Expect(err).ToNot(HaveOccurred(), "Failed to load image %q into the kind cluster %q", image.Name, input.Name)
-		case framework.TryLoadImage:
-			if err != nil {
+		if err := loadImage(ctx, input.Name, image.Name); err != nil {
+			switch image.LoadBehavior {
+			case framework.MustLoadImage:
+				return errors.Wrapf(err, "Failed to load image %q into the kind cluster %q", image.Name, input.Name)
+			case framework.TryLoadImage:
 				log.Logf("[WARNING] Unable to load image %q into the kind cluster %q: %v", image.Name, input.Name, err)
 			}
 		}
 	}
+	return nil
 }
 
 // LoadImage will put a local image onto the kind node
@@ -135,10 +143,11 @@ func loadImage(ctx context.Context, cluster, image string) error {
 // copied from kind https://github.com/kubernetes-sigs/kind/blob/v0.7.0/pkg/cmd/kind/load/docker-image/docker-image.go#L168
 // save saves image to dest, as in `docker save`
 func save(ctx context.Context, image, dest string) error {
-	_, _, err := exec.NewCommand(
+	sout, serr, err := exec.NewCommand(
 		exec.WithCommand("docker"),
-		exec.WithArgs("save", "-o", dest, image)).Run(ctx)
-	return err
+		exec.WithArgs("save", "-o", dest, image),
+	).Run(ctx)
+	return errors.Wrapf(err, "stdout: %q, stderr: %q", string(sout), string(serr))
 }
 
 // copied from kind https://github.com/kubernetes-sigs/kind/blob/v0.7.0/pkg/cmd/kind/load/docker-image/docker-image.go#L158


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now if the e2e's fail while setting up the kind cluster, it gets orphaned on my machine. I didn't know why I was always failing to run the e2es using the CAPD config, but today was the day I decided to track it down. It was because of a missing Docker image, so I added in better error handling for surfacing Docker CLI output on `LoadImage`.

@fabriziopandini 