### PR TITLE
🐛 Rotate MachinePool bootstrap token

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -214,10 +214,7 @@ func (r *KubeadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	// Migrate plaintext data to secret.
 	case config.Status.BootstrapData != nil && config.Status.DataSecretName == nil:
-		if err := r.storeBootstrapData(ctx, scope, config.Status.BootstrapData); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, r.storeBootstrapData(ctx, scope, config.Status.BootstrapData)
 	// Reconcile status for machines that already have a secret reference, but our status isn't up to date.
 	// This case solves the pivoting scenario (or a backup restore) which doesn't preserve the status subresource on objects.
 	case configOwner.DataSecretName() != nil && (!config.Status.Ready || config.Status.DataSecretName == nil):
@@ -227,28 +224,17 @@ func (r *KubeadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	// Status is ready means a config has been generated.
 	case config.Status.Ready:
-		// If the BootstrapToken has been generated for a join and the infrastructure is not ready.
-		// This indicates the token in the join config has not been consumed and it may need a refresh.
-		if (config.Spec.JoinConfiguration != nil && config.Spec.JoinConfiguration.Discovery.BootstrapToken != nil) && !configOwner.IsInfrastructureReady() {
-
-			token := config.Spec.JoinConfiguration.Discovery.BootstrapToken.Token
-
-			remoteClient, err := r.remoteClientGetter(ctx, r.Client, util.ObjectKey(cluster))
-			if err != nil {
-				log.Error(err, "Error creating remote cluster client")
-				return ctrl.Result{}, err
+		if config.Spec.JoinConfiguration != nil && config.Spec.JoinConfiguration.Discovery.BootstrapToken != nil {
+			if !configOwner.IsInfrastructureReady() {
+				// If the BootstrapToken has been generated for a join and the infrastructure is not ready.
+				// This indicates the token in the join config has not been consumed and it may need a refresh.
+				return r.refreshBootstrapToken(ctx, config, cluster)
 			}
-
-			log.Info("Refreshing token until the infrastructure has a chance to consume it")
-			err = refreshToken(ctx, remoteClient, token)
-			if err != nil {
-				// It would be nice to re-create the bootstrap token if the error was "not found", but we have no way to update the Machine's bootstrap data
-				return ctrl.Result{}, errors.Wrapf(err, "failed to refresh bootstrap token")
+			if configOwner.IsMachinePool() {
+				// If the BootstrapToken has been generated and infrastructure is ready but the configOwner is a MachinePool,
+				// we rotate the token to keep it fresh for future scale ups.
+				return r.rotateMachinePoolBootstrapToken(ctx, config, cluster, scope)
 			}
-			// NB: this may not be sufficient to keep the token live if we don't see it before it expires, but when we generate a config we will set the status to "ready" which should generate an update event
-			return ctrl.Result{
-				RequeueAfter: DefaultTokenTTL / 2,
-			}, nil
 		}
 		// In any other case just return as the config is already generated and need not be generated again.
 		return ctrl.Result{}, nil
@@ -277,6 +263,56 @@ func (r *KubeadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// It's a worker join
 	return r.joinWorker(ctx, scope)
+}
+
+func (r *KubeadmConfigReconciler) refreshBootstrapToken(ctx context.Context, config *bootstrapv1.KubeadmConfig, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	token := config.Spec.JoinConfiguration.Discovery.BootstrapToken.Token
+
+	remoteClient, err := r.remoteClientGetter(ctx, r.Client, util.ObjectKey(cluster))
+	if err != nil {
+		log.Error(err, "Error creating remote cluster client")
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Refreshing token until the infrastructure has a chance to consume it")
+	if err := refreshToken(ctx, remoteClient, token); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to refresh bootstrap token")
+	}
+	return ctrl.Result{
+		RequeueAfter: DefaultTokenTTL / 2,
+	}, nil
+}
+
+func (r *KubeadmConfigReconciler) rotateMachinePoolBootstrapToken(ctx context.Context, config *bootstrapv1.KubeadmConfig, cluster *clusterv1.Cluster, scope *Scope) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.V(2).Info("Config is owned by a MachinePool, checking if token should be rotated")
+	remoteClient, err := r.remoteClientGetter(ctx, r.Client, util.ObjectKey(cluster))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	token := config.Spec.JoinConfiguration.Discovery.BootstrapToken.Token
+	shouldRotate, err := shouldRotate(ctx, remoteClient, token)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if shouldRotate {
+		log.V(2).Info("Creating new bootstrap token")
+		token, err := createToken(ctx, remoteClient)
+		if err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to create new bootstrap token")
+		}
+
+		config.Spec.JoinConfiguration.Discovery.BootstrapToken.Token = token
+		log.Info("Altering JoinConfiguration.Discovery.BootstrapToken", "Token", token)
+
+		// update the bootstrap data
+		return r.joinWorker(ctx, scope)
+	}
+	return ctrl.Result{
+		RequeueAfter: DefaultTokenTTL / 3,
+	}, nil
 }
 
 func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Context, scope *Scope) (_ ctrl.Result, reterr error) {
@@ -827,7 +863,10 @@ func (r *KubeadmConfigReconciler) storeBootstrapData(ctx context.Context, scope 
 		if !apierrors.IsAlreadyExists(err) {
 			return errors.Wrapf(err, "failed to create bootstrap data secret for KubeadmConfig %s/%s", scope.Config.Namespace, scope.Config.Name)
 		}
-		log.Info("bootstrap data secret for KubeadmConfig already exists", "secret", secret.Name, "KubeadmConfig", scope.Config.Name)
+		log.Info("bootstrap data secret for KubeadmConfig already exists, updating", "secret", secret.Name, "KubeadmConfig", scope.Config.Name)
+		if err := r.Client.Update(ctx, secret); err != nil {
+			return errors.Wrapf(err, "failed to update bootstrap data secret for KubeadmConfig %s/%s", scope.Config.Namespace, scope.Config.Name)
+		}
 	}
 	scope.Config.Status.DataSecretName = pointer.StringPtr(secret.Name)
 	scope.Config.Status.Ready = true

--- a/bootstrap/kubeadm/controllers/token.go
+++ b/bootstrap/kubeadm/controllers/token.go
@@ -71,24 +71,47 @@ func createToken(ctx context.Context, c client.Client) (string, error) {
 	return token, nil
 }
 
-// refreshToken extends the TTL for an existing token
-func refreshToken(ctx context.Context, c client.Client, token string) error {
+// getToken fetches the token Secret and returns an error if it is invalid.
+func getToken(ctx context.Context, c client.Client, token string) (*v1.Secret, error) {
 	substrs := bootstraputil.BootstrapTokenRegexp.FindStringSubmatch(token)
 	if len(substrs) != 3 {
-		return errors.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
+		return nil, errors.Errorf("the bootstrap token %q was not of the form %q", token, bootstrapapi.BootstrapTokenPattern)
 	}
 	tokenID := substrs[1]
 
 	secretName := bootstraputil.BootstrapTokenSecretName(tokenID)
 	secret := &v1.Secret{}
 	if err := c.Get(ctx, client.ObjectKey{Name: secretName, Namespace: metav1.NamespaceSystem}, secret); err != nil {
-		return err
+		return secret, err
 	}
 
 	if secret.Data == nil {
-		return errors.Errorf("Invalid bootstrap secret %q, remove the token from the kubadm config to re-create", secretName)
+		return nil, errors.Errorf("Invalid bootstrap secret %q, remove the token from the kubadm config to re-create", secretName)
+	}
+	return secret, nil
+}
+
+// refreshToken extends the TTL for an existing token.
+func refreshToken(ctx context.Context, c client.Client, token string) error {
+	secret, err := getToken(ctx, c, token)
+	if err != nil {
+		return err
 	}
 	secret.Data[bootstrapapi.BootstrapTokenExpirationKey] = []byte(time.Now().UTC().Add(DefaultTokenTTL).Format(time.RFC3339))
 
 	return c.Update(ctx, secret)
+}
+
+// shouldRotate returns true if an existing token is past half of its TTL and should to be rotated.
+func shouldRotate(ctx context.Context, c client.Client, token string) (bool, error) {
+	secret, err := getToken(ctx, c, token)
+	if err != nil {
+		return false, err
+	}
+
+	expiration, err := time.Parse(time.RFC3339, string(secret.Data[bootstrapapi.BootstrapTokenExpirationKey]))
+	if err != nil {
+		return false, err
+	}
+	return expiration.Before(time.Now().UTC().Add(DefaultTokenTTL / 2)), nil
 }

--- a/bootstrap/util/configowner.go
+++ b/bootstrap/util/configowner.go
@@ -76,6 +76,11 @@ func (co ConfigOwner) IsControlPlaneMachine() bool {
 	return ok
 }
 
+// IsMachinePool checks if an unstructured object is a MachinePool.
+func (co ConfigOwner) IsMachinePool() bool {
+	return co.GetKind() == "MachinePool"
+}
+
 // GetConfigOwner returns the Unstructured object owning the current resource.
 func GetConfigOwner(ctx context.Context, c client.Client, obj metav1.Object) (*ConfigOwner, error) {
 	allowedGKs := []schema.GroupKind{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Each MachinePool has one KubeadmConfig which means all instances of a MachinePool share the same bootstrap data. Currently, new MachinePool replicas are unable to join the cluster after the initial bootstrap token has expired (token TTL is 15 minutes). 

This PR implements to behavior that was described in https://github.com/kubernetes-sigs/cluster-api/issues/3359#issuecomment-660154973, that is: When a KubeadmConfig is owned by a MachinePool, we create a new token if the current one is expiring in less than TTL/2 (7.5 minutes), and update the MachinePool's bootstrap data secret. If the token is not ready to be rotated, we requeue after TTL/3 (5 minutes), to ensure that we get to rotate before it expires. 

This means MachinePools will always have a fresh token ready to be used by any new replicas that need to join the cluster (Scale up, rolling upgrade, etc.).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3359 https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1000
