### PR TITLE
🐛 KCP health checks handle consistently errors and check failures

### DIFF
--- a/controlplane/kubeadm/controllers/fakes_test.go
+++ b/controlplane/kubeadm/controllers/fakes_test.go
@@ -98,18 +98,18 @@ func (f fakeWorkloadCluster) UpdateKubeletConfigMap(ctx context.Context, version
 	return nil
 }
 
-func (f fakeWorkloadCluster) ControlPlaneIsHealthy(ctx context.Context) (internal.HealthCheckResult, error) {
+func (f fakeWorkloadCluster) ControlPlaneIsHealthy(ctx context.Context, machines []*clusterv1.Machine) error {
 	if !f.ControlPlaneHealthy {
-		return nil, errors.New("control plane is not healthy")
+		return errors.New("control plane is not healthy")
 	}
-	return nil, nil
+	return nil
 }
 
-func (f fakeWorkloadCluster) EtcdIsHealthy(ctx context.Context) (internal.HealthCheckResult, error) {
+func (f fakeWorkloadCluster) EtcdIsHealthy(ctx context.Context, machines []*clusterv1.Machine) error {
 	if !f.EtcdHealthy {
-		return nil, errors.New("etcd is not healthy")
+		return errors.New("etcd is not healthy")
 	}
-	return nil, nil
+	return nil
 }
 
 type fakeMigrator struct {

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -96,6 +96,11 @@ func TestCheckStaticPodNotReadyCondition(t *testing.T) {
 func TestControlPlaneIsHealthy(t *testing.T) {
 	g := NewWithT(t)
 
+	machines := []*clusterv1.Machine{
+		controlPlaneMachine("first-control-plane"),
+		controlPlaneMachine("second-control-plane"),
+		controlPlaneMachine("third-control-plane"),
+	}
 	readyStatus := corev1.PodStatus{
 		Conditions: []corev1.PodCondition{
 			{
@@ -118,10 +123,8 @@ func TestControlPlaneIsHealthy(t *testing.T) {
 		},
 	}
 
-	health, err := workloadCluster.ControlPlaneIsHealthy(context.Background())
+	err := workloadCluster.ControlPlaneIsHealthy(context.Background(), machines)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(health).NotTo(HaveLen(0))
-	g.Expect(health).To(HaveLen(len(nodeListForTestControlPlaneIsHealthy().Items)))
 }
 
 func TestGetMachinesForCluster(t *testing.T) {

--- a/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
@@ -39,6 +39,12 @@ import (
 func TestWorkload_EtcdIsHealthy(t *testing.T) {
 	g := NewWithT(t)
 
+	machines := []*clusterv1.Machine{
+		controlPlaneMachine("test-1"),
+		controlPlaneMachine("test-2"),
+		controlPlaneMachine("test-3"),
+		controlPlaneMachine("test-4"),
+	}
 	workload := &Workload{
 		Client: &fakeClient{
 			get: map[string]interface{}{
@@ -75,12 +81,8 @@ func TestWorkload_EtcdIsHealthy(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	health, err := workload.EtcdIsHealthy(ctx)
+	err := workload.EtcdIsHealthy(ctx, machines)
 	g.Expect(err).NotTo(HaveOccurred())
-
-	for _, err := range health {
-		g.Expect(err).NotTo(HaveOccurred())
-	}
 }
 
 func TestUpdateEtcdVersionInKubeadmConfigMap(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes KCP not calling reconcileEtcdMembers for deleted machines by handling more consistently errors and check failures (everything is an error)

**Which issue(s) this PR fixes**:
Fixes: https://github.com/kubernetes-sigs/cluster-api/issues/3860

/assign @sedefsavas 
/assign @vincepri 