### PR TITLE
:book: Document our compatibility notices for sub-folders

### DIFF
--- a/cmd/clusterctl/README.md
+++ b/cmd/clusterctl/README.md
@@ -2,6 +2,6 @@
 
 ## Compatibility notice
 
-Clusterctl CLI is developed in lock-step with Cluster API, it's strongly recommended to  use the latest released version for the series you're using. For example, if you're managing clusters with Cluster API v0.3.7, clusterctl version should be >= v0.3.7.
+The `clusterctl` CLI is developed in lock-step with Cluster API. We strongly recommend using the latest released version for the series you're using. For example, if you're managing clusters with Cluster API v0.3.7, the `clusterctl` version should be >= v0.3.7.
 
-When used as a library, clusterctl does not provide compatibility guarantees. While code should not be deleted and should follow some deprecation phase, breaking changes can happen when necessary.
+When this package is used as a library, we do not currently provide any compatibility guarantees. We will make reasonable efforts to follow a typical deprecation period prior to removal, but breaking changes can happen when necessary.

--- a/cmd/clusterctl/README.md
+++ b/cmd/clusterctl/README.md
@@ -1,0 +1,7 @@
+# Clusterctl
+
+## Compatibility notice
+
+Clusterctl CLI is developed in lock-step with Cluster API, it's strongly recommended to  use the latest released version for the series you're using. For example, if you're managing clusters with Cluster API v0.3.7, clusterctl version should be >= v0.3.7.
+
+When used as a library, clusterctl does not provide compatibility guarantees. While code should not be deleted and should follow some deprecation phase, breaking changes can happen when necessary.

--- a/exp/README.md
+++ b/exp/README.md
@@ -1,16 +1,11 @@
-# exp
+# Experimental
 
-This subrepository holds experimental code and API types.
+⚠️ This folder holds experimental code and API types. ⚠️
 
-**Warning**: Packages here are experimental and unreliable. Some may one day be promoted to the main repository, or they may be modified arbitrarily or even disappear altogether.
+## Compatibility notice
 
-In short, code in this subrepository is not subject to any compatibility or deprecation promise.
+Packages and code does not follow any compatibility guarantees and it's considered unreliable. Some projects may be promoted to the main repository in time, some other may be modified arbitrarily or even disappear altogether.
 
-Experiments follow a strict lifecycle: Alpha -> Beta prior to Graduation.
+## Graduation criteria
 
 For more information on graduation criteria, see: [Contributing Guidelines](../CONTRIBUTING.md#experiments)
-
-## Active Features
- MachinePool  (alpha)
- 
- ClusterResourceSet (alpha)

--- a/exp/README.md
+++ b/exp/README.md
@@ -1,10 +1,10 @@
 # Experimental
 
-⚠️ This folder holds experimental code and API types. ⚠️
+⚠️ This package holds experimental code and API types. ⚠️
 
 ## Compatibility notice
 
-Packages and code does not follow any compatibility guarantees and it's considered unreliable. Some projects may be promoted to the main repository in time, some other may be modified arbitrarily or even disappear altogether.
+This package does not adhere to any compatibility guarantees. Some portions may eventually be promoted out of this package and considered stable/GA, while others may be removed entirely.
 
 ## Graduation criteria
 

--- a/test/README.md
+++ b/test/README.md
@@ -2,9 +2,8 @@
 
 ## Compatibility notice
 
-Code under the `test/` subfolder is not subject to deprecation notices or compatbility guarantees.
+This package is not subject to deprecation notices or compatibility guarantees.
 
-- The test framework for Cluster API, given its quick pace allows for breaking changes, external providers using this codebase should update to the latest API changes when updating Cluster API. Maintainers and contributors must give notice in release notes when a breaking change happens.
+- We iterate on the test framework quickly and frequently, and breaking changes are likely. External providers using this package should update to the latest API changes when updating Cluster API. Maintainers and contributors must give notice in release notes when a breaking change happens.
 
-- The docker provider, including its APIs should only be used in development environments, API and code can change at any time without notice.
-
+- The docker provider, including its APIs, should only be used for development/testing purposes. Its API and code can change at any time without notice.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,10 @@
+# Test
+
+## Compatibility notice
+
+Code under the `test/` subfolder is not subject to deprecation notices or compatbility guarantees.
+
+- The test framework for Cluster API, given its quick pace allows for breaking changes, external providers using this codebase should update to the latest API changes when updating Cluster API. Maintainers and contributors must give notice in release notes when a breaking change happens.
+
+- The docker provider, including its APIs should only be used in development environments, API and code can change at any time without notice.
+


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR is meant to document the *current development practices* that we've either agreed to in the past, or have been practicing. In an effort to be more explicit and openly document when and where breaking changes are allowed, and when we should be required to give notice to our users.

/milestone v0.3.10
/assign @CecileRobertMichon @ncdc 
