### PR TITLE
:bug: util.HasOwner should not compare with the API version

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -493,15 +493,25 @@ func UnstructuredUnmarshalField(obj *unstructured.Unstructured, v interface{}, f
 	return nil
 }
 
-// HasOwner checks if any of the references in the passed list match the given apiVersion and one of the given kinds
+// HasOwner checks if any of the references in the passed list match the given group from apiVersion and one of the given kinds.
 func HasOwner(refList []metav1.OwnerReference, apiVersion string, kinds []string) bool {
+	gv, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return false
+	}
+
 	kMap := make(map[string]bool)
 	for _, kind := range kinds {
 		kMap[kind] = true
 	}
 
 	for _, mr := range refList {
-		if mr.APIVersion == apiVersion && kMap[mr.Kind] {
+		mrGroupVersion, err := schema.ParseGroupVersion(mr.APIVersion)
+		if err != nil {
+			return false
+		}
+
+		if mrGroupVersion.Group == gv.Group && kMap[mr.Kind] {
 			return true
 		}
 	}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -256,6 +256,26 @@ func TestHasOwner(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "owned by cluster from older version",
+			refList: []metav1.OwnerReference{
+				{
+					Kind:       "Cluster",
+					APIVersion: "cluster.x-k8s.io/v1alpha2",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "owned by a MachineDeployment from older version",
+			refList: []metav1.OwnerReference{
+				{
+					Kind:       "MachineDeployment",
+					APIVersion: "cluster.x-k8s.io/v1alpha2",
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "owned by something else",
 			refList: []metav1.OwnerReference{
 				{


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fixes an issue where a v1alpha2 MachineSet that has an owner reference with an older API version, after being reconciled with a v1alpha3 controller, thinks it doesn't have an owner.

/milestone v0.3.10
/assign @ncdc 
