### PR TITLE
✨ Changes priority of infrastructure failures in machine summary condition

### DIFF
--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -208,8 +208,8 @@ func patchMachine(ctx context.Context, patchHelper *patch.Helper, machine *clust
 	// after provisioning - e.g. when a MHC condition exists - or during the deletion process).
 	conditions.SetSummary(machine,
 		conditions.WithConditions(
-			clusterv1.BootstrapReadyCondition,
 			clusterv1.InfrastructureReadyCondition,
+			clusterv1.BootstrapReadyCondition,
 			// TODO: add MHC conditions here
 		),
 		conditions.WithStepCounterIf(machine.ObjectMeta.DeletionTimestamp.IsZero()),

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/test/helpers"
 	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -355,7 +356,7 @@ func TestReconcileRequest(t *testing.T) {
 						Kind:       "InfrastructureMachine",
 						Name:       "infra-config1",
 					},
-					Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+					Bootstrap: clusterv1.Bootstrap{DataSecretName: pointer.StringPtr("data")},
 				},
 				Status: clusterv1.MachineStatus{
 					NodeRef: &corev1.ObjectReference{
@@ -383,7 +384,7 @@ func TestReconcileRequest(t *testing.T) {
 						Kind:       "InfrastructureMachine",
 						Name:       "infra-config1",
 					},
-					Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+					Bootstrap: clusterv1.Bootstrap{DataSecretName: pointer.StringPtr("data")},
 				},
 				Status: clusterv1.MachineStatus{
 					NodeRef: &corev1.ObjectReference{
@@ -415,7 +416,7 @@ func TestReconcileRequest(t *testing.T) {
 						Kind:       "InfrastructureMachine",
 						Name:       "infra-config1",
 					},
-					Bootstrap: clusterv1.Bootstrap{Data: pointer.StringPtr("data")},
+					Bootstrap: clusterv1.Bootstrap{DataSecretName: pointer.StringPtr("data")},
 				},
 			},
 			expected: expected{
@@ -451,6 +452,244 @@ func TestReconcileRequest(t *testing.T) {
 			}
 
 			g.Expect(result).To(Equal(tc.expected.result))
+		})
+	}
+}
+
+func TestMachineConditions(t *testing.T) {
+	infraConfig := func(ready bool) *unstructured.Unstructured {
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"kind":       "InfrastructureMachine",
+				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "infra-config1",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"providerID": "test://id-1",
+				},
+				"status": map[string]interface{}{
+					"ready": ready,
+					"addresses": []interface{}{
+						map[string]interface{}{
+							"type":    "InternalIP",
+							"address": "10.0.0.1",
+						},
+					},
+				},
+			},
+		}
+	}
+
+	boostrapConfig := func(ready bool) *unstructured.Unstructured {
+		status := map[string]interface{}{
+			"ready": ready,
+		}
+		if ready {
+			status["dataSecretName"] = "data"
+		}
+		return &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"kind":       "BootstrapMachine",
+				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+				"metadata": map[string]interface{}{
+					"name":      "bootstrap-config1",
+					"namespace": "default",
+				},
+				"status": status,
+			},
+		}
+	}
+
+	testCluster := clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+	}
+
+	machine := clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "blah",
+			Namespace: "default",
+			Labels: map[string]string{
+				clusterv1.MachineControlPlaneLabelName: "",
+			},
+			Finalizers: []string{clusterv1.MachineFinalizer},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: "test-cluster",
+			InfrastructureRef: corev1.ObjectReference{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+				Kind:       "InfrastructureMachine",
+				Name:       "infra-config1",
+			},
+			Bootstrap: clusterv1.Bootstrap{
+				ConfigRef: &corev1.ObjectReference{
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+					Kind:       "BootstrapMachine",
+					Name:       "bootstrap-config1",
+				},
+			},
+		},
+		Status: clusterv1.MachineStatus{
+			NodeRef: &corev1.ObjectReference{
+				Name: "test",
+			},
+			ObservedGeneration: 1,
+		},
+	}
+
+	testcases := []struct {
+		name                string
+		infraReady          bool
+		bootstrapReady      bool
+		beforeFunc          func(bootstrap, infra *unstructured.Unstructured, m *clusterv1.Machine)
+		conditionAssertFunc func(t *testing.T, getter conditions.Getter)
+	}{
+		{
+			name:           "all conditions true",
+			infraReady:     true,
+			bootstrapReady: true,
+			conditionAssertFunc: func(t *testing.T, getter conditions.Getter) {
+				g := NewWithT(t)
+				g.Expect(getter.GetConditions()).NotTo(HaveLen(0))
+				for _, c := range getter.GetConditions() {
+					g.Expect(c.Status).To(Equal(corev1.ConditionTrue))
+				}
+			},
+		},
+		{
+			name:           "infra condition consumes reason from the infra config",
+			infraReady:     false,
+			bootstrapReady: true,
+			beforeFunc: func(bootstrap, infra *unstructured.Unstructured, m *clusterv1.Machine) {
+				addConditionsToExternal(infra, clusterv1.Conditions{
+					{
+						Type:     clusterv1.ReadyCondition,
+						Status:   corev1.ConditionFalse,
+						Severity: clusterv1.ConditionSeverityInfo,
+						Reason:   "Custom reason",
+					},
+				})
+			},
+			conditionAssertFunc: func(t *testing.T, getter conditions.Getter) {
+				g := NewWithT(t)
+
+				g.Expect(conditions.Has(getter, clusterv1.InfrastructureReadyCondition)).To(BeTrue())
+				infraReadyCondition := conditions.Get(getter, clusterv1.InfrastructureReadyCondition)
+				g.Expect(infraReadyCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(infraReadyCondition.Reason).To(Equal("Custom reason"))
+			},
+		},
+		{
+			name:           "infra condition consumes the fallback reason",
+			infraReady:     false,
+			bootstrapReady: true,
+			conditionAssertFunc: func(t *testing.T, getter conditions.Getter) {
+				g := NewWithT(t)
+
+				g.Expect(conditions.Has(getter, clusterv1.InfrastructureReadyCondition)).To(BeTrue())
+				infraReadyCondition := conditions.Get(getter, clusterv1.InfrastructureReadyCondition)
+				g.Expect(infraReadyCondition.Status).To(Equal(corev1.ConditionFalse))
+
+				g.Expect(conditions.Has(getter, clusterv1.ReadyCondition)).To(BeTrue())
+				readyCondition := conditions.Get(getter, clusterv1.ReadyCondition)
+				g.Expect(readyCondition.Status).To(Equal(corev1.ConditionFalse))
+			},
+		},
+		{
+			name:           "bootstrap condition consumes reason from the bootstrap config",
+			infraReady:     true,
+			bootstrapReady: false,
+			beforeFunc: func(bootstrap, infra *unstructured.Unstructured, m *clusterv1.Machine) {
+				addConditionsToExternal(bootstrap, clusterv1.Conditions{
+					{
+						Type:     clusterv1.ReadyCondition,
+						Status:   corev1.ConditionFalse,
+						Severity: clusterv1.ConditionSeverityInfo,
+						Reason:   "Custom reason",
+					},
+				})
+			},
+			conditionAssertFunc: func(t *testing.T, getter conditions.Getter) {
+				g := NewWithT(t)
+
+				g.Expect(conditions.Has(getter, clusterv1.BootstrapReadyCondition)).To(BeTrue())
+				infraReadyCondition := conditions.Get(getter, clusterv1.BootstrapReadyCondition)
+				g.Expect(infraReadyCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(infraReadyCondition.Reason).To(Equal("Custom reason"))
+			},
+		},
+		{
+			name:           "bootstrap condition consumes the fallback reason",
+			infraReady:     true,
+			bootstrapReady: false,
+			conditionAssertFunc: func(t *testing.T, getter conditions.Getter) {
+				g := NewWithT(t)
+
+				g.Expect(conditions.Has(getter, clusterv1.BootstrapReadyCondition)).To(BeTrue())
+				infraReadyCondition := conditions.Get(getter, clusterv1.BootstrapReadyCondition)
+				g.Expect(infraReadyCondition.Status).To(Equal(corev1.ConditionFalse))
+
+				g.Expect(conditions.Has(getter, clusterv1.ReadyCondition)).To(BeTrue())
+				readyCondition := conditions.Get(getter, clusterv1.ReadyCondition)
+				g.Expect(readyCondition.Status).To(Equal(corev1.ConditionFalse))
+			},
+		},
+		// infra condition takes precedence over bootstrap condition in generating summary
+		{
+			name:           "ready condition summary consumes reason from the infra condition",
+			infraReady:     false,
+			bootstrapReady: false,
+			conditionAssertFunc: func(t *testing.T, getter conditions.Getter) {
+				g := NewWithT(t)
+
+				g.Expect(conditions.Has(getter, clusterv1.ReadyCondition)).To(BeTrue())
+				readyCondition := conditions.Get(getter, clusterv1.ReadyCondition)
+				g.Expect(readyCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(readyCondition.Reason).To(Equal(clusterv1.WaitingForInfrastructureFallbackReason))
+			},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// setup objects
+			bootstrap := boostrapConfig(tt.bootstrapReady)
+			infra := infraConfig(tt.infraReady)
+			m := machine.DeepCopy()
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(bootstrap, infra, m)
+			}
+
+			clientFake := helpers.NewFakeClientWithScheme(
+				scheme.Scheme,
+				&testCluster,
+				m,
+				external.TestGenericInfrastructureCRD.DeepCopy(),
+				infra,
+				external.TestGenericBootstrapCRD.DeepCopy(),
+				bootstrap,
+			)
+
+			r := &MachineReconciler{
+				Client: clientFake,
+				Log:    log.Log,
+				scheme: scheme.Scheme,
+			}
+
+			_, err := r.Reconcile(reconcile.Request{NamespacedName: util.ObjectKey(&machine)})
+			g.Expect(err).NotTo(HaveOccurred())
+
+			m = &clusterv1.Machine{}
+			machineKey, _ := client.ObjectKeyFromObject(&machine)
+			g.Expect(r.Client.Get(ctx, machineKey, m)).NotTo(HaveOccurred())
+
+			tt.conditionAssertFunc(t, m)
 		})
 	}
 }
@@ -864,4 +1103,14 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			}
 		})
 	}
+}
+
+// adds a condition list to an external object
+func addConditionsToExternal(u *unstructured.Unstructured, newConditions clusterv1.Conditions) {
+	existingConditions := clusterv1.Conditions{}
+	if cs := conditions.UnstructuredGetter(u).GetConditions(); len(cs) != 0 {
+		existingConditions = cs
+	}
+	existingConditions = append(existingConditions, newConditions...)
+	conditions.UnstructuredSetter(u).SetConditions(existingConditions)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch switches the condition order for summary condition generation so that the InfrastructureReady gets precedence over BootstrapReady Condition.

**Which issue(s) this PR fixes**:
Fixes #3678 
