### PR TITLE
⚠️  clusterctl completion zsh: Use native zsh completion

### DIFF
--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -17,14 +17,15 @@ limitations under the License.
 package cmd
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
 )
 
-const completionBoilerPlate = `
-# Copyright 2020 The Kubernetes Authors.
+const completionBoilerPlate = `# Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,22 +45,10 @@ var (
 		Output shell completion code for the specified shell (bash or zsh).
 		The shell code must be evaluated to provide interactive completion of
 		clusterctl commands. This can be done by sourcing it from the
-		.bash_profile.
-
-		Note: this requires the bash-completion framework.
-
-		To install it on macOS use Homebrew:
-		    $ brew install bash-completion
-		Once installed, bash_completion must be evaluated. This can be done by
-		adding the following line to the .bash_profile
-		    [[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
-
-		If bash-completion is not installed on Linux, please install the
-		'bash-completion' package via your distribution's package manager.
-
-		Note for zsh users: [1] zsh completions are only supported in versions of zsh >= 5.2`)
+		.bash_profile.`)
 
 	completionExample = Examples(`
+		Bash:
 		# Install bash completion on macOS using Homebrew
 		brew install bash-completion
 		printf "\n# Bash completion support\nsource $(brew --prefix)/etc/bash_completion\n" >> $HOME/.bash_profile
@@ -73,20 +62,29 @@ var (
 		printf "\n# clusterctl shell completion\nsource '$HOME/.kube/clusterctl_completion.bash.inc'\n" >> $HOME/.bash_profile
 		source $HOME/.bash_profile
 
-		# Load the clusterctl completion code for zsh[1] into the current shell
-		source <(clusterctl completion zsh)`)
+		Zsh:
+		# If shell completion is not already enabled in your environment you will need
+		# to enable it.  You can execute the following once:
+		echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+		# To load completions for each session, execute once:
+		clusterctl completion zsh > "${fpath[1]}/_clusterctl"
+
+		# You will need to start a new shell for this setup to take effect.`)
 
 	completionCmd = &cobra.Command{
-		Use:       "completion [bash|zsh]",
-		Short:     "Output shell completion code for the specified shell (bash or zsh)",
-		Long:      LongDesc(completionLong),
-		Example:   completionExample,
-		Args:      cobra.ExactArgs(1),
-		RunE:      runCompletion,
+		Use:     "completion [bash|zsh]",
+		Short:   "Output shell completion code for the specified shell (bash or zsh)",
+		Long:    LongDesc(completionLong),
+		Example: completionExample,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCompletion(os.Stdout, cmd, args[0])
+		},
 		ValidArgs: GetSupportedShells(),
 	}
 
-	completionShells = map[string]func(cmd *cobra.Command) error{
+	completionShells = map[string]func(out io.Writer, cmd *cobra.Command) error{
 		"bash": runCompletionBash,
 		"zsh":  runCompletionZsh,
 	}
@@ -105,129 +103,35 @@ func init() {
 	RootCmd.AddCommand(completionCmd)
 }
 
-func runCompletion(cmd *cobra.Command, args []string) error {
-
-	run, found := completionShells[args[0]]
+func runCompletion(out io.Writer, cmd *cobra.Command, shell string) error {
+	run, found := completionShells[shell]
 	if !found {
-		return fmt.Errorf("unsupported shell type %q", args[0])
+		return fmt.Errorf("unsupported shell type %q", shell)
 	}
 
-	return run(cmd.Parent())
+	return run(out, cmd)
 }
 
-func runCompletionBash(cmd *cobra.Command) error {
-	return cmd.GenBashCompletion(os.Stdout)
+func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
+	fmt.Fprintf(out, "%s\n", completionBoilerPlate)
+
+	return cmd.Root().GenBashCompletion(out)
 }
 
-const (
-	completionZshHead = "#compdef clusterctl\n"
+func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
+	var b bytes.Buffer
 
-	completionZshInitialization = `
-__clusterctl_bash_source() {
-	alias shopt=':'
-	emulate -L sh
-	setopt kshglob noshglob braceexpand
-	source "$@"
-}
-__clusterctl_type() {
-	# -t is not supported by zsh
-	if [ "$1" == "-t" ]; then
-		shift
-		# fake Bash 4 to disable "complete -o nospace". Instead
-		# "compopt +-o nospace" is used in the code to toggle trailing
-		# spaces. We don't support that, but leave trailing spaces on
-		# all the time
-		if [ "$1" = "__clusterctl_compopt" ]; then
-			echo builtin
-			return 0
-		fi
-	fi
-	type "$@"
-}
-__clusterctl_compgen() {
-	local completions w
-	completions=( $(compgen "$@") ) || return $?
-	# filter by given word as prefix
-	while [[ "$1" = -* && "$1" != -- ]]; do
-		shift
-		shift
-	done
-	if [[ "$1" == -- ]]; then
-		shift
-	fi
-	for w in "${completions[@]}"; do
-		if [[ "${w}" = "$1"* ]]; then
-			echo "${w}"
-		fi
-	done
-}
-__clusterctl_compopt() {
-	true # don't do anything. Not supported by bashcompinit in zsh
-}
-__clusterctl_ltrim_colon_completions()
-{
-	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
-		# Remove colon-word prefix from COMPREPLY items
-		local colon_word=${1%${1##*:}}
-		local i=${#COMPREPLY[*]}
-		while [[ $((--i)) -ge 0 ]]; do
-			COMPREPLY[$i]=${COMPREPLY[$i]#"$colon_word"}
-		done
-	fi
-}
-__clusterctl_get_comp_words_by_ref() {
-	cur="${COMP_WORDS[COMP_CWORD]}"
-	prev="${COMP_WORDS[${COMP_CWORD}-1]}"
-	words=("${COMP_WORDS[@]}")
-	cword=("${COMP_CWORD[@]}")
-}
-__clusterctl_filedir() {
-	# Don't need to do anything here.
-	# Otherwise we will get trailing space without "compopt -o nospace"
-	true
-}
-autoload -U +X bashcompinit && bashcompinit
-# use word boundary patterns for BSD or GNU sed
-LWORD='[[:<:]]'
-RWORD='[[:>:]]'
-if sed --help 2>&1 | grep -q 'GNU\|BusyBox'; then
-	LWORD='\<'
-	RWORD='\>'
-fi
-__clusterctl_convert_bash_to_zsh() {
-	sed \
-	-e 's/declare -F/whence -w/' \
-	-e 's/_get_comp_words_by_ref "\$@"/_get_comp_words_by_ref "\$*"/' \
-	-e 's/local \([a-zA-Z0-9_]*\)=/local \1; \1=/' \
-	-e 's/flags+=("\(--.*\)=")/flags+=("\1"); two_word_flags+=("\1")/' \
-	-e 's/must_have_one_flag+=("\(--.*\)=")/must_have_one_flag+=("\1")/' \
-	-e "s/${LWORD}_filedir${RWORD}/__clusterctl_filedir/g" \
-	-e "s/${LWORD}_get_comp_words_by_ref${RWORD}/__clusterctl_get_comp_words_by_ref/g" \
-	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__clusterctl_ltrim_colon_completions/g" \
-	-e "s/${LWORD}compgen${RWORD}/__clusterctl_compgen/g" \
-	-e "s/${LWORD}compopt${RWORD}/__clusterctl_compopt/g" \
-	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
-	-e "s/\\\$(type${RWORD}/\$(__clusterctl_type/g" \
-	<<'BASH_COMPLETION_EOF'
-`
-
-	completionZshTail = `
-BASH_COMPLETION_EOF
-}
-__clusterctl_bash_source <(__clusterctl_convert_bash_to_zsh)
-`
-)
-
-func runCompletionZsh(cmd *cobra.Command) error {
-	fmt.Print(completionZshHead)
-	fmt.Print(completionBoilerPlate)
-	fmt.Print(completionZshInitialization)
-
-	if err := cmd.GenBashCompletion(os.Stdout); err != nil {
+	if err := cmd.Root().GenZshCompletion(&b); err != nil {
 		return err
 	}
 
-	fmt.Print(completionZshTail)
+	// Insert boilerplate after the first line.
+	// The first line of a zsh completion function file must be "#compdef foobar".
+	line, err := b.ReadBytes('\n')
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "%s\n%s%s", string(line), completionBoilerPlate, b.String())
 
 	return nil
 }

--- a/docs/book/src/clusterctl/commands/completion.md
+++ b/docs/book/src/clusterctl/commands/completion.md
@@ -53,19 +53,19 @@ Zsh completions are only supported in versions of zsh >= 5.2
 </aside>
 
 The clusterctl completion script for Zsh can be generated with the command
-`clusterctl completion zsh`. Sourcing the completion script in your shell
-enables clusterctl autocompletion.
+`clusterctl completion zsh`.
 
-To do so in all your shell sessions, add the following to your `~/.zshrc` file:
-```sh
-source <(clusterctl completion zsh)
+If shell completion is not already enabled in your environment you will need to
+enable it. You can execute the following once:
+
+```zsh
+echo "autoload -U compinit; compinit" >> ~/.zshrc
 ```
 
-After reloading your shell, clusterctl autocompletion should be working.
+To load completions for each session, execute once:
 
-If you get an error like `complete:13: command not found: compdef`, then add
-the following to the beginning of your `~/.zshrc` file:
-```sh
-autoload -Uz compinit
-compinit
+```zsh
+clusterctl completion zsh > "${fpath[1]}/_clusterctl"
 ```
+
+You will need to start a new shell for this setup to take effect.

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,8 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=


### PR DESCRIPTION
**What this PR does / why we need it**:

ref/ #4090 

Due to this change, we will not able to load the zsh completion code
with the following method:
```
source <(clusterctl completion zsh)
```

Instead, we execute the following command once:
```
clusterctl completion zsh >"${fpath[1]}/_clusterctl"
```
Then we need to start a new shell for this setup to take effect.

---

In addition, github.com/spf13/cobra is updated to v1.1.1 in order to use
native zsh completion feature.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Closes #4090 
