### PR TITLE
:seedling: Remove verbose log line from CRS controller

### DIFF
--- a/exp/addons/controllers/clusterresourceset_controller.go
+++ b/exp/addons/controllers/clusterresourceset_controller.go
@@ -233,8 +233,6 @@ func (r *ClusterResourceSetReconciler) getClustersByClusterResourceSetSelector(c
 func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Context, cluster *clusterv1.Cluster, clusterResourceSet *addonsv1.ClusterResourceSet) error {
 	logger := r.Log.WithValues("clusterresourceset", clusterResourceSet.Name, "namespace", clusterResourceSet.Namespace, "cluster-name", cluster.Name)
 
-	logger.Info("Applying ClusterResourceSet to cluster")
-
 	remoteClient, err := r.Tracker.GetClient(ctx, util.ObjectKey(cluster))
 	if err != nil {
 		conditions.MarkFalse(clusterResourceSet, addonsv1.ResourcesAppliedCondition, addonsv1.RemoteClusterClientFailedReason, clusterv1.ConditionSeverityError, err.Error())


### PR DESCRIPTION
This log line was logged every time the function ApplyClusterResourceSet
was called. This function is called every time CRS reconciles, even if
it doesn't have any more work to do, causing a lot of similar error
lines to be printed to users.

This change removes the log line for quieter logs.

Signed-off-by: Vince Prignano <vincepri@vmware.com>
