### PR TITLE
🌱 Clusterctl now logs when objects aren't moved

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -88,7 +88,9 @@ func (o *objectMover) Move(namespace string, toCluster Client, dryRun bool) erro
 	if err := o.checkProvisioningCompleted(objectGraph); err != nil {
 		return err
 	}
-	//TODO: consider if to add additional preflight checks ensuring the object graph is complete (no virtual nodes left)
+
+	// Check whether nodes are not included in GVK considered for move
+	objectGraph.checkVirtualNode()
 
 	// Move the objects to the target cluster.
 	var proxy Proxy

--- a/cmd/clusterctl/client/cluster/objectgraph.go
+++ b/cmd/clusterctl/client/cluster/objectgraph.go
@@ -479,3 +479,13 @@ func (o *objectGraph) setCRSTenant(node, tenant *node) {
 		}
 	}
 }
+
+// checkVirtualNode logs if nodes are still virtual
+func (o *objectGraph) checkVirtualNode() {
+	log := logf.Log
+	for _, node := range o.uidToNode {
+		if node.virtual {
+			log.V(5).Info("Object won't be moved because it's not included in GVK considered for move", "kind", node.identity.Kind, "name", node.identity.Name)
+		}
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

add a virtual node checker , so that we can remove the TODO in mover function

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
