### PR TITLE
🌱 Update CAPD examples to use MachineDeployment

### DIFF
--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -92,8 +92,6 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: worker-md-0
-  labels:
-    cluster.x-k8s.io/cluster-name: my-cluster
 spec:
   clusterName: my-cluster
   replicas: 1
@@ -101,9 +99,6 @@ spec:
     matchLabels:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
-    metadata:
-      labels:
-        cluster.x-k8s.io/cluster-name: my-cluster
     spec:
       version: v1.18.6
       clusterName: my-cluster

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -68,40 +68,51 @@ spec:
         eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: DockerMachine
+kind: DockerMachineTemplate
 metadata:
-  name: worker-0
-  namespace: default
----
-apiVersion: cluster.x-k8s.io/v1alpha3
-kind: Machine
-metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: my-cluster
-  name: worker-0
+  name: worker
   namespace: default
 spec:
-  version: "v1.14.2"
-  clusterName: my-cluster
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-      kind: KubeadmConfig
-      name: worker-0-config
-      namespace: default
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: DockerMachine
-    name: worker-0
-    namespace: default
+  template:
+    spec: {}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: KubeadmConfig
+kind: KubeadmConfigTemplate
 metadata:
-  name: worker-0-config
-  namespace: default
+  name: worker
 spec:
-  joinConfiguration:
-    nodeRegistration:
-      kubeletExtraArgs:
-        eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineDeployment
+metadata:
+  name: worker-md-0
+  labels:
+    cluster.x-k8s.io/cluster-name: my-cluster
+spec:
+  clusterName: my-cluster
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: my-cluster
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: my-cluster
+    spec:
+      version: "v1.14.2"
+      clusterName: my-cluster
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: KubeadmConfigTemplate
+          name: worker
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: DockerMachineTemplate
+        name: worker

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -38,7 +38,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: "v1.14.2"
+  version: v1.18.6
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -105,7 +105,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: my-cluster
     spec:
-      version: "v1.14.2"
+      version: v1.18.6
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -85,8 +85,6 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineDeployment
 metadata:
   name: worker-md-0
-  labels:
-    cluster.x-k8s.io/cluster-name: my-cluster
 spec:
   clusterName: my-cluster
   replicas: 1
@@ -94,9 +92,6 @@ spec:
     matchLabels:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
-    metadata:
-      labels:
-        cluster.x-k8s.io/cluster-name: my-cluster
     spec:
       version: v1.18.6
       clusterName: my-cluster

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -37,7 +37,7 @@ spec:
   template:
     spec: {}
 ---
-apiVersion: "controlplane.cluster.x-k8s.io/v1alpha3"
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: KubeadmControlPlane
 metadata:
   name: controlplane
@@ -61,40 +61,51 @@ spec:
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: DockerMachine
+kind: DockerMachineTemplate
 metadata:
-  name: worker-0
-  namespace: default
----
-apiVersion: cluster.x-k8s.io/v1alpha3
-kind: Machine
-metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: my-cluster
-  name: worker-0
+  name: worker
   namespace: default
 spec:
-  version: "v1.14.2"
-  clusterName: my-cluster
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-      kind: KubeadmConfig
-      name: worker-0-config
-      namespace: default
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: DockerMachine
-    name: worker-0
-    namespace: default
+  template:
+    spec: {}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: KubeadmConfig
+kind: KubeadmConfigTemplate
 metadata:
-  name: worker-0-config
-  namespace: default
+  name: worker
 spec:
-  joinConfiguration:
-    nodeRegistration:
-      kubeletExtraArgs:
-        eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineDeployment
+metadata:
+  name: worker-md-0
+  labels:
+    cluster.x-k8s.io/cluster-name: my-cluster
+spec:
+  clusterName: my-cluster
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: my-cluster
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: my-cluster
+    spec:
+      version: v1.14.2
+      clusterName: my-cluster
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: KubeadmConfigTemplate
+          name: worker
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: DockerMachineTemplate
+        name: worker

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.14.2
+  version: v1.18.6
   infrastructureTemplate:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: DockerMachineTemplate
@@ -98,7 +98,7 @@ spec:
       labels:
         cluster.x-k8s.io/cluster-name: my-cluster
     spec:
-      version: v1.14.2
+      version: v1.18.6
       clusterName: my-cluster
       bootstrap:
         configRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the existing two CAPD examples to use `MachineDeployment` instead of individual `Machine` and bumps the K8S version in those examples from v1.14.2 to v1.18.6. 

Using `MachineDeployment` is generally recommended as of today and there are also people asking for `MachineDeployment` examples in #cluster-api channel. So it would be nice we could have our existing examples up to date. 