### PR TITLE
 🐛 Indicate in KCP conditions, when template cloning fails

### DIFF
--- a/controlplane/kubeadm/api/v1alpha4/condition_consts.go
+++ b/controlplane/kubeadm/api/v1alpha4/condition_consts.go
@@ -131,4 +131,21 @@ const (
 
 	// EtcdMemberUnhealthyReason (Severity=Error) documents a Machine's etcd member is unhealthy.
 	EtcdMemberUnhealthyReason = "EtcdMemberUnhealthy"
+
+	// MachinesCreatedCondition documents that the machines controlled by the KubeadmControlPlane are created.
+	// When this condition is false, it indicates that there was an error when cloning the infrastructure/bootstrap template or
+	// when generating the machine object
+	MachinesCreatedCondition clusterv1.ConditionType = "MachinesCreated"
+
+	// InfrastructureTemplateCloningFailedReason (Severity=Error) documents a KubeadmControlPlane failing to
+	// clone the infrastructure template
+	InfrastructureTemplateCloningFailedReason = "InfrastructureTemplateCloningFailed"
+
+	// BootstrapTemplateCloningFailedReason (Severity=Error) documents a KubeadmControlPlane failing to
+	// clone the bootstrap template
+	BootstrapTemplateCloningFailedReason = "BootstrapTemplateCloningFailed"
+
+	// MachineGenerationFailedReason (Severity=Error) documents a KubeadmControlPlane failing to
+	// generate a machine object
+	MachineGenerationFailedReason = "MachineGenerationFailed"
 )

--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -208,6 +208,7 @@ func patchKubeadmControlPlane(ctx context.Context, patchHelper *patch.Helper, kc
 	// Always update the readyCondition by summarizing the state of other conditions.
 	conditions.SetSummary(kcp,
 		conditions.WithConditions(
+			controlplanev1.MachinesCreatedCondition,
 			controlplanev1.MachinesSpecUpToDateCondition,
 			controlplanev1.ResizedCondition,
 			controlplanev1.MachinesReadyCondition,
@@ -221,6 +222,7 @@ func patchKubeadmControlPlane(ctx context.Context, patchHelper *patch.Helper, kc
 		ctx,
 		kcp,
 		patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
+			controlplanev1.MachinesCreatedCondition,
 			clusterv1.ReadyCondition,
 			controlplanev1.MachinesSpecUpToDateCondition,
 			controlplanev1.ResizedCondition,

--- a/controlplane/kubeadm/controllers/status.go
+++ b/controlplane/kubeadm/controllers/status.go
@@ -72,6 +72,9 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 	// We are scaling down
 	case replicas > desiredReplicas:
 		conditions.MarkFalse(kcp, controlplanev1.ResizedCondition, controlplanev1.ScalingDownReason, clusterv1.ConditionSeverityWarning, "Scaling down control plane to %d replicas (actual %d)", desiredReplicas, replicas)
+
+		// This means that there was no error in generating the desired number of machine objects
+		conditions.MarkTrue(kcp, controlplanev1.MachinesCreatedCondition)
 	default:
 		// make sure last resize operation is marked as completed.
 		// NOTE: we are checking the number of machines ready so we report resize completed only when the machines
@@ -80,6 +83,9 @@ func (r *KubeadmControlPlaneReconciler) updateStatus(ctx context.Context, kcp *c
 		if int32(len(readyMachines)) == replicas {
 			conditions.MarkTrue(kcp, controlplanev1.ResizedCondition)
 		}
+
+		// This means that there was no error in generating the desired number of machine objects
+		conditions.MarkTrue(kcp, controlplanev1.MachinesCreatedCondition)
 	}
 
 	workloadCluster, err := r.managementCluster.GetWorkloadCluster(ctx, util.ObjectKey(cluster))

--- a/util/conditions/getter_test.go
+++ b/util/conditions/getter_test.go
@@ -20,9 +20,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
-	"github.com/onsi/gomega/types"
-	"github.com/pkg/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
@@ -46,7 +43,7 @@ func TestGetAndHas(t *testing.T) {
 	cluster.SetConditions(conditionList(TrueCondition("conditionBaz")))
 
 	g.Expect(Has(cluster, "conditionBaz")).To(BeTrue())
-	g.Expect(Get(cluster, "conditionBaz")).To(haveSameStateOf(TrueCondition("conditionBaz")))
+	g.Expect(Get(cluster, "conditionBaz")).To(HaveSameStateOf(TrueCondition("conditionBaz")))
 }
 
 func TestIsMethods(t *testing.T) {
@@ -125,7 +122,7 @@ func TestMirror(t *testing.T) {
 				g.Expect(got).To(BeNil())
 				return
 			}
-			g.Expect(got).To(haveSameStateOf(tt.want))
+			g.Expect(got).To(HaveSameStateOf(tt.want))
 		})
 	}
 }
@@ -234,7 +231,7 @@ func TestSummary(t *testing.T) {
 				g.Expect(got).To(BeNil())
 				return
 			}
-			g.Expect(got).To(haveSameStateOf(tt.want))
+			g.Expect(got).To(HaveSameStateOf(tt.want))
 		})
 	}
 }
@@ -278,7 +275,7 @@ func TestAggregate(t *testing.T) {
 				g.Expect(got).To(BeNil())
 				return
 			}
-			g.Expect(got).To(haveSameStateOf(tt.want))
+			g.Expect(got).To(HaveSameStateOf(tt.want))
 		})
 	}
 }
@@ -297,30 +294,4 @@ func conditionList(conditions ...*clusterv1.Condition) clusterv1.Conditions {
 		}
 	}
 	return cs
-}
-
-func haveSameStateOf(expected *clusterv1.Condition) types.GomegaMatcher {
-	return &ConditionMatcher{
-		Expected: expected,
-	}
-}
-
-type ConditionMatcher struct {
-	Expected *clusterv1.Condition
-}
-
-func (matcher *ConditionMatcher) Match(actual interface{}) (success bool, err error) {
-	actualCondition, ok := actual.(*clusterv1.Condition)
-	if !ok {
-		return false, errors.New("Value should be a condition")
-	}
-
-	return hasSameState(actualCondition, matcher.Expected), nil
-}
-
-func (matcher *ConditionMatcher) FailureMessage(actual interface{}) (message string) {
-	return format.Message(actual, "to have the same state of", matcher.Expected)
-}
-func (matcher *ConditionMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return format.Message(actual, "not to have the same state of", matcher.Expected)
 }

--- a/util/conditions/matchers.go
+++ b/util/conditions/matchers.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"errors"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+)
+
+func HaveSameStateOf(expected *clusterv1.Condition) types.GomegaMatcher {
+	return &ConditionMatcher{
+		Expected: expected,
+	}
+}
+
+type ConditionMatcher struct {
+	Expected *clusterv1.Condition
+}
+
+func (matcher *ConditionMatcher) Match(actual interface{}) (success bool, err error) {
+	actualCondition, ok := actual.(*clusterv1.Condition)
+	if !ok {
+		return false, errors.New("value should be a condition")
+	}
+
+	return hasSameState(actualCondition, matcher.Expected), nil
+}
+
+func (matcher *ConditionMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to have the same state of", matcher.Expected)
+}
+func (matcher *ConditionMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to have the same state of", matcher.Expected)
+}

--- a/util/conditions/merge_test.go
+++ b/util/conditions/merge_test.go
@@ -140,7 +140,7 @@ func TestMergeRespectPriority(t *testing.T) {
 				g.Expect(got).To(BeNil())
 				return
 			}
-			g.Expect(got).To(haveSameStateOf(tt.want))
+			g.Expect(got).To(HaveSameStateOf(tt.want))
 		})
 	}
 }

--- a/util/conditions/setter_test.go
+++ b/util/conditions/setter_test.go
@@ -199,14 +199,14 @@ func TestMarkMethods(t *testing.T) {
 
 	// test MarkTrue
 	MarkTrue(cluster, "conditionFoo")
-	g.Expect(Get(cluster, "conditionFoo")).To(haveSameStateOf(&clusterv1.Condition{
+	g.Expect(Get(cluster, "conditionFoo")).To(HaveSameStateOf(&clusterv1.Condition{
 		Type:   "conditionFoo",
 		Status: corev1.ConditionTrue,
 	}))
 
 	// test MarkFalse
 	MarkFalse(cluster, "conditionBar", "reasonBar", clusterv1.ConditionSeverityError, "messageBar")
-	g.Expect(Get(cluster, "conditionBar")).To(haveSameStateOf(&clusterv1.Condition{
+	g.Expect(Get(cluster, "conditionBar")).To(HaveSameStateOf(&clusterv1.Condition{
 		Type:     "conditionBar",
 		Status:   corev1.ConditionFalse,
 		Severity: clusterv1.ConditionSeverityError,
@@ -216,7 +216,7 @@ func TestMarkMethods(t *testing.T) {
 
 	// test MarkUnknown
 	MarkUnknown(cluster, "conditionBaz", "reasonBaz", "messageBaz")
-	g.Expect(Get(cluster, "conditionBaz")).To(haveSameStateOf(&clusterv1.Condition{
+	g.Expect(Get(cluster, "conditionBaz")).To(HaveSameStateOf(&clusterv1.Condition{
 		Type:    "conditionBaz",
 		Status:  corev1.ConditionUnknown,
 		Reason:  "reasonBaz",


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adds a new condition (~~ControlPlaneInitialized~~ MachinesCreatedCondition) to indicate failures during control plane initialization, specifically during:
1. Infrastructure reference resource creation
2. Bootstrap config resource creation
3. Machine resource creation
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3540 
