### PR TITLE
🐛 Generate etcd client if at least one member is healthy

### DIFF
--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -123,18 +123,15 @@ func (m *Management) GetWorkloadCluster(ctx context.Context, clusterKey client.O
 
 	caPool := x509.NewCertPool()
 	caPool.AppendCertsFromPEM(crtData)
-	cfg := &tls.Config{
+	tlsConfig := &tls.Config{
 		RootCAs:      caPool,
 		Certificates: []tls.Certificate{clientCert},
 	}
-	cfg.InsecureSkipVerify = true
+	tlsConfig.InsecureSkipVerify = true
 	return &Workload{
-		Client:          c,
-		CoreDNSMigrator: &CoreDNSMigrator{},
-		etcdClientGenerator: &etcdClientGenerator{
-			restConfig: restConfig,
-			tlsConfig:  cfg,
-		},
+		Client:              c,
+		CoreDNSMigrator:     &CoreDNSMigrator{},
+		etcdClientGenerator: NewEtcdClientGenerator(restConfig, tlsConfig),
 	}, nil
 }
 

--- a/controlplane/kubeadm/internal/etcd_client_generator.go
+++ b/controlplane/kubeadm/internal/etcd_client_generator.go
@@ -30,36 +30,44 @@ import (
 
 // etcdClientGenerator generates etcd clients that connect to specific etcd members on particular control plane nodes.
 type etcdClientGenerator struct {
-	restConfig *rest.Config
-	tlsConfig  *tls.Config
-	clientFactory
+	restConfig   *rest.Config
+	tlsConfig    *tls.Config
+	createClient clientCreator
 }
 
-type clientFactory func(ctx context.Context, endpoints []string) (*etcd.Client, error)
+type clientCreator func(ctx context.Context, endpoints []string) (*etcd.Client, error)
 
-func (c *etcdClientGenerator) getClientFactory() clientFactory {
-	if c.clientFactory == nil {
-		c.clientFactory = func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
-			p := proxy.Proxy{
-				Kind:       "pods",
-				Namespace:  metav1.NamespaceSystem,
-				KubeConfig: c.restConfig,
-				TLSConfig:  c.tlsConfig,
-				Port:       2379,
-			}
-			return etcd.NewClient(ctx, endpoints, p, c.tlsConfig)
+// NewEtcdClientGenerator returns a new etcdClientGenerator instance.
+func NewEtcdClientGenerator(restConfig *rest.Config, tlsConfig *tls.Config) *etcdClientGenerator {
+	ecg := &etcdClientGenerator{restConfig: restConfig, tlsConfig: tlsConfig}
+
+	ecg.createClient = func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
+		p := proxy.Proxy{
+			Kind:       "pods",
+			Namespace:  metav1.NamespaceSystem,
+			KubeConfig: ecg.restConfig,
+			TLSConfig:  ecg.tlsConfig,
+			Port:       2379,
 		}
+		return etcd.NewClient(ctx, endpoints, p, ecg.tlsConfig)
 	}
-	return c.clientFactory
+
+	return ecg
 }
 
-func (c *etcdClientGenerator) forNodes(ctx context.Context, nodeNames []string) (*etcd.Client, error) {
-	endpoints := make([]string, len(nodeNames))
-	for i, name := range nodeNames {
-		endpoints[i] = staticPodName("etcd", name)
+// forFirstAvailableNode takes a list of nodes and returns a client for the first one that connects.
+func (c *etcdClientGenerator) forFirstAvailableNode(ctx context.Context, nodeNames []string) (*etcd.Client, error) {
+	var errs []error
+	for _, name := range nodeNames {
+		endpoints := []string{staticPodName("etcd", name)}
+		client, err := c.createClient(ctx, endpoints)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		return client, nil
 	}
-
-	return c.getClientFactory()(ctx, endpoints)
+	return nil, errors.Wrap(kerrors.NewAggregate(errs), "could not establish a connection to any etcd node")
 }
 
 // forLeader takes a list of nodes and returns a client to the leader node
@@ -67,7 +75,7 @@ func (c *etcdClientGenerator) forLeader(ctx context.Context, nodeNames []string)
 	var errs []error
 
 	for _, nodeName := range nodeNames {
-		client, err := c.forNodes(ctx, []string{nodeName})
+		client, err := c.forFirstAvailableNode(ctx, []string{nodeName})
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -80,7 +88,7 @@ func (c *etcdClientGenerator) forLeader(ctx context.Context, nodeNames []string)
 		}
 		for _, member := range members {
 			if member.Name == nodeName && member.ID == client.LeaderID {
-				return c.forNodes(ctx, []string{nodeName})
+				return c.forFirstAvailableNode(ctx, []string{nodeName})
 			}
 		}
 	}

--- a/controlplane/kubeadm/internal/etcd_client_generator_test.go
+++ b/controlplane/kubeadm/internal/etcd_client_generator_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/etcdserver/etcdserverpb"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd"
+	etcdfake "sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/etcd/fake"
+)
+
+var (
+	subject *etcdClientGenerator
+)
+
+func TestGetClientFactoryDefault(t *testing.T) {
+	g := NewWithT(t)
+	subject = &etcdClientGenerator{
+		restConfig: &rest.Config{},
+		tlsConfig:  &tls.Config{},
+	}
+	subject.getClientFactory()
+	g.Expect(subject.clientFactory).To(Not(BeNil()))
+}
+
+func TestForNodes(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name  string
+		nodes []string
+		cf    clientFactory
+
+		expectedErr    string
+		expectedClient etcd.Client
+	}{
+		{
+			name:  "Returns client successfully",
+			nodes: []string{"node-1"},
+			cf: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
+				return &etcd.Client{Endpoint: endpoints[0]}, nil
+			},
+			expectedClient: etcd.Client{Endpoint: "etcd-node-1"},
+		},
+		{
+			name:  "Returns error",
+			nodes: []string{"node-1"},
+			cf: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
+				return nil, errors.New("something went wrong")
+			},
+			expectedErr: "something went wrong",
+		},
+	}
+
+	for _, tt := range tests {
+		subject = &etcdClientGenerator{
+			restConfig:    &rest.Config{},
+			tlsConfig:     &tls.Config{},
+			clientFactory: tt.cf,
+		}
+
+		client, err := subject.forNodes(ctx, toNodes(tt.nodes))
+
+		if tt.expectedErr != "" {
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).Should(Equal(tt.expectedErr))
+		} else {
+			g.Expect(*client).Should(Equal(tt.expectedClient))
+		}
+
+	}
+}
+
+func TestForLeader(t *testing.T) {
+	g := NewWithT(t)
+
+	tests := []struct {
+		name  string
+		nodes []string
+		cf    clientFactory
+
+		expectedErr    string
+		expectedClient etcd.Client
+	}{
+		{
+			name:  "Returns client for leader successfully",
+			nodes: []string{"node-1", "node-leader"},
+			cf: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
+				return &etcd.Client{
+					Endpoint: endpoints[0],
+					LeaderID: 1729,
+					EtcdClient: &etcdfake.FakeEtcdClient{
+						MemberListResponse: &clientv3.MemberListResponse{
+							Members: []*etcdserverpb.Member{
+								{ID: 1234, Name: "node-1"},
+								{ID: 1729, Name: "node-leader"},
+							},
+						},
+						AlarmResponse: &clientv3.AlarmResponse{
+						},
+					}}, nil
+			},
+			expectedClient: etcd.Client{
+				Endpoint: "etcd-node-leader",
+				LeaderID: 1729, EtcdClient: &etcdfake.FakeEtcdClient{
+					MemberListResponse: &clientv3.MemberListResponse{
+						Members: []*etcdserverpb.Member{
+							{ID: 1234, Name: "node-1"},
+							{ID: 1729, Name: "node-leader"},
+						},
+					},
+					AlarmResponse: &clientv3.AlarmResponse{
+					},
+				}},
+		},
+
+		{
+			name:  "Returns client for leader even when one or more nodes are down",
+			nodes: []string{"node-down-1", "node-down-2", "node-leader"},
+			cf: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
+				if strings.Contains(endpoints[0], "node-down") {
+					return nil, errors.New("node down")
+				}
+				return &etcd.Client{
+					Endpoint: endpoints[0],
+					LeaderID: 1729,
+					EtcdClient: &etcdfake.FakeEtcdClient{
+						MemberListResponse: &clientv3.MemberListResponse{
+							Members: []*etcdserverpb.Member{
+								{ID: 1729, Name: "node-leader"},
+							},
+						},
+						AlarmResponse: &clientv3.AlarmResponse{
+						},
+					}}, nil
+			},
+			expectedClient: etcd.Client{
+				Endpoint: "etcd-node-leader",
+				LeaderID: 1729, EtcdClient: &etcdfake.FakeEtcdClient{
+					MemberListResponse: &clientv3.MemberListResponse{
+						Members: []*etcdserverpb.Member{
+							{ID: 1729, Name: "node-leader"},
+						},
+					},
+					AlarmResponse: &clientv3.AlarmResponse{
+					},
+				}},
+		},
+		{
+			name:  "Returns error when all nodes are down",
+			nodes: []string{"node-down-1", "node-down-2", "node-down-3"},
+			cf: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
+				return nil, errors.New("node down")
+			},
+			expectedErr: "could not establish a connection to the etcd leader: node down",
+		},
+	}
+
+	for _, tt := range tests {
+		subject = &etcdClientGenerator{
+			restConfig:    &rest.Config{},
+			tlsConfig:     &tls.Config{},
+			clientFactory: tt.cf,
+		}
+
+		client, err := subject.forLeader(ctx, toNodes(tt.nodes))
+
+		if tt.expectedErr != "" {
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).Should(Equal(tt.expectedErr))
+		} else {
+			g.Expect(*client).Should(Equal(tt.expectedClient))
+		}
+	}
+
+}
+
+func toNodes(nodeNames []string) []corev1.Node {
+	nodes := make([]corev1.Node, len(nodeNames))
+	for i, n := range nodeNames {
+		nodes[i] = corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: n},
+		}
+	}
+	return nodes
+}

--- a/controlplane/kubeadm/internal/workload_cluster_etcd.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd.go
@@ -29,7 +29,7 @@ import (
 )
 
 type etcdClientFor interface {
-	forNodes(ctx context.Context, nodeNames []string) (*etcd.Client, error)
+	forFirstAvailableNode(ctx context.Context, nodeNames []string) (*etcd.Client, error)
 	forLeader(ctx context.Context, nodeNames []string) (*etcd.Client, error)
 }
 
@@ -40,7 +40,7 @@ func (w *Workload) ReconcileEtcdMembers(ctx context.Context, nodeNames []string)
 	errs := []error{}
 	for _, nodeName := range nodeNames {
 		// Create the etcd Client for the etcd Pod scheduled on the Node
-		etcdClient, err := w.etcdClientGenerator.forNodes(ctx, []string{nodeName})
+		etcdClient, err := w.etcdClientGenerator.forFirstAvailableNode(ctx, []string{nodeName})
 		if err != nil {
 			continue
 		}
@@ -126,7 +126,7 @@ func (w *Workload) removeMemberForNode(ctx context.Context, name string) error {
 			remainingNodes = append(remainingNodes, n.Name)
 		}
 	}
-	etcdClient, err := w.etcdClientGenerator.forNodes(ctx, remainingNodes)
+	etcdClient, err := w.etcdClientGenerator.forFirstAvailableNode(ctx, remainingNodes)
 	if err != nil {
 		return errors.Wrap(err, "failed to create etcd client")
 	}

--- a/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
@@ -577,7 +577,7 @@ type fakeEtcdClientGenerator struct {
 	forLeaderErr       error
 }
 
-func (c *fakeEtcdClientGenerator) forNodes(_ context.Context, n []string) (*etcd.Client, error) {
+func (c *fakeEtcdClientGenerator) forFirstAvailableNode(_ context.Context, n []string) (*etcd.Client, error) {
 	if c.forNodesClientFunc != nil {
 		return c.forNodesClientFunc(n)
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This pr fixes the bug where `etcdClientGenerator.forNodes` failed even when some(not all) etcd members were up. It also does some refactoring for writing unit tests. There are 2 commits:
1. 3417409 - Refacoring and unit tests
2. fbfdf6e2ce8be3f31ff20330508af3e707c4b7c9 - `etcdClientGenerator.forNodes` fix

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3839 
