### PR TITLE
🌱, Align print columns between machinedeployment and kubeadmcontrolplanes

### DIFF
--- a/api/v1alpha3/machinedeployment_types.go
+++ b/api/v1alpha3/machinedeployment_types.go
@@ -245,9 +245,10 @@ func (md *MachineDeploymentStatus) GetTypedPhase() MachineDeploymentPhase {
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown"
-// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="Total number of non-terminated machines targeted by this deployment"
-// +kubebuilder:printcolumn:name="Available",type="integer",JSONPath=".status.availableReplicas",description="Total number of available machines (ready for at least minReadySeconds)"
-// +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Total number of ready machines targeted by this deployment."
+// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".status.replicas",description="Total number of non-terminated machines targeted by this MachineDeployment"
+// +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Total number of ready machines targeted by this MachineDeployment"
+// +kubebuilder:printcolumn:name="Updated",type=integer,JSONPath=".status.updatedReplicas",description="Total number of non-terminated machines targeted by this deployment that have the desired template spec"
+// +kubebuilder:printcolumn:name="Unavailable",type=integer,JSONPath=".status.unavailableReplicas",description="Total number of unavailable machines targeted by this MachineDeployment"
 
 // MachineDeployment is the Schema for the machinedeployments API
 type MachineDeployment struct {

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -547,17 +547,22 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
-    - description: Total number of non-terminated machines targeted by this deployment
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
       jsonPath: .status.replicas
       name: Replicas
       type: integer
-    - description: Total number of available machines (ready for at least minReadySeconds)
-      jsonPath: .status.availableReplicas
-      name: Available
-      type: integer
-    - description: Total number of ready machines targeted by this deployment.
+    - description: Total number of ready machines targeted by this MachineDeployment
       jsonPath: .status.readyReplicas
       name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
       type: integer
     name: v1alpha3
     schema:

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -135,12 +135,12 @@ type KubeadmControlPlaneStatus struct {
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
-// +kubebuilder:printcolumn:name="Ready",type=boolean,JSONPath=".status.ready",description="KubeadmControlPlane API Server is ready to receive requests"
 // +kubebuilder:printcolumn:name="Initialized",type=boolean,JSONPath=".status.initialized",description="This denotes whether or not the control plane has the uploaded kubeadm-config configmap"
+// +kubebuilder:printcolumn:name="API Server Available",type=boolean,JSONPath=".status.ready",description="KubeadmControlPlane API Server is ready to receive requests"
 // +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=".status.replicas",description="Total number of non-terminated machines targeted by this control plane"
-// +kubebuilder:printcolumn:name="Ready Replicas",type=integer,JSONPath=".status.readyReplicas",description="Total number of fully running and ready control plane machines"
-// +kubebuilder:printcolumn:name="Updated Replicas",type=integer,JSONPath=".status.updatedReplicas",description="Total number of non-terminated machines targeted by this control plane that have the desired template spec"
-// +kubebuilder:printcolumn:name="Unavailable Replicas",type=integer,JSONPath=".status.unavailableReplicas",description="Total number of unavailable machines targeted by this control plane"
+// +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=".status.readyReplicas",description="Total number of fully running and ready control plane machines"
+// +kubebuilder:printcolumn:name="Updated",type=integer,JSONPath=".status.updatedReplicas",description="Total number of non-terminated machines targeted by this control plane that have the desired template spec"
+// +kubebuilder:printcolumn:name="Unavailable",type=integer,JSONPath=".status.unavailableReplicas",description="Total number of unavailable machines targeted by this control plane"
 
 // KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
 type KubeadmControlPlane struct {

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -21,14 +21,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: KubeadmControlPlane API Server is ready to receive requests
-      jsonPath: .status.ready
-      name: Ready
-      type: boolean
     - description: This denotes whether or not the control plane has the uploaded
         kubeadm-config configmap
       jsonPath: .status.initialized
       name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
       type: boolean
     - description: Total number of non-terminated machines targeted by this control
         plane
@@ -37,16 +37,16 @@ spec:
       type: integer
     - description: Total number of fully running and ready control plane machines
       jsonPath: .status.readyReplicas
-      name: Ready Replicas
+      name: Ready
       type: integer
     - description: Total number of non-terminated machines targeted by this control
         plane that have the desired template spec
       jsonPath: .status.updatedReplicas
-      name: Updated Replicas
+      name: Updated
       type: integer
     - description: Total number of unavailable machines targeted by this control plane
       jsonPath: .status.unavailableReplicas
-      name: Unavailable Replicas
+      name: Unavailable
       type: integer
     name: v1alpha3
     schema:


### PR DESCRIPTION
**What this PR does / why we need it**:

Reconcile the fields printed between these two types to keep a
consistent user experience between machines and control plane.

## kubeadmcontrolplanes

**before**
```
kubectl get kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
NAME                READY   INITIALIZED   REPLICAS   READY REPLICAS   UPDATED REPLICAS   UNAVAILABLE REPLICAS
ivy-control-plane   true    true          1          1                1
```

**after**
```
NAME                INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE
ivy-control-plane   true          true                   1          1       1
```

## machinedeployments

**before**
```
kubectl get machinedeployments.cluster.x-k8s.io
NAME       PHASE     REPLICAS   AVAILABLE   READY
ivy-md-0   Running   3          3           3
```

**after**
```
kubectl get machinedeployments.cluster.x-k8s.io
NAME       PHASE     REPLICAS   READY   UPDATED   UNAVAILABLE
ivy-md-0   Running   3          3       3
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3096
