### PR TITLE
✨ add progress hooks for ApplyClusterTemplateAndWait

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
-
 	"github.com/blang/semver"
+	. "github.com/onsi/ginkgo"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/test/framework"
 	"sigs.k8s.io/cluster-api/util"

--- a/test/e2e/k8s_conformance.go
+++ b/test/e2e/k8s_conformance.go
@@ -98,6 +98,11 @@ func K8SConformanceSpec(ctx context.Context, inputGetter func() K8SConformanceSp
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			PostControlPlaneInitialized: func(res *clusterctl.ApplyClusterTemplateAndWaitResult) error {
+				// in case the cluster fails the initialize set an intermediate result
+				clusterResources = res
+				return nil
+			},
 		})
 
 		workloadProxy := input.BootstrapClusterProxy.GetWorkloadCluster(ctx, namespace.Name, clusterResources.Cluster.Name)

--- a/test/e2e/kcp_upgrade.go
+++ b/test/e2e/kcp_upgrade.go
@@ -88,6 +88,11 @@ func KCPUpgradeSpec(ctx context.Context, inputGetter func() KCPUpgradeSpecInput)
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			PostWorkloadClusterProvisioned: func(res *clusterctl.ApplyClusterTemplateAndWaitResult) error {
+				// in case the cluster fails to initialize set an intermediate result for logging
+				clusterResources = res
+				return nil
+			},
 		})
 
 		By("Upgrading Kubernetes, DNS, kube-proxy, and etcd versions")

--- a/test/e2e/machine_pool.go
+++ b/test/e2e/machine_pool.go
@@ -88,6 +88,11 @@ func MachinePoolSpec(ctx context.Context, inputGetter func() MachinePoolInput) {
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachinePools:          input.E2EConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
+			PostWorkloadClusterProvisioned: func(res *clusterctl.ApplyClusterTemplateAndWaitResult) error {
+				// in case the cluster fails to initialize set an intermediate result for logging
+				clusterResources = res
+				return nil
+			},
 		})
 
 		By("Scaling the machine pool up")

--- a/test/e2e/md_upgrades.go
+++ b/test/e2e/md_upgrades.go
@@ -88,6 +88,11 @@ func MachineDeploymentUpgradesSpec(ctx context.Context, inputGetter func() Machi
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			PostWorkloadClusterProvisioned: func(res *clusterctl.ApplyClusterTemplateAndWaitResult) error {
+				// in case the cluster fails to initialize set an intermediate result for logging
+				clusterResources = res
+				return nil
+			},
 		})
 
 		By("Upgrading MachineDeployment's Kubernetes version to a valid version")

--- a/test/e2e/mhc_remediations.go
+++ b/test/e2e/mhc_remediations.go
@@ -86,6 +86,11 @@ func MachineRemediationSpec(ctx context.Context, inputGetter func() MachineRemed
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			PostWorkloadClusterProvisioned: func(res *clusterctl.ApplyClusterTemplateAndWaitResult) error {
+				// in case the cluster fails to initialize set an intermediate result for logging
+				clusterResources = res
+				return nil
+			},
 		})
 
 		By("Setting a machine unhealthy and wait for MachineDeployment remediation")

--- a/test/e2e/quick_start.go
+++ b/test/e2e/quick_start.go
@@ -89,6 +89,11 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			PostWorkloadClusterProvisioned: func(res *clusterctl.ApplyClusterTemplateAndWaitResult) error {
+				// in case the cluster fails to initialize set an intermediate result for logging
+				clusterResources = res
+				return nil
+			},
 		})
 
 		By("PASSED!")

--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -94,6 +94,11 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			PostWorkloadClusterProvisioned: func(res *clusterctl.ApplyClusterTemplateAndWaitResult) error {
+				// in case the cluster fails to initialize set an intermediate result for logging
+				clusterResources = res
+				return nil
+			},
 		})
 
 		By("Turning the workload cluster into a management cluster")

--- a/test/framework/clusterctl/clusterctl_helpers_test.go
+++ b/test/framework/clusterctl/clusterctl_helpers_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterctl_test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+)
+
+func TestApplyAndWaitHook_Do(t *testing.T) {
+	cases := []struct {
+		Name string
+		Test func(g *WithT)
+	}{
+		{
+			Name: "will not panic with nil hook",
+			Test: func(g *WithT) {
+				var hook clusterctl.ApplyAndWaitHook = nil
+				g.Expect(hook.Do(new(clusterctl.ApplyClusterTemplateAndWaitResult))).To(Succeed())
+			},
+		},
+		{
+			Name: "if hook is not nil, will pass result",
+			Test: func(g *WithT) {
+				var actual *clusterctl.ApplyClusterTemplateAndWaitResult
+				var hook = clusterctl.ApplyAndWaitHook(func(res *clusterctl.ApplyClusterTemplateAndWaitResult) error {
+					actual = res
+					return nil
+				})
+
+				expected := &clusterctl.ApplyClusterTemplateAndWaitResult{
+					Cluster: &clusterv1.Cluster{},
+				}
+				g.Expect(hook.Do(expected)).To(Succeed())
+				g.Expect(expected).To(Equal(actual))
+			},
+		},
+		{
+			Name: "non-nil hook will return error",
+			Test: func(g *WithT) {
+				var hook = clusterctl.ApplyAndWaitHook(func(res *clusterctl.ApplyClusterTemplateAndWaitResult) error {
+					return errors.New("boom")
+				})
+
+				g.Expect(hook.Do(nil)).To(HaveOccurred())
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			c.Test(NewWithT(t))
+		})
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
`clusterctl.ApplyClusterTemplateAndWait` in the case of failure when building a cluster during e2e tests, the function will not return. This makes it tough for callers to interrogate / debug a cluster if it never successfully provisions. It would be useful to either return an error up the stack or provide hooks to cluster provisioning lifecycle. Since rebuilding the test framework to return errors up the stack would be a huge undertaking, adding hooks seems like a pragmatic way to provide access. By providing these hooks, a caller can get updates about the cluster's lifecycle and even act on the cluster along the way.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
related to #2955
