### PR TITLE
🐛 KubeadmControlPlane should adopt v1alpha2 kubeconfig secrets

### DIFF
--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -265,7 +265,7 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, cluster *
 	}
 
 	// Generate Cluster Kubeconfig if needed
-	if err := r.reconcileKubeconfig(ctx, util.ObjectKey(cluster), cluster.Spec.ControlPlaneEndpoint, kcp); err != nil {
+	if err := r.reconcileKubeconfig(ctx, cluster, kcp); err != nil {
 		log.Error(err, "failed to reconcile Kubeconfig")
 		return ctrl.Result{}, err
 	}

--- a/controlplane/kubeadm/controllers/helpers.go
+++ b/controlplane/kubeadm/controllers/helpers.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"encoding/json"
-	"sigs.k8s.io/cluster-api/util/conditions"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -37,21 +36,23 @@ import (
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/certs"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/secret"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context, clusterName client.ObjectKey, endpoint clusterv1.APIEndpoint, kcp *controlplanev1.KubeadmControlPlane) error {
+func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane) error {
 	log := ctrl.LoggerFrom(ctx)
 
+	endpoint := cluster.Spec.ControlPlaneEndpoint
 	if endpoint.IsZero() {
 		return nil
 	}
 
 	controllerOwnerRef := *metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))
+	clusterName := util.ObjectKey(cluster)
 	configSecret, err := secret.GetFromNamespacedName(ctx, r.Client, clusterName, secret.Kubeconfig)
 	switch {
 	case apierrors.IsNotFound(err):
@@ -72,6 +73,14 @@ func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 		return errors.Wrap(err, "failed to retrieve kubeconfig Secret")
 	}
 
+	// check if the kubeconfig secret was created by v1alpha2 controllers, and thus it has the Cluster as the owner instead of KCP;
+	// if yes, adopt it.
+	if util.IsOwnedByObject(configSecret, cluster) && !util.IsControlledBy(configSecret, kcp) {
+		if err := r.adoptKubeconfigSecret(ctx, cluster, configSecret, controllerOwnerRef); err != nil {
+			return err
+		}
+	}
+
 	// only do rotation on owned secrets
 	if !util.IsControlledBy(configSecret, kcp) {
 		return nil
@@ -89,6 +98,27 @@ func (r *KubeadmControlPlaneReconciler) reconcileKubeconfig(ctx context.Context,
 		}
 	}
 
+	return nil
+}
+
+func (r *KubeadmControlPlaneReconciler) adoptKubeconfigSecret(ctx context.Context, cluster *clusterv1.Cluster, configSecret *corev1.Secret, controllerOwnerRef metav1.OwnerReference) error {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Adopting KubeConfig secret created by v1alpha2 controllers", "Name", configSecret.Name)
+
+	patch, err := patch.NewHelper(configSecret, r.Client)
+	if err != nil {
+		return errors.Wrap(err, "failed to create patch helper for the kubeconfig secret")
+	}
+	configSecret.OwnerReferences = util.RemoveOwnerRef(configSecret.OwnerReferences, metav1.OwnerReference{
+		APIVersion: clusterv1.GroupVersion.String(),
+		Kind:       "Cluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+	})
+	configSecret.OwnerReferences = util.EnsureOwnerRef(configSecret.OwnerReferences, controllerOwnerRef)
+	if err := patch.Patch(ctx, configSecret); err != nil {
+		return errors.Wrap(err, "failed to patch the kubeconfig secret")
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures kubeconfig secrets created by v1alpha2 controllers are adopted by KCP, thus allowing periodic kubeconfig secrete re-generation preventing the expiration of the embedded client certificate.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4011
