### PR TITLE
🌱Add Node watch to Machine controller

### DIFF
--- a/api/v1alpha3/common_types.go
+++ b/api/v1alpha3/common_types.go
@@ -59,6 +59,9 @@ const (
 	MachineInternalIP  MachineAddressType = "InternalIP"
 	MachineExternalDNS MachineAddressType = "ExternalDNS"
 	MachineInternalDNS MachineAddressType = "InternalDNS"
+
+	// MachineNodeNameIndex is used by the Machine Controller to index Machines by Node name, and add a watch on Nodes.
+	MachineNodeNameIndex = "status.nodeRef.name"
 )
 
 // MachineAddress contains information for the node's address.

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -74,6 +74,7 @@ type MachineReconciler struct {
 	Log     logr.Logger
 	Tracker *remote.ClusterCacheTracker
 
+	controller      controller.Controller
 	restConfig      *rest.Config
 	scheme          *runtime.Scheme
 	recorder        record.EventRecorder
@@ -106,6 +107,16 @@ func (r *MachineReconciler) SetupWithManager(mgr ctrl.Manager, options controlle
 	if err != nil {
 		return errors.Wrap(err, "failed to add Watch for Clusters to controller manager")
 	}
+
+	// Add index to Machine for listing by Node reference.
+	if err := mgr.GetCache().IndexField(&clusterv1.Machine{},
+		clusterv1.MachineNodeNameIndex,
+		r.indexMachineByNodeName,
+	); err != nil {
+		return errors.Wrap(err, "error setting index fields")
+	}
+
+	r.controller = controller
 
 	r.recorder = mgr.GetEventRecorderFor("machine-controller")
 	r.restConfig = mgr.GetConfig()
@@ -235,6 +246,14 @@ func patchMachine(ctx context.Context, patchHelper *patch.Helper, machine *clust
 }
 
 func (r *MachineReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, m *clusterv1.Machine) (ctrl.Result, error) {
+	logger := r.Log.WithValues("machine", m.Name, "namespace", m.Namespace)
+
+	if cluster.Status.ControlPlaneInitialized {
+		if err := r.watchClusterNodes(ctx, cluster); err != nil {
+			logger.Error(err, "error watching nodes on target cluster")
+			return ctrl.Result{}, err
+		}
+	}
 
 	// If the Machine belongs to a cluster, add an owner reference.
 	if r.shouldAdopt(m) {
@@ -606,6 +625,68 @@ func (r *MachineReconciler) reconcileDeleteExternal(ctx context.Context, m *clus
 
 func (r *MachineReconciler) shouldAdopt(m *clusterv1.Machine) bool {
 	return metav1.GetControllerOf(m) == nil && !util.HasOwner(m.OwnerReferences, clusterv1.GroupVersion.String(), []string{"Cluster"})
+}
+
+func (r *MachineReconciler) watchClusterNodes(ctx context.Context, cluster *clusterv1.Cluster) error {
+	// If there is no tracker, don't watch remote nodes
+	if r.Tracker == nil {
+		return nil
+	}
+
+	if err := r.Tracker.Watch(ctx, remote.WatchInput{
+		Name:         "machine-watchNodes",
+		Cluster:      util.ObjectKey(cluster),
+		Watcher:      r.controller,
+		Kind:         &corev1.Node{},
+		EventHandler: &handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(r.nodeToMachine)},
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *MachineReconciler) nodeToMachine(o handler.MapObject) []reconcile.Request {
+	node, ok := o.Object.(*corev1.Node)
+	if !ok {
+		r.Log.Error(errors.New("incorrect type"), "expected a Node", "type", fmt.Sprintf("%T", o))
+		return nil
+	}
+
+	machineList := &clusterv1.MachineList{}
+	if err := r.Client.List(
+		context.TODO(),
+		machineList,
+		client.MatchingFields{clusterv1.MachineNodeNameIndex: node.Name},
+	); err != nil {
+		r.Log.Error(err, "Failed to list machines for node", "node", node.GetName())
+		return nil
+	}
+
+	// Found no Machine for Node
+	if len(machineList.Items) != 1 {
+		if len(machineList.Items) == 0 {
+			r.Log.Error(errors.New("no matching Machine"), "Unable to retrieve machine from node", "node", node.GetName())
+		} else {
+			r.Log.Error(errors.New("multiple matching Machines"), "There are multiple machines for node", "node", node.GetName())
+		}
+		return nil
+	}
+
+	return []reconcile.Request{{NamespacedName: util.ObjectKey(&machineList.Items[0])}}
+}
+
+func (r *MachineReconciler) indexMachineByNodeName(o runtime.Object) []string {
+	machine, ok := o.(*clusterv1.Machine)
+	if !ok {
+		r.Log.Error(errors.New("incorrect type"), "expected a Machine", "type", fmt.Sprintf("%T", o))
+		return nil
+	}
+
+	if machine.Status.NodeRef != nil {
+		return []string{machine.Status.NodeRef.Name}
+	}
+
+	return nil
 }
 
 // writer implements io.Writer interface as a pass-through for klog.

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -34,12 +34,185 @@ import (
 	"sigs.k8s.io/cluster-api/test/helpers"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+func TestWatches(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, "test-machine-watches")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	infraMachine := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "InfrastructureMachine",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha3",
+			"metadata": map[string]interface{}{
+				"name":      "infra-config1",
+				"namespace": ns.Name,
+			},
+			"spec": map[string]interface{}{
+				"providerID": "test://id-1",
+			},
+			"status": map[string]interface{}{
+				"ready": true,
+				"addresses": []interface{}{
+					map[string]interface{}{
+						"type":    "InternalIP",
+						"address": "10.0.0.1",
+					},
+				},
+			},
+		},
+	}
+
+	defaultBootstrap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "BootstrapMachine",
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+			"metadata": map[string]interface{}{
+				"name":      "bootstrap-config-machinereconcile",
+				"namespace": ns.Name,
+			},
+			"spec":   map[string]interface{}{},
+			"status": map[string]interface{}{},
+		},
+	}
+
+	testCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "machine-reconcile-",
+			Namespace:    ns.Name,
+		},
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-1",
+			Namespace: ns.Name,
+		},
+		Spec: corev1.NodeSpec{
+			ProviderID: "test:///id-1",
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, testCluster)).To(BeNil())
+	g.Expect(testEnv.CreateKubeconfigSecret(testCluster)).To(Succeed())
+	g.Expect(testEnv.Create(ctx, defaultBootstrap)).To(BeNil())
+	g.Expect(testEnv.Create(ctx, node)).To(Succeed())
+	g.Expect(testEnv.Create(ctx, infraMachine)).To(BeNil())
+
+	defer func(do ...runtime.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, testCluster, defaultBootstrap)
+
+	// Patch cluster control plane initialized (this is required to start node watch)
+	patchHelper, err := patch.NewHelper(testCluster, testEnv)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	testCluster.Status.ControlPlaneInitialized = true
+	g.Expect(patchHelper.Patch(ctx, testCluster, patch.WithStatusObservedGeneration{})).To(Succeed())
+
+	// Patch infra machine ready
+	patchHelper, err = patch.NewHelper(infraMachine, testEnv)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(unstructured.SetNestedField(infraMachine.Object, true, "status", "ready")).To(Succeed())
+	g.Expect(patchHelper.Patch(ctx, infraMachine, patch.WithStatusObservedGeneration{})).To(Succeed())
+
+	// Patch bootstrap ready
+	patchHelper, err = patch.NewHelper(defaultBootstrap, testEnv)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(unstructured.SetNestedField(defaultBootstrap.Object, true, "status", "ready")).To(Succeed())
+	g.Expect(unstructured.SetNestedField(defaultBootstrap.Object, "secretData", "status", "dataSecretName")).To(Succeed())
+	g.Expect(patchHelper.Patch(ctx, defaultBootstrap, patch.WithStatusObservedGeneration{})).To(Succeed())
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "machine-created-",
+			Namespace:    ns.Name,
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: testCluster.Name,
+			InfrastructureRef: corev1.ObjectReference{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+				Kind:       "InfrastructureMachine",
+				Name:       "infra-config1",
+			},
+			Bootstrap: clusterv1.Bootstrap{
+				ConfigRef: &corev1.ObjectReference{
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+					Kind:       "BootstrapMachine",
+					Name:       "bootstrap-config-machinereconcile",
+				},
+			}},
+	}
+
+	g.Expect(testEnv.Create(ctx, machine)).To(BeNil())
+	defer func() {
+		g.Expect(testEnv.Cleanup(ctx, machine)).To(Succeed())
+	}()
+
+	// Wait for reconciliation to happen.
+	// Since infra and bootstrap objects are ready, a nodeRef will be assigned during node reconciliation.
+	key := client.ObjectKey{Name: machine.Name, Namespace: machine.Namespace}
+	g.Eventually(func() bool {
+		if err := testEnv.Get(ctx, key, machine); err != nil {
+			return false
+		}
+		return machine.Status.NodeRef != nil
+	}, timeout).Should(BeTrue())
+
+	// Node deletion will trigger node watchers and a request will be added to the queue.
+	g.Expect(testEnv.Delete(ctx, node)).To(Succeed())
+	// TODO: Once conditions are in place, check if node deletion triggered a reconcile.
+
+	// Delete infra machine, external tracker will trigger reconcile
+	// and machine Status.FailureReason should be non-nil after reconcileInfrastructure
+	g.Expect(testEnv.Delete(ctx, infraMachine)).To(Succeed())
+	g.Eventually(func() bool {
+		if err := testEnv.Get(ctx, key, machine); err != nil {
+			return false
+		}
+		return machine.Status.FailureMessage != nil
+	}, timeout).Should(BeTrue())
+}
+
+func TestIndexMachineByNodeName(t *testing.T) {
+	r := &MachineReconciler{}
+	testCases := []struct {
+		name     string
+		object   runtime.Object
+		expected []string
+	}{
+		{
+			name:     "when the machine has no NodeRef",
+			object:   &clusterv1.Machine{},
+			expected: []string{},
+		},
+		{
+			name: "when the machine has valid a NodeRef",
+			object: &clusterv1.Machine{
+				Status: clusterv1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{
+						Name: "node1",
+					},
+				},
+			},
+			expected: []string{"node1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := r.indexMachineByNodeName(tc.object)
+			g.Expect(got).To(ConsistOf(tc.expected))
+		})
+	}
+}
 
 func TestMachineFinalizer(t *testing.T) {
 	bootstrapData := "some valid data"

--- a/controllers/machinehealthcheck_controller_test.go
+++ b/controllers/machinehealthcheck_controller_test.go
@@ -1310,48 +1310,6 @@ func TestNodeToMachineHealthCheck(t *testing.T) {
 	}
 }
 
-func TestIndexMachineByNodeName(t *testing.T) {
-	r := &MachineHealthCheckReconciler{
-		Log: log.Log,
-	}
-
-	testCases := []struct {
-		name     string
-		object   runtime.Object
-		expected []string
-	}{
-		{
-			name:     "when the machine has no NodeRef",
-			object:   &clusterv1.Machine{},
-			expected: []string{},
-		},
-		{
-			name: "when the machine has valid a NodeRef",
-			object: &clusterv1.Machine{
-				Status: clusterv1.MachineStatus{
-					NodeRef: &corev1.ObjectReference{
-						Name: "node1",
-					},
-				},
-			},
-			expected: []string{"node1"},
-		},
-		{
-			name:     "when the object passed is not a Machine",
-			object:   &corev1.Node{},
-			expected: []string{},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewWithT(t)
-			got := r.indexMachineByNodeName(tc.object)
-			g.Expect(got).To(ConsistOf(tc.expected))
-		})
-	}
-}
-
 func TestIsAllowedRemediation(t *testing.T) {
 	testCases := []struct {
 		name               string


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a watch on Node in Machine controller so that when a node changes, Machine reconcile is triggered.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3729
