### PR TITLE
:bug: Properly check errors.Cause when checking with apierrors

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -137,7 +137,7 @@ func (r *KubeadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// Look up the owner of this KubeConfig if there is one
 	configOwner, err := bsutil.GetConfigOwner(ctx, r.Client, config)
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(errors.Cause(err)) {
 		// Could not find the owner yet, this is not an error and will rereconcile when the owner gets set.
 		return ctrl.Result{}, nil
 	}
@@ -158,7 +158,7 @@ func (r *KubeadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, nil
 		}
 
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(errors.Cause(err)) {
 			log.Info("Cluster does not exist yet, waiting until it is created")
 			return ctrl.Result{}, nil
 		}

--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -281,7 +281,7 @@ func (cm *certManagerClient) deleteObjs(objs []unstructured.Unstructured) error 
 		if err := retryWithExponentialBackoff(deleteCertManagerBackoff, func() error {
 			if err := cm.deleteObj(obj); err != nil {
 				// tolerate NotFound errors when deleting the test resources
-				if apierrors.IsNotFound(err) {
+				if apierrors.IsNotFound(errors.Cause(err)) {
 					return nil
 				}
 				return err
@@ -523,7 +523,7 @@ func (cm *certManagerClient) waitForAPIReady(ctx context.Context, retry bool) er
 		if err := retryWithExponentialBackoff(deleteCertManagerBackoff, func() error {
 			if err := cm.deleteObj(obj); err != nil {
 				// tolerate NotFound errors when deleting the test resources
-				if apierrors.IsNotFound(err) {
+				if apierrors.IsNotFound(errors.Cause(err)) {
 					return nil
 				}
 				return err

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -264,7 +264,7 @@ func (r *ClusterReconciler) reconcileKubeconfig(ctx context.Context, cluster *cl
 
 	_, err := secret.Get(ctx, r.Client, util.ObjectKey(cluster), secret.Kubeconfig)
 	switch {
-	case apierrors.IsNotFound(err):
+	case apierrors.IsNotFound(errors.Cause(err)):
 		if err := kubeconfig.CreateSecret(ctx, r.Client, cluster); err != nil {
 			if err == kubeconfig.ErrDependentCertificateNotFound {
 				log.Info("could not find secret for cluster, requeuing", "secret", secret.ClusterCA)

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -438,7 +438,7 @@ func (r *MachineReconciler) isDeleteNodeAllowed(ctx context.Context, cluster *cl
 	// managed control plane check if it is nil
 	if cluster.Spec.ControlPlaneRef != nil {
 		controlPlane, err := external.Get(ctx, r.Client, cluster.Spec.ControlPlaneRef, cluster.Spec.ControlPlaneRef.Namespace)
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(errors.Cause(err)) {
 			// If control plane object in the reference does not exist, log and skip check for
 			// external managed control plane
 			log.Error(err, "control plane object specified in cluster spec.controlPlaneRef does not exist", "kind", cluster.Spec.ControlPlaneRef.Kind, "name", cluster.Spec.ControlPlaneRef.Name)

--- a/controllers/machinehealthcheck_targets.go
+++ b/controllers/machinehealthcheck_targets.go
@@ -181,7 +181,7 @@ func (r *MachineHealthCheckReconciler) getTargetsFromMHC(ctx context.Context, cl
 		}
 		node, err := r.getNodeFromMachine(ctx, clusterClient, target.Machine)
 		if err != nil {
-			if !apierrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(errors.Cause(err)) {
 				return nil, errors.Wrap(err, "error getting node")
 			}
 

--- a/controlplane/kubeadm/controllers/helpers.go
+++ b/controlplane/kubeadm/controllers/helpers.go
@@ -53,7 +53,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 	controllerOwnerRef := *metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))
 	configSecret, err := secret.GetFromNamespacedName(ctx, r.Client, clusterName, secret.Kubeconfig)
 	switch {
-	case apierrors.IsNotFound(err):
+	case apierrors.IsNotFound(errors.Cause(err)):
 		createErr := kubeconfig.CreateSecretWithOwner(
 			ctx,
 			r.Client,

--- a/exp/addons/controllers/clusterresourceset_controller.go
+++ b/exp/addons/controllers/clusterresourceset_controller.go
@@ -276,7 +276,7 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RetrievingResourceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
 
 				// Continue without adding the error to the aggregate if we can't find the resource.
-				if apierrors.IsNotFound(err) {
+				if apierrors.IsNotFound(errors.Cause(err)) {
 					continue
 				}
 			}

--- a/exp/addons/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/controllers/clusterresourcesetbinding_controller.go
@@ -73,12 +73,12 @@ func (r *ClusterResourceSetBindingReconciler) Reconcile(ctx context.Context, req
 	}
 
 	cluster, err := util.GetOwnerCluster(ctx, r.Client, binding.ObjectMeta)
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(errors.Cause(err)) {
 		return ctrl.Result{}, err
 	}
 
 	// If the owner cluster is already deleted or in deletion process, delete its ClusterResourceSetBinding
-	if apierrors.IsNotFound(err) || !cluster.DeletionTimestamp.IsZero() {
+	if apierrors.IsNotFound(errors.Cause(err)) || !cluster.DeletionTimestamp.IsZero() {
 		log.Info("deleting ClusterResourceSetBinding because the owner Cluster no longer exists")
 		err := r.Client.Delete(ctx, binding)
 		return ctrl.Result{}, err

--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
@@ -383,7 +383,7 @@ func (r *DockerMachineReconciler) DockerClusterToDockerMachines(o client.Object)
 
 	cluster, err := util.GetOwnerCluster(context.TODO(), r.Client, c.ObjectMeta)
 	switch {
-	case apierrors.IsNotFound(err) || cluster == nil:
+	case apierrors.IsNotFound(errors.Cause(err)) || cluster == nil:
 		return result
 	case err != nil:
 		return result

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -201,7 +201,7 @@ func RegenerateSecret(ctx context.Context, c client.Client, configSecret *corev1
 func generateKubeconfig(ctx context.Context, c client.Client, clusterName client.ObjectKey, endpoint string) ([]byte, error) {
 	clusterCA, err := secret.GetFromNamespacedName(ctx, c, clusterName, secret.ClusterCA)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(errors.Cause(err)) {
 			return nil, ErrDependentCertificateNotFound
 		}
 		return nil, err


### PR DESCRIPTION
And when not using the client directly.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

/assign @CecileRobertMichon 
/milestone v0.4.0

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
