### PR TITLE
🌱 Tiltfile: Parameterize kustomize and main.go for providers

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -229,8 +229,10 @@ COPY --from=tilt-helper /usr/bin/docker /usr/bin/docker
 COPY --from=tilt-helper /go/kubernetes/client/bin/kubectl /usr/bin/kubectl
 ```
 
-**kustomize_config** (Bool, default="true"): Whether or not running kustomize on the ./config folder of the provider.
+**kustomize_config** (Bool, default=true): Whether or not running kustomize on the ./config folder of the provider.
 Set to `false` if your provider does not have a ./config folder or you do not want it to be applied in the cluster.
+
+**go_main** (String, default="main.go"): The go main file if not located at the root of the folder
 
 ## Customizing Tilt
 

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -148,7 +148,7 @@ base64 -i ~/path/to/gcp/credentials.json
 Set to `manual` to disable auto-rebuilding and require users to trigger rebuilds of individual changed components through the UI.
 
 **extra_args** (Object, default={}): A mapping of provider to additional arguments to pass to the main binary configured
-for this provider. Each item in the array will be passed in to the manager for the given provider. 
+for this provider. Each item in the array will be passed in to the manager for the given provider.
 
 Example:
 
@@ -228,6 +228,9 @@ The manager image will use docker-slim, so to download files, use `additional_he
 COPY --from=tilt-helper /usr/bin/docker /usr/bin/docker
 COPY --from=tilt-helper /go/kubernetes/client/bin/kubectl /usr/bin/kubectl
 ```
+
+**kustomize_config** (Bool, default="true"): Whether or not running kustomize on the ./config folder of the provider.
+Set to `false` if your provider does not have a ./config folder or you do not want it to be applied in the cluster.
 
 ## Customizing Tilt
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This comes from a need in Metal3. The CAPM3 provider contains for now three controllers, each of them in a separate repository. Only the main repository (the CAPM3 controller) contains a ./config folder that should be applied, and that includes the the two other controllers. It is currently possible to develop CAPM3 using CAPI tiltfile but that limits us to working with CAPM3 only, as the two other controllers repositories are not considered. If the Tiltfile was not trying to build the ./config folder of all providers, those two other repositories could be given as additional providers to allow development there too. In addition, when the provider is not built using Kubebuilder, but an old version of operator-sdk for example, the main.go file is not located at the root of the repository.

This PR adds a configuration field to be able to disable the kustomize step of the Tiltfile. It allows the user to prevent running kustomize on the ./config folder by setting the `kustomize_config` boolean field in the tilt-provider.json file. It also allows the user to provide a specific main.go file for the provider. For example:

```json
{
    "name": "bmo",
    "config": {
        "kustomize_config": false,
        "go_main": "cmd/manager/main.go",
        "image": "quay.io/metal3-io/baremetal-operator",
        "live_reload_deps": [
            "cmd", "pkg"
        ]
    }
}
```
