### PR TITLE
🐛 Avoid reporting health check error when the cache is stopped

### DIFF
--- a/controllers/remote/cluster_cache.go
+++ b/controllers/remote/cluster_cache.go
@@ -346,7 +346,9 @@ func (t *ClusterCacheTracker) healthCheckCluster(ctx context.Context, in *health
 	err := wait.PollImmediateUntil(in.interval, runHealthCheckWithThreshold, ctx.Done())
 	// An error returned implies the health check has failed a sufficient number of
 	// times for the cluster to be considered unhealthy
-	if err != nil {
+	// NB. we are ignoring ErrWaitTimeout because this error happens when the channel is close, that in this case
+	// happens when the cache is explicitly stopped.
+	if err != nil && err != wait.ErrWaitTimeout {
 		t.log.Error(err, "Error health checking cluster", "cluster", in.cluster.String())
 		t.deleteAccessor(in.cluster)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

While investigating some unit test flakes I have found the cluster cache logging "msg"="Error health checking cluster" "error"="timed out waiting for the condition" while doing the MHC unit tests.

This isn't a real flake, it is just a log entry, however, it generates a lot of noise and makes it difficult to spot the real problems.

This PR is fixing this by making to log the entry only when necessary (and not when the cluster cache is intentionally stopped)

/cc @vincepri 