### PR TITLE
⚠️ E2E framework resolves CNI_RESOURCES without using env vars

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -159,18 +159,23 @@ func loadE2EConfig(configPath string) *clusterctl.E2EConfig {
 	config := clusterctl.LoadE2EConfig(context.TODO(), clusterctl.LoadE2EConfigInput{ConfigPath: configPath})
 	Expect(config).ToNot(BeNil(), "Failed to load E2E config from %s", configPath)
 
-	// Read CNI file and set CNI_RESOURCES environmental variable
-	Expect(config.Variables).To(HaveKey(CNIPath), "Missing %s variable in the config", CNIPath)
-	clusterctl.SetCNIEnvVar(config.GetVariable(CNIPath), CNIResources)
-
 	return config
 }
 
 func createClusterctlLocalRepository(config *clusterctl.E2EConfig, repositoryFolder string) string {
-	clusterctlConfig := clusterctl.CreateRepository(context.TODO(), clusterctl.CreateRepositoryInput{
+	createRepositoryInput := clusterctl.CreateRepositoryInput{
 		E2EConfig:        config,
 		RepositoryFolder: repositoryFolder,
-	})
+	}
+
+	// Ensuring a CNI file is defined in the config and register a FileTransformation to inject the referenced file in place of the CNI_RESOURCES envSubst variable.
+	Expect(config.Variables).To(HaveKey(CNIPath), "Missing %s variable in the config", CNIPath)
+	cniPath := config.GetVariable(CNIPath)
+	Expect(cniPath).To(BeAnExistingFile(), "The %s variable should resolve to an existing file", CNIPath)
+
+	createRepositoryInput.RegisterClusterResourceSetConfigMapTransformation(cniPath, CNIResources)
+
+	clusterctlConfig := clusterctl.CreateRepository(context.TODO(), createRepositoryInput)
 	Expect(clusterctlConfig).To(BeAnExistingFile(), "The clusterctl config file does not exists in the local repository %s", repositoryFolder)
 	return clusterctlConfig
 }

--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -18,7 +18,6 @@ package clusterctl
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -62,19 +61,6 @@ func LoadE2EConfig(ctx context.Context, input LoadE2EConfigInput) *E2EConfig {
 	Expect(config.Validate()).To(Succeed(), "The e2e test config file is not valid")
 
 	return config
-}
-
-// SetCNIEnvVar read CNI from cniManifestPath and sets an environmental variable that keeps CNI resources.
-// A ClusterResourceSet can be used to apply CNI using this environmental variable.
-func SetCNIEnvVar(cniManifestPath string, cniEnvVar string) {
-	cniData, err := ioutil.ReadFile(cniManifestPath)
-	Expect(err).ToNot(HaveOccurred(), "Failed to read the e2e test CNI file")
-	Expect(cniData).ToNot(BeEmpty(), "CNI file should not be empty")
-	data := map[string]interface{}{}
-	data["resources"] = string(cniData)
-	marshalledData, err := json.Marshal(data)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(os.Setenv(cniEnvVar, string(marshalledData))).NotTo(HaveOccurred())
 }
 
 // E2EConfig defines the configuration of an e2e test environment.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Forward Ports #3846 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3874
