### PR TITLE
🌱 update golangci-lint config to use disable-all/enable

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,39 @@
 linters:
-  enable-all: true
-  disable:
-    - dupl
-    - funlen
-    - gochecknoglobals
-    - gochecknoinits
-    - lll
-    - godox
-    - wsl
-    - whitespace
-    - gocognit
-    - gomnd
-    - interfacer
-    - godot
-    - goerr113
-    - nestif
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - errcheck
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - maligned
+    - misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - testpackage
+    - typecheck
+    - unconvert
+    - unparam
+    - varcheck
   # Run with --fast=false for more extensive checks
   fast: true
 issues:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

As mentioned in #4243, golang lint documentation suggests using `disable-all/enable` instead of `enable-all/disable`(it is deprecated and will be removed soon). So we should implement `disable-all: true / enable: [...]`.

Fixes #4243
