### PR TITLE
🌱 Implement e2e test for clusterctl upgrade

### DIFF
--- a/cmd/clusterctl/client/cluster/components.go
+++ b/cmd/clusterctl/client/cluster/components.go
@@ -219,7 +219,7 @@ func (p *providerComponents) Delete(options DeleteOptions) error {
 
 func (p *providerComponents) DeleteWebhookNamespace() error {
 	log := logf.Log
-	log.V(5).Info("Deleting %s namespace", repository.WebhookNamespaceName)
+	log.V(5).Info("Deleting", "namespace", repository.WebhookNamespaceName)
 
 	c, err := p.proxy.NewClient()
 	if err != nil {

--- a/cmd/clusterctl/hack/create-local-repository.py
+++ b/cmd/clusterctl/hack/create-local-repository.py
@@ -53,24 +53,24 @@ settings = {}
 providers = {
       'cluster-api': {
               'componentsFile': 'core-components.yaml',
-              'nextVersion': 'v0.4.0',
+              'nextVersion': 'v0.4.99',
               'type': 'CoreProvider',
       },
       'bootstrap-kubeadm': {
             'componentsFile': 'bootstrap-components.yaml',
-            'nextVersion': 'v0.4.0',
+            'nextVersion': 'v0.4.99',
             'type': 'BootstrapProvider',
             'configFolder': 'bootstrap/kubeadm/config/default',
       },
       'control-plane-kubeadm': {
             'componentsFile': 'control-plane-components.yaml',
-            'nextVersion': 'v0.4.0',
+            'nextVersion': 'v0.4.99',
             'type': 'ControlPlaneProvider',
             'configFolder': 'controlplane/kubeadm/config/default',
       },
       'infrastructure-docker': {
           'componentsFile': 'infrastructure-components.yaml',
-          'nextVersion': 'v0.4.0',
+          'nextVersion': 'v0.4.99',
           'type': 'InfrastructureProvider',
           'configFolder': 'test/infrastructure/docker/config/default',
       },

--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -1,0 +1,300 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	"sigs.k8s.io/cluster-api/test/e2e/internal/log"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const initWithBinaryVariableName = "INIT_WITH_BINARY"
+
+// ClusterctlUpgradeSpecInput is the input for ClusterctlUpgradeSpec.
+type ClusterctlUpgradeSpecInput struct {
+	E2EConfig             *clusterctl.E2EConfig
+	ClusterctlConfigPath  string
+	BootstrapClusterProxy framework.ClusterProxy
+	ArtifactFolder        string
+	SkipCleanup           bool
+}
+
+// ClusterctlUpgradeSpec implements a test that verifies clusterctl upgrade of a management cluster.
+//
+// NOTE: this test is designed to test v1alpha3 --> v1alpha4 upgrades and v1alpha4 --> v1alpha4.
+func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpgradeSpecInput) {
+	var (
+		specName = "clusterctl-upgrade"
+		input    ClusterctlUpgradeSpecInput
+
+		managementClusterNamespace     *corev1.Namespace
+		managementClusterCancelWatches context.CancelFunc
+		managementClusterResources     *clusterctl.ApplyClusterTemplateAndWaitResult
+		managementClusterProxy         framework.ClusterProxy
+
+		testNamespace     *corev1.Namespace
+		testCancelWatches context.CancelFunc
+		clusterName       string
+	)
+
+	BeforeEach(func() {
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+		input = inputGetter()
+		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(input.E2EConfig.Variables).To(HaveKey(initWithBinaryVariableName), "Invalid argument. INIT_WITH_BINARY variable must be defined when calling %s spec", specName)
+		Expect(input.E2EConfig.Variables[initWithBinaryVariableName]).ToNot(BeEmpty(), "Invalid argument. INIT_WITH_BINARY variable can't be empty when calling %s spec", specName)
+		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
+		Expect(os.MkdirAll(input.ArtifactFolder, 0755)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		managementClusterNamespace, managementClusterCancelWatches = setupSpecNamespace(context.TODO(), specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		managementClusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	})
+
+	It("Should create a management cluster and then upgrade all the providers", func() {
+		By("Creating a workload cluster to be used as a new management cluster")
+		// NOTE: given that the bootstrap cluster could be shared by several tests, it is not practical to use it for testing clusterctl upgrades.
+		// So we are creating a workload cluster that will be used as a new management cluster where to install older version of providers
+
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: input.BootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   clusterctl.DefaultFlavor,
+				Namespace:                managementClusterNamespace.Name,
+				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
+				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
+				ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, managementClusterResources)
+
+		By("Turning the workload cluster into a management cluster with older versions of providers")
+
+		// In case of the cluster id a DockerCluster, we should load controller images into the nodes.
+		// Nb. this can be achieved also by changing the DockerMachine spec, but for the time being we are using
+		// this approach because this allows to have a single source of truth for images, the e2e config
+		// Nb. the images for official version of the providers will be pulled from internet, but the latest images must be
+		// built locally and loaded into kind
+		cluster := managementClusterResources.Cluster
+		if cluster.Spec.InfrastructureRef.Kind == "DockerCluster" {
+			Expect(bootstrap.LoadImagesToKindCluster(ctx, bootstrap.LoadImagesToKindClusterInput{
+				Name:   cluster.Name,
+				Images: input.E2EConfig.Images,
+			})).To(Succeed())
+		}
+
+		// Get a ClusterBroker so we can interact with the workload cluster
+		managementClusterProxy = input.BootstrapClusterProxy.GetWorkloadCluster(ctx, cluster.Namespace, cluster.Name)
+
+		// Download the v1alpha3 clusterctl version to be used for setting up the management cluster to be upgraded
+		clusterctlBinaryURL := input.E2EConfig.GetVariable(initWithBinaryVariableName)
+		clusterctlBinaryURL = strings.ReplaceAll(clusterctlBinaryURL, "{OS}", runtime.GOOS)
+		clusterctlBinaryURL = strings.ReplaceAll(clusterctlBinaryURL, "{ARCH}", runtime.GOARCH)
+
+		log.Logf("downloading clusterctl binary from %s", clusterctlBinaryURL)
+		binaryFileclusterctlBinaryPath := downloadToTmpFile(clusterctlBinaryURL)
+		defer os.Remove(binaryFileclusterctlBinaryPath) // clean up
+
+		err := os.Chmod(binaryFileclusterctlBinaryPath, 0744)
+		Expect(err).ToNot(HaveOccurred(), "failed to chmod temporary file")
+
+		By("Initializing the workload cluster with older versions of providers")
+		clusterctl.InitManagementClusterAndWatchControllerLogs(ctx, clusterctl.InitManagementClusterAndWatchControllerLogsInput{
+			ClusterctlBinaryPath:    binaryFileclusterctlBinaryPath, // use older version of clusterctl to init the management cluster
+			ClusterProxy:            managementClusterProxy,
+			ClusterctlConfigPath:    input.ClusterctlConfigPath,
+			CoreProvider:            input.E2EConfig.GetProvidersWithOldestVersion(config.ClusterAPIProviderName)[0],
+			BootstrapProviders:      input.E2EConfig.GetProvidersWithOldestVersion(config.KubeadmBootstrapProviderName),
+			ControlPlaneProviders:   input.E2EConfig.GetProvidersWithOldestVersion(config.KubeadmControlPlaneProviderName),
+			InfrastructureProviders: input.E2EConfig.GetProvidersWithOldestVersion(input.E2EConfig.InfrastructureProviders()...),
+			LogFolder:               filepath.Join(input.ArtifactFolder, "clusters", cluster.Name),
+		}, input.E2EConfig.GetIntervals(specName, "wait-controllers")...)
+
+		By("THE MANAGEMENT CLUSTER WITH THE OLDER VERSION OF PROVIDERS IS UP&RUNNING!")
+
+		Byf("Creating a namespace for hosting the %s test workload cluster", specName)
+		testNamespace, testCancelWatches = framework.CreateNamespaceAndWatchEvents(ctx, framework.CreateNamespaceAndWatchEventsInput{
+			Creator:   managementClusterProxy.GetClient(),
+			ClientSet: managementClusterProxy.GetClientSet(),
+			Name:      specName,
+			LogFolder: filepath.Join(input.ArtifactFolder, "clusters", "bootstrap"),
+		})
+
+		By("Creating a test workload cluster")
+
+		// NOTE: This workload cluster is used to check the old management cluster works fine.
+		// In this case ApplyClusterTemplateAndWait can't be used because this helpers is linked to last version of the API;
+		// so the are getting a template using the downloaded version of clusterctl, applying it, and wait for machines to be provisioned.
+
+		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+		kubernetesVersion := input.E2EConfig.GetVariable(KubernetesVersion)
+		controlPlaneMachineCount := pointer.Int64Ptr(1)
+		workerMachineCount := pointer.Int64Ptr(1)
+
+		log.Logf("Creating the workload cluster with name %q using the %q template (Kubernetes %s, %d control-plane machines, %d worker machines)",
+			clusterName, "(default)", kubernetesVersion, controlPlaneMachineCount, workerMachineCount)
+
+		log.Logf("Getting the cluster template yaml")
+		workloadClusterTemplate := clusterctl.ConfigClusterWithBinary(ctx, binaryFileclusterctlBinaryPath, clusterctl.ConfigClusterInput{
+			// pass reference to the management cluster hosting this test
+			KubeconfigPath: managementClusterProxy.GetKubeconfigPath(),
+			// pass the clusterctl config file that points to the local provider repository created for this test,
+			ClusterctlConfigPath: input.ClusterctlConfigPath,
+			// select template
+			Flavor: clusterctl.DefaultFlavor,
+			// define template variables
+			Namespace:                testNamespace.Name,
+			ClusterName:              clusterName,
+			KubernetesVersion:        kubernetesVersion,
+			ControlPlaneMachineCount: controlPlaneMachineCount,
+			WorkerMachineCount:       workerMachineCount,
+			InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+			// setup clusterctl logs folder
+			LogFolder: filepath.Join(input.ArtifactFolder, "clusters", managementClusterProxy.GetName()),
+		})
+		Expect(workloadClusterTemplate).ToNot(BeNil(), "Failed to get the cluster template")
+
+		log.Logf("Applying the cluster template yaml to the cluster")
+		Expect(managementClusterProxy.Apply(ctx, workloadClusterTemplate)).To(Succeed())
+
+		By("Waiting for the machines to exists")
+		Eventually(func() (int64, error) {
+			var n int64 = 0
+			machineList := &clusterv1old.MachineList{}
+			if err := managementClusterProxy.GetClient().List(ctx, machineList, client.InNamespace(testNamespace.Name), client.MatchingLabels{clusterv1.ClusterLabelName: clusterName}); err == nil {
+				for _, machine := range machineList.Items {
+					if machine.Status.NodeRef != nil {
+						n++
+					}
+				}
+			}
+			return n, nil
+		}, input.E2EConfig.GetIntervals(specName, "wait-worker-nodes")...).Should(Equal(*controlPlaneMachineCount + *workerMachineCount))
+
+		By("THE MANAGEMENT CLUSTER WITH OLDER VERSION OF PROVIDERS WORKS!")
+
+		By("Upgrading providers to the latest version available")
+		clusterctl.UpgradeManagementClusterAndWait(ctx, clusterctl.UpgradeManagementClusterAndWaitInput{
+			ClusterctlConfigPath: input.ClusterctlConfigPath,
+			ClusterProxy:         managementClusterProxy,
+			ManagementGroup:      fmt.Sprintf("capi-system/%s", config.ClusterAPIProviderName),
+			Contract:             clusterv1.GroupVersion.Version,
+			LogFolder:            filepath.Join(input.ArtifactFolder, "clusters", cluster.Name),
+		}, input.E2EConfig.GetIntervals(specName, "wait-controllers")...)
+
+		By("THE MANAGEMENT CLUSTER WAS SUCCESSFULLY UPGRADED!")
+
+		// After upgrading we are sure the version is the latest version of the API,
+		// so it is possible to use the standard helpers
+
+		testMachineDeployments := framework.GetMachineDeploymentsByCluster(ctx, framework.GetMachineDeploymentsByClusterInput{
+			Lister:      managementClusterProxy.GetClient(),
+			ClusterName: clusterName,
+			Namespace:   testNamespace.Name,
+		})
+
+		framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
+			ClusterProxy:              managementClusterProxy,
+			Cluster:                   &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace.Name}},
+			MachineDeployment:         testMachineDeployments[0],
+			Replicas:                  2,
+			WaitForMachineDeployments: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		})
+
+		By("THE UPGRADED MANAGEMENT CLUSTER WORKS!")
+
+		By("PASSED!")
+	})
+
+	AfterEach(func() {
+		if testNamespace != nil {
+			// Dump all the logs from the workload cluster before deleting them.
+			managementClusterProxy.CollectWorkloadClusterLogs(ctx, testNamespace.Name, clusterName, filepath.Join(input.ArtifactFolder, "clusters", clusterName, "machines"))
+
+			framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
+				Lister:    managementClusterProxy.GetClient(),
+				Namespace: managementClusterNamespace.Name,
+				LogPath:   filepath.Join(input.ArtifactFolder, "clusters", managementClusterResources.Cluster.Name, "resources"),
+			})
+
+			if !input.SkipCleanup {
+				Byf("Deleting cluster %s/%s", testNamespace.Name, clusterName)
+				framework.DeleteAllClustersAndWait(ctx, framework.DeleteAllClustersAndWaitInput{
+					Client:    managementClusterProxy.GetClient(),
+					Namespace: testNamespace.Name,
+				}, input.E2EConfig.GetIntervals(specName, "wait-delete-cluster")...)
+
+				Byf("Deleting namespace used for hosting the %q test", specName)
+				framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
+					Deleter: managementClusterProxy.GetClient(),
+					Name:    testNamespace.Name,
+				})
+			}
+			testCancelWatches()
+		}
+
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		dumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, managementClusterNamespace, managementClusterCancelWatches, managementClusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
+	})
+}
+
+func downloadToTmpFile(url string) string {
+	tmpFile, err := ioutil.TempFile("", "clusterctl")
+	Expect(err).ToNot(HaveOccurred(), "failed to get temporary file")
+	defer tmpFile.Close()
+
+	// Get the data
+	resp, err := http.Get(url)
+	Expect(err).ToNot(HaveOccurred(), "failed to get clusterctl")
+	defer resp.Body.Close()
+
+	// Write the body to file
+	_, err = io.Copy(tmpFile, resp.Body)
+	Expect(err).ToNot(HaveOccurred(), "failed to write temporary file")
+
+	return tmpFile.Name()
+}

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -1,0 +1,39 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("When testing clusterctl upgrades", func() {
+
+	ClusterctlUpgradeSpec(context.TODO(), func() ClusterctlUpgradeSpecInput {
+		return ClusterctlUpgradeSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+		}
+	})
+
+})

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -29,8 +29,13 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v0.4.0
-  # Use manifest from source files
+  - name: v0.3.16 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/core-components.yaml"
+    type: "url"
+    replacements:
+    - old: --metrics-addr=127.0.0.1:8080
+      new: --metrics-addr=:8080
+  - name: v0.4.99 # next; use manifest from source files
     value: ../../../config/default
     replacements:
     - old: --metrics-bind-addr=127.0.0.1:8080
@@ -41,8 +46,13 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v0.4.0
-  # Use manifest from source files
+  - name: v0.3.16 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/bootstrap-components.yaml"
+    type: "url"
+    replacements:
+      - old: --metrics-addr=127.0.0.1:8080
+        new: --metrics-addr=:8080
+  - name: v0.4.99 # next; use manifest from source files
     value: ../../../bootstrap/kubeadm/config/default
     replacements:
     - old: --metrics-bind-addr=127.0.0.1:8080
@@ -53,8 +63,13 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v0.4.0
-  # Use manifest from source files
+  - name: v0.3.16 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/control-plane-components.yaml"
+    type: "url"
+    replacements:
+      - old: --metrics-addr=127.0.0.1:8080
+        new: --metrics-addr=:8080
+  - name: v0.4.99 # next; use manifest from source files
     value: ../../../controlplane/kubeadm/config/default
     replacements:
     - old: --metrics-bind-addr=127.0.0.1:8080
@@ -65,8 +80,16 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
-  - name: v0.4.0
-  # Use manifest from source files
+  - name: v0.3.16 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/infrastructure-components-development.yaml"
+    type: "url"
+    replacements:
+      - old: --metrics-addr=127.0.0.1:8080
+        new: --metrics-addr=:8080
+    files:
+      # Add cluster templates
+      - sourcePath: "../data/infrastructure-docker/v1alpha3/cluster-template.yaml"
+  - name: v0.4.99 # next; use manifest from source files
     value: ../../../test/infrastructure/docker/config/default
     replacements:
     - old: --metrics-bind-addr=127.0.0.1:8080
@@ -86,6 +109,7 @@ providers:
 variables:
   # default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
+  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/clusterctl-{OS}-{ARCH}"
   KUBERNETES_VERSION: "v1.19.1"
   ETCD_VERSION_UPGRADE_TO: "3.4.9-0"
   COREDNS_VERSION_UPGRADE_TO: "1.7.0"

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -109,7 +109,6 @@ providers:
 variables:
   # default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
-  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/clusterctl-{OS}-{ARCH}"
   KUBERNETES_VERSION: "v1.19.1"
   ETCD_VERSION_UPGRADE_TO: "3.4.9-0"
   COREDNS_VERSION_UPGRADE_TO: "1.7.0"
@@ -124,6 +123,8 @@ variables:
   EXP_MACHINE_POOL: "true"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   NODE_DRAIN_TIMEOUT: "60s"
+  # NOTE: INIT_WITH_BINARY is used only by the clusterctl upgrade test to initialize the management cluster to be upgraded
+  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/clusterctl-{OS}-{ARCH}"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -96,9 +96,9 @@ func InitWithBinary(_ context.Context, binary string, input InitInput) {
 
 	cmd := exec.Command(binary, "init",
 		"--core", input.CoreProvider,
-		"--bootstrap", strings.Join(input.BootstrapProviders, ", "),
-		"--control-plane", strings.Join(input.ControlPlaneProviders, ", "),
-		"--infrastructure", strings.Join(input.InfrastructureProviders, ", "),
+		"--bootstrap", strings.Join(input.BootstrapProviders, ","),
+		"--control-plane", strings.Join(input.ControlPlaneProviders, ","),
+		"--infrastructure", strings.Join(input.InfrastructureProviders, ","),
 		"--config", input.ClusterctlConfigPath,
 		"--kubeconfig", input.KubeconfigPath,
 	)
@@ -209,7 +209,7 @@ func ConfigClusterWithBinary(_ context.Context, clusterctlBinaryPath string, inp
 	cmd := exec.Command(clusterctlBinaryPath, "config", "cluster",
 		input.ClusterName,
 		"--infrastructure", input.InfrastructureProvider,
-		"--kubernetes-version", input.InfrastructureProvider,
+		"--kubernetes-version", input.KubernetesVersion,
 		"--control-plane-machine-count", fmt.Sprint(*input.ControlPlaneMachineCount),
 		"--worker-machine-count", fmt.Sprint(*input.WorkerMachineCount),
 		"--flavor", input.Flavor,

--- a/test/framework/convenience.go
+++ b/test/framework/convenience.go
@@ -25,6 +25,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
@@ -46,12 +47,15 @@ func TryAddDefaultSchemes(scheme *runtime.Scheme) {
 	// Add the apps schemes.
 	_ = appsv1.AddToScheme(scheme)
 
-	// Add the core CAPI scheme.
+	// Add the core CAPI v1alpha4 scheme.
 	_ = clusterv1.AddToScheme(scheme)
 
-	// Add the experiments CAPI scheme.
+	// Add the CAPI v1alpha4 experiments scheme.
 	_ = expv1.AddToScheme(scheme)
 	_ = addonsv1.AddToScheme(scheme)
+
+	// Add the core CAPI v1alpha3 scheme.
+	_ = clusterv1old.AddToScheme(scheme)
 
 	// Add the kubeadm bootstrapper scheme.
 	_ = bootstrapv1.AddToScheme(scheme)

--- a/test/framework/interfaces.go
+++ b/test/framework/interfaces.go
@@ -49,11 +49,3 @@ type GetLister interface {
 	Getter
 	Lister
 }
-
-// ComponentGenerator is used to install components, generally any YAML bundle.
-type ComponentGenerator interface {
-	// GetName returns the name of the component.
-	GetName() string
-	// Manifests return the YAML bundle.
-	Manifests(context.Context) ([]byte, error)
-}

--- a/test/infrastructure/docker/config/webhook/service.yaml
+++ b/test/infrastructure/docker/config/webhook/service.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,6 +6,5 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 9443
-  selector:
-    control-plane: controller-manager
+      targetPort: webhook-server
+


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a new E2E test providing a signal on clusterctl upgrades

- init a management cluster with providers in version X
- create a workload cluster
- upgrade providers to version Y using clusterctl upgrade
- check everything works fine (e.g. add a machine to the workload cluster)
- cleanup

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3690
