### PR TITLE
🌱 Move davidewatson to emeritus since he has not contributed for too

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,6 +11,7 @@ emeritus_approvers:
   - kris-nova
   - ncdc
   - roberthbailey
+  - davidewatson
 
 emeritus_maintainers:
   - ncdc

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,7 +16,6 @@ aliases:
   cluster-api-admins:
   - justinsb
   - detiber
-  - davidewatson
   - vincepri
 
   # non-admin folks who have write-access and can approve any PRs in the repo


### PR DESCRIPTION
long.

**What this PR does / why we need it**:
I have not contributed for too long, so it makes sense to give someone else the opportunity to have a more official role. FWIW I intend to focus on other Cluster Lifecycle operators for the time being. Hope to see everyone at the next KubeCon.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

N/A
