### PR TITLE
🌱 Add etcd endpoint health check to KCP

### DIFF
--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -181,7 +181,7 @@ func (m *Management) getApiServerEtcdClientCert(ctx context.Context, clusterKey 
 
 type healthCheck func(context.Context) (HealthCheckResult, error)
 
-// HealthCheck will run a generic health check function and report any errors discovered.
+// healthCheck will run a generic health check function and report any errors discovered.
 // In addition to the health check, it also ensures there is a 1;1 match between nodes and machines.
 func (m *Management) healthCheck(ctx context.Context, check healthCheck, clusterKey client.ObjectKey) error {
 	var errorList []error

--- a/controlplane/kubeadm/internal/etcd/etcd_test.go
+++ b/controlplane/kubeadm/internal/etcd/etcd_test.go
@@ -85,6 +85,7 @@ func TestEtcdMembers_WithSuccess(t *testing.T) {
 		MemberRemoveResponse: &clientv3.MemberRemoveResponse{},
 		AlarmResponse:        &clientv3.AlarmResponse{},
 		StatusResponse:       &clientv3.StatusResponse{},
+		GetResponse:          &clientv3.GetResponse{},
 	}
 
 	client, err := newEtcdClient(ctx, fakeEtcdClient)

--- a/controlplane/kubeadm/internal/etcd/fake/client.go
+++ b/controlplane/kubeadm/internal/etcd/fake/client.go
@@ -30,6 +30,7 @@ type FakeEtcdClient struct {
 	MemberUpdateResponse *clientv3.MemberUpdateResponse
 	MoveLeaderResponse   *clientv3.MoveLeaderResponse
 	StatusResponse       *clientv3.StatusResponse
+	GetResponse          *clientv3.GetResponse
 	ErrorResponse        error
 	MovedLeader          uint64
 	RemovedMember        uint64
@@ -64,4 +65,8 @@ func (c *FakeEtcdClient) MemberUpdate(_ context.Context, _ uint64, _ []string) (
 }
 func (c *FakeEtcdClient) Status(_ context.Context, _ string) (*clientv3.StatusResponse, error) {
 	return c.StatusResponse, nil
+}
+
+func (c *FakeEtcdClient) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	return c.GetResponse, nil
 }

--- a/controlplane/kubeadm/internal/etcd_client_generator.go
+++ b/controlplane/kubeadm/internal/etcd_client_generator.go
@@ -21,10 +21,9 @@ import (
 	"crypto/tls"
 
 	"github.com/pkg/errors"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/proxy"

--- a/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
@@ -70,10 +70,12 @@ func TestWorkload_EtcdIsHealthy(t *testing.T) {
 					AlarmResponse: &clientv3.AlarmResponse{
 						Alarms: []*pb.AlarmMember{},
 					},
+					GetResponse: &clientv3.GetResponse{},
 				},
 			},
 		},
 	}
+	ctx := context.Background()
 	health, err := workload.EtcdIsHealthy(ctx)
 	g.Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds endpoint health check to etcd health check in KCP.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of https://github.com/kubernetes-sigs/cluster-api/pull/3674
