### PR TITLE
⚠️ clustectl v1alpha3 version checks preventing to install/manage v1alpha4 clusters

### DIFF
--- a/cmd/clusterctl/client/cluster/installer.go
+++ b/cmd/clusterctl/client/cluster/installer.go
@@ -244,6 +244,10 @@ func (i *providerInstaller) getProviderContract(providerInstanceContracts map[st
 		return "", errors.Errorf("invalid provider metadata: version %s for the provider %s does not match any release series", provider.Version, provider.InstanceName())
 	}
 
+	if releaseSeries.Contract != clusterctlv1.GroupVersion.Version {
+		return "", errors.Errorf("current version of clusterctl could install only %s providers, detected %s", clusterctlv1.GroupVersion.Version, releaseSeries.Contract)
+	}
+
 	providerInstanceContracts[provider.InstanceName()] = releaseSeries.Contract
 	return releaseSeries.Contract, nil
 }

--- a/cmd/clusterctl/client/cluster/installer_test.go
+++ b/cmd/clusterctl/client/cluster/installer_test.go
@@ -42,12 +42,17 @@ func Test_providerInstaller_Validate(t *testing.T) {
 					{Major: 1, Minor: 0, Contract: "v1alpha3"},
 				},
 			}).
-			WithMetadata("v2.0.0", &clusterctlv1.Metadata{
-				ReleaseSeries: []clusterctlv1.ReleaseSeries{
-					{Major: 1, Minor: 0, Contract: "v1alpha3"},
-					{Major: 2, Minor: 0, Contract: "v1alpha4"},
-				},
-			}),
+			WithRawMetadata("v2.0.0",
+				"apiVersion: clusterctl.cluster.x-k8s.io/v1alpha4\n"+ // this can't be processed by clusterctl v1alpha3
+					"kind: Metadata\n"+
+					"releaseSeries:\n"+
+					"- major: 1\n"+
+					"  minor: 0\n"+
+					"  contract: v1alpha3\n"+
+					"- major: 2\n"+
+					"  minor: 0\n"+
+					"  contract: v1alpha4\n",
+			),
 		"infrastructure-infra1": test.NewFakeRepository().
 			WithVersions("v1.0.0", "v1.0.1").
 			WithMetadata("v1.0.0", &clusterctlv1.Metadata{
@@ -55,12 +60,17 @@ func Test_providerInstaller_Validate(t *testing.T) {
 					{Major: 1, Minor: 0, Contract: "v1alpha3"},
 				},
 			}).
-			WithMetadata("v2.0.0", &clusterctlv1.Metadata{
-				ReleaseSeries: []clusterctlv1.ReleaseSeries{
-					{Major: 1, Minor: 0, Contract: "v1alpha3"},
-					{Major: 2, Minor: 0, Contract: "v1alpha4"},
-				},
-			}),
+			WithRawMetadata("v2.0.0",
+				"apiVersion: clusterctl.cluster.x-k8s.io/v1alpha4\n"+ // this can't be processed by clusterctl v1alpha3
+					"kind: Metadata\n"+
+					"releaseSeries:\n"+
+					"- major: 1\n"+
+					"  minor: 0\n"+
+					"  contract: v1alpha3\n"+
+					"- major: 2\n"+
+					"  minor: 0\n"+
+					"  contract: v1alpha4\n",
+			),
 		"infrastructure-infra2": test.NewFakeRepository().
 			WithVersions("v1.0.0", "v1.0.1").
 			WithMetadata("v1.0.0", &clusterctlv1.Metadata{
@@ -68,12 +78,17 @@ func Test_providerInstaller_Validate(t *testing.T) {
 					{Major: 1, Minor: 0, Contract: "v1alpha3"},
 				},
 			}).
-			WithMetadata("v2.0.0", &clusterctlv1.Metadata{
-				ReleaseSeries: []clusterctlv1.ReleaseSeries{
-					{Major: 1, Minor: 0, Contract: "v1alpha3"},
-					{Major: 2, Minor: 0, Contract: "v1alpha4"},
-				},
-			}),
+			WithRawMetadata("v2.0.0",
+				"apiVersion: clusterctl.cluster.x-k8s.io/v1alpha4\n"+ // this can't be processed by clusterctl v1alpha3
+					"kind: Metadata\n"+
+					"releaseSeries:\n"+
+					"- major: 1\n"+
+					"  minor: 0\n"+
+					"  contract: v1alpha3\n"+
+					"- major: 2\n"+
+					"  minor: 0\n"+
+					"  contract: v1alpha4\n",
+			),
 	}
 
 	type fields struct {
@@ -86,7 +101,7 @@ func Test_providerInstaller_Validate(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "install core + infra1 on an empty cluster",
+			name: "install core v1alpha3 + infra1 v1alpha3 on an empty cluster",
 			fields: fields{
 				proxy: test.NewFakeProxy(), //empty cluster
 				installQueue: []repository.Components{ // install core + infra1, v1alpha3 contract
@@ -97,7 +112,7 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "install infra2 on a cluster already initialized with core + infra1",
+			name: "install infra2 v1alpha3 on a cluster already initialized with core v1alpha3 + infra1 v1alpha3",
 			fields: fields{
 				proxy: test.NewFakeProxy(). // cluster with core + infra1, v1alpha3 contract
 								WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
@@ -109,7 +124,7 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "install another instance of infra1 on a cluster already initialized with core + infra1, no overlaps",
+			name: "install another instance of infra1 v1alpha3 on a cluster already initialized with core v1alpha3 + infra1 v1alpha3, no overlaps",
 			fields: fields{
 				proxy: test.NewFakeProxy(). // cluster with core + infra1, v1alpha3 contract
 								WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
@@ -121,7 +136,7 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "install another instance of infra1 on a cluster already initialized with core + infra1, same namespace of the existing infra1",
+			name: "install another instance of infra1 v1alpha3 on a cluster already initialized with core v1alpha3 + infra1 v1alpha3, same namespace of the existing infra1",
 			fields: fields{
 				proxy: test.NewFakeProxy(). // cluster with core + infra1, v1alpha3 contract
 								WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
@@ -133,7 +148,7 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "install another instance of infra1 on a cluster already initialized with core + infra1, watching overlap with the existing infra1",
+			name: "install another instance of infra1 v1alpha3 on a cluster already initialized with core v1alpha3 + infra1 v1alpha3, watching overlap with the existing infra1",
 			fields: fields{
 				proxy: test.NewFakeProxy(). // cluster with core + infra1, v1alpha3 contract
 								WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
@@ -145,7 +160,7 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "install another instance of infra1 on a cluster already initialized with core + infra1, not part of the existing management group",
+			name: "install another instance of infra1 v1alpha3 on a cluster already initialized with core v1alpha3 + infra1 v1alpha3, not part of the existing management group",
 			fields: fields{
 				proxy: test.NewFakeProxy(). // cluster with core + infra1, v1alpha3 contract
 								WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "ns1", "ns1").
@@ -157,7 +172,7 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "install an instance of infra1 on a cluster already initialized with two core, but it is part of two management group",
+			name: "install an instance of infra1 v1alpha3 on a cluster already initialized with two core v1alpha3, but it is part of two management group",
 			fields: fields{
 				proxy: test.NewFakeProxy(). // cluster with two core (two management groups)
 								WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "ns1", "ns1").
@@ -169,7 +184,18 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "install core@v1alpha3 + infra1@v1alpha4 on an empty cluster",
+			name: "install core v1alpha4 + infra1 v1alpha4 on an empty cluster (not supported)",
+			fields: fields{
+				proxy: test.NewFakeProxy(), //empty cluster
+				installQueue: []repository.Components{ // install core, v1alpha4 contract + infra1, v1alpha4 contract
+					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v2.0.0", "cluster-api-system", ""),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra1-system", ""),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "install core v1alpha3 + infra1 v1alpha4 on an empty cluster (not supported)",
 			fields: fields{
 				proxy: test.NewFakeProxy(), //empty cluster
 				installQueue: []repository.Components{ // install core + infra1, v1alpha3 contract
@@ -180,7 +206,7 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "install infra1@v1alpha4 on a cluster already initialized with core@v1alpha3 +",
+			name: "install infra1 v1alpha4 (not supported) on a cluster already initialized with core v1alpha3",
 			fields: fields{
 				proxy: test.NewFakeProxy(). // cluster with one core, v1alpha3 contract
 								WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "ns1", "ns1"),

--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -100,7 +100,7 @@ func (u *providerUpgrader) Plan() ([]UpgradePlan, error) {
 		// in a management group are expected to support the same API Version of Cluster API (contract).
 		// e.g if the core provider supports v1alpha3, all the providers in the same management group should support v1alpha3 as well;
 		// all the providers in the management group can upgrade to the latest release supporting v1alpha3, or if available,
-		// or if available, all the providers in the management group can upgrade to the latest release supporting v1alpha4.
+		// or if available, all the providers in the management group can upgrade to the latest release supporting v1alpha4 (not supported in current clusterctl release).
 
 		// Gets the upgrade info for the core provider.
 		coreUpgradeInfo, err := u.getUpgradeInfo(managementGroup.CoreProvider)
@@ -118,7 +118,7 @@ func (u *providerUpgrader) Plan() ([]UpgradePlan, error) {
 		// Creates an UpgradePlan for each contract considered for upgrades; each upgrade plans contains
 		// an UpgradeItem for each provider defining the next available version with the target contract, if available.
 		// e.g. v1alpha3, cluster-api --> v0.3.2, kubeadm bootstrap --> v0.3.2, aws --> v0.5.4
-		// e.g. v1alpha4, cluster-api --> v0.4.1, kubeadm bootstrap --> v0.4.1, aws --> v0.6.2
+		// e.g. v1alpha4, cluster-api --> v0.4.1, kubeadm bootstrap --> v0.4.1, aws --> v0.6.2 (not supported in current clusterctl release).
 		for _, contract := range contractsForUpgrade {
 			upgradePlan, err := u.getUpgradePlan(managementGroup, contract)
 			if err != nil {
@@ -140,6 +140,10 @@ func (u *providerUpgrader) Plan() ([]UpgradePlan, error) {
 }
 
 func (u *providerUpgrader) ApplyPlan(coreProvider clusterctlv1.Provider, contract string) error {
+	if contract != clusterctlv1.GroupVersion.Version {
+		return errors.Errorf("current version of clusterctl could only upgrade to %s contract, requested %s", clusterctlv1.GroupVersion.Version, contract)
+	}
+
 	log := logf.Log
 	log.Info("Performing upgrade...")
 
@@ -243,6 +247,10 @@ func (u *providerUpgrader) createCustomPlan(coreProvider clusterctlv1.Provider, 
 	targetContract, err := u.getProviderContractByVersion(managementGroup.CoreProvider, targetCoreProviderVersion)
 	if err != nil {
 		return nil, err
+	}
+
+	if targetContract != clusterctlv1.GroupVersion.Version {
+		return nil, errors.Errorf("current version of clusterctl could only upgrade to %s contract, requested %s", clusterctlv1.GroupVersion.Version, targetContract)
 	}
 
 	// Builds the custom upgrade plan, by adding all the upgrade items after checking consistency with the targetContract.

--- a/cmd/clusterctl/client/cluster/upgrader_info.go
+++ b/cmd/clusterctl/client/cluster/upgrader_info.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
 // upgradeInfo holds all the information required for taking upgrade decisions for a provider
@@ -45,6 +46,8 @@ type upgradeInfo struct {
 
 // getUpgradeInfo returns all the info required for taking upgrade decisions for a provider.
 func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgradeInfo, error) {
+	log := logf.Log
+
 	// Gets the list of versions available in the provider repository.
 	configRepository, err := u.configClient.Providers().Get(provider.ProviderName, provider.GetProviderType())
 	if err != nil {
@@ -56,6 +59,11 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 		return nil, err
 	}
 
+	currentVersion, err := version.ParseSemantic(provider.Version)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse current version for the %s provider", provider.InstanceName())
+	}
+
 	repositoryVersions, err := providerRepository.GetVersions()
 	if err != nil {
 		return nil, err
@@ -65,53 +73,55 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 		return nil, errors.Errorf("failed to get available versions for the %s provider", provider.InstanceName())
 	}
 
-	//  Pick the provider's latest version available in the repository and use it to get the most recent metadata for the provider.
-	var latestVersion *version.Version
-	for _, availableVersion := range repositoryVersions {
-		availableSemVersion, err := version.ParseSemantic(availableVersion)
+	// Check all the versions are semantic versions
+	repositorySemVersions := make([]version.Version, 0, len(repositoryVersions))
+	for _, v := range repositoryVersions {
+		semV, err := version.ParseSemantic(v)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse available version for the %s provider", provider.InstanceName())
 		}
+		repositorySemVersions = append(repositorySemVersions, *semV)
+	}
 
-		if latestVersion == nil || latestVersion.LessThan(availableSemVersion) {
-			latestVersion = availableSemVersion
+	// Pick the most recent metadata that this version of clusterctl can process.
+	// E.g. clusterctl v1alpha3 can process only v1alpha3 metadata files, but not v1alpha4 metadata files;
+	// so it will use the latest v1alpha3 metadata file available (ignoring v1alpha4 metadata files).
+	var latestMetadata *clusterctlv1.Metadata
+	sort.Slice(repositorySemVersions, func(i, j int) bool {
+		return !repositorySemVersions[i].LessThan(&repositorySemVersions[j])
+	})
+	for i := range repositorySemVersions {
+		tag := versionTag(&repositorySemVersions[i])
+		if vMetadata, err := providerRepository.Metadata(tag).Get(); err == nil {
+			latestMetadata = vMetadata
+			break
 		}
+		log.Info("Failed to get metadata, falling back to metadata from previous version ...", "Provider", provider.Name, "Version", tag)
+	}
+	if latestMetadata == nil {
+		return nil, errors.Errorf("failed to get metadata for upgrading provider %s", provider.InstanceName())
 	}
 
-	latestMetadata, err := providerRepository.Metadata(versionTag(latestVersion)).Get()
-	if err != nil {
-		return nil, err
-	}
-
-	// Get current provider version and check if the releaseSeries defined in metadata includes it.
-	currentVersion, err := version.ParseSemantic(provider.Version)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse current version for the %s provider", provider.InstanceName())
-	}
-
+	// Check if the releaseSeries defined in metadata includes the current version.
 	if latestMetadata.GetReleaseSeriesForVersion(currentVersion) == nil {
 		return nil, errors.Errorf("invalid provider metadata: version %s (the current version) for the provider %s does not match any release series", provider.Version, provider.InstanceName())
 	}
 
-	// Filters the versions to be considered for upgrading the provider (next
-	// versions) and checks if the releaseSeries defined in metadata includes
-	// all of them.
+	// Filters the versions to be considered for upgrading the provider (next versions).
 	nextVersions := []version.Version{}
-	for _, repositoryVersion := range repositoryVersions {
-		// we are ignoring the conversion error here because a first check already passed above
-		repositorySemVersion, _ := version.ParseSemantic(repositoryVersion)
+	for i := range repositorySemVersions {
+		semV := repositorySemVersions[i]
 
 		// Drop the nextVersion version if older or equal that the current version
-		// NB. Using !LessThan because version does not implements a GreaterThan method.
-		if !currentVersion.LessThan(repositorySemVersion) {
-			continue
+		if currentVersion.LessThan(&semV) {
+			nextVersions = append(nextVersions, semV)
 		}
 
-		if latestMetadata.GetReleaseSeriesForVersion(repositorySemVersion) == nil {
-			return nil, errors.Errorf("invalid provider metadata: version %s (one of the available versions) for the provider %s does not match any release series", repositoryVersion, provider.InstanceName())
+		// Drop the nextVersion version not included in the metadata file; this includes
+		// also version of the next clusterctl contract, e.g. v1alpha4.
+		if latestMetadata.GetReleaseSeriesForVersion(&semV) == nil {
+			log.Info("Skipping version not included in latest metadata available", "Provider", provider.Name, "Version", versionTag(&semV))
 		}
-
-		nextVersions = append(nextVersions, *repositorySemVersion)
 	}
 
 	return newUpgradeInfo(latestMetadata, currentVersion, nextVersions), nil
@@ -146,7 +156,7 @@ func newUpgradeInfo(metadata *clusterctlv1.Metadata, currentVersion *version.Ver
 
 // getContractsForUpgrade return the list of API Version of Cluster API (contract) version available for a provider upgrade. e.g.
 // - If the current version of the provider support v1alpha3 contract (the latest), it returns v1alpha3
-// - If the current version of the provider support v1alpha3 contract but there is also the v1alpha4 contract available, it returns v1alpha3, v1alpha4
+// - If the current version of the provider support v1alpha3 contract but there is also the v1alpha4 contract available, it returns v1alpha3, v1alpha4 (not supported in current clusterctl release).
 func (i *upgradeInfo) getContractsForUpgrade() []string {
 	contractsForUpgrade := sets.NewString()
 	for _, releaseSeries := range i.metadata.ReleaseSeries {

--- a/cmd/clusterctl/client/cluster/upgrader_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_test.go
@@ -40,7 +40,7 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Single Management group, no multi-tenancy, upgrade within the same contract",
+			name: "Single Management group, no multi-tenancy, upgrade within the same contract - v1alpha3 (current)",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
@@ -140,7 +140,7 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, no multi-tenancy, upgrade for two contracts",
+			name: "Single Management group, no multi-tenancy, upgrade for two contracts - v1alpha3 (current), v1alpha4 (not supported)",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
@@ -150,18 +150,27 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
-						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
 							},
-						}),
+						}).
+						WithRawMetadata("v2.0.0",
+							"apiVersion: clusterctl.cluster.x-k8s.io/v1alpha4\n"+ // this can't be processed by clusterctl v1alpha3
+								"kind: Metadata\n"+
+								"releaseSeries:\n"+
+								"- major: 1\n"+
+								"  minor: 0\n"+
+								"  contract: v1alpha3\n"+
+								"- major: 2\n"+
+								"  minor: 0\n"+
+								"  contract: v1alpha4\n",
+						),
 					"infrastructure-infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
 							},
 						}),
 				},
@@ -185,25 +194,12 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 contract
-					Contract:     "v1alpha4",
-					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-					Providers: []UpgradeItem{
-						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-							NextVersion: "v2.0.0",
-						},
-						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-							NextVersion: "v3.0.0",
-						},
-					},
-				},
+				// upgrade plan with for the v1alpha4 contract should be ignored
 			},
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Infra multi-tenancy, upgrade within the same contract",
+			name: "Single Management group, n-Infra multi-tenancy, upgrade within the same contract - v1alpha3 (current)",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
@@ -255,7 +251,7 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Infra multi-tenancy, upgrade for two contracts",
+			name: "Single Management group, n-Infra multi-tenancy, upgrade for two contracts - v1alpha3 (current), v1alpha4 (not supported)",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
@@ -265,20 +261,40 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
-						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
 							},
-						}),
+						}).
+						WithRawMetadata("v2.0.0",
+							"apiVersion: clusterctl.cluster.x-k8s.io/v1alpha4\n"+ // this can't be processed by clusterctl v1alpha3
+								"kind: Metadata\n"+
+								"releaseSeries:\n"+
+								"- major: 1\n"+
+								"  minor: 0\n"+
+								"  contract: v1alpha3\n"+
+								"- major: 2\n"+
+								"  minor: 0\n"+
+								"  contract: v1alpha4\n",
+						),
 					"infrastructure-infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
-						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
 							},
-						}),
+						}).
+						WithRawMetadata("v3.0.0",
+							"apiVersion: clusterctl.cluster.x-k8s.io/v1alpha4\n"+ // this can't be processed by clusterctl v1alpha3
+								"kind: Metadata\n"+
+								"releaseSeries:\n"+
+								"- major: 2\n"+
+								"  minor: 0\n"+
+								"  contract: v1alpha3\n"+
+								"- major: 3\n"+
+								"  minor: 0\n"+
+								"  contract: v1alpha4\n",
+						),
 				},
 				// one core and two infra providers existing in the cluster
 				proxy: test.NewFakeProxy().
@@ -305,29 +321,12 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 contract
-					Contract:     "v1alpha4",
-					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-					Providers: []UpgradeItem{
-						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-							NextVersion: "v2.0.0",
-						},
-						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system1", "ns1"),
-							NextVersion: "v3.0.0",
-						},
-						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
-							NextVersion: "v3.0.0",
-						},
-					},
-				},
+				// upgrade plan for the v1alpha4 contract should be ignored
 			},
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Core multi-tenancy, upgrade within the same contract",
+			name: "Single Management group, n-Core multi-tenancy, upgrade within the same contract - v1alpha3 (current)",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
@@ -390,7 +389,7 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Core multi-tenancy, upgrade for two contracts",
+			name: "Single Management group, n-Core multi-tenancy, upgrade for two contracts - v1alpha3 (current), v1alpha4 (not supported)",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
@@ -400,20 +399,41 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
-						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 1, Minor: 0, Contract: "v1alpha3"},
 								{Major: 2, Minor: 0, Contract: "v1alpha4"},
 							},
-						}),
+						}).
+						WithRawMetadata("v2.0.0",
+							"apiVersion: clusterctl.cluster.x-k8s.io/v1alpha4\n"+ // this can't be processed by clusterctl v1alpha3
+								"kind: Metadata\n"+
+								"releaseSeries:\n"+
+								"- major: 1\n"+
+								"  minor: 0\n"+
+								"  contract: v1alpha3\n"+
+								"- major: 2\n"+
+								"  minor: 0\n"+
+								"  contract: v1alpha4\n",
+						),
 					"infrastructure-infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
-						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
 							},
-						}),
+						}).
+						WithRawMetadata("v3.0.0",
+							"apiVersion: clusterctl.cluster.x-k8s.io/v1alpha4\n"+ // this can't be processed by clusterctl v1alpha3
+								"kind: Metadata\n"+
+								"releaseSeries:\n"+
+								"- major: 2\n"+
+								"  minor: 0\n"+
+								"  contract: v1alpha3\n"+
+								"- major: 3\n"+
+								"  minor: 0\n"+
+								"  contract: v1alpha4\n",
+						),
 				},
 				// two management groups existing in the cluster
 				proxy: test.NewFakeProxy().
@@ -437,20 +457,7 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 contract for the first management group
-					Contract:     "v1alpha4",
-					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system1", "ns1"),
-					Providers: []UpgradeItem{
-						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system1", "ns1"),
-							NextVersion: "v2.0.0",
-						},
-						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system1", "ns1"),
-							NextVersion: "v3.0.0",
-						},
-					},
-				},
+				// upgrade plan for the v1alpha4 contract for the first management group not supported
 				{ // one upgrade plan with the latest releases in the v1alpha3 contract for the second management group
 					Contract:     "v1alpha3",
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2"),
@@ -465,42 +472,28 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 contract for the second management group
-					Contract:     "v1alpha4",
-					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2"),
-					Providers: []UpgradeItem{
-						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2"),
-							NextVersion: "v2.0.0",
-						},
-						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
-							NextVersion: "v3.0.0",
-						},
-					},
-				},
+				// upgrade plan for the v1alpha4 contract for the second management group not supported
 			},
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, no multi-tenancy, upgrade for two contracts, but the upgrade for the second one is partially available",
+			name: "Single Management group, no multi-tenancy, upgrade partial upgrades for v1alpha3 (current)",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, the first with a new version for current v1alpha3 contract and a new version for the v1alpha4 contract, the second without new releases
+				// two provider repositories, the first with a new version for current v1alpha3 contract, the second without new releases
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
-						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
+						WithVersions("v1.0.0", "v1.0.1").
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
 							},
 						}),
 					"infrastructure-infra": test.NewFakeRepository().
-						WithVersions("v2.0.0"). // no v1alpha3 or v1alpha3 new releases yet available for the infra provider (only the current release exists)
+						WithVersions("v2.0.0"). // no v1alpha3 new releases yet available for the infra provider (only the current release exists)
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 2, Minor: 0, Contract: "v1alpha3"},
@@ -527,7 +520,6 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				// the upgrade plan with the latest releases in the v1alpha4 contract should be dropped because all the provider are required to change the contract at the same time
 			},
 			wantErr: false,
 		},
@@ -675,7 +667,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "fail if upgrade infra provider, changing contract",
+			name: "fail if upgrade infra provider, changing contract", // not supported in current clusterctl release.
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
@@ -688,7 +680,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
+								{Major: 2, Minor: 0, Contract: "v1alpha4"}, // not supported in current clusterctl release, but this makes it possible to test the scenario that is required in future versions of clusterctl.
 							},
 						}),
 					"infra": test.NewFakeRepository().
@@ -696,7 +688,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
+								{Major: 3, Minor: 0, Contract: "v1alpha4"}, // not supported in current clusterctl release, but this makes it possible to test the scenario that is required in future versions of clusterctl.
 							},
 						}),
 				},
@@ -710,7 +702,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				providersToUpgrade: []UpgradeItem{
 					{
 						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-						NextVersion: "v3.0.0", // upgrade to next release in the v1alpha4 contract
+						NextVersion: "v3.0.0", // upgrade to next release in the v1alpha4 contract; not supported in current clusterctl release.
 					},
 				},
 			},
@@ -731,7 +723,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
+								{Major: 2, Minor: 0, Contract: "v1alpha4"}, // not supported in current clusterctl release, but this makes it possible to test the scenario that is required in future versions of clusterctl.
 							},
 						}),
 					"infra": test.NewFakeRepository().
@@ -739,7 +731,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
+								{Major: 3, Minor: 0, Contract: "v1alpha4"}, // not supported in current clusterctl release, but this makes it possible to test the scenario that is required in future versions of clusterctl.
 							},
 						}),
 				},
@@ -753,7 +745,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				providersToUpgrade: []UpgradeItem{
 					{
 						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-						NextVersion: "v2.0.0", // upgrade to next release in the v1alpha4 contract
+						NextVersion: "v2.0.0", // upgrade to next release in the v1alpha4 contract; not supported in current clusterctl release.
 					},
 				},
 			},
@@ -761,7 +753,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "pass if upgrade core and infra provider, changing contract",
+			name: "fail if upgrade core and infra provider, changing contract", // not supported in current clusterctl release
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
@@ -774,7 +766,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
+								{Major: 2, Minor: 0, Contract: "v1alpha4"}, // not supported in current clusterctl release, but this makes it possible to test the scenario that is required in future versions of clusterctl.
 							},
 						}),
 					"infra": test.NewFakeRepository().
@@ -782,7 +774,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
 								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
+								{Major: 3, Minor: 0, Contract: "v1alpha4"}, // not supported in current clusterctl release, but this makes it possible to test the scenario that is required in future versions of clusterctl.
 							},
 						}),
 				},
@@ -796,29 +788,16 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				providersToUpgrade: []UpgradeItem{
 					{
 						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-						NextVersion: "v2.0.0", // upgrade to next release in the v1alpha4 contract
+						NextVersion: "v2.0.0", // upgrade to next release in the v1alpha4 contract; not supported in current clusterctl release.
 					},
 					{
 						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-						NextVersion: "v3.0.0", // upgrade to next release in the v1alpha4 contract
+						NextVersion: "v3.0.0", // upgrade to next release in the v1alpha4 contract; not supported in current clusterctl release.
 					},
 				},
 			},
-			want: &UpgradePlan{
-				Contract:     "v1alpha4",
-				CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-				Providers: []UpgradeItem{
-					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-						NextVersion: "v2.0.0", // upgrade to next release in the v1alpha4 contract
-					},
-					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-						NextVersion: "v3.0.0", // upgrade to next release in the v1alpha4 contract
-					},
-				},
-			},
-			wantErr: false,
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -91,6 +91,9 @@ func (f *metadataClient) Get() (*clusterctlv1.Metadata, error) {
 	codecFactory := serializer.NewCodecFactory(scheme.Scheme)
 
 	if err := runtime.DecodeInto(codecFactory.UniversalDecoder(), file, obj); err != nil {
+		if runtime.IsNotRegisteredError(err) {
+			return nil, errors.Errorf("%q for provider \"%s:%s\" appears to be in an usupported version. This version of clusterctl supports %q metadata and provider versions only", name, f.provider.ManifestLabel(), version, clusterctlv1.GroupVersion.Version)
+		}
 		return nil, errors.Wrapf(err, "error decoding %q for provider %q", name, f.provider.ManifestLabel())
 	}
 

--- a/cmd/clusterctl/client/tree/tree_test.go
+++ b/cmd/clusterctl/client/tree/tree_test.go
@@ -297,7 +297,7 @@ func Test_updateGroupNode(t *testing.T) {
 
 	group := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "virtual.cluster.x-k8s.io/v1alpha4",
+			"apiVersion": "virtual.cluster.x-k8s.io/v1alpha3",
 			"kind":       "MachineGroup",
 			"metadata": map[string]interface{}{
 				"namespace": "ns",
@@ -338,7 +338,7 @@ func Test_updateGroupNode(t *testing.T) {
 
 	want := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": "virtual.cluster.x-k8s.io/v1alpha4",
+			"apiVersion": "virtual.cluster.x-k8s.io/v1alpha3",
 			"kind":       "MachineGroup",
 			"metadata": map[string]interface{}{
 				"namespace": "ns",

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -99,6 +99,10 @@ type ApplyUpgradeOptions struct {
 }
 
 func (c *clusterctlClient) ApplyUpgrade(options ApplyUpgradeOptions) error {
+	if options.Contract != "" && options.Contract != clusterctlv1.GroupVersion.Version {
+		return errors.Errorf("current version of clusterctl could only upgrade to %s contract, requested %s", clusterctlv1.GroupVersion.Version, options.Contract)
+	}
+
 	// Get the client for interacting with the management cluster.
 	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {

--- a/cmd/clusterctl/cmd/upgrade_plan.go
+++ b/cmd/clusterctl/cmd/upgrade_plan.go
@@ -118,7 +118,7 @@ func runUpgradePlan() error {
 		if upgradeAvailable {
 			fmt.Println("You can now apply the upgrade by executing the following command:")
 			fmt.Println("")
-			fmt.Printf("   upgrade apply --management-group %s --contract %s\n", plan.CoreProvider.InstanceName(), plan.Contract)
+			fmt.Printf(" clusterctl upgrade apply --management-group %s --contract %s\n", plan.CoreProvider.InstanceName(), plan.Contract)
 		} else {
 			fmt.Println("You are already up to date!")
 		}

--- a/cmd/clusterctl/internal/test/fake_repository.go
+++ b/cmd/clusterctl/internal/test/fake_repository.go
@@ -122,6 +122,10 @@ func (f *FakeRepository) WithMetadata(version string, metadata *clusterctlv1.Met
 	return f.WithFile(version, "metadata.yaml", data)
 }
 
+func (f *FakeRepository) WithRawMetadata(version string, raw string) *FakeRepository {
+	return f.WithFile(version, "metadata.yaml", []byte(raw))
+}
+
 func vpath(version string, path string) string {
 	return fmt.Sprintf("%s/%s", version, path)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements clusterctl v1alpha3 version checks to prevent prevents potentially destructive operations due to version skew. More specifically

- clusterctl version v1alpha3 should not be allowed to install v1alpha4 version of providers
- clusterctl version v1alpha3 should not be allowed to manage management cluster with v1alpha4 version of providers

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4192
