### PR TITLE
🌱 Re-enable link checker

### DIFF
--- a/docs/book/Makefile
+++ b/docs/book/Makefile
@@ -43,13 +43,22 @@ $(MDBOOK_LINKCHECK):
 	$(CRATE_INSTALL) --git Michael-F-Bryan/mdbook-linkcheck --tag v0.7.0 --to $(TOOLS_BIN_DIR) --force
 
 .PHONY: serve
-serve: $(MDBOOK) $(TABULATE) $(RELEASELINK) $(MDBOOK_LINKCHECK)
+serve: $(MDBOOK) $(TABULATE) $(RELEASELINK) clean-linkcheck
 	$(MDBOOK) serve
 
 .PHONY: build
-build: $(MDBOOK) $(TABULATE) $(RELEASELINK) $(MDBOOK_LINKCHECK)
+build: $(MDBOOK) $(TABULATE) $(RELEASELINK) clean-linkcheck
 	$(MDBOOK) build
 
 .PHONY: verify
 verify: $(MDBOOK) $(TABULATE) $(RELEASELINK) $(MDBOOK_LINKCHECK)
 	$(MDBOOK) build
+
+# We remove the linkcheck binary when not running `verify` because mdbook
+# always run optional plugins if they are installed, but will only print a
+# warning if they're not. This is the best solution we could figure out for how
+# to integrate it into the mdbook plugin model while not gating all mdbook
+# tasks on verification.
+.PHONY: clean-linkcheck
+clean-linkcheck:
+	rm -f $(MDBOOK_LINKCHECK)

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -21,8 +21,8 @@ command = "./util-embed.sh"
 [preprocessor.releaselink]
 command = "./util-releaselink.sh"
 
-# [output.linkcheck]
-# optional = true
+[output.linkcheck]
+optional = true
 
-# [output.linkcheck.http-headers]
-# 'github\.com' = ["Authorization: Bearer $GITHUB_TOKEN"]
+[output.linkcheck.http-headers]
+'github\.com' = ["Authorization: Bearer $GITHUB_TOKEN"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts the part of #3709 that disables the linkchecker entirely. I think @randomvariable may have been confused in thinking that the linkchecker was blocking Netlify deploys.

It will log 

> The command `mdbook-linkcheck` for backend `linkcheck` was not found, but was marked as optional.

But this is just a warning, not a failure. If you have the linkchecker installed in your `hack/tools/bin` directory it will run the linkchecker, so we specifically don't install it for make targets other than `verify`.