### PR TITLE
🌱 Predicates: move log delcarations inside closures

### DIFF
--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -26,10 +26,9 @@ import (
 // ClusterCreateInfraReady returns a predicate that returns true for a create event when a cluster has Status.InfrastructureReady set as true
 // it also returns true if the resource provided is not a Cluster to allow for use with controller-runtime NewControllerManagedBy
 func ClusterCreateInfraReady(logger logr.Logger) predicate.Funcs {
-	log := logger.WithValues("predicate", "ClusterCreateInfraReady")
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			log = log.WithValues("eventType", "create")
+			log := logger.WithValues("predicate", "ClusterCreateInfraReady", "eventType", "create")
 
 			c, ok := e.Object.(*clusterv1.Cluster)
 			if !ok {
@@ -57,14 +56,12 @@ func ClusterCreateInfraReady(logger logr.Logger) predicate.Funcs {
 // ClusterCreateNotPaused returns a predicate that returns true for a create event when a cluster has Spec.Paused set as false
 // it also returns true if the resource provided is not a Cluster to allow for use with controller-runtime NewControllerManagedBy
 func ClusterCreateNotPaused(logger logr.Logger) predicate.Funcs {
-	log := logger.WithValues("predicate", "ClusterCreateNotPaused")
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			log = log.WithValues("eventType", "create")
+			log := logger.WithValues("predicate", "ClusterCreateNotPaused", "eventType", "create")
 
 			c, ok := e.Object.(*clusterv1.Cluster)
 			if !ok {
-
 				log.V(4).Info("Expected Cluster", "type", e.Object.GetObjectKind().GroupVersionKind().String())
 				return false
 			}
@@ -88,10 +85,9 @@ func ClusterCreateNotPaused(logger logr.Logger) predicate.Funcs {
 // ClusterUpdateInfraReady returns a predicate that returns true for an update event when a cluster has Status.InfrastructureReady changed from false to true
 // it also returns true if the resource provided is not a Cluster to allow for use with controller-runtime NewControllerManagedBy
 func ClusterUpdateInfraReady(logger logr.Logger) predicate.Funcs {
-	log := logger.WithValues("predicate", "ClusterUpdateInfraReady")
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			log = log.WithValues("eventType", "update")
+			log := logger.WithValues("predicate", "ClusterUpdateInfraReady", "eventType", "update")
 
 			oldCluster, ok := e.ObjectOld.(*clusterv1.Cluster)
 			if !ok {
@@ -120,10 +116,9 @@ func ClusterUpdateInfraReady(logger logr.Logger) predicate.Funcs {
 // ClusterUpdateUnpaused returns a predicate that returns true for an update event when a cluster has Spec.Paused changed from true to false
 // it also returns true if the resource provided is not a Cluster to allow for use with controller-runtime NewControllerManagedBy
 func ClusterUpdateUnpaused(logger logr.Logger) predicate.Funcs {
-	log := logger.WithValues("predicate", "ClusterUpdateUnpaused")
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			log = log.WithValues("eventType", "update")
+			log := logger.WithValues("predicate", "ClusterUpdateUnpaused", "eventType", "update")
 
 			oldCluster, ok := e.ObjectOld.(*clusterv1.Cluster)
 			if !ok {

--- a/util/predicates/generic_predicates.go
+++ b/util/predicates/generic_predicates.go
@@ -30,9 +30,9 @@ import (
 
 // All returns a predicate that returns true only if all given predicates return true
 func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
-	log := logger.WithValues("predicateAggregation", "All")
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			log := logger.WithValues("predicateAggregation", "All")
 			for _, p := range predicates {
 				if !p.UpdateFunc(e) {
 					log.V(4).Info("One of the provided predicates returned false, blocking further processing")
@@ -43,6 +43,7 @@ func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 			return true
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
+			log := logger.WithValues("predicateAggregation", "All")
 			for _, p := range predicates {
 				if !p.CreateFunc(e) {
 					log.V(4).Info("One of the provided predicates returned false, blocking further processing")
@@ -53,6 +54,7 @@ func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
+			log := logger.WithValues("predicateAggregation", "All")
 			for _, p := range predicates {
 				if !p.DeleteFunc(e) {
 					log.V(4).Info("One of the provided predicates returned false, blocking further processing")
@@ -63,6 +65,7 @@ func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 			return true
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
+			log := logger.WithValues("predicateAggregation", "All")
 			for _, p := range predicates {
 				if !p.GenericFunc(e) {
 					log.V(4).Info("One of the provided predicates returned false, blocking further processing")
@@ -77,9 +80,9 @@ func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 
 // Any returns a predicate that returns true only if any given predicate returns true
 func Any(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
-	log := logger.WithValues("predicateAggregation", "Any")
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			log := logger.WithValues("predicateAggregation", "Any")
 			for _, p := range predicates {
 				if p.UpdateFunc(e) {
 					log.V(4).Info("One of the provided predicates returned true, allowing further processing")
@@ -90,6 +93,7 @@ func Any(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 			return false
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
+			log := logger.WithValues("predicateAggregation", "Any")
 			for _, p := range predicates {
 				if p.CreateFunc(e) {
 					log.V(4).Info("One of the provided predicates returned true, allowing further processing")
@@ -100,6 +104,7 @@ func Any(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
+			log := logger.WithValues("predicateAggregation", "Any")
 			for _, p := range predicates {
 				if p.DeleteFunc(e) {
 					log.V(4).Info("One of the provided predicates returned true, allowing further processing")
@@ -110,6 +115,7 @@ func Any(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 			return false
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
+			log := logger.WithValues("predicateAggregation", "Any")
 			for _, p := range predicates {
 				if p.GenericFunc(e) {
 					log.V(4).Info("One of the provided predicates returned true, allowing further processing")


### PR DESCRIPTION
**What this PR does / why we need it**:
Move log declarations inside function definitions to try to minimize
them escaping to the heap.

Part of #3609 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
