### PR TITLE
🐛 Improve logging for workload connection error

### DIFF
--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -180,7 +180,7 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(req ctrl.Request) (res ctrl.Re
 		if err := r.updateStatus(ctx, kcp, cluster); err != nil {
 			var connFailure *internal.RemoteClusterConnectionError
 			if errors.As(err, &connFailure) {
-				logger.Info("Could not connect to workload cluster to fetch status", "err", err)
+				logger.Info("Could not connect to workload cluster to fetch status", "err", err.Error())
 			} else {
 				logger.Error(err, "Failed to update KubeadmControlPlane Status")
 				reterr = kerrors.NewAggregate([]error{reterr, err})


### PR DESCRIPTION
Before this change the log line says `err={}`.

Probably the logging implementation should be changed to fix this more generically: if someone points out where that code lives I could take a look.
