### PR TITLE
🌱 Eliminate extra DeepCopy for CRDs

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -527,10 +527,11 @@ func GetCRDWithContract(ctx context.Context, c client.Client, gvk schema.GroupVe
 			return nil, errors.Wrapf(err, "failed to list CustomResourceDefinitions for %v", gvk)
 		}
 
-		for _, crd := range crdList.Items {
+		for i := range crdList.Items {
+			crd := crdList.Items[i]
 			if crd.Spec.Group == gvk.Group &&
 				crd.Spec.Names.Kind == gvk.Kind {
-				return crd.DeepCopy(), nil
+				return &crd, nil
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Eliminate an unnecessary DeepCopy for CRDs - we only ever read them, and
they're already deep copied as part of the List() call from the cached
reader.

Part of #3609 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
