### PR TITLE
🐛 Fix a bug that fails to write the version state file

### DIFF
--- a/cmd/clusterctl/cmd/version_checker.go
+++ b/cmd/clusterctl/cmd/version_checker.go
@@ -166,13 +166,15 @@ func (v *versionChecker) getLatestRelease() (*ReleaseInfo, error) {
 
 }
 
-func writeStateFile(filepath string, vs *VersionState) error {
+func writeStateFile(path string, vs *VersionState) error {
 	vsb, err := yaml.Marshal(vs)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath, vsb, 0600)
-	if err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(path, vsb, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/clusterctl/cmd/version_checker_test.go
+++ b/cmd/clusterctl/cmd/version_checker_test.go
@@ -349,9 +349,7 @@ func TestVersionChecker_ReadFromStateFileWithin24Hrs(t *testing.T) {
 			URL:     "https://github.com/foo/bar/releases/v0.3.8",
 		},
 	}
-	b, err := yaml.Marshal(reallyOldVersionState)
-	g.Expect(err).ToNot(HaveOccurred())
-	g.Expect(ioutil.WriteFile(tmpVersionFile, b, 0600)).To(Succeed())
+	g.Expect(writeStateFile(tmpVersionFile, reallyOldVersionState)).To(Succeed())
 
 	fakeGithubClient1, mux1, cleanup1 := test.NewFakeGitHub()
 	mux1.HandleFunc(
@@ -366,7 +364,7 @@ func TestVersionChecker_ReadFromStateFileWithin24Hrs(t *testing.T) {
 	versionChecker.versionFilePath = tmpVersionFile
 	versionChecker.githubClient = fakeGithubClient1
 
-	_, err = versionChecker.getLatestRelease()
+	_, err := versionChecker.getLatestRelease()
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Since the state file is more that 24 hours old we want to retrieve the
@@ -381,7 +379,7 @@ func generateTempVersionFilePath(g *WithT) (string, func()) {
 	dir, err := ioutil.TempDir("", "clusterctl")
 	g.Expect(err).NotTo(HaveOccurred())
 	// don't create the state file, just have a path to the file
-	tmpVersionFile := filepath.Join(dir, "state.yaml")
+	tmpVersionFile := filepath.Join(dir, "clusterctl", "state.yaml")
 
 	return tmpVersionFile, func() {
 		os.RemoveAll(dir)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR fixes a bug that fails to write the version state file. Since v0.3.9, clusterctl has added the ability to check for the latest version, but an error occurs because the directory where the version state file will be created does not exist.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3573  
