### PR TITLE
🌱 Print provider type and name to match config file naming

### DIFF
--- a/cmd/clusterctl/client/repository/components_client.go
+++ b/cmd/clusterctl/client/repository/components_client.go
@@ -74,7 +74,7 @@ func (f *componentsClient) Get(options ComponentsOptions) (Components, error) {
 	}
 
 	if file == nil {
-		log.V(5).Info("Fetching", "File", path, "Provider", f.provider.ManifestLabel(), "Version", options.Version)
+		log.V(5).Info("Fetching", "File", path, "Provider", f.provider.Name(), "Type", f.provider.Type(), "Version", options.Version)
 		file, err = f.repository.GetFile(options.Version, path)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read %q from provider's repository %q", path, f.provider.ManifestLabel())

--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -72,7 +72,7 @@ func (f *metadataClient) Get() (*clusterctlv1.Metadata, error) {
 		return nil, err
 	}
 	if file == nil {
-		log.V(5).Info("Fetching", "File", name, "Provider", f.provider.ManifestLabel(), "Version", version)
+		log.V(5).Info("Fetching", "File", name, "Provider", f.provider.Name(), "Type", f.provider.Type(), "Version", version)
 		file, err = f.repository.GetFile(version, name)
 		if err != nil {
 			// if there are problems in reading the metadata file from the repository, check if there are embedded metadata for the provider, if yes use them

--- a/cmd/clusterctl/client/repository/template_client.go
+++ b/cmd/clusterctl/client/repository/template_client.go
@@ -86,7 +86,7 @@ func (c *templateClient) Get(flavor, targetNamespace string, listVariablesOnly b
 	}
 
 	if rawArtifact == nil {
-		log.V(5).Info("Fetching", "File", name, "Provider", c.provider.ManifestLabel(), "Version", version)
+		log.V(5).Info("Fetching", "File", name, "Provider", c.provider.Name(), "Type", c.provider.Type(), "Version", version)
 		rawArtifact, err = c.repository.GetFile(version, name)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to read %q from provider's repository %q", name, c.provider.ManifestLabel())


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the log lines printed by `clusterctl` to be more helpful when trying to create config overrides.

I was head-scratching why my CAPI override was working but my CAPBK wasn't:

```yaml
providers:
- name: "cluster-api"
  url: "https://github.com/benmoss/cluster-api/releases/latest/core-components.yaml"
  type: "CoreProvider"
- name: "bootstrap-kubeadm"
  url: "https://github.com/benmoss/cluster-api/releases/latest/bootstrap-components.yaml"
  type: "BootstrapProvider"
```

```
Fetching File="metadata.yaml" Provider="cluster-api" Version="v0.4.0-rc.1"
Fetching File="metadata.yaml" Provider="bootstrap-kubeadm" Version="v0.3.10"
```

I inferred from the log lines that the correct "name" for CAPBK would be `bootstrap-kubeadm`, since `cluster-api` was the right name for core CAPI. 

This changes it to print out the correct name and the provider type as well, so users can more easily infer what they need to put in their override config.

```
Fetching File="core-components.yaml" Provider="cluster-api" Type="CoreProvider" Version="v0.4.0-rc.1"
Fetching File="bootstrap-components.yaml" Provider="kubeadm" Type="BootstrapProvider" Version="v0.3.10"
Fetching File="control-plane-components.yaml" Provider="kubeadm" Type="ControlPlaneProvider" Version="v0.3.10"
Fetching File="infrastructure-components.yaml" Provider="kubemark" Type="InfrastructureProvider" Version="v0.2.2"
Fetching File="infrastructure-components-development.yaml" Provider="docker" Type="InfrastructureProvider" Version="v0.3.10"
Fetching File="metadata.yaml" Provider="cluster-api" Type="CoreProvider" Version="v0.4.0-rc.1"
Fetching File="metadata.yaml" Provider="kubeadm" Type="BootstrapProvider" Version="v0.3.10"
```