### PR TITLE
🐛 Handle stopped containers in capd

### DIFF
--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
@@ -299,6 +299,9 @@ func (r *DockerMachineReconciler) reconcileNormal(ctx context.Context, cluster *
 	// Requeue if there is an error, as this is likely momentary load balancer
 	// state changes during control plane provisioning.
 	if err := externalMachine.SetNodeProviderID(ctx); err != nil {
+		if errors.As(err, &docker.ContainerNotRunningError{}) {
+			return ctrl.Result{}, errors.Wrap(err, "failed to patch the Kubernetes node with the machine providerID")
+		}
 		log.Error(err, "failed to patch the Kubernetes node with the machine providerID")
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}

--- a/test/infrastructure/docker/docker/errors.go
+++ b/test/infrastructure/docker/docker/errors.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import "fmt"
+
+// ContainerNotRunningError is returned when trying to patch a container that is not running
+type ContainerNotRunningError struct {
+	Name string
+}
+
+// Error returns the error string
+func (cse ContainerNotRunningError) Error() string {
+	return fmt.Sprintf("container with name %q is not running", cse.Name)
+}

--- a/test/infrastructure/docker/docker/machine.go
+++ b/test/infrastructure/docker/docker/machine.go
@@ -325,6 +325,9 @@ func (m *Machine) SetNodeProviderID(ctx context.Context) error {
 	if kubectlNode == nil {
 		return errors.New("unable to set NodeProviderID. there are no kubectl node available")
 	}
+	if !kubectlNode.IsRunning() {
+		return errors.Wrapf(ContainerNotRunningError{Name: kubectlNode.Name}, "unable to set NodeProviderID")
+	}
 
 	log.Info("Setting Kubernetes node providerID")
 	patch := fmt.Sprintf(`{"spec": {"providerID": "%s"}}`, m.ProviderID())

--- a/test/infrastructure/docker/docker/types/node.go
+++ b/test/infrastructure/docker/docker/types/node.go
@@ -35,6 +35,7 @@ type Node struct {
 	ClusterRole string
 	InternalIP  string
 	Image       string
+	status      string
 	Commander   *containerCmder
 }
 
@@ -46,6 +47,12 @@ func NewNode(name, image, role string) *Node {
 		ClusterRole: role,
 		Commander:   ContainerCmder(name),
 	}
+}
+
+// WithStatus sets the status of the container and returns the node
+func (n *Node) WithStatus(status string) *Node {
+	n.status = status
+	return n
 }
 
 // String returns the name of the node.
@@ -77,6 +84,11 @@ func (n *Node) IP(ctx context.Context) (ipv4 string, ipv6 string, err error) {
 		return "", "", errors.Errorf("container addresses should have 2 values, got %d values", len(ips))
 	}
 	return ips[0], ips[1], nil
+}
+
+// IsRunning returns if the container is running
+func (n *Node) IsRunning() bool {
+	return strings.HasPrefix(n.status, "Up")
 }
 
 // Delete removes the container.

--- a/test/infrastructure/docker/docker/util.go
+++ b/test/infrastructure/docker/docker/util.go
@@ -110,7 +110,7 @@ func list(visit func(string, *types.Node), filters ...string) error {
 		// filter for nodes with the cluster label
 		"--filter", "label=" + clusterLabelKey,
 		// format to include friendly name and the cluster name
-		"--format", fmt.Sprintf(`{{.Names}}\t{{.Label "%s"}}\t{{.Image}}`, clusterLabelKey),
+		"--format", fmt.Sprintf(`{{.Names}}\t{{.Label "%s"}}\t{{.Image}}\t{{.Status}}`, clusterLabelKey),
 	}
 	for _, filter := range filters {
 		args = append(args, "--filter", filter)
@@ -122,13 +122,14 @@ func list(visit func(string, *types.Node), filters ...string) error {
 	}
 	for _, line := range lines {
 		parts := strings.Split(line, "\t")
-		if len(parts) != 3 {
+		if len(parts) != 4 {
 			return errors.Errorf("invalid output when listing nodes: %s", line)
 		}
 		names := strings.Split(parts[0], ",")
 		cluster := parts[1]
 		image := parts[2]
-		visit(cluster, types.NewNode(names[0], image, "undetermined"))
+		status := parts[3]
+		visit(cluster, types.NewNode(names[0], image, "undetermined").WithStatus(status))
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This pr checks returns an error and prevent reconciliation loop if a stopped container is being patched. 
It does NOT handle when two clusters are created with the same name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3973 
