### PR TITLE
:seedling: Increase leader election lease values for KCP

### DIFF
--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -77,13 +77,13 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 
-	fs.DurationVar(&leaderElectionLeaseDuration, "leader-elect-lease-duration", 15*time.Second,
+	fs.DurationVar(&leaderElectionLeaseDuration, "leader-elect-lease-duration", 1*time.Minute,
 		"Interval at which non-leader candidates will wait to force acquire leadership (duration string)")
 
-	fs.DurationVar(&leaderElectionRenewDeadline, "leader-elect-renew-deadline", 10*time.Second,
+	fs.DurationVar(&leaderElectionRenewDeadline, "leader-elect-renew-deadline", 40*time.Second,
 		"Duration that the leading controller manager will retry refreshing leadership before giving up (duration string)")
 
-	fs.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 2*time.Second,
+	fs.DurationVar(&leaderElectionRetryPeriod, "leader-elect-retry-period", 5*time.Second,
 		"Duration the LeaderElector clients should wait between tries of actions (duration string)")
 
 	fs.StringVar(&watchNamespace, "namespace", "",


### PR DESCRIPTION


Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

To improve a self-managed cluster resilience to temporary errors related
to etcd leadership, this change increases the duration for all the lease
times.

The following are the most important values for leader election, we
increase the amount the non-leader candidates wait (1m now) and we
increase the renew deadline to 40s instead of 10, which should give
enough time for etcd connectivity to be established again.

- Lease duration is now 1 minute instead of 15s
- Renew deadline has been increased to 40 seconds instead of 10

In addition:

- Retry period has been increased to 5 seconds instead of 2
  - Avoid overloading the API Server / etcd with lease retry requests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #3978 
