### PR TITLE
🌱 Update linkchecker to use retry with exponential backoff 

### DIFF
--- a/docs/book/Makefile
+++ b/docs/book/Makefile
@@ -34,6 +34,10 @@ RELEASELINK := $(TOOLS_BIN_DIR)/mdbook-releaselink
 $(RELEASELINK): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/mdbook-releaselink ./mdbook/releaselink
 
+RETRY := $(TOOLS_BIN_DIR)/retry
+$(RETRY): $(TOOLS_DIR)/go.mod
+	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/retry github.com/joshdk/retry
+
 MDBOOK := $(TOOLS_BIN_DIR)/mdbook
 $(MDBOOK):
 	$(CRATE_INSTALL) --git rust-lang/mdBook --tag v0.4.3 --to $(TOOLS_BIN_DIR) --force
@@ -43,13 +47,22 @@ $(MDBOOK_LINKCHECK):
 	$(CRATE_INSTALL) --git Michael-F-Bryan/mdbook-linkcheck --tag v0.7.0 --to $(TOOLS_BIN_DIR) --force
 
 .PHONY: serve
-serve: $(MDBOOK) $(TABULATE) $(RELEASELINK) $(MDBOOK_LINKCHECK)
+serve: $(MDBOOK) $(TABULATE) $(RELEASELINK) clean-linkcheck
 	$(MDBOOK) serve
 
 .PHONY: build
-build: $(MDBOOK) $(TABULATE) $(RELEASELINK) $(MDBOOK_LINKCHECK)
+build: $(MDBOOK) $(TABULATE) $(RELEASELINK) clean-linkcheck
 	$(MDBOOK) build
 
 .PHONY: verify
-verify: $(MDBOOK) $(TABULATE) $(RELEASELINK) $(MDBOOK_LINKCHECK)
-	$(MDBOOK) build
+verify: $(MDBOOK) $(TABULATE) $(RELEASELINK) $(MDBOOK_LINKCHECK) $(RETRY)
+	$(RETRY) -backoff -attempts 10 -max-time 20m $(MDBOOK) build
+
+# We remove the linkcheck binary when not running `verify` because mdbook
+# always run optional plugins if they are installed, but will only print a
+# warning if they're not. This is the best solution we could figure out for how
+# to integrate it into the mdbook plugin model while not gating all mdbook
+# tasks on verification.
+.PHONY: clean-linkcheck
+clean-linkcheck:
+	rm -f $(MDBOOK_LINKCHECK)

--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -21,8 +21,5 @@ command = "./util-embed.sh"
 [preprocessor.releaselink]
 command = "./util-releaselink.sh"
 
-# [output.linkcheck]
-# optional = true
-
-# [output.linkcheck.http-headers]
-# 'github\.com' = ["Authorization: Bearer $GITHUB_TOKEN"]
+[output.linkcheck]
+optional = true

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/golangci/golangci-lint v1.27.0
 	github.com/joelanford/go-apidiff v0.0.0-20191206194835-106bcff5f060
+	github.com/joshdk/retry v1.1.0
 	github.com/onsi/ginkgo v1.12.0
 	github.com/raviqqe/liche v0.0.0-20200229003944-f57a5d1c5be4
 	golang.org/x/tools v0.0.0-20200502202811-ed308ab3e770

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -338,6 +338,8 @@ github.com/joelanford/go-apidiff v0.0.0-20191206194835-106bcff5f060 h1:ZboxBXJqP
 github.com/joelanford/go-apidiff v0.0.0-20191206194835-106bcff5f060/go.mod h1:wgVWgVCwYYkjcYpJtBnWYkyUYZfVovO3Y5pX49mJsqs=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/joshdk/retry v1.1.0 h1:3LWG5kFTzSaWq/9BGBgRNcUwldugVaKWwK4nARZu4xc=
+github.com/joshdk/retry v1.1.0/go.mod h1:tAsV0H2fH9an4AcJiNqEN8gGmk73Hm+krrxMEuy8W10=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/go-bindata/go-bindata"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/joelanford/go-apidiff"
+	_ "github.com/joshdk/retry"
 	_ "github.com/onsi/ginkgo/ginkgo"
 	_ "github.com/raviqqe/liche"
 	_ "k8s.io/code-generator/cmd/conversion-gen"

--- a/test/infrastructure/docker/hack/tools/go.sum
+++ b/test/infrastructure/docker/hack/tools/go.sum
@@ -288,6 +288,7 @@ github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod 
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joelanford/go-apidiff v0.0.0-20191206194835-106bcff5f060/go.mod h1:wgVWgVCwYYkjcYpJtBnWYkyUYZfVovO3Y5pX49mJsqs=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/joshdk/retry v1.1.0/go.mod h1:tAsV0H2fH9an4AcJiNqEN8gGmk73Hm+krrxMEuy8W10=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
**What this PR does / why we need it**:
Sorry this has turned into such an ordeal! I didn't think it'd be this complicated 😸 

Turns out we can't use an API token for getting around the rate-limiting of GitHub. We will try using retry with backoff, since each run of the linkcheck writes to a cache and so will not re-check already successful links.

Marking plugins as optional means that they only run if installed, and do not fail if not installed. We want to not install the linkchecker for any targets except "verify" so that we don't run the verification in CI environments that aren't specifically trying to do verification.

Explicitly remove the `mdbook-linkcheck` binary in the `serve` and `build` targets so that they works the same in dev environments where the linkchecker may have been previously installed by running `verify`.