### PR TITLE
🐛 Fix E2E self-hosting E2E test by adding docker mount to control-plane nodes

### DIFF
--- a/test/e2e/data/infrastructure-docker/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/bases/cluster-with-kcp.yaml
@@ -37,7 +37,10 @@ metadata:
   name: "${CLUSTER_NAME}-control-plane"
 spec:
   template:
-    spec: {}
+    spec:
+      extraMounts:
+        - containerPath: "/var/run/docker.sock"
+          hostPath: "/var/run/docker.sock"
 ---
 # KubeadmControlPlane referenced by the Cluster object with
 # - the label kcp-adoption.step2, because it should be created in the second step of the kcp-adoption test.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a flake in self-hosting failing when CAPD controller gets scheduler on the control-plane nodes.

Those nodes were is missing the mounts for the docker socket, so CAPD was falling to reconcile existing machines after move.
