### PR TITLE
:seedling: Save a DeepCopy when patching typed objects

### DIFF
--- a/util/patch/patch.go
+++ b/util/patch/patch.go
@@ -54,11 +54,10 @@ func NewHelper(obj runtime.Object, crClient client.Client) (*Helper, error) {
 	}
 
 	// Convert the object to unstructured to compare against our before copy.
-	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj.DeepCopyObject())
+	unstructuredObj, err := toUnstructured(obj)
 	if err != nil {
 		return nil, err
 	}
-	unstructuredObj := &unstructured.Unstructured{Object: raw}
 
 	// Check if the object satisfies the Cluster API conditions contract.
 	_, canInterfaceConditions := obj.(conditions.Setter)
@@ -84,11 +83,11 @@ func (h *Helper) Patch(ctx context.Context, obj runtime.Object, opts ...Option) 
 	}
 
 	// Convert the object to unstructured to compare against our before copy.
-	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj.DeepCopyObject())
+	var err error
+	h.after, err = toUnstructured(obj)
 	if err != nil {
 		return err
 	}
-	h.after = &unstructured.Unstructured{Object: raw}
 
 	// Determine if the object has status.
 	if unstructuredHasStatus(h.after) {

--- a/util/patch/utils_test.go
+++ b/util/patch/utils_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+func TestToUnstructured(t *testing.T) {
+
+	t.Run("with a typed object", func(t *testing.T) {
+		g := NewWithT(t)
+		// Test with a typed object.
+		obj := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cluster-1",
+				Namespace: "namespace-1",
+			},
+			Spec: clusterv1.ClusterSpec{
+				Paused: true,
+			},
+		}
+		newObj, err := toUnstructured(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(newObj.GetName()).To(Equal(obj.Name))
+		g.Expect(newObj.GetNamespace()).To(Equal(obj.Namespace))
+
+		// Change a spec field and validate that it stays the same in the incoming object.
+		g.Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
+		g.Expect(obj.Spec.Paused).To(BeTrue())
+	})
+
+	t.Run("with an unstructured object", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "test.x.y.z/v1",
+				"metadata": map[string]interface{}{
+					"name":      "test-1",
+					"namespace": "namespace-1",
+				},
+				"spec": map[string]interface{}{
+					"paused": true,
+				},
+			},
+		}
+
+		newObj, err := toUnstructured(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(newObj.GetName()).To(Equal(obj.GetName()))
+		g.Expect(newObj.GetNamespace()).To(Equal(obj.GetNamespace()))
+
+		// Validate that the maps point to different addresses.
+		g.Expect(obj.Object).ToNot(BeIdenticalTo(newObj.Object))
+
+		// Change a spec field and validate that it stays the same in the incoming object.
+		g.Expect(unstructured.SetNestedField(newObj.Object, false, "spec", "paused")).To(Succeed())
+		pausedValue, _, err := unstructured.NestedBool(obj.Object, "spec", "paused")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(pausedValue).To(BeTrue())
+
+		// Change the name of the new object and make sure it doesn't change it the old one.
+		newObj.SetName("test-2")
+		g.Expect(obj.GetName()).To(Equal("test-1"))
+	})
+
+}


### PR DESCRIPTION
When using the patch helper to patch objects, we perform lots of
DeepCopy for safety purposes. After giving a closer look, it seems we
can definitely save one deep copy when the patch helper is created and
when Patch() is invoked by checking if the incoming object is
unstructured or not.

The deep copy was previously performed because the unstructured coverter
in the runtime package returns the inner map of an unstructured object
instead of making it a copy (this isn't a bug, it's how it's meant to be
used).

Signed-off-by: Vince Prignano <vincepri@vmware.com>

/milestone v0.3.10
