### PR TITLE
🐛 Increase timeout in clusterresourceset controller unit tests

### DIFF
--- a/exp/addons/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/controllers/clusterresourceset_controller_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	timeout              = time.Second * 10
+	timeout              = time.Second * 20
 	defaultNamespaceName = "default"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases timeout in clusterresourceset controller unit tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4075 
