### PR TITLE
:seedling: Remove the image placeholder in release notes

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -174,7 +174,6 @@ func run() int {
 		}
 	}
 
-	fmt.Println("The image for this release is: `<ADD_IMAGE_HERE>`.")
 	fmt.Println("")
 	fmt.Println("_Thanks to all our contributors!_ 😊")
 


### PR DESCRIPTION

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This has been unused for a while, removing it now to avoid confusion.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/assign @CecileRobertMichon 
/milestone v0.4.0
