### PR TITLE
🐛 KubeadmControlPlane should adopt v1alpha2 kubeconfig secrets

### DIFF
--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -270,7 +270,7 @@ func (r *KubeadmControlPlaneReconciler) reconcile(ctx context.Context, cluster *
 	}
 
 	// Generate Cluster Kubeconfig if needed
-	if err := r.reconcileKubeconfig(ctx, util.ObjectKey(cluster), cluster.Spec.ControlPlaneEndpoint, kcp); err != nil {
+	if err := r.reconcileKubeconfig(ctx, cluster, kcp); err != nil {
 		logger.Error(err, "failed to reconcile Kubeconfig")
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Backports the fix made to the `main` branch as part of #4034 

**Which issue(s) this PR fixes**:
Fixes #4047 
