### PR TITLE
📖 Update mdbook to 0.4.5 to fix CVE-2020-26297

### DIFF
--- a/docs/book/Makefile
+++ b/docs/book/Makefile
@@ -36,7 +36,7 @@ $(RELEASELINK): $(TOOLS_DIR)/go.mod
 
 MDBOOK := $(TOOLS_BIN_DIR)/mdbook
 $(MDBOOK):
-	$(CRATE_INSTALL) --git rust-lang/mdBook --tag v0.4.3 --to $(TOOLS_BIN_DIR) --force
+	$(CRATE_INSTALL) --git rust-lang/mdBook --tag v0.4.5 --to $(TOOLS_BIN_DIR) --force
 
 MDBOOK_LINKCHECK := $(TOOLS_BIN_DIR)/mdbook-linkcheck
 $(MDBOOK_LINKCHECK):


### PR DESCRIPTION
See https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html for more details.

Thanks!
📖 