### PR TITLE
:seedling: Remove verbose log line from CRS controller

### DIFF
--- a/exp/addons/controllers/clusterresourceset_controller.go
+++ b/exp/addons/controllers/clusterresourceset_controller.go
@@ -232,7 +232,6 @@ func (r *ClusterResourceSetReconciler) getClustersByClusterResourceSetSelector(c
 // TODO: If a resource already exists in the cluster but not applied by ClusterResourceSet, the resource will be updated ?
 func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Context, cluster *clusterv1.Cluster, clusterResourceSet *addonsv1.ClusterResourceSet) error {
 	log := ctrl.LoggerFrom(ctx, "cluster", cluster.Name)
-	log.Info("Applying ClusterResourceSet to cluster")
 
 	remoteClient, err := r.Tracker.GetClient(ctx, util.ObjectKey(cluster))
 	if err != nil {


### PR DESCRIPTION
This log line was logged every time the function ApplyClusterResourceSet
was called. This function is called every time CRS reconciles, even if
it doesn't have any more work to do, causing a lot of similar error
lines to be printed to users.

This change removes the log line for quieter logs.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->
