### PR TITLE
🌱 Ensure provider deployments are available on init

### DIFF
--- a/cmd/clusterctl/client/init_test.go
+++ b/cmd/clusterctl/client/init_test.go
@@ -749,6 +749,9 @@ func templateYAML(ns string, clusterName string) []byte {
 
 // infraComponentsYAML defines a namespace and deployment with container
 // images and a variable
+// Including status object as part of the Deployment, so that when the
+// provider components are installed, the providerComponents.Create doesn't
+// fail as part of the check to ensure the deployment is up and running.
 func infraComponentsYAML(namespace string) []byte {
 	var infraComponentsYAML string = `---
 apiVersion: v1
@@ -776,6 +779,12 @@ spec:
       - name: credentials
         secret:
           secretName: ${SOME_VARIABLE}
+status:
+  conditions:
+  - message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
 `
 	return []byte(fmt.Sprintf(infraComponentsYAML, namespace))
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds a check to ensure the `Deployment`s are `Available` as part of `clusterctl init` operation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3720 
