### PR TITLE
🌱 Annotate nodes with cluster info

### DIFF
--- a/api/v1alpha4/common_types.go
+++ b/api/v1alpha4/common_types.go
@@ -31,6 +31,21 @@ const (
 	// tool uses this label for implementing provider's lifecycle operations.
 	ProviderLabelName = "cluster.x-k8s.io/provider"
 
+	// ClusterNameAnnotation is the annotation set on nodes identifying the name of the cluster the node belongs to.
+	ClusterNameAnnotation = "cluster.x-k8s.io/cluster-name"
+
+	// ClusterNamespaceAnnotation is the annotation set on nodes identifying the namespace of the cluster the node belongs to.
+	ClusterNamespaceAnnotation = "cluster.x-k8s.io/cluster-namespace"
+
+	// MachineAnnotation is the annotation set on nodes identifying the machine the node belongs to.
+	MachineAnnotation = "cluster.x-k8s.io/machine"
+
+	// OwnerKindAnnotation is the annotation set on nodes identifying the owner kind.
+	OwnerKindAnnotation = "cluster.x-k8s.io/owner-kind"
+
+	// OwnerNameAnnotation is the annotation set on nodes identifying the owner name.
+	OwnerNameAnnotation = "cluster.x-k8s.io/owner-name"
+
 	// PausedAnnotation is an annotation that can be applied to any Cluster API
 	// object to prevent a controller from processing a resource.
 	//

--- a/controllers/machine_controller_noderef.go
+++ b/controllers/machine_controller_noderef.go
@@ -19,6 +19,9 @@ package controllers
 import (
 	"context"
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -83,6 +86,27 @@ func (r *MachineReconciler) reconcileNode(ctx context.Context, cluster *clusterv
 		}
 		log.Info("Set Machine's NodeRef", "noderef", machine.Status.NodeRef.Name)
 		r.recorder.Event(machine, corev1.EventTypeNormal, "SuccessfulSetNodeRef", machine.Status.NodeRef.Name)
+	}
+
+	// Reconcile node annotations.
+	patchHelper, err := patch.NewHelper(node, remoteClient)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	desired := map[string]string{
+		clusterv1.ClusterNameAnnotation:      machine.Spec.ClusterName,
+		clusterv1.ClusterNamespaceAnnotation: machine.GetNamespace(),
+		clusterv1.MachineAnnotation:          machine.Name,
+	}
+	if owner := metav1.GetControllerOfNoCopy(machine); owner != nil {
+		desired[clusterv1.OwnerKindAnnotation] = owner.Kind
+		desired[clusterv1.OwnerNameAnnotation] = owner.Name
+	}
+	if annotations.AddAnnotations(node, desired) {
+		if err := patchHelper.Patch(ctx, node); err != nil {
+			log.V(2).Info("Failed patch node to set annotations", "err", err, "node name", node.Name)
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Do the remaining node health checks, then set the node health to true if all checks pass.

--- a/exp/controllers/machinepool_controller_noderef.go
+++ b/exp/controllers/machinepool_controller_noderef.go
@@ -19,6 +19,8 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -99,6 +101,31 @@ func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, cluster *
 
 	log.Info("Set MachinePools's NodeRefs", "noderefs", mp.Status.NodeRefs)
 	r.recorder.Event(mp, apicorev1.EventTypeNormal, "SuccessfulSetNodeRefs", fmt.Sprintf("%+v", mp.Status.NodeRefs))
+
+	// Reconcile node annotations.
+	for _, nodeRef := range nodeRefsResult.references {
+		node := &corev1.Node{}
+		if err := clusterClient.Get(ctx, client.ObjectKey{Name: nodeRef.Name}, node); err != nil {
+			log.V(2).Info("Failed to get Node, skipping setting annotations", "err", err, "nodeRef.Name", nodeRef.Name)
+			continue
+		}
+		patchHelper, err := patch.NewHelper(node, clusterClient)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		desired := map[string]string{
+			clusterv1.ClusterNameAnnotation:      mp.Spec.ClusterName,
+			clusterv1.ClusterNamespaceAnnotation: mp.GetNamespace(),
+			clusterv1.OwnerKindAnnotation:        mp.Kind,
+			clusterv1.OwnerNameAnnotation:        mp.Name,
+		}
+		if annotations.AddAnnotations(node, desired) {
+			if err := patchHelper.Patch(ctx, node); err != nil {
+				log.V(2).Info("Failed patch node to set annotations", "err", err, "node name", node.Name)
+				return ctrl.Result{}, err
+			}
+		}
+	}
 
 	if mp.Status.Replicas != mp.Status.ReadyReplicas || len(nodeRefsResult.references) != int(mp.Status.ReadyReplicas) {
 		log.Info("NodeRefs != ReadyReplicas", "NodeRefs", len(nodeRefsResult.references), "ReadyReplicas", mp.Status.ReadyReplicas)

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -49,3 +49,19 @@ func HasWithPrefix(prefix string, annotations map[string]string) bool {
 	}
 	return false
 }
+
+// AddAnnotations sets the desired annotations on the object and returns true if the annotations have changed.
+func AddAnnotations(o metav1.Object, desired map[string]string) bool {
+	annotations := o.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	hasChanged := false
+	for k, v := range desired {
+		if cur, ok := annotations[k]; !ok || cur != v {
+			annotations[k] = v
+			hasChanged = true
+		}
+	}
+	return hasChanged
+}

--- a/util/annotations/helpers_test.go
+++ b/util/annotations/helpers_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestAddAnnotations(t *testing.T) {
+	g := NewWithT(t)
+
+	var testcases = []struct {
+		name     string
+		obj      metav1.Object
+		input    map[string]string
+		expected map[string]string
+		changed  bool
+	}{
+		{
+			name: "should return false if no changes are made",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input: map[string]string{
+				"foo": "bar",
+			},
+			expected: map[string]string{
+				"foo": "bar",
+			},
+			changed: false,
+		},
+		{
+			name: "should do nothing if no annotations are provided",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input: map[string]string{},
+			expected: map[string]string{
+				"foo": "bar",
+			},
+			changed: false,
+		},
+		{
+			name: "should return true if annotations are added",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input: map[string]string{
+				"thing1": "thing2",
+				"buzz":   "blah",
+			},
+			expected: map[string]string{
+				"foo":    "bar",
+				"thing1": "thing2",
+				"buzz":   "blah",
+			},
+			changed: true,
+		},
+		{
+			name: "should return true if annotations are changed",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input: map[string]string{
+				"foo": "buzz",
+			},
+			expected: map[string]string{
+				"foo": "buzz",
+			},
+			changed: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := AddAnnotations(tc.obj, tc.input)
+			g.Expect(res).To(Equal(tc.changed))
+			g.Expect(tc.obj.GetAnnotations()).To(Equal(tc.expected))
+		})
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Adds basic cluster info to nodes as annotations to allow users to know if the node was created using cluster api and which cluster/namespace/machine or machine pool it belongs to.

Tested using release-0.3 branch:

```
 k --kubeconfig ./kubeconfig describe node capz-cluster-7-md-0-5f9fq
Name:               capz-cluster-7-md-0-5f9fq
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=Standard_D2s_v3
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=southcentralus
                    failure-domain.beta.kubernetes.io/zone=0
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=capz-cluster-7-md-0-5f9fq
                    kubernetes.io/os=linux
                    node.kubernetes.io/instance-type=Standard_D2s_v3
                    topology.kubernetes.io/region=southcentralus
                    topology.kubernetes.io/zone=0
Annotations:        cluster.x-k8s.io/cluster-name: capz-cluster-7
                    cluster.x-k8s.io/cluster-namespace: default
                    cluster.x-k8s.io/machine: capz-cluster-7-md-0-567986c6b8-xk8k8
                    cluster.x-k8s.io/owner-kind: MachineSet
                    cluster.x-k8s.io/owner-name: capz-cluster-7-md-0-567986c6b8
                    kubeadm.alpha.kubernetes.io/cri-socket: /run/containerd/containerd.sock
                    node.alpha.kubernetes.io/ttl: 0
                    projectcalico.org/IPv4Address: 10.1.0.9/16
                    projectcalico.org/IPv4VXLANTunnelAddr: 192.168.194.128
                    volumes.kubernetes.io/controller-managed-attach-detach: true
``` 

```
 k --kubeconfig ./kubeconfig describe node capz-cluster-b-mp-0000001
Name:               capz-cluster-b-mp-0000001
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=Standard_D2s_v3
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=southcentralus
                    failure-domain.beta.kubernetes.io/zone=1
                    kubernetes.io/arch=amd64
                    kubernetes.io/hostname=capz-cluster-b-mp-0000001
                    kubernetes.io/os=linux
                    node.kubernetes.io/instance-type=Standard_D2s_v3
                    topology.kubernetes.io/region=southcentralus
                    topology.kubernetes.io/zone=1
Annotations:        cluster.x-k8s.io/cluster-name: capz-cluster-b
                    cluster.x-k8s.io/cluster-namespace: default
                    cluster.x-k8s.io/owner-kind: MachinePool
                    cluster.x-k8s.io/owner-name: capz-cluster-b-mp-0
                    kubeadm.alpha.kubernetes.io/cri-socket: /run/containerd/containerd.sock
                    node.alpha.kubernetes.io/ttl: 0
                    projectcalico.org/IPv4Address: 10.1.0.7/16
                    projectcalico.org/IPv4VXLANTunnelAddr: 192.168.219.0
                    volumes.kubernetes.io/controller-managed-attach-detach: true
```                 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4044 
