### PR TITLE
🌱Update e2e Kubernetes versions

### DIFF
--- a/test/e2e/config/docker-ci.yaml
+++ b/test/e2e/config/docker-ci.yaml
@@ -74,11 +74,11 @@ providers:
   - sourcePath: "../data/infrastructure-docker/cluster-template-kcp-adoption.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.18.2"
-  ETCD_VERSION_UPGRADE_TO: "3.4.3-0"
-  COREDNS_VERSION_UPGRADE_TO: "1.6.7"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.18.2"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.17.2"
+  KUBERNETES_VERSION: "v1.19.0"
+  ETCD_VERSION_UPGRADE_TO: "3.4.9-0"
+  COREDNS_VERSION_UPGRADE_TO: "1.7.0"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.19.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.18.2"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"
   # IMPORTANT! This values should match the one used by the CNI provider

--- a/test/e2e/config/docker-dev.yaml
+++ b/test/e2e/config/docker-dev.yaml
@@ -100,11 +100,11 @@ providers:
   - sourcePath: "../data/infrastructure-docker/cluster-template-kcp-adoption.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.18.2"
-  ETCD_VERSION_UPGRADE_TO: "3.4.3-0"
-  COREDNS_VERSION_UPGRADE_TO: "1.6.7"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.18.2"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.17.2"
+  KUBERNETES_VERSION: "v1.19.0"
+  ETCD_VERSION_UPGRADE_TO: "3.4.9-0"
+  COREDNS_VERSION_UPGRADE_TO: "1.7.0"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.19.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.18.2"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"
   # IMPORTANT! This values should match the one used by the CNI provider


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Kubernetes version used in e2e tests from 1.18.2 to 1.19.0. Also updates etcd and CoreDNS versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
