### PR TITLE
:bug: Test environments should wait for manager before running tests

### DIFF
--- a/bootstrap/kubeadm/controllers/suite_test.go
+++ b/bootstrap/kubeadm/controllers/suite_test.go
@@ -44,7 +44,7 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = helpers.NewTestEnvironment()
 
@@ -55,7 +55,6 @@ var _ = BeforeSuite(func(done Done) {
 	}()
 
 	<-testEnv.Manager.Elected()
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/bootstrap/kubeadm/controllers/suite_test.go
+++ b/bootstrap/kubeadm/controllers/suite_test.go
@@ -54,6 +54,7 @@ var _ = BeforeSuite(func(done Done) {
 		Expect(testEnv.StartManager(ctx)).To(Succeed())
 	}()
 
+	<-testEnv.Manager.Elected()
 	close(done)
 }, 60)
 

--- a/controllers/remote/cluster_cache_healthcheck_test.go
+++ b/controllers/remote/cluster_cache_healthcheck_test.go
@@ -65,6 +65,7 @@ var _ = Describe("ClusterCache HealthCheck suite", func() {
 			go func() {
 				Expect(mgr.Start(mgrContext)).To(Succeed())
 			}()
+			<-testEnv.Manager.Elected()
 
 			k8sClient = mgr.GetClient()
 

--- a/controllers/remote/cluster_cache_reconciler_test.go
+++ b/controllers/remote/cluster_cache_reconciler_test.go
@@ -101,6 +101,7 @@ var _ = Describe("ClusterCache Reconciler suite", func() {
 			go func() {
 				Expect(mgr.Start(mgrContext)).To(Succeed())
 			}()
+			<-testEnv.Manager.Elected()
 
 			k8sClient = mgr.GetClient()
 

--- a/controllers/remote/cluster_cache_tracker_test.go
+++ b/controllers/remote/cluster_cache_tracker_test.go
@@ -80,6 +80,7 @@ var _ = Describe("ClusterCache Tracker suite", func() {
 			go func() {
 				Expect(mgr.Start(mgrContext)).To(Succeed())
 			}()
+			<-testEnv.Manager.Elected()
 
 			k8sClient = mgr.GetClient()
 

--- a/controllers/remote/suite_test.go
+++ b/controllers/remote/suite_test.go
@@ -49,7 +49,7 @@ func TestGinkgoSuite(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = helpers.NewTestEnvironment()
 
@@ -60,7 +60,6 @@ var _ = BeforeSuite(func(done Done) {
 	}()
 
 	<-testEnv.Manager.Elected()
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/controllers/remote/suite_test.go
+++ b/controllers/remote/suite_test.go
@@ -59,6 +59,7 @@ var _ = BeforeSuite(func(done Done) {
 		Expect(testEnv.StartManager(ctx)).To(Succeed())
 	}()
 
+	<-testEnv.Manager.Elected()
 	close(done)
 }, 60)
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -107,6 +107,8 @@ func TestMain(m *testing.M) {
 			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
 		}
 	}()
+	<-testEnv.Manager.Elected()
+
 	// wait for webhook port to be open prior to running tests
 	testEnv.WaitForWebhooks()
 

--- a/controlplane/kubeadm/controllers/suite_test.go
+++ b/controlplane/kubeadm/controllers/suite_test.go
@@ -54,6 +54,8 @@ func TestMain(m *testing.M) {
 			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
 		}
 	}()
+	<-testEnv.Manager.Elected()
+
 	// Run tests
 	code := m.Run()
 	// Tearing down the test environment

--- a/controlplane/kubeadm/internal/suite_test.go
+++ b/controlplane/kubeadm/internal/suite_test.go
@@ -37,6 +37,7 @@ func TestMain(m *testing.M) {
 			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
 		}
 	}()
+	<-testEnv.Manager.Elected()
 
 	code := m.Run()
 

--- a/exp/addons/controllers/suite_test.go
+++ b/exp/addons/controllers/suite_test.go
@@ -47,7 +47,7 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = helpers.NewTestEnvironment()
 	trckr, err := remote.NewClusterCacheTracker(log.NullLogger{}, testEnv.Manager)
@@ -67,7 +67,6 @@ var _ = BeforeSuite(func(done Done) {
 	}()
 
 	<-testEnv.Manager.Elected()
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/exp/addons/controllers/suite_test.go
+++ b/exp/addons/controllers/suite_test.go
@@ -66,6 +66,7 @@ var _ = BeforeSuite(func(done Done) {
 		Expect(testEnv.StartManager(ctx)).To(Succeed())
 	}()
 
+	<-testEnv.Manager.Elected()
 	close(done)
 }, 60)
 

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -45,7 +45,7 @@ func TestAPIs(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = helpers.NewTestEnvironment()
 
@@ -61,7 +61,6 @@ var _ = BeforeSuite(func(done Done) {
 	}()
 
 	<-testEnv.Manager.Elected()
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -60,6 +60,7 @@ var _ = BeforeSuite(func(done Done) {
 		Expect(testEnv.StartManager(ctx)).To(Succeed())
 	}()
 
+	<-testEnv.Manager.Elected()
 	close(done)
 }, 60)
 

--- a/util/patch/suite_test.go
+++ b/util/patch/suite_test.go
@@ -49,7 +49,7 @@ func TestPatch(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = helpers.NewTestEnvironment()
 
@@ -60,7 +60,6 @@ var _ = BeforeSuite(func(done Done) {
 	}()
 
 	<-testEnv.Manager.Elected()
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/util/patch/suite_test.go
+++ b/util/patch/suite_test.go
@@ -59,6 +59,7 @@ var _ = BeforeSuite(func(done Done) {
 		Expect(testEnv.StartManager(ctx)).To(Succeed())
 	}()
 
+	<-testEnv.Manager.Elected()
 	close(done)
 }, 60)
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds a one liner in BeforeSuite, and all the other places where we start a Manager that properly waits for the manager to be elected (and therefore for the cache to sync) before running any sort of test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4068 

/milestone v0.4.0
