### PR TITLE
🐛 Fix nil pointer dereference

### DIFF
--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
@@ -368,7 +368,7 @@ func (in *KubeadmControlPlane) validateEtcd(prev *KubeadmControlPlane) (allErrs 
 	}
 
 	// update validations
-	if prev != nil {
+	if prev != nil && prev.Spec.KubeadmConfigSpec.ClusterConfiguration != nil {
 		if in.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External != nil && prev.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local != nil {
 			allErrs = append(
 				allErrs,

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
@@ -457,6 +457,11 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	withoutClusterConfiguration := before.DeepCopy()
 	withoutClusterConfiguration.Spec.KubeadmConfigSpec.ClusterConfiguration = nil
 
+	afterEtcdLocalDirAddition := before.DeepCopy()
+	afterEtcdLocalDirAddition.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local = &kubeadmv1beta1.LocalEtcd{
+		DataDir: "/data",
+	}
+
 	disallowedUpgrade118Prev := prevKCPWithVersion("v1.18.8")
 	disallowedUpgrade119Version := before.DeepCopy()
 	disallowedUpgrade119Version.Spec.Version = "v1.19.0"
@@ -700,6 +705,12 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: false,
 			before:    withoutClusterConfiguration,
 			kcp:       withoutClusterConfiguration,
+		},
+		{
+			name:      "should fail if etcd local dir is changed from missing ClusterConfiguration",
+			expectErr: true,
+			before:    withoutClusterConfiguration,
+			kcp:       afterEtcdLocalDirAddition,
 		},
 		{
 			name:      "should fail when skipping control plane minor versions",


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a webhook panic caused by a nil pointer dereference

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Didn't open an issue, fixed it right away.