### PR TITLE
🌱  0.3 Backport: CAPD webhooks should use 9443 as port

### DIFF
--- a/test/infrastructure/docker/config/webhook/manager_webhook_patch.yaml
+++ b/test/infrastructure/docker/config/webhook/manager_webhook_patch.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       - name: manager
         ports:
-        - containerPort: 443
+        - containerPort: 9443
           name: webhook-server
           protocol: TCP
         volumeMounts:

--- a/test/infrastructure/docker/config/webhook/service.yaml
+++ b/test/infrastructure/docker/config/webhook/service.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 443
+      targetPort: 9443
   selector:
     control-plane: controller-manager

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -18,10 +18,11 @@ package main
 
 import (
 	"flag"
-	"github.com/spf13/pflag"
 	"math/rand"
 	"os"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -80,6 +81,7 @@ func main() {
 		LeaderElectionID:       "controller-leader-election-capd",
 		SyncPeriod:             &syncPeriod,
 		HealthProbeBindAddress: healthAddr,
+		Port:                   9443,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Backport of #3758

I am running into a problem since this landed that using `tilt up` from master ends up clashing with the deployment created by `clusterctl init --infrastructure docker`:

```
The Deployment "capd-controller-manager" is invalid: spec.template.spec.containers[1].ports[1].name: Duplicate value: "webhook-server"
```

This will just be a creature comfort to have consistency between clusterctl and tilt, at least when 0.3.11 comes out with this fix.