### PR TITLE
📖 point users to owners_aliases file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,5 @@
-# See the OWNERS docs at https://go.k8s.io/owners
+# See the OWNERS docs at https://go.k8s.io/owners for information on OWNERS files.
+# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/cluster-api/blob/master/OWNERS_ALIASES for a list of members for each alias. 
 
 approvers:
   - sig-cluster-lifecycle-leads


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a comment to OWNERS file that points folks to OWNERS_ALIASES file for a list of members names. Aims to provides more clarity to folks looking through the owner's file and how to find out members of an alias. 

