### PR TITLE
🌱 Add Node related condition to Machine conditions

### DIFF
--- a/api/v1alpha3/condition_consts.go
+++ b/api/v1alpha3/condition_consts.go
@@ -109,9 +109,6 @@ const (
 	// MachineHasFailureReason is the reason used when a machine has either a FailureReason or a FailureMessage set on its status.
 	MachineHasFailureReason = "MachineHasFailure"
 
-	// NodeNotFoundReason is the reason used when a machine's node has previously been observed but is now gone.
-	NodeNotFoundReason = "NodeNotFound"
-
 	// NodeStartupTimeoutReason is the reason used when a machine's node does not appear within the specified timeout.
 	NodeStartupTimeoutReason = "NodeStartupTimeout"
 
@@ -126,4 +123,25 @@ const (
 
 	// WaitingForRemediationReason is the reason used when a machine fails a health check and remediation is needed.
 	WaitingForRemediationReason = "WaitingForRemediation"
+)
+
+// Conditions and condition Reasons for the Machine's Node object
+const (
+	// MachineNodeHealthyCondition provides info about the operational state of the Kubernetes node hosted on the machine by summarizing  node conditions.
+	// If the conditions defined in a Kubernetes node (i.e., NodeReady, NodeMemoryPressure, NodeDiskPressure, NodePIDPressure, and NodeNetworkUnavailable) are in a healthy state, it will be set to True.
+	MachineNodeHealthyCondition ConditionType = "NodeHealthy"
+
+	// WaitingForNodeRefReason (Severity=Info) documents a machine.spec.providerId is not assigned yet.
+	WaitingForNodeRefReason = "WaitingForNodeRef"
+
+	// NodeProvisioningReason (Severity=Info) documents machine in the process of provisioning a node.
+	// NB. provisioning --> NodeRef == ""
+	NodeProvisioningReason = "NodeProvisioning"
+
+	// NodeNotFoundReason (Severity=Error) documents a machine's node has previously been observed but is now gone.
+	// NB. provisioned --> NodeRef != ""
+	NodeNotFoundReason = "NodeNotFound"
+
+	// NodeConditionsFailedReason (Severity=Warning) documents a node is not in a healthy state due to the failed state of at least 1 Kubelet condition.
+	NodeConditionsFailedReason = "NodeConditionsFailed"
 )

--- a/api/v1alpha4/condition_consts.go
+++ b/api/v1alpha4/condition_consts.go
@@ -116,9 +116,6 @@ const (
 	// MachineHasFailureReason is the reason used when a machine has either a FailureReason or a FailureMessage set on its status.
 	MachineHasFailureReason = "MachineHasFailure"
 
-	// NodeNotFoundReason is the reason used when a machine's node has previously been observed but is now gone.
-	NodeNotFoundReason = "NodeNotFound"
-
 	// NodeStartupTimeoutReason is the reason used when a machine's node does not appear within the specified timeout.
 	NodeStartupTimeoutReason = "NodeStartupTimeout"
 
@@ -133,4 +130,25 @@ const (
 
 	// WaitingForRemediationReason is the reason used when a machine fails a health check and remediation is needed.
 	WaitingForRemediationReason = "WaitingForRemediation"
+)
+
+// Conditions and condition Reasons for the Machine's Node object
+const (
+	// MachineNodeHealthyCondition provides info about the operational state of the Kubernetes node hosted on the machine by summarizing  node conditions.
+	// If the conditions defined in a Kubernetes node (i.e., NodeReady, NodeMemoryPressure, NodeDiskPressure, NodePIDPressure, and NodeNetworkUnavailable) are in a healthy state, it will be set to True.
+	MachineNodeHealthyCondition ConditionType = "NodeHealthy"
+
+	// WaitingForNodeRefReason (Severity=Info) documents a machine.spec.providerId is not assigned yet.
+	WaitingForNodeRefReason = "WaitingForNodeRef"
+
+	// NodeProvisioningReason (Severity=Info) documents machine in the process of provisioning a node.
+	// NB. provisioning --> NodeRef == ""
+	NodeProvisioningReason = "NodeProvisioning"
+
+	// NodeNotFoundReason (Severity=Error) documents a machine's node has previously been observed but is now gone.
+	// NB. provisioned --> NodeRef != ""
+	NodeNotFoundReason = "NodeNotFound"
+
+	// NodeConditionsFailedReason (Severity=Warning) documents a node is not in a healthy state due to the failed state of at least 1 Kubelet condition.
+	NodeConditionsFailedReason = "NodeConditionsFailed"
 )

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -263,7 +263,7 @@ func (r *MachineReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cl
 	phases := []func(context.Context, *clusterv1.Cluster, *clusterv1.Machine) (ctrl.Result, error){
 		r.reconcileBootstrap,
 		r.reconcileInfrastructure,
-		r.reconcileNodeRef,
+		r.reconcileNode,
 	}
 
 	res := ctrl.Result{}
@@ -346,6 +346,16 @@ func (r *MachineReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 	// Return early and don't remove the finalizer if we got an error or
 	// the external reconciliation deletion isn't ready.
 
+	patchHelper, err := patch.NewHelper(m, r.Client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	conditions.MarkFalse(m, clusterv1.MachineNodeHealthyCondition, clusterv1.DeletingReason, clusterv1.ConditionSeverityInfo, "")
+	if err := patchMachine(ctx, patchHelper, m); err != nil {
+		conditions.MarkFalse(m, clusterv1.MachineNodeHealthyCondition, clusterv1.DeletionFailedReason, clusterv1.ConditionSeverityInfo, "")
+		return ctrl.Result{}, errors.Wrap(err, "failed to patch Machine")
+	}
+
 	if ok, err := r.reconcileDeleteInfrastructure(ctx, m); !ok || err != nil {
 		return ctrl.Result{}, err
 	}
@@ -368,6 +378,7 @@ func (r *MachineReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 		})
 		if waitErr != nil {
 			log.Error(deleteNodeErr, "Timed out deleting node, moving on", "node", m.Status.NodeRef.Name)
+			conditions.MarkFalse(m, clusterv1.MachineNodeHealthyCondition, clusterv1.DeletionFailedReason, clusterv1.ConditionSeverityWarning, "")
 			r.recorder.Eventf(m, corev1.EventTypeWarning, "FailedDeleteNode", "error deleting Machine's node: %v", deleteNodeErr)
 		}
 	}

--- a/controllers/machine_controller_noderef_test.go
+++ b/controllers/machine_controller_noderef_test.go
@@ -25,11 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetNodeReference(t *testing.T) {
@@ -106,7 +105,7 @@ func TestGetNodeReference(t *testing.T) {
 			providerID, err := noderefutil.NewProviderID(test.providerID)
 			gt.Expect(err).NotTo(HaveOccurred(), "Expected no error parsing provider id %q, got %v", test.providerID, err)
 
-			reference, err := r.getNodeReference(ctx, client, providerID)
+			node, err := r.getNode(ctx, client, providerID)
 			if test.err == nil {
 				g.Expect(err).To(BeNil())
 			} else {
@@ -114,13 +113,77 @@ func TestGetNodeReference(t *testing.T) {
 				gt.Expect(err).To(Equal(test.err), "Expected error %v, got %v", test.err, err)
 			}
 
-			if test.expected == nil && reference == nil {
+			if test.expected == nil && node == nil {
 				return
 			}
 
-			gt.Expect(reference.Name).To(Equal(test.expected.Name), "Expected NodeRef's name to be %v, got %v", reference.Name, test.expected.Name)
-			gt.Expect(reference.Namespace).To(Equal(test.expected.Namespace), "Expected NodeRef's namespace to be %v, got %v", reference.Namespace, test.expected.Namespace)
+			gt.Expect(node.Name).To(Equal(test.expected.Name), "Expected NodeRef's name to be %v, got %v", node.Name, test.expected.Name)
+			gt.Expect(node.Namespace).To(Equal(test.expected.Namespace), "Expected NodeRef's namespace to be %v, got %v", node.Namespace, test.expected.Namespace)
 		})
 
+	}
+}
+
+func TestSummarizeNodeConditions(t *testing.T) {
+	testCases := []struct {
+		name       string
+		conditions []corev1.NodeCondition
+		status     corev1.ConditionStatus
+	}{
+		{
+			name: "node is healthy",
+			conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+				{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+				{Type: corev1.NodePIDPressure, Status: corev1.ConditionFalse},
+			},
+			status: corev1.ConditionTrue,
+		},
+		{
+			name: "all conditions are unknown",
+			conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionUnknown},
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionUnknown},
+				{Type: corev1.NodeDiskPressure, Status: corev1.ConditionUnknown},
+				{Type: corev1.NodePIDPressure, Status: corev1.ConditionUnknown},
+			},
+			status: corev1.ConditionUnknown,
+		},
+		{
+			name: "multiple semantically failed condition",
+			conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionUnknown},
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue},
+				{Type: corev1.NodeDiskPressure, Status: corev1.ConditionTrue},
+				{Type: corev1.NodePIDPressure, Status: corev1.ConditionTrue},
+			},
+			status: corev1.ConditionFalse,
+		},
+		{
+			name: "one positive condition when the rest is unknown",
+			conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionUnknown},
+				{Type: corev1.NodeDiskPressure, Status: corev1.ConditionUnknown},
+				{Type: corev1.NodePIDPressure, Status: corev1.ConditionUnknown},
+			},
+			status: corev1.ConditionTrue,
+		},
+	}
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-1",
+				},
+				Status: corev1.NodeStatus{
+					Conditions: test.conditions,
+				},
+			}
+			status, _ := summarizeNodeConditions(node)
+			g.Expect(status).To(Equal(test.status))
+		})
 	}
 }

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -23,18 +23,21 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/external"
+	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/test/helpers"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -208,6 +211,144 @@ func TestIndexMachineByNodeName(t *testing.T) {
 			g.Expect(got).To(ConsistOf(tc.expected))
 		})
 	}
+}
+
+func TestMachine_Reconcile(t *testing.T) {
+	g := NewWithT(t)
+	infraMachine := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "InfrastructureMachine",
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha4",
+			"metadata": map[string]interface{}{
+				"name":      "infra-config1",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"providerID": "test://id-1",
+			},
+		},
+	}
+
+	defaultBootstrap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "BootstrapMachine",
+			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
+			"metadata": map[string]interface{}{
+				"name":      "bootstrap-config-machinereconcile",
+				"namespace": "default",
+			},
+			"spec":   map[string]interface{}{},
+			"status": map[string]interface{}{},
+		},
+	}
+
+	testCluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "machine-reconcile-",
+			Namespace:    "default",
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, testCluster)).To(BeNil())
+	g.Expect(testEnv.Create(ctx, infraMachine)).To(BeNil())
+	g.Expect(testEnv.Create(ctx, defaultBootstrap)).To(BeNil())
+
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(testCluster)
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "machine-created-",
+			Namespace:    "default",
+			Finalizers:   []string{clusterv1.MachineFinalizer},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: testCluster.Name,
+			InfrastructureRef: corev1.ObjectReference{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+				Kind:       "InfrastructureMachine",
+				Name:       "infra-config1",
+			},
+			Bootstrap: clusterv1.Bootstrap{
+				ConfigRef: &corev1.ObjectReference{
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha4",
+					Kind:       "BootstrapMachine",
+					Name:       "bootstrap-config-machinereconcile",
+				},
+			}},
+		Status: clusterv1.MachineStatus{
+			NodeRef: &corev1.ObjectReference{
+				Name: "test",
+			},
+		},
+	}
+	g.Expect(testEnv.Create(ctx, machine)).To(BeNil())
+
+	key := client.ObjectKey{Name: machine.Name, Namespace: machine.Namespace}
+
+	// Wait for reconciliation to happen when infra and bootstrap objects are not ready.
+	g.Eventually(func() bool {
+		if err := testEnv.Get(ctx, key, machine); err != nil {
+			return false
+		}
+		return len(machine.Finalizers) > 0
+	}, timeout).Should(BeTrue())
+
+	// Set bootstrap ready.
+	bootstrapPatch := client.MergeFrom(defaultBootstrap.DeepCopy())
+	g.Expect(unstructured.SetNestedField(defaultBootstrap.Object, true, "status", "ready")).NotTo(HaveOccurred())
+	g.Expect(testEnv.Status().Patch(ctx, defaultBootstrap, bootstrapPatch)).To(Succeed())
+
+	// Set infrastructure ready.
+	infraMachinePatch := client.MergeFrom(infraMachine.DeepCopy())
+	g.Expect(unstructured.SetNestedField(infraMachine.Object, true, "status", "ready")).To(Succeed())
+	g.Expect(testEnv.Status().Patch(ctx, infraMachine, infraMachinePatch)).To(Succeed())
+
+	// Wait for Machine Ready Condition to become True.
+	g.Eventually(func() bool {
+		if err := testEnv.Get(ctx, key, machine); err != nil {
+			return false
+		}
+		if conditions.Has(machine, clusterv1.InfrastructureReadyCondition) != true {
+			return false
+		}
+		readyCondition := conditions.Get(machine, clusterv1.ReadyCondition)
+		return readyCondition.Status == corev1.ConditionTrue
+	}, timeout).Should(BeTrue())
+
+	g.Expect(testEnv.Delete(ctx, machine)).NotTo(HaveOccurred())
+	// Wait for Machine to be deleted.
+	g.Eventually(func() bool {
+		if err := testEnv.Get(ctx, key, machine); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true
+			}
+		}
+		return false
+	}, timeout).Should(BeTrue())
+
+	// Check if Machine deletion successfully deleted infrastructure external reference.
+	keyInfra := client.ObjectKey{Name: infraMachine.GetName(), Namespace: infraMachine.GetNamespace()}
+	g.Eventually(func() bool {
+		if err := testEnv.Get(ctx, keyInfra, infraMachine); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true
+			}
+		}
+		return false
+	}, timeout).Should(BeTrue())
+
+	// Check if Machine deletion successfully deleted bootstrap external reference.
+	keyBootstrap := client.ObjectKey{Name: defaultBootstrap.GetName(), Namespace: defaultBootstrap.GetNamespace()}
+	g.Eventually(func() bool {
+		if err := testEnv.Get(ctx, keyBootstrap, defaultBootstrap); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true
+			}
+		}
+		return false
+	}, timeout).Should(BeTrue())
 }
 
 func TestMachineFinalizer(t *testing.T) {
@@ -500,6 +641,14 @@ func TestReconcileRequest(t *testing.T) {
 		},
 	}
 
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: corev1.NodeSpec{ProviderID: "test://id-1"},
+	}
+
 	type expected struct {
 		result reconcile.Result
 		err    bool
@@ -598,6 +747,7 @@ func TestReconcileRequest(t *testing.T) {
 
 			clientFake := helpers.NewFakeClientWithScheme(
 				scheme.Scheme,
+				node,
 				&testCluster,
 				&tc.machine,
 				external.TestGenericInfrastructureCRD.DeepCopy(),
@@ -605,7 +755,8 @@ func TestReconcileRequest(t *testing.T) {
 			)
 
 			r := &MachineReconciler{
-				Client: clientFake,
+				Client:  clientFake,
+				Tracker: remote.NewTestClusterCacheTracker(log.NullLogger{}, clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			}
 
 			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(&tc.machine)})
@@ -683,6 +834,7 @@ func TestMachineConditions(t *testing.T) {
 			Finalizers: []string{clusterv1.MachineFinalizer},
 		},
 		Spec: clusterv1.MachineSpec{
+			ProviderID:  pointer.StringPtr("test://id-1"),
 			ClusterName: "test-cluster",
 			InfrastructureRef: corev1.ObjectReference{
 				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
@@ -703,6 +855,14 @@ func TestMachineConditions(t *testing.T) {
 			},
 			ObservedGeneration: 1,
 		},
+	}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: corev1.NodeSpec{ProviderID: "test://id-1"},
 	}
 
 	testcases := []struct {
@@ -837,10 +997,12 @@ func TestMachineConditions(t *testing.T) {
 				infra,
 				external.TestGenericBootstrapCRD.DeepCopy(),
 				bootstrap,
+				node,
 			)
 
 			r := &MachineReconciler{
-				Client: clientFake,
+				Client:  clientFake,
+				Tracker: remote.NewTestClusterCacheTracker(log.NullLogger{}, clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			}
 
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(&machine)})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a condition for Node health to Machine conditions that will be managed by Machine controller.
Forward porting the feature from the release-0.3 branch: https://github.com/kubernetes-sigs/cluster-api/pull/3670