### PR TITLE
🌱 Switch KCP to use ClusterCacheTracker.GetClient for the workload cluster

### DIFF
--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -98,6 +98,7 @@ func (r *KubeadmControlPlaneReconciler) SetupWithManager(ctx context.Context, mg
 		}
 		r.managementCluster = &internal.Management{Client: r.Client, Tracker: r.Tracker}
 	}
+
 	if r.managementClusterUncached == nil {
 		r.managementClusterUncached = &internal.Management{Client: mgr.GetAPIReader()}
 	}

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -97,6 +97,10 @@ func (m *Management) GetWorkloadCluster(ctx context.Context, clusterKey client.O
 	}
 	restConfig.Timeout = 30 * time.Second
 
+	if m.Tracker == nil {
+		return nil, errors.New("Cannot get WorkloadCluster: No remote Cluster Cache")
+	}
+
 	c, err := m.Tracker.GetClient(ctx, clusterKey)
 	if err != nil {
 		return nil, err

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/internal/machinefilters"
@@ -49,7 +48,8 @@ type ManagementCluster interface {
 
 // Management holds operations on the management cluster.
 type Management struct {
-	Client ctrlclient.Reader
+	Client  ctrlclient.Reader
+	Tracker *remote.ClusterCacheTracker
 }
 
 // RemoteClusterConnectionError represents a failure to connect to a remote cluster
@@ -97,9 +97,9 @@ func (m *Management) GetWorkloadCluster(ctx context.Context, clusterKey client.O
 	}
 	restConfig.Timeout = 30 * time.Second
 
-	c, err := client.New(restConfig, client.Options{Scheme: scheme.Scheme})
+	c, err := m.Tracker.GetClient(ctx, clusterKey)
 	if err != nil {
-		return nil, &RemoteClusterConnectionError{Name: clusterKey.String(), Err: err}
+		return nil, err
 	}
 
 	// Retrieves the etcd CA key Pair

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -107,9 +107,8 @@ func TestGetWorkloadCluster(t *testing.T) {
 		log.Log,
 		testEnv.Manager,
 	)
-	if err != nil {
-		panic(fmt.Sprintf("unable to create cluster cache tracker: %v", err))
-	}
+	g.Expect(err).ToNot(HaveOccurred())
+
 	// Create kubeconfig secret
 	// Store the envtest config as the contents of the kubeconfig secret.
 	// This way we are using the envtest environment as both the

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -107,6 +107,9 @@ func TestGetWorkloadCluster(t *testing.T) {
 		log.Log,
 		testEnv.Manager,
 	)
+	if err != nil {
+		panic(fmt.Sprintf("unable to create cluster cache tracker: %v", err))
+	}
 	// Create kubeconfig secret
 	// Store the envtest config as the contents of the kubeconfig secret.
 	// This way we are using the envtest environment as both the


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses ` remote.ClusterCacheTracker ` to get a client for KCP to be used for the workload cluster, instead of creating one.

**Which issue(s) this PR fixes**:
Fixes #3457 
