### PR TITLE
:warning: Disallow KubeadmControlPlane upgrades to v1.19.0

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_webhook_test.go
@@ -59,7 +59,7 @@ func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
 				Name:      "infraTemplate",
 			},
 			Replicas: pointer.Int32Ptr(1),
-			Version:  "v1.16.6",
+			Version:  "v1.19.0",
 		},
 	}
 	invalidNamespace := valid.DeepCopy()
@@ -433,6 +433,10 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	withoutClusterConfiguration := before.DeepCopy()
 	withoutClusterConfiguration.Spec.KubeadmConfigSpec.ClusterConfiguration = nil
 
+	disallowedUpgrade118Prev := prevKCPWithVersion("v1.18.8")
+	disallowedUpgrade119Version := before.DeepCopy()
+	disallowedUpgrade119Version.Spec.Version = "v1.19.0"
+
 	tests := []struct {
 		name      string
 		expectErr bool
@@ -690,6 +694,12 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: false,
 			before:    before,
 			kcp:       before.DeepCopy(),
+		},
+		{
+			name:      "should return error when trying to upgrade to v1.19.0",
+			expectErr: true,
+			before:    disallowedUpgrade118Prev,
+			kcp:       disallowedUpgrade119Version,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
See https://kubernetes.slack.com/archives/C8TSNPY4T/p1598899864038100 for more information, Cluster API v0.3.9 won't support upgrading directly to v1.19.0

/milestone v0.3.9

