### PR TITLE
🌱 Use openAPI scheme for defaulting replicas

### DIFF
--- a/api/v1alpha4/machinedeployment_types.go
+++ b/api/v1alpha4/machinedeployment_types.go
@@ -52,6 +52,8 @@ type MachineDeploymentSpec struct {
 
 	// Number of desired machines. Defaults to 1.
 	// This is a pointer to distinguish between explicit zero and not specified.
+	// +optional
+	// +kubebuilder:default=1
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Label selector for machines. Existing MachineSets whose machines are

--- a/api/v1alpha4/machinedeployment_webhook.go
+++ b/api/v1alpha4/machinedeployment_webhook.go
@@ -107,10 +107,6 @@ func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
 	}
 	d.Labels[ClusterLabelName] = d.Spec.ClusterName
 
-	if d.Spec.Replicas == nil {
-		d.Spec.Replicas = pointer.Int32Ptr(1)
-	}
-
 	if d.Spec.MinReadySeconds == nil {
 		d.Spec.MinReadySeconds = pointer.Int32Ptr(0)
 	}

--- a/api/v1alpha4/machinedeployment_webhook_test.go
+++ b/api/v1alpha4/machinedeployment_webhook_test.go
@@ -36,7 +36,6 @@ func TestMachineDeploymentDefault(t *testing.T) {
 	md.Default()
 
 	g.Expect(md.Labels[ClusterLabelName]).To(Equal(md.Spec.ClusterName))
-	g.Expect(md.Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
 	g.Expect(md.Spec.MinReadySeconds).To(Equal(pointer.Int32Ptr(0)))
 	g.Expect(md.Spec.RevisionHistoryLimit).To(Equal(pointer.Int32Ptr(1)))
 	g.Expect(md.Spec.ProgressDeadlineSeconds).To(Equal(pointer.Int32Ptr(600)))

--- a/api/v1alpha4/machineset_types.go
+++ b/api/v1alpha4/machineset_types.go
@@ -36,6 +36,7 @@ type MachineSetSpec struct {
 	// This is a pointer to distinguish between explicit zero and unspecified.
 	// Defaults to 1.
 	// +optional
+	// +kubebuilder:default=1
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready.

--- a/api/v1alpha4/machineset_webhook.go
+++ b/api/v1alpha4/machineset_webhook.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -47,10 +46,6 @@ func (m *MachineSet) Default() {
 		m.Labels = make(map[string]string)
 	}
 	m.Labels[ClusterLabelName] = m.Spec.ClusterName
-
-	if m.Spec.Replicas == nil {
-		m.Spec.Replicas = pointer.Int32Ptr(1)
-	}
 
 	if m.Spec.DeletePolicy == "" {
 		randomPolicy := string(RandomMachineSetDeletePolicy)

--- a/api/v1alpha4/machineset_webhook_test.go
+++ b/api/v1alpha4/machineset_webhook_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 )
 
 func TestMachineSetDefault(t *testing.T) {
@@ -36,7 +35,6 @@ func TestMachineSetDefault(t *testing.T) {
 	md.Default()
 
 	g.Expect(md.Labels[ClusterLabelName]).To(Equal(md.Spec.ClusterName))
-	g.Expect(md.Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
 	g.Expect(md.Spec.DeletePolicy).To(Equal(string(RandomMachineSetDeletePolicy)))
 	g.Expect(md.Spec.Selector.MatchLabels).To(HaveKeyWithValue(MachineSetLabelName, "test-ms"))
 	g.Expect(md.Spec.Template.Labels).To(HaveKeyWithValue(MachineSetLabelName, "test-ms"))

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -375,6 +375,7 @@ spec:
                 format: int32
                 type: integer
               replicas:
+                default: 1
                 description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -329,6 +329,7 @@ spec:
                 format: int32
                 type: integer
               replicas:
+                default: 1
                 description: Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.
                 format: int32
                 type: integer

--- a/controllers/schema_test.go
+++ b/controllers/schema_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestMachineSetScheme(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, "schema-test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	testMachineSet := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      "test-machineset",
+		},
+		Spec: clusterv1.MachineSetSpec{
+			ClusterName: "test",
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "test",
+				},
+			},
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, testMachineSet)).To(Succeed())
+
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, testMachineSet)
+
+	g.Expect(testMachineSet.Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
+}
+
+func TestMachineDeploymentScheme(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, "schema-test")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	testMachineDeployment := &clusterv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      "test-machinedeployment",
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			ClusterName: "test",
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "test",
+				},
+			},
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, testMachineDeployment)).To(Succeed())
+
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, testMachineDeployment)
+
+	g.Expect(testMachineDeployment.Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Use openAPI scheme for defaulting machineset and machinedeployment replicas. This is a trivial validation that can be without usage of webhooks and it doesn't need to be unit tested.