### PR TITLE
🌱 Add e2e test for node drain timeout feature

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -65,6 +65,7 @@ cluster-templates-v1alpha4: $(KUSTOMIZE) ## Generate cluster templates for v1alp
 	echo "---" >> $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-kcp-adoption.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-kcp-adoption/step2 --load_restrictor none >> $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-kcp-adoption.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-machine-pool --load_restrictor none > $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-machine-pool.yaml
+	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-node-drain --load_restrictor none > $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-node-drain.yaml
 
 ## --------------------------------------
 ## Testing

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -71,6 +71,7 @@ providers:
   - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-mhc.yaml"
   - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-kcp-adoption.yaml"
   - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-machine-pool.yaml"
+  - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-node-drain.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.19.1"
@@ -86,6 +87,7 @@ variables:
   EXP_CLUSTER_RESOURCE_SET: "true"
   EXP_MACHINE_POOL: "true"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
+  NODE_DRAIN_TIMEOUT: "60s"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]
@@ -97,3 +99,5 @@ intervals:
   default/wait-machine-upgrade: ["20m", "10s"]
   default/wait-machine-pool-upgrade: ["5m", "10s"]
   default/wait-machine-remediation: ["5m", "10s"]
+  node-drain/wait-deployment-available: ["3m", "10s"]
+  node-drain/wait-control-plane: ["15m", "10s"]

--- a/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-node-drain/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-node-drain/cluster-with-kcp.yaml
@@ -1,0 +1,8 @@
+# KubeadmControlPlane referenced by the Cluster object with
+# - the label kcp-adoption.step2, because it should be created in the second step of the kcp-adoption test.
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  nodeDrainTimeout: ${NODE_DRAIN_TIMEOUT}

--- a/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-node-drain/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-node-drain/kustomization.yaml
@@ -1,0 +1,8 @@
+bases:
+- ../bases/crs.yaml
+- ../bases/md.yaml
+- ../bases/cluster-with-kcp.yaml
+
+patchesStrategicMerge:
+- ./md.yaml
+- ./cluster-with-kcp.yaml

--- a/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-node-drain/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-node-drain/md.yaml
@@ -1,0 +1,8 @@
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      nodeDrainTimeout: "${NODE_DRAIN_TIMEOUT}"

--- a/test/e2e/node_drain_timeout.go
+++ b/test/e2e/node_drain_timeout.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// NodeDrainTimeoutInput is the input for NodeDrainTimeoutSpec.
+type NodeDrainTimeoutSpecInput struct {
+	E2EConfig             *clusterctl.E2EConfig
+	ClusterctlConfigPath  string
+	BootstrapClusterProxy framework.ClusterProxy
+	ArtifactFolder        string
+	SkipCleanup           bool
+}
+
+func NodeDrainTimeoutSpec(ctx context.Context, inputGetter func() NodeDrainTimeoutSpecInput) {
+	var (
+		specName           = "node-drain"
+		input              NodeDrainTimeoutSpecInput
+		namespace          *corev1.Namespace
+		cancelWatches      context.CancelFunc
+		cluster            *clusterv1.Cluster
+		machineDeployments []*clusterv1.MachineDeployment
+		controlplane       *controlplanev1.KubeadmControlPlane
+	)
+
+	BeforeEach(func() {
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+		input = inputGetter()
+		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0755)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+
+		Expect(input.E2EConfig.GetIntervals(specName, "wait-deployment-available")).ToNot(BeNil())
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+	})
+
+	It("A node should be forcefully removed if it cannot be drained in time", func() {
+		By("Creating a workload cluster")
+		controlPlaneReplicas := 3
+		applyClusterTemplateResult := clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: input.BootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   "node-drain",
+				Namespace:                namespace.Name,
+				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
+				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
+				ControlPlaneMachineCount: pointer.Int64Ptr(int64(controlPlaneReplicas)),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		})
+		cluster = applyClusterTemplateResult.Cluster
+		controlplane = applyClusterTemplateResult.ControlPlane
+		machineDeployments = applyClusterTemplateResult.MachineDeployments
+
+		By("Add a deployment with unevictable pods and podDisruptionBudget to the workload cluster. The deployed pods cannot be evicted in the node draining process.")
+		workloadClusterProxy := input.BootstrapClusterProxy.GetWorkloadCluster(context.TODO(), cluster.Namespace, cluster.Name)
+		framework.DeployUnevictablePod(ctx, framework.DeployUnevictablePodInput{
+			WorkloadClusterProxy:               workloadClusterProxy,
+			DeploymentName:                     fmt.Sprintf("%s-%s", "unevictable-pod", util.RandomString(3)),
+			Namespace:                          namespace.Name + "-unevictable-workload",
+			WaitForDeploymentAvailableInterval: input.E2EConfig.GetIntervals(specName, "wait-deployment-available"),
+		})
+
+		By("Scale the machinedeployment down to zero. If we didn't have the NodeDrainTimeout duration, the node drain process would block this operator.")
+		// Because all the machines of a machinedeployment can be deleted at the same time, so we only prepare the interval for 1 replica.
+		nodeDrainTimeoutMachineDeploymentInterval := convertDurationToInterval(machineDeployments[0].Spec.Template.Spec.NodeDrainTimeout, 1)
+		for _, md := range machineDeployments {
+			framework.ScaleAndWaitMachineDeployment(ctx, framework.ScaleAndWaitMachineDeploymentInput{
+				ClusterProxy:              input.BootstrapClusterProxy,
+				Cluster:                   cluster,
+				MachineDeployment:         md,
+				WaitForMachineDeployments: nodeDrainTimeoutMachineDeploymentInterval,
+				Replicas:                  0,
+			})
+		}
+
+		By("Deploy deployment with unevictable pods on control plane nodes.")
+		framework.DeployUnevictablePod(ctx, framework.DeployUnevictablePodInput{
+			WorkloadClusterProxy:               workloadClusterProxy,
+			ControlPlane:                       controlplane,
+			DeploymentName:                     fmt.Sprintf("%s-%s", "unevictable-pod", util.RandomString(3)),
+			Namespace:                          namespace.Name + "-unevictable-workload",
+			WaitForDeploymentAvailableInterval: input.E2EConfig.GetIntervals(specName, "wait-deployment-available"),
+		})
+
+		By("Scale down the controlplane of the workload cluster and make sure that nodes running workload can be deleted even the draining process is blocked.")
+		// When we scale down the KCP, controlplane machines are by default deleted one by one, so it requires more time.
+		nodeDrainTimeoutKCPInterval := convertDurationToInterval(controlplane.Spec.NodeDrainTimeout, controlPlaneReplicas)
+		framework.ScaleAndWaitControlPlane(ctx, framework.ScaleAndWaitControlPlaneInput{
+			ClusterProxy:        input.BootstrapClusterProxy,
+			Cluster:             cluster,
+			ControlPlane:        controlplane,
+			Replicas:            1,
+			WaitForControlPlane: nodeDrainTimeoutKCPInterval,
+		})
+
+		By("PASSED!")
+	})
+
+	AfterEach(func() {
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		dumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
+	})
+}
+
+func convertDurationToInterval(duration *metav1.Duration, replicas int) []interface{} {
+	pollingInterval := time.Second * 10
+	// After the drain timeout is over, the cluster still needs more time to completely delete the machine, that why we need an extra 2-minute amount of time.
+	intervalDuration := (duration.Duration + time.Minute*2) * time.Duration(replicas)
+	res := []interface{}{intervalDuration.String(), pollingInterval.String()}
+	return res
+}

--- a/test/e2e/node_drain_timeout_test.go
+++ b/test/e2e/node_drain_timeout_test.go
@@ -1,0 +1,38 @@
+// +build e2e
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("When testing node drain timeout", func() {
+
+	NodeDrainTimeoutSpec(context.TODO(), func() NodeDrainTimeoutSpecInput {
+		return NodeDrainTimeoutSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+		}
+	})
+})

--- a/test/framework/clusterresourceset_helpers.go
+++ b/test/framework/clusterresourceset_helpers.go
@@ -68,7 +68,7 @@ type DiscoverClusterResourceSetAndWaitForSuccessInput struct {
 	Cluster      *clusterv1.Cluster
 }
 
-// DiscoverClusterResourceSetAndWaitForSuccessInput patches a ClusterResourceSet label to the cluster and waits for resources to be created in that cluster.
+// DiscoverClusterResourceSetAndWaitForSuccess patches a ClusterResourceSet label to the cluster and waits for resources to be created in that cluster.
 func DiscoverClusterResourceSetAndWaitForSuccess(ctx context.Context, input DiscoverClusterResourceSetAndWaitForSuccessInput, intervals ...interface{}) {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for DiscoverClusterResourceSetAndWaitForSuccess")
 	Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.ClusterProxy can't be nil when calling DiscoverClusterResourceSetAndWaitForSuccess")

--- a/test/framework/control_plane.go
+++ b/test/framework/control_plane.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// WaitForControlPlaneToBeReadyInput is the input for WaitForControlPlaneToBeReady.
+// WaitForControlPlaneToBeUpToDateInput is the input for WaitForControlPlaneToBeUpToDate.
 type WaitForControlPlaneToBeUpToDateInput struct {
 	Getter       Getter
 	ControlPlane *controlplanev1.KubeadmControlPlane

--- a/test/framework/machinedeployment_helpers.go
+++ b/test/framework/machinedeployment_helpers.go
@@ -213,7 +213,7 @@ type WaitForMachineDeploymentRollingUpgradeToCompleteInput struct {
 	MachineDeployment *clusterv1.MachineDeployment
 }
 
-// WaitForMachineDeploymentNodesToExist waits until rolling upgrade is complete.
+// WaitForMachineDeploymentRollingUpgradeToComplete waits until rolling upgrade is complete.
 func WaitForMachineDeploymentRollingUpgradeToComplete(ctx context.Context, input WaitForMachineDeploymentRollingUpgradeToCompleteInput, intervals ...interface{}) {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for WaitForMachineDeploymentRollingUpgradeToComplete")
 	Expect(input.Getter).ToNot(BeNil(), "Invalid argument. input.Getter can't be nil when calling WaitForMachineDeploymentRollingUpgradeToComplete")

--- a/test/framework/machinehealthcheck_helpers.go
+++ b/test/framework/machinehealthcheck_helpers.go
@@ -38,7 +38,7 @@ type DiscoverMachineHealthCheckAndWaitForRemediationInput struct {
 	WaitForMachineRemediation []interface{}
 }
 
-// DiscoverMachineHealthCheckAndWait patches an unhealthy node condition to one node observed by the Machine Health Check and then wait for remediation.
+// DiscoverMachineHealthCheckAndWaitForRemediation patches an unhealthy node condition to one node observed by the Machine Health Check and then wait for remediation.
 func DiscoverMachineHealthChecksAndWaitForRemediation(ctx context.Context, input DiscoverMachineHealthCheckAndWaitForRemediationInput) {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for DiscoverMachineHealthChecksAndWaitForRemediation")
 	Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.ClusterProxy can't be nil when calling DiscoverMachineHealthChecksAndWaitForRemediation")


### PR DESCRIPTION
**What this PR does / why we need it**:
This is an e2e test for the node drain timeout feature implemented in PR #3662 
This test aims to make sure that all machines can be removed after a specific amount of time even when they have workloads running inside that block the draining process. 
The test scenario is as follows:
- Create a management cluster with one control plane and one worker machine.
- Update the `NodeDrainTImeout` field of the `MachineDeployment`, and wait until all worker machines to be updated.
- Add some workloads that cannot be evicted during the node draining process (using pod deployment and `podDisruptionBudget`)
- Make sure that all worker nodes can still be deleted after a specific amount of time.

- Untaint the control plane so they can run workloads.
- Update the `NodeDrainTImeout` field of KCP and all the existing control plane machine. 
- Scale up the KCP and make sure all new control plane machines have the new value of `NodeDrainTimeout`
- Wait until all control plane machines to have workloads running inside them.
- Make sure that all control plane nodes can still be deleted after a specific amount of time.