### PR TITLE
🌱 Fix yaml file write issue in create-local-repository.py

### DIFF
--- a/cmd/clusterctl/hack/create-local-repository.py
+++ b/cmd/clusterctl/hack/create-local-repository.py
@@ -126,7 +126,7 @@ def write_local_repository(provider, version, components_file, components_yaml):
             if e.errno != errno.EEXIST:
                 raise
         components_path = os.path.join(provider_folder, components_file)
-        f = open(components_path, 'w')
+        f = open(components_path, 'wb')
         f.write(components_yaml)
         f.close()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a file write issue in create-local-repository.py which is detected during component upgrade using clusterctl.

**Which issue(s) this PR fixes**
```
Traceback (most recent call last):
File "cmd/clusterctl/hack/create-local-repository.py", line 130, in write_local_repository
f.write(components_yaml)
TypeError: write() argument must be str, not bytes

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "cmd/clusterctl/hack/create-local-repository.py", line 241, in
repos = list(create_local_repositories())
File "cmd/clusterctl/hack/create-local-repository.py", line 162, in create_local_repositories
components_path = write_local_repository(provider, next_version, components_file, components_yaml)
File "cmd/clusterctl/hack/create-local-repository.py", line 138, in write_local_repository
raise Exception('failed to write {} to {}: {}'.format(components_file, provider_folder, e))
Exception: failed to write core-components.yaml to /home/****/.cluster-api/dev-repository/cluster-api/v0.3.8: write() argument must be str, not bytes

```