### PR TITLE
🌱clusterctl v1alpha3 should not install v1alpha4 providers

### DIFF
--- a/cmd/clusterctl/client/cluster/installer.go
+++ b/cmd/clusterctl/client/cluster/installer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
@@ -242,6 +243,10 @@ func (i *providerInstaller) getProviderContract(providerInstanceContracts map[st
 	releaseSeries := latestMetadata.GetReleaseSeriesForVersion(currentVersion)
 	if releaseSeries == nil {
 		return "", errors.Errorf("invalid provider metadata: version %s for the provider %s does not match any release series", provider.Version, provider.InstanceName())
+	}
+
+	if releaseSeries.Contract != clusterv1.GroupVersion.Version {
+		return "", errors.Errorf("current version of clusterctl could install only %s providers, detected %s for provider %s", clusterv1.GroupVersion.Version, releaseSeries.Contract, provider.ManifestLabel())
 	}
 
 	providerInstanceContracts[provider.InstanceName()] = releaseSeries.Contract

--- a/cmd/clusterctl/client/init_test.go
+++ b/cmd/clusterctl/client/init_test.go
@@ -240,7 +240,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Init (with an empty cluster) with default provider versions",
+			name: "Init (with an empty cluster) with default provider versions/current contract",
 			field: field{
 				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap, control plane and infra provider)
 				hasCRD: false,
@@ -282,7 +282,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Init (with an empty cluster) opting out from automatic install of providers",
+			name: "Init (with an empty cluster) opting out from automatic install of providers/current contract",
 			field: field{
 				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap, control plane and infra provider)
 				hasCRD: false,
@@ -312,7 +312,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Init (with an empty cluster) with custom provider versions",
+			name: "Init (with an empty cluster) with custom provider versions/current contract",
 			field: field{
 				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap, control plane and infra provider)
 				hasCRD: false,
@@ -354,7 +354,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Init (with an empty cluster) with target namespace",
+			name: "Init (with an empty cluster) with target namespace/current contract",
 			field: field{
 				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap, control plane and infra provider)
 				hasCRD: false,
@@ -395,7 +395,7 @@ func Test_clusterctlClient_Init(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Init (with a NOT empty cluster) adds a provider",
+			name: "Init (with a NOT empty cluster) adds a provider/current contract",
 			field: field{
 				client: fakeInitializedCluster(), // clusterctl client for an management cluster with capi installed (with repository setup for capi, bootstrap, control plane and infra provider)
 				hasCRD: true,
@@ -501,6 +501,68 @@ func Test_clusterctlClient_Init(t *testing.T) {
 				watchingNamespace:      "",
 			},
 			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Init (with an empty cluster) with custom provider versions/previous contract, not supported",
+			field: field{
+				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap, control plane and infra provider)
+				hasCRD: false,
+			},
+			args: args{
+				coreProvider:           fmt.Sprintf("%s:v0.9.0", config.ClusterAPIProviderName),
+				bootstrapProvider:      []string{fmt.Sprintf("%s:v0.9.0", config.KubeadmBootstrapProviderName)},
+				controlPlaneProvider:   []string{fmt.Sprintf("%s:v0.9.0", config.KubeadmControlPlaneProviderName)},
+				infrastructureProvider: []string{"infra:v0.9.0"},
+				targetNameSpace:        "",
+				watchingNamespace:      "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Init (with a NOT empty cluster) adds a provider/previous contract, not supported",
+			field: field{
+				client: fakeInitializedCluster(), // clusterctl client for an management cluster with capi installed (with repository setup for capi, bootstrap, control plane and infra provider)
+				hasCRD: true,
+			},
+			args: args{
+				coreProvider:           "", // with a NOT empty cluster, a core provider should NOT be added automatically
+				bootstrapProvider:      []string{fmt.Sprintf("%s:v0.9.0", config.KubeadmBootstrapProviderName)},
+				infrastructureProvider: []string{"infra:v0.9.0"},
+				targetNameSpace:        "",
+				watchingNamespace:      "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Init (with an empty cluster) with custom provider versions/next contract, not supported",
+			field: field{
+				client: fakeEmptyCluster(), // clusterctl client for an empty management cluster (with repository setup for capi, bootstrap, control plane and infra provider)
+				hasCRD: false,
+			},
+			args: args{
+				coreProvider:           fmt.Sprintf("%s:v2.0.0", config.ClusterAPIProviderName),
+				bootstrapProvider:      []string{fmt.Sprintf("%s:v3.0.0", config.KubeadmBootstrapProviderName)},
+				controlPlaneProvider:   []string{fmt.Sprintf("%s:v3.0.0", config.KubeadmControlPlaneProviderName)},
+				infrastructureProvider: []string{"infra:v4.0.0"},
+				targetNameSpace:        "",
+				watchingNamespace:      "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Init (with a NOT empty cluster) adds a provider/next contract, not supported",
+			field: field{
+				client: fakeInitializedCluster(), // clusterctl client for an management cluster with capi installed (with repository setup for capi, bootstrap, control plane and infra provider)
+				hasCRD: true,
+			},
+			args: args{
+				coreProvider:           "", // with a NOT empty cluster, a core provider should NOT be added automatically
+				bootstrapProvider:      []string{fmt.Sprintf("%s:v3.0.0", config.KubeadmBootstrapProviderName)},
+				infrastructureProvider: []string{"infra:v4.0.0"},
+				targetNameSpace:        "",
+				watchingNamespace:      "",
+			},
 			wantErr: true,
 		},
 	}
@@ -612,61 +674,133 @@ func fakeRepositories(config *fakeConfigClient, providers []Provider) []*fakeRep
 	repository1 := newFakeRepository(capiProviderConfig, config).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v1.0.0").
+		WithFile("v0.9.0", "components.yaml", componentsYAML("ns1")).
+		WithMetadata("v0.9.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+			},
+		}).
 		WithFile("v1.0.0", "components.yaml", componentsYAML("ns1")).
 		WithMetadata("v1.0.0", &clusterctlv1.Metadata{
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
-				{Major: 1, Minor: 0, Contract: "v1alpha3"},
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
 			},
 		}).
 		WithFile("v1.1.0", "components.yaml", componentsYAML("ns1")).
 		WithMetadata("v1.1.0", &clusterctlv1.Metadata{
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
-				{Major: 1, Minor: 1, Contract: "v1alpha3"},
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
+				{Major: 1, Minor: 1, Contract: test.CurrentCAPIContract},
+			},
+		}).
+		WithFile("v2.0.0", "components.yaml", componentsYAML("ns1")).
+		WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
+				{Major: 1, Minor: 1, Contract: test.CurrentCAPIContract},
+				{Major: 2, Minor: 0, Contract: test.NextCAPIContractNotSupported},
 			},
 		})
 	repository2 := newFakeRepository(bootstrapProviderConfig, config).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v2.0.0").
+		WithFile("v0.9.0", "components.yaml", componentsYAML("ns1")).
+		WithMetadata("v0.9.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+			},
+		}).
 		WithFile("v2.0.0", "components.yaml", componentsYAML("ns2")).
 		WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
-				{Major: 2, Minor: 0, Contract: "v1alpha3"},
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 			},
 		}).
 		WithFile("v2.1.0", "components.yaml", componentsYAML("ns2")).
 		WithMetadata("v2.1.0", &clusterctlv1.Metadata{
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
-				{Major: 2, Minor: 1, Contract: "v1alpha3"},
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+				{Major: 2, Minor: 1, Contract: test.CurrentCAPIContract},
+			},
+		}).
+		WithFile("v3.0.0", "components.yaml", componentsYAML("ns2")).
+		WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+				{Major: 2, Minor: 1, Contract: test.CurrentCAPIContract},
+				{Major: 3, Minor: 0, Contract: test.NextCAPIContractNotSupported},
 			},
 		})
 	repository3 := newFakeRepository(controlPlaneProviderConfig, config).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v2.0.0").
+		WithFile("v0.9.0", "components.yaml", componentsYAML("ns1")).
+		WithMetadata("v0.9.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+			},
+		}).
 		WithFile("v2.0.0", "components.yaml", componentsYAML("ns3")).
 		WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
-				{Major: 2, Minor: 0, Contract: "v1alpha3"},
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 			},
 		}).
 		WithFile("v2.1.0", "components.yaml", componentsYAML("ns3")).
 		WithMetadata("v2.1.0", &clusterctlv1.Metadata{
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
-				{Major: 2, Minor: 1, Contract: "v1alpha3"},
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+				{Major: 2, Minor: 1, Contract: test.CurrentCAPIContract},
+			},
+		}).
+		WithFile("v3.0.0", "components.yaml", componentsYAML("ns2")).
+		WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+				{Major: 2, Minor: 1, Contract: test.CurrentCAPIContract},
+				{Major: 3, Minor: 0, Contract: test.NextCAPIContractNotSupported},
 			},
 		})
 	repository4 := newFakeRepository(infraProviderConfig, config).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v3.0.0").
+		WithFile("v0.9.0", "components.yaml", componentsYAML("ns1")).
+		WithMetadata("v0.9.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+			},
+		}).
 		WithFile("v3.0.0", "components.yaml", infraComponentsYAML("ns4")).
 		WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
-				{Major: 3, Minor: 0, Contract: "v1alpha3"},
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
 			},
 		}).
 		WithFile("v3.1.0", "components.yaml", infraComponentsYAML("ns4")).
 		WithMetadata("v3.1.0", &clusterctlv1.Metadata{
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
-				{Major: 3, Minor: 1, Contract: "v1alpha3"},
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
+				{Major: 3, Minor: 1, Contract: test.CurrentCAPIContract},
+			},
+		}).
+		WithFile("v4.0.0", "components.yaml", componentsYAML("ns2")).
+		WithMetadata("v4.0.0", &clusterctlv1.Metadata{
+			ReleaseSeries: []clusterctlv1.ReleaseSeries{
+				{Major: 0, Minor: 9, Contract: test.PreviousCAPIContractNotSupported},
+				{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
+				{Major: 3, Minor: 1, Contract: test.CurrentCAPIContract},
+				{Major: 4, Minor: 0, Contract: test.NextCAPIContractNotSupported},
 			},
 		}).
 		WithFile("v3.0.0", "cluster-template.yaml", templateYAML("ns4", "test"))
@@ -681,7 +815,7 @@ func fakeRepositories(config *fakeConfigClient, providers []Provider) []*fakeRep
 				WithFile("v2.0.0", "components.yaml", componentsYAML("ns2")).
 				WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 					ReleaseSeries: []clusterctlv1.ReleaseSeries{
-						{Major: 2, Minor: 0, Contract: "v1alpha3"},
+						{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 					},
 				}))
 	}

--- a/cmd/clusterctl/internal/test/contracts.go
+++ b/cmd/clusterctl/internal/test/contracts.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha2"
+import clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+// PreviousCAPIContractNotSupported define the previous Cluster API contract, not supported by this release of clusterctl.
+var PreviousCAPIContractNotSupported = clusterv1old.GroupVersion.Version
+
+// CurrentCAPIContract define the current Cluster API contract.
+var CurrentCAPIContract = clusterv1.GroupVersion.Version
+
+// NextCAPIContractNotSupported define the next Cluster API contract, not supported by this release of clusterctl.
+const NextCAPIContractNotSupported = "v99"


### PR DESCRIPTION
**What this PR does / why we need it**:
this is a back port of https://github.com/kubernetes-sigs/cluster-api/pull/4200

Cluster API v1alpha4 is introducing changes in how providers are deployed (see e.g webhooks running with manager).

As a consequence, clusterctl version v1alpha3 should not be allowed to install v1alpha4 providers

NB: While doing the change, also clusterctl version v1alpha3 should not be allowed to install v1alpha2 providers was implemented, and tests are now refactored accordingly.

**Which issue(s) this PR fixes**:
Rif #4192