### PR TITLE
✨ Adds machine health check conditions to Machine Ready condition

### DIFF
--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -210,7 +210,8 @@ func patchMachine(ctx context.Context, patchHelper *patch.Helper, machine *clust
 		conditions.WithConditions(
 			clusterv1.InfrastructureReadyCondition,
 			clusterv1.BootstrapReadyCondition,
-			// TODO: add MHC conditions here
+			clusterv1.MachineOwnerRemediatedCondition,
+			clusterv1.MachineHealthCheckSuccededCondition,
 		),
 		conditions.WithStepCounterIf(machine.ObjectMeta.DeletionTimestamp.IsZero()),
 		conditions.WithStepCounterIfOnly(
@@ -228,6 +229,8 @@ func patchMachine(ctx context.Context, patchHelper *patch.Helper, machine *clust
 			clusterv1.BootstrapReadyCondition,
 			clusterv1.InfrastructureReadyCondition,
 			clusterv1.DrainingSucceededCondition,
+			clusterv1.MachineOwnerRemediatedCondition,
+			clusterv1.MachineHealthCheckSuccededCondition,
 		}},
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch adds the machine health check conditions while computing the machine ready condition summary

**Which issue(s) this PR fixes**:
Fixes #3677 