### PR TITLE
🐛 Update the docker cluster template to reference v1alpha4 resources

### DIFF
--- a/test/infrastructure/docker/templates/cluster-template-development.yaml
+++ b/test/infrastructure/docker/templates/cluster-template-development.yaml
@@ -1,4 +1,4 @@
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: Cluster
 metadata:
   name: "${CLUSTER_NAME}"
@@ -11,23 +11,23 @@ spec:
       cidrBlocks: ${POD_CIDR:=["192.168.0.0/16"]}
     serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
     kind: DockerCluster
     name: "${CLUSTER_NAME}"
     namespace: "${NAMESPACE}"
   controlPlaneRef:
     kind: KubeadmControlPlane
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
     name: "${CLUSTER_NAME}-control-plane"
     namespace: "${NAMESPACE}"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: DockerCluster
 metadata:
   name: "${CLUSTER_NAME}"
   namespace: "${NAMESPACE}"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: DockerMachineTemplate
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
@@ -40,7 +40,7 @@ spec:
           hostPath: "/var/run/docker.sock"
 ---
 kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
   namespace: "${NAMESPACE}"
@@ -48,7 +48,7 @@ spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   infrastructureTemplate:
     kind: DockerMachineTemplate
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
     name: "${CLUSTER_NAME}-control-plane"
     namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
@@ -67,7 +67,7 @@ spec:
         kubeletExtraArgs: {eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'}
   version: "${KUBERNETES_VERSION}"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: DockerMachineTemplate
 metadata:
   name: "${CLUSTER_NAME}-md-0"
@@ -76,7 +76,7 @@ spec:
   template:
     spec: {}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
 kind: KubeadmConfigTemplate
 metadata:
   name: "${CLUSTER_NAME}-md-0"
@@ -88,7 +88,7 @@ spec:
         nodeRegistration:
           kubeletExtraArgs: {eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'}
 ---
-apiVersion: cluster.x-k8s.io/v1alpha3
+apiVersion: cluster.x-k8s.io/v1alpha4
 kind: MachineDeployment
 metadata:
   name: "${CLUSTER_NAME}-md-0"
@@ -105,10 +105,10 @@ spec:
         configRef:
           name: "${CLUSTER_NAME}-md-0"
           namespace: "${NAMESPACE}"
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
         namespace: "${NAMESPACE}"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
         kind: DockerMachineTemplate


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR update the docker cluster template resources to v1alpha4 from v1alpha3 so that when users follow the [developer instructions](https://cluster-api.sigs.k8s.io/clusterctl/developers.html) to setup a CAPD environment, they don't get borked with errors such as 
```
root@master-1:~# kubectl apply -f capi-quickstart.yaml
dockercluster.infrastructure.cluster.x-k8s.io/capi-quickstart created
dockermachinetemplate.infrastructure.cluster.x-k8s.io/capi-quickstart-control-plane created
dockermachinetemplate.infrastructure.cluster.x-k8s.io/capi-quickstart-md-0 created
Error from server (InternalError): error when creating "capi-quickstart.yaml": Internal error occurred: conversion webhook for cluster.x-k8s.io/v1alpha3, Kind=Cluster failed: the server could not find the requested resource
Error from server (InternalError): error when creating "capi-quickstart.yaml": Internal error occurred: conversion webhook for controlplane.cluster.x-k8s.io/v1alpha3, Kind=KubeadmControlPlane failed: the server could not find the requested resource
Error from server: error when creating "capi-quickstart.yaml": conversion webhook for bootstrap.cluster.x-k8s.io/v1alpha3, Kind=KubeadmConfigTemplate failed: the server could not find the requested resource
Error from server (InternalError): error when creating "capi-quickstart.yaml": Internal error occurred: conversion webhook for cluster.x-k8s.io/v1alpha3, Kind=MachineDeployment failed: the server could not find the requested resource
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3930 
