### PR TITLE
✨ Clusterctl version check

### DIFF
--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -46,6 +46,23 @@ var RootCmd = &cobra.Command{
 	Long: LongDesc(`
 		Get started with Cluster API using clusterctl to create a management cluster,
 		install providers, and create templates for your workload cluster.`),
+	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		// Check if clusterctl needs an upgrade "AFTER" running each command
+		// and sub-command.
+		configClient, err := config.New(cfgFile)
+		if err != nil {
+			return err
+		}
+		output, err := newVersionChecker(configClient.Variables()).Check()
+		if err != nil {
+			return errors.Wrap(err, "unable to verify clusterctl version")
+		}
+		if len(output) != 0 {
+			// Print the output in yellow so it is more visible.
+			fmt.Fprintf(os.Stderr, "\033[33m%s\033[0m", output)
+		}
+		return nil
+	},
 }
 
 func Execute() {

--- a/cmd/clusterctl/cmd/version_checker.go
+++ b/cmd/clusterctl/cmd/version_checker.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/blang/semver"
+	"github.com/google/go-github/github"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"k8s.io/client-go/util/homedir"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
+	"sigs.k8s.io/cluster-api/cmd/version"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	// gitVersionRegEx matches git versions of style 0.3.7-45-c1aeccb679cd56
+	// see ./hack/version.sh for more info.
+	gitVersionRegEx = regexp.MustCompile(`(.*)-(\d+)-([0-9,a-f]{14})`)
+)
+
+type versionChecker struct {
+	versionFilePath string
+	cliVersion      func() version.Info
+	githubClient    *github.Client
+}
+
+// newVersionChecker returns a versionChecker. Its behavior has been inspired
+// by https://github.com/cli/cli.
+func newVersionChecker(vc config.VariablesClient) *versionChecker {
+	var client *github.Client
+	token, err := vc.Get("GITHUB_TOKEN")
+	if err == nil {
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: token},
+		)
+		tc := oauth2.NewClient(context.TODO(), ts)
+		client = github.NewClient(tc)
+	} else {
+		client = github.NewClient(nil)
+	}
+
+	return &versionChecker{
+		versionFilePath: filepath.Join(homedir.HomeDir(), ".cluster-api", "version.yaml"),
+		cliVersion:      version.Get,
+		githubClient:    client,
+	}
+}
+
+// ReleaseInfo stores information about the release.
+type ReleaseInfo struct {
+	Version string
+	URL     string
+}
+
+// VersionState stores the release info and the last time it was updated.
+type VersionState struct {
+	LastCheck     time.Time
+	LatestRelease ReleaseInfo
+}
+
+// Check returns a message if the current clusterctl version is less than the
+// latest available release for CAPI
+// (https://github.com/kubernetes-sigs/cluster-api). It gets the latest
+// release from github at most once during a 24 hour period and caches the
+// state by default in $HOME/.cluster-api/state.yaml. If the clusterctl
+// version is the same or greater it returns nothing.
+func (v *versionChecker) Check() (string, error) {
+	log := logf.Log
+	cliVer, err := semver.ParseTolerant(v.cliVersion().GitVersion)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to semver parse clusterctl GitVersion")
+	}
+
+	release, err := v.getLatestRelease()
+	if err != nil {
+		return "", err
+	}
+	if release == nil {
+		return "", nil
+	}
+	latestVersion, err := semver.ParseTolerant(release.Version)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to semver parse latest release version")
+	}
+
+	// if we are using a dirty dev build, just log it out
+	if strings.HasSuffix(cliVer.String(), "-dirty") {
+		log.V(1).Info("⚠️  Using a development build of clusterctl.", "CLIVersion", cliVer.String(), "LatestGithubRelease", release.Version)
+		return "", nil
+	}
+
+	// if the cli version is a dev build off of the latest available release,
+	// the just log it out as informational.
+	if strings.HasPrefix(cliVer.String(), latestVersion.String()) && gitVersionRegEx.MatchString(cliVer.String()) {
+		log.V(1).Info("⚠️  Using a development build of clusterctl.", "CLIVersion", cliVer.String(), "LatestGithubRelease", release.Version)
+		return "", nil
+	}
+
+	if cliVer.Major == latestVersion.Major &&
+		cliVer.Minor == latestVersion.Minor &&
+		latestVersion.GT(cliVer) {
+		return fmt.Sprintf(`
+New clusterctl version available: v%s -> v%s
+%s
+`, cliVer, latestVersion.String(), release.URL), nil
+	}
+	return "", nil
+}
+
+func (v *versionChecker) getLatestRelease() (*ReleaseInfo, error) {
+	log := logf.Log
+	vs, err := readStateFile(v.versionFilePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read version state file")
+	}
+
+	// if there is no release info in the state file, pull latest release from github
+	if vs == nil {
+		release, _, err := v.githubClient.Repositories.GetLatestRelease(context.TODO(), "kubernetes-sigs", "cluster-api")
+		if err != nil {
+			log.V(1).Info("⚠️ Unable to get latest github release for clusterctl")
+			// failing silently here so we don't error out in air-gapped
+			// environments.
+			return nil, nil
+		}
+
+		vs = &VersionState{
+			LastCheck: time.Now(),
+			LatestRelease: ReleaseInfo{
+				Version: release.GetTagName(),
+				URL:     release.GetHTMLURL(),
+			},
+		}
+	}
+
+	if err := writeStateFile(v.versionFilePath, vs); err != nil {
+		return nil, errors.Wrap(err, "unable to write version state file")
+	}
+
+	return &vs.LatestRelease, nil
+
+}
+
+func writeStateFile(filepath string, vs *VersionState) error {
+	vsb, err := yaml.Marshal(vs)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(filepath, vsb, 0600)
+	if err != nil {
+		return err
+	}
+	return nil
+
+}
+
+func readStateFile(filepath string) (*VersionState, error) {
+	b, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// if the file doesn't exist yet, don't error
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	vs := new(VersionState)
+	if err := yaml.Unmarshal(b, vs); err != nil {
+		return nil, err
+	}
+
+	// If the last check is more than 24 hours ago, then don't return the
+	// version state of the file.
+	if time.Since(vs.LastCheck).Hours() > 24 {
+		return nil, nil
+	}
+
+	return vs, nil
+}

--- a/cmd/clusterctl/cmd/version_checker_test.go
+++ b/cmd/clusterctl/cmd/version_checker_test.go
@@ -1,0 +1,389 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/util/homedir"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
+	"sigs.k8s.io/cluster-api/cmd/version"
+	"sigs.k8s.io/yaml"
+)
+
+func TestVersionChecker_newVersionChecker(t *testing.T) {
+	g := NewWithT(t)
+
+	versionChecker := newVersionChecker(test.NewFakeVariableClient())
+
+	expectedStateFilePath := filepath.Join(homedir.HomeDir(), ".cluster-api", "version.yaml")
+	g.Expect(versionChecker.versionFilePath).To(Equal(expectedStateFilePath))
+	g.Expect(versionChecker.cliVersion).ToNot(BeNil())
+	g.Expect(versionChecker.githubClient).ToNot(BeNil())
+}
+
+func TestVersionChecker(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		cliVersion     func() version.Info
+		githubResponse string
+		expectErr      bool
+		expectedOutput string
+	}{
+		{
+			name: "returns error if unable to parse cli version",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "bla-version",
+				}
+			},
+			expectErr: true,
+		},
+		{
+			name: "returns error if unable to parse latest version",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8",
+				}
+			},
+			githubResponse: `{"tag_name": "bla-version"}`,
+			expectErr:      true,
+		},
+		{
+			name: "returns error if github request fails",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8",
+				}
+			},
+			githubResponse: `bad-response`,
+			expectErr:      false,
+			// here we are printing out a log instead
+			expectedOutput: "",
+		},
+		{
+			name: "returns message if cli version is less than latest available release within minor version only",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8",
+				}
+			},
+			githubResponse: `{"tag_name": "v0.3.10", "html_url": "https://github.com/foo/bar/releases/v0.3.10"}`,
+			expectErr:      false,
+			expectedOutput: `
+New clusterctl version available: v0.3.8 -> v0.3.10
+https://github.com/foo/bar/releases/v0.3.10
+`,
+		},
+		{
+			name: "returns message if cli version is a dev build deriving from latest-1 available release",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.7-45-c1aeccb679cd56",
+				}
+			},
+			githubResponse: `{"tag_name": "v0.3.8", "html_url": "https://github.com/foo/bar/releases/v0.3.8"}`,
+			expectErr:      false,
+			expectedOutput: `
+New clusterctl version available: v0.3.7-45-c1aeccb679cd56 -> v0.3.8
+https://github.com/foo/bar/releases/v0.3.8
+`,
+		},
+		{
+			name: "returns message if latest available release is a pre-release",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8",
+				}
+			},
+			githubResponse: `{"tag_name": "v0.3.9-alpha.0", "html_url": "https://github.com/foo/bar/releases/v0.3.9-alpha.0"}`,
+			expectErr:      false,
+			expectedOutput: `
+New clusterctl version available: v0.3.8 -> v0.3.9-alpha.0
+https://github.com/foo/bar/releases/v0.3.9-alpha.0
+`,
+		},
+		{
+			name: "returns message if cli version is a pre-release of the latest available release",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.9-alpha.0",
+				}
+			},
+			githubResponse: `{"tag_name": "v0.3.9", "html_url": "https://github.com/foo/bar/releases/v0.3.9"}`,
+			expectErr:      false,
+			expectedOutput: `
+New clusterctl version available: v0.3.9-alpha.0 -> v0.3.9
+https://github.com/foo/bar/releases/v0.3.9
+`,
+		},
+		{
+			name: "returns message if cli version is a pre-release and latest available release is the next pre-release",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8-alpha.0",
+				}
+			},
+			githubResponse: `{"tag_name": "v0.3.8-alpha.1", "html_url": "https://github.com/foo/bar/releases/v0.3.8-alpha.1"}`,
+			expectErr:      false,
+			expectedOutput: `
+New clusterctl version available: v0.3.8-alpha.0 -> v0.3.8-alpha.1
+https://github.com/foo/bar/releases/v0.3.8-alpha.1
+`,
+		},
+		{
+			name: "does not return message if cli version is a dirty build deriving from latest available release",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8-45-c1aeccb679cd56-dirty",
+				}
+			},
+			githubResponse: `{"tag_name": "v0.3.8", "html_url": "https://github.com/foo/bar/releases/v0.3.8"}`,
+			expectErr:      false,
+			// here we are printing out a log instead
+			expectedOutput: "",
+		},
+		{
+			name: "does not return message if cli version is a dev build deriving from latest available release",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8-45-c1aeccb679cd56",
+				}
+			},
+			githubResponse: `{"tag_name": "v0.3.8", "html_url": "https://github.com/foo/bar/releases/v0.3.8"}`,
+			expectErr:      false,
+			// here we are printing out a log instead
+			expectedOutput: "",
+		},
+		{
+			name: "does not return message if latest available version has a higher minor version than the cli version",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8",
+				}
+			},
+			githubResponse: `{"tag_name": "v0.4.0", "html_url": "https://github.com/foo/bar/releases/v0.4.0"}`,
+			expectErr:      false,
+			expectedOutput: "",
+		},
+		{
+			name: "does not return message if latest available version has a higher major version and same minor version than the cli version",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8",
+				}
+			},
+			githubResponse: `{"tag_name": "v100.3.9", "html_url": "https://github.com/foo/bar/releases/v100.3.9"}`,
+			expectErr:      false,
+			// we are only prompting upgrade within minor versions of the cli
+			// version
+			expectedOutput: "",
+		},
+		{
+			name: "does not return message if cli version is greater than latest available release",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8",
+				}
+			},
+			githubResponse: `{"tag_name": "v0.3.7"}`,
+			expectErr:      false,
+			expectedOutput: "",
+		},
+		{
+			name: "does not return message if cli version is equal to latest available release",
+			cliVersion: func() version.Info {
+				return version.Info{
+					GitVersion: "v0.3.8",
+				}
+			},
+			githubResponse: `{"tag_name": "v0.3.8"}`,
+			expectErr:      false,
+			expectedOutput: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			tmpVersionFile, cleanDir := generateTempVersionFilePath(g)
+			defer cleanDir()
+
+			fakeGithubClient, mux, cleanup := test.NewFakeGitHub()
+			// test.NewFakeGitHub and handler for returning a fake release
+			mux.HandleFunc(
+				"/repos/kubernetes-sigs/cluster-api/releases/latest",
+				func(w http.ResponseWriter, r *http.Request) {
+					g.Expect(r.Method).To(Equal("GET"))
+					fmt.Fprint(w, tt.githubResponse)
+				},
+			)
+			defer cleanup()
+			versionChecker := newVersionChecker(test.NewFakeVariableClient())
+			versionChecker.cliVersion = tt.cliVersion
+			versionChecker.githubClient = fakeGithubClient
+			versionChecker.versionFilePath = tmpVersionFile
+
+			output, err := versionChecker.Check()
+
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(output).To(Equal(tt.expectedOutput))
+		})
+	}
+}
+
+func TestVersionChecker_WriteStateFile(t *testing.T) {
+	g := NewWithT(t)
+	fakeGithubClient, mux, cleanup := test.NewFakeGitHub()
+	mux.HandleFunc(
+		"/repos/kubernetes-sigs/cluster-api/releases/latest",
+		func(w http.ResponseWriter, r *http.Request) {
+			g.Expect(r.Method).To(Equal("GET"))
+			fmt.Fprint(w, `{"tag_name": "v0.3.8", "html_url": "https://github.com/foo/bar/releases/v0.3.8"}`)
+		},
+	)
+	defer cleanup()
+
+	tmpVersionFile, cleanDir := generateTempVersionFilePath(g)
+	defer cleanDir()
+
+	versionChecker := newVersionChecker(test.NewFakeVariableClient())
+	versionChecker.versionFilePath = tmpVersionFile
+	versionChecker.githubClient = fakeGithubClient
+
+	release, err := versionChecker.getLatestRelease()
+
+	g.Expect(err).ToNot(HaveOccurred())
+	// ensure that the state file has been created
+	g.Expect(tmpVersionFile).Should(BeARegularFile())
+	fb, err := ioutil.ReadFile(tmpVersionFile)
+	g.Expect(err).ToNot(HaveOccurred())
+	var actualVersionState VersionState
+	g.Expect(yaml.Unmarshal(fb, &actualVersionState)).To(Succeed())
+	g.Expect(actualVersionState.LatestRelease).To(Equal(*release))
+}
+
+func TestVersionChecker_ReadFromStateFile(t *testing.T) {
+	g := NewWithT(t)
+
+	tmpVersionFile, cleanDir := generateTempVersionFilePath(g)
+	defer cleanDir()
+
+	fakeGithubClient1, mux1, cleanup1 := test.NewFakeGitHub()
+	mux1.HandleFunc(
+		"/repos/kubernetes-sigs/cluster-api/releases/latest",
+		func(w http.ResponseWriter, r *http.Request) {
+			g.Expect(r.Method).To(Equal("GET"))
+			fmt.Fprint(w, `{"tag_name": "v0.3.8", "html_url": "https://github.com/foo/bar/releases/v0.3.8"}`)
+		},
+	)
+	defer cleanup1()
+	versionChecker := newVersionChecker(test.NewFakeVariableClient())
+	versionChecker.versionFilePath = tmpVersionFile
+	versionChecker.githubClient = fakeGithubClient1
+
+	// this call to getLatestRelease will pull from our fakeGithubClient1 and
+	// store the information including timestamp into the state file.
+	_, err := versionChecker.getLatestRelease()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// override the github client with response to a new version v0.3.99
+	var githubCalled bool = false
+	fakeGithubClient2, mux2, cleanup2 := test.NewFakeGitHub()
+	mux2.HandleFunc(
+		"/repos/kubernetes-sigs/cluster-api/releases/latest",
+		func(w http.ResponseWriter, r *http.Request) {
+			githubCalled = true
+			fmt.Fprint(w, `{"tag_name": "v0.3.99", "html_url": "https://github.com/foo/bar/releases/v0.3.99"}`)
+		},
+	)
+	defer cleanup2()
+	versionChecker.githubClient = fakeGithubClient2
+
+	// now instead of making another call to github, we want to read from the
+	// file. This will avoid unnecessary calls to github.
+	release, err := versionChecker.getLatestRelease()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(release.Version).To(Equal("v0.3.8"))
+	g.Expect(release.URL).To(Equal("https://github.com/foo/bar/releases/v0.3.8"))
+	g.Expect(githubCalled).To(BeFalse())
+}
+
+func TestVersionChecker_ReadFromStateFileWithin24Hrs(t *testing.T) {
+	g := NewWithT(t)
+
+	tmpVersionFile, cleanDir := generateTempVersionFilePath(g)
+	defer cleanDir()
+
+	// this state file was generated more than 24 hours ago.
+	reallyOldVersionState := &VersionState{
+		LastCheck: time.Now().Add(-25 * time.Hour),
+		LatestRelease: ReleaseInfo{
+			Version: "v0.3.8",
+			URL:     "https://github.com/foo/bar/releases/v0.3.8",
+		},
+	}
+	b, err := yaml.Marshal(reallyOldVersionState)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(ioutil.WriteFile(tmpVersionFile, b, 0600)).To(Succeed())
+
+	fakeGithubClient1, mux1, cleanup1 := test.NewFakeGitHub()
+	mux1.HandleFunc(
+		"/repos/kubernetes-sigs/cluster-api/releases/latest",
+		func(w http.ResponseWriter, r *http.Request) {
+			g.Expect(r.Method).To(Equal("GET"))
+			fmt.Fprint(w, `{"tag_name": "v0.3.10", "html_url": "https://github.com/foo/bar/releases/v0.3.10"}`)
+		},
+	)
+	defer cleanup1()
+	versionChecker := newVersionChecker(test.NewFakeVariableClient())
+	versionChecker.versionFilePath = tmpVersionFile
+	versionChecker.githubClient = fakeGithubClient1
+
+	_, err = versionChecker.getLatestRelease()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Since the state file is more that 24 hours old we want to retrieve the
+	// latest release from github.
+	release, err := versionChecker.getLatestRelease()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(release.Version).To(Equal("v0.3.10"))
+	g.Expect(release.URL).To(Equal("https://github.com/foo/bar/releases/v0.3.10"))
+}
+
+func generateTempVersionFilePath(g *WithT) (string, func()) {
+	dir, err := ioutil.TempDir("", "clusterctl")
+	g.Expect(err).NotTo(HaveOccurred())
+	// don't create the state file, just have a path to the file
+	tmpVersionFile := filepath.Join(dir, "state.yaml")
+
+	return tmpVersionFile, func() {
+		os.RemoveAll(dir)
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR allows clusterctl to prompt the user if it detects that the version being used is different from the latest available release. If the clusterctl version being used is either older or a dev release compared to the latest available release, it will print out a message to the terminal via os.Stderr. The version check happens on any sub-command of clusterctl.

An example of the output printed is:
```shell
$ clusterctl version
clusterctl version: &version.Info{Major:"0", Minor:"3", GitVersion:"v0.3.8-50-352a3a9d8b5430-dirty", GitCommit:"352a3a9d8b543078d194d80a34a2268652b314a0", GitTreeState:"dirty", BuildDate:"2020-08-13T20:01:57Z", GoVersion:"go1.13.14", Compiler:"gc", Platform:"darwin/amd64"}
Using configuration File="/Users/wfernandes/.cluster-api/clusterctl.yaml"


New clusterctl version available: v0.3.8-50-352a3a9d8b5430-dirty -> v0.3.8
https://github.com/kubernetes-sigs/cluster-api/releases/tag/v0.3.8
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3466 
