### PR TITLE
:book: Relax our backporting guidelines and policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,10 +145,18 @@ process.
 
 ## Backporting a Patch
 
-Cluster API maintains older versions through `release-X.Y` branches. We accept backports of bug fixes to the most recent
-release branch. For example, if the most recent branch is `release-0.2`, and the `master` branch is under active
-development for v0.3.0, a bug fix that merged to `master` that also affects `v0.2.x` may be considered for backporting
-to `release-0.2`. We generally do not accept PRs against older release branches.
+Cluster API maintains older versions through `release-X.Y` branches.
+We accept backports of bug fixes and non breaking features to the most recent release branch.
+Backports MUST not be breaking for both API and behavioral changes.
+We generally do not accept PRs against older release branches.
+
+As an example:
+
+  Let's assume that the most recent release branch is `release-0.3`
+  and the main branch is under active development for the next release.
+  A pull request that has been merged in the main branch can be backported to the `release-0.3`
+  if at least one maintainer approves the cherry pick, or asks the PR's author to backport.
+
 
 ## Features and bugs
 


### PR DESCRIPTION
This change relaxes and defines a bit more what can be backported and
how. After this change is merged, we'll allow both bug fixes and minor
(non-breaking) features to be backported if at least one or more
maintainers approves the cherry pick.

With these changes we aim to be more welcoming of changes to the current
stable branch instead of stopping the world until the next releases.

The only caveat is that backports that I'd like to highlight is that
backporting is an expensive operation. More often that not,
a cherry-picked commit requires another full review because changes are
usually not compatible.

Going forward, we won't allow PRs to target a release branch directly,
we'll always require changes to go in the main branch first, and only
after they've been merged, to backport them.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

/assign @CecileRobertMichon @ncdc @detiber 

