### PR TITLE
🐛 Fix KCP remediation when node Name & etcd member Name != machine Name

### DIFF
--- a/controlplane/kubeadm/controllers/remediation.go
+++ b/controlplane/kubeadm/controllers/remediation.go
@@ -207,7 +207,7 @@ func (r *KubeadmControlPlaneReconciler) canSafelyRemoveEtcdMember(ctx context.Co
 	unhealthyMembers := []string{}
 	for _, etcdMember := range etcdMembers {
 		// Skip the machine to be deleted because it won't be part of the target etcd cluster.
-		if etcdMember == machineToBeRemediated.Name {
+		if machineToBeRemediated.Status.NodeRef != nil && machineToBeRemediated.Status.NodeRef.Name == etcdMember {
 			continue
 		}
 

--- a/controlplane/kubeadm/controllers/remediation_test.go
+++ b/controlplane/kubeadm/controllers/remediation_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"testing"
 
@@ -153,7 +154,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -188,7 +189,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -226,7 +227,7 @@ func TestReconcileUnhealthyMachines(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -278,7 +279,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -308,7 +309,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -339,7 +340,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -370,7 +371,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -403,7 +404,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -436,7 +437,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -471,7 +472,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -506,7 +507,7 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 			recorder: record.NewFakeRecorder(32),
 			managementCluster: &fakeManagementCluster{
 				Workload: fakeWorkloadCluster{
-					EtcdMembersResult: controlPlane.Machines.Names(),
+					EtcdMembersResult: nodes(controlPlane.Machines),
 				},
 			},
 		}
@@ -518,6 +519,16 @@ func TestCanSafelyRemoveEtcdMember(t *testing.T) {
 		g.Expect(testEnv.Cleanup(ctx, m1, m2, m3, m4, m5, m6, m7)).To(Succeed())
 	})
 	g.Expect(testEnv.Cleanup(ctx, ns)).To(Succeed())
+}
+
+func nodes(machines collections.Machines) []string {
+	nodes := make([]string, 0, machines.Len())
+	for _, m := range machines {
+		if m.Status.NodeRef != nil {
+			nodes = append(nodes, m.Status.NodeRef.Name)
+		}
+	}
+	return nodes
 }
 
 type machineOption func(*clusterv1.Machine)
@@ -568,7 +579,7 @@ func createMachine(ctx context.Context, g *WithT, namespace, name string, option
 	patchHelper, err := patch.NewHelper(m, testEnv.GetClient())
 	g.Expect(err).ToNot(HaveOccurred())
 
-	for _, opt := range append(options, withNodeRef(m.Name)) {
+	for _, opt := range append(options, withNodeRef(fmt.Sprintf("node-%s", m.Name))) {
 		opt(m)
 	}
 
@@ -592,7 +603,7 @@ func getDeletingMachine(namespace, name string, options ...machineOption) *clust
 		},
 	}
 
-	for _, opt := range append(options, withNodeRef(m.Name)) {
+	for _, opt := range append(options, withNodeRef(fmt.Sprintf("node-%s", m.Name))) {
 		opt(m)
 	}
 	return m


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a problem in KCP remediation not properly computing the targetCluster when node Name & etcd member Name != machine Name (e.g. AWS)

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4239
