### PR TITLE
✨ Make KubeadmControlPlane Spec mutable

### DIFF
--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
@@ -88,6 +88,9 @@ const (
 	postKubeadmCommands  = "postKubeadmCommands"
 	files                = "files"
 	users                = "users"
+	apiServer            = "apiServer"
+	controllerManager    = "controllerManager"
+	scheduler            = "scheduler"
 )
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -101,6 +104,9 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageRepository"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageTag"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, "imageRepository"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, apiServer, "*"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, controllerManager, "*"},
+		{spec, kubeadmConfigSpec, clusterConfiguration, scheduler, "*"},
 		{spec, kubeadmConfigSpec, initConfiguration, nodeRegistration, "*"},
 		{spec, kubeadmConfigSpec, joinConfiguration, nodeRegistration, "*"},
 		{spec, kubeadmConfigSpec, preKubeadmCommands},

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
@@ -319,17 +319,24 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 
 	apiServer := before.DeepCopy()
 	apiServer.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer = kubeadmv1beta1.APIServer{
+		ControlPlaneComponent: kubeadmv1beta1.ControlPlaneComponent{
+			ExtraArgs:    map[string]string{"foo": "bar"},
+			ExtraVolumes: []kubeadmv1beta1.HostPathMount{{Name: "mount1"}},
+		},
 		TimeoutForControlPlane: &metav1.Duration{Duration: 5 * time.Minute},
+		CertSANs:               []string{"foo", "bar"},
 	}
 
 	controllerManager := before.DeepCopy()
 	controllerManager.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager = kubeadmv1beta1.ControlPlaneComponent{
-		ExtraArgs: map[string]string{"controller manager field": "controller manager value"},
+		ExtraArgs:    map[string]string{"controller manager field": "controller manager value"},
+		ExtraVolumes: []kubeadmv1beta1.HostPathMount{{Name: "mount", HostPath: "/foo", MountPath: "bar", ReadOnly: true, PathType: "File"}},
 	}
 
 	scheduler := before.DeepCopy()
 	scheduler.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler = kubeadmv1beta1.ControlPlaneComponent{
-		ExtraArgs: map[string]string{"scheduler field": "scheduler value"},
+		ExtraArgs:    map[string]string{"scheduler field": "scheduler value"},
+		ExtraVolumes: []kubeadmv1beta1.HostPathMount{{Name: "mount", HostPath: "/foo", MountPath: "bar", ReadOnly: true, PathType: "File"}},
 	}
 
 	dns := before.DeepCopy()
@@ -563,20 +570,20 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			kcp:       controlPlaneEndpoint,
 		},
 		{
-			name:      "should fail when making a change to the cluster config's apiServer",
-			expectErr: true,
+			name:      "should allow changes to the cluster config's apiServer",
+			expectErr: false,
 			before:    before,
 			kcp:       apiServer,
 		},
 		{
-			name:      "should fail when making a change to the cluster config's controllerManager",
-			expectErr: true,
+			name:      "should allow changes to the cluster config's controllerManager",
+			expectErr: false,
 			before:    before,
 			kcp:       controllerManager,
 		},
 		{
-			name:      "should fail when making a change to the cluster config's scheduler",
-			expectErr: true,
+			name:      "should allow changes to the cluster config's scheduler",
+			expectErr: false,
 			before:    before,
 			kcp:       scheduler,
 		},

--- a/controlplane/kubeadm/controllers/upgrade.go
+++ b/controlplane/kubeadm/controllers/upgrade.go
@@ -82,6 +82,20 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 		}
 	}
 
+	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration != nil {
+		if err := workloadCluster.UpdateAPIServerInKubeadmConfigMap(ctx, kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer); err != nil {
+			return ctrl.Result{}, errors.Wrap(err, "failed to update api server in the kubeadm config map")
+		}
+
+		if err := workloadCluster.UpdateControllerManagerInKubeadmConfigMap(ctx, kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.ControllerManager); err != nil {
+			return ctrl.Result{}, errors.Wrap(err, "failed to update controller manager in the kubeadm config map")
+		}
+
+		if err := workloadCluster.UpdateSchedulerInKubeadmConfigMap(ctx, kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Scheduler); err != nil {
+			return ctrl.Result{}, errors.Wrap(err, "failed to update scheduler in the kubeadm config map")
+		}
+	}
+
 	if err := workloadCluster.UpdateKubeletConfigMap(ctx, parsedVersion); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "failed to upgrade kubelet config map")
 	}

--- a/controlplane/kubeadm/internal/workload_cluster_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -483,6 +484,357 @@ imageRepository: k8s.gcr.io
 				&actualConfig,
 			)).To(Succeed())
 			g.Expect(actualConfig.Data[clusterConfigurationKey]).To(ContainSubstring(tt.imageRepository))
+		})
+	}
+}
+
+func TestUpdateApiServerInKubeadmConfigMap(t *testing.T) {
+	validAPIServerConfig := `apiServer:
+  certSANs:
+  - foo
+  extraArgs:
+    foo: bar
+  extraVolumes:
+  - hostPath: /foo/bar
+    mountPath: /bar/baz
+    name: mount1
+  timeoutForControlPlane: 3m0s
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+`
+	kubeadmConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeadmConfigKey,
+			Namespace: metav1.NamespaceSystem,
+		},
+		Data: map[string]string{
+			clusterConfigurationKey: validAPIServerConfig,
+		},
+	}
+
+	kubeadmConfigNoKey := kubeadmConfig.DeepCopy()
+	delete(kubeadmConfigNoKey.Data, clusterConfigurationKey)
+
+	kubeadmConfigBadData := kubeadmConfig.DeepCopy()
+	kubeadmConfigBadData.Data[clusterConfigurationKey] = `badConfigAPIServer`
+
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	tests := []struct {
+		name              string
+		apiServer         kubeadmv1beta1.APIServer
+		objs              []client.Object
+		expectErr         bool
+		expectedChanged   bool
+		expectedAPIServer string
+	}{
+		{
+			name:            "updates the config map",
+			apiServer:       kubeadmv1beta1.APIServer{CertSANs: []string{"foo", "bar"}},
+			objs:            []client.Object{kubeadmConfig},
+			expectErr:       false,
+			expectedChanged: true,
+			expectedAPIServer: `apiServer:
+  certSANs:
+  - foo
+  - bar
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+`,
+		},
+		{
+			name:              "returns error if cannot find config map",
+			expectErr:         true,
+			expectedAPIServer: validAPIServerConfig,
+		},
+		{
+			name:              "returns error if config has bad data",
+			objs:              []client.Object{kubeadmConfigBadData},
+			apiServer:         kubeadmv1beta1.APIServer{CertSANs: []string{"foo", "bar"}},
+			expectErr:         true,
+			expectedAPIServer: validAPIServerConfig,
+		},
+		{
+			name:              "returns error if config doesn't have cluster config key",
+			objs:              []client.Object{kubeadmConfigNoKey},
+			apiServer:         kubeadmv1beta1.APIServer{CertSANs: []string{"foo", "bar"}},
+			expectErr:         true,
+			expectedAPIServer: validAPIServerConfig,
+		},
+		{
+			name:            "should not update config map if no changes are detected",
+			objs:            []client.Object{kubeadmConfig},
+			expectedChanged: false,
+			apiServer: kubeadmv1beta1.APIServer{
+				ControlPlaneComponent: kubeadmv1beta1.ControlPlaneComponent{
+					ExtraArgs:    map[string]string{"foo": "bar"},
+					ExtraVolumes: []kubeadmv1beta1.HostPathMount{{Name: "mount1", HostPath: "/foo/bar", MountPath: "/bar/baz"}},
+				},
+				CertSANs:               []string{"foo"},
+				TimeoutForControlPlane: &metav1.Duration{Duration: 3 * time.Minute},
+			},
+			expectedAPIServer: validAPIServerConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objs...).Build()
+			w := &Workload{
+				Client: fakeClient,
+			}
+
+			err := w.UpdateAPIServerInKubeadmConfigMap(ctx, tt.apiServer)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			var actualConfig corev1.ConfigMap
+			g.Expect(w.Client.Get(
+				ctx,
+				client.ObjectKey{Name: kubeadmConfigKey, Namespace: metav1.NamespaceSystem},
+				&actualConfig,
+			)).To(Succeed())
+			g.Expect(actualConfig.Data[clusterConfigurationKey]).Should(Equal(tt.expectedAPIServer))
+
+			// check resource version to see if client.update was called or not
+			if !tt.expectedChanged {
+				g.Expect(tt.objs[0].GetResourceVersion()).Should(Equal(actualConfig.ResourceVersion))
+			} else {
+				g.Expect(tt.objs[0].GetResourceVersion()).ShouldNot(Equal(actualConfig.ResourceVersion))
+			}
+		})
+	}
+}
+
+func TestUpdateControllerManagerInKubeadmConfigMap(t *testing.T) {
+	validControllerManagerConfig := `apiVersion: kubeadm.k8s.io/v1beta2
+controllerManager:
+  extraArgs:
+    foo: bar
+  extraVolumes:
+  - hostPath: /foo/bar
+    mountPath: /bar/baz
+    name: mount1
+kind: ClusterConfiguration
+`
+	kubeadmConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeadmConfigKey,
+			Namespace: metav1.NamespaceSystem,
+		},
+		Data: map[string]string{
+			clusterConfigurationKey: validControllerManagerConfig,
+		},
+	}
+
+	kubeadmConfigNoKey := kubeadmConfig.DeepCopy()
+	delete(kubeadmConfigNoKey.Data, clusterConfigurationKey)
+
+	kubeadmConfigBadData := kubeadmConfig.DeepCopy()
+	kubeadmConfigBadData.Data[clusterConfigurationKey] = `badConfigControllerManager`
+
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	tests := []struct {
+		name                      string
+		controllerManager         kubeadmv1beta1.ControlPlaneComponent
+		objs                      []client.Object
+		expectErr                 bool
+		expectedChanged           bool
+		expectedControllerManager string
+	}{
+		{
+			name:              "updates the config map",
+			controllerManager: kubeadmv1beta1.ControlPlaneComponent{ExtraArgs: map[string]string{"foo": "bar"}},
+			objs:              []client.Object{kubeadmConfig},
+			expectErr:         false,
+			expectedChanged:   true,
+			expectedControllerManager: `apiVersion: kubeadm.k8s.io/v1beta2
+controllerManager:
+  extraArgs:
+    foo: bar
+kind: ClusterConfiguration
+`,
+		},
+		{
+			name:                      "returns error if cannot find config map",
+			expectErr:                 true,
+			expectedControllerManager: validControllerManagerConfig,
+		},
+		{
+			name:                      "returns error if config has bad data",
+			objs:                      []client.Object{kubeadmConfigBadData},
+			controllerManager:         kubeadmv1beta1.ControlPlaneComponent{ExtraArgs: map[string]string{"foo": "bar"}},
+			expectErr:                 true,
+			expectedControllerManager: validControllerManagerConfig,
+		},
+		{
+			name:                      "returns error if config doesn't have cluster config key",
+			objs:                      []client.Object{kubeadmConfigNoKey},
+			controllerManager:         kubeadmv1beta1.ControlPlaneComponent{ExtraArgs: map[string]string{"foo": "bar"}},
+			expectErr:                 true,
+			expectedControllerManager: validControllerManagerConfig,
+		},
+		{
+			name:            "should not update config map if no changes are detected",
+			objs:            []client.Object{kubeadmConfig},
+			expectedChanged: false,
+			controllerManager: kubeadmv1beta1.ControlPlaneComponent{
+				ExtraArgs:    map[string]string{"foo": "bar"},
+				ExtraVolumes: []kubeadmv1beta1.HostPathMount{{Name: "mount1", HostPath: "/foo/bar", MountPath: "/bar/baz"}},
+			},
+			expectedControllerManager: validControllerManagerConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objs...).Build()
+			w := &Workload{
+				Client: fakeClient,
+			}
+			err := w.UpdateControllerManagerInKubeadmConfigMap(ctx, tt.controllerManager)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			var actualConfig corev1.ConfigMap
+			g.Expect(w.Client.Get(
+				ctx,
+				client.ObjectKey{Name: kubeadmConfigKey, Namespace: metav1.NamespaceSystem},
+				&actualConfig,
+			)).To(Succeed())
+			g.Expect(actualConfig.Data[clusterConfigurationKey]).Should(Equal(tt.expectedControllerManager))
+
+			// check resource version to see if client.update was called or not
+			if !tt.expectedChanged {
+				g.Expect(tt.objs[0].GetResourceVersion()).Should(Equal(actualConfig.ResourceVersion))
+			} else {
+				g.Expect(tt.objs[0].GetResourceVersion()).ShouldNot(Equal(actualConfig.ResourceVersion))
+			}
+		})
+	}
+}
+
+func TestUpdateSchedulerInKubeadmConfigMap(t *testing.T) {
+	validSchedulerConfig := `apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+scheduler:
+  extraArgs:
+    foo: bar
+  extraVolumes:
+  - hostPath: /foo/bar
+    mountPath: /bar/baz
+    name: mount1
+`
+	kubeadmConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeadmConfigKey,
+			Namespace: metav1.NamespaceSystem,
+		},
+		Data: map[string]string{
+			clusterConfigurationKey: validSchedulerConfig,
+		},
+	}
+
+	kubeadmConfigNoKey := kubeadmConfig.DeepCopy()
+	delete(kubeadmConfigNoKey.Data, clusterConfigurationKey)
+
+	kubeadmConfigBadData := kubeadmConfig.DeepCopy()
+	kubeadmConfigBadData.Data[clusterConfigurationKey] = `badConfigScheduler`
+
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	tests := []struct {
+		name              string
+		scheduler         kubeadmv1beta1.ControlPlaneComponent
+		objs              []client.Object
+		expectErr         bool
+		expectedChanged   bool
+		expectedScheduler string
+	}{
+		{
+			name:            "updates the config map",
+			scheduler:       kubeadmv1beta1.ControlPlaneComponent{ExtraArgs: map[string]string{"foo": "bar"}},
+			objs:            []client.Object{kubeadmConfig},
+			expectErr:       false,
+			expectedChanged: true,
+			expectedScheduler: `apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+scheduler:
+  extraArgs:
+    foo: bar
+`,
+		},
+		{
+			name:              "returns error if cannot find config map",
+			expectErr:         true,
+			expectedScheduler: validSchedulerConfig,
+		},
+		{
+			name:              "returns error if config has bad data",
+			objs:              []client.Object{kubeadmConfigBadData},
+			scheduler:         kubeadmv1beta1.ControlPlaneComponent{ExtraArgs: map[string]string{"foo": "bar"}},
+			expectErr:         true,
+			expectedScheduler: validSchedulerConfig,
+		},
+		{
+			name:              "returns error if config doesn't have cluster config key",
+			objs:              []client.Object{kubeadmConfigNoKey},
+			scheduler:         kubeadmv1beta1.ControlPlaneComponent{ExtraArgs: map[string]string{"foo": "bar"}},
+			expectErr:         true,
+			expectedScheduler: validSchedulerConfig,
+		},
+		{
+			name:            "should not update config map if no changes are detected",
+			objs:            []client.Object{kubeadmConfig},
+			expectedChanged: false,
+			scheduler: kubeadmv1beta1.ControlPlaneComponent{
+				ExtraArgs:    map[string]string{"foo": "bar"},
+				ExtraVolumes: []kubeadmv1beta1.HostPathMount{{Name: "mount1", HostPath: "/foo/bar", MountPath: "/bar/baz"}},
+			},
+			expectedScheduler: validSchedulerConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objs...).Build()
+			w := &Workload{
+				Client: fakeClient,
+			}
+			err := w.UpdateSchedulerInKubeadmConfigMap(ctx, tt.scheduler)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			var actualConfig corev1.ConfigMap
+			g.Expect(w.Client.Get(
+				ctx,
+				client.ObjectKey{Name: kubeadmConfigKey, Namespace: metav1.NamespaceSystem},
+				&actualConfig,
+			)).To(Succeed())
+			g.Expect(actualConfig.Data[clusterConfigurationKey]).Should(Equal(tt.expectedScheduler))
+
+			// check resource version to see if client.update was called or not
+			if !tt.expectedChanged {
+				g.Expect(tt.objs[0].GetResourceVersion()).Should(Equal(actualConfig.ResourceVersion))
+			} else {
+				g.Expect(tt.objs[0].GetResourceVersion()).ShouldNot(Equal(actualConfig.ResourceVersion))
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR enables mutation for the following fields in KubeadmControlPlane Spec: 
- [x] APIServer
- [x] ControllerManager
- [x] Scheduler
- [x] ~~FeatureGates~~

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2083 
