### PR TITLE
 🐛 Backport of high cpu usage during kubectl drain

### DIFF
--- a/third_party/kubernetes-drain/drain.go
+++ b/third_party/kubernetes-drain/drain.go
@@ -290,7 +290,6 @@ func (d *Helper) evictPods(ctx context.Context, pods []corev1.Pod, policyGroupVe
 			if err != nil {
 				errors = append(errors, err)
 			}
-		default:
 		}
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3911 
