### PR TITLE
:book: default GOPROXY if not set when building mdbook preprocessors

### DIFF
--- a/docs/book/util-embed.sh
+++ b/docs/book/util-embed.sh
@@ -19,5 +19,5 @@ set -o nounset
 set -o pipefail
 
 EMBED="../../hack/tools/bin/mdbook-embed"
-make ${EMBED} &>/dev/null
+make ${EMBED} GOPROXY="${GOPROXY:-"https://proxy.golang.org"}" &>/dev/null
 ${EMBED} "$@"

--- a/docs/book/util-releaselink.sh
+++ b/docs/book/util-releaselink.sh
@@ -19,5 +19,5 @@ set -o nounset
 set -o pipefail
 
 RELEASELINK="../../hack/tools/bin/mdbook-releaselink"
-make ${RELEASELINK} &>/dev/null
+make ${RELEASELINK} GOPROXY="${GOPROXY:-"https://proxy.golang.org"}" &>/dev/null
 ${RELEASELINK} "$@"

--- a/docs/book/util-tabulate.sh
+++ b/docs/book/util-tabulate.sh
@@ -19,5 +19,5 @@ set -o nounset
 set -o pipefail
 
 TABULATE="../../hack/tools/bin/mdbook-tabulate"
-make ${TABULATE} &>/dev/null
+make ${TABULATE} GOPROXY="${GOPROXY:-"https://proxy.golang.org"}" &>/dev/null
 ${TABULATE} "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempts to fix the book build

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3658
