### PR TITLE
🌱  clusterctl v1alpha4 should not install v1alpha3 providers

### DIFF
--- a/cmd/clusterctl/client/cluster/installer.go
+++ b/cmd/clusterctl/client/cluster/installer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
@@ -242,6 +243,10 @@ func (i *providerInstaller) getProviderContract(providerInstanceContracts map[st
 	releaseSeries := latestMetadata.GetReleaseSeriesForVersion(currentVersion)
 	if releaseSeries == nil {
 		return "", errors.Errorf("invalid provider metadata: version %s for the provider %s does not match any release series", provider.Version, provider.InstanceName())
+	}
+
+	if releaseSeries.Contract != clusterv1.GroupVersion.Version {
+		return "", errors.Errorf("current version of clusterctl could install only %s providers, detected %s for provider %s", clusterv1.GroupVersion.Version, releaseSeries.Contract, provider.ManifestLabel())
 	}
 
 	providerInstanceContracts[provider.InstanceName()] = releaseSeries.Contract

--- a/cmd/clusterctl/internal/test/contracts.go
+++ b/cmd/clusterctl/internal/test/contracts.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+
+// PreviousCAPIContractNotSupported define the previous Cluster API contract, not supported by this release of clusterctl.
+const PreviousCAPIContractNotSupported = "v1alpha3"
+
+// CurrentCAPIContract define the current Cluster API contract.
+var CurrentCAPIContract = clusterv1.GroupVersion.Version
+
+// NextCAPIContractNotSupported define the next Cluster API contract, not supported by this release of clusterctl.
+const NextCAPIContractNotSupported = "v1alpha5"

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -29,7 +29,7 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v0.3.0
+  - name: v0.4.0
   # Use manifest from source files
     value: ../../../config/default
     replacements:
@@ -41,7 +41,7 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v0.3.0
+  - name: v0.4.0
   # Use manifest from source files
     value: ../../../bootstrap/kubeadm/config/default
     replacements:
@@ -53,7 +53,7 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v0.3.0
+  - name: v0.4.0
   # Use manifest from source files
     value: ../../../controlplane/kubeadm/config/default
     replacements:
@@ -65,7 +65,7 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
-  - name: v0.3.0
+  - name: v0.4.0
   # Use manifest from source files
     value: ../../../test/infrastructure/docker/config/default
     replacements:

--- a/test/e2e/data/shared/v1alpha4/metadata.yaml
+++ b/test/e2e/data/shared/v1alpha4/metadata.yaml
@@ -2,6 +2,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 0
+    minor: 4
+    contract: v1alpha4
+  - major: 0
     minor: 3
     contract: v1alpha3
   - major: 0


### PR DESCRIPTION
**What this PR does / why we need it**:
Cluster API v1alpha4 is introducing changes in how providers are deployed (see e.g webhooks running with manager).

As a consequence, clusterctl version v1alpha4 should not be allowed to install v1alpha3 providers

NB: While doing the change, also clusterctl version v1alpha4 should not be allowed to install v1alpha5 providers was implemented, and tests are now refactored in order to make changes for supporting the next contract less invasive.

This will also ensure easier backport

**Which issue(s) this PR fixes**:
Rif #4191
