### PR TITLE
Allow custom providers in clusterctl client

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -87,16 +87,16 @@ type clusterctlClient struct {
 // RepositoryClientFactoryInput represents the inputs required by the
 // RepositoryClientFactory
 type RepositoryClientFactoryInput struct {
-	provider  Provider
-	processor Processor
+	Provider  Provider
+	Processor Processor
 }
 type RepositoryClientFactory func(RepositoryClientFactoryInput) (repository.Client, error)
 
 // ClusterClientFactoryInput reporesents the inputs required by the
 // ClusterClientFactory
 type ClusterClientFactoryInput struct {
-	kubeconfig Kubeconfig
-	processor  Processor
+	Kubeconfig Kubeconfig
+	Processor  Processor
 }
 type ClusterClientFactory func(ClusterClientFactoryInput) (cluster.Client, error)
 
@@ -167,9 +167,9 @@ func newClusterctlClient(path string, options ...Option) (*clusterctlClient, err
 func defaultRepositoryFactory(configClient config.Client) RepositoryClientFactory {
 	return func(input RepositoryClientFactoryInput) (repository.Client, error) {
 		return repository.New(
-			input.provider,
+			input.Provider,
 			configClient,
-			repository.InjectYamlProcessor(input.processor),
+			repository.InjectYamlProcessor(input.Processor),
 		)
 	}
 }
@@ -179,9 +179,9 @@ func defaultClusterFactory(configClient config.Client) ClusterClientFactory {
 	return func(input ClusterClientFactoryInput) (cluster.Client, error) {
 		return cluster.New(
 			// Kubeconfig is a type alias to cluster.Kubeconfig
-			cluster.Kubeconfig(input.kubeconfig),
+			cluster.Kubeconfig(input.Kubeconfig),
 			configClient,
-			cluster.InjectYamlProcessor(input.processor),
+			cluster.InjectYamlProcessor(input.Processor),
 		), nil
 	}
 }

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -133,9 +133,9 @@ func newFakeClient(configClient config.Client) *fakeClient {
 
 	var clusterClientFactory = func(i ClusterClientFactoryInput) (cluster.Client, error) {
 		// converting the client.Kubeconfig to cluster.Kubeconfig alias
-		k := cluster.Kubeconfig(i.kubeconfig)
+		k := cluster.Kubeconfig(i.Kubeconfig)
 		if _, ok := fake.clusters[k]; !ok {
-			return nil, errors.Errorf("Cluster for kubeconfig %q and/or context %q does not exist.", i.kubeconfig.Path, i.kubeconfig.Context)
+			return nil, errors.Errorf("Cluster for kubeconfig %q and/or context %q does not exist.", i.Kubeconfig.Path, i.Kubeconfig.Context)
 		}
 		return fake.clusters[k], nil
 	}
@@ -144,10 +144,10 @@ func newFakeClient(configClient config.Client) *fakeClient {
 		InjectConfig(fake.configClient),
 		InjectClusterClientFactory(clusterClientFactory),
 		InjectRepositoryFactory(func(input RepositoryClientFactoryInput) (repository.Client, error) {
-			if _, ok := fake.repositories[input.provider.ManifestLabel()]; !ok {
-				return nil, errors.Errorf("Repository for kubeconfig %q does not exist.", input.provider.ManifestLabel())
+			if _, ok := fake.repositories[input.Provider.ManifestLabel()]; !ok {
+				return nil, errors.Errorf("Repository for kubeconfig %q does not exist.", input.Provider.ManifestLabel())
 			}
-			return fake.repositories[input.provider.ManifestLabel()], nil
+			return fake.repositories[input.Provider.ManifestLabel()], nil
 		}),
 	)
 

--- a/cmd/clusterctl/client/common.go
+++ b/cmd/clusterctl/client/common.go
@@ -47,7 +47,7 @@ func (c *clusterctlClient) getComponentsByName(provider string, providerType clu
 	// and watching namespace etc.
 	// Currently we are not supporting custom yaml processors for the provider
 	// components. So we revert to using the default SimpleYamlProcessor.
-	repositoryClientFactory, err := c.repositoryClientFactory(RepositoryClientFactoryInput{provider: providerConfig})
+	repositoryClientFactory, err := c.repositoryClientFactory(RepositoryClientFactoryInput{Provider: providerConfig})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -102,7 +102,7 @@ func (c *clusterctlClient) ProcessYAML(options ProcessYAMLOptions) (YamlPrinter,
 	cluster, err := c.clusterClientFactory(
 		ClusterClientFactoryInput{
 			// use the default kubeconfig
-			kubeconfig: Kubeconfig{},
+			Kubeconfig: Kubeconfig{},
 		},
 	)
 	if err != nil {
@@ -320,7 +320,7 @@ func (c *clusterctlClient) getTemplateFromRepository(cluster cluster.Client, opt
 		return nil, err
 	}
 
-	repo, err := c.repositoryClientFactory(RepositoryClientFactoryInput{provider: providerConfig, processor: processor})
+	repo, err := c.repositoryClientFactory(RepositoryClientFactoryInput{Provider: providerConfig, Processor: processor})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/delete.go
+++ b/cmd/clusterctl/client/delete.go
@@ -61,7 +61,7 @@ type DeleteOptions struct {
 }
 
 func (c *clusterctlClient) Delete(options DeleteOptions) error {
-	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/get_kubeconfig.go
+++ b/cmd/clusterctl/client/get_kubeconfig.go
@@ -33,7 +33,7 @@ type GetKubeconfigOptions struct {
 
 func (c *clusterctlClient) GetKubeconfig(options GetKubeconfigOptions) (string, error) {
 	// gets access to the management cluster
-	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return "", err
 	}

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -71,7 +71,7 @@ func (c *clusterctlClient) Init(options InitOptions) ([]Components, error) {
 	log := logf.Log
 
 	// gets access to the management cluster
-	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})
+	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (c *clusterctlClient) Init(options InitOptions) ([]Components, error) {
 // Init returns the list of images required for init.
 func (c *clusterctlClient) InitImages(options InitOptions) ([]string, error) {
 	// gets access to the management cluster
-	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})
+	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -33,7 +33,7 @@ type MoveOptions struct {
 
 func (c *clusterctlClient) Move(options MoveOptions) error {
 	// Get the client for interacting with the source management cluster.
-	fromCluster, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.FromKubeconfig})
+	fromCluster, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.FromKubeconfig})
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func (c *clusterctlClient) Move(options MoveOptions) error {
 	}
 
 	// Get the client for interacting with the target management cluster.
-	toCluster, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.ToKubeconfig})
+	toCluster, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.ToKubeconfig})
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -33,7 +33,7 @@ type PlanUpgradeOptions struct {
 
 func (c *clusterctlClient) PlanCertManagerUpgrade(options PlanUpgradeOptions) (CertManagerUpgradePlan, error) {
 	// Get the client for interacting with the management cluster.
-	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})
+	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return CertManagerUpgradePlan{}, err
 	}
@@ -44,7 +44,7 @@ func (c *clusterctlClient) PlanCertManagerUpgrade(options PlanUpgradeOptions) (C
 
 func (c *clusterctlClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePlan, error) {
 	// Get the client for interacting with the management cluster.
-	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})
+	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ type ApplyUpgradeOptions struct {
 
 func (c *clusterctlClient) ApplyUpgrade(options ApplyUpgradeOptions) error {
 	// Get the client for interacting with the management cluster.
-	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{kubeconfig: options.Kubeconfig})
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
:bug:

**What this PR does / why we need it**:
Allows to inject custom repository interfaces for providers by making fields in RepositoryClientFactoryInput and ClusterClientFactoryInput public.

This will allow external libraries read the inputs and pass them further to create a client or implement custom based clients. Please see related issue for more details.

**Which issue(s) this PR fixes** :
Fixes #3584
