### PR TITLE
:sparkles: new EKS bootstrap provider in clusterctl

### DIFF
--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -44,6 +44,7 @@ const (
 	// Bootstrap providers
 	KubeadmBootstrapProviderName = "kubeadm"
 	TalosBootstrapProviderName   = "talos"
+	EKSBootstrapProviderName     = "eks"
 
 	// ControlPlane providers
 	KubeadmControlPlaneProviderName = "kubeadm"
@@ -152,7 +153,11 @@ func (p *providersClient) defaults() []Provider {
 			url:          "https://github.com/talos-systems/cluster-api-bootstrap-provider-talos/releases/latest/bootstrap-components.yaml",
 			providerType: clusterctlv1.BootstrapProviderType,
 		},
-
+		&provider{
+			name:         EKSBootstrapProviderName,
+			url:          "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/eks-bootstrap-components.yaml",
+			providerType: clusterctlv1.BootstrapProviderType,
+		},
 		// ControlPlane providers
 		&provider{
 			name:         KubeadmControlPlaneProviderName,

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -55,6 +55,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 			// note: these will be sorted by name by the Providers() call, so be sure they are in alphabetical order here too
 			wantProviders: []string{
 				config.ClusterAPIProviderName,
+				config.EKSBootstrapProviderName,
 				config.KubeadmBootstrapProviderName,
 				config.TalosBootstrapProviderName,
 				config.KubeadmControlPlaneProviderName,
@@ -80,6 +81,7 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 			wantProviders: []string{
 				config.ClusterAPIProviderName,
 				customProviderConfig.Name(),
+				config.EKSBootstrapProviderName,
 				config.KubeadmBootstrapProviderName,
 				config.TalosBootstrapProviderName,
 				config.KubeadmControlPlaneProviderName,

--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -156,6 +156,17 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 					// older version are not supported by clusterctl
 				},
 			}
+		case config.EKSBootstrapProviderName:
+			return &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "Metadata",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					// v1alpha3 release series
+					{Major: 0, Minor: 6, Contract: "v1alpha3"},
+				},
+			}
 		default:
 			return nil
 		}

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -44,6 +44,7 @@ func Test_runGetRepositories(t *testing.T) {
 			g.Expect(runGetRepositories(path, buf)).To(Succeed())
 			out, err := ioutil.ReadAll(buf)
 			g.Expect(err).ToNot(HaveOccurred())
+
 			if val == RepositoriesOutputText {
 				g.Expect(string(out)).To(Equal(expectedOutputText))
 			} else if val == RepositoriesOutputYaml {
@@ -101,6 +102,7 @@ providers:
 var expectedOutputText = `NAME                TYPE                     URL                                                                                          FILE
 cluster-api         CoreProvider             https://github.com/myorg/myforkofclusterapi/releases/latest/                                 core_components.yaml
 another-provider    BootstrapProvider        ./                                                                                           bootstrap-components.yaml
+eks                 BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/                 eks-bootstrap-components.yaml
 kubeadm             BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api/releases/latest/                              bootstrap-components.yaml
 talos               BootstrapProvider        https://github.com/talos-systems/cluster-api-bootstrap-provider-talos/releases/latest/       bootstrap-components.yaml
 kubeadm             ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api/releases/latest/                              control-plane-components.yaml
@@ -125,6 +127,10 @@ var expectedOutputYaml = `- File: core_components.yaml
   Name: another-provider
   ProviderType: BootstrapProvider
   URL: ./
+- File: eks-bootstrap-components.yaml
+  Name: eks
+  ProviderType: BootstrapProvider
+  URL: https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/
 - File: bootstrap-components.yaml
   Name: kubeadm
   ProviderType: BootstrapProvider

--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -8,6 +8,7 @@ updated info about which API version they are supporting.
 ## Bootstrap
 - [Kubeadm](https://github.com/kubernetes-sigs/cluster-api/tree/master/bootstrap/kubeadm)
 - [Talos](https://github.com/talos-systems/cluster-api-bootstrap-provider-talos)
+- [EKS](https://github.com/kubernetes-sigs/cluster-api-provider-aws/tree/master/bootstrap/eks)
 
 
 ## Infrastructure


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
There's a new EKS bootstrap provider in CAPA and it should be a pre defined provider in `clusterctl`
https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/tag/v0.6.0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3620
