### PR TITLE
🌱[e2e] Delete GINKGO_FOCUS from ci-e2e.sh

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -51,7 +51,6 @@ docker pull kindest/node:v1.18.2
 docker pull kindest/node:v1.17.2
 
 # Configure e2e tests
-export GINKGO_FOCUS=
 export GINKGO_NODES=3
 export GINKGO_NOCOLOR=true
 export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/docker-ci.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
Delete GINKGO_FOCUS from ci-e2e.sh to avoid overriding it in prow scripts (https://github.com/kubernetes/test-infra/pull/19092).


/assign @wfernandes 