### PR TITLE
🌱 Add deleting failure reason

### DIFF
--- a/api/v1alpha3/condition_consts.go
+++ b/api/v1alpha3/condition_consts.go
@@ -29,6 +29,10 @@ const (
 	// DeletingReason (Severity=Info) documents an condition not in Status=True because the underlying object it is currently being deleted.
 	DeletingReason = "Deleting"
 
+	// DeletionFailedReason (Severity=Warning) documents an condition not in Status=True because the underlying object
+	// encountered problems during deletion. This is a warning because the reconciler will retry deletion.
+	DeletionFailedReason = "DeletionFailed"
+
 	// DeletedReason (Severity=Info) documents an condition not in Status=True because the underlying object was deleted.
 	DeletedReason = "Deleted"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `DeletingFailedReason` that can be useful for providers implementing conditions for the delete workflow.

/assign @vincepri 
