### PR TITLE
⚠️Remove hard code manifest version and hash

### DIFF
--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -253,8 +253,8 @@ func (f fakeClusterClient) Proxy() cluster.Proxy {
 	return f.fakeProxy
 }
 
-func (f *fakeClusterClient) CertManager() cluster.CertManagerClient {
-	return f.certManager
+func (f *fakeClusterClient) CertManager() (cluster.CertManagerClient, error) {
+	return f.certManager, nil
 }
 
 func (f fakeClusterClient) ProviderComponents() cluster.ComponentsClient {

--- a/cmd/clusterctl/client/cluster/cert_manager_test.go
+++ b/cmd/clusterctl/client/cluster/cert_manager_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"testing"
 	"time"
@@ -35,21 +34,28 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
-	manifests "sigs.k8s.io/cluster-api/cmd/clusterctl/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/scheme"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func Test_VersionMarkerUpToDate(t *testing.T) {
-	yaml, err := manifests.Asset(embeddedCertManagerManifestPath)
-	if err != nil {
-		t.Fatalf("Failed to get cert-manager.yaml asset data: %v", err)
-	}
+const (
+	// Those values are dummy for test only
+	expectedHash    = "dummy-hash"
+	expectedVersion = "v0.11.2"
+)
 
-	actualHash := fmt.Sprintf("%x", sha256.Sum256(yaml))
+func Test_VersionMarkerUpToDate(t *testing.T) {
+	pollImmediateWaiter := func(interval, timeout time.Duration, condition wait.ConditionFunc) error {
+		return nil
+	}
+	fakeConfigClient := newFakeConfig("")
+	cm, err := newCertManagerClient(fakeConfigClient, nil, pollImmediateWaiter)
+
 	g := NewWithT(t)
-	g.Expect(actualHash).To(Equal(embeddedCertManagerManifestHash), "The cert-manager.yaml asset data has changed, but embeddedCertManagerManifestVersion and embeddedCertManagerManifestHash has not been updated.")
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(cm.embeddedCertManagerManifestVersion).ToNot(BeEmpty())
+	g.Expect(cm.embeddedCertManagerManifestHash).ToNot(BeEmpty())
 }
 
 func Test_certManagerClient_getManifestObjects(t *testing.T) {
@@ -134,7 +140,9 @@ func Test_certManagerClient_getManifestObjects(t *testing.T) {
 			}
 			fakeConfigClient := newFakeConfig("")
 
-			cm := newCertMangerClient(fakeConfigClient, nil, pollImmediateWaiter)
+			cm, err := newCertManagerClient(fakeConfigClient, nil, pollImmediateWaiter)
+			g.Expect(err).ToNot(HaveOccurred())
+
 			objs, err := cm.getManifestObjs()
 
 			if tt.expectErr {
@@ -180,7 +188,9 @@ func Test_GetTimeout(t *testing.T) {
 
 			fakeConfigClient := newFakeConfig(tt.timeout)
 
-			cm := newCertMangerClient(fakeConfigClient, nil, pollImmediateWaiter)
+			cm, err := newCertManagerClient(fakeConfigClient, nil, pollImmediateWaiter)
+			g.Expect(err).ToNot(HaveOccurred())
+
 			tm := cm.getWaitTimeout()
 
 			g.Expect(tm).To(Equal(tt.want))
@@ -221,15 +231,15 @@ func Test_shouldUpgrade(t *testing.T) {
 						Object: map[string]interface{}{
 							"metadata": map[string]interface{}{
 								"annotations": map[string]interface{}{
-									certmanagerVersionAnnotation: embeddedCertManagerManifestVersion,
-									certmanagerHashAnnotation:    embeddedCertManagerManifestHash,
+									certmanagerVersionAnnotation: expectedVersion,
+									certmanagerHashAnnotation:    expectedHash,
 								},
 							},
 						},
 					},
 				},
 			},
-			wantVersion: embeddedCertManagerManifestVersion,
+			wantVersion: expectedVersion,
 			want:        false,
 			wantErr:     false,
 		},
@@ -241,7 +251,7 @@ func Test_shouldUpgrade(t *testing.T) {
 						Object: map[string]interface{}{
 							"metadata": map[string]interface{}{
 								"annotations": map[string]interface{}{
-									certmanagerVersionAnnotation: embeddedCertManagerManifestVersion,
+									certmanagerVersionAnnotation: expectedVersion,
 									certmanagerHashAnnotation:    "foo",
 								},
 							},
@@ -249,7 +259,7 @@ func Test_shouldUpgrade(t *testing.T) {
 					},
 				},
 			},
-			wantVersion: fmt.Sprintf("%s (%s)", embeddedCertManagerManifestVersion, "foo"),
+			wantVersion: fmt.Sprintf("%s (%s)", expectedVersion, "foo"),
 			want:        true,
 			wantErr:     false,
 		},
@@ -315,8 +325,18 @@ func Test_shouldUpgrade(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
+			proxy := test.NewFakeProxy()
+			fakeConfigClient := newFakeConfig("")
+			pollImmediateWaiter := func(interval, timeout time.Duration, condition wait.ConditionFunc) error {
+				return nil
+			}
+			cm, err := newCertManagerClient(fakeConfigClient, proxy, pollImmediateWaiter)
+			// set dummy expected hash
+			cm.embeddedCertManagerManifestHash = expectedHash
+			cm.embeddedCertManagerManifestVersion = expectedVersion
+			g.Expect(err).ToNot(HaveOccurred())
 
-			gotVersion, got, err := shouldUpgrade(tt.args.objs)
+			gotVersion, got, err := cm.shouldUpgrade(tt.args.objs)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return
@@ -521,7 +541,7 @@ func Test_certManagerClient_PlanUpgrade(t *testing.T) {
 			expectErr: false,
 			expectedPlan: CertManagerUpgradePlan{
 				From:          "v0.11.0",
-				To:            embeddedCertManagerManifestVersion,
+				To:            expectedVersion,
 				ShouldUpgrade: true,
 			},
 		},
@@ -536,14 +556,14 @@ func Test_certManagerClient_PlanUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "cert-manager",
 						Labels:      map[string]string{clusterctlv1.ClusterctlCoreLabelName: "cert-manager"},
-						Annotations: map[string]string{certmanagerVersionAnnotation: "v0.16.0", certmanagerHashAnnotation: "some-hash"},
+						Annotations: map[string]string{certmanagerVersionAnnotation: "v0.10.2", certmanagerHashAnnotation: "some-hash"},
 					},
 				},
 			},
 			expectErr: false,
 			expectedPlan: CertManagerUpgradePlan{
-				From:          "v0.16.0",
-				To:            embeddedCertManagerManifestVersion,
+				From:          "v0.10.2",
+				To:            expectedVersion,
 				ShouldUpgrade: true,
 			},
 		},
@@ -558,14 +578,14 @@ func Test_certManagerClient_PlanUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "cert-manager",
 						Labels:      map[string]string{clusterctlv1.ClusterctlCoreLabelName: "cert-manager"},
-						Annotations: map[string]string{certmanagerVersionAnnotation: embeddedCertManagerManifestVersion, certmanagerHashAnnotation: "some-other-hash"},
+						Annotations: map[string]string{certmanagerVersionAnnotation: expectedVersion, certmanagerHashAnnotation: "some-other-hash"},
 					},
 				},
 			},
 			expectErr: false,
 			expectedPlan: CertManagerUpgradePlan{
-				From:          "v0.16.1 (some-other-hash)",
-				To:            embeddedCertManagerManifestVersion,
+				From:          fmt.Sprintf("%s (some-other-hash)", expectedVersion),
+				To:            expectedVersion,
 				ShouldUpgrade: true,
 			},
 		},
@@ -580,14 +600,14 @@ func Test_certManagerClient_PlanUpgrade(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "cert-manager",
 						Labels:      map[string]string{clusterctlv1.ClusterctlCoreLabelName: "cert-manager"},
-						Annotations: map[string]string{certmanagerVersionAnnotation: embeddedCertManagerManifestVersion, certmanagerHashAnnotation: embeddedCertManagerManifestHash},
+						Annotations: map[string]string{certmanagerVersionAnnotation: expectedVersion, certmanagerHashAnnotation: expectedHash},
 					},
 				},
 			},
 			expectErr: false,
 			expectedPlan: CertManagerUpgradePlan{
-				From:          embeddedCertManagerManifestVersion,
-				To:            embeddedCertManagerManifestVersion,
+				From:          expectedVersion,
+				To:            expectedVersion,
 				ShouldUpgrade: false,
 			},
 		},
@@ -619,9 +639,18 @@ func Test_certManagerClient_PlanUpgrade(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			cm := &certManagerClient{
-				proxy: test.NewFakeProxy().WithObjs(tt.objs...),
+			proxy := test.NewFakeProxy().WithObjs(tt.objs...)
+			fakeConfigClient := newFakeConfig("")
+			pollImmediateWaiter := func(interval, timeout time.Duration, condition wait.ConditionFunc) error {
+				return nil
 			}
+			cm, err := newCertManagerClient(fakeConfigClient, proxy, pollImmediateWaiter)
+			// set dummy expected hash
+			cm.embeddedCertManagerManifestHash = expectedHash
+			cm.embeddedCertManagerManifestVersion = expectedVersion
+
+			g.Expect(err).ToNot(HaveOccurred())
+
 			actualPlan, err := cm.PlanUpgrade()
 			if tt.expectErr {
 				g.Expect(err).To(HaveOccurred())

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -63,7 +63,7 @@ type Client interface {
 
 	// CertManager returns a CertManagerClient that can be user for
 	// operating the cert-manager components in the cluster.
-	CertManager() CertManagerClient
+	CertManager() (CertManagerClient, error)
 
 	// ProviderComponents returns a ComponentsClient object that can be user for
 	// operating provider components objects in the management cluster (e.g. the CRDs, controllers, RBAC).
@@ -117,8 +117,8 @@ func (c *clusterClient) Proxy() Proxy {
 	return c.proxy
 }
 
-func (c *clusterClient) CertManager() CertManagerClient {
-	return newCertMangerClient(c.configClient, c.proxy, c.pollImmediateWaiter)
+func (c *clusterClient) CertManager() (CertManagerClient, error) {
+	return newCertManagerClient(c.configClient, c.proxy, c.pollImmediateWaiter)
 }
 
 func (c *clusterClient) ProviderComponents() ComponentsClient {

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -105,7 +105,12 @@ func (c *clusterctlClient) Init(options InitOptions) ([]Components, error) {
 	}
 
 	// Before installing the providers, ensure the cert-manager Webhook is in place.
-	if err := cluster.CertManager().EnsureInstalled(); err != nil {
+	certManager, err := cluster.CertManager()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := certManager.EnsureInstalled(); err != nil {
 		return nil, err
 	}
 
@@ -156,8 +161,13 @@ func (c *clusterctlClient) InitImages(options InitOptions) ([]string, error) {
 		return nil, err
 	}
 
+	certManager, err := cluster.CertManager()
+	if err != nil {
+		return nil, err
+	}
+
 	// Gets the list of container images required for the cert-manager (if not already installed).
-	images, err := cluster.CertManager().Images()
+	images, err := certManager.Images()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -38,7 +38,11 @@ func (c *clusterctlClient) PlanCertManagerUpgrade(options PlanUpgradeOptions) (C
 		return CertManagerUpgradePlan{}, err
 	}
 
-	plan, err := cluster.CertManager().PlanUpgrade()
+	certManager, err := cluster.CertManager()
+	if err != nil {
+		return CertManagerUpgradePlan{}, err
+	}
+	plan, err := certManager.PlanUpgrade()
 	return CertManagerUpgradePlan(plan), err
 }
 
@@ -122,7 +126,12 @@ func (c *clusterctlClient) ApplyUpgrade(options ApplyUpgradeOptions) error {
 	// NOTE: it is safe to upgrade to latest version of cert-manager given that it provides
 	// conversion web-hooks around Issuer/Certificate kinds, so installing an older versions of providers
 	// should continue to work with the latest cert-manager.
-	if err := clusterClient.CertManager().EnsureLatestVersion(); err != nil {
+	certManager, err := clusterClient.CertManager()
+	if err != nil {
+		return err
+	}
+
+	if err := certManager.EnsureLatestVersion(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
 ⚠️Fixes #3505 

(*clusterClient).CertManager: changed from func() CertManagerClient to func() (CertManagerClient, error)
Client.CertManager: changed from func() CertManagerClient to func() (CertManagerClient, error)




