### PR TITLE
✨ clusterctl completion: Add dynamic shell auto completion

### DIFF
--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -194,6 +194,7 @@ var (
 		"from-config-map":           "__clusterctl_kubectl_get_resource_configmap",
 		"from-config-map-namespace": "__clusterctl_kubectl_get_resource_namespace",
 		"target-namespace":          "__clusterctl_kubectl_get_resource_namespace",
+		"watching-namespace":        "__clusterctl_kubectl_get_resource_namespace",
 	}
 )
 

--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -98,6 +98,11 @@ __clusterctl_kubectl_get_resource_namespace()
     __clusterctl_kubectl_parse_get "namespace"
 }
 
+__clusterctl_kubectl_get_resource_cluster()
+{
+    __clusterctl_kubectl_parse_get "cluster"
+}
+
 # $1 has to be "contexts", "clusters" or "users"
 __clusterctl_kubectl_parse_config()
 {
@@ -111,6 +116,17 @@ __clusterctl_kubectl_parse_config()
 __clusterctl_kubectl_config_get_contexts()
 {
     __kubectl_parse_config "contexts"
+}
+
+__clusterctl_custom_func() {
+    case "$last_command" in
+        clusterctl_get_kubeconfig)
+            __clusterctl_kubectl_get_resource_cluster
+            return
+            ;;
+        *)
+            ;;
+    esac
 }
 `
 )

--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -123,6 +123,34 @@ __clusterctl_kubectl_config_get_contexts()
     __kubectl_parse_config "contexts"
 }
 
+__clusterctl_config_repositories()
+{
+    local clusterctl_out
+    if clusterctl_out=$(__clusterctl_debug_out "clusterctl config repositories --output name --provider \"$1\""); then
+        COMPREPLY=( $( compgen -W "${clusterctl_out[*]}" -- "$cur" ) )
+    fi
+}
+
+__clusterctl_config_repositories_bootstrap()
+{
+    __clusterctl_config_repositories "bootstrap"
+}
+
+__clusterctl_config_repositories_control-plane()
+{
+    __clusterctl_config_repositories "control-plane"
+}
+
+__clusterctl_config_repositories_core()
+{
+    __clusterctl_config_repositories "core"
+}
+
+__clusterctl_config_repositories_infrastructure()
+{
+    __clusterctl_config_repositories "infrastructure"
+}
+
 __clusterctl_custom_func() {
     case "$last_command" in
         clusterctl_get_kubeconfig)
@@ -195,6 +223,10 @@ var (
 		"from-config-map-namespace": "__clusterctl_kubectl_get_resource_namespace",
 		"target-namespace":          "__clusterctl_kubectl_get_resource_namespace",
 		"watching-namespace":        "__clusterctl_kubectl_get_resource_namespace",
+		"bootstrap":                 "__clusterctl_config_repositories_bootstrap",
+		"core":                      "__clusterctl_config_repositories_core",
+		"control-plane":             "__clusterctl_config_repositories_control-plane",
+		"infrastructure":            "__clusterctl_config_repositories_infrastructure",
 	}
 )
 

--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -98,6 +98,11 @@ __clusterctl_kubectl_get_resource_namespace()
     __clusterctl_kubectl_parse_get "namespace"
 }
 
+__clusterctl_kubectl_get_resource_configmap()
+{
+    __clusterctl_kubectl_parse_get "configmap"
+}
+
 __clusterctl_kubectl_get_resource_cluster()
 {
     __clusterctl_kubectl_parse_get "cluster"
@@ -184,8 +189,11 @@ var (
 	}
 
 	bashCompletionFlags = map[string]string{
-		"namespace":          "__clusterctl_kubectl_get_resource_namespace",
-		"kubeconfig-context": "__clusterctl_kubectl_config_get_contexts",
+		"namespace":                 "__clusterctl_kubectl_get_resource_namespace",
+		"kubeconfig-context":        "__clusterctl_kubectl_config_get_contexts",
+		"from-config-map":           "__clusterctl_kubectl_get_resource_configmap",
+		"from-config-map-namespace": "__clusterctl_kubectl_get_resource_namespace",
+		"target-namespace":          "__clusterctl_kubectl_get_resource_namespace",
 	}
 )
 

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -39,7 +39,7 @@ func Test_runGetRepositories(t *testing.T) {
 
 		buf := bytes.NewBufferString("")
 
-		for _, val := range RepositoriesOutputs {
+		for val, _ := range RepositoriesOutputs {
 			cro.output = val
 			g.Expect(runGetRepositories(path, buf)).To(Succeed())
 			out, err := ioutil.ReadAll(buf)
@@ -49,8 +49,17 @@ func Test_runGetRepositories(t *testing.T) {
 				g.Expect(string(out)).To(Equal(expectedOutputText))
 			} else if val == RepositoriesOutputYaml {
 				g.Expect(string(out)).To(Equal(expectedOutputYaml))
+			} else if val == RepositoriesOutputName {
+				g.Expect(string(out)).To(Equal(expectedOutputName))
 			}
 		}
+
+		cro.output = RepositoriesOutputName
+		cro.provider = RepositoriesProviderBootstrap
+		g.Expect(runGetRepositories(path, buf)).To(Succeed())
+		out, err := ioutil.ReadAll(buf)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(string(out)).To(Equal(expectedOutputNameBootstrapProvider))
 	})
 
 	t.Run("returns error for bad cfgFile path", func(t *testing.T) {
@@ -192,4 +201,29 @@ var expectedOutputYaml = `- File: core_components.yaml
   Name: vsphere
   ProviderType: InfrastructureProvider
   URL: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/latest/
+`
+var expectedOutputName = `cluster-api
+another-provider
+aws-eks
+kubeadm
+talos
+aws-eks
+kubeadm
+talos
+aws
+azure
+do
+docker
+metal3
+my-infra-provider
+openstack
+packet
+sidero
+vsphere
+`
+
+var expectedOutputNameBootstrapProvider = `another-provider
+aws-eks
+kubeadm
+talos
 `

--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -85,6 +85,7 @@ var RootCmd = &cobra.Command{
 
 		return nil
 	},
+	BashCompletionFunction: bashCompletionFunc,
 }
 
 func Execute() {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This PR adds support for dynamic shell auto completion of `clusterctl`.

- `--namespace` flag
- `--kubeconfig-context` flag
- cluster name argument of `clusterctl config kubeconfig` command
- `--from-config-map`, `--rom-config-map-namespace` and `--target-namespace` flags
- `--watching-namespace` flag
- `--bootstrap`, `--control-plane`, `--core` and `--infrastructure` flags
    - To support these flags, `clusterctl config repositories` command is added `--output name` and `--provider <provider-type>` options

You can try to use auto-completion as follows:
```
$ make clusterctl
$ source <(bin/clusterctl completion bash)
$ export PATH="${PWD}/bin:$PATH"
$ clusterctl get kubeconfig --namespace <tab>
```

Ref #3595 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #