### PR TITLE
🌱 Include docker output in error when we receive a non-zero exit code

### DIFF
--- a/test/infrastructure/docker/docker/util.go
+++ b/test/infrastructure/docker/docker/util.go
@@ -118,7 +118,7 @@ func list(visit func(string, *types.Node), filters ...string) error {
 	cmd := exec.Command("docker", args...)
 	lines, err := exec.CombinedOutputLines(cmd)
 	if err != nil {
-		return errors.Wrap(err, "failed to list nodes")
+		return errors.Wrapf(err, "failed to list nodes. Output: %s", lines)
 	}
 	for _, line := range lines {
 		parts := strings.Split(line, "\t")


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now if you encounter an error from CAPD running `docker list` you just get an unhelpful error like:
> failed to list containers: failed to list nodes: command \"docker ps -q -a --no-trunc --filter label=io.x-k8s.kind.cluster --format '{{.Names}}\\t{{.Label \"io.x-k8s.kind.cluster\"}}\\t{{.Image}}' --filter label=io.x-k8s.kind.cluster=bmo --filter label=io.x-k8s.kind.role=external-load-balancer\" failed with error: exit status 1

This fixes the error to print the combined stdout/stderr from Docker as well so we get
> failed to list containers: failed to list nodes. Output: [Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?]: command \"docker ps -q -a --no-trunc --filter label=io.x-k8s.kind.cluster --format '{{.Names}}\\t{{.Label \"io.x-k8s.kind.cluster\"}}\\t{{.Image}}' --filter label=io.x-k8s.kind.cluster=bmo --filter label=io.x-k8s.kind.role=external-load-balancer\" failed with error: exit status 1
