### PR TITLE
🌱  Refactor MHC tests

### DIFF
--- a/controllers/machinehealthcheck_targets.go
+++ b/controllers/machinehealthcheck_targets.go
@@ -228,7 +228,11 @@ func (r *MachineHealthCheckReconciler) getNodeFromMachine(clusterClient client.R
 		Name: machine.Status.NodeRef.Name,
 	}
 	err := clusterClient.Get(context.TODO(), nodeKey, node)
-	return node, err
+	// if it cannot find a node, send a nil node back...
+	if err != nil {
+		return nil, err
+	}
+	return node, nil
 }
 
 // healthCheckTargets health checks a slice of targets

--- a/controllers/machinehealthcheck_targets_test.go
+++ b/controllers/machinehealthcheck_targets_test.go
@@ -92,7 +92,7 @@ func TestGetTargetsFromMHC(t *testing.T) {
 				{
 					Machine:     testMachine1,
 					MHC:         testMHC,
-					Node:        &corev1.Node{},
+					Node:        nil,
 					nodeMissing: true,
 				},
 			},

--- a/controllers/remote/suite_test.go
+++ b/controllers/remote/suite_test.go
@@ -41,11 +41,11 @@ var (
 	ctx     = context.Background()
 )
 
-func TestAPIs(t *testing.T) {
+func TestGinkgoSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
 
 	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
+		"Remote Controller Suite",
 		[]Reporter{printer.NewlineReporter{}})
 }
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -37,31 +38,17 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
 const (
 	timeout = time.Second * 30
 )
 
 var (
-	testEnv           *helpers.TestEnvironment
-	clusterReconciler *ClusterReconciler
-	ctx               = context.Background()
+	testEnv *helpers.TestEnvironment
+	ctx     = context.Background()
 )
 
-func TestAPIs(t *testing.T) {
-	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
-	SetDefaultEventuallyTimeout(30 * time.Second)
-	RegisterFailHandler(Fail)
-
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
-}
-
-var _ = BeforeSuite(func(done Done) {
-	By("bootstrapping test environment")
+func TestMain(m *testing.M) {
+	fmt.Println("Creating new test environment")
 	testEnv = helpers.NewTestEnvironment()
 
 	// Set up a ClusterCacheTracker and ClusterCacheReconciler to provide to controllers
@@ -70,61 +57,85 @@ var _ = BeforeSuite(func(done Done) {
 		log.Log,
 		testEnv.Manager,
 	)
-	Expect(err).ToNot(HaveOccurred())
-
-	Expect((&remote.ClusterCacheReconciler{
+	if err != nil {
+		panic(fmt.Sprintf("unable to create cluster cache tracker: %v", err))
+	}
+	if err := (&remote.ClusterCacheReconciler{
 		Client:  testEnv,
 		Log:     log.Log,
 		Tracker: tracker,
-	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
-
-	clusterReconciler = &ClusterReconciler{
-		Client:   testEnv,
-		Log:      log.Log,
-		recorder: testEnv.GetEventRecorderFor("cluster-controller"),
+	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		panic(fmt.Sprintf("Failed to start ClusterCacheReconciler: %v", err))
 	}
-	Expect(clusterReconciler.SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
-	Expect((&MachineReconciler{
+	if err := (&ClusterReconciler{
 		Client:   testEnv,
-		Log:      log.Log,
+		Log:      log.Log.WithName("controllers").WithName("Cluster"),
+		recorder: testEnv.GetEventRecorderFor("cluster-controller"),
+	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		panic(fmt.Sprintf("Failed to start ClusterReconciler: %v", err))
+	}
+	if err := (&MachineReconciler{
+		Client:   testEnv,
+		Log:      log.Log.WithName("controllers").WithName("Machine"),
 		Tracker:  tracker,
 		recorder: testEnv.GetEventRecorderFor("machine-controller"),
-	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
-	Expect((&MachineSetReconciler{
+	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		panic(fmt.Sprintf("Failed to start MachineReconciler: %v", err))
+	}
+	if err := (&MachineSetReconciler{
 		Client:   testEnv,
-		Log:      log.Log,
+		Log:      log.Log.WithName("controllers").WithName("MachineSet"),
 		Tracker:  tracker,
 		recorder: testEnv.GetEventRecorderFor("machineset-controller"),
-	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
-	Expect((&MachineDeploymentReconciler{
+	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		panic(fmt.Sprintf("Failed to start MMachineSetReconciler: %v", err))
+	}
+	if err := (&MachineDeploymentReconciler{
 		Client:   testEnv,
-		Log:      log.Log,
+		Log:      log.Log.WithName("controllers").WithName("MachineDeployment"),
 		recorder: testEnv.GetEventRecorderFor("machinedeployment-controller"),
-	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
-	Expect((&MachineHealthCheckReconciler{
+	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		panic(fmt.Sprintf("Failed to start MMachineDeploymentReconciler: %v", err))
+	}
+	if err := (&MachineHealthCheckReconciler{
 		Client:   testEnv,
-		Log:      log.Log,
+		Log:      log.Log.WithName("controllers").WithName("MachineHealthCheck"),
 		Tracker:  tracker,
 		recorder: testEnv.GetEventRecorderFor("machinehealthcheck-controller"),
-	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
+	}).SetupWithManager(testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		panic(fmt.Sprintf("Failed to start MachineHealthCheckReconciler : %v", err))
+	}
 
-	By("starting the manager")
 	go func() {
-		defer GinkgoRecover()
-		Expect(testEnv.StartManager()).To(Succeed())
+		fmt.Println("Starting the manager")
+		if err := testEnv.StartManager(); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
 	}()
-
 	// wait for webhook port to be open prior to running tests
 	testEnv.WaitForWebhooks()
-	close(done)
-}, 80)
 
-var _ = AfterSuite(func() {
-	if testEnv != nil {
-		By("tearing down the test environment")
-		Expect(testEnv.Stop()).To(Succeed())
+	code := m.Run()
+
+	fmt.Println("Tearing down test suite")
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
 	}
-})
+
+	os.Exit(code)
+}
+
+// TestGinkgoSuite will run the ginkgo tests.
+// This will run with the testEnv setup and teardown in TestMain.
+func TestGinkgoSuite(t *testing.T) {
+	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
+	SetDefaultEventuallyTimeout(timeout)
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controllers Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
 
 func ContainRefOfGroupKind(group, kind string) types.GomegaMatcher {
 	return &refGroupKindMatcher{

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -121,7 +121,6 @@ type TestEnvironment struct {
 // This function should be called only once for each package you're running tests within,
 // usually the environment is initialized in a suite_test.go file within a `BeforeSuite` ginkgo block.
 func NewTestEnvironment() *TestEnvironment {
-
 	// initialize webhook here to be able to test the envtest install via webhookOptions
 	// This should set LocalServingCertDir and LocalServingPort that are used below.
 	initializeWebhookInEnvironment()


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR refactors some flaky MHC tests. It is moving us away from Ginkgo to vanilla Go test with envtest.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3539 

**NOTES**
- There are currently three tests that have been marked with `t.Skip`. As of now, they seem to be the most flaky (on my machine). Also there is an opportunity to refactor them using conditions. See #3026 for more info. The refactor of these tests can be done in separate PRs if not part of the work for #3026.
- There are still Ginkgo tests in the `controllers` package. We should refactor those tests as well, so that we can have more consistent tests. This can be done in subsequent PRs. IMO these are great `good-first-issue`s and helps make our test codebase more consistent!