### PR TITLE
🐛 E2E conformance tests now use kind network

### DIFF
--- a/test/e2e/data/infrastructure-docker/v1alpha4/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1alpha4/bases/cluster-with-kcp.yaml
@@ -61,7 +61,8 @@ spec:
       controllerManager:
         extraArgs: {enable-hostpath-provisioner: 'true'}
       apiServer:
-        certSANs: [localhost, 127.0.0.1, 0.0.0.0]
+        # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
+        certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]
     initConfiguration:
       nodeRegistration:
         criSocket: /var/run/containerd/containerd.sock

--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -141,7 +141,8 @@ func Run(ctx context.Context, input RunInput) error {
 		return errors.Wrap(err, "unable to determine current user")
 	}
 	userArg := user.Uid + ":" + user.Gid
-	e2eCmd := exec.Command("docker", "run", "--user", userArg, kubeConfigVolumeMount, outputVolumeMount, viperVolumeMount, "-t", input.ConformanceImage)
+	networkArg := "--network=kind"
+	e2eCmd := exec.Command("docker", "run", "--user", userArg, kubeConfigVolumeMount, outputVolumeMount, viperVolumeMount, "-t", networkArg, input.ConformanceImage)
 	e2eCmd.Args = append(e2eCmd.Args, "/usr/local/bin/ginkgo")
 	e2eCmd.Args = append(e2eCmd.Args, ginkgoArgs...)
 	e2eCmd.Args = append(e2eCmd.Args, "/usr/local/bin/e2e.test")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the e2e conformance test for working with CAPD after this has been changed to use the kind network
It also fixes v1alpha4 test running locally on mac os.
