### PR TITLE
🐛 add APIEndpoint IsValid() when both host and port are non-zero value

### DIFF
--- a/api/v1alpha3/cluster_types.go
+++ b/api/v1alpha3/cluster_types.go
@@ -178,9 +178,14 @@ type APIEndpoint struct {
 	Port int32 `json:"port"`
 }
 
-// IsZero returns true if host and the port are zero values.
+// IsZero returns true if both host and port are zero values.
 func (v APIEndpoint) IsZero() bool {
 	return v.Host == "" && v.Port == 0
+}
+
+// IsValid returns true if both host and port are non-zero values.
+func (v APIEndpoint) IsValid() bool {
+	return v.Host != "" && v.Port != 0
 }
 
 // String returns a formatted version HOST:PORT of this APIEndpoint.

--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -727,7 +727,7 @@ func (r *KubeadmConfigReconciler) reconcileDiscovery(ctx context.Context, cluste
 	// if BootstrapToken already contains an APIServerEndpoint, respect it; otherwise inject the APIServerEndpoint endpoint defined in cluster status
 	apiServerEndpoint := config.Spec.JoinConfiguration.Discovery.BootstrapToken.APIServerEndpoint
 	if apiServerEndpoint == "" {
-		if cluster.Spec.ControlPlaneEndpoint.IsZero() {
+		if !cluster.Spec.ControlPlaneEndpoint.IsValid() {
 			log.V(1).Info("Waiting for Cluster Controller to set Cluster.Spec.ControlPlaneEndpoint")
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
@@ -770,7 +770,7 @@ func (r *KubeadmConfigReconciler) reconcileTopLevelObjectSettings(cluster *clust
 	// If there is no ControlPlaneEndpoint defined in ClusterConfiguration but
 	// there is a ControlPlaneEndpoint defined at Cluster level (e.g. the load balancer endpoint),
 	// then use Cluster's ControlPlaneEndpoint as a control plane endpoint for the Kubernetes cluster.
-	if config.Spec.ClusterConfiguration.ControlPlaneEndpoint == "" && !cluster.Spec.ControlPlaneEndpoint.IsZero() {
+	if config.Spec.ClusterConfiguration.ControlPlaneEndpoint == "" && cluster.Spec.ControlPlaneEndpoint.IsValid() {
 		config.Spec.ClusterConfiguration.ControlPlaneEndpoint = cluster.Spec.ControlPlaneEndpoint.String()
 		log.Info("Altering ClusterConfiguration", "ControlPlaneEndpoint", config.Spec.ClusterConfiguration.ControlPlaneEndpoint)
 	}

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -49,7 +49,7 @@ func (r *ClusterReconciler) reconcilePhase(_ context.Context, cluster *clusterv1
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhaseProvisioning)
 	}
 
-	if cluster.Status.InfrastructureReady && !cluster.Spec.ControlPlaneEndpoint.IsZero() {
+	if cluster.Status.InfrastructureReady && cluster.Spec.ControlPlaneEndpoint.IsValid() {
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhaseProvisioned)
 	}
 
@@ -180,7 +180,7 @@ func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster
 	}
 
 	// Get and parse Spec.ControlPlaneEndpoint field from the infrastructure provider.
-	if cluster.Spec.ControlPlaneEndpoint.IsZero() {
+	if !cluster.Spec.ControlPlaneEndpoint.IsValid() {
 		if err := util.UnstructuredUnmarshalField(infraConfig, &cluster.Spec.ControlPlaneEndpoint, "spec", "controlPlaneEndpoint"); err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "failed to retrieve Spec.ControlPlaneEndpoint from infrastructure provider for Cluster %q in namespace %q",
 				cluster.Name, cluster.Namespace)
@@ -251,7 +251,7 @@ func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, cluster *
 func (r *ClusterReconciler) reconcileKubeconfig(ctx context.Context, cluster *clusterv1.Cluster) (ctrl.Result, error) {
 	logger := r.Log.WithValues("cluster", cluster.Name, "namespace", cluster.Namespace)
 
-	if cluster.Spec.ControlPlaneEndpoint.IsZero() {
+	if !cluster.Spec.ControlPlaneEndpoint.IsValid() {
 		return ctrl.Result{}, nil
 	}
 

--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -249,7 +249,7 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, cluster *
 	conditions.MarkTrue(kcp, controlplanev1.CertificatesAvailableCondition)
 
 	// If ControlPlaneEndpoint is not set, return early
-	if cluster.Spec.ControlPlaneEndpoint.IsZero() {
+	if !cluster.Spec.ControlPlaneEndpoint.IsValid() {
 		logger.Info("Cluster does not yet have a ControlPlaneEndpoint defined")
 		return ctrl.Result{}, nil
 	}

--- a/controlplane/kubeadm/controllers/controller_test.go
+++ b/controlplane/kubeadm/controllers/controller_test.go
@@ -392,6 +392,7 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 
 		cluster, kcp, tmpl := createClusterWithControlPlane()
 		cluster.Spec.ControlPlaneEndpoint.Host = "bar"
+		cluster.Spec.ControlPlaneEndpoint.Port = 6443
 		kcp.Spec.Version = version
 
 		fmc := &fakeManagementCluster{
@@ -460,6 +461,7 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 
 		cluster, kcp, tmpl := createClusterWithControlPlane()
 		cluster.Spec.ControlPlaneEndpoint.Host = "bar"
+		cluster.Spec.ControlPlaneEndpoint.Port = 6443
 		kcp.Spec.Version = version
 
 		fmc := &fakeManagementCluster{
@@ -571,6 +573,7 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 
 		cluster, kcp, tmpl := createClusterWithControlPlane()
 		cluster.Spec.ControlPlaneEndpoint.Host = "nodomain.example.com"
+		cluster.Spec.ControlPlaneEndpoint.Port = 6443
 		kcp.Spec.Version = version
 
 		now := metav1.Now()
@@ -640,6 +643,7 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 
 		cluster, kcp, tmpl := createClusterWithControlPlane()
 		cluster.Spec.ControlPlaneEndpoint.Host = "nodomain.example.com"
+		cluster.Spec.ControlPlaneEndpoint.Port = 6443
 		kcp.Spec.Version = "v1.17.0"
 
 		fmc := &fakeManagementCluster{


### PR DESCRIPTION
**What this PR does / why we need it**:

Current Endpoint.IsZero() check will allow empty Host with non-empty Port to pass the check (vice versa). This will cause issue if Infra provider have partial endpoint information with either of them is empty. The specific case we saw is with CAPV when user need to manually configure endpoint for kube-vip based HA.  

Add IsValid() when both host and port are non-zero. Change controllers to use IsValid() to decide whether to proceed or keep waiting. 