### PR TITLE
🐛 Add embedded metadata for cluster-api providers

### DIFF
--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -18,6 +18,7 @@ package repository
 
 import (
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
@@ -74,6 +75,10 @@ func (f *metadataClient) Get() (*clusterctlv1.Metadata, error) {
 		log.V(5).Info("Fetching", "File", name, "Provider", f.provider.Name(), "Type", f.provider.Type(), "Version", version)
 		file, err = f.repository.GetFile(version, name)
 		if err != nil {
+			// if there are problems in reading the metadata file from the repository, check if there are embedded metadata for the provider, if yes use them
+			if obj := f.getEmbeddedMetadata(); obj != nil {
+				return obj, nil
+			}
 			return nil, errors.Wrapf(err, "failed to read %q from the repository for provider %q", name, f.provider.ManifestLabel())
 		}
 	} else {
@@ -91,4 +96,78 @@ func (f *metadataClient) Get() (*clusterctlv1.Metadata, error) {
 	//TODO: consider if to add metadata validation (TBD)
 
 	return obj, nil
+}
+
+// getEmbeddedMetadata includes hard-coded metadata for cluster-API providers
+// that are shipped as part of the main cluster-api project. These providers
+// include the CoreProvider/cluster-api, BootstrapProvider/Kubeadm and
+// ControlPlaneProvider/Kubeadm.
+// All other providers are required to ship a `metadata.yaml` file as part of
+// the provider contract.
+func (f *metadataClient) getEmbeddedMetadata() *clusterctlv1.Metadata {
+	switch f.provider.Type() {
+	case clusterctlv1.CoreProviderType:
+		switch f.provider.Name() {
+		case config.ClusterAPIProviderName:
+			return &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "Metadata",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					// v1alpha4 release series
+					{Major: 0, Minor: 4, Contract: "v1alpha4"},
+					// v1alpha3 release series
+					{Major: 0, Minor: 3, Contract: "v1alpha3"},
+					// v1alpha2 release series are supported only for upgrades
+					{Major: 0, Minor: 2, Contract: "v1alpha2"},
+					// older version are not supported by clusterctl
+				},
+			}
+		default:
+			return nil
+		}
+	case clusterctlv1.BootstrapProviderType:
+		switch f.provider.Name() {
+		case config.KubeadmBootstrapProviderName:
+			return &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "Metadata",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					// v1alpha4 release series
+					{Major: 0, Minor: 4, Contract: "v1alpha4"},
+					// v1alpha3 release series
+					{Major: 0, Minor: 3, Contract: "v1alpha3"}, // From this release series CABPK version scheme is linked to CAPI; The 0.2 release series was skipped when doing this change.
+					// v1alpha2 release series are supported only for upgrades
+					{Major: 0, Minor: 1, Contract: "v1alpha2"}, // This release was hosted on a different repository
+					// older version are not supported by clusterctl
+				},
+			}
+		default:
+			return nil
+		}
+	case clusterctlv1.ControlPlaneProviderType:
+		switch f.provider.Name() {
+		case config.KubeadmControlPlaneProviderName:
+			return &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "Metadata",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					// v1alpha4 release series
+					{Major: 0, Minor: 4, Contract: "v1alpha4"},
+					// v1alpha3 release series
+					{Major: 0, Minor: 3, Contract: "v1alpha3"}, // KCP version scheme is linked to CAPI.
+					// there are no older version for KCP
+				},
+			}
+		default:
+			return nil
+		}
+	default:
+		return nil
+	}
 }

--- a/cmd/clusterctl/client/repository/metadata_client_test.go
+++ b/cmd/clusterctl/client/repository/metadata_client_test.go
@@ -73,6 +73,71 @@ func Test_metadataClient_Get(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Pass with embedded metadata for CoreProviderType",
+			fields: fields{
+				provider: config.NewProvider(config.ClusterAPIProviderName, "", clusterctlv1.CoreProviderType),
+				version:  "v1.0.0",
+				repository: test.NewFakeRepository(). //repository without a metadata file
+									WithPaths("root", "").
+									WithDefaultVersion("v1.0.0"),
+			},
+			want: &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "Metadata",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 0, Minor: 4, Contract: "v1alpha4"},
+					{Major: 0, Minor: 3, Contract: "v1alpha3"},
+					{Major: 0, Minor: 2, Contract: "v1alpha2"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Pass with embedded metadata for KubeadmBootstrapProvider Type",
+			fields: fields{
+				provider: config.NewProvider(config.KubeadmBootstrapProviderName, "", clusterctlv1.BootstrapProviderType),
+				version:  "v1.0.0",
+				repository: test.NewFakeRepository(). //repository without a metadata file
+									WithPaths("root", "").
+									WithDefaultVersion("v1.0.0"),
+			},
+			want: &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "Metadata",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 0, Minor: 4, Contract: "v1alpha4"},
+					{Major: 0, Minor: 3, Contract: "v1alpha3"},
+					{Major: 0, Minor: 1, Contract: "v1alpha2"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Pass with embedded metadata for KubeadmControlPlaneProvider Type",
+			fields: fields{
+				provider: config.NewProvider(config.KubeadmControlPlaneProviderName, "", clusterctlv1.ControlPlaneProviderType),
+				version:  "v1.0.0",
+				repository: test.NewFakeRepository(). //repository without a metadata file
+									WithPaths("root", "").
+									WithDefaultVersion("v1.0.0"),
+			},
+			want: &clusterctlv1.Metadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: clusterctlv1.GroupVersion.String(),
+					Kind:       "Metadata",
+				},
+				ReleaseSeries: []clusterctlv1.ReleaseSeries{
+					{Major: 0, Minor: 4, Contract: "v1alpha4"},
+					{Major: 0, Minor: 3, Contract: "v1alpha3"},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Fails if the file does not exists",
 			fields: fields{
 				provider: config.NewProvider("p1", "", clusterctlv1.CoreProviderType),


### PR DESCRIPTION
Add metadata information for the following since we don't ship a
metadata yaml for each of these as part of the cluster-api release
assets.
CoreProvider/cluster-api
BootstrapProvider/Kubeadm
ControlPlaneProvider/Kubeadm

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Explained in the issue but basically we don't have a metadata yaml for the providers shipped with the cluster-api assets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4156

/area clusterctl