### PR TITLE
:seedling: Enable ClusterResourceSet by default

### DIFF
--- a/feature/feature.go
+++ b/feature/feature.go
@@ -44,5 +44,5 @@ func init() {
 var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	// Every feature should be initiated here:
 	MachinePool:        {Default: false, PreRelease: featuregate.Alpha},
-	ClusterResourceSet: {Default: false, PreRelease: featuregate.Alpha},
+	ClusterResourceSet: {Default: true, PreRelease: featuregate.Beta},
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Graduate CRS in v0.4.0 by enabling the functionality by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3311 

/milestone v0.4.0
/assign @CecileRobertMichon @sedefsavas 