### PR TITLE
:seedling: Use util.ManagerDelegatingClientFunc in all managers

### DIFF
--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	"k8s.io/klog/klogr"
 	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -35,9 +34,8 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/version"
 	kubeadmcontrolplanev1alpha3 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	kubeadmcontrolplanecontrollers "sigs.k8s.io/cluster-api/controlplane/kubeadm/controllers"
+	"sigs.k8s.io/cluster-api/util"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	// +kubebuilder:scaffold:imports
 )
@@ -128,7 +126,7 @@ func main() {
 		RetryPeriod:        &leaderElectionRetryPeriod,
 		Namespace:          watchNamespace,
 		SyncPeriod:         &syncPeriod,
-		NewClient:          newClientFunc,
+		NewClient:          util.ManagerDelegatingClientFunc,
 		Port:               webhookPort,
 	})
 	if err != nil {
@@ -174,21 +172,4 @@ func setupWebhooks(mgr ctrl.Manager) {
 
 func concurrency(c int) controller.Options {
 	return controller.Options{MaxConcurrentReconciles: c}
-}
-
-// newClientFunc returns a client reads from cache and write directly to the server
-// this avoid get unstructured object directly from the server
-// see issue: https://github.com/kubernetes-sigs/cluster-api/issues/1663
-func newClientFunc(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
-	// Create the Client for Write operations.
-	c, err := client.New(config, options)
-	if err != nil {
-		return nil, err
-	}
-
-	return &client.DelegatingClient{
-		Reader:       cache,
-		Writer:       c,
-		StatusClient: c,
-	}, nil
 }


### PR DESCRIPTION
Removes the duplicated private newClientFunc that were dangling around
in multiple places, which were completely identical. Moves to
util.ManagerDelegatingClientFunc, which is a function that was
introduced a while ago and it has the same effect.

/assign @fabriziopandini 
/milestone v0.4.0