### PR TITLE
🌱 Pre-pull e2e images on CI (revert to v1.17/v1.18)

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -48,7 +48,7 @@ docker pull quay.io/jetstack/cert-manager-controller:v0.16.1
 
 ## Pulling kind images used by tests
 docker pull kindest/node:v1.18.2
-docker pull kindest/node:v1.19.0
+docker pull kindest/node:v1.17.2
 
 # Configure e2e tests
 export GINKGO_FOCUS=


### PR DESCRIPTION
**What this PR does / why we need it**:
Align to changes introduced by https://github.com/kubernetes-sigs/cluster-api/pull/3563

