### PR TITLE
⚠️ Default Kubelet cgroupDriver to systemd for Kubernetes >= 1.21

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -179,10 +179,13 @@ func (w *Workload) UpdateKubeletConfigMap(ctx context.Context, version semver.Ve
 		return err
 	}
 
-	// In order to avoid using two cgroup managers on the same machine,
-	// cgroupfs and systemd cgroup, starting from
-	// 1.21 image builder is going to configure containerd for using systemd cgroup,
-	// and the Kubelet configuration should be changed accordingly.
+	// In order to avoid using two cgroup drivers on the same machine,
+	// (cgroupfs and systemd cgroup drivers), starting from
+	// 1.21 image builder is going to configure containerd for using the
+	// systemd driver, and the Kubelet configuration must
+	// NOTE: It is considered safe to update the kubelet-config-1.21 ConfigMap
+	// because only new nodes using v1.21 images will pick up the change during
+	// kubeadm join.
 	if version.GE(minVerKubeletSystemdDriver) {
 		data, ok := cm.Data[kubeletConfigKey]
 		if !ok {

--- a/controlplane/kubeadm/internal/workload_cluster_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_test.go
@@ -19,6 +19,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -277,33 +278,74 @@ kind: ClusterStatus
 }
 
 func TestUpdateKubeletConfigMap(t *testing.T) {
-	kubeletConfig := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "kubelet-config-1.1",
-			Namespace:       metav1.NamespaceSystem,
-			ResourceVersion: "some-resource-version",
-		},
-	}
-
 	g := NewWithT(t)
 	scheme := runtime.NewScheme()
 	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	tests := []struct {
-		name      string
-		version   semver.Version
-		objs      []client.Object
-		expectErr bool
+		name               string
+		version            semver.Version
+		objs               []client.Object
+		expectErr          bool
+		expectCgroupDriver string
 	}{
 		{
-			name:      "create new config map",
-			version:   semver.Version{Major: 1, Minor: 2},
-			objs:      []client.Object{kubeletConfig},
-			expectErr: false,
+			name:    "create new config map",
+			version: semver.Version{Major: 1, Minor: 20},
+			objs: []client.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "kubelet-config-1.19",
+					Namespace:       metav1.NamespaceSystem,
+					ResourceVersion: "some-resource-version",
+				},
+				Data: map[string]string{
+					kubeletConfigKey: "apiVersion: kubelet.config.k8s.io/v1beta1\n" +
+						"kind: KubeletConfiguration\n",
+				},
+			}},
+			expectErr:          false,
+			expectCgroupDriver: "",
 		},
 		{
-			name:      "returns error if cannot find previous config map",
-			version:   semver.Version{Major: 1, Minor: 2},
-			expectErr: true,
+			name:    "KubeletConfig 1.21 gets the cgroupDriver set if empty",
+			version: semver.Version{Major: 1, Minor: 21},
+			objs: []client.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "kubelet-config-1.20",
+					Namespace:       metav1.NamespaceSystem,
+					ResourceVersion: "some-resource-version",
+				},
+				Data: map[string]string{
+					kubeletConfigKey: "apiVersion: kubelet.config.k8s.io/v1beta1\n" +
+						"kind: KubeletConfiguration\n",
+				},
+			}},
+			expectErr:          false,
+			expectCgroupDriver: "systemd",
+		},
+		{
+			name:    "KubeletConfig 1.21 preserves cgroupDriver if already set",
+			version: semver.Version{Major: 1, Minor: 21},
+			objs: []client.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "kubelet-config-1.20",
+					Namespace:       metav1.NamespaceSystem,
+					ResourceVersion: "some-resource-version",
+				},
+				Data: map[string]string{
+					kubeletConfigKey: "apiVersion: kubelet.config.k8s.io/v1beta1\n" +
+						"kind: KubeletConfiguration\n" +
+						"cgroupDriver: foo\n",
+				},
+			}},
+			expectErr:          false,
+			expectCgroupDriver: "foo",
+		},
+		{
+			name:               "returns error if cannot find previous config map",
+			version:            semver.Version{Major: 1, Minor: 21},
+			objs:               nil,
+			expectErr:          true,
+			expectCgroupDriver: "",
 		},
 	}
 
@@ -323,10 +365,11 @@ func TestUpdateKubeletConfigMap(t *testing.T) {
 			var actualConfig corev1.ConfigMap
 			g.Expect(w.Client.Get(
 				ctx,
-				client.ObjectKey{Name: "kubelet-config-1.2", Namespace: metav1.NamespaceSystem},
+				client.ObjectKey{Name: fmt.Sprintf("kubelet-config-%d.%d", tt.version.Major, tt.version.Minor), Namespace: metav1.NamespaceSystem},
 				&actualConfig,
 			)).To(Succeed())
-			g.Expect(actualConfig.ResourceVersion).ToNot(Equal(kubeletConfig.ResourceVersion))
+			g.Expect(actualConfig.ResourceVersion).ToNot(Equal("some-resource-version"))
+			g.Expect(actualConfig.Data[kubeletConfigKey]).To(ContainSubstring(tt.expectCgroupDriver))
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
For Kubernetes >= 1.21, image builder is going to setup containerd for using systemd cgroup.
KCP should take care of adapting the Kubelet-Config map to be consistent with this change.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4099

/area control-plane
/milestone v0.4.0

/hold 
for the change in image builder to be merged, rif https://github.com/kubernetes-sigs/image-builder/issues/471
