### PR TITLE
🐛 Skip E2E Conformance tests labeled as Serial

### DIFF
--- a/test/e2e/data/kubetest/conformance.yaml
+++ b/test/e2e/data/kubetest/conformance.yaml
@@ -1,4 +1,5 @@
 ginkgo.focus: \[Conformance\]
+ginkgo.skip: \[Serial\]
 disable-log-dump: true
 ginkgo.progress: true
 ginkgo.slowSpecThreshold: 120.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `ginkgo.skip` to E2E Conformance tests labeled as Serial.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4077 
