### PR TITLE
🐛 Fix node deletion under managed control planes

### DIFF
--- a/docs/book/src/developer/architecture/controllers/control-plane.md
+++ b/docs/book/src/developer/architecture/controllers/control-plane.md
@@ -174,10 +174,13 @@ following fields defined:
 
 #### Optional `status` fields
 
-The `status` object **may** define several fields that do not affect functionality if missing:
+The `status` object **may** define several fields:
 
 * `failureReason` - is a string that explains why an error has occurred, if possible.
 * `failureMessage` - is a string that holds the message contained by the error.
+* `externalManagedControlPlane` - is a bool that should be set to true if the Node objects do not
+  exist in the cluster. For example, managed control plane providers for AKS, EKS, GKE, etc, should
+  set this to `true`. Leaving the field undefined is equivalent to setting the value to `false`.
 
 ## Example usage
 

--- a/util/util.go
+++ b/util/util.go
@@ -197,6 +197,16 @@ func GetControlPlaneMachinesFromList(machineList *clusterv1.MachineList) (res []
 	return
 }
 
+// IsExternalManagedControlPlane returns a bool indicating whether the control plane referenced
+// in the passed Unstructured resource is an externally managed control plane such as AKS, EKS, GKE, etc.
+func IsExternalManagedControlPlane(controlPlane *unstructured.Unstructured) bool {
+	managed, found, err := unstructured.NestedBool(controlPlane.Object, "status", "externalManagedControlPlane")
+	if err != nil || !found {
+		return false
+	}
+	return managed
+}
+
 // GetMachineIfExists gets a machine from the API server if it exists.
 func GetMachineIfExists(c client.Client, namespace, name string) (*clusterv1.Machine, error) {
 	if c == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows the Machine controller to drain and delete Nodes when running under managed control planes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3631 
