### PR TITLE
🌱[e2e] Add PR-Blocking label to Quick-Start test

### DIFF
--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = Describe("When following the Cluster API quick-start", func() {
+var _ = Describe("When following the Cluster API quick-start [PR-Blocking]", func() {
 
 	QuickStartSpec(context.TODO(), func() QuickStartSpecInput {
 		return QuickStartSpecInput{


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding [PR-Blocking] label to Quick-Start e2e test which will be run in pre-submit tests.


cc @fabriziopandini @wfernandes 
