### PR TITLE
 🐛 [WIP] spoke-hub-spoke conversion test (#3877) to 0.3.x 

### DIFF
--- a/api/v1alpha2/conversion.go
+++ b/api/v1alpha2/conversion.go
@@ -253,7 +253,6 @@ func (src *MachineDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	if restored.Spec.ClusterName != "" {
 		dst.Spec.ClusterName = restored.Spec.ClusterName
 	}
-	dst.Spec.Paused = restored.Spec.Paused
 	dst.Status.Phase = restored.Status.Phase
 	restoreMachineSpec(&restored.Spec.Template.Spec, &dst.Spec.Template.Spec)
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Backports spoke-hub-spoke conversion test implemented in #3877  to 0.3.x
- Cherry pick 04087a56e6a94509573b2f10feb99b6e103f9370
- Add a pre comparison hook to modify spoke fields before comparing for equality. This is required for ignoring deprecated fields
- Remove status conversion from machine deployment since it is not needed

The PR is marked as WIP to get a consensus on the approach to copy deprecated fields (`ObjectMeta` in `MachineSpec`)  to make it equal in both old and new versions of spokes. This is based on a suggestion by @ncdc  [here](https://github.com/kubernetes-sigs/cluster-api/issues/3885#issuecomment-719035012)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3885 


