### PR TITLE
🌱 Fix message for clusterctl EnsureCustomResourceDefinitions failure

### DIFF
--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -273,7 +273,7 @@ func (c *clusterctlClient) getTemplateFromRepository(cluster cluster.Client, opt
 	if provider == "" {
 		// ensure the custom resource definitions required by clusterctl are in place
 		if err := cluster.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
-			return nil, errors.Wrapf(err, "failed to identify the default infrastructure provider. Please specify an infrastructure provider")
+			return nil, errors.Wrapf(err, "custom resource definitions are not in place")
 		}
 		ensureCustomResourceDefinitions = true
 

--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -273,7 +273,7 @@ func (c *clusterctlClient) getTemplateFromRepository(cluster cluster.Client, opt
 	if provider == "" {
 		// ensure the custom resource definitions required by clusterctl are in place
 		if err := cluster.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
-			return nil, errors.Wrapf(err, "custom resource definitions are not in place")
+			return nil, errors.Wrapf(err, "provider custom resource definitions (CRDs) are not installed")
 		}
 		ensureCustomResourceDefinitions = true
 


### PR DESCRIPTION
Looks like the message got copy-pasted from about ten lines down, resulting in a confusing report to the user.
