### PR TITLE
🌱 Remove verbose flag from make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,15 @@ help:  ## Display this help
 
 .PHONY: test
 test: ## Run tests.
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v ./... $(TEST_ARGS)
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test ./... $(TEST_ARGS)
+
+.PHONY: test-verbose
+test-verbose: ## Run tests with verbose settings.
+	TEST_ARGS="$(TEST_ARGS) -v" $(MAKE) test
 
 .PHONY: test-cover
-test-cover: ## Run tests with code coverage and code generate  reports
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test -v -coverprofile=out/coverage.out ./... $(TEST_ARGS)
+test-cover: ## Run tests with code coverage and code generate reports.
+	TEST_ARGS="$(TEST_ARGS) -coverprofile=out/coverage.out" $(MAKE) test
 	go tool cover -func=out/coverage.out -o out/coverage.txt
 	go tool cover -html=out/coverage.out -o out/coverage.html
 

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -25,9 +25,9 @@ cd "${REPO_ROOT}" || exit 1
 source "${REPO_ROOT}/hack/ensure-go.sh"
 
 echo "*** Testing Cluster API ***"
-make test
+make test-verbose
 
 echo -e "\n*** Testing Cluster API Provider Docker ***\n"
 # Docker provider
 cd test/infrastructure/docker
-make test
+make test-verbose

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -69,8 +69,12 @@ help:  ## Display this help
 ## --------------------------------------
 
 .PHONY: test
-test: ## Run tests
-	go test -v ./...
+test: ## Run tests.
+	go test ./... $(TEST_ARGS)
+
+.PHONY: test-verbose
+test-verbose: ## Run tests with verbose settings.
+	TEST_ARGS="$(TEST_ARGS) -v" $(MAKE) test
 
 ## --------------------------------------
 ## Binaries


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

`make test` now has very concise output when run in local development, making it easier to spot actual failures. There is an additional target called `make test-verbose` which is used in CI to continue to have the full verbose output.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4182 
