### PR TITLE
:seedling: Update controller-runtime to latest main version v0.7.0-alpha.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,8 +346,14 @@ modules: ## Runs go mod to ensure modules are up to date.
 ## Docker
 ## --------------------------------------
 
+.PHONY: docker-pull-prerequisites
+docker-pull-prerequisites:
+	docker pull docker.io/docker/dockerfile:experimental
+	docker pull docker.io/library/golang:1.15.3
+	docker pull gcr.io/distroless/static:latest
+
 .PHONY: docker-build
-docker-build: ## Build the docker images for controller managers
+docker-build: docker-pull-prerequisites ## Build the docker images for controller managers
 	$(MAKE) ARCH=$(ARCH) docker-build-core
 	$(MAKE) ARCH=$(ARCH) docker-build-kubeadm-bootstrap
 	$(MAKE) ARCH=$(ARCH) docker-build-kubeadm-control-plane
@@ -511,9 +517,6 @@ release-binary: $(RELEASE_DIR)
 
 .PHONY: release-staging
 release-staging: ## Builds and push container images to the staging bucket.
-	docker pull docker.io/docker/dockerfile:experimental
-	docker pull docker.io/library/golang:1.15.3
-	docker pull gcr.io/distroless/static:latest
 	REGISTRY=$(STAGING_REGISTRY) $(MAKE) docker-build-all docker-push-all release-alias-tag
 
 RELEASE_ALIAS_TAG=$(PULL_BASE_REF)

--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
@@ -1821,7 +1821,7 @@ func assertHasFalseCondition(g *WithT, myclient client.Client, req ctrl.Request,
 		},
 	}
 
-	configKey, _ := client.ObjectKeyFromObject(config)
+	configKey := client.ObjectKeyFromObject(config)
 	g.Expect(myclient.Get(ctx, configKey, config)).To(Succeed())
 	c := conditions.Get(config, t)
 	g.Expect(c).ToNot(BeNil())
@@ -1838,7 +1838,7 @@ func assertHasTrueCondition(g *WithT, myclient client.Client, req ctrl.Request, 
 		},
 	}
 
-	configKey, _ := client.ObjectKeyFromObject(config)
+	configKey := client.ObjectKeyFromObject(config)
 	g.Expect(myclient.Get(ctx, configKey, config)).To(Succeed())
 	c := conditions.Get(config, t)
 	g.Expect(c).ToNot(BeNil())

--- a/cmd/clusterctl/client/cluster/cert_manager_test.go
+++ b/cmd/clusterctl/client/cluster/cert_manager_test.go
@@ -514,10 +514,7 @@ func Test_certManagerClient_deleteObjs(t *testing.T) {
 				cl, err := proxy.NewClient()
 				g.Expect(err).ToNot(HaveOccurred())
 
-				key, err := client.ObjectKeyFromObject(obj)
-				g.Expect(err).ToNot(HaveOccurred())
-
-				err = cl.Get(ctx, key, obj)
+				err = cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)
 				switch objShouldStillExist {
 				case true:
 					g.Expect(err).ToNot(HaveOccurred())

--- a/cmd/clusterctl/client/cluster/inventory.go
+++ b/cmd/clusterctl/client/cluster/inventory.go
@@ -150,11 +150,7 @@ func (p *inventoryClient) EnsureCustomResourceDefinitions() error {
 
 		// If the object is a CRDs, waits for it being Established.
 		if apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition").GroupKind() == o.GroupVersionKind().GroupKind() {
-			crdKey, err := client.ObjectKeyFromObject(&o)
-			if err != nil {
-				return nil
-			}
-
+			crdKey := client.ObjectKeyFromObject(&o)
 			if err := p.pollImmediateWaiter(waitInventoryCRDInterval, waitInventoryCRDTimeout, func() (bool, error) {
 				c, err := p.proxy.NewClient()
 				if err != nil {

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -847,8 +847,7 @@ func TestMachineConditions(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			m = &clusterv1.Machine{}
-			machineKey, _ := client.ObjectKeyFromObject(&machine)
-			g.Expect(r.Client.Get(ctx, machineKey, m)).NotTo(HaveOccurred())
+			g.Expect(r.Client.Get(ctx, client.ObjectKeyFromObject(&machine), m)).NotTo(HaveOccurred())
 
 			assertConditions(t, m, tt.conditionsToAssert...)
 		})

--- a/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
@@ -300,8 +300,7 @@ kind: ClusterConfiguration
 				// this makes sure that the cache is updated with the object
 				// to avoid 404 errors leading to test flakes
 				g.Eventually(func() bool {
-					key, _ := client.ObjectKeyFromObject(o)
-					err := testEnv.Get(ctx, key, o)
+					err := testEnv.Get(ctx, client.ObjectKeyFromObject(o), o)
 					return err == nil
 				}, "10s").Should(BeTrue())
 			}
@@ -313,8 +312,7 @@ kind: ClusterConfiguration
 				g.Eventually(func() bool {
 					for _, o := range tt.objs {
 						o := o.DeepCopyObject().(client.Object)
-						key, _ := client.ObjectKeyFromObject(o)
-						err := testEnv.Get(ctx, key, o)
+						err := testEnv.Get(ctx, client.ObjectKeyFromObject(o), o)
 						if err == nil || (err != nil && !apierrors.IsNotFound(err)) {
 							return false
 						}

--- a/controlplane/kubeadm/internal/workload_cluster_rbac.go
+++ b/controlplane/kubeadm/internal/workload_cluster_rbac.go
@@ -50,10 +50,7 @@ const (
 // EnsureResource creates a resoutce if the target resource doesn't exist. If the resource exists already, this function will ignore the resource instead.
 func (w *Workload) EnsureResource(ctx context.Context, obj client.Object) error {
 	testObj := obj.DeepCopyObject().(client.Object)
-	key, err := ctrlclient.ObjectKeyFromObject(obj)
-	if err != nil {
-		return errors.Wrap(err, "unable to derive key for resource")
-	}
+	key := ctrlclient.ObjectKeyFromObject(obj)
 	if err := w.Client.Get(ctx, key, testObj); err != nil && !apierrors.IsNotFound(err) {
 		return errors.Wrapf(err, "failed to determine if resource %s/%s already exists", key.Namespace, key.Name)
 	} else if err == nil {

--- a/exp/controllers/machinepool_controller_test.go
+++ b/exp/controllers/machinepool_controller_test.go
@@ -848,7 +848,7 @@ func TestMachinePoolConditions(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			m := &expv1.MachinePool{}
-			machinePoolKey, _ := client.ObjectKeyFromObject(machinePool)
+			machinePoolKey := client.ObjectKeyFromObject(machinePool)
 			g.Expect(r.Client.Get(ctx, machinePoolKey, m)).NotTo(HaveOccurred())
 
 			tt.conditionAssertFunc(t, m)

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	k8s.io/component-base v0.19.2
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20200912215256-4140de9c8800
-	sigs.k8s.io/controller-runtime v0.7.0-alpha.3
+	sigs.k8s.io/controller-runtime v0.7.0-alpha.5
 	sigs.k8s.io/kind v0.9.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -797,8 +797,8 @@ k8s.io/utils v0.0.0-20200912215256-4140de9c8800 h1:9ZNvfPvVIEsp/T1ez4GQuzCcCTEQW
 k8s.io/utils v0.0.0-20200912215256-4140de9c8800/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
-sigs.k8s.io/controller-runtime v0.7.0-alpha.3 h1:2M5hPRhlAlvqywBouX/jAdY49aVMEZ4xL/gDYpdtuUs=
-sigs.k8s.io/controller-runtime v0.7.0-alpha.3/go.mod h1:yNpmlc7C6HaRnHubtIcOqnlVF/iTrNRISKKQhZ3mkHk=
+sigs.k8s.io/controller-runtime v0.7.0-alpha.5 h1:U0eZrtiuLMLE6RJTPCjr/CsrauJZc5gxqZxDE8HlBpg=
+sigs.k8s.io/controller-runtime v0.7.0-alpha.5/go.mod h1:03b1n6EtlDvuBPPEOHadJUusruwLWgoT4BDCybMibnA=
 sigs.k8s.io/kind v0.9.0 h1:SoDlXq6pEc7dGagHULNRCCBYrLH6xOi7lqXTRXeAlg4=
 sigs.k8s.io/kind v0.9.0/go.mod h1:cxKQWwmbtRDzQ+RNKnR6gZG6fjbeTtItp5cGf+ww+1Y=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -100,8 +100,7 @@ func WatchDeploymentLogs(ctx context.Context, input WatchDeploymentLogsInput) {
 	Expect(input.Deployment).NotTo(BeNil(), "input.Deployment is required for WatchControllerLogs")
 
 	deployment := &appsv1.Deployment{}
-	key, err := client.ObjectKeyFromObject(input.Deployment)
-	Expect(err).NotTo(HaveOccurred(), "Failed to get key for deployment %s/%s", input.Deployment.Namespace, input.Deployment.Name)
+	key := client.ObjectKeyFromObject(input.Deployment)
 	Expect(input.GetLister.Get(ctx, key, deployment)).To(Succeed(), "Failed to get deployment %s/%s", input.Deployment.Namespace, input.Deployment.Name)
 
 	selector, err := metav1.LabelSelectorAsMap(deployment.Spec.Selector)
@@ -169,8 +168,7 @@ func WatchPodMetrics(ctx context.Context, input WatchPodMetricsInput) {
 	Expect(input.Deployment).NotTo(BeNil(), "input.Deployment is required for dumpContainerMetrics")
 
 	deployment := &appsv1.Deployment{}
-	key, err := client.ObjectKeyFromObject(input.Deployment)
-	Expect(err).NotTo(HaveOccurred(), "Failed to get key for deployment %s/%s", input.Deployment.Namespace, input.Deployment.Name)
+	key := client.ObjectKeyFromObject(input.Deployment)
 	Expect(input.GetLister.Get(ctx, key, deployment)).To(Succeed(), "Failed to get deployment %s/%s", input.Deployment.Namespace, input.Deployment.Name)
 
 	selector, err := metav1.LabelSelectorAsMap(deployment.Spec.Selector)

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -142,8 +142,14 @@ modules: ## Runs go mod to ensure modules are up to date.
 ## Docker
 ## --------------------------------------
 
+.PHONY: docker-pull-prerequisites
+docker-pull-prerequisites:
+	docker pull docker.io/docker/dockerfile:experimental
+	docker pull docker.io/library/golang:1.15.3
+	docker pull gcr.io/distroless/static:latest
+
 .PHONY: docker-build
-docker-build: ## Build the docker image for controller-manager
+docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
 	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) ../../.. -t $(CONTROLLER_IMG)-$(ARCH):$(TAG) --file Dockerfile
 	MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
 	$(MAKE) set-manifest-pull-policy
@@ -216,9 +222,6 @@ release-manifests: $(RELEASE_DIR) ## Builds the manifests to publish with a rele
 
 .PHONY: release-staging
 release-staging: ## Builds and push container images to the staging bucket.
-	docker pull docker.io/docker/dockerfile:experimental
-	docker pull docker.io/library/golang:1.15.3
-	docker pull gcr.io/distroless/static:latest
 	REGISTRY=$(STAGING_REGISTRY) $(MAKE) docker-build-all docker-push-all release-alias-tag
 
 RELEASE_ALIAS_TAG=$(PULL_BASE_REF)

--- a/test/infrastructure/docker/go.mod
+++ b/test/infrastructure/docker/go.mod
@@ -13,7 +13,7 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20200912215256-4140de9c8800
 	sigs.k8s.io/cluster-api v0.3.3
-	sigs.k8s.io/controller-runtime v0.7.0-alpha.3
+	sigs.k8s.io/controller-runtime v0.7.0-alpha.5
 	sigs.k8s.io/kind v0.9.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/test/infrastructure/docker/go.sum
+++ b/test/infrastructure/docker/go.sum
@@ -741,8 +741,8 @@ k8s.io/utils v0.0.0-20200912215256-4140de9c8800 h1:9ZNvfPvVIEsp/T1ez4GQuzCcCTEQW
 k8s.io/utils v0.0.0-20200912215256-4140de9c8800/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
-sigs.k8s.io/controller-runtime v0.7.0-alpha.3 h1:2M5hPRhlAlvqywBouX/jAdY49aVMEZ4xL/gDYpdtuUs=
-sigs.k8s.io/controller-runtime v0.7.0-alpha.3/go.mod h1:yNpmlc7C6HaRnHubtIcOqnlVF/iTrNRISKKQhZ3mkHk=
+sigs.k8s.io/controller-runtime v0.7.0-alpha.5 h1:U0eZrtiuLMLE6RJTPCjr/CsrauJZc5gxqZxDE8HlBpg=
+sigs.k8s.io/controller-runtime v0.7.0-alpha.5/go.mod h1:03b1n6EtlDvuBPPEOHadJUusruwLWgoT4BDCybMibnA=
 sigs.k8s.io/kind v0.9.0 h1:SoDlXq6pEc7dGagHULNRCCBYrLH6xOi7lqXTRXeAlg4=
 sigs.k8s.io/kind v0.9.0/go.mod h1:cxKQWwmbtRDzQ+RNKnR6gZG6fjbeTtItp5cGf+ww+1Y=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/util/patch/patch.go
+++ b/util/patch/patch.go
@@ -187,10 +187,7 @@ func (h *Helper) patchStatusConditions(ctx context.Context, obj client.Object, f
 	}
 
 	// Make a copy of the object and store the key used if we have conflicts.
-	key, err := client.ObjectKeyFromObject(after)
-	if err != nil {
-		return err
-	}
+	key := client.ObjectKeyFromObject(after)
 
 	// Define and start a backoff loop to handle conflicts
 	// between controllers working on the same object.


### PR DESCRIPTION

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Pulls in some of the latest changes, including the metadata only watches, in preparation to reduce the amount of objects we cache.

/milestone v0.4.0
/assign @ncdc
