### PR TITLE
:bug: [clusterctl] accept prereleases when no releases published

### DIFF
--- a/cmd/clusterctl/client/repository/repository_github.go
+++ b/cmd/clusterctl/client/repository/repository_github.go
@@ -249,7 +249,11 @@ func (g *gitHubRepository) getLatestRelease() (string, error) {
 	// Search for the latest release according to semantic version ordering.
 	// Releases with tag name that are not in semver format are ignored.
 	var latestTag string
+	var latestPrereleaseTag string
+
 	var latestReleaseVersion *version.Version
+	var latestPrereleaseVersion *version.Version
+
 	for _, v := range versions {
 		sv, err := version.ParseSemantic(v)
 		if err != nil {
@@ -257,8 +261,12 @@ func (g *gitHubRepository) getLatestRelease() (string, error) {
 			continue
 		}
 
-		// ignore pre-releases when getting latest release
+		// track prereleases separately
 		if sv.PreRelease() != "" {
+			if latestPrereleaseVersion == nil || latestPrereleaseVersion.LessThan(sv) {
+				latestPrereleaseTag = v
+				latestPrereleaseVersion = sv
+			}
 			continue
 		}
 
@@ -268,8 +276,13 @@ func (g *gitHubRepository) getLatestRelease() (string, error) {
 		}
 	}
 
+	// Fall back to returning latest prereleases if no release has been cut or bail if it's also empty
 	if latestTag == "" {
-		return "", errors.New("failed to find releases tagged with a valid semantic version number")
+		if latestPrereleaseTag == "" {
+			return "", errors.New("failed to find releases tagged with a valid semantic version number")
+		}
+
+		return latestPrereleaseTag, nil
 	}
 	return latestTag, nil
 }

--- a/cmd/clusterctl/client/repository/repository_local_test.go
+++ b/cmd/clusterctl/client/repository/repository_local_test.go
@@ -190,6 +190,10 @@ func Test_localRepository_GetFile(t *testing.T) {
 	p2URLLatestAbs := filepath.Join(tmpDir, p2URLLatest)
 	p2 := config.NewProvider("bar", p2URLLatestAbs, clusterctlv1.BootstrapProviderType)
 
+	// Provider 3: URL is for only prerelease available
+	dst3 := createLocalTestProviderFile(t, tmpDir, "bootstrap-baz/v1.0.0-alpha.0/bootstrap-components.yaml", "version: v1.0.0-alpha.0")
+	p3 := config.NewProvider("baz", dst3, clusterctlv1.BootstrapProviderType)
+
 	type fields struct {
 		provider              config.Provider
 		configVariablesClient config.VariablesClient
@@ -265,6 +269,21 @@ func Test_localRepository_GetFile(t *testing.T) {
 			},
 			want: want{
 				contents: "version: v2.0.0-alpha.0", // We use the file contents to determine data was read from latest release
+			},
+			wantErr: false,
+		},
+		{
+			name: "Get file from latest prerelease directory if no releases",
+			fields: fields{
+				provider:              p3,
+				configVariablesClient: test.NewFakeVariableClient(),
+			},
+			args: args{
+				version:  "latest",
+				fileName: "bootstrap-components.yaml",
+			},
+			want: want{
+				contents: "version: v1.0.0-alpha.0", // We use the file contents to determine data was read from latest prerelease
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug in clusterctl where, if a provider repo didn't have
*any* stable releases published, all releases were ignored and the init
failed. We now fall back to accepting prereleases if no stables are
found.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3496 
