### PR TITLE
🌱 Update util functions for secret generation

### DIFF
--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -143,6 +143,7 @@ func GenerateSecretWithOwner(clusterName client.ObjectKey, data []byte, owner me
 		Data: map[string][]byte{
 			secret.KubeconfigDataName: data,
 		},
+		Type: clusterv1.ClusterSecretType,
 	}
 }
 

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -74,6 +74,7 @@ users:
 		Data: map[string][]byte{
 			secret.KubeconfigDataName: []byte(validKubeConfig),
 		},
+		Type: clusterv1.ClusterSecretType,
 	}
 )
 
@@ -281,6 +282,7 @@ func TestCreateSecretWithOwner(t *testing.T) {
 	key := client.ObjectKey{Name: "test1-kubeconfig", Namespace: "test"}
 	g.Expect(c.Get(ctx, key, s)).To(Succeed())
 	g.Expect(s.OwnerReferences).To(ContainElement(owner))
+	g.Expect(s.Type).To(Equal(clusterv1.ClusterSecretType))
 
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(s.Data[secret.KubeconfigDataName])
 	g.Expect(err).NotTo(HaveOccurred())
@@ -343,6 +345,7 @@ func TestCreateSecret(t *testing.T) {
 			APIVersion: clusterv1.GroupVersion.String(),
 		},
 	))
+	g.Expect(s.Type).To(Equal(clusterv1.ClusterSecretType))
 
 	clientConfig, err := clientcmd.NewClientConfigFromBytes(s.Data[secret.KubeconfigDataName])
 	g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch includes setting the **Type** field for CAPI secrets generated by the util functions. 

**Which issue(s) this PR fixes**:
resolves #2478 
