### PR TITLE
✨ Add support to skip Machine remediation, and respect paused Machines in MHC

### DIFF
--- a/api/v1alpha4/common_types.go
+++ b/api/v1alpha4/common_types.go
@@ -71,6 +71,9 @@ const (
 	// that was cloned for the machine. This annotation is set only during cloning a template. Older/adopted machines will not have this annotation.
 	TemplateClonedFromGroupKindAnnotation = "cluster.x-k8s.io/cloned-from-groupkind"
 
+	// MachineSkipRemediationAnnotation is the annotation used to mark the machines that should not be considered for remediation by MachineHealthCheck reconciler.
+	MachineSkipRemediationAnnotation = "cluster.x-k8s.io/skip-remediation"
+
 	// ClusterSecretType defines the type of secret created by core components
 	ClusterSecretType corev1.SecretType = "cluster.x-k8s.io/secret" //nolint:gosec
 

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -194,7 +194,7 @@ func (r *MachineHealthCheckReconciler) reconcile(ctx context.Context, logger log
 
 	// fetch all targets
 	logger.V(3).Info("Finding targets")
-	targets, err := r.getTargetsFromMHC(ctx, remoteClient, m)
+	targets, err := r.getTargetsFromMHC(ctx, logger, remoteClient, m)
 	if err != nil {
 		logger.Error(err, "Failed to fetch targets from MachineHealthCheck")
 		return ctrl.Result{}, err

--- a/controllers/machinehealthcheck_targets_test.go
+++ b/controllers/machinehealthcheck_targets_test.go
@@ -75,6 +75,14 @@ func TestGetTargetsFromMHC(t *testing.T) {
 	testNode4 := newTestNode("node4")
 	testMachine4 := newTestMachine("machine4", namespace, "other-cluster", testNode4.Name, mhcSelector)
 
+	// machines for skip remediation
+	testNode5 := newTestNode("node5")
+	testMachine5 := newTestMachine("machine5", namespace, clusterName, testNode5.Name, mhcSelector)
+	testMachine5.Annotations = map[string]string{"cluster.x-k8s.io/skip-remediation": ""}
+	testNode6 := newTestNode("node6")
+	testMachine6 := newTestMachine("machine6", namespace, clusterName, testNode6.Name, mhcSelector)
+	testMachine6.Annotations = map[string]string{"cluster.x-k8s.io/paused": ""}
+
 	testCases := []struct {
 		desc            string
 		toCreate        []client.Object
@@ -124,6 +132,17 @@ func TestGetTargetsFromMHC(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:     "with machines having skip-remediation or paused annotation",
+			toCreate: append(baseObjects, testNode1, testMachine1, testMachine5, testMachine6),
+			expectedTargets: []healthCheckTarget{
+				{
+					Machine: testMachine1,
+					MHC:     testMHC,
+					Node:    testNode1,
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -143,7 +162,7 @@ func TestGetTargetsFromMHC(t *testing.T) {
 				t.patchHelper = patchHelper
 			}
 
-			targets, err := reconciler.getTargetsFromMHC(ctx, k8sClient, testMHC)
+			targets, err := reconciler.getTargetsFromMHC(ctx, ctrl.LoggerFrom(ctx), k8sClient, testMHC)
 			gs.Expect(err).ToNot(HaveOccurred())
 
 			gs.Expect(len(targets)).To(Equal(len(tc.expectedTargets)))

--- a/docs/book/src/tasks/healthcheck.md
+++ b/docs/book/src/tasks/healthcheck.md
@@ -100,6 +100,18 @@ If `maxUnhealthy` is set to `40%` and there are 6 Machines being checked:
 
 Note, when the percentage is not a whole number, the allowed number is rounded down.
 
+## Skipping Remediation
+
+There are scenarios where remediation for a machine may be undesirable (eg. during cluster migration using `clustrctl move`). For such cases, MachineHealthCheck provides 2 mechanisms to skip machines for remediation.
+
+Implicit skipping when the resource is paused (using `cluster.x-k8s.io/paused` annotation):
+- When a cluster is paused, none of the machines in that cluster are considered for remediation.
+- When a machine is paused, only that machine is not considered for remediation.
+- A cluster or a machine is usually paused automatically by cluster api when it detects a migration.
+
+Explicit skipping using `cluster.x-k8s.io/skip-remediation` annotation:
+- Users can also skip any machine for remediation by setting the `cluster.x-k8s.io/skip-remediation` for that machine.
+
 ## Limitations and Caveats of a MachineHealthCheck
 
 Before deploying a MachineHealthCheck, please familiarise yourself with the following limitations and caveats:

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -33,12 +33,12 @@ func IsPaused(cluster *clusterv1.Cluster, o metav1.Object) bool {
 
 // HasPausedAnnotation returns true if the object has the `paused` annotation.
 func HasPausedAnnotation(o metav1.Object) bool {
-	annotations := o.GetAnnotations()
-	if annotations == nil {
-		return false
-	}
-	_, ok := annotations[clusterv1.PausedAnnotation]
-	return ok
+	return hasAnnotation(o, clusterv1.PausedAnnotation)
+}
+
+// HasSkipRemediationAnnotation returns true if the object has the `skip-remediation` annotation.
+func HasSkipRemediationAnnotation(o metav1.Object) bool {
+	return hasAnnotation(o, clusterv1.MachineSkipRemediationAnnotation)
 }
 
 func HasWithPrefix(prefix string, annotations map[string]string) bool {
@@ -64,4 +64,14 @@ func AddAnnotations(o metav1.Object, desired map[string]string) bool {
 		}
 	}
 	return hasChanged
+}
+
+// hasAnnotation returns true if the object has the specified annotation
+func hasAnnotation(o metav1.Object, annotation string) bool {
+	annotations := o.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, ok := annotations[annotation]
+	return ok
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- Skips remediation for paused machines
- Adds a new annotation to mark machines for skipping remediation

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4032 
