### PR TITLE
🌱 Use 1.1 experimental dockerfile image and cache go/pkg/mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,7 +348,7 @@ modules: ## Runs go mod to ensure modules are up to date.
 
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
-	docker pull docker.io/docker/dockerfile:experimental
+	docker pull docker.io/docker/dockerfile:1.1-experimental
 	docker pull docker.io/library/golang:1.15.3
 	docker pull gcr.io/distroless/static:latest
 

--- a/cmd/example-provider/Dockerfile
+++ b/cmd/example-provider/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:experimental
+# syntax=docker/dockerfile:1.1-experimental
 
 # Copyright 2019 The Kubernetes Authors.
 #
@@ -15,32 +15,45 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.13.15 as builder
+FROM golang:1.15.3 as builder
+WORKDIR /workspace
 
 # Run this with docker build --build_arg goproxy=$(go env GOPROXY) to override the goproxy
 ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
 
-WORKDIR /workspace
-
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 # Copy the sources
 COPY ./ ./
 
+# Cache the go build into the the Go’s compiler cache folder so we take benefits of compiler caching across docker build calls
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    go build .
+
 # Build
-ARG ARCH=amd64
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
-    go build -a -ldflags '-extldflags "-static"' \
+ARG package=.
+ARG ARCH
+ARG ldflags
+
+# Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
+    go build -ldflags "${ldflags} -extldflags '-static'" \
     -o manager sigs.k8s.io/cluster-api/cmd/example-provider
 
 # Copy the controller-manager into a thin image
 FROM gcr.io/distroless/static:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
+USER nobody
 ENTRYPOINT ["/manager"]

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:experimental
+# syntax=docker/dockerfile:1.1-experimental
 
 # Copyright 2019 The Kubernetes Authors.
 #

--- a/hack/boilerplate/boilerplate.Dockerfile.txt
+++ b/hack/boilerplate/boilerplate.Dockerfile.txt
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:experimental
+# syntax=docker/dockerfile:1.1-experimental
 
 # Copyright YEAR The Kubernetes Authors.
 #

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:experimental
+# syntax=docker/dockerfile:1.1-experimental
 
 # Copyright 2019 The Kubernetes Authors.
 #
@@ -32,7 +32,8 @@ COPY test/infrastructure/docker/go.sum go.sum
 
 # Cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 # This needs to build with the entire Cluster API context
 WORKDIR /workspace
@@ -44,6 +45,7 @@ WORKDIR /workspace/test/infrastructure/docker
 
 # Build the CAPD manager using the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /workspace/manager main.go
 
 # Use alpine:latest as minimal base image to package the manager binary and its dependencies

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -144,7 +144,7 @@ modules: ## Runs go mod to ensure modules are up to date.
 
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
-	docker pull docker.io/docker/dockerfile:experimental
+	docker pull docker.io/docker/dockerfile:1.1-experimental
 	docker pull docker.io/library/golang:1.15.3
 	docker pull gcr.io/distroless/static:latest
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: port some improvements made in https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1061, namely:
- specify the dockerfile experimental image version to avoid being impacted by potential future breaking changes
- cache go/pkg/mod

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
