### PR TITLE
✨ Label interruptible nodes

### DIFF
--- a/api/v1alpha4/common_types.go
+++ b/api/v1alpha4/common_types.go
@@ -48,6 +48,9 @@ const (
 
 	// ClusterSecretType defines the type of secret created by core components
 	ClusterSecretType corev1.SecretType = "cluster.x-k8s.io/secret" //nolint:gosec
+
+	// InterruptibleLabel is the label used to mark the nodes that run on interruptible instances
+	InterruptibleLabel = "cluster.x-k8s.io/interruptible"
 )
 
 // MachineAddressType describes a valid MachineAddress type.

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -264,6 +264,7 @@ func (r *MachineReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cl
 		r.reconcileBootstrap,
 		r.reconcileInfrastructure,
 		r.reconcileNode,
+		r.reconcileInterruptibleNodeLabel,
 	}
 
 	res := ctrl.Result{}

--- a/controllers/machine_controller_node_labels.go
+++ b/controllers/machine_controller_node_labels.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	apicorev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/patch"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (r *MachineReconciler) reconcileInterruptibleNodeLabel(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (ctrl.Result, error) {
+	// Check that the Machine hasn't been deleted or in the process
+	// and that the Machine has a NodeRef.
+	if !machine.DeletionTimestamp.IsZero() || machine.Status.NodeRef == nil {
+		return ctrl.Result{}, nil
+	}
+
+	// Get the infrastructure object
+	infra, err := external.Get(ctx, r.Client, &machine.Spec.InfrastructureRef, machine.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+
+	// Get interruptible instance status from the infrastructure provider.
+	interruptible, _, err := unstructured.NestedBool(infra.Object, "status", "interruptible")
+	if err != nil {
+		log.V(1).Error(err, "Failed to get interruptible status from infrastructure provider", "machinename", machine.Name)
+		return ctrl.Result{}, nil
+	}
+	if !interruptible {
+		return ctrl.Result{}, nil
+	}
+
+	remoteClient, err := r.Tracker.GetClient(ctx, util.ObjectKey(cluster))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := r.setInterruptibleNodeLabel(ctx, remoteClient, machine.Status.NodeRef.Name); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	log.V(3).Info("Set interruptible label to Machine's Node", "nodename", machine.Status.NodeRef.Name)
+	r.recorder.Event(machine, apicorev1.EventTypeNormal, "SuccessfulSetInterruptibleNodeLabel", machine.Status.NodeRef.Name)
+
+	return ctrl.Result{}, nil
+}
+
+func (r *MachineReconciler) setInterruptibleNodeLabel(ctx context.Context, remoteClient client.Client, nodeName string) error {
+	node := &apicorev1.Node{}
+	if err := remoteClient.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
+		return err
+	}
+
+	if node.Labels == nil {
+		node.Labels = map[string]string{}
+	}
+
+	if _, ok := node.Labels[clusterv1.InterruptibleLabel]; ok {
+		return nil
+	}
+
+	patchHelper, err := patch.NewHelper(node, r.Client)
+	if err != nil {
+		return err
+	}
+
+	node.Labels[clusterv1.InterruptibleLabel] = ""
+
+	return patchHelper.Patch(ctx, node)
+}

--- a/controllers/machine_controller_node_labels_test.go
+++ b/controllers/machine_controller_node_labels_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestReconcileInterruptibleNodeLabel(t *testing.T) {
+	g := NewWithT(t)
+
+	ns, err := testEnv.CreateNamespace(ctx, "test-interruptible-node-label")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	infraMachine := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "InfrastructureMachine",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha4",
+			"metadata": map[string]interface{}{
+				"name":      "infra-config1",
+				"namespace": ns.Name,
+			},
+			"status": map[string]interface{}{
+				"interruptible": true,
+			},
+		},
+	}
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-1",
+			Namespace: ns.Name,
+		},
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1",
+		},
+	}
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machine-test",
+			Namespace: ns.Name,
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: cluster.Name,
+			InfrastructureRef: corev1.ObjectReference{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+				Kind:       "InfrastructureMachine",
+				Name:       "infra-config1",
+				Namespace:  ns.Name,
+			},
+			Bootstrap: clusterv1.Bootstrap{
+				ConfigRef: &corev1.ObjectReference{
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha4",
+					Kind:       "BootstrapMachine",
+					Name:       "bootstrap-config1",
+				},
+			},
+		},
+		Status: clusterv1.MachineStatus{
+			NodeRef: &corev1.ObjectReference{
+				Name: "node-1",
+			},
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, cluster)).To(Succeed())
+	g.Expect(testEnv.Create(ctx, node)).To(Succeed())
+	g.Expect(testEnv.Create(ctx, infraMachine)).To(Succeed())
+	g.Expect(testEnv.Create(ctx, machine)).To(Succeed())
+
+	// Patch infra machine status
+	patchHelper, err := patch.NewHelper(infraMachine, testEnv)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(unstructured.SetNestedField(infraMachine.Object, true, "status", "interruptible")).To(Succeed())
+	g.Expect(patchHelper.Patch(ctx, infraMachine, patch.WithStatusObservedGeneration{})).To(Succeed())
+
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(cluster, node, infraMachine, machine)
+
+	r := &MachineReconciler{
+		Client:   testEnv.Client,
+		Tracker:  remote.NewTestClusterCacheTracker(log.NullLogger{}, testEnv.Client, scheme.Scheme, client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}),
+		recorder: record.NewFakeRecorder(32),
+	}
+
+	_, err = r.reconcileInterruptibleNodeLabel(context.Background(), cluster, machine)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Check if node gets interruptible label
+	g.Eventually(func() bool {
+		updatedNode := &corev1.Node{}
+		err := testEnv.Get(ctx, client.ObjectKey{Name: node.Name}, updatedNode)
+		if err != nil {
+			return false
+		}
+
+		if updatedNode.Labels == nil {
+			return false
+		}
+
+		_, ok := updatedNode.Labels[clusterv1.InterruptibleLabel]
+
+		return ok
+	}, 10*time.Second).Should(BeTrue())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Transfer machine labels to the node. The use-case is described here https://github.com/kubernetes-sigs/cluster-api/issues/3504. 

The transfer of machine labels to the node is similar to setting `Noderef`. Important thing to mention is that only labels with `"cluster.x-k8s.io"` prefix are transferred.

This PR should help with implementing the termination handler for spot instances - https://github.com/kubernetes-sigs/cluster-api/pull/3528

Happy to hear what others think about this change.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3504
