### PR TITLE
🌱 Make clusterctl completion zsh work with sourcing

### DIFF
--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -131,7 +131,10 @@ func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(out, "%s\n%s%s", string(line), completionBoilerPlate, b.String())
+	fmt.Fprintf(out, "%s\n%s%s\n", string(line), completionBoilerPlate, b.String())
+
+	// Cobra doesn't source zsh completion file, explicitly doing it here
+	fmt.Fprintln(out, "compdef _clusterctl clusterctl")
 
 	return nil
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Enabling completion with `clusterctl completion zsh` only supports putting a completion file to `fpath`. This is a breaking change for users currently using sourcing.

This change allows users to continue to enable completion via sourcing.

ref/ https://github.com/kubernetes-sigs/cluster-api/pull/4113
cc/ @wfernandes 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
