### PR TITLE
📖 docs: change to clusterctl instead of kubectl

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -92,7 +92,7 @@ Download the latest release; for example, to download version v0.3.0 on linux, t
 ```
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-amd64" version:"0.3.x"}} -o clusterctl
 ```
-Make the kubectl binary executable.
+Make the clusterctl binary executable.
 ```
 chmod +x ./clusterctl
 ```
@@ -113,7 +113,7 @@ Download the latest release; for example, to download version v0.3.0 on macOS, t
 ```
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-amd64" version:"0.3.x"}} -o clusterctl
 ```
-Make the kubectl binary executable.
+Make the clusterctl binary executable.
 ```
 chmod +x ./clusterctl
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
changes documentation to refer to clusterctl instead of kubectl under cluster installation intructions 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
