### PR TITLE
🌱 add possibility to specify webhook cert dir

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -69,6 +69,7 @@ var (
 	kubeadmConfigConcurrency    int
 	syncPeriod                  time.Duration
 	webhookPort                 int
+	webhookCertDir              string
 )
 
 func InitFlags(fs *pflag.FlagSet) {
@@ -105,6 +106,9 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port")
 
+	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
+		"Webhook cert dir, only used when webhook-port is specified.")
+
 	feature.MutableGates.AddFlag(fs)
 }
 
@@ -138,7 +142,8 @@ func main() {
 			&corev1.ConfigMap{},
 			&corev1.Secret{},
 		},
-		Port: webhookPort,
+		Port:    webhookPort,
+		CertDir: webhookCertDir,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -69,6 +69,7 @@ var (
 	kubeadmControlPlaneConcurrency int
 	syncPeriod                     time.Duration
 	webhookPort                    int
+	webhookCertDir                 string
 )
 
 // InitFlags initializes the flags.
@@ -102,6 +103,9 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port")
+
+	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
+		"Webhook cert dir, only used when webhook-port is specified.")
 }
 func main() {
 	rand.Seed(time.Now().UnixNano())
@@ -133,7 +137,8 @@ func main() {
 			&corev1.ConfigMap{},
 			&corev1.Secret{},
 		},
-		Port: webhookPort,
+		Port:    webhookPort,
+		CertDir: webhookCertDir,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
+++ b/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
@@ -59,6 +59,10 @@ Specific changes related to this topic will be detailed in this document.
 
 The conversion-gen code from the `1.20.x` release onward generates incorrect conversion functions for types having arrays of pointers to custom objects. Change the existing types to contain objects instead of pointer references.
 
+## Optional flag for specifying webhook certificates dir
+Add optional flag `--webhook-cert-dir={string-value}` which allows user to specify directory where webhooks will get tls certificates. 
+If flag has not provided, default value from `controller-runtime` should be used.
+
 ## Required kustomize changes to have a single manager watching all namespaces and answer to webhook calls
 
 In an effort to simplify the management of Cluster API components, and realign with Kubebuilder configuration,

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ var (
 	machineHealthCheckConcurrency int
 	syncPeriod                    time.Duration
 	webhookPort                   int
+	webhookCertDir                string
 	healthAddr                    string
 )
 
@@ -132,6 +133,9 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port")
 
+	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
+		"Webhook cert dir, only used when webhook-port is specified.")
+
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
 
@@ -169,6 +173,7 @@ func main() {
 			&corev1.Secret{},
 		},
 		Port:                   webhookPort,
+		CertDir:                webhookCertDir,
 		HealthProbeBindAddress: healthAddr,
 	})
 	if err != nil {

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -54,6 +54,7 @@ var (
 	concurrency          int
 	healthAddr           string
 	webhookPort          int
+	webhookCertDir       string
 )
 
 func init() {
@@ -65,6 +66,25 @@ func init() {
 	_ = clusterv1.AddToScheme(myscheme)
 	_ = expv1.AddToScheme(myscheme)
 	// +kubebuilder:scaffold:scheme
+}
+
+func initFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&metricsBindAddr, "metrics-bind-addr", ":8080",
+		"The address the metric endpoint binds to.")
+	fs.IntVar(&concurrency, "concurrency", 10,
+		"The number of docker machines to process simultaneously")
+	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
+		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
+	fs.StringVar(&healthAddr, "health-addr", ":9440",
+		"The address the health endpoint binds to.")
+	fs.IntVar(&webhookPort, "webhook-port", 9443,
+		"Webhook Server port")
+	fs.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/",
+		"Webhook cert dir, only used when webhook-port is specified.")
+
+	feature.MutableGates.AddFlag(fs)
 }
 
 func main() {
@@ -84,6 +104,7 @@ func main() {
 		SyncPeriod:             &syncPeriod,
 		HealthProbeBindAddress: healthAddr,
 		Port:                   webhookPort,
+		CertDir:                webhookCertDir,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -103,23 +124,6 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-}
-
-func initFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&metricsBindAddr, "metrics-bind-addr", ":8080",
-		"The address the metric endpoint binds to.")
-	fs.IntVar(&concurrency, "concurrency", 10,
-		"The number of docker machines to process simultaneously")
-	fs.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
-		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
-	fs.StringVar(&healthAddr, "health-addr", ":9440",
-		"The address the health endpoint binds to.")
-	fs.IntVar(&webhookPort, "webhook-port", 9443,
-		"Webhook Server port")
-
-	feature.MutableGates.AddFlag(fs)
 }
 
 func setupChecks(mgr ctrl.Manager) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows to specify webhook cert dir for being able to use anything else then default controller-runtime one.

Useful for debugging purposes and potentially in environments with different certificate management flow.

#4165 