### PR TITLE
🌱 e2e: Display path of the kubeconfig file for the bootstrap cluster

### DIFF
--- a/test/framework/bootstrap/kind_util.go
+++ b/test/framework/bootstrap/kind_util.go
@@ -62,6 +62,8 @@ func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKi
 	clusterProvider.Create(ctx)
 	Expect(clusterProvider.GetKubeconfigPath()).To(BeAnExistingFile(), "The kubeconfig file for the kind cluster with name %q does not exists at %q as expected", input.Name, clusterProvider.GetKubeconfigPath())
 
+	log.Logf("The kubeconfig file for the kind cluster is %s", clusterProvider.kubeconfigPath)
+
 	LoadImagesToKindCluster(ctx, LoadImagesToKindClusterInput{
 		Name:   input.Name,
 		Images: input.Images,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR displays the path of the kubeconfig file for the bootstrap cluster for E2e tests. It makes it easier to debug provider controllers if it fails to initialize the bootstrap cluster.

```
STEP: Setting up the bootstrap cluster
INFO: Creating a kind cluster with name "test-6lnn2w"
INFO: The kubeconfig file for the kind cluster is /var/folders/d3/lsp0h4wx7wsd4_yrymm9nnm80000gn/T/e2e-kind675530722
STEP: Initializing the bootstrap cluster
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
