### PR TITLE
🐛 relax update validation to allow rotating ssh keys for KCP

### DIFF
--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
@@ -87,6 +87,7 @@ const (
 	preKubeadmCommands   = "preKubeadmCommands"
 	postKubeadmCommands  = "postKubeadmCommands"
 	files                = "files"
+	users                = "users"
 )
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -106,6 +107,7 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, postKubeadmCommands},
 		{spec, kubeadmConfigSpec, files},
 		{spec, kubeadmConfigSpec, "verbosity"},
+		{spec, kubeadmConfigSpec, users},
 		{spec, "infrastructureTemplate", "name"},
 		{spec, "replicas"},
 		{spec, "version"},

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
@@ -209,6 +209,14 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 						Path: "test",
 					},
 				},
+				Users: []bootstrapv1.User{
+					{
+						Name: "user",
+						SSHAuthorizedKeys: []string{
+							"ssh-rsa foo",
+						},
+					},
+				},
 			},
 			Version: "v1.16.6",
 		},
@@ -242,6 +250,15 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 		},
 	}
 	validUpdate.Spec.Version = "v1.17.1"
+	validUpdate.Spec.KubeadmConfigSpec.Users = []bootstrapv1.User{
+		{
+			Name: "bar",
+			SSHAuthorizedKeys: []string{
+				"ssh-rsa bar",
+				"ssh-rsa foo",
+			},
+		},
+	}
 	validUpdate.Spec.InfrastructureTemplate.Name = "orange"
 	validUpdate.Spec.Replicas = pointer.Int32Ptr(5)
 	now := metav1.NewTime(time.Now())


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: This PR relaxes validation and allows rotating ssh keys as part of a machine rollout

**Which issue(s) this PR fixes**:  Fixes #3926
