### PR TITLE
🌱Have hack/create-local-repository.py write yaml files in native text format

### DIFF
--- a/cmd/clusterctl/hack/create-local-repository.py
+++ b/cmd/clusterctl/hack/create-local-repository.py
@@ -126,7 +126,7 @@ def write_local_repository(provider, version, components_file, components_yaml):
             if e.errno != errno.EEXIST:
                 raise
         components_path = os.path.join(provider_folder, components_file)
-        f = open(components_path, 'wb')
+        f = open(components_path, 'w')
         f.write(components_yaml)
         f.close()
 
@@ -178,7 +178,7 @@ def create_dev_config(repos):
     try:
         repository_folder = get_repository_folder()
         config_path = os.path.join(repository_folder, "config.yaml")
-        f = open(config_path, 'wb')
+        f = open(config_path, 'w')
         f.write(yaml)
         f.close()
         return components_path


### PR DESCRIPTION
The original code doesn't work under Python 3, and it seems reasonable to write text (yaml) files in the native format of the system you are running on.

Fixes #3601 
