### PR TITLE
🐛 Fix a panic when getExternalRemediationRequest returns nil

### DIFF
--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -299,10 +299,11 @@ func (r *MachineHealthCheckReconciler) PatchHealthyTargets(ctx context.Context, 
 			// Get remediation request object
 			obj, err := r.getExternalRemediationRequest(ctx, m, t.Machine.Name)
 			if err != nil {
-				if apierrors.IsNotFound(errors.Cause(err)) {
-					continue
+				if !apierrors.IsNotFound(errors.Cause(err)) {
+					wrappedErr := errors.Wrapf(err, "failed to fetch remediation request for machine %q in namespace %q within cluster %q", t.Machine.Name, t.Machine.Namespace, t.Machine.ClusterName)
+					errList = append(errList, wrappedErr)
 				}
-				logger.Error(err, "failed to fetch remediation request for machine %q in namespace %q within cluster %q", t.Machine.Name, t.Machine.Namespace, t.Machine.ClusterName)
+				continue
 			}
 			// Check that obj has no DeletionTimestamp to avoid hot loop
 			if obj.GetDeletionTimestamp() == nil {


### PR DESCRIPTION
:bug:, patch and bugfixes
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
fix bug
obj, err := r.getExternalRemediationRequest(ctx, m, t.Machine.Name) 
when obj is nil will cause panic
obj.GetDeletionTimestamp()

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
