### PR TITLE
📖  Control Plane provider doc lists management of kubeconfig secret as a requirement

### DIFF
--- a/docs/book/src/developer/architecture/controllers/control-plane.md
+++ b/docs/book/src/developer/architecture/controllers/control-plane.md
@@ -7,6 +7,7 @@ The Control Plane controller's main responsibilities are:
 * Managing a set of machines that represent a Kubernetes control plane.
 * Provide information about the state of the control plane to downstream
   consumers.
+* Create/manage a secret with the kubeconfig file for accessing the workload cluster.
 
 A reference implementation is managed within the core Cluster API project as the
 Kubeadm control plane controller (`KubeadmControlPlane`). In this document,


### PR DESCRIPTION
**What this PR does / why we need it**:
The Control Plane provider docs should list creation/management of the kubeconfig secret as a requirement for a ControlPlane provider implementation.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2778
