### PR TITLE
🐛 MHC sort mhc status targets to avoid status keep changing

### DIFF
--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -207,6 +208,8 @@ func (r *MachineHealthCheckReconciler) reconcile(ctx context.Context, logger log
 	for i, t := range targets {
 		m.Status.Targets[i] = t.Machine.Name
 	}
+	// do sort to avoid keep changing m.Status as the returned machines are not in order
+	sort.Strings(m.Status.Targets)
 
 	// health check all targets and reconcile mhc status
 	healthy, unhealthy, nextCheckTimes := r.healthCheckTargets(targets, logger, m.Spec.NodeStartupTimeout.Duration)

--- a/controllers/machinehealthcheck_controller_test.go
+++ b/controllers/machinehealthcheck_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -203,6 +204,8 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		for i, m := range machines {
 			targetMachines[i] = m.Name
 		}
+		sort.Strings(targetMachines)
+
 		// Make sure the status matches.
 		g.Eventually(func() *clusterv1.MachineHealthCheckStatus {
 			err := testEnv.Get(ctx, util.ObjectKey(mhc), mhc)
@@ -258,6 +261,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		for i, m := range machines {
 			targetMachines[i] = m.Name
 		}
+		sort.Strings(targetMachines)
 
 		// Make sure the status matches.
 		g.Eventually(func() *clusterv1.MachineHealthCheckStatus {
@@ -316,6 +320,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		for i, m := range machines {
 			targetMachines[i] = m.Name
 		}
+		sort.Strings(targetMachines)
 
 		// Make sure the status matches.
 		g.Eventually(func() *clusterv1.MachineHealthCheckStatus {
@@ -412,6 +417,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		for i, m := range machines {
 			targetMachines[i] = m.Name
 		}
+		sort.Strings(targetMachines)
 
 		// Make sure the status matches.
 		g.Eventually(func() *clusterv1.MachineHealthCheckStatus {
@@ -508,6 +514,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		for i, m := range machines {
 			targetMachines[i] = m.Name
 		}
+		sort.Strings(targetMachines)
 
 		// Make sure the MHC status matches. We have two healthy machines and
 		// one unhealthy.
@@ -596,6 +603,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		for i, m := range machines {
 			targetMachines[i] = m.Name
 		}
+		sort.Strings(targetMachines)
 
 		// Forcibly remove the last machine's node.
 		g.Eventually(func() bool {
@@ -688,6 +696,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		for i, m := range machines {
 			targetMachines[i] = m.Name
 		}
+		sort.Strings(targetMachines)
 
 		// Make sure the status matches.
 		g.Eventually(func() *clusterv1.MachineHealthCheckStatus {
@@ -945,6 +954,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		for i, m := range machines {
 			targetMachines[i] = m.Name
 		}
+		sort.Strings(targetMachines)
 
 		// Make sure the status matches.
 		g.Eventually(func() *clusterv1.MachineHealthCheckStatus {
@@ -1094,6 +1104,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		for i, m := range machines {
 			targetMachines[i] = m.Name
 		}
+		sort.Strings(targetMachines)
 
 		// Make sure the status matches.
 		g.Eventually(func() *clusterv1.MachineHealthCheckStatus {
@@ -1240,6 +1251,7 @@ func TestMachineHealthCheck_Reconcile(t *testing.T) {
 		for i, m := range machines {
 			targetMachines[i] = m.Name
 		}
+		sort.Strings(targetMachines)
 
 		// Make sure the status matches.
 		g.Eventually(func() *clusterv1.MachineHealthCheckStatus {

--- a/controllers/machinehealthcheck_status_matcher.go
+++ b/controllers/machinehealthcheck_status_matcher.go
@@ -54,7 +54,7 @@ func (m machineHealthCheckStatusMatcher) Match(actual interface{}) (success bool
 	if !ok {
 		return ok, err
 	}
-	ok, err = ConsistOf(m.expected.Targets).Match(actualStatus.Targets)
+	ok, err = Equal(m.expected.Targets).Match(actualStatus.Targets)
 	if !ok {
 		return ok, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The array of Machines passed to MachineHealthCheck is not ordered, which cause MHC.Status.Targets not ordered, then MHC.Status keep changing. 

Add sort to fix the targets in order.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
