### PR TITLE
⚠️ Eliminate possible deadlocks in ClusterCacheTracker

### DIFF
--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -404,6 +404,7 @@ func (r *MachineHealthCheckReconciler) watchClusterNodes(ctx context.Context, cl
 	}
 
 	if err := r.Tracker.Watch(ctx, remote.WatchInput{
+		Name:         "machinehealthcheck-watchClusterNodes",
 		Cluster:      util.ObjectKey(cluster),
 		Watcher:      r.controller,
 		Kind:         &corev1.Node{},

--- a/controllers/remote/cluster_cache.go
+++ b/controllers/remote/cluster_cache.go
@@ -18,19 +18,15 @@ package remote
 
 import (
 	"context"
-	"fmt"
-	"reflect"
 	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -39,10 +35,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -54,57 +48,150 @@ const (
 	healthCheckUnhealthyThreshold = 10
 )
 
-// clusterCache embeds cache.Cache and combines it with a stop channel.
-type clusterCache struct {
-	cache.Cache
-
-	lock    sync.Mutex
-	mapper  meta.RESTMapper
-	stopped bool
-	stop    chan struct{}
-}
-
-// Stop closes the cache.Cache's stop channel if it has not already been stopped.
-func (cc *clusterCache) Stop() {
-	cc.lock.Lock()
-	defer cc.lock.Unlock()
-
-	if cc.stopped {
-		return
-	}
-
-	cc.stopped = true
-	close(cc.stop)
-}
-
 // ClusterCacheTracker manages client caches for workload clusters.
 type ClusterCacheTracker struct {
 	log    logr.Logger
 	client client.Client
 	scheme *runtime.Scheme
 
-	delegatingClientsLock sync.RWMutex
-	delegatingClients     map[client.ObjectKey]*client.DelegatingClient
-
-	clusterCachesLock sync.RWMutex
-	clusterCaches     map[client.ObjectKey]*clusterCache
-
-	watchesLock sync.RWMutex
-	watches     map[client.ObjectKey]map[watchInfo]struct{}
+	lock             sync.RWMutex
+	clusterAccessors map[client.ObjectKey]*clusterAccessor
 }
 
 // NewClusterCacheTracker creates a new ClusterCacheTracker.
 func NewClusterCacheTracker(log logr.Logger, manager ctrl.Manager) (*ClusterCacheTracker, error) {
-	m := &ClusterCacheTracker{
-		log:               log,
-		client:            manager.GetClient(),
-		scheme:            manager.GetScheme(),
-		delegatingClients: make(map[client.ObjectKey]*client.DelegatingClient),
-		clusterCaches:     make(map[client.ObjectKey]*clusterCache),
-		watches:           make(map[client.ObjectKey]map[watchInfo]struct{}),
+	return &ClusterCacheTracker{
+		log:              log,
+		client:           manager.GetClient(),
+		scheme:           manager.GetScheme(),
+		clusterAccessors: make(map[client.ObjectKey]*clusterAccessor),
+	}, nil
+}
+
+// GetClient returns a client for the given cluster.
+func (t *ClusterCacheTracker) GetClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	accessor, err := t.getClusterAccessorLH(ctx, cluster)
+	if err != nil {
+		return nil, err
 	}
 
-	return m, nil
+	return accessor.client, nil
+}
+
+// clusterAccessor represents the combination of a client, cache, and watches for a remote cluster.
+type clusterAccessor struct {
+	cache   *stoppableCache
+	client  *client.DelegatingClient
+	watches sets.String
+}
+
+// clusterAccessorExists returns true if a clusterAccessor exists for cluster.
+func (t *ClusterCacheTracker) clusterAccessorExists(cluster client.ObjectKey) bool {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	_, exists := t.clusterAccessors[cluster]
+	return exists
+}
+
+// getClusterAccessorLH first tries to return an already-created clusterAccessor for cluster, falling back to creating a
+// new clusterAccessor if needed. Note, this method requires t.lock to already be held (LH=lock held).
+func (t *ClusterCacheTracker) getClusterAccessorLH(ctx context.Context, cluster client.ObjectKey) (*clusterAccessor, error) {
+	a := t.clusterAccessors[cluster]
+	if a != nil {
+		return a, nil
+	}
+
+	a, err := t.newClusterAccessor(ctx, cluster)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating client and cache for remote cluster")
+	}
+
+	t.clusterAccessors[cluster] = a
+
+	return a, nil
+}
+
+// newClusterAccessor creates a new clusterAccessor.
+func (t *ClusterCacheTracker) newClusterAccessor(ctx context.Context, cluster client.ObjectKey) (*clusterAccessor, error) {
+	// Get a rest config for the remote cluster
+	config, err := RESTConfig(ctx, t.client, cluster)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error fetching REST client config for remote cluster %q", cluster.String())
+	}
+	config.Timeout = defaultClientTimeout
+
+	// Create a mapper for it
+	mapper, err := apiutil.NewDynamicRESTMapper(config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating dynamic rest mapper for remote cluster %q", cluster.String())
+	}
+
+	// Create the client for the remote cluster
+	c, err := client.New(config, client.Options{Scheme: t.scheme, Mapper: mapper})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating client for remote cluster %q", cluster.String())
+	}
+
+	// Create the cache for the remote cluster
+	cacheOptions := cache.Options{
+		Scheme: t.scheme,
+		Mapper: mapper,
+	}
+	remoteCache, err := cache.New(config, cacheOptions)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating cache for remote cluster %q", cluster.String())
+	}
+
+	// We need to be able to stop the cache's shared informers, so wrap this in a stoppableCache.
+	cache := &stoppableCache{
+		Cache: remoteCache,
+		stop:  make(chan struct{}),
+	}
+
+	// Start the cache!!!
+	go cache.Start(cache.stop)
+
+	// Start cluster healthcheck!!!
+	go t.healthCheckCluster(&healthCheckInput{
+		stop:    cache.stop,
+		cluster: cluster,
+		cfg:     config,
+	})
+
+	delegatingClient := &client.DelegatingClient{
+		Reader:       cache,
+		Writer:       c,
+		StatusClient: c,
+	}
+
+	return &clusterAccessor{
+		cache:   cache,
+		client:  delegatingClient,
+		watches: sets.NewString(),
+	}, nil
+}
+
+// deleteAccessor stops a clusterAccessor's cache and removes the clusterAccessor from the tracker.
+func (t *ClusterCacheTracker) deleteAccessor(cluster client.ObjectKey) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	a, exists := t.clusterAccessors[cluster]
+	if !exists {
+		return
+	}
+
+	t.log.V(2).Info("Deleting clusterAccessor", "cluster", cluster.String())
+
+	t.log.V(4).Info("Stopping cache", "cluster", cluster.String())
+	a.cache.Stop()
+	t.log.V(4).Info("Cache stopped", "cluster", cluster.String())
+
+	delete(t.clusterAccessors, cluster)
 }
 
 // Watcher is a scoped-down interface from Controller that only knows how to watch.
@@ -113,52 +200,11 @@ type Watcher interface {
 	Watch(src source.Source, eventHandler handler.EventHandler, predicates ...predicate.Predicate) error
 }
 
-// watchInfo is used as a map key to uniquely identify a watch. Because predicates is a slice, it cannot be included.
-type watchInfo struct {
-	watcher Watcher
-	gvk     schema.GroupVersionKind
-
-	// Comparing the eventHandler as an interface doesn't work because reflect.DeepEqual
-	// will assert functions are false if they are non-nil.
-	// Use a signature string representation instead as this can be compared.
-	// The signature function is expected to produce a unique output for each unique handler
-	// function that is passed to it.
-	// In combination with the watcher, this should be enough to identify unique watches.
-	eventHandlerSignature string
-}
-
-// eventHandlerSignature generates a unique identifier for the given eventHandler by
-// printing it to a string using "%#v".
-// Eg "&handler.EnqueueRequestsFromMapFunc{ToRequests:(handler.ToRequestsFunc)(0x271afb0)}"
-func eventHandlerSignature(h handler.EventHandler) string {
-	return fmt.Sprintf("%#v", h)
-}
-
-// watchExists returns true if watch has already been established. This does NOT hold any lock.
-func (m *ClusterCacheTracker) watchExists(cluster client.ObjectKey, watch watchInfo) bool {
-	watchesForCluster, clusterFound := m.watches[cluster]
-	if !clusterFound {
-		return false
-	}
-
-	for w := range watchesForCluster {
-		if reflect.DeepEqual(w, watch) {
-			return true
-		}
-	}
-	return false
-}
-
-// deleteWatchesForCluster removes the watches for cluster from the tracker.
-func (m *ClusterCacheTracker) deleteWatchesForCluster(cluster client.ObjectKey) {
-	m.watchesLock.Lock()
-	defer m.watchesLock.Unlock()
-
-	delete(m.watches, cluster)
-}
-
 // WatchInput specifies the parameters used to establish a new watch for a remote cluster.
 type WatchInput struct {
+	// Name represents a unique watch request for the specified Cluster.
+	Name string
+
 	// Cluster is the key for the remote cluster.
 	Cluster client.ObjectKey
 
@@ -175,198 +221,33 @@ type WatchInput struct {
 	Predicates []predicate.Predicate
 }
 
-// Watch watches a remote cluster for resource events. If the watch already exists based on cluster, watcher,
-// kind, and eventHandler, then this is a no-op.
-func (m *ClusterCacheTracker) Watch(ctx context.Context, input WatchInput) error {
-	gvk, err := apiutil.GVKForObject(input.Kind, m.scheme)
+// Watch watches a remote cluster for resource events. If the watch already exists based on input.Name, this is a no-op.
+func (t *ClusterCacheTracker) Watch(ctx context.Context, input WatchInput) error {
+	if input.Name == "" {
+		return errors.New("input.Name is required")
+	}
+
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	a, err := t.getClusterAccessorLH(ctx, input.Cluster)
 	if err != nil {
 		return err
 	}
 
-	wi := watchInfo{
-		watcher:               input.Watcher,
-		gvk:                   gvk,
-		eventHandlerSignature: eventHandlerSignature(input.EventHandler),
-	}
-
-	// First, check if the watch already exists
-	var exists bool
-	m.watchesLock.RLock()
-	exists = m.watchExists(input.Cluster, wi)
-	m.watchesLock.RUnlock()
-
-	if exists {
-		m.log.V(4).Info("Watch already exists", "namespace", input.Cluster.Namespace, "cluster", input.Cluster.Name, "kind", fmt.Sprintf("%T", input.Kind))
-		return nil
-	}
-
-	// Doesn't exist - grab the write lock
-	m.watchesLock.Lock()
-	defer m.watchesLock.Unlock()
-
-	// Need to check if another goroutine created the watch while this one was waiting for the lock
-	if m.watchExists(input.Cluster, wi) {
-		m.log.V(4).Info("Watch already exists", "namespace", input.Cluster.Namespace, "cluster", input.Cluster.Name, "kind", fmt.Sprintf("%T", input.Kind))
+	if a.watches.Has(input.Name) {
+		t.log.V(4).Info("Watch already exists", "namespace", input.Cluster.Namespace, "cluster", input.Cluster.Name, "name", input.Name)
 		return nil
 	}
 
 	// Need to create the watch
-	watchesForCluster, found := m.watches[input.Cluster]
-	if !found {
-		watchesForCluster = make(map[watchInfo]struct{})
-		m.watches[input.Cluster] = watchesForCluster
-	}
-
-	cache, err := m.getOrCreateClusterCache(ctx, input.Cluster)
-	if err != nil {
-		return err
-	}
-
-	if err := input.Watcher.Watch(source.NewKindWithCache(input.Kind, cache), input.EventHandler, input.Predicates...); err != nil {
+	if err := input.Watcher.Watch(source.NewKindWithCache(input.Kind, a.cache), input.EventHandler, input.Predicates...); err != nil {
 		return errors.Wrap(err, "error creating watch")
 	}
 
-	watchesForCluster[wi] = struct{}{}
+	a.watches.Insert(input.Name)
 
 	return nil
-}
-
-// GetClient returns a client for the given cluster.
-func (m *ClusterCacheTracker) GetClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error) {
-	return m.getOrCreateDelegatingClient(ctx, cluster)
-}
-
-// getOrCreateClusterClient returns a delegating client for the specified cluster, creating a new one if needed.
-func (m *ClusterCacheTracker) getOrCreateDelegatingClient(ctx context.Context, cluster client.ObjectKey) (client.Client, error) {
-	c := m.getDelegatingClient(cluster)
-	if c != nil {
-		return c, nil
-	}
-
-	return m.newDelegatingClient(ctx, cluster)
-}
-
-// getClusterCache returns the clusterCache for cluster, or nil if it does not exist.
-func (m *ClusterCacheTracker) getDelegatingClient(cluster client.ObjectKey) *client.DelegatingClient {
-	m.delegatingClientsLock.RLock()
-	defer m.delegatingClientsLock.RUnlock()
-
-	return m.delegatingClients[cluster]
-}
-
-// newDelegatingClient creates a new delegating client.
-func (m *ClusterCacheTracker) newDelegatingClient(ctx context.Context, cluster client.ObjectKey) (*client.DelegatingClient, error) {
-	m.delegatingClientsLock.Lock()
-	defer m.delegatingClientsLock.Unlock()
-
-	// If another goroutine created the client while this one was waiting to acquire the write lock, return that
-	// instead of overwriting it.
-	if delegatingClient, exists := m.delegatingClients[cluster]; exists {
-		return delegatingClient, nil
-	}
-
-	cache, err := m.getOrCreateClusterCache(ctx, cluster)
-	if err != nil {
-		return nil, err
-	}
-	config, err := RESTConfig(ctx, m.client, cluster)
-	if err != nil {
-		return nil, errors.Wrap(err, "error fetching REST client config for remote cluster")
-	}
-	config.Timeout = defaultClientTimeout
-	c, err := client.New(config, client.Options{Scheme: m.scheme, Mapper: cache.mapper})
-	if err != nil {
-		return nil, err
-	}
-	delegatingClient := &client.DelegatingClient{
-		Reader:       cache,
-		Writer:       c,
-		StatusClient: c,
-	}
-	m.delegatingClients[cluster] = delegatingClient
-	return delegatingClient, nil
-}
-
-func (m *ClusterCacheTracker) deleteDelegatingClient(cluster client.ObjectKey) {
-	m.delegatingClientsLock.Lock()
-	defer m.delegatingClientsLock.Unlock()
-
-	delete(m.delegatingClients, cluster)
-}
-
-// getOrCreateClusterCache returns the clusterCache for cluster, creating a new ClusterCache if needed.
-func (m *ClusterCacheTracker) getOrCreateClusterCache(ctx context.Context, cluster client.ObjectKey) (*clusterCache, error) {
-	cache := m.getClusterCache(cluster)
-	if cache != nil {
-		return cache, nil
-	}
-
-	return m.newClusterCache(ctx, cluster)
-}
-
-// getClusterCache returns the clusterCache for cluster, or nil if it does not exist.
-func (m *ClusterCacheTracker) getClusterCache(cluster client.ObjectKey) *clusterCache {
-	m.clusterCachesLock.RLock()
-	defer m.clusterCachesLock.RUnlock()
-
-	return m.clusterCaches[cluster]
-}
-
-// newClusterCache creates and starts a new clusterCache for cluster.
-func (m *ClusterCacheTracker) newClusterCache(ctx context.Context, cluster client.ObjectKey) (*clusterCache, error) {
-	m.clusterCachesLock.Lock()
-	defer m.clusterCachesLock.Unlock()
-
-	// If another goroutine created the cache while this one was waiting to acquire the write lock, return that
-	// instead of overwriting it.
-	if c, exists := m.clusterCaches[cluster]; exists {
-		return c, nil
-	}
-
-	config, err := RESTConfig(ctx, m.client, cluster)
-	if err != nil {
-		return nil, errors.Wrap(err, "error fetching REST client config for remote cluster")
-	}
-
-	mapper, err := apiutil.NewDynamicRESTMapper(config)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating dynamic rest mapper for remote cluster")
-	}
-
-	cacheOptions := cache.Options{
-		Scheme: m.scheme,
-		Mapper: mapper,
-	}
-	remoteCache, err := cache.New(config, cacheOptions)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating cache for remote cluster")
-	}
-	stop := make(chan struct{})
-
-	cc := &clusterCache{
-		Cache:  remoteCache,
-		stop:   stop,
-		mapper: mapper,
-	}
-	m.clusterCaches[cluster] = cc
-
-	// Start the cache!!!
-	go remoteCache.Start(cc.stop)
-	// Start cluster healthcheck!!!
-	go m.healthCheckCluster(&healthCheckInput{
-		stop:    cc.stop,
-		cluster: cluster,
-		cfg:     config,
-	})
-
-	return cc, nil
-}
-
-func (m *ClusterCacheTracker) deleteClusterCache(cluster client.ObjectKey) {
-	m.clusterCachesLock.Lock()
-	defer m.clusterCachesLock.Unlock()
-
-	delete(m.clusterCaches, cluster)
 }
 
 // healthCheckInput provides the input for the healthCheckCluster method
@@ -380,8 +261,8 @@ type healthCheckInput struct {
 	path               string
 }
 
-// validate sets default values if optional parameters are not set
-func (h *healthCheckInput) validate() {
+// setDefaults sets default values if optional parameters are not set
+func (h *healthCheckInput) setDefaults() {
 	if h.interval == 0 {
 		h.interval = healthCheckPollInterval
 	}
@@ -399,16 +280,17 @@ func (h *healthCheckInput) validate() {
 // healthCheckCluster will poll the cluster's API at the path given and, if there are
 // `unhealthyThreshold` consecutive failures, will deem the cluster unhealthy.
 // Once the cluster is deemed unhealthy, the cluster's cache is stopped and removed.
-func (m *ClusterCacheTracker) healthCheckCluster(in *healthCheckInput) {
+func (t *ClusterCacheTracker) healthCheckCluster(in *healthCheckInput) {
 	// populate optional params for healthCheckInput
-	in.validate()
+	in.setDefaults()
 
 	unhealthyCount := 0
 
+	// This gets us a client that can make raw http(s) calls to the remote apiserver. We only need to create it once
+	// and we can reuse it inside the polling loop.
 	codec := runtime.NoopEncoder{Decoder: scheme.Codecs.UniversalDecoder()}
 	cfg := rest.CopyConfig(in.cfg)
 	cfg.NegotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{Serializer: codec})
-
 	restClient, restClientErr := rest.UnversionedRESTClientFor(cfg)
 
 	runHealthCheckWithThreshold := func() (bool, error) {
@@ -417,7 +299,7 @@ func (m *ClusterCacheTracker) healthCheckCluster(in *healthCheckInput) {
 		}
 
 		cluster := &clusterv1.Cluster{}
-		if err := m.client.Get(context.TODO(), in.cluster, cluster); err != nil {
+		if err := t.client.Get(context.TODO(), in.cluster, cluster); err != nil {
 			if apierrors.IsNotFound(err) {
 				// If the cluster can't be found, we should delete the cache.
 				return false, err
@@ -425,22 +307,21 @@ func (m *ClusterCacheTracker) healthCheckCluster(in *healthCheckInput) {
 			// Otherwise, requeue.
 			return false, nil
 		}
+
 		if !cluster.Status.InfrastructureReady || !cluster.Status.ControlPlaneInitialized {
 			// If the infrastructure or control plane aren't marked as ready, we should requeue and wait.
 			return false, nil
 		}
 
-		remoteCache := m.getClusterCache(in.cluster)
-		if remoteCache == nil {
+		if !t.clusterAccessorExists(in.cluster) {
 			// Cache for this cluster has already been cleaned up.
 			// Nothing to do, so return true.
 			return true, nil
 		}
 
-		// healthCheckPath returning an error is considered a failed health check
-		// (Either an issue was encountered connecting or the API returned an error).
-		// If no error occurs, reset the unhealthy coutner.
-		err := healthCheckPath(restClient, in.requestTimeout, in.path)
+		// An error here means there was either an issue connecting or the API returned an error.
+		// If no error occurs, reset the unhealthy counter.
+		_, err := restClient.Get().AbsPath(in.path).Timeout(in.requestTimeout).DoRaw()
 		if err != nil {
 			unhealthyCount++
 		} else {
@@ -448,9 +329,7 @@ func (m *ClusterCacheTracker) healthCheckCluster(in *healthCheckInput) {
 		}
 
 		if unhealthyCount >= in.unhealthyThreshold {
-			// `healthCheckUnhealthyThreshold` (or more) consecutive failures.
 			// Cluster is now considered unhealthy.
-			// return last error from `doHealthCheck`
 			return false, err
 		}
 
@@ -461,83 +340,7 @@ func (m *ClusterCacheTracker) healthCheckCluster(in *healthCheckInput) {
 	// An error returned implies the health check has failed a sufficient number of
 	// times for the cluster to be considered unhealthy
 	if err != nil {
-		c := m.getClusterCache(in.cluster)
-		if c == nil {
-			return
-		}
-
-		m.log.Error(err, "Error health checking cluster", "cluster", in.cluster.String())
-
-		// Stop the cache and clean up
-		c.Stop()
-		m.deleteClusterCache(in.cluster)
-		m.deleteDelegatingClient(in.cluster)
-		m.deleteWatchesForCluster(in.cluster)
+		t.log.Error(err, "Error health checking cluster", "cluster", in.cluster.String())
+		t.deleteAccessor(in.cluster)
 	}
-}
-
-// healthCheckPath attempts to request a given absolute path from the API server
-// defined in the rest.Config and returns any errors that occurred during the request.
-func healthCheckPath(restClient *rest.RESTClient, requestTimeout time.Duration, path string) error {
-	_, err := restClient.Get().AbsPath(path).Timeout(requestTimeout).DoRaw()
-	return err
-}
-
-// ClusterCacheReconciler is responsible for stopping remote cluster caches when
-// the cluster for the remote cache is being deleted.
-type ClusterCacheReconciler struct {
-	Log     logr.Logger
-	Client  client.Client
-	Tracker *ClusterCacheTracker
-}
-
-func (r *ClusterCacheReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
-	_, err := ctrl.NewControllerManagedBy(mgr).
-		For(&clusterv1.Cluster{}).
-		WithOptions(options).
-		Build(r)
-
-	if err != nil {
-		return errors.Wrap(err, "failed setting up with a controller manager")
-	}
-	return nil
-}
-
-// Reconcile reconciles Clusters and removes ClusterCaches for any Cluster that cannot be retrieved from the
-// management cluster.
-func (r *ClusterCacheReconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
-	ctx := context.Background()
-
-	log := r.Log.WithValues("namespace", req.Namespace, "name", req.Name)
-	log.V(4).Info("Reconciling")
-
-	var cluster clusterv1.Cluster
-
-	err := r.Client.Get(ctx, req.NamespacedName, &cluster)
-	if err == nil {
-		log.V(4).Info("Cluster still exists")
-		return reconcile.Result{}, nil
-	} else if !kerrors.IsNotFound(err) {
-		log.Error(err, "Error retrieving cluster")
-		return reconcile.Result{}, err
-	}
-
-	log.V(4).Info("Cluster no longer exists")
-
-	c := r.Tracker.getClusterCache(req.NamespacedName)
-	if c == nil {
-		log.V(4).Info("No current cluster cache exists - nothing to do")
-		return reconcile.Result{}, nil
-	}
-
-	log.V(4).Info("Stopping cluster cache")
-	c.Stop()
-
-	r.Tracker.deleteClusterCache(req.NamespacedName)
-	r.Tracker.deleteDelegatingClient(req.NamespacedName)
-
-	log.V(4).Info("Deleting watches for cluster cache")
-	r.Tracker.deleteWatchesForCluster(req.NamespacedName)
-
-	return reconcile.Result{}, nil
 }

--- a/controllers/remote/cluster_cache_reconciler.go
+++ b/controllers/remote/cluster_cache_reconciler.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// ClusterCacheReconciler is responsible for stopping remote cluster caches when
+// the cluster for the remote cache is being deleted.
+type ClusterCacheReconciler struct {
+	Log     logr.Logger
+	Client  client.Client
+	Tracker *ClusterCacheTracker
+}
+
+func (r *ClusterCacheReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
+	_, err := ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.Cluster{}).
+		WithOptions(options).
+		Build(r)
+
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+	return nil
+}
+
+// Reconcile reconciles Clusters and removes ClusterCaches for any Cluster that cannot be retrieved from the
+// management cluster.
+func (r *ClusterCacheReconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	ctx := context.Background()
+
+	log := r.Log.WithValues("namespace", req.Namespace, "name", req.Name)
+	log.V(4).Info("Reconciling")
+
+	var cluster clusterv1.Cluster
+
+	err := r.Client.Get(ctx, req.NamespacedName, &cluster)
+	if err == nil {
+		log.V(4).Info("Cluster still exists")
+		return reconcile.Result{}, nil
+	} else if !kerrors.IsNotFound(err) {
+		log.Error(err, "Error retrieving cluster")
+		return reconcile.Result{}, err
+	}
+
+	log.V(2).Info("Cluster no longer exists")
+
+	r.Tracker.deleteAccessor(req.NamespacedName)
+
+	return reconcile.Result{}, nil
+
+}

--- a/controllers/remote/cluster_cache_reconciler_test.go
+++ b/controllers/remote/cluster_cache_reconciler_test.go
@@ -20,37 +20,30 @@ import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	gtypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var _ = Describe("ClusterCache Reconciler suite", func() {
 	Context("When running the ClusterCacheReconciler", func() {
-		var mgr manager.Manager
-		var doneMgr chan struct{}
-		var cct *ClusterCacheTracker
-		var k8sClient client.Client
+		var (
+			mgr           manager.Manager
+			doneMgr       chan struct{}
+			cct           *ClusterCacheTracker
+			k8sClient     client.Client
+			testNamespace *corev1.Namespace
+		)
 
-		var testNamespace *corev1.Namespace
-		var clusterRequest1, clusterRequest2, clusterRequest3 reconcile.Request
-		var clusterCache1, clusterCache2, clusterCache3 *clusterCache
-
-		// createAndWatchCluster creates a new cluster and ensures the clusterCacheTracker is watching the cluster
-		createAndWatchCluster := func(clusterName string) (reconcile.Request, *clusterCache) {
+		// createAndWatchCluster creates a new cluster and ensures the clusterCacheTracker has a clusterAccessor for it
+		createAndWatchCluster := func(clusterName string) {
 			By(fmt.Sprintf("Creating a cluster %q", clusterName))
 			testCluster := &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -60,45 +53,24 @@ var _ = Describe("ClusterCache Reconciler suite", func() {
 			}
 			Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
 
-			// Check the cluster can be fetch from the API server
+			// Check the cluster can be fetched from the API server
 			testClusterKey := util.ObjectKey(testCluster)
 			Eventually(func() error {
 				return k8sClient.Get(ctx, testClusterKey, &clusterv1.Cluster{})
 			}, timeout).Should(Succeed())
 
 			By("Creating a test cluster kubeconfig")
-			Expect(kubeconfig.CreateEnvTestSecret(k8sClient, testEnv.Config, testCluster)).To(Succeed())
-			// Check the secret can be fetch from the API server
+			Expect(testEnv.CreateKubeconfigSecret(testCluster)).To(Succeed())
+
+			// Check the secret can be fetched from the API server
 			secretKey := client.ObjectKey{Namespace: testNamespace.GetName(), Name: fmt.Sprintf("%s-kubeconfig", testCluster.GetName())}
 			Eventually(func() error {
 				return k8sClient.Get(ctx, secretKey, &corev1.Secret{})
 			}, timeout).Should(Succeed())
 
-			watcher, _ := newTestWatcher()
-			kind := &corev1.Node{}
-			eventHandler := &handler.Funcs{}
-
-			By("Calling watch on the test cluster")
-			// TODO: Make this test not rely on Watch doing its job?
-			Expect(cct.Watch(ctx, WatchInput{
-				Cluster:      testClusterKey,
-				Watcher:      watcher,
-				Kind:         kind,
-				EventHandler: eventHandler,
-				Predicates: []predicate.Predicate{
-					&predicate.ResourceVersionChangedPredicate{},
-					&predicate.GenerationChangedPredicate{},
-				},
-			})).To(Succeed())
-
-			// Check that a cache was created for the cluster
-			cc := func() *clusterCache {
-				cct.clusterCachesLock.RLock()
-				defer cct.clusterCachesLock.RUnlock()
-				return cct.clusterCaches[testClusterKey]
-			}()
-			Expect(cc).ToNot(BeNil())
-			return reconcile.Request{NamespacedName: testClusterKey}, cc
+			By("Creating a clusterAccessor for the cluster")
+			_, err := cct.GetClient(ctx, testClusterKey)
+			Expect(err).To(BeNil())
 		}
 
 		BeforeEach(func() {
@@ -110,42 +82,34 @@ var _ = Describe("ClusterCache Reconciler suite", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			doneMgr = make(chan struct{})
+			By("Setting up a ClusterCacheTracker")
+			cct, err = NewClusterCacheTracker(log.NullLogger{}, mgr)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Creating the ClusterCacheReconciler")
+			r := &ClusterCacheReconciler{
+				Log:     log.NullLogger{},
+				Client:  mgr.GetClient(),
+				Tracker: cct,
+			}
+			Expect(r.SetupWithManager(mgr, controller.Options{})).To(Succeed())
+
 			By("Starting the manager")
+			doneMgr = make(chan struct{})
 			go func() {
 				Expect(mgr.Start(doneMgr)).To(Succeed())
 			}()
 
 			k8sClient = mgr.GetClient()
 
-			By("Setting up a ClusterCacheTracker")
-			cct, err = NewClusterCacheTracker(log.NullLogger{}, mgr)
-			Expect(err).NotTo(HaveOccurred())
-
 			By("Creating a namespace for the test")
 			testNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "cluster-cache-test-"}}
 			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
 
-			By("Starting the ClusterCacheReconciler")
-			r := &ClusterCacheReconciler{
-				Log:     &log.NullLogger{},
-				Client:  mgr.GetClient(),
-				Tracker: cct,
-			}
-			Expect(r.SetupWithManager(mgr, controller.Options{})).To(Succeed())
-
 			By("Creating clusters to test with")
-			clusterRequest1, clusterCache1 = createAndWatchCluster("cluster-1")
-			clusterRequest2, clusterCache2 = createAndWatchCluster("cluster-2")
-			clusterRequest3, clusterCache3 = createAndWatchCluster("cluster-3")
-
-			// Manually call Reconcile to ensure the Reconcile is completed before assertions
-			_, err = r.Reconcile(clusterRequest1)
-			Expect(err).ToNot(HaveOccurred())
-			_, err = r.Reconcile(clusterRequest2)
-			Expect(err).ToNot(HaveOccurred())
-			_, err = r.Reconcile(clusterRequest3)
-			Expect(err).ToNot(HaveOccurred())
+			createAndWatchCluster("cluster-1")
+			createAndWatchCluster("cluster-2")
+			createAndWatchCluster("cluster-3")
 		})
 
 		AfterEach(func() {
@@ -157,171 +121,20 @@ var _ = Describe("ClusterCache Reconciler suite", func() {
 			close(doneMgr)
 		})
 
-		type clusterKeyAndCache struct {
-			key   client.ObjectKey
-			cache *clusterCache
-		}
-
-		type clusterDeletedInput struct {
-			stoppedClusters func() []clusterKeyAndCache
-			runningClusters func() []clusterKeyAndCache
-		}
-
-		DescribeTable("when clusters are deleted", func(in *clusterDeletedInput) {
-			for _, cluster := range in.stoppedClusters() {
-				By(fmt.Sprintf("Deleting cluster %q", cluster.key.Name))
+		It("should remove clusterAccessors when clusters are deleted", func() {
+			for _, clusterName := range []string{"cluster-1", "cluster-2", "cluster-3"} {
+				By(fmt.Sprintf("Deleting cluster %q", clusterName))
 				obj := &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      cluster.key.Name,
-						Namespace: cluster.key.Namespace,
+						Namespace: testNamespace.Name,
+						Name:      clusterName,
 					},
 				}
 				Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
+
+				By(fmt.Sprintf("Checking cluster %q's clusterAccessor is removed", clusterName))
+				Eventually(func() bool { return cct.clusterAccessorExists(util.ObjectKey(obj)) }, timeout).Should(BeFalse())
 			}
-
-			// Check the stopped clustser's caches eventually stop
-			for _, cluster := range in.stoppedClusters() {
-				By(fmt.Sprintf("Checking cluster %q's cache is stopped", cluster.key.Name))
-				cc := cluster.cache
-				Eventually(func() bool {
-					cc.lock.Lock()
-					defer cc.lock.Unlock()
-					return cc.stopped
-				}, timeout).Should(BeTrue())
-			}
-
-			// Check the running cluster's caches are still running
-			for _, cluster := range in.runningClusters() {
-				By(fmt.Sprintf("Checking cluster %q's cache is running", cluster.key.Name))
-				cc := cluster.cache
-				Consistently(func() bool {
-					cc.lock.Lock()
-					defer cc.lock.Unlock()
-					return cc.stopped
-				}).Should(BeFalse())
-			}
-
-			By("Checking deleted Cluster's Caches are removed", func() {
-				matchers := []gtypes.GomegaMatcher{}
-				for _, cluster := range in.stoppedClusters() {
-					matchers = append(matchers, Not(HaveKey(cluster.key)))
-				}
-				for _, cluster := range in.runningClusters() {
-					matchers = append(matchers, HaveKeyWithValue(cluster.key, cluster.cache))
-				}
-				matchers = append(matchers, HaveLen(len(in.runningClusters())))
-
-				Eventually(func() map[client.ObjectKey]*clusterCache {
-					cct.clusterCachesLock.RLock()
-					defer cct.clusterCachesLock.RUnlock()
-					return cct.clusterCaches
-				}, timeout).Should(SatisfyAll(matchers...))
-			})
-
-			By("Checking deleted Cluster's Watches are removed", func() {
-				matchers := []gtypes.GomegaMatcher{}
-				for _, cluster := range in.stoppedClusters() {
-					matchers = append(matchers, Not(HaveKey(cluster.key)))
-				}
-				for _, cluster := range in.runningClusters() {
-					matchers = append(matchers, HaveKeyWithValue(cluster.key, Not(BeEmpty())))
-				}
-				matchers = append(matchers, HaveLen(len(in.runningClusters())))
-
-				Eventually(func() map[client.ObjectKey]map[watchInfo]struct{} {
-					cct.watchesLock.RLock()
-					defer cct.watchesLock.RUnlock()
-					return cct.watches
-				}(), timeout).Should(SatisfyAll(matchers...))
-			})
-		},
-			Entry("when no clusters deleted", &clusterDeletedInput{
-				stoppedClusters: func() []clusterKeyAndCache {
-					return []clusterKeyAndCache{}
-				},
-				runningClusters: func() []clusterKeyAndCache {
-					return []clusterKeyAndCache{
-						{
-							key:   clusterRequest1.NamespacedName,
-							cache: clusterCache1,
-						},
-						{
-							key:   clusterRequest2.NamespacedName,
-							cache: clusterCache2,
-						},
-						{
-							key:   clusterRequest3.NamespacedName,
-							cache: clusterCache3,
-						},
-					}
-				},
-			}),
-			Entry("when test-cluster-1 is deleted", &clusterDeletedInput{
-				stoppedClusters: func() []clusterKeyAndCache {
-					return []clusterKeyAndCache{
-						{
-							key:   clusterRequest1.NamespacedName,
-							cache: clusterCache1,
-						},
-					}
-				},
-				runningClusters: func() []clusterKeyAndCache {
-					return []clusterKeyAndCache{
-						{
-							key:   clusterRequest2.NamespacedName,
-							cache: clusterCache2,
-						},
-						{
-							key:   clusterRequest3.NamespacedName,
-							cache: clusterCache3,
-						},
-					}
-				},
-			}),
-			Entry("when test-cluster-2 is deleted", &clusterDeletedInput{
-				stoppedClusters: func() []clusterKeyAndCache {
-					return []clusterKeyAndCache{
-						{
-							key:   clusterRequest2.NamespacedName,
-							cache: clusterCache2,
-						},
-					}
-				},
-				runningClusters: func() []clusterKeyAndCache {
-					return []clusterKeyAndCache{
-						{
-							key:   clusterRequest1.NamespacedName,
-							cache: clusterCache1,
-						},
-						{
-							key:   clusterRequest3.NamespacedName,
-							cache: clusterCache3,
-						},
-					}
-				},
-			}),
-			Entry("when test-cluster-1 and test-cluster-3 are deleted", &clusterDeletedInput{
-				stoppedClusters: func() []clusterKeyAndCache {
-					return []clusterKeyAndCache{
-						{
-							key:   clusterRequest1.NamespacedName,
-							cache: clusterCache1,
-						},
-						{
-							key:   clusterRequest3.NamespacedName,
-							cache: clusterCache3,
-						},
-					}
-				},
-				runningClusters: func() []clusterKeyAndCache {
-					return []clusterKeyAndCache{
-						{
-							key:   clusterRequest2.NamespacedName,
-							cache: clusterCache2,
-						},
-					}
-				},
-			}),
-		)
+		})
 	})
 })

--- a/controllers/remote/stoppable_cache.go
+++ b/controllers/remote/stoppable_cache.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+// stoppableCache embeds cache.Cache and combines it with a stop channel.
+type stoppableCache struct {
+	cache.Cache
+
+	lock    sync.Mutex
+	stopped bool
+	stop    chan struct{}
+}
+
+// Stop closes the cache.Cache's stop channel if it has not already been stopped.
+func (cc *stoppableCache) Stop() {
+	cc.lock.Lock()
+	defer cc.lock.Unlock()
+
+	if cc.stopped {
+		return
+	}
+
+	cc.stopped = true
+	close(cc.stop)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch to a single lock in ClusterCacheTracker to eliminate possible
deadlocks when simultaneously deleted & recreating a client/cache for
the same cluster.

Note, with this change, ClusterCacheTracker's WatchInput has a new required field - Name.