### PR TITLE
🌱 Fix the E2E MHC remediation errors

### DIFF
--- a/test/infrastructure/docker/docker/util.go
+++ b/test/infrastructure/docker/docker/util.go
@@ -39,6 +39,9 @@ func roleLabel(role string) string {
 }
 
 func machineContainerName(cluster, machine string) string {
+	if strings.HasPrefix(machine, cluster) {
+		return machine
+	}
 	return fmt.Sprintf("%s-%s", cluster, machine)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes `\"sethostname: invalid argument\""` when the generated container name is too long
It does so by avoiding to repeat the cluster name if it is already included in the machine name

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3599
