### PR TITLE
✨ Print upgrade notice for cert-manager

### DIFF
--- a/cmd/clusterctl/client/alias.go
+++ b/cmd/clusterctl/client/alias.go
@@ -41,6 +41,10 @@ type Template repository.Template
 // UpgradePlan defines a list of possible upgrade targets for a management group.
 type UpgradePlan cluster.UpgradePlan
 
+// CertManagerUpgradePlan defines the upgrade plan if cert-manager needs to be
+// upgraded to a different version.
+type CertManagerUpgradePlan cluster.CertManagerUpgradePlan
+
 // Kubeconfig is a type that specifies inputs related to the actual kubeconfig.
 type Kubeconfig cluster.Kubeconfig
 

--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -56,6 +56,9 @@ type Client interface {
 	//   - Upgrade to the latest version in the the v1alpha3 series: ....
 	PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePlan, error)
 
+	// PlanCertManagerUpgrade returns a CertManagerUpgradePlan.
+	PlanCertManagerUpgrade(options PlanUpgradeOptions) (CertManagerUpgradePlan, error)
+
 	// ApplyUpgrade executes an upgrade plan.
 	ApplyUpgrade(options ApplyUpgradeOptions) error
 

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -105,6 +105,10 @@ func (f fakeClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePlan, erro
 	return f.internalClient.PlanUpgrade(options)
 }
 
+func (f fakeClient) PlanCertManagerUpgrade(options PlanUpgradeOptions) (CertManagerUpgradePlan, error) {
+	return f.internalClient.PlanCertManagerUpgrade(options)
+}
+
 func (f fakeClient) ApplyUpgrade(options ApplyUpgradeOptions) error {
 	return f.internalClient.ApplyUpgrade(options)
 }
@@ -194,7 +198,7 @@ func newFakeCluster(kubeconfig cluster.Kubeconfig, configClient config.Client) *
 
 // newFakeCertManagerClient creates a new CertManagerClient
 // allows the caller to define which images are needed for the manager to run
-func newFakeCertManagerClient(imagesReturnImages []string, imagesReturnError error) cluster.CertManagerClient {
+func newFakeCertManagerClient(imagesReturnImages []string, imagesReturnError error) *fakeCertManagerClient {
 	return &fakeCertManagerClient{
 		images:      imagesReturnImages,
 		imagesError: imagesReturnError,
@@ -202,8 +206,9 @@ func newFakeCertManagerClient(imagesReturnImages []string, imagesReturnError err
 }
 
 type fakeCertManagerClient struct {
-	images      []string
-	imagesError error
+	images          []string
+	imagesError     error
+	certManagerPlan cluster.CertManagerUpgradePlan
 }
 
 var _ cluster.CertManagerClient = &fakeCertManagerClient{}
@@ -216,8 +221,17 @@ func (p *fakeCertManagerClient) EnsureLatestVersion() error {
 	return nil
 }
 
+func (p *fakeCertManagerClient) PlanUpgrade() (cluster.CertManagerUpgradePlan, error) {
+	return p.certManagerPlan, nil
+}
+
 func (p *fakeCertManagerClient) Images() ([]string, error) {
 	return p.images, p.imagesError
+}
+
+func (p *fakeCertManagerClient) WithCertManagerPlan(plan CertManagerUpgradePlan) *fakeCertManagerClient {
+	p.certManagerPlan = cluster.CertManagerUpgradePlan(plan)
+	return p
 }
 
 type fakeClusterClient struct {

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -31,6 +31,17 @@ type PlanUpgradeOptions struct {
 	Kubeconfig Kubeconfig
 }
 
+func (c *clusterctlClient) PlanCertManagerUpgrade(options PlanUpgradeOptions) (CertManagerUpgradePlan, error) {
+	// Get the client for interacting with the management cluster.
+	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})
+	if err != nil {
+		return CertManagerUpgradePlan{}, err
+	}
+
+	plan, err := cluster.CertManager().PlanUpgrade()
+	return CertManagerUpgradePlan(plan), err
+}
+
 func (c *clusterctlClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePlan, error) {
 	// Get the client for interacting with the management cluster.
 	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
When using 'clusterctl upgrade plan', we now notify the user if the
cert-manager version will be upgraded as part of 'clusterctl upgrade
apply'.

**Sample output**
```shell
$ clusterctl upgrade plan --config ~/.cluster-api/dev-repository/config.yaml
Checking cert-manager version...
Cert-Manager will be upgraded from "v0.11.0" to "v0.16.1"

Checking new release availability...

Management group: capi-system/cluster-api, latest release available for the v1alpha3 API Version of Cluster API (contract):

NAME                    NAMESPACE                           TYPE                     CURRENT VERSION   NEXT VERSION
bootstrap-kubeadm       capi-kubeadm-bootstrap-system       BootstrapProvider        v0.3.8            Already up to date
control-plane-kubeadm   capi-kubeadm-control-plane-system   ControlPlaneProvider     v0.3.8            Already up to date
cluster-api             capi-system                         CoreProvider             v0.3.8            Already up to date
infrastructure-aws      foobar                              InfrastructureProvider   v0.5.0            Already up to date
infrastructure-docker   capd-system                         InfrastructureProvider   v0.3.8            Already up to date

You are already up to date!
```



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3491 
