### PR TITLE
⚠️ Add GVK object validation to patch helper

### DIFF
--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -865,6 +865,38 @@ var _ = Describe("Patch Helper", func() {
 			}, timeout).Should(BeTrue())
 		})
 	})
+
+	It("Should error if the object isn't the same", func() {
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Namespace:    "default",
+			},
+		}
+
+		machineSet := &clusterv1.MachineSet{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-ms",
+				Namespace:    "default",
+			},
+			Spec: clusterv1.MachineSetSpec{
+				ClusterName: "test1",
+				Template: clusterv1.MachineTemplateSpec{
+					Spec: clusterv1.MachineSpec{
+						ClusterName: "test1",
+					},
+				},
+			},
+		}
+
+		Expect(testEnv.Create(ctx, cluster)).To(Succeed())
+		Expect(testEnv.Create(ctx, machineSet)).To(Succeed())
+
+		patcher, err := NewHelper(cluster, testEnv)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(patcher.Patch(ctx, machineSet)).ToNot(Succeed())
+	})
 })
 
 func TestNewHelperNil(t *testing.T) {


### PR DESCRIPTION


Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The following changes add more validation to the patch helper to avoid
possible issues by patching different objects by mistake. Part of this
change is also checking that users don't pass in nil objects to the
Patch() method.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3269 

/milestone v0.4.0
/assign @CecileRobertMichon 