### PR TITLE
✨ Delete CAPD machines even if the LB does not exist

### DIFF
--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
@@ -326,7 +326,7 @@ func (r *DockerMachineReconciler) reconcileDelete(ctx context.Context, machine *
 
 	// if the deleted machine is a control-plane node, remove it from the load balancer configuration;
 	if util.IsControlPlaneMachine(machine) {
-		if err := externalLoadBalancer.UpdateConfiguration(ctx); err != nil {
+		if err := externalLoadBalancer.UpdateConfiguration(ctx); err != nil && !errors.Is(err, docker.ErrLoadBalancerNotExist) {
 			return ctrl.Result{}, errors.Wrap(err, "failed to update DockerCluster.loadbalancer configuration")
 		}
 	}

--- a/test/infrastructure/docker/docker/loadbalancer.go
+++ b/test/infrastructure/docker/docker/loadbalancer.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 )
 
+var ErrLoadBalancerNotExist = errors.New("unable to configure load balancer: load balancer container does not exist")
+
 type lbCreator interface {
 	CreateExternalLoadBalancerNode(name, image, clusterLabel, listenAddress string, port int32) (*types.Node, error)
 }
@@ -94,7 +96,7 @@ func (s *LoadBalancer) Create() error {
 // UpdateConfiguration updates the external load balancer configuration with new control plane nodes.
 func (s *LoadBalancer) UpdateConfiguration(ctx context.Context) error {
 	if s.container == nil {
-		return errors.New("unable to configure load balancer: load balancer container does not exists")
+		return ErrLoadBalancerNotExist
 	}
 
 	// collect info about the existing controlplane nodes


### PR DESCRIPTION
**What this PR does / why we need it**:
I was trying to delete my CAPD cluster and saw it get stuck with the error

```
controller.go:257] controller-runtime/controller "msg"="Reconciler error" "error"="failed to update DockerCluster.loadbalancer configuration: unable to configure load balancer: load balancer container does not exists" "controller"="dockermachine" "name"="bmo-control-plane-kr722" "namespace"="default"
```

I don't know how it got into this state but it seems like we shouldn't block deletion on deregistering this machine from a load balancer that doesn't even exist.