### PR TITLE
📖 Update mdbook to 0.4.5 to fix CVE-2020-26297

### DIFF
--- a/docs/book/install-and-build.sh
+++ b/docs/book/install-and-build.sh
@@ -54,9 +54,9 @@ esac
 
 # grab mdbook
 # we hardcode linux/amd64 since rust uses a different naming scheme and it's a pain to tran
-echo "downloading mdBook-v0.3.1-${arch}-${target}.${ext}"
+echo "downloading mdBook-v0.4.5-${arch}-${target}.${ext}"
 set -x
-curl -sL -o /tmp/mdbook.${ext} "https://github.com/rust-lang-nursery/mdBook/releases/download/v0.3.1/mdBook-v0.3.1-${arch}-${target}.${ext}"
+curl -sL -o /tmp/mdbook.${ext} "https://github.com/rust-lang-nursery/mdBook/releases/download/v0.4.5/mdBook-v0.4.5-${arch}-${target}.${ext}"
 ${cmd} /tmp/mdbook.${ext}
 chmod +x /tmp/mdbook
 


### PR DESCRIPTION
Follow-on from https://github.com/kubernetes-sigs/cluster-api/pull/4127

Not sure how CI works on these release branches, but https://release-0-2.cluster-api.sigs.k8s.io/ has the same problem as https://cluster-api.sigs.k8s.io/, so I figured I'd follow up.