### PR TITLE
Fix conditions counter in case of mismatching order of conditions between WithConditions and WithStepCounterIfOnly

### DIFF
--- a/util/conditions/getter.go
+++ b/util/conditions/getter.go
@@ -153,14 +153,19 @@ func summary(from Getter, options ...MergeOption) *clusterv1.Condition {
 	}
 
 	// If it is required to add a step counter only if a subset of condition exists, check if the conditions
-	// in scope are included in this subset.
+	// in scope are included in this subset or not.
 	if mergeOpt.addStepCounterIfOnlyConditionTypes != nil {
 		for _, c := range conditionsInScope {
+			found := false
 			for _, t := range mergeOpt.addStepCounterIfOnlyConditionTypes {
-				if c.Type != t {
-					mergeOpt.addStepCounter = false
+				if c.Type == t {
+					found = true
 					break
 				}
+			}
+			if !found {
+				mergeOpt.addStepCounter = false
+				break
 			}
 		}
 	}

--- a/util/conditions/getter_test.go
+++ b/util/conditions/getter_test.go
@@ -201,6 +201,12 @@ func TestSummary(t *testing.T) {
 			want:    FalseCondition(clusterv1.ReadyCondition, "reason falseInfo1", clusterv1.ConditionSeverityInfo, "0 of 1 completed"),
 		},
 		{
+			name:    "Returns ready condition with the summary of selected conditions (using WithConditions and WithStepCounterIfOnly options - with inconsistent order between the two)",
+			from:    getterWithConditions(bar),
+			options: []MergeOption{WithConditions("baz", "bar"), WithStepCounter(), WithStepCounterIfOnly("bar", "baz")}, // conditions in WithStepCounterIfOnly could be in different order than in WithConditions
+			want:    FalseCondition(clusterv1.ReadyCondition, "reason falseInfo1", clusterv1.ConditionSeverityInfo, "0 of 2 completed"),
+		},
+		{
 			name:    "Returns ready condition with the summary of selected conditions (using WithConditions and WithStepCounterIfOnly options)",
 			from:    getterWithConditions(bar, baz),
 			options: []MergeOption{WithConditions("bar", "baz"), WithStepCounter(), WithStepCounterIfOnly("bar")}, // there is also baz, so the step counter should not be set


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix conditions counter in case of mismatching order of conditions between WithConditions and WithStepCounterIfOnly

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3739
