### PR TITLE
🌱 Increase timeout to fix self-hosting flakes

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -86,7 +86,7 @@ variables:
 
 intervals:
   default/wait-controllers: ["3m", "10s"]
-  default/wait-cluster: ["3m", "10s"]
+  default/wait-cluster: ["5m", "10s"]
   default/wait-control-plane: ["10m", "10s"]
   default/wait-worker-nodes: ["5m", "10s"]
   default/wait-delete-cluster: ["3m", "10s"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Still trying to get rid of e2e failures in the self-hosted test...

/milestone v0.3.10