### PR TITLE
🌱 Fix small typo in clusterctl command docs

### DIFF
--- a/docs/book/src/clusterctl/commands/generate-yaml.md
+++ b/docs/book/src/clusterctl/commands/generate-yaml.md
@@ -1,6 +1,6 @@
 # clusterctl generate yaml
 
-The `clusterctl generate yaml` command processes yaml using clusterct's yaml
+The `clusterctl generate yaml` command processes yaml using clusterctl's yaml
 processor.
 
 The intent of this command is to allow users who may have specific templates


### PR DESCRIPTION


<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Fixes a small typo in clusterctl generate YAML command documentation.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

**Which issue(s) this PR fixes** 

n/a
