### PR TITLE
🌱 Update broken link to CAPA prerequisites

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -695,7 +695,7 @@ kind delete cluster
 See the [clusterctl] documentation for more detail about clusterctl supported actions.
 
 <!-- links -->
-[AWS provider prerequisites]: https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/docs/prerequisites.md
+[AWS provider prerequisites]: https://cluster-api-aws.sigs.k8s.io/topics/using-clusterawsadm-to-fulfill-prerequisites.html
 [AWS provider releases]: https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases
 [Azure Provider Prerequisites]: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/docs/getting-started.md#prerequisites
 [bootstrap cluster]: ../reference/glossary.md#bootstrap-cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the link to CAPA prerequisites. It was broken in the shift in docs structure from https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1947

Still trying to figure out why the `GITHUB_TOKEN` doesn't seem to prevent us from being rate-limited in  https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-cluster-api#periodic%20docs%20link%20verification, but it is at least running now.