### PR TITLE
:bug: Properly check errors.Cause when checking with apierrors

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -148,7 +148,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 
 	// Look up the owner of this KubeConfig if there is one
 	configOwner, err := bsutil.GetConfigOwner(ctx, r.Client, config)
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(errors.Cause(err)) {
 		// Could not find the owner yet, this is not an error and will rereconcile when the owner gets set.
 		return ctrl.Result{}, nil
 	}
@@ -169,7 +169,7 @@ func (r *KubeadmConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
 			return ctrl.Result{}, nil
 		}
 
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(errors.Cause(err)) {
 			log.Info("Cluster does not exist yet, waiting until it is created")
 			return ctrl.Result{}, nil
 		}

--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller_test.go
@@ -134,7 +134,7 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnEarlyIfKubeadmConfigIsReady(t *
 }
 
 // Reconcile returns an error in this case because the owning machine should not go away before the things it owns.
-func TestKubeadmConfigReconciler_Reconcile_ReturnErrorIfReferencedMachineIsNotFound(t *testing.T) {
+func TestKubeadmConfigReconciler_Reconcile_ReturnNilIfReferencedMachineIsNotFound(t *testing.T) {
 	g := NewWithT(t)
 
 	machine := newMachine(nil, "machine")
@@ -158,7 +158,7 @@ func TestKubeadmConfigReconciler_Reconcile_ReturnErrorIfReferencedMachineIsNotFo
 		},
 	}
 	_, err := k.Reconcile(request)
-	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(BeNil())
 }
 
 // If the machine has bootstrap data secret reference, there is no need to generate more bootstrap data.

--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -241,7 +241,7 @@ func (cm *certManagerClient) deleteObjs(objs []unstructured.Unstructured) error 
 		if err := retryWithExponentialBackoff(deleteCertManagerBackoff, func() error {
 			if err := cm.deleteObj(obj); err != nil {
 				// tolerate NotFound errors when deleting the test resources
-				if apierrors.IsNotFound(err) {
+				if apierrors.IsNotFound(errors.Cause(err)) {
 					return nil
 				}
 				return err
@@ -483,7 +483,7 @@ func (cm *certManagerClient) waitForAPIReady(ctx context.Context, retry bool) er
 		if err := retryWithExponentialBackoff(deleteCertManagerBackoff, func() error {
 			if err := cm.deleteObj(obj); err != nil {
 				// tolerate NotFound errors when deleting the test resources
-				if apierrors.IsNotFound(err) {
+				if apierrors.IsNotFound(errors.Cause(err)) {
 					return nil
 				}
 				return err

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -264,7 +264,7 @@ func (r *ClusterReconciler) reconcileKubeconfig(ctx context.Context, cluster *cl
 
 	_, err := secret.Get(ctx, r.Client, util.ObjectKey(cluster), secret.Kubeconfig)
 	switch {
-	case apierrors.IsNotFound(err):
+	case apierrors.IsNotFound(errors.Cause(err)):
 		if err := kubeconfig.CreateSecret(ctx, r.Client, cluster); err != nil {
 			if err == kubeconfig.ErrDependentCertificateNotFound {
 				logger.Info("could not find secret for cluster, requeuing", "secret", secret.ClusterCA)

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -383,7 +383,7 @@ func (r *MachineReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 
 		var deleteNodeErr error
 		waitErr := wait.PollImmediate(2*time.Second, 10*time.Second, func() (bool, error) {
-			if deleteNodeErr = r.deleteNode(ctx, cluster, m.Status.NodeRef.Name); deleteNodeErr != nil && !apierrors.IsNotFound(deleteNodeErr) {
+			if deleteNodeErr = r.deleteNode(ctx, cluster, m.Status.NodeRef.Name); deleteNodeErr != nil && !apierrors.IsNotFound(errors.Cause(deleteNodeErr)) {
 				return false, nil
 			}
 			return true, nil

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -446,7 +446,7 @@ func (r *MachineReconciler) isDeleteNodeAllowed(ctx context.Context, cluster *cl
 	// managed control plane check if it is nil
 	if cluster.Spec.ControlPlaneRef != nil {
 		controlPlane, err := external.Get(ctx, r.Client, cluster.Spec.ControlPlaneRef, cluster.Spec.ControlPlaneRef.Namespace)
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(errors.Cause(err)) {
 			// If control plane object in the reference does not exist, log and skip check for
 			// external managed control plane
 			r.Log.Error(err, "control plane object specified in cluster spec.controlPlaneRef does not exist", "kind", cluster.Spec.ControlPlaneRef.Kind, "name", cluster.Spec.ControlPlaneRef.Name)

--- a/controllers/machinehealthcheck_targets.go
+++ b/controllers/machinehealthcheck_targets.go
@@ -181,7 +181,7 @@ func (r *MachineHealthCheckReconciler) getTargetsFromMHC(clusterClient client.Re
 		}
 		node, err := r.getNodeFromMachine(clusterClient, target.Machine)
 		if err != nil {
-			if !apierrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(errors.Cause(err)) {
 				return nil, errors.Wrap(err, "error getting node")
 			}
 

--- a/controlplane/kubeadm/controllers/helpers.go
+++ b/controlplane/kubeadm/controllers/helpers.go
@@ -50,7 +50,7 @@ func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 	controllerOwnerRef := *metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))
 	configSecret, err := secret.GetFromNamespacedName(ctx, r.Client, clusterName, secret.Kubeconfig)
 	switch {
-	case apierrors.IsNotFound(err):
+	case apierrors.IsNotFound(errors.Cause(err)):
 		createErr := kubeconfig.CreateSecretWithOwner(
 			ctx,
 			r.Client,

--- a/exp/addons/controllers/clusterresourceset_controller.go
+++ b/exp/addons/controllers/clusterresourceset_controller.go
@@ -289,7 +289,7 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 				conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RetrievingResourceFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
 
 				// Continue without adding the error to the aggregate if we can't find the resource.
-				if apierrors.IsNotFound(err) {
+				if apierrors.IsNotFound(errors.Cause(err)) {
 					continue
 				}
 			}

--- a/exp/addons/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/controllers/clusterresourcesetbinding_controller.go
@@ -75,12 +75,12 @@ func (r *ClusterResourceSetBindingReconciler) Reconcile(req ctrl.Request) (_ ctr
 	}
 
 	cluster, err := util.GetOwnerCluster(ctx, r.Client, binding.ObjectMeta)
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(errors.Cause(err)) {
 		return ctrl.Result{}, err
 	}
 
 	// If the owner cluster is already deleted or in deletion process, delete its ClusterResourceSetBinding
-	if apierrors.IsNotFound(err) || !cluster.DeletionTimestamp.IsZero() {
+	if apierrors.IsNotFound(errors.Cause(err)) || !cluster.DeletionTimestamp.IsZero() {
 		log.Info("deleting ClusterResourceSetBinding because the owner Cluster no longer exists")
 		err := r.Client.Delete(ctx, binding)
 		return ctrl.Result{}, err

--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
@@ -413,7 +413,7 @@ func (r *DockerMachineReconciler) DockerClusterToDockerMachines(o handler.MapObj
 
 	cluster, err := util.GetOwnerCluster(context.TODO(), r.Client, c.ObjectMeta)
 	switch {
-	case apierrors.IsNotFound(err) || cluster == nil:
+	case apierrors.IsNotFound(errors.Cause(err)) || cluster == nil:
 		return result
 	case err != nil:
 		log.Error(err, "failed to get owning cluster")

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -201,7 +201,7 @@ func RegenerateSecret(ctx context.Context, c client.Client, configSecret *corev1
 func generateKubeconfig(ctx context.Context, c client.Client, clusterName client.ObjectKey, endpoint string) ([]byte, error) {
 	clusterCA, err := secret.GetFromNamespacedName(ctx, c, clusterName, secret.ClusterCA)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(errors.Cause(err)) {
 			return nil, ErrDependentCertificateNotFound
 		}
 		return nil, err


### PR DESCRIPTION
And when not using the client directly.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR targets only `release-0.3` because the underlying issue has been fixed in k/k upstream.

/milestone v0.3.12

