### PR TITLE
⚠️ Set user agent and timeout for remote cluster client

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -53,6 +53,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+const (
+	// KubeadmConfigControllerName defines the controller used when creating clients
+	KubeadmConfigControllerName = "kubeadmconfig-controller"
+)
+
 // InitLocker is a lock that is used around kubeadm init
 type InitLocker interface {
 	Lock(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) bool
@@ -266,7 +271,7 @@ func (r *KubeadmConfigReconciler) refreshBootstrapToken(ctx context.Context, con
 	log := ctrl.LoggerFrom(ctx)
 	token := config.Spec.JoinConfiguration.Discovery.BootstrapToken.Token
 
-	remoteClient, err := r.remoteClientGetter(ctx, r.Client, util.ObjectKey(cluster))
+	remoteClient, err := r.remoteClientGetter(ctx, KubeadmConfigControllerName, r.Client, util.ObjectKey(cluster))
 	if err != nil {
 		log.Error(err, "Error creating remote cluster client")
 		return ctrl.Result{}, err
@@ -284,7 +289,7 @@ func (r *KubeadmConfigReconciler) refreshBootstrapToken(ctx context.Context, con
 func (r *KubeadmConfigReconciler) rotateMachinePoolBootstrapToken(ctx context.Context, config *bootstrapv1.KubeadmConfig, cluster *clusterv1.Cluster, scope *Scope) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Config is owned by a MachinePool, checking if token should be rotated")
-	remoteClient, err := r.remoteClientGetter(ctx, r.Client, util.ObjectKey(cluster))
+	remoteClient, err := r.remoteClientGetter(ctx, KubeadmConfigControllerName, r.Client, util.ObjectKey(cluster))
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -757,7 +762,7 @@ func (r *KubeadmConfigReconciler) reconcileDiscovery(ctx context.Context, cluste
 
 	// if BootstrapToken already contains a token, respect it; otherwise create a new bootstrap token for the node to join
 	if config.Spec.JoinConfiguration.Discovery.BootstrapToken.Token == "" {
-		remoteClient, err := r.remoteClientGetter(ctx, r.Client, util.ObjectKey(cluster))
+		remoteClient, err := r.remoteClientGetter(ctx, KubeadmConfigControllerName, r.Client, util.ObjectKey(cluster))
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -52,6 +52,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+const (
+	// MachineControllerName defines the controller used when creating clients
+	MachineControllerName = "machine-controller"
+)
+
 var (
 	errNilNodeRef                 = errors.New("noderef is nil")
 	errLastControlPlaneNode       = errors.New("last control plane member")
@@ -487,7 +492,7 @@ func (r *MachineReconciler) isDeleteNodeAllowed(ctx context.Context, cluster *cl
 func (r *MachineReconciler) drainNode(ctx context.Context, cluster *clusterv1.Cluster, nodeName string) error {
 	log := ctrl.LoggerFrom(ctx, "cluster", cluster.Name, "node", nodeName)
 
-	restConfig, err := remote.RESTConfig(ctx, r.Client, util.ObjectKey(cluster))
+	restConfig, err := remote.RESTConfig(ctx, MachineControllerName, r.Client, util.ObjectKey(cluster))
 	if err != nil {
 		log.Error(err, "Error creating a remote client while deleting Machine, won't retry")
 		return nil

--- a/controllers/remote/cluster_cache.go
+++ b/controllers/remote/cluster_cache.go
@@ -42,11 +42,10 @@ import (
 )
 
 const (
-	defaultClientTimeout = 10 * time.Second
-
 	healthCheckPollInterval       = 10 * time.Second
 	healthCheckRequestTimeout     = 5 * time.Second
 	healthCheckUnhealthyThreshold = 10
+	ClusterCacheControllerName    = "cluster-cache-tracker"
 )
 
 // ClusterCacheTracker manages client caches for workload clusters.
@@ -119,11 +118,10 @@ func (t *ClusterCacheTracker) getClusterAccessorLH(ctx context.Context, cluster 
 // newClusterAccessor creates a new clusterAccessor.
 func (t *ClusterCacheTracker) newClusterAccessor(ctx context.Context, cluster client.ObjectKey) (*clusterAccessor, error) {
 	// Get a rest config for the remote cluster
-	config, err := RESTConfig(ctx, t.client, cluster)
+	config, err := RESTConfig(ctx, ClusterCacheControllerName, t.client, cluster)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error fetching REST client config for remote cluster %q", cluster.String())
 	}
-	config.Timeout = defaultClientTimeout
 
 	// Create a mapper for it
 	mapper, err := apiutil.NewDynamicRESTMapper(config)

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -18,6 +18,7 @@ package remote
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -95,21 +96,23 @@ func TestNewClusterClient(t *testing.T) {
 		gs := NewWithT(t)
 
 		client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(validSecret).Build()
-		_, err := NewClusterClient(ctx, client, clusterWithValidKubeConfig)
+		_, err := NewClusterClient(ctx, "test-source", client, clusterWithValidKubeConfig)
 		// Since we do not have a remote server to connect to, we should expect to get
 		// an error to that effect for the purpose of this test.
 		gs.Expect(err).To(MatchError(ContainSubstring("no such host")))
 
-		restConfig, err := RESTConfig(ctx, client, clusterWithValidKubeConfig)
+		restConfig, err := RESTConfig(ctx, "test-source", client, clusterWithValidKubeConfig)
 		gs.Expect(err).NotTo(HaveOccurred())
 		gs.Expect(restConfig.Host).To(Equal("https://test-cluster-api.nodomain.example.com:6443"))
+		gs.Expect(restConfig.UserAgent).To(MatchRegexp("remote.test/unknown test-source (.*) cluster.x-k8s.io/unknown"))
+		gs.Expect(restConfig.Timeout).To(Equal(10 * time.Second))
 	})
 
 	t.Run("cluster with no kubeconfig", func(t *testing.T) {
 		gs := NewWithT(t)
 
 		client := fake.NewClientBuilder().WithScheme(testScheme).Build()
-		_, err := NewClusterClient(ctx, client, clusterWithNoKubeConfig)
+		_, err := NewClusterClient(ctx, "test-source", client, clusterWithNoKubeConfig)
 		gs.Expect(err).To(MatchError(ContainSubstring("not found")))
 	})
 
@@ -117,7 +120,7 @@ func TestNewClusterClient(t *testing.T) {
 		gs := NewWithT(t)
 
 		client := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(invalidSecret).Build()
-		_, err := NewClusterClient(ctx, client, clusterWithInvalidKubeConfig)
+		_, err := NewClusterClient(ctx, "test-source", client, clusterWithInvalidKubeConfig)
 		gs.Expect(err).To(HaveOccurred())
 		gs.Expect(apierrors.IsNotFound(err)).To(BeFalse())
 	})

--- a/controllers/remote/fake/cluster.go
+++ b/controllers/remote/fake/cluster.go
@@ -24,6 +24,6 @@ import (
 
 // NewClusterClient returns the same client passed as input, as output. It is assumed that the client is a
 // fake controller-runtime client
-func NewClusterClient(_ context.Context, c client.Client, _ client.ObjectKey) (client.Client, error) {
+func NewClusterClient(_ context.Context, sourceName string, c client.Client, _ client.ObjectKey) (client.Client, error) {
 	return c, nil
 }

--- a/controllers/remote/restconfig.go
+++ b/controllers/remote/restconfig.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	gruntime "runtime"
+	"strings"
+
+	"sigs.k8s.io/cluster-api/version"
+)
+
+const (
+	unknowString = "unknown"
+)
+
+func buildUserAgent(command, version, sourceName, os, arch, commit string) string {
+	return fmt.Sprintf(
+		"%s/%s %s (%s/%s) cluster.x-k8s.io/%s", command, version, sourceName, os, arch, commit)
+}
+
+// DefaultClusterAPIUserAgent returns a User-Agent string built from static global vars.
+func DefaultClusterAPIUserAgent(sourceName string) string {
+	return buildUserAgent(
+		adjustCommand(os.Args[0]),
+		adjustVersion(version.Get().GitVersion),
+		adjustSourceName(sourceName),
+		gruntime.GOOS,
+		gruntime.GOARCH,
+		adjustCommit(version.Get().GitCommit))
+}
+
+// adjustSourceName returns the name of the source calling the client
+func adjustSourceName(c string) string {
+	if len(c) == 0 {
+		return unknowString
+	}
+	return c
+}
+
+// adjustCommit returns sufficient significant figures of the commit's git hash.
+func adjustCommit(c string) string {
+	if len(c) == 0 {
+		return unknowString
+	}
+	if len(c) > 7 {
+		return c[:7]
+	}
+	return c
+}
+
+// adjustVersion strips "alpha", "beta", etc. from version in form
+// major.minor.patch-[alpha|beta|etc].
+func adjustVersion(v string) string {
+	if len(v) == 0 {
+		return unknowString
+	}
+	seg := strings.SplitN(v, "-", 2)
+	return seg[0]
+}
+
+// adjustCommand returns the last component of the
+// OS-specific command path for use in User-Agent.
+func adjustCommand(p string) string {
+	// Unlikely, but better than returning "".
+	if len(p) == 0 {
+		return unknowString
+	}
+	return filepath.Base(p)
+}

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -34,6 +34,11 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	// KubeadmControlPlaneControllerName defines the controller used when creating clients
+	KubeadmControlPlaneControllerName = "kubeadm-controlplane-controller"
+)
+
 // ManagementCluster defines all behaviors necessary for something to function as a management cluster.
 type ManagementCluster interface {
 	ctrlclient.Reader
@@ -86,7 +91,7 @@ func (m *Management) GetMachinesForCluster(ctx context.Context, cluster client.O
 func (m *Management) GetWorkloadCluster(ctx context.Context, clusterKey client.ObjectKey) (WorkloadCluster, error) {
 	// TODO(chuckha): Inject this dependency.
 	// TODO(chuckha): memoize this function. The workload client only exists as long as a reconciliation loop.
-	restConfig, err := remote.RESTConfig(ctx, m.Client, clusterKey)
+	restConfig, err := remote.RESTConfig(ctx, KubeadmControlPlaneControllerName, m.Client, clusterKey)
 	if err != nil {
 		return nil, err
 	}

--- a/exp/controllers/machinepool_controller.go
+++ b/exp/controllers/machinepool_controller.go
@@ -51,6 +51,11 @@ import (
 // +kubebuilder:rbac:groups=exp.infrastructure.cluster.x-k8s.io;infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=exp.cluster.x-k8s.io,resources=machinepools;machinepools/status,verbs=get;list;watch;create;update;patch;delete
 
+const (
+	// MachinePoolControllerName defines the controller used when creating clients
+	MachinePoolControllerName = "machinepool-controller"
+)
+
 // MachinePoolReconciler reconciles a MachinePool object
 type MachinePoolReconciler struct {
 	Client client.Client
@@ -230,7 +235,7 @@ func (r *MachinePoolReconciler) reconcileDeleteNodes(ctx context.Context, cluste
 		return nil
 	}
 
-	clusterClient, err := remote.NewClusterClient(ctx, r.Client, util.ObjectKey(cluster))
+	clusterClient, err := remote.NewClusterClient(ctx, MachinePoolControllerName, r.Client, util.ObjectKey(cluster))
 	if err != nil {
 		return err
 	}

--- a/exp/controllers/machinepool_controller_noderef.go
+++ b/exp/controllers/machinepool_controller_noderef.go
@@ -19,9 +19,10 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
-	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -74,7 +75,7 @@ func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, cluster *
 		return ctrl.Result{}, nil
 	}
 
-	clusterClient, err := remote.NewClusterClient(ctx, r.Client, util.ObjectKey(cluster))
+	clusterClient, err := remote.NewClusterClient(ctx, MachinePoolControllerName, r.Client, util.ObjectKey(cluster))
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- set a UserAgent and Timeout for remote cluster client

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2993 
