### PR TITLE
:warning: Add required coordination/leases RBAC for v0.7 leader election

### DIFF
--- a/bootstrap/kubeadm/config/rbac/leader_election_role.yaml
+++ b/bootstrap/kubeadm/config/rbac/leader_election_role.yaml
@@ -30,3 +30,15 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/ci/rbac/leader_election_role.yaml
+++ b/config/ci/rbac/leader_election_role.yaml
@@ -31,3 +31,15 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -31,3 +31,15 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/controlplane/kubeadm/config/rbac/leader_election_role.yaml
+++ b/controlplane/kubeadm/config/rbac/leader_election_role.yaml
@@ -30,3 +30,15 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/test/infrastructure/docker/config/rbac/leader_election_role.yaml
+++ b/test/infrastructure/docker/config/rbac/leader_election_role.yaml
@@ -30,3 +30,15 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete


### PR DESCRIPTION
This change is in preparation for controller runtime new default leader
election in v0.7.x which uses configmapleases instead of plain
configmap.

/assign @fabriziopandini 
/milestone v0.4.0