### PR TITLE
🌱 Ensure provider deployments are available on init

### DIFF
--- a/cmd/clusterctl/client/cluster/components.go
+++ b/cmd/clusterctl/client/cluster/components.go
@@ -21,10 +21,13 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
@@ -53,32 +56,87 @@ type ComponentsClient interface {
 
 // providerComponents implements ComponentsClient.
 type providerComponents struct {
-	proxy Proxy
+	proxy                        Proxy
+	createComponentObjectBackoff wait.Backoff
+	readComponentObjectBackoff   wait.Backoff
+}
+
+type ProviderComponentsOption func(*providerComponents)
+
+func withCreateComponentObjectBackoff(b wait.Backoff) ProviderComponentsOption {
+	return func(p *providerComponents) {
+		p.createComponentObjectBackoff = b
+	}
+}
+
+func withReadComponentObjectBackoff(b wait.Backoff) ProviderComponentsOption {
+	return func(p *providerComponents) {
+		p.readComponentObjectBackoff = b
+	}
+}
+
+// newComponentsClient returns a providerComponents.
+func newComponentsClient(proxy Proxy, opts ...ProviderComponentsOption) *providerComponents {
+	pc := &providerComponents{
+		proxy:                        proxy,
+		createComponentObjectBackoff: newWriteBackoff(),
+		readComponentObjectBackoff:   newReadBackoff(),
+	}
+
+	for _, o := range opts {
+		o(pc)
+	}
+	return pc
 }
 
 func (p *providerComponents) Create(objs []unstructured.Unstructured) error {
-	createComponentObjectBackoff := newWriteBackoff()
+	c, err := p.proxy.NewClient()
+	if err != nil {
+		return err
+	}
+
 	for i := range objs {
 		obj := objs[i]
 
 		// Create the Kubernetes object.
 		// Nb. The operation is wrapped in a retry loop to make Create more resilient to unexpected conditions.
-		if err := retryWithExponentialBackoff(createComponentObjectBackoff, func() error {
-			return p.createObj(obj)
+		if err := retryWithExponentialBackoff(p.createComponentObjectBackoff, func() error {
+			return p.createObj(c, obj)
 		}); err != nil {
 			return err
+		}
+
+		// Verify that Deployments are running and available before moving on.
+		if obj.GetKind() == "Deployment" {
+			err := retryWithExponentialBackoff(p.readComponentObjectBackoff, func() error {
+				d := appsv1.Deployment{}
+				key := client.ObjectKey{
+					Namespace: obj.GetNamespace(),
+					Name:      obj.GetName(),
+				}
+
+				err := c.Get(ctx, key, &d)
+				if err != nil {
+					return err
+				}
+				for _, condition := range d.Status.Conditions {
+					if condition.Type == appsv1.DeploymentAvailable && condition.Status == corev1.ConditionTrue {
+						return nil
+					}
+				}
+				return fmt.Errorf("deployment %s/%s is not ready yet", obj.GetNamespace(), obj.GetName())
+			})
+			if err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
 }
 
-func (p *providerComponents) createObj(obj unstructured.Unstructured) error {
+func (p *providerComponents) createObj(c client.Client, obj unstructured.Unstructured) error {
 	log := logf.Log
-	c, err := p.proxy.NewClient()
-	if err != nil {
-		return err
-	}
 
 	// check if the component already exists, and eventually update it
 	currentR := &unstructured.Unstructured{}
@@ -209,11 +267,4 @@ func (p *providerComponents) Delete(options DeleteOptions) error {
 	}
 
 	return kerrors.NewAggregate(errList)
-}
-
-// newComponentsClient returns a providerComponents.
-func newComponentsClient(proxy Proxy) *providerComponents {
-	return &providerComponents{
-		proxy: proxy,
-	}
 }

--- a/cmd/clusterctl/client/init_test.go
+++ b/cmd/clusterctl/client/init_test.go
@@ -749,6 +749,9 @@ func templateYAML(ns string, clusterName string) []byte {
 
 // infraComponentsYAML defines a namespace and deployment with container
 // images and a variable
+// Including status object as part of the Deployment, so that when the
+// provider components are installed, the providerComponents.Create doesn't
+// fail as part of the check to ensure the deployment is up and running.
 func infraComponentsYAML(namespace string) []byte {
 	var infraComponentsYAML string = `---
 apiVersion: v1
@@ -776,6 +779,12 @@ spec:
       - name: credentials
         secret:
           secretName: ${SOME_VARIABLE}
+status:
+  conditions:
+  - message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
 `
 	return []byte(fmt.Sprintf(infraComponentsYAML, namespace))
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds a check to ensure the `Deployment`s are `Available` as part of `clusterctl init` operation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3720 
