### PR TITLE
:seedling: Update kubectl version to 1.19

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -80,7 +80,7 @@ providers = {
             "third_party",
         ],
         "additional_docker_helper_commands": """
-RUN wget -qO- https://dl.k8s.io/v1.14.4/kubernetes-client-linux-amd64.tar.gz | tar xvz
+RUN wget -qO- https://dl.k8s.io/v1.19.2/kubernetes-client-linux-amd64.tar.gz | tar xvz
 RUN wget -qO- https://get.docker.com | sh
 """,
         "additional_docker_build_commands": """

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -216,7 +216,7 @@ for the provider and performs a live update of the running container.
 docker build. e.g.
 
 ``` Dockerfile
-RUN wget -qO- https://dl.k8s.io/v1.14.4/kubernetes-client-linux-amd64.tar.gz | tar xvz
+RUN wget -qO- https://dl.k8s.io/v1.19.2/kubernetes-client-linux-amd64.tar.gz | tar xvz
 RUN wget -qO- https://get.docker.com | sh
 ```
 

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KUBECTL_VERSION=v1.15.0
+MINIMUM_KUBECTL_VERSION=v1.19.0
 
 # Ensure the kubectl tool exists and is a viable version, or installs it
 verify_kubectl_version() {

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN apk add --update \
     curl \
     && rm -rf /var/cache/apk/*
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl && \
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.2/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 

--- a/test/infrastructure/docker/Dockerfile.dev
+++ b/test/infrastructure/docker/Dockerfile.dev
@@ -28,7 +28,7 @@ ENV GOPROXY=$goproxy
 
 WORKDIR /tmp
 # install a couple of dependencies
-RUN curl -L https://dl.k8s.io/v1.14.4/kubernetes-client-linux-amd64.tar.gz | tar xvz
+RUN curl -L https://dl.k8s.io/v1.19.2/kubernetes-client-linux-amd64.tar.gz | tar xvz
 RUN mv /tmp/kubernetes/client/bin/kubectl /usr/local/bin
 RUN curl https://get.docker.com | sh
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the kubectl version used and required to 1.19

/milestone v0.4.0
/assign @fabriziopandini 
