### PR TITLE
✨ Add `remediationsAllowed` field to MHC status

### DIFF
--- a/api/v1alpha3/condition_consts.go
+++ b/api/v1alpha3/condition_consts.go
@@ -159,3 +159,15 @@ const (
 	// NodeConditionsFailedReason (Severity=Warning) documents a node is not in a healthy state due to the failed state of at least 1 Kubelet condition.
 	NodeConditionsFailedReason = "NodeConditionsFailed"
 )
+
+// Conditions and condition Reasons for the MachineHealthCheck object
+
+const (
+	// RemediationAllowedCondition is set on MachineHealthChecks to show the status of whether the MachineHealthCheck is
+	// allowed to remediate any Machines or whether it is blocked from remediating any further.
+	RemediationAllowedCondition ConditionType = "RemediationAllowed"
+
+	// TooManyUnhealthy is the reason used when too many Machines are unhealthy and the MachineHealthCheck is blocked
+	// from making any further remediations.
+	TooManyUnhealthyReason = "TooManyUnhealthy"
+)

--- a/api/v1alpha3/machinehealthcheck_types.go
+++ b/api/v1alpha3/machinehealthcheck_types.go
@@ -93,6 +93,11 @@ type MachineHealthCheckStatus struct {
 	// +kubebuilder:validation:Minimum=0
 	CurrentHealthy int32 `json:"currentHealthy,omitempty"`
 
+	// RemediationsAllowed is the number of further remediations allowed by this machine health check before
+	// maxUnhealthy short circuiting will be applied
+	// +kubebuilder:validation:Minimum=0
+	RemediationsAllowed int32 `json:"remediationsAllowed,omitempty"`
+
 	// ObservedGeneration is the latest generation observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -899,6 +899,7 @@ func Convert_v1alpha4_MachineHealthCheckSpec_To_v1alpha3_MachineHealthCheckSpec(
 func autoConvert_v1alpha3_MachineHealthCheckStatus_To_v1alpha4_MachineHealthCheckStatus(in *MachineHealthCheckStatus, out *v1alpha4.MachineHealthCheckStatus, s conversion.Scope) error {
 	out.ExpectedMachines = in.ExpectedMachines
 	out.CurrentHealthy = in.CurrentHealthy
+	out.RemediationsAllowed = in.RemediationsAllowed
 	out.ObservedGeneration = in.ObservedGeneration
 	out.Targets = *(*[]string)(unsafe.Pointer(&in.Targets))
 	out.Conditions = *(*v1alpha4.Conditions)(unsafe.Pointer(&in.Conditions))
@@ -913,6 +914,7 @@ func Convert_v1alpha3_MachineHealthCheckStatus_To_v1alpha4_MachineHealthCheckSta
 func autoConvert_v1alpha4_MachineHealthCheckStatus_To_v1alpha3_MachineHealthCheckStatus(in *v1alpha4.MachineHealthCheckStatus, out *MachineHealthCheckStatus, s conversion.Scope) error {
 	out.ExpectedMachines = in.ExpectedMachines
 	out.CurrentHealthy = in.CurrentHealthy
+	out.RemediationsAllowed = in.RemediationsAllowed
 	out.ObservedGeneration = in.ObservedGeneration
 	out.Targets = *(*[]string)(unsafe.Pointer(&in.Targets))
 	out.Conditions = *(*Conditions)(unsafe.Pointer(&in.Conditions))

--- a/api/v1alpha4/condition_consts.go
+++ b/api/v1alpha4/condition_consts.go
@@ -166,3 +166,15 @@ const (
 	// NodeConditionsFailedReason (Severity=Warning) documents a node is not in a healthy state due to the failed state of at least 1 Kubelet condition.
 	NodeConditionsFailedReason = "NodeConditionsFailed"
 )
+
+// Conditions and condition Reasons for the MachineHealthCheck object
+
+const (
+	// RemediationAllowedCondition is set on MachineHealthChecks to show the status of whether the MachineHealthCheck is
+	// allowed to remediate any Machines or whether it is blocked from remediating any further.
+	RemediationAllowedCondition ConditionType = "RemediationAllowed"
+
+	// TooManyUnhealthy is the reason used when too many Machines are unhealthy and the MachineHealthCheck is blocked
+	// from making any further remediations.
+	TooManyUnhealthyReason = "TooManyUnhealthy"
+)

--- a/api/v1alpha4/machinehealthcheck_types.go
+++ b/api/v1alpha4/machinehealthcheck_types.go
@@ -93,6 +93,11 @@ type MachineHealthCheckStatus struct {
 	// +kubebuilder:validation:Minimum=0
 	CurrentHealthy int32 `json:"currentHealthy,omitempty"`
 
+	// RemediationsAllowed is the number of further remediations allowed by this machine health check before
+	// maxUnhealthy short circuiting will be applied
+	// +kubebuilder:validation:Minimum=0
+	RemediationsAllowed int32 `json:"remediationsAllowed,omitempty"`
+
 	// ObservedGeneration is the latest generation observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -189,6 +189,11 @@ spec:
                 description: ObservedGeneration is the latest generation observed by the controller.
                 format: int64
                 type: integer
+              remediationsAllowed:
+                description: RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
               targets:
                 description: Targets shows the current list of machines the machine health check is watching
                 items:
@@ -367,6 +372,11 @@ spec:
               observedGeneration:
                 description: ObservedGeneration is the latest generation observed by the controller.
                 format: int64
+                type: integer
+              remediationsAllowed:
+                description: RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
                 type: integer
               targets:
                 description: Targets shows the current list of machines the machine health check is watching

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -215,15 +215,27 @@ func (r *MachineHealthCheckReconciler) reconcile(ctx context.Context, logger log
 			"max unhealthy", m.Spec.MaxUnhealthy,
 			"unhealthy targets", len(unhealthy),
 		)
+		message := fmt.Sprintf("Remediation is not allowed, the number of not started or unhealthy machines exceeds maxUnhealthy (total: %v, unhealthy: %v, maxUnhealthy: %v)",
+			totalTargets,
+			len(unhealthy),
+			m.Spec.MaxUnhealthy,
+		)
+
+		// Remediation not allowed, the number of not started or unhealthy machines exceeds maxUnhealthy
+		m.Status.RemediationsAllowed = 0
+		conditions.Set(m, &clusterv1.Condition{
+			Type:     clusterv1.RemediationAllowedCondition,
+			Status:   corev1.ConditionFalse,
+			Severity: clusterv1.ConditionSeverityWarning,
+			Reason:   clusterv1.TooManyUnhealthyReason,
+			Message:  message,
+		})
 
 		r.recorder.Eventf(
 			m,
 			corev1.EventTypeWarning,
 			EventRemediationRestricted,
-			"Remediation restricted due to exceeded number of unhealthy machines (total: %v, unhealthy: %v, maxUnhealthy: %v)",
-			totalTargets,
-			m.Status.CurrentHealthy,
-			m.Spec.MaxUnhealthy,
+			message,
 		)
 		for _, t := range append(healthy, unhealthy...) {
 			if err := t.patchHelper.Patch(ctx, t.Machine); err != nil {
@@ -238,6 +250,15 @@ func (r *MachineHealthCheckReconciler) reconcile(ctx context.Context, logger log
 		"max unhealthy", m.Spec.MaxUnhealthy,
 		"unhealthy targets", len(unhealthy),
 	)
+
+	maxUnhealthy, err := getMaxUnhealthy(m)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "Failed to get value for maxUnhealthy")
+	}
+
+	// Remediation is allowed so maxUnhealthy - unhealthyMachineCount >= 0
+	m.Status.RemediationsAllowed = int32(maxUnhealthy - unhealthyMachineCount(m))
+	conditions.MarkTrue(m, clusterv1.RemediationAllowedCondition)
 
 	// mark for remediation
 	errList := []error{}
@@ -469,17 +490,36 @@ func (r *MachineHealthCheckReconciler) watchClusterNodes(ctx context.Context, cl
 // isAllowedRemediation checks the value of the MaxUnhealthy field to determine
 // whether remediation should be allowed or not
 func isAllowedRemediation(mhc *clusterv1.MachineHealthCheck) bool {
+	// TODO(JoelSpeed): return an error from isAllowedRemediation when maxUnhealthy
+	// is nil, we expect it to be defaulted always.
 	if mhc.Spec.MaxUnhealthy == nil {
 		return true
 	}
-	maxUnhealthy, err := intstr.GetValueFromIntOrPercent(mhc.Spec.MaxUnhealthy, int(mhc.Status.ExpectedMachines), false)
+
+	maxUnhealthy, err := getMaxUnhealthy(mhc)
 	if err != nil {
 		return false
 	}
 
-	// If unhealthy is above maxUnhealthy, short circuit any further remediation
-	unhealthy := mhc.Status.ExpectedMachines - mhc.Status.CurrentHealthy
-	return int(unhealthy) <= maxUnhealthy
+	// Remediation is not allowed if unhealthy is above maxUnhealthy
+	return unhealthyMachineCount(mhc) <= maxUnhealthy
+}
+
+func getMaxUnhealthy(mhc *clusterv1.MachineHealthCheck) (int, error) {
+	if mhc.Spec.MaxUnhealthy == nil {
+		return 0, errors.New("spec.maxUnhealthy must be set")
+	}
+	maxUnhealthy, err := intstr.GetValueFromIntOrPercent(mhc.Spec.MaxUnhealthy, int(mhc.Status.ExpectedMachines), false)
+	if err != nil {
+		return 0, err
+	}
+	return maxUnhealthy, nil
+}
+
+// unhealthyMachineCount calculates the number of presently unhealthy or missing machines
+// ie the delta between the expected number of machines and the current number deemed healthy
+func unhealthyMachineCount(mhc *clusterv1.MachineHealthCheck) int {
+	return int(mhc.Status.ExpectedMachines - mhc.Status.CurrentHealthy)
 }
 
 func machineNames(machines []*clusterv1.Machine) []string {

--- a/controllers/machinehealthcheck_controller_test.go
+++ b/controllers/machinehealthcheck_controller_test.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -198,11 +199,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   2,
-			CurrentHealthy:     2,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    2,
+			CurrentHealthy:      2,
+			RemediationsAllowed: 2,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 	})
 
 	t.Run("it marks unhealthy machines for remediation when there is one unhealthy Machine", func(t *testing.T) {
@@ -246,10 +254,17 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   3,
-			CurrentHealthy:     2,
-			ObservedGeneration: 1,
-			Targets:            targetMachines,
+			ExpectedMachines:    3,
+			CurrentHealthy:      2,
+			RemediationsAllowed: 2,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
 		}))
 	})
 
@@ -296,11 +311,21 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   3,
-			CurrentHealthy:     1,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    3,
+			CurrentHealthy:      1,
+			RemediationsAllowed: 0,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:     clusterv1.RemediationAllowedCondition,
+					Status:   corev1.ConditionFalse,
+					Severity: clusterv1.ConditionSeverityWarning,
+					Reason:   clusterv1.TooManyUnhealthyReason,
+					Message:  "Remediation is not allowed, the number of not started or unhealthy machines exceeds maxUnhealthy (total: 3, unhealthy: 2, maxUnhealthy: 40%)",
+				},
+			},
+		}))
 
 		// Calculate how many Machines have health check succeeded = false.
 		g.Eventually(func() (unhealthy int) {
@@ -381,11 +406,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   3,
-			CurrentHealthy:     2,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    3,
+			CurrentHealthy:      2,
+			RemediationsAllowed: 2,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Calculate how many Machines have health check succeeded = false.
 		g.Eventually(func() (unhealthy int) {
@@ -471,11 +503,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}, timeout, 100*time.Millisecond).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   3,
-			CurrentHealthy:     2,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    3,
+			CurrentHealthy:      2,
+			RemediationsAllowed: 2,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Calculate how many Machines have health check succeeded = false.
 		g.Eventually(func() (unhealthy int) {
@@ -558,11 +597,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   3,
-			CurrentHealthy:     2,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    3,
+			CurrentHealthy:      2,
+			RemediationsAllowed: 2,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Calculate how many Machines have health check succeeded = false.
 		g.Eventually(func() (unhealthy int) {
@@ -633,11 +679,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   1,
-			CurrentHealthy:     1,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    1,
+			CurrentHealthy:      1,
+			RemediationsAllowed: 1,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Transition the node to unhealthy.
 		node := nodes[0]
@@ -662,8 +715,14 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			ExpectedMachines:   1,
 			CurrentHealthy:     0,
 			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			Targets:            targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Calculate how many Machines have health check succeeded = false.
 		g.Eventually(func() (unhealthy int) {
@@ -878,8 +937,14 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			ExpectedMachines:   1,
 			CurrentHealthy:     1,
 			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			Targets:            targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Pause the machine
 		machinePatch := client.MergeFrom(machines[0].DeepCopy())
@@ -908,11 +973,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   1,
-			CurrentHealthy:     0,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    1,
+			CurrentHealthy:      0,
+			RemediationsAllowed: 0,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Calculate how many Machines have health check succeeded = false.
 		g.Eventually(func() (unhealthy int) {
@@ -1011,11 +1083,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   1,
-			CurrentHealthy:     1,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    1,
+			CurrentHealthy:      1,
+			RemediationsAllowed: 1,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Transition the node to unhealthy.
 		node := nodes[0]
@@ -1037,11 +1116,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   1,
-			CurrentHealthy:     0,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    1,
+			CurrentHealthy:      0,
+			RemediationsAllowed: 0,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Calculate how many Machines have health check succeeded = false.
 		g.Eventually(func() (unhealthy int) {
@@ -1143,11 +1229,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   1,
-			CurrentHealthy:     1,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    1,
+			CurrentHealthy:      1,
+			RemediationsAllowed: 1,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Transition the node to unhealthy.
 		node := nodes[0]
@@ -1169,11 +1262,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   1,
-			CurrentHealthy:     0,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    1,
+			CurrentHealthy:      0,
+			RemediationsAllowed: 0,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Calculate how many Machines have health check succeeded = false.
 		g.Eventually(func() (unhealthy int) {
@@ -1213,11 +1313,18 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 			}
 			return &mhc.Status
 		}).Should(MatchMachineHealthCheckStatus(&clusterv1.MachineHealthCheckStatus{
-			ExpectedMachines:   1,
-			CurrentHealthy:     1,
-			ObservedGeneration: 1,
-			Targets:            targetMachines},
-		))
+			ExpectedMachines:    1,
+			CurrentHealthy:      1,
+			RemediationsAllowed: 1,
+			ObservedGeneration:  1,
+			Targets:             targetMachines,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.RemediationAllowedCondition,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		}))
 
 		// Calculate how many Machines have health check succeeded = false.
 		g.Eventually(func() (unhealthy int) {
@@ -1628,6 +1735,75 @@ func TestIsAllowedRemediation(t *testing.T) {
 	}
 }
 
+func TestGetMaxUnhealthy(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		maxUnhealthy         *intstr.IntOrString
+		expectedMaxUnhealthy int
+		actualMachineCount   int32
+		expectedErr          error
+	}{
+		{
+			name:                 "when maxUnhealthy is nil",
+			maxUnhealthy:         nil,
+			expectedMaxUnhealthy: 0,
+			actualMachineCount:   7,
+			expectedErr:          errors.New("spec.maxUnhealthy must be set"),
+		},
+		{
+			name:                 "when maxUnhealthy is not an int or percentage",
+			maxUnhealthy:         &intstr.IntOrString{Type: intstr.String, StrVal: "abcdef"},
+			expectedMaxUnhealthy: 0,
+			actualMachineCount:   3,
+			expectedErr:          errors.New("invalid value for IntOrString: invalid value \"abcdef\": strconv.Atoi: parsing \"abcdef\": invalid syntax"),
+		},
+		{
+			name:                 "when maxUnhealthy is an int",
+			maxUnhealthy:         &intstr.IntOrString{Type: intstr.Int, IntVal: 3},
+			actualMachineCount:   2,
+			expectedMaxUnhealthy: 3,
+			expectedErr:          nil,
+		},
+		{
+			name:                 "when maxUnhealthy is a 40% (of 5)",
+			maxUnhealthy:         &intstr.IntOrString{Type: intstr.String, StrVal: "40%"},
+			actualMachineCount:   5,
+			expectedMaxUnhealthy: 2,
+			expectedErr:          nil,
+		},
+		{
+			name:                 "when maxUnhealthy is a 60% (of 7)",
+			maxUnhealthy:         &intstr.IntOrString{Type: intstr.String, StrVal: "60%"},
+			actualMachineCount:   7,
+			expectedMaxUnhealthy: 4,
+			expectedErr:          nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			mhc := &clusterv1.MachineHealthCheck{
+				Spec: clusterv1.MachineHealthCheckSpec{
+					MaxUnhealthy: tc.maxUnhealthy,
+				},
+				Status: clusterv1.MachineHealthCheckStatus{
+					ExpectedMachines: tc.actualMachineCount,
+				},
+			}
+
+			maxUnhealthy, err := getMaxUnhealthy(mhc)
+			if tc.expectedErr != nil {
+				g.Expect(err).To(MatchError(tc.expectedErr.Error()))
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(maxUnhealthy).To(Equal(tc.expectedMaxUnhealthy))
+		})
+	}
+}
+
 func ownerReferenceForCluster(ctx context.Context, g *WithT, c *clusterv1.Cluster) metav1.OwnerReference {
 	// Fetch the cluster to populate the UID
 	cc := &clusterv1.Cluster{}
@@ -1884,6 +2060,7 @@ func newMachineHealthCheckWithLabels(name, namespace, cluster string, labels map
 }
 
 func newMachineHealthCheck(namespace, clusterName string) *clusterv1.MachineHealthCheck {
+	maxUnhealthy := intstr.FromString("100%")
 	return &clusterv1.MachineHealthCheck{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "test-mhc-",
@@ -1896,6 +2073,7 @@ func newMachineHealthCheck(namespace, clusterName string) *clusterv1.MachineHeal
 					"selector": string(uuid.NewUUID()),
 				},
 			},
+			MaxUnhealthy:       &maxUnhealthy,
 			NodeStartupTimeout: &metav1.Duration{Duration: 1 * time.Millisecond},
 			UnhealthyConditions: []clusterv1.UnhealthyCondition{
 				{

--- a/controllers/machinehealthcheck_status_matcher_test.go
+++ b/controllers/machinehealthcheck_status_matcher_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/util/conditions"
 )
 
 // MatchMachineHealthCheckStatus returns a custom matcher to check equality of clusterv1.MachineHealthCheckStatus
@@ -49,7 +50,15 @@ func (m machineHealthCheckStatusMatcher) Match(actual interface{}) (success bool
 	if !ok {
 		return ok, err
 	}
+	ok, err = Equal(m.expected.RemediationsAllowed).Match(actualStatus.RemediationsAllowed)
+	if !ok {
+		return ok, err
+	}
 	ok, err = ConsistOf(m.expected.Targets).Match(actualStatus.Targets)
+	if !ok {
+		return ok, err
+	}
+	ok, err = conditions.MatchConditions(m.expected.Conditions).Match(actualStatus.Conditions)
 	return ok, err
 }
 

--- a/util/conditions/matcher.go
+++ b/util/conditions/matcher.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"fmt"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+)
+
+// MatchConditions returns a custom matcher to check equality of clusterv1.Conditions
+func MatchConditions(expected clusterv1.Conditions) types.GomegaMatcher {
+	return &matchConditions{
+		expected: expected,
+	}
+}
+
+type matchConditions struct {
+	expected clusterv1.Conditions
+}
+
+func (m matchConditions) Match(actual interface{}) (success bool, err error) {
+	elems := []interface{}{}
+	for _, condition := range m.expected {
+		elems = append(elems, MatchCondition(condition))
+	}
+
+	return ConsistOf(elems).Match(actual)
+}
+
+func (m matchConditions) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+func (m matchConditions) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}
+
+// MatchCondition returns a custom matcher to check equality of clusterv1.Condition
+func MatchCondition(expected clusterv1.Condition) types.GomegaMatcher {
+	return &matchCondition{
+		expected: expected,
+	}
+}
+
+type matchCondition struct {
+	expected clusterv1.Condition
+}
+
+func (m matchCondition) Match(actual interface{}) (success bool, err error) {
+	actualCondition, ok := actual.(clusterv1.Condition)
+	if !ok {
+		return false, fmt.Errorf("actual should be of type Condition")
+	}
+
+	ok, err = Equal(m.expected.Type).Match(actualCondition.Type)
+	if !ok {
+		return ok, err
+	}
+	ok, err = Equal(m.expected.Status).Match(actualCondition.Status)
+	if !ok {
+		return ok, err
+	}
+	ok, err = Equal(m.expected.Severity).Match(actualCondition.Severity)
+	if !ok {
+		return ok, err
+	}
+	ok, err = Equal(m.expected.Reason).Match(actualCondition.Reason)
+	if !ok {
+		return ok, err
+	}
+	ok, err = Equal(m.expected.Message).Match(actualCondition.Message)
+	if !ok {
+		return ok, err
+	}
+
+	return ok, err
+}
+
+func (m matchCondition) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto match\n\t%#v\n", actual, m.expected)
+}
+
+func (m matchCondition) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("expected\n\t%#v\nto not match\n\t%#v\n", actual, m.expected)
+}

--- a/util/conditions/matcher_test.go
+++ b/util/conditions/matcher_test.go
@@ -1,0 +1,316 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditions
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+)
+
+func TestMatchConditions(t *testing.T) {
+	testCases := []struct {
+		name        string
+		actual      interface{}
+		expected    clusterv1.Conditions
+		expectMatch bool
+	}{
+		{
+			name:        "with an empty conditions",
+			actual:      clusterv1.Conditions{},
+			expected:    clusterv1.Conditions{},
+			expectMatch: true,
+		},
+		{
+			name: "with matching conditions",
+			actual: clusterv1.Conditions{
+				{
+					Type:               clusterv1.ConditionType("type"),
+					Status:             corev1.ConditionTrue,
+					Severity:           clusterv1.ConditionSeverityNone,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+			},
+			expected: clusterv1.Conditions{
+				{
+					Type:               clusterv1.ConditionType("type"),
+					Status:             corev1.ConditionTrue,
+					Severity:           clusterv1.ConditionSeverityNone,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+			},
+			expectMatch: true,
+		},
+		{
+			name: "with non-matching conditions",
+			actual: clusterv1.Conditions{
+				{
+					Type:               clusterv1.ConditionType("type"),
+					Status:             corev1.ConditionTrue,
+					Severity:           clusterv1.ConditionSeverityNone,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+				{
+					Type:               clusterv1.ConditionType("type"),
+					Status:             corev1.ConditionTrue,
+					Severity:           clusterv1.ConditionSeverityNone,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+			},
+			expected: clusterv1.Conditions{
+				{
+					Type:               clusterv1.ConditionType("type"),
+					Status:             corev1.ConditionTrue,
+					Severity:           clusterv1.ConditionSeverityNone,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+				{
+					Type:               clusterv1.ConditionType("different"),
+					Status:             corev1.ConditionTrue,
+					Severity:           clusterv1.ConditionSeverityNone,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "different",
+					Message:            "different",
+				},
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with a different number of conditions",
+			actual: clusterv1.Conditions{
+				{
+					Type:               clusterv1.ConditionType("type"),
+					Status:             corev1.ConditionTrue,
+					Severity:           clusterv1.ConditionSeverityNone,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+				{
+					Type:               clusterv1.ConditionType("type"),
+					Status:             corev1.ConditionTrue,
+					Severity:           clusterv1.ConditionSeverityNone,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+			},
+			expected: clusterv1.Conditions{
+				{
+					Type:               clusterv1.ConditionType("type"),
+					Status:             corev1.ConditionTrue,
+					Severity:           clusterv1.ConditionSeverityNone,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "reason",
+					Message:            "message",
+				},
+			},
+			expectMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			if tc.expectMatch {
+				g.Expect(tc.actual).To(MatchConditions(tc.expected))
+			} else {
+				g.Expect(tc.actual).ToNot(MatchConditions(tc.expected))
+			}
+		})
+	}
+}
+
+func TestMatchCondition(t *testing.T) {
+	testCases := []struct {
+		name        string
+		actual      interface{}
+		expected    clusterv1.Condition
+		expectMatch bool
+	}{
+		{
+			name:        "with an empty condition",
+			actual:      clusterv1.Condition{},
+			expected:    clusterv1.Condition{},
+			expectMatch: true,
+		},
+		{
+			name: "with a matching condition",
+			actual: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expectMatch: true,
+		},
+		{
+			name: "with a different time",
+			actual: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Time{},
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expectMatch: true,
+		},
+		{
+			name: "with a different type",
+			actual: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("different"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with a different status",
+			actual: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionFalse,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with a different severity",
+			actual: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityInfo,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with a different reason",
+			actual: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "different",
+				Message:            "message",
+			},
+			expectMatch: false,
+		},
+		{
+			name: "with a different message",
+			actual: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "message",
+			},
+			expected: clusterv1.Condition{
+				Type:               clusterv1.ConditionType("type"),
+				Status:             corev1.ConditionTrue,
+				Severity:           clusterv1.ConditionSeverityNone,
+				LastTransitionTime: metav1.Now(),
+				Reason:             "reason",
+				Message:            "different",
+			},
+			expectMatch: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			if tc.expectMatch {
+				g.Expect(tc.actual).To(MatchCondition(tc.expected))
+			} else {
+				g.Expect(tc.actual).ToNot(MatchCondition(tc.expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adds a new field to the MHC status called remediationsAllowed as proposed in #3371

Forward porting the feature from the release-0.3 branch (#3372)

/cc @wfernandes @CecileRobertMichon 