### PR TITLE
🐛 fixes link to proposal root to /docs/proposals/

### DIFF
--- a/docs/proposals/YYYYMMDD-template.md
+++ b/docs/proposals/YYYYMMDD-template.md
@@ -29,7 +29,7 @@ To get started with this template:
   Aim for single topic PRs to keep discussions focused.
   If you disagree with what is already in a document, open a new PR with suggested changes.
 
-The canonical place for the latest set of instructions (and the likely source of this file) is [here](/proposals/YYYYMMDD-proposal-template.md).
+The canonical place for the latest set of instructions (and the likely source of this file) is [here](/docs/proposals/YYYYMMDD-template.md).
 
 The `Metadata` section above is intended to support the creation of tooling around the proposal process.
 This will be a YAML section that is fenced as a code block.


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the proposal doc to properly link back to itself which broke when they became nested under `/docs/` and renamed to not include `proposal` in the name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3840

Signed-off-by: Chris Hein <me@chrishein.com>