### PR TITLE
🌱 Add Fabrizio Pandini to maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -26,6 +26,7 @@ aliases:
   - ncdc
   - vincepri
   - CecileRobertMichon
+  - fabriziopandini
 
   # folks who can review and LGTM any PRs in the repo
   cluster-api-reviewers:
@@ -48,6 +49,7 @@ aliases:
   # -----------------------------------------------------------
 
   cluster-api-provider-docker-maintainers:
+  - fabriziopandini
   - ncdc
 
   # -----------------------------------------------------------


### PR DESCRIPTION
**What this PR does / why we need it**:
I already have approver rights via `sig-cluster-lifecycle-leads` group, but apparently this is not enough for the `/milestone` bot

> @fabriziopandini: You must be a member of the kubernetes-sigs/cluster-api-maintainers GitHub team to set the milestone.

This should fix this so I can help more for the issue triage duty