### PR TITLE
🌱 Bump cert-manager version on CI

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -42,9 +42,9 @@ make docker-build
 make -C test/infrastructure/docker docker-build
 
 ## Pulling cert manager images so we can pre-load in kind nodes
-docker pull quay.io/jetstack/cert-manager-cainjector:v0.11.0
-docker pull quay.io/jetstack/cert-manager-webhook:v0.11.0
-docker pull quay.io/jetstack/cert-manager-controller:v0.11.0
+docker pull quay.io/jetstack/cert-manager-cainjector:v0.16.1
+docker pull quay.io/jetstack/cert-manager-webhook:v0.16.1
+docker pull quay.io/jetstack/cert-manager-controller:v0.16.1
 
 # Configure e2e tests
 export GINKGO_FOCUS=

--- a/test/e2e/config/docker-ci.yaml
+++ b/test/e2e/config/docker-ci.yaml
@@ -17,11 +17,11 @@ images:
   loadBehavior: mustLoad
 - name: gcr.io/k8s-staging-cluster-api/capd-manager-amd64:ci
   loadBehavior: mustLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v0.11.0
+- name: quay.io/jetstack/cert-manager-cainjector:v0.16.1
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v0.11.0
+- name: quay.io/jetstack/cert-manager-webhook:v0.16.1
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v0.11.0
+- name: quay.io/jetstack/cert-manager-controller:v0.16.1
   loadBehavior: tryLoad
 
 providers:

--- a/test/e2e/config/docker-dev.yaml
+++ b/test/e2e/config/docker-dev.yaml
@@ -19,11 +19,11 @@ images:
   loadBehavior: mustLoad
 - name: gcr.io/k8s-staging-cluster-api/capd-manager-amd64:dev
   loadBehavior: mustLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v0.11.0
+- name: quay.io/jetstack/cert-manager-cainjector:v0.16.1
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v0.11.0
+- name: quay.io/jetstack/cert-manager-webhook:v0.16.1
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v0.11.0
+- name: quay.io/jetstack/cert-manager-controller:v0.16.1
   loadBehavior: tryLoad
 # If using Calico uncomment following lines to speed up test by pre-loading required images on nodes
 # - name: calico/kube-controllers:v3.13.1


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump CI scripts and config to cert-manager v0.16.1