### PR TITLE
⚠️ Align flag names with upstream Kubernetes components

### DIFF
--- a/bootstrap/kubeadm/config/manager/manager.yaml
+++ b/bootstrap/kubeadm/config/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
       - command:
         - /manager
         args:
-        - --enable-leader-election
+        - --leader-elect
         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}
         image: controller:latest
         name: manager

--- a/bootstrap/kubeadm/config/manager/manager_auth_proxy_patch.yaml
+++ b/bootstrap/kubeadm/config/manager/manager_auth_proxy_patch.yaml
@@ -21,6 +21,6 @@ spec:
           name: https
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--metrics-bind-addr=127.0.0.1:8080"
+        - "--leader-elect"
         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}"

--- a/bootstrap/kubeadm/config/webhook/manager_webhook_patch.yaml
+++ b/bootstrap/kubeadm/config/webhook/manager_webhook_patch.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
+        - "--metrics-bind-addr=127.0.0.1:8080"
         - "--webhook-port=9443"
         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}"
         ports:

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -58,7 +58,7 @@ func init() {
 }
 
 var (
-	metricsAddr                 string
+	metricsBindAddr             string
 	enableLeaderElection        bool
 	leaderElectionLeaseDuration time.Duration
 	leaderElectionRenewDeadline time.Duration
@@ -71,19 +71,19 @@ var (
 )
 
 func InitFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&metricsAddr, "metrics-addr", ":8080",
+	fs.StringVar(&metricsBindAddr, "metrics-bind-addr", ":8080",
 		"The address the metric endpoint binds to.")
 
-	fs.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 
-	fs.DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second,
+	fs.DurationVar(&leaderElectionLeaseDuration, "leader-elect-lease-duration", 15*time.Second,
 		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)")
 
-	fs.DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second,
+	fs.DurationVar(&leaderElectionRenewDeadline, "leader-elect-renew-deadline", 10*time.Second,
 		"Duration that the leading controller manager will retry refreshing leadership before giving up (duration string)")
 
-	fs.DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second,
+	fs.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 2*time.Second,
 		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
 	fs.StringVar(&watchNamespace, "namespace", "",
@@ -125,7 +125,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
-		MetricsBindAddress: metricsAddr,
+		MetricsBindAddress: metricsBindAddr,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "kubeadm-bootstrap-manager-leader-election-capi",
 		LeaseDuration:      &leaderElectionLeaseDuration,

--- a/config/ci/manager/manager_auth_proxy_patch.yaml
+++ b/config/ci/manager/manager_auth_proxy_patch.yaml
@@ -21,6 +21,6 @@ spec:
               name: https
         - name: manager
           args:
-            - "--metrics-addr=127.0.0.1:8080"
-            - "--enable-leader-election"
+            - "--metrics-bind-addr=127.0.0.1:8080"
+            - "--leader-elect"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=false}"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
       - command:
         - /manager
         args:
-        - --enable-leader-election
+        - --leader-elect
         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=false}
         image: controller:latest
         name: manager

--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -21,6 +21,6 @@ spec:
               name: https
         - name: manager
           args:
-            - "--metrics-addr=127.0.0.1:8080"
-            - "--enable-leader-election"
+            - "--metrics-bind-addr=127.0.0.1:8080"
+            - "--leader-elect"
             - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=false}"

--- a/config/webhook/manager_webhook_patch.yaml
+++ b/config/webhook/manager_webhook_patch.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
+        - "--metrics-bind-addr=127.0.0.1:8080"
         - "--webhook-port=9443"
         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=false}"
         ports:

--- a/controlplane/kubeadm/config/manager/manager.yaml
+++ b/controlplane/kubeadm/config/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
       - command:
         - /manager
         args:
-        - --enable-leader-election
+        - --leader-elect
         image: controller:latest
         name: manager
       terminationGracePeriodSeconds: 10

--- a/controlplane/kubeadm/config/manager/manager_auth_proxy_patch.yaml
+++ b/controlplane/kubeadm/config/manager/manager_auth_proxy_patch.yaml
@@ -21,5 +21,5 @@ spec:
           name: https
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--metrics-bind-addr=127.0.0.1:8080"
+        - "--leader-elect"

--- a/controlplane/kubeadm/config/webhook/manager_webhook_patch.yaml
+++ b/controlplane/kubeadm/config/webhook/manager_webhook_patch.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       - name: manager
         args:
-        - "--metrics-addr=127.0.0.1:8080"
+        - "--metrics-bind-addr=127.0.0.1:8080"
         - "--webhook-port=9443"
         ports:
         - containerPort: 9443

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -57,7 +57,7 @@ func init() {
 }
 
 var (
-	metricsAddr                    string
+	metricsBindAddr                string
 	enableLeaderElection           bool
 	leaderElectionLeaseDuration    time.Duration
 	leaderElectionRenewDeadline    time.Duration
@@ -71,19 +71,19 @@ var (
 
 // InitFlags initializes the flags.
 func InitFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&metricsAddr, "metrics-addr", ":8080",
+	fs.StringVar(&metricsBindAddr, "metrics-bind-addr", ":8080",
 		"The address the metric endpoint binds to.")
 
-	fs.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 
-	fs.DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second,
+	fs.DurationVar(&leaderElectionLeaseDuration, "leader-elect-lease-duration", 15*time.Second,
 		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)")
 
-	fs.DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second,
+	fs.DurationVar(&leaderElectionRenewDeadline, "leader-elect-renew-deadline", 10*time.Second,
 		"Duration that the leading controller manager will retry refreshing leadership before giving up (duration string)")
 
-	fs.DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second,
+	fs.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 2*time.Second,
 		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
 	fs.StringVar(&watchNamespace, "namespace", "",
@@ -119,7 +119,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
-		MetricsBindAddress: metricsAddr,
+		MetricsBindAddress: metricsBindAddr,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "kubeadm-control-plane-manager-leader-election-capi",
 		LeaseDuration:      &leaderElectionLeaseDuration,

--- a/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md
+++ b/docs/book/src/developer/providers/v1alpha2-to-v1alpha3.md
@@ -369,7 +369,7 @@ Steps:
     - **manager_webhook_patch.yaml**
       - Under `containers` find `manager` and add after `name`
         ```yaml
-        - "--metrics-addr=127.0.0.1:8080"
+        - "--metrics-bind-addr=127.0.0.1:8080"
         - "--webhook-port=9443"
         ```
       - Under `volumes` find `cert` and replace `secretName`'s value with `$(SERVICE_NAME)-cert`.

--- a/docs/book/src/reference/ports.md
+++ b/docs/book/src/reference/ports.md
@@ -2,7 +2,7 @@
 
 Name      | Port Number | Description |
 ---       | ---         | ---
-`metrics` | `8080`      | Port that exposes the metrics. Can be customized, for that set the `--metrics-addr` flag when starting the manager.
+`metrics` | `8080`      | Port that exposes the metrics. Can be customized, for that set the `--metrics-bind-addr` flag when starting the manager.
 `webhook` | `9443`      | Webhook server port. To disable this set `--webhook-port` flag to `0`.
 `health`  | `9440`      | Port that exposes the heatlh endpoint. Can be customized, for that set the `--health-addr` flag when starting the manager.
 `profiler`| ` `         | Expose the pprof profiler. By default is not configured. Can set the `--profiler-address` flag. e.g. `--profiler-address 6060`

--- a/docs/book/src/tasks/experimental-features/experimental-features.md
+++ b/docs/book/src/tasks/experimental-features/experimental-features.md
@@ -58,10 +58,10 @@ For more details on setting up a development environment with `tilt`, see [Devel
 To enable/disable features on existing management clusters, users can modify CAPI controller manager deployment which will restart all controllers with requested features.
 ```
 #  kubectl edit -n capi-system deployment.apps/capi-controller-manager
-   // Enable/disable available feautures by modifying Args below. 
+   // Enable/disable available feautures by modifying Args below.
     Args:
-      --metrics-addr=127.0.0.1:8080
-      --enable-leader-election
+      --metrics-bind-addr=127.0.0.1:8080
+      --leader-elect
       --feature-gates=MachinePool=true,ClusterResourceSet=true
 ```
 Similarly, to **validate** if a particular feature is enabled, see cluster-api-provider deployment arguments by:

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 
 	// flags
-	metricsAddr                   string
+	metricsBindAddr               string
 	enableLeaderElection          bool
 	leaderElectionLeaseDuration   time.Duration
 	leaderElectionRenewDeadline   time.Duration
@@ -83,19 +83,19 @@ func init() {
 
 // InitFlags initializes the flags.
 func InitFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&metricsAddr, "metrics-addr", ":8080",
+	fs.StringVar(&metricsBindAddr, "metrics-bind-addr", ":8080",
 		"The address the metric endpoint binds to.")
 
-	fs.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 
-	fs.DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second,
+	fs.DurationVar(&leaderElectionLeaseDuration, "leader-elect-lease-duration", 15*time.Second,
 		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)")
 
-	fs.DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second,
+	fs.DurationVar(&leaderElectionRenewDeadline, "leader-elect-renew-deadline", 10*time.Second,
 		"Duration that the leading controller manager will retry refreshing leadership before giving up (duration string)")
 
-	fs.DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second,
+	fs.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 2*time.Second,
 		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
 	fs.StringVar(&watchNamespace, "namespace", "",
@@ -155,7 +155,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
+		MetricsBindAddress:     metricsBindAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "controller-leader-election-capi",
 		LeaseDuration:          &leaderElectionLeaseDuration,

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -33,8 +33,8 @@ providers:
   # Use manifest from source files
     value: ../../../config
     replacements:
-    - old: --metrics-addr=127.0.0.1:8080
-      new: --metrics-addr=:8080
+    - old: --metrics-bind-addr=127.0.0.1:8080
+      new: --metrics-bind-addr=:8080
 
 - name: kubeadm
   type: BootstrapProvider
@@ -43,8 +43,8 @@ providers:
   # Use manifest from source files
     value: ../../../bootstrap/kubeadm/config
     replacements:
-    - old: --metrics-addr=127.0.0.1:8080
-      new: --metrics-addr=:8080
+    - old: --metrics-bind-addr=127.0.0.1:8080
+      new: --metrics-bind-addr=:8080
 
 - name: kubeadm
   type: ControlPlaneProvider
@@ -53,8 +53,8 @@ providers:
   # Use manifest from source files
     value: ../../../controlplane/kubeadm/config
     replacements:
-    - old: --metrics-addr=127.0.0.1:8080
-      new: --metrics-addr=:8080
+    - old: --metrics-bind-addr=127.0.0.1:8080
+      new: --metrics-bind-addr=:8080
 
 - name: docker
   type: InfrastructureProvider
@@ -63,8 +63,8 @@ providers:
   # Use manifest from source files
     value: ../../../test/infrastructure/docker/config
     replacements:
-    - old: --metrics-addr=127.0.0.1:8080
-      new: --metrics-addr=:8080
+    - old: --metrics-bind-addr=127.0.0.1:8080
+      new: --metrics-bind-addr=:8080
   files:
   # Add cluster templates
   - sourcePath: "../data/infrastructure-docker/cluster-template.yaml"

--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -158,7 +158,7 @@ type WatchPodMetricsInput struct {
 
 // WatchPodMetrics captures metrics from all pods every 5s. It expects to find port 8080 open on the controller.
 // Use replacements in an e2econfig to enable metrics scraping without kube-rbac-proxy, e.g:
-//     - new: --metrics-addr=:8080
+//     - new: --metrics-bind-addr=:8080
 //       old: --metrics-addr=127.0.0.1:8080
 func WatchPodMetrics(ctx context.Context, input WatchPodMetricsInput) {
 	// Dump machine metrics every 5 seconds

--- a/test/infrastructure/docker/config/manager/manager.yaml
+++ b/test/infrastructure/docker/config/manager/manager.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - args:
-        - --enable-leader-election
+        - --leader-elect
         image: controller:latest
         name: manager
         ports:

--- a/test/infrastructure/docker/config/manager/manager_auth_proxy_patch.yaml
+++ b/test/infrastructure/docker/config/manager/manager_auth_proxy_patch.yaml
@@ -22,5 +22,5 @@ spec:
       - name: manager
         args:
         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}"
-        - "--metrics-addr=0"
+        - "--metrics-bind-addr=0"
         - "-v=4"

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -48,7 +48,7 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 
 	//flags
-	metricsAddr          string
+	metricsBindAddr      string
 	enableLeaderElection bool
 	syncPeriod           time.Duration
 	concurrency          int
@@ -77,7 +77,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 myscheme,
-		MetricsBindAddress:     metricsAddr,
+		MetricsBindAddress:     metricsBindAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "controller-leader-election-capd",
 		SyncPeriod:             &syncPeriod,
@@ -105,9 +105,9 @@ func main() {
 }
 
 func initFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	fs.StringVar(&metricsBindAddr, "metrics-bind-addr", ":8080", "The address the metric endpoint binds to.")
 	fs.IntVar(&concurrency, "concurrency", 10, "The number of docker machines to process simultaneously")
-	fs.BoolVar(&enableLeaderElection, "enable-leader-election", false,
+	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes the names of the flags to align with the k8s components
Below are the flags that have been altered: 
- `--metrics-addr` ==> `--metrics-bind-addr`
- `--leader-election` ==> `--leader-elect` (multiple flags beginning with the same prefix based around leader election)

**Which issue(s) this PR fixes**:
Fixes #3924
