### PR TITLE
🌱 pre-pull kind images on CI

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -46,6 +46,10 @@ docker pull quay.io/jetstack/cert-manager-cainjector:v0.16.1
 docker pull quay.io/jetstack/cert-manager-webhook:v0.16.1
 docker pull quay.io/jetstack/cert-manager-controller:v0.16.1
 
+## Pulling kind images used by tests
+docker pull kindest/node:v1.18.2
+docker pull kindest/node:v1.19.0
+
 # Configure e2e tests
 export GINKGO_FOCUS=
 export GINKGO_NODES=3


### PR DESCRIPTION
**What this PR does / why we need it**:
pre-pull the two kind images we are using in CI so we can remove another variable (docker hub speed) out of the GINKO run