### PR TITLE
🐛  Fix APIEndpoint for IPv6

### DIFF
--- a/api/v1alpha3/cluster_types.go
+++ b/api/v1alpha3/cluster_types.go
@@ -18,6 +18,7 @@ package v1alpha3
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -190,7 +191,7 @@ func (v APIEndpoint) IsValid() bool {
 
 // String returns a formatted version HOST:PORT of this APIEndpoint.
 func (v APIEndpoint) String() string {
-	return fmt.Sprintf("%s:%d", v.Host, v.Port)
+	return net.JoinHostPort(v.Host, fmt.Sprintf("%d", v.Port))
 }
 
 // ANCHOR_END: APIEndpoint

--- a/api/v1alpha4/cluster_types.go
+++ b/api/v1alpha4/cluster_types.go
@@ -18,6 +18,7 @@ package v1alpha4
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -190,7 +191,7 @@ func (v APIEndpoint) IsValid() bool {
 
 // String returns a formatted version HOST:PORT of this APIEndpoint.
 func (v APIEndpoint) String() string {
-	return fmt.Sprintf("%s:%d", v.Host, v.Port)
+	return net.JoinHostPort(v.Host, fmt.Sprintf("%d", v.Port))
 }
 
 // ANCHOR_END: APIEndpoint


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Currently the `cluster-api` fails to connect to an IPv6 cluster because of improper parsing of the IPv6 address and port combination. This PR fixes that.
