### PR TITLE
✨  clusterctl: add option to use configuration file in remote locations

### DIFF
--- a/cmd/clusterctl/cmd/version_checker.go
+++ b/cmd/clusterctl/cmd/version_checker.go
@@ -65,7 +65,7 @@ func newVersionChecker(vc config.VariablesClient) *versionChecker {
 	}
 
 	return &versionChecker{
-		versionFilePath: filepath.Join(homedir.HomeDir(), ".cluster-api", "version.yaml"),
+		versionFilePath: filepath.Join(homedir.HomeDir(), config.ConfigFolder, "version.yaml"),
 		cliVersion:      version.Get,
 		githubClient:    client,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add option to use the clusterctl configuration from a remote location like stored in some github/gitlab repo.


usage:

```
$ clusterctl init --infrastructure aws --config https://raw.githubusercontent.com/cpanato/testing-ghactions/master/clusterctl.yaml

$ clusterctl config cluster test --kubernetes-version 1.18.9 --config  https://raw.githubusercontent.com/cpanato/testing-ghactions/master/clusterctl.yaml 
```

/hold Will add tests for that.

Opening to get feedback

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3099

/cc @vincepri @wfernandes 
