### PR TITLE
🌱 DockerMachinePool should not use Status.instances from previous reconciliation

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -77,6 +77,7 @@ providers = {
             "cloudinit",
             "controllers",
             "docker",
+            "exp",
             "third_party",
         ],
         "additional_docker_helper_commands": """

--- a/test/framework/machinepool_helpers.go
+++ b/test/framework/machinepool_helpers.go
@@ -70,7 +70,7 @@ func WaitForMachinePoolNodesToExist(ctx context.Context, input WaitForMachinePoo
 	Expect(input.Getter).ToNot(BeNil(), "Invalid argument. input.Getter can't be nil when calling WaitForMachinePoolNodesToExist")
 	Expect(input.MachinePool).ToNot(BeNil(), "Invalid argument. input.MachinePool can't be nil when calling WaitForMachinePoolNodesToExist")
 
-	By("waiting for the machine pool workload nodes to exist")
+	By("Waiting for the machine pool workload nodes to exist")
 	Eventually(func() (int, error) {
 		nn := client.ObjectKey{
 			Namespace: input.MachinePool.Namespace,

--- a/test/infrastructure/docker/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/controllers/dockercluster_controller.go
@@ -72,7 +72,7 @@ func (r *DockerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	log = log.WithValues("cluster", cluster.Name)
 
 	// Create a helper for managing a docker container hosting the loadbalancer.
-	externalLoadBalancer, err := docker.NewLoadBalancer(cluster.Name, log)
+	externalLoadBalancer, err := docker.NewLoadBalancer(cluster.Name)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the externalLoadBalancer")
 	}
@@ -135,7 +135,7 @@ func patchDockerCluster(ctx context.Context, patchHelper *patch.Helper, dockerCl
 
 func (r *DockerClusterReconciler) reconcileNormal(ctx context.Context, dockerCluster *infrav1.DockerCluster, externalLoadBalancer *docker.LoadBalancer) (ctrl.Result, error) {
 	//Create the docker container hosting the load balancer
-	if err := externalLoadBalancer.Create(); err != nil {
+	if err := externalLoadBalancer.Create(ctx); err != nil {
 		conditions.MarkFalse(dockerCluster, infrav1.LoadBalancerAvailableCondition, infrav1.LoadBalancerProvisioningFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
 		return ctrl.Result{}, errors.Wrap(err, "failed to create load balancer")
 	}

--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
@@ -131,7 +131,7 @@ func (r *DockerMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Create a helper for managing the docker container hosting the machine.
-	externalMachine, err := docker.NewMachine(cluster.Name, machine.Name, dockerMachine.Spec.CustomImage, nil, log)
+	externalMachine, err := docker.NewMachine(cluster.Name, machine.Name, dockerMachine.Spec.CustomImage, nil)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the externalMachine")
 	}
@@ -140,7 +140,7 @@ func (r *DockerMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// NB. the machine controller has to manage the cluster load balancer because the current implementation of the
 	// docker load balancer does not support auto-discovery of control plane nodes, so CAPD should take care of
 	// updating the cluster load balancer configuration when control plane machines are added/removed
-	externalLoadBalancer, err := docker.NewLoadBalancer(cluster.Name, log)
+	externalLoadBalancer, err := docker.NewLoadBalancer(cluster.Name)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the externalLoadBalancer")
 	}

--- a/test/infrastructure/docker/docker/loadbalancer.go
+++ b/test/infrastructure/docker/docker/loadbalancer.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/docker/types"
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/third_party/forked/loadbalancer"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 )
 
@@ -33,7 +33,6 @@ type lbCreator interface {
 
 // LoadBalancer manages the load balancer for a specific docker cluster.
 type LoadBalancer struct {
-	log       logr.Logger
 	name      string
 	container *types.Node
 
@@ -41,12 +40,9 @@ type LoadBalancer struct {
 }
 
 // NewLoadBalancer returns a new helper for managing a docker loadbalancer with a given name.
-func NewLoadBalancer(name string, logger logr.Logger) (*LoadBalancer, error) {
+func NewLoadBalancer(name string) (*LoadBalancer, error) {
 	if name == "" {
 		return nil, errors.New("name is required when creating a docker.LoadBalancer")
-	}
-	if logger == nil {
-		return nil, errors.New("logger is required when creating a docker.LoadBalancer")
 	}
 
 	container, err := getContainer(
@@ -60,7 +56,6 @@ func NewLoadBalancer(name string, logger logr.Logger) (*LoadBalancer, error) {
 	return &LoadBalancer{
 		name:      name,
 		container: container,
-		log:       logger,
 		lbCreator: &Manager{},
 	}, nil
 }
@@ -71,11 +66,13 @@ func (s *LoadBalancer) containerName() string {
 }
 
 // Create creates a docker container hosting a load balancer for the cluster.
-func (s *LoadBalancer) Create() error {
+func (s *LoadBalancer) Create(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx)
+
 	// Create if not exists.
 	if s.container == nil {
 		var err error
-		s.log.Info("Creating load balancer container")
+		log.Info("Creating load balancer container")
 		s.container, err = s.lbCreator.CreateExternalLoadBalancerNode(
 			s.containerName(),
 			loadbalancer.Image,
@@ -93,6 +90,8 @@ func (s *LoadBalancer) Create() error {
 
 // UpdateConfiguration updates the external load balancer configuration with new control plane nodes.
 func (s *LoadBalancer) UpdateConfiguration(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx)
+
 	if s.container == nil {
 		return errors.New("unable to configure load balancer: load balancer container does not exists")
 	}
@@ -124,7 +123,7 @@ func (s *LoadBalancer) UpdateConfiguration(ctx context.Context) error {
 		return errors.WithStack(err)
 	}
 
-	s.log.Info("Updating load balancer configuration")
+	log.Info("Updating load balancer configuration")
 	if err := s.container.WriteFile(ctx, loadbalancer.ConfigPath, loadBalancerConfig); err != nil {
 		return errors.WithStack(err)
 	}
@@ -143,8 +142,10 @@ func (s *LoadBalancer) IP(ctx context.Context) (string, error) {
 
 // Delete the docker container hosting the cluster load balancer.
 func (s *LoadBalancer) Delete(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx)
+
 	if s.container != nil {
-		s.log.Info("Deleting load balancer container")
+		log.Info("Deleting load balancer container")
 		if err := s.container.Delete(ctx); err != nil {
 			return err
 		}

--- a/test/infrastructure/docker/exp/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/controllers/dockermachinepool_controller.go
@@ -115,11 +115,11 @@ func (r *DockerMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Handle deleted machines
 	if !dockerMachinePool.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, cluster, machinePool, dockerMachinePool, log)
+		return r.reconcileDelete(ctx, cluster, machinePool, dockerMachinePool)
 	}
 
 	// Handle non-deleted machines
-	return r.reconcileNormal(ctx, cluster, machinePool, dockerMachinePool, log)
+	return r.reconcileNormal(ctx, cluster, machinePool, dockerMachinePool)
 }
 
 // SetupWithManager will add watches for this controller
@@ -149,8 +149,8 @@ func (r *DockerMachinePoolReconciler) SetupWithManager(mgr ctrl.Manager, options
 	)
 }
 
-func (r *DockerMachinePoolReconciler) reconcileDelete(ctx context.Context, cluster *clusterv1.Cluster, machinePool *clusterv1exp.MachinePool, dockerMachinePool *infrav1exp.DockerMachinePool, log logr.Logger) (ctrl.Result, error) {
-	pool, err := docker.NewNodePool(r.Client, cluster, machinePool, dockerMachinePool, log)
+func (r *DockerMachinePoolReconciler) reconcileDelete(ctx context.Context, cluster *clusterv1.Cluster, machinePool *clusterv1exp.MachinePool, dockerMachinePool *infrav1exp.DockerMachinePool) (ctrl.Result, error) {
+	pool, err := docker.NewNodePool(r.Client, cluster, machinePool, dockerMachinePool)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to build new node pool")
 	}
@@ -163,7 +163,9 @@ func (r *DockerMachinePoolReconciler) reconcileDelete(ctx context.Context, clust
 	return ctrl.Result{}, nil
 }
 
-func (r *DockerMachinePoolReconciler) reconcileNormal(ctx context.Context, cluster *clusterv1.Cluster, machinePool *clusterv1exp.MachinePool, dockerMachinePool *infrav1exp.DockerMachinePool, log logr.Logger) (ctrl.Result, error) {
+func (r *DockerMachinePoolReconciler) reconcileNormal(ctx context.Context, cluster *clusterv1.Cluster, machinePool *clusterv1exp.MachinePool, dockerMachinePool *infrav1exp.DockerMachinePool) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
 	// Make sure bootstrap data is available and populated.
 	if machinePool.Spec.Template.Spec.Bootstrap.DataSecretName == nil {
 		log.Info("Waiting for the Bootstrap provider controller to set bootstrap data")
@@ -174,13 +176,13 @@ func (r *DockerMachinePoolReconciler) reconcileNormal(ctx context.Context, clust
 		machinePool.Spec.Replicas = pointer.Int32Ptr(1)
 	}
 
-	pool, err := docker.NewNodePool(r.Client, cluster, machinePool, dockerMachinePool, log)
+	pool, err := docker.NewNodePool(r.Client, cluster, machinePool, dockerMachinePool)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to build new node pool")
 	}
 
 	// Reconcile machines and updates Status.Instances
-	if err := pool.ReconcileMachines(ctx, log); err != nil {
+	if err := pool.ReconcileMachines(ctx); err != nil {
 		if errors.Is(err, &docker.TransientError{}) {
 			log.V(4).Info("requeue in 5 seconds due docker machine reconcile transient error")
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil

--- a/test/infrastructure/docker/exp/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/controllers/dockermachinepool_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -182,13 +181,8 @@ func (r *DockerMachinePoolReconciler) reconcileNormal(ctx context.Context, clust
 	}
 
 	// Reconcile machines and updates Status.Instances
-	if err := pool.ReconcileMachines(ctx); err != nil {
-		if errors.Is(err, &docker.TransientError{}) {
-			log.V(4).Info("requeue in 5 seconds due docker machine reconcile transient error")
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-
-		return ctrl.Result{}, errors.Wrap(err, "failed to reconcile machines")
+	if res, err := pool.ReconcileMachines(ctx); err != nil || !res.IsZero() {
+		return res, err
 	}
 
 	// Derive info from Status.Instances


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes DockerMachinePool, and most specifically the Docker NodePool construct, not use `Status.instances` from previous reconciliation in order to determine which machine to delete.

The previous implementation, relying on `Status.instances` and the ordering of elements in this struct, was found as a root cause for test failures in https://github.com/kubernetes-sigs/cluster-api/pull/3916

Instead, we are using the list of machines/containers as a source of truth for the current state, with the only exception that info on `status.instances` are used to determine if a machine is already bootstrapped or not (this information is not available elsewhere).

