### PR TITLE
✨ Removes step counter from kubeadmconfig ready condition

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -203,7 +203,6 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 				bootstrapv1.DataSecretAvailableCondition,
 				bootstrapv1.CertificatesAvailableCondition,
 			),
-			conditions.WithStepCounter(),
 		)
 		// Patch ObservedGeneration only if the reconciliation completed successfully
 		patchOpts := []patch.Option{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the step counter from the ready condition summary of KubeadmConfig 

**Which issue(s) this PR fixes**:
Fixes #3679 
