### PR TITLE
:seedling: Save a DeepCopy when calculating patches in Patch helper

### DIFF
--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -505,7 +505,7 @@ var _ = Describe("Patch Helper", func() {
 			}, timeout).Should(BeTrue())
 		})
 
-		Specify("updating both spec and status", func() {
+		Specify("updating both spec, status, and adding a condition", func() {
 			obj := obj.DeepCopy()
 			obj.ObjectMeta.Namespace = "test-namespace"
 
@@ -531,6 +531,9 @@ var _ = Describe("Patch Helper", func() {
 			By("Updating the object status")
 			obj.Status.InfrastructureReady = true
 
+			By("Setting Ready condition")
+			conditions.MarkTrue(obj, clusterv1.ReadyCondition)
+
 			By("Patching the object")
 			Expect(patcher.Patch(ctx, obj)).To(Succeed())
 
@@ -541,7 +544,8 @@ var _ = Describe("Patch Helper", func() {
 					return false
 				}
 
-				return reflect.DeepEqual(obj.Status, objAfter.Status) &&
+				return obj.Status.InfrastructureReady == objAfter.Status.InfrastructureReady &&
+					conditions.IsTrue(objAfter, clusterv1.ReadyCondition) &&
 					reflect.DeepEqual(obj.Spec, objAfter.Spec)
 			}, timeout).Should(BeTrue())
 		})

--- a/util/patch/utils.go
+++ b/util/patch/utils.go
@@ -60,3 +60,38 @@ func toUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
 	}
 	return &unstructured.Unstructured{Object: rawMap}, nil
 }
+
+// unsafeUnstructuredCopy returns a shallow copy of the unstructured object given as input.
+// It copies the common fields such as `kind`, `apiVersion`, `metadata` and the patchType specified.
+//
+// It's not safe to modify any of the keys in the returned unstructured object, the result should be treated as read-only.
+func unsafeUnstructuredCopy(obj *unstructured.Unstructured, focus patchType, isConditionsSetter bool) *unstructured.Unstructured {
+	// Create the return focused-unstructured object with a preallocated map.
+	res := &unstructured.Unstructured{Object: make(map[string]interface{}, len(obj.Object))}
+
+	// Ranges over the keys of the unstructured object, think of this as the very top level of an object
+	// when submitting a yaml to kubectl or a client.
+	// These would be keys like `apiVersion`, `kind`, `metadata`, `spec`, `status`, etc.
+	for key := range obj.Object {
+		value := obj.Object[key]
+
+		// Perform a shallow copy only for the keys we're interested in, or the ones that should be always preserved.
+		if key == focus.Key() || preserveUnstructuredKeys[key] {
+			res.Object[key] = value
+		}
+
+		// If we've determined that we're able to interface with conditions.Setter interface,
+		// when dealing with the status patch, remove the status.conditions sub-field from the object.
+		if isConditionsSetter && focus == statusPatch {
+			// NOTE: Removing status.conditions changes the incoming object! This is safe because the condition patch
+			// doesn't use the unstructured fields, and it runs before any other patch.
+			//
+			// If we want to be 100% safe, we could make a copy of the incoming object before modifying it, although
+			// copies have a high cpu and high memory usage, therefore we intentionally choose to avoid extra copies
+			// given that the ordering of operations and safety is handled internally by the patch helper.
+			unstructured.RemoveNestedField(res.Object, "status", "conditions")
+		}
+	}
+
+	return res
+}


### PR DESCRIPTION
This PR reshuffles the code in a way that avoids copying the
unstructured objects first and then removing un-needed parameters from
the final object.

With these changes we opt to operate a shallow copy of the unstructured
objects with only the keys that are of interest, and then covert these
back to the actual object.

/milestone v0.3.10
