### PR TITLE
🌱 feat: add EKS controlplane provider

### DIFF
--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -44,11 +44,12 @@ const (
 	// Bootstrap providers
 	KubeadmBootstrapProviderName = "kubeadm"
 	TalosBootstrapProviderName   = "talos"
-	EKSBootstrapProviderName     = "eks"
+	AWSEKSBootstrapProviderName  = "aws-eks"
 
 	// ControlPlane providers
 	KubeadmControlPlaneProviderName = "kubeadm"
 	TalosControlPlaneProviderName   = "talos"
+	AWSEKSControlPlaneProviderName  = "aws-eks"
 
 	// Other
 	ProvidersConfigKey = "providers"
@@ -154,7 +155,7 @@ func (p *providersClient) defaults() []Provider {
 			providerType: clusterctlv1.BootstrapProviderType,
 		},
 		&provider{
-			name:         EKSBootstrapProviderName,
+			name:         AWSEKSBootstrapProviderName,
 			url:          "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/eks-bootstrap-components.yaml",
 			providerType: clusterctlv1.BootstrapProviderType,
 		},
@@ -167,6 +168,11 @@ func (p *providersClient) defaults() []Provider {
 		&provider{
 			name:         TalosControlPlaneProviderName,
 			url:          "https://github.com/talos-systems/cluster-api-control-plane-provider-talos/releases/latest/control-plane-components.yaml",
+			providerType: clusterctlv1.ControlPlaneProviderType,
+		},
+		&provider{
+			name:         AWSEKSControlPlaneProviderName,
+			url:          "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/eks-controlplane-components.yaml",
 			providerType: clusterctlv1.ControlPlaneProviderType,
 		},
 	}

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -55,9 +55,10 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 			// note: these will be sorted by name by the Providers() call, so be sure they are in alphabetical order here too
 			wantProviders: []string{
 				config.ClusterAPIProviderName,
-				config.EKSBootstrapProviderName,
+				config.AWSEKSBootstrapProviderName,
 				config.KubeadmBootstrapProviderName,
 				config.TalosBootstrapProviderName,
+				config.AWSEKSControlPlaneProviderName,
 				config.KubeadmControlPlaneProviderName,
 				config.TalosControlPlaneProviderName,
 				config.AWSProviderName,
@@ -80,10 +81,11 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 			// note: these will be sorted by name by the Providers() call, so be sure they are in alphabetical order here too
 			wantProviders: []string{
 				config.ClusterAPIProviderName,
+				config.AWSEKSBootstrapProviderName,
 				customProviderConfig.Name(),
-				config.EKSBootstrapProviderName,
 				config.KubeadmBootstrapProviderName,
 				config.TalosBootstrapProviderName,
+				config.AWSEKSControlPlaneProviderName,
 				config.KubeadmControlPlaneProviderName,
 				config.TalosControlPlaneProviderName,
 				config.AWSProviderName,

--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -156,7 +156,7 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 					// older version are not supported by clusterctl
 				},
 			}
-		case config.EKSBootstrapProviderName:
+		case config.AWSEKSBootstrapProviderName:
 			return &clusterctlv1.Metadata{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: clusterctlv1.GroupVersion.String(),
@@ -194,6 +194,16 @@ func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
 					// v1alpha3 release series
 					{Major: 0, Minor: 1, Contract: "v1alpha3"},
 					// there are no older version for Talos controlplane
+				},
+			}
+		case config.AWSEKSControlPlaneProviderName:
+			return &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "Metadata",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 0, Minor: 6, Contract: "v1alpha3"},
 				},
 			}
 		default:

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -102,9 +102,10 @@ providers:
 var expectedOutputText = `NAME                TYPE                     URL                                                                                          FILE
 cluster-api         CoreProvider             https://github.com/myorg/myforkofclusterapi/releases/latest/                                 core_components.yaml
 another-provider    BootstrapProvider        ./                                                                                           bootstrap-components.yaml
-eks                 BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/                 eks-bootstrap-components.yaml
+aws-eks             BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/                 eks-bootstrap-components.yaml
 kubeadm             BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api/releases/latest/                              bootstrap-components.yaml
 talos               BootstrapProvider        https://github.com/talos-systems/cluster-api-bootstrap-provider-talos/releases/latest/       bootstrap-components.yaml
+aws-eks             ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/                 eks-controlplane-components.yaml
 kubeadm             ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api/releases/latest/                              control-plane-components.yaml
 talos               ControlPlaneProvider     https://github.com/talos-systems/cluster-api-control-plane-provider-talos/releases/latest/   control-plane-components.yaml
 aws                 InfrastructureProvider                                                                                                my-aws-infrastructure-components.yaml
@@ -128,7 +129,7 @@ var expectedOutputYaml = `- File: core_components.yaml
   ProviderType: BootstrapProvider
   URL: ./
 - File: eks-bootstrap-components.yaml
-  Name: eks
+  Name: aws-eks
   ProviderType: BootstrapProvider
   URL: https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/
 - File: bootstrap-components.yaml
@@ -139,6 +140,10 @@ var expectedOutputYaml = `- File: core_components.yaml
   Name: talos
   ProviderType: BootstrapProvider
   URL: https://github.com/talos-systems/cluster-api-bootstrap-provider-talos/releases/latest/
+- File: eks-controlplane-components.yaml
+  Name: aws-eks
+  ProviderType: ControlPlaneProvider
+  URL: https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/
 - File: control-plane-components.yaml
   Name: kubeadm
   ProviderType: ControlPlaneProvider


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This adds the eks control plane provider to clusterctl. This is to enable users to install the provider using `clusterctl init`. The EKS Control Plane has been split into its own provider and will be avaiyable in the 0.6.1 release of CAPA.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1970
