### PR TITLE
📖 add a cluster autoscaler page to the book

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
     - [Configure a MachineHealthCheck](./tasks/healthcheck.md)
     - [Kubeadm based control plane management](./tasks/kubeadm-control-plane.md)
     - [Changing a Machine Template](./tasks/change-machine-template.md)
+    - [Using the Cluster Autoscaler](./tasks/cluster-autoscaler.md)
     - [Experimental Features](./tasks/experimental-features/experimental-features.md)
         - [MachinePools](./tasks/experimental-features/machine-pools.md)
         - [ClusterResourceSet](./tasks/experimental-features/cluster-resource-set.md)

--- a/docs/book/src/tasks/cluster-autoscaler.md
+++ b/docs/book/src/tasks/cluster-autoscaler.md
@@ -1,0 +1,11 @@
+# Using the Cluster Autoscaler
+
+Cluster Autoscaler is a tool that automatically adjusts the size of the Kubernetes cluster based
+on the utilization of Pods and Nodes in your cluster. For more general information about the
+Cluster Autoscaler, please see the
+[project documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler).
+
+The following instructions are a reproduction of the Cluster API provider specific documentation
+from the [Autoscaler project documentation](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/clusterapi).
+
+{{#embed-github repo:"kubernetes/autoscaler" path:"cluster-autoscaler/cloudprovider/clusterapi/README.md" }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds a new task page named "Using the Cluster Autoscaler"
which primarily imports the README.md from the cluster autoscaler capi
instructions, with a little extra text to indicate the linkage.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partial #4139 
