### PR TITLE
📖 Document policy for workloads on KCP controlled machines

### DIFF
--- a/docs/book/src/tasks/kubeadm-control-plane.md
+++ b/docs/book/src/tasks/kubeadm-control-plane.md
@@ -16,6 +16,22 @@ See the section on [upgrading clusters][upgrades].
 
 See the section on [Adopting existing machines into KubeadmControlPlane management][adoption]
 
+### Running workloads on control plane machines
+
+We don't suggest running workloads on control planes, and highly encourage avoiding it unless absolutely necessary.
+
+However, in the case the user wants to run non-control plane workloads on control plane machines they
+are ultimately responsible for ensuring the proper functioning of those workloads, given that KCP is not 
+aware of the specific requirements for each type of workload (e.g. preserving quorum, shutdown procedures etc.).
+
+In order to do so, the user could leverage on the same assumption that applies to all the
+Cluster API Machines:
+
+- The Kubernetes node hosted on the Machine will be cordoned & drained before removal (with well
+  known exceptions like full Cluster deletion).
+- The Machine will respect PreDrainDeleteHook and PreTerminateDeleteHook. see the
+  [Machine Deletion Phase Hooks proposal](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/20200602-machine-deletion-phase-hooks.md)
+  for additional details.
 
 <!-- links -->
 [adoption]: upgrading-cluster-api-versions.md#adopting-existing-machines-into-kubeadmcontrolplane-management


### PR DESCRIPTION
**What this PR does / why we need it**:
Document current behaviour for workloads on KCP controlled machines

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/2064
