### PR TITLE
:bug: KCP reconcileEtcdMembers should use its own NodeRefs

### DIFF
--- a/controlplane/kubeadm/controllers/fakes_test.go
+++ b/controlplane/kubeadm/controllers/fakes_test.go
@@ -64,7 +64,7 @@ func (f fakeWorkloadCluster) ForwardEtcdLeadership(_ context.Context, _ *cluster
 	return nil
 }
 
-func (f fakeWorkloadCluster) ReconcileEtcdMembers(ctx context.Context) ([]string, error) {
+func (f fakeWorkloadCluster) ReconcileEtcdMembers(ctx context.Context, nodeNames []string) ([]string, error) {
 	return nil, nil
 }
 

--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -54,6 +54,8 @@ var (
 )
 
 // WorkloadCluster defines all behaviors necessary to upgrade kubernetes on a workload cluster
+//
+// TODO: Add a detailed description to each of these method definitions.
 type WorkloadCluster interface {
 	// Basic health and status checks.
 	ClusterStatus(ctx context.Context) (ClusterStatus, error)
@@ -77,7 +79,7 @@ type WorkloadCluster interface {
 	AllowBootstrapTokensToGetNodes(ctx context.Context) error
 
 	// State recovery tasks.
-	ReconcileEtcdMembers(ctx context.Context) ([]string, error)
+	ReconcileEtcdMembers(ctx context.Context, nodeNames []string) ([]string, error)
 }
 
 // Workload defines operations on workload clusters.
@@ -92,7 +94,6 @@ func (w *Workload) getControlPlaneNodes(ctx context.Context) (*corev1.NodeList, 
 	labels := map[string]string{
 		labelNodeRoleControlPlane: "",
 	}
-
 	if err := w.Client.List(ctx, nodes, ctrlclient.MatchingLabels(labels)); err != nil {
 		return nil, err
 	}

--- a/controlplane/kubeadm/internal/workload_cluster_conditions.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions.go
@@ -101,7 +101,7 @@ func (w *Workload) updateManagedEtcdConditions(ctx context.Context, controlPlane
 		}
 
 		// Create the etcd Client for the etcd Pod scheduled on the Node
-		etcdClient, err := w.etcdClientGenerator.forNodes(ctx, []corev1.Node{node})
+		etcdClient, err := w.etcdClientGenerator.forNodes(ctx, []string{node.Name})
 		if err != nil {
 			conditions.MarkUnknown(machine, controlplanev1.MachineEtcdMemberHealthyCondition, controlplanev1.EtcdMemberInspectionFailedReason, "Failed to connect to the etcd pod on the %s node", node.Name)
 			continue

--- a/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_conditions_test.go
@@ -206,8 +206,8 @@ func TestUpdateEtcdConditions(t *testing.T) {
 				},
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(n []corev1.Node) (*etcd.Client, error) {
-					switch n[0].Name {
+				forNodesClientFunc: func(n []string) (*etcd.Client, error) {
+					switch n[0] {
 					case "n1":
 						return &etcd.Client{
 							EtcdClient: &fake2.FakeEtcdClient{
@@ -274,8 +274,8 @@ func TestUpdateEtcdConditions(t *testing.T) {
 				},
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(n []corev1.Node) (*etcd.Client, error) {
-					switch n[0].Name {
+				forNodesClientFunc: func(n []string) (*etcd.Client, error) {
+					switch n[0] {
 					case "n1":
 						return &etcd.Client{
 							EtcdClient: &fake2.FakeEtcdClient{
@@ -342,8 +342,8 @@ func TestUpdateEtcdConditions(t *testing.T) {
 				},
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(n []corev1.Node) (*etcd.Client, error) {
-					switch n[0].Name {
+				forNodesClientFunc: func(n []string) (*etcd.Client, error) {
+					switch n[0] {
 					case "n1":
 						return &etcd.Client{
 							EtcdClient: &fake2.FakeEtcdClient{
@@ -392,8 +392,8 @@ func TestUpdateEtcdConditions(t *testing.T) {
 				},
 			},
 			injectEtcdClientGenerator: &fakeEtcdClientGenerator{
-				forNodesClientFunc: func(n []corev1.Node) (*etcd.Client, error) {
-					switch n[0].Name {
+				forNodesClientFunc: func(n []string) (*etcd.Client, error) {
+					switch n[0] {
 					case "n1":
 						return &etcd.Client{
 							EtcdClient: &fake2.FakeEtcdClient{


### PR DESCRIPTION
These changes bring more safety when we reconcile the etcd members for
the given workload cluster.

To perform these changes, some modifications to the internal structs and
interfaces were needed. The etcd client generator now accepts node names
(as []string) instead of corev1.Node(s). This allows us to be more
flexible in how we pass in the list of nodes that we expect the etcd
member list to have.

The reconcileEtcdMembers method already waits for all machines to have
NodeRefs set before proceeding. While we check for that, now we also
collect all the names in a slice before passing it in to the inner
Workload struct method.

A NodeRef is assigned by the Machine controller as soon as that
Machine's infrastructure provider exposes the ProviderID, the machine
controller then compares the ProviderID to the list of nodes available
in the workload cluster, and finally assigns the NodeRef under the
Machine's Status field.

If a NodeRef is assigned to a Machine that KCP owns, we know it _should_
be a control plane machine even if kubeadm join hasn't set the label on
the Node object.

(cherry picked from commit 979197c35281c21bb34a7bc0b70f5c66af6c48cb)

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
