### PR TITLE
⚠️ Use Kind's default network in CAPD

### DIFF
--- a/docs/book/src/developer/testing.md
+++ b/docs/book/src/developer/testing.md
@@ -54,10 +54,6 @@ Following guidelines should be followed when developing E2E tests:
 See [e2e development] for more information on developing e2e tests for CAPI and external providers.
 
 ## Running the end-to-end tests
-Before running the tests, ensure kind is using the default **bridge** network. This can be done by exporting the variable `KIND_EXPERIMENTAL_DOCKER_NETWORK`:
-```bash
-export KIND_EXPERIMENTAL_DOCKER_NETWORK=bridge
-```
 
 `make docker-build-e2e` will build the images for all providers that will be needed for the e2e test.
 

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -49,10 +49,6 @@ please follow the additional instructions in the dedicated tab:
 {{#tabs name:"install-kind" tabs:"v0.9.x,Docker"}}
 {{#tab v0.9.x}}
 
-Export the variable **KIND_EXPERIMENTAL_DOCKER_NETWORK=bridge** to let kind run in the default **bridge** network:
-```bash
-export KIND_EXPERIMENTAL_DOCKER_NETWORK=bridge
-```
 Create the kind cluster:
 ```bash
 kind create cluster

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -61,7 +61,6 @@ export E2E_CONF_FILE="${REPO_ROOT}/test/e2e/config/docker.yaml"
 export ARTIFACTS="${ARTIFACTS:-${REPO_ROOT}/_artifacts}"
 export SKIP_RESOURCE_CLEANUP=false
 export USE_EXISTING_CLUSTER=false
-export KIND_EXPERIMENTAL_DOCKER_NETWORK="bridge"
 
 # Run e2e tests
 mkdir -p "$ARTIFACTS"

--- a/test/infrastructure/docker/docker/kind_manager.go
+++ b/test/infrastructure/docker/docker/kind_manager.go
@@ -118,6 +118,7 @@ func createNode(name, image, clusterLabel, role string, mounts []v1alpha4.Mount,
 		// some k8s things want to read /lib/modules
 		"--volume", "/lib/modules:/lib/modules:ro",
 		"--hostname", name, // make hostname match container name
+		"--network", defaultNetwork,
 		"--name", name, // ... and set the container name
 		// label the node with the cluster ID
 		"--label", clusterLabel,
@@ -186,8 +187,7 @@ type proxyDetails struct {
 }
 
 const (
-	// Docker default bridge network is named "bridge" (https://docs.docker.com/network/bridge/#use-the-default-bridge-network)
-	defaultNetwork = "bridge"
+	defaultNetwork = "kind"
 	httpProxy      = "HTTP_PROXY"
 	httpsProxy     = "HTTPS_PROXY"
 	noProxy        = "NO_PROXY"


### PR DESCRIPTION
**What this PR does / why we need it**:
This will remove the need to set `KIND_EXPERIMENTAL_DOCKER_NETWORK` to `bridge` when running local clusters or E2E tests.

**Which issue(s) this PR fixes**
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/3832
