### PR TITLE
:warning: ClusterAPI Components Use Separate Service Accounts

### DIFF
--- a/bootstrap/kubeadm/config/manager/manager.yaml
+++ b/bootstrap/kubeadm/config/manager/manager.yaml
@@ -24,6 +24,7 @@ spec:
         image: controller:latest
         name: manager
       terminationGracePeriodSeconds: 10
+      serviceAccountName: manager-cabpk
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master

--- a/bootstrap/kubeadm/config/rbac/auth_proxy_role_binding.yaml
+++ b/bootstrap/kubeadm/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-cabpk
   namespace: system

--- a/bootstrap/kubeadm/config/rbac/kustomization.yaml
+++ b/bootstrap/kubeadm/config/rbac/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
+- service_account.yaml

--- a/bootstrap/kubeadm/config/rbac/leader_election_role_binding.yaml
+++ b/bootstrap/kubeadm/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-cabpk
   namespace: system

--- a/bootstrap/kubeadm/config/rbac/role_binding.yaml
+++ b/bootstrap/kubeadm/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-cabpk
   namespace: system

--- a/bootstrap/kubeadm/config/rbac/service_account.yaml
+++ b/bootstrap/kubeadm/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager-cabpk
+  namespace: system

--- a/bootstrap/kubeadm/config/webhook/kustomization.yaml
+++ b/bootstrap/kubeadm/config/webhook/kustomization.yaml
@@ -3,6 +3,7 @@ namespace: capi-webhook-system
 resources:
 - manifests.yaml
 - service.yaml
+- service_account.yaml
 - ../certmanager
 - ../manager
 

--- a/bootstrap/kubeadm/config/webhook/service_account.yaml
+++ b/bootstrap/kubeadm/config/webhook/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager-cabpk

--- a/config/ci/manager/manager_pull_policy.yaml
+++ b/config/ci/manager/manager_pull_policy.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
       - name: manager
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent

--- a/config/ci/rbac/kustomization.yaml
+++ b/config/ci/rbac/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
 - auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
+- service_account.yaml

--- a/config/ci/rbac/leader_election_role_binding.yaml
+++ b/config/ci/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-capi
   namespace: system

--- a/config/ci/rbac/service_account.yaml
+++ b/config/ci/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager-capi
+  namespace: system

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,3 +40,4 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+      serviceAccountName: capi-manager-capi

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-capi
   namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
 - auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
+- service_account.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-capi
   namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-capi
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager-capi
+  namespace: system

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - namespace.yaml
 - manifests.yaml
 - service.yaml
+- service_account.yaml
 - ../certmanager
 - ../manager
 

--- a/config/webhook/service_account.yaml
+++ b/config/webhook/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager-capi

--- a/controlplane/kubeadm/config/manager/manager.yaml
+++ b/controlplane/kubeadm/config/manager/manager.yaml
@@ -23,6 +23,7 @@ spec:
         image: controller:latest
         name: manager
       terminationGracePeriodSeconds: 10
+      serviceAccountName: manager-kcp
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master

--- a/controlplane/kubeadm/config/rbac/auth_proxy_role_binding.yaml
+++ b/controlplane/kubeadm/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-kcp
   namespace: system

--- a/controlplane/kubeadm/config/rbac/kustomization.yaml
+++ b/controlplane/kubeadm/config/rbac/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - aggregated_role.yaml
+- service_account.yaml

--- a/controlplane/kubeadm/config/rbac/leader_election_role_binding.yaml
+++ b/controlplane/kubeadm/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-kcp
   namespace: system

--- a/controlplane/kubeadm/config/rbac/role_binding.yaml
+++ b/controlplane/kubeadm/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-kcp
   namespace: system

--- a/controlplane/kubeadm/config/rbac/service_account.yaml
+++ b/controlplane/kubeadm/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager-kcp
+  namespace: system

--- a/controlplane/kubeadm/config/webhook/kustomization.yaml
+++ b/controlplane/kubeadm/config/webhook/kustomization.yaml
@@ -3,6 +3,7 @@ namespace: capi-webhook-system
 resources:
 - manifests.yaml
 - service.yaml
+- service_account.yaml
 - ../certmanager
 - ../manager
 

--- a/controlplane/kubeadm/config/webhook/service_account.yaml
+++ b/controlplane/kubeadm/config/webhook/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager-kcp

--- a/test/infrastructure/docker/config/manager/manager.yaml
+++ b/test/infrastructure/docker/config/manager/manager.yaml
@@ -41,6 +41,7 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      serviceAccountName: manager-capd
       volumes:
         - name: dockersock
           hostPath:

--- a/test/infrastructure/docker/config/rbac/auth_proxy_role_binding.yaml
+++ b/test/infrastructure/docker/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-capd
   namespace: system

--- a/test/infrastructure/docker/config/rbac/kustomization.yaml
+++ b/test/infrastructure/docker/config/rbac/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - auth_proxy_service.yaml
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
+- service_account.yaml

--- a/test/infrastructure/docker/config/rbac/role_binding.yaml
+++ b/test/infrastructure/docker/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: manager-capd
   namespace: system

--- a/test/infrastructure/docker/config/rbac/service_account.yaml
+++ b/test/infrastructure/docker/config/rbac/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manager-capd
+  namespace: system


### PR DESCRIPTION
Modify CAPI, CABPK, KCP and CAPD to use their own, respective SA's instead of the namespace's default.

Fixes #4015
