### PR TITLE
🐛 Use nonroot user with id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,9 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o manager ${package}
 
 # Production image
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nobody
+# Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
+USER 65532
 ENTRYPOINT ["/manager"]

--- a/bootstrap/kubeadm/config/manager/manager_auth_proxy_patch.yaml
+++ b/bootstrap/kubeadm/config/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/cmd/clusterctl/client/init_test.go
+++ b/cmd/clusterctl/client/init_test.go
@@ -80,7 +80,7 @@ func Test_clusterctlClient_InitImages(t *testing.T) {
 				kubeconfigContext:      "mgmt-context",
 			},
 			expectedImages: []string{
-				"gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0",
+				"gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0",
 				"us.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller:v0.5.3",
 			},
 			wantErr: false,
@@ -765,7 +765,7 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+      - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
       - image: us.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller:v0.5.3
         name: manager

--- a/cmd/clusterctl/internal/util/objs_test.go
+++ b/cmd/clusterctl/internal/util/objs_test.go
@@ -80,7 +80,7 @@ func Test_inspectImages(t *testing.T) {
 											},
 											{
 												"name":  "kube-rbac-proxy",
-												"image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0",
+												"image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0",
 											},
 										},
 									},
@@ -90,7 +90,7 @@ func Test_inspectImages(t *testing.T) {
 					},
 				},
 			},
-			want:    []string{"gcr.io/k8s-staging-cluster-api/cluster-api-controller:master", "gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0"},
+			want:    []string{"gcr.io/k8s-staging-cluster-api/cluster-api-controller:master", "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"},
 			wantErr: false,
 		},
 		{

--- a/config/ci/manager/manager_auth_proxy_patch.yaml
+++ b/config/ci/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/controlplane/kubeadm/config/manager/manager_auth_proxy_patch.yaml
+++ b/controlplane/kubeadm/config/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
+++ b/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
@@ -12,9 +12,9 @@
 
 - The KIND version used for this release is v0.9.x
 
-## Upgrade kube-rbac-proxy to v0.5.0
+## Upgrade kube-rbac-proxy to v0.8.0
 
-- Find and replace the `kube-rbac-proxy` version (usually the image is `gcr.io/kubebuilder/kube-rbac-proxy`) and update it to `v0.5.0`.
+- Find and replace the `kube-rbac-proxy` version (usually the image is `gcr.io/kubebuilder/kube-rbac-proxy`) and update it to `v0.8.0`.
 
 ## The controllers.DeleteNodeAnnotation constant has been removed
 

--- a/test/infrastructure/docker/config/manager/manager_auth_proxy_patch.yaml
+++ b/test/infrastructure/docker/config/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This pr updates the non root user from `nobody` to `nonroot` (with id). This is needed when pod security policies are enabled in the cluster to prevent containers from running as root.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4046 
