### PR TITLE
:seedling: Support patch ForceOverwriteConditions option

### DIFF
--- a/util/patch/options.go
+++ b/util/patch/options.go
@@ -30,9 +30,24 @@ type HelperOptions struct {
 	// on the incoming object to match metadata.generation, only if there is a change.
 	IncludeStatusObservedGeneration bool
 
+	// ForceOverwriteConditions allows the patch helper to overwrite conditions in case of conflicts.
+	// This option should only ever be set in controller managing the object being patched.
+	ForceOverwriteConditions bool
+
 	// OwnedConditions defines condition types owned by the controller.
 	// In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+	//
+	// DEPRECATED: Use ForceOverwriteConditions.
 	OwnedConditions []clusterv1.ConditionType
+}
+
+// WithForceOverwriteConditions allows the patch helper to overwrite conditions in case of conflicts.
+// This option should only ever be set in controller managing the object being patched.
+type WithForceOverwriteConditions struct{}
+
+// ApplyToHelper applies this configuration to the given HelperOptions.
+func (w WithForceOverwriteConditions) ApplyToHelper(in *HelperOptions) {
+	in.ForceOverwriteConditions = true
 }
 
 // WithStatusObservedGeneration sets the status.observedGeneration field
@@ -46,6 +61,8 @@ func (w WithStatusObservedGeneration) ApplyToHelper(in *HelperOptions) {
 
 // WithOwnedConditions allows to define condition types owned by the controller.
 // In case of conflicts for the owned conditions, the patch helper will always use the value provided by the controller.
+//
+// DEPRECATED: Use WithForceOverwriteConditions.
 type WithOwnedConditions struct {
 	Conditions []clusterv1.ConditionType
 }

--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -321,7 +321,7 @@ var _ = Describe("Patch Helper", func() {
 				}, timeout).Should(BeTrue())
 			})
 
-			Specify("should return not an error if there is an unresolvable conflict but the conditions is owned by the controller", func() {
+			Specify("should not return an error if there is an unresolvable conflict but the conditions is owned by the controller", func() {
 				obj := obj.DeepCopy()
 
 				By("Creating the object")
@@ -348,6 +348,48 @@ var _ = Describe("Patch Helper", func() {
 
 				By("Patching the object")
 				Expect(patcher.Patch(ctx, obj, WithOwnedConditions{Conditions: []clusterv1.ConditionType{clusterv1.ReadyCondition}})).To(Succeed())
+
+				By("Validating the object has been updated")
+				Eventually(func() bool {
+					objAfter := obj.DeepCopy()
+					if err := testEnv.Get(ctx, key, objAfter); err != nil {
+						return false
+					}
+
+					readyBefore := conditions.Get(obj, clusterv1.ReadyCondition)
+					readyAfter := conditions.Get(objAfter, clusterv1.ReadyCondition)
+
+					return cmp.Equal(readyBefore, readyAfter)
+				}, timeout).Should(BeTrue())
+			})
+
+			Specify("should not return an error if there is an unresolvable conflict when force overwrite is enabled", func() {
+				obj := obj.DeepCopy()
+
+				By("Creating the object")
+				Expect(testEnv.Create(ctx, obj)).ToNot(HaveOccurred())
+				key := client.ObjectKey{Name: obj.Name, Namespace: obj.Namespace}
+				defer func() {
+					Expect(testEnv.Delete(ctx, obj)).To(Succeed())
+				}()
+				objCopy := obj.DeepCopy()
+
+				By("Marking a custom condition to be false")
+				conditions.MarkFalse(objCopy, clusterv1.ReadyCondition, "reason", clusterv1.ConditionSeverityInfo, "message")
+				Expect(testEnv.Status().Update(ctx, objCopy)).To(Succeed())
+
+				By("Validating that the local object's resource version is behind")
+				Expect(obj.ResourceVersion).ToNot(Equal(objCopy.ResourceVersion))
+
+				By("Creating a new patch helper")
+				patcher, err := NewHelper(obj, testEnv)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Marking Ready=True")
+				conditions.MarkTrue(obj, clusterv1.ReadyCondition)
+
+				By("Patching the object")
+				Expect(patcher.Patch(ctx, obj, WithForceOverwriteConditions{})).To(Succeed())
 
 				By("Validating the object has been updated")
 				Eventually(func() bool {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds support for an option in the patch helper that allows controllers to force-overwrite conditions in case of a conflict.

This option should only be used in owning controllers, for example the Machine controller can set it when patching machines. While nothing will stop a different controller from using this option on non-owned objects, this is true as well if folks aren't using our patch helper.

/assign @ncdc @fabriziopandini 
