### PR TITLE
📖 Remove leading colon between --infrastructure flag and provider

### DIFF
--- a/docs/book/src/clusterctl/commands/config-cluster.md
+++ b/docs/book/src/clusterctl/commands/config-cluster.md
@@ -30,14 +30,14 @@ provider to use for the workload cluster:
 
 ```
 clusterctl config cluster my-cluster --kubernetes-version v1.16.3 \
-    --infrastructure:aws > my-cluster.yaml
+    --infrastructure aws > my-cluster.yaml
 ```
 
 or
 
 ```
 clusterctl config cluster my-cluster --kubernetes-version v1.16.3 \
-    --infrastructure:aws:v0.4.1 > my-cluster.yaml
+    --infrastructure aws:v0.4.1 > my-cluster.yaml
 ```
 
 ### Flavors


### PR DESCRIPTION
The leading colon was breaking the flag

**What this PR does / why we need it**:

The colon was breaking the `--infrastructure` flag
