### PR TITLE
🐛 fetch_ext_bins should cleanup the temp file after downloading it

### DIFF
--- a/scripts/fetch_ext_bins.sh
+++ b/scripts/fetch_ext_bins.sh
@@ -66,10 +66,9 @@ tmp_root=/tmp
 # $ SKIP_FETCH_TOOLS=1 ./fetch_ext_bins.sh
 #
 # If you skip fetching tools, this script will use the tools already on your
-# machine, but rebuild the kubebuilder and kubebuilder-bin binaries.
+# machine.
 SKIP_FETCH_TOOLS=${SKIP_FETCH_TOOLS:-""}
 
-# fetch k8s API gen tools and make it available under kb_root_dir/bin.
 function fetch_tools {
   if [[ -n "$SKIP_FETCH_TOOLS" ]]; then
     return 0
@@ -94,6 +93,7 @@ function fetch_tools {
     curl -fsL ${kb_tools_download_url} -o "${kb_tools_archive_path}"
   fi
   tar -zvxf "${kb_tools_archive_path}" -C "${tmp_root}/"
+  rm "${kb_tools_archive_path}"
 }
 
 function setup_envs {


### PR DESCRIPTION
  $ make test
  $ ls -l /tmp/ | grep kubebuilder-tools
-rw-r--r--  1 root root 52352311 Nov 26 10:33 kubebuilder-tools-1.19.2-linux-amd64.tar.gz

Signed-off-by: Ma Xinjian <maxj.fnst@cn.fujitsu.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
