### PR TITLE
:seedling: Use debian-based container for CAPD

### DIFF
--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -48,14 +48,10 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /workspace/manager main.go
 
-# Use alpine:latest as minimal base image to package the manager binary and its dependencies
-FROM alpine:latest
+FROM golang:1.15.7
 
 # install a couple of dependencies
 WORKDIR /tmp
-RUN apk add --update \
-    curl \
-    && rm -rf /var/cache/apk/*
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.2/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \


### PR DESCRIPTION


<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This change bring the CAPD deployed container in line with the other
build containers, using golang 1.15.3, which is based off debian.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

/assign @fabriziopandini 
/milestone v0.4.0
