### PR TITLE
:bug: Fix Makefile target to clean-release-git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,9 +451,9 @@ release: clean-release ## Builds and push container images using the latest git 
 	$(MAKE) set-manifest-pull-policy PULL_POLICY=IfNotPresent TARGET_RESOURCE="./bootstrap/kubeadm/config/manager/manager_pull_policy.yaml"
 	$(MAKE) set-manifest-pull-policy PULL_POLICY=IfNotPresent TARGET_RESOURCE="./controlplane/kubeadm/config/manager/manager_pull_policy.yaml"
 	## Build the manifests
-	$(MAKE) release-manifests clean-git-release
+	$(MAKE) release-manifests clean-release-git
 	## Build the development manifests
-	$(MAKE) release-manifests-dev clean-git-release
+	$(MAKE) release-manifests-dev clean-release-git
 
 .PHONY: release-manifests
 release-manifests: $(RELEASE_DIR) $(KUSTOMIZE) ## Builds the manifests to publish with a release


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
/assign @fabriziopandini @ncdc 
/milestone v0.3.10

This is a bug, I had to generate the development manifests manually because it wasn't referencing the correct makefile target