### PR TITLE
🌱[e2e] Revert e2e test Kubernetes version to 1.18.2

### DIFF
--- a/test/e2e/config/docker-ci.yaml
+++ b/test/e2e/config/docker-ci.yaml
@@ -74,11 +74,11 @@ providers:
   - sourcePath: "../data/infrastructure-docker/cluster-template-kcp-adoption.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.19.0"
-  ETCD_VERSION_UPGRADE_TO: "3.4.9-0"
-  COREDNS_VERSION_UPGRADE_TO: "1.7.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.19.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.18.2"
+  KUBERNETES_VERSION: "v1.18.2"
+  ETCD_VERSION_UPGRADE_TO: "3.4.3-0"
+  COREDNS_VERSION_UPGRADE_TO: "1.6.7"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.18.2"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.17.2"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"
   # IMPORTANT! This values should match the one used by the CNI provider

--- a/test/e2e/config/docker-dev.yaml
+++ b/test/e2e/config/docker-dev.yaml
@@ -100,11 +100,11 @@ providers:
   - sourcePath: "../data/infrastructure-docker/cluster-template-kcp-adoption.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.19.0"
-  ETCD_VERSION_UPGRADE_TO: "3.4.9-0"
-  COREDNS_VERSION_UPGRADE_TO: "1.7.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.19.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.18.2"
+  KUBERNETES_VERSION: "v1.18.2"
+  ETCD_VERSION_UPGRADE_TO: "3.4.3-0"
+  COREDNS_VERSION_UPGRADE_TO: "1.6.7"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.18.2"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.17.2"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"
   # IMPORTANT! This values should match the one used by the CNI provider


### PR DESCRIPTION
**What this PR does / why we need it**:
We recently upgraded e2e tests Kubernetes version to 1.19.0 but due to some changes in that version of Kubernetes, tests were failing. 

Before upgrading tests, a fix should go in, copying the discussion on slack (https://kubernetes.slack.com/archives/C8TSNPY4T/p1598899864038100):

```
ncdc  1 hour ago
In Kubernetes 1.19.0, the certificates API (which does CertificateSigningRequests for node bootstrapping, among other things) introduced version v1. The kube-controller-manager switched to only speaking v1 of this API.
If you have a control plane with a load balancer in front, it is possible/likely that during an upgrade from 1.18 to 1.19, the 1.18 kube-controller-manager will be removed (as part of deleting one of the old machines), and the 1.19 kube-controller-manager will potentially acquire the leader election lock. It then connects to the load balancer, and there’s a chance it gets routed to one of the remaining 1.18 apiservers. If/when this happens, the kube-controller-manager will be unable to process any new CertificateSigningRequests (because it’s asking for certificates v1, which doesn’t exist in 1.18). This means all new node bootstrapping will fail.
The solution is to update kubeadm so the kube-controller-manager, kube-scheduler, and kubelet of control plane nodes talk to the local API endpoint for the apiserver (i.e. the local apiserver static pod), instead of going through the load balancer.
```