### PR TITLE
🐛  Fixes issue with Windows, paths can't be escaped

### DIFF
--- a/cmd/clusterctl/client/repository/repository_local.go
+++ b/cmd/clusterctl/client/repository/repository_local.go
@@ -142,10 +142,12 @@ func newLocalRepository(providerConfig config.Provider, configVariablesClient co
 	}
 
 	// gets the path part of the url and check it is an absolute path
-	// in case of windows, we should take care of removing the additional / which is required by the URI standard
-	// for windows local paths. see https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/ for more details
-	path := url.EscapedPath()
+	path := url.Path
 	if runtime.GOOS == "windows" {
+		// in case of windows, we should take care of removing the additional / which is required by the URI standard
+		// for windows local paths. see https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/ for more details.
+		// Encoded file paths are not required in Windows 10 versions <1803 and are unsupported in Windows 10 >=1803
+		// https://support.microsoft.com/en-us/help/4467268/url-encoded-unc-paths-not-url-decoded-in-windows-10-version-1803-later
 		path = strings.TrimPrefix(path, "/")
 		path = filepath.FromSlash(path)
 	}


### PR DESCRIPTION
Authored-by: Gene Hynson <ghynson@vmware.com>

**What this PR does / why we need it**:
- This PR removes the `url.EscapedPath()` step from Windows local repositories. On Windows 10 versions >= 1803, Windows will no longer decode file paths. This causes a failure when clusterctl tries to read the providers if your Windows username has a space in it (e.g. `C:\Users\Gene Hynson\...`):

**Which issue(s) this PR fixes**:

Fixes #3487 

**Testing**

I'm not exactly sure what's the best way to add automated tests for this change, since it would require setting `runtime.GOOS`. If anyone has suggestions, I'm all ears!

In terms of manual tests, I tested this on the latest version of Windows and on Mac - it works fine.