### PR TITLE
:seedling: Use a debian based container for CAPD

### DIFF
--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -46,14 +46,8 @@ WORKDIR /workspace/test/infrastructure/docker
 RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /workspace/manager main.go
 
-# Use alpine:latest as minimal base image to package the manager binary and its dependencies
-FROM alpine:latest
-
-# install a couple of dependencies
+FROM golang:1.13.15
 WORKDIR /tmp
-RUN apk add --update \
-    curl \
-    && rm -rf /var/cache/apk/*
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This is a backport of #4140 

/approve
/assign @fabriziopandini 
/area dependency
/milestone v0.3.x