### PR TITLE
⚠️ Clustectl v1alpha3 should block on v1alpha4 clusters

### DIFF
--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -229,6 +229,11 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 		return nil, err
 	}
 
+	// Ensure this command only runs against management clusters with the current Cluster API contract.
+	if err := cluster.ProviderInventory().CheckCAPIContract(); err != nil {
+		return nil, err
+	}
+
 	// If the option specifying the targetNamespace is empty, try to detect it.
 	if options.TargetNamespace == "" {
 		currentNamespace, err := cluster.Proxy().CurrentNamespace()

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -26,6 +26,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -469,7 +470,8 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 
 	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1).
 		WithProviderInventory(infraProviderConfig.Name(), infraProviderConfig.Type(), "v3.0.0", "foo", "bar").
-		WithObjs(configMap)
+		WithObjs(configMap).
+		WithObjs(test.FakeCAPISetupObjects()...)
 
 	client := newFakeClient(config1).
 		WithCluster(cluster1).

--- a/cmd/clusterctl/client/delete.go
+++ b/cmd/clusterctl/client/delete.go
@@ -66,6 +66,12 @@ func (c *clusterctlClient) Delete(options DeleteOptions) error {
 		return err
 	}
 
+	// Ensure this command only runs against management clusters with the current Cluster API contract.
+	if err := clusterClient.ProviderInventory().CheckCAPIContract(); err != nil {
+		return err
+	}
+
+	// Ensure the custom resource definitions required by clusterctl are in place.
 	if err := clusterClient.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/delete_test.go
+++ b/cmd/clusterctl/client/delete_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
@@ -207,6 +206,7 @@ func fakeClusterForDelete() *fakeClient {
 	cluster1.fakeProxy.WithProviderInventory(bootstrapProviderConfig.Name(), bootstrapProviderConfig.Type(), "v1.0.0", "capbpk-system", "")
 	cluster1.fakeProxy.WithProviderInventory(controlPlaneProviderConfig.Name(), controlPlaneProviderConfig.Type(), "v1.0.0", namespace, "")
 	cluster1.fakeProxy.WithProviderInventory(infraProviderConfig.Name(), infraProviderConfig.Type(), "v1.0.0", namespace, "")
+	cluster1.fakeProxy.WithFakeCAPISetup()
 
 	client := newFakeClient(config1).
 		// fake repository for capi, bootstrap, controlplane and infra provider (matching provider's config)

--- a/cmd/clusterctl/client/describe.go
+++ b/cmd/clusterctl/client/describe.go
@@ -55,6 +55,11 @@ func (c *clusterctlClient) DescribeCluster(options DescribeClusterOptions) (*tre
 		return nil, err
 	}
 
+	// Ensure this command only runs against management clusters with the current Cluster API contract.
+	if err := cluster.ProviderInventory().CheckCAPIContract(); err != nil {
+		return nil, err
+	}
+
 	// If the option specifying the Namespace is empty, try to detect it.
 	if options.Namespace == "" {
 		currentNamespace, err := cluster.Proxy().CurrentNamespace()

--- a/cmd/clusterctl/client/get_kubeconfig.go
+++ b/cmd/clusterctl/client/get_kubeconfig.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package client
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+)
 
 //GetKubeconfigOptions carries all the options supported by GetKubeconfig
 type GetKubeconfigOptions struct {
@@ -35,6 +37,11 @@ func (c *clusterctlClient) GetKubeconfig(options GetKubeconfigOptions) (string, 
 	// gets access to the management cluster
 	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
+		return "", err
+	}
+
+	// Ensure this command only runs against management clusters with the current Cluster API contract.
+	if err := clusterClient.ProviderInventory().CheckCAPIContract(); err != nil {
 		return "", err
 	}
 

--- a/cmd/clusterctl/client/get_kubeconfig_test.go
+++ b/cmd/clusterctl/client/get_kubeconfig_test.go
@@ -28,11 +28,10 @@ func Test_clusterctlClient_GetKubeconfig(t *testing.T) {
 
 	configClient := newFakeConfig()
 	kubeconfig := cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}
-	clusterClient := &fakeClusterClient{
-		kubeconfig: kubeconfig,
-	}
+	clusterClient := newFakeCluster(cluster.Kubeconfig{Path: "cluster1"}, configClient)
+
 	// create a clusterctl client where the proxy returns an empty namespace
-	clusterClient.fakeProxy = test.NewFakeProxy().WithNamespace("")
+	clusterClient.fakeProxy = test.NewFakeProxy().WithNamespace("").WithFakeCAPISetup()
 	badClient := newFakeClient(configClient).WithCluster(clusterClient)
 
 	tests := []struct {

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -45,6 +45,11 @@ func (c *clusterctlClient) Move(options MoveOptions) error {
 		return err
 	}
 
+	// Ensure this command only runs against management clusters with the current Cluster API contract.
+	if err := fromCluster.ProviderInventory().CheckCAPIContract(); err != nil {
+		return err
+	}
+
 	// Ensures the custom resource definitions required by clusterctl are in place.
 	if err := fromCluster.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
 		return err
@@ -55,6 +60,11 @@ func (c *clusterctlClient) Move(options MoveOptions) error {
 		// Get the client for interacting with the target management cluster.
 		toCluster, err = c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.ToKubeconfig})
 		if err != nil {
+			return err
+		}
+
+		// Ensure this command only runs against management clusters with the current Cluster API contract.
+		if err := toCluster.ProviderInventory().CheckCAPIContract(); err != nil {
 			return err
 		}
 

--- a/cmd/clusterctl/client/move_test.go
+++ b/cmd/clusterctl/client/move_test.go
@@ -23,6 +23,7 @@ import (
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 )
 
 func Test_clusterctlClient_Move(t *testing.T) {
@@ -104,12 +105,14 @@ func fakeClientForMove() *fakeClient {
 	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1).
 		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "").
 		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "").
-		WithObjectMover(&fakeObjectMover{})
+		WithObjectMover(&fakeObjectMover{}).
+		WithObjs(test.FakeCAPISetupObjects()...)
 
 	// Creating this cluster for move_test
 	cluster2 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "worker-context"}, config1).
 		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "").
-		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "")
+		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "").
+		WithObjs(test.FakeCAPISetupObjects()...)
 
 	client := newFakeClient(config1).
 		WithCluster(cluster1).

--- a/cmd/clusterctl/client/repository/metadata_client_test.go
+++ b/cmd/clusterctl/client/repository/metadata_client_test.go
@@ -27,14 +27,6 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 )
 
-var metadataYaml = []byte("apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3\n" +
-	"kind: Metadata\n" +
-	"releaseSeries:\n" +
-	" - major: 1\n" +
-	"   minor: 2\n" +
-	"   contract: v1alpha3\n" +
-	"")
-
 func Test_metadataClient_Get(t *testing.T) {
 	type fields struct {
 		provider   config.Provider
@@ -55,18 +47,22 @@ func Test_metadataClient_Get(t *testing.T) {
 				repository: test.NewFakeRepository().
 					WithPaths("root", "").
 					WithDefaultVersion("v1.0.0").
-					WithFile("v1.0.0", "metadata.yaml", metadataYaml),
+					WithMetadata("v1.0.0", &clusterctlv1.Metadata{
+						ReleaseSeries: []clusterctlv1.ReleaseSeries{
+							{Major: 1, Minor: 2, Contract: test.CurrentCAPIContract},
+						},
+					}),
 			},
 			want: &clusterctlv1.Metadata{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "clusterctl.cluster.x-k8s.io/v1alpha3",
+					APIVersion: clusterctlv1.GroupVersion.String(),
 					Kind:       "Metadata",
 				},
 				ReleaseSeries: []clusterctlv1.ReleaseSeries{
 					{
 						Major:    1,
 						Minor:    2,
-						Contract: "v1alpha3",
+						Contract: test.CurrentCAPIContract,
 					},
 				},
 			},
@@ -113,7 +109,11 @@ func Test_metadataClient_Get(t *testing.T) {
 				repository: test.NewFakeRepository().
 					WithPaths("root", "").
 					WithDefaultVersion("v2.0.0").
-					WithFile("v2.0.0", "metadata.yaml", metadataYaml), // metadata file exists for version 2.0.0, while we are checking metadata for v1.0.0
+					WithMetadata("v2.0.0", &clusterctlv1.Metadata{ // metadata file exists for version 2.0.0, while we are checking metadata for v1.0.0
+						ReleaseSeries: []clusterctlv1.ReleaseSeries{
+							{Major: 1, Minor: 2, Contract: test.CurrentCAPIContract},
+						},
+					}),
 			},
 			want:    nil,
 			wantErr: true,

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 )
@@ -44,17 +45,22 @@ func (c *clusterctlClient) PlanCertManagerUpgrade(options PlanUpgradeOptions) (C
 
 func (c *clusterctlClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePlan, error) {
 	// Get the client for interacting with the management cluster.
-	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return nil, err
 	}
 
-	// Ensures the custom resource definitions required by clusterctl are in place.
-	if err := cluster.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
+	// Ensure this command only runs against management clusters with the current Cluster API contract (default) or the previous one.
+	if err := clusterClient.ProviderInventory().CheckCAPIContract(cluster.AllowCAPIContract{Contract: clusterv1old.GroupVersion.Version}); err != nil {
 		return nil, err
 	}
 
-	upgradePlans, err := cluster.ProviderUpgrader().Plan()
+	// Ensures the custom resource definitions required by clusterctl are in place.
+	if err := clusterClient.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
+		return nil, err
+	}
+
+	upgradePlans, err := clusterClient.ProviderUpgrader().Plan()
 	if err != nil {
 		return nil, err
 	}
@@ -102,6 +108,11 @@ func (c *clusterctlClient) ApplyUpgrade(options ApplyUpgradeOptions) error {
 	// Get the client for interacting with the management cluster.
 	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
+		return err
+	}
+
+	// Ensure this command only runs against management clusters with the current Cluster API contract (default) or the previous one.
+	if err := clusterClient.ProviderInventory().CheckCAPIContract(cluster.AllowCAPIContract{Contract: clusterv1old.GroupVersion.Version}); err != nil {
 		return err
 	}
 

--- a/cmd/clusterctl/client/upgrade_test.go
+++ b/cmd/clusterctl/client/upgrade_test.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 )
 
 func Test_clusterctlClient_PlanCertUpgrade(t *testing.T) {
@@ -342,7 +342,8 @@ func fakeClientForUpgrade() *fakeClient {
 		WithRepository(repository1).
 		WithRepository(repository2).
 		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "watchingNS").
-		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "watchingNS")
+		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "watchingNS").
+		WithObjs(test.FakeCAPISetupObjects()...)
 
 	client := newFakeClient(config1).
 		WithRepository(repository1).

--- a/cmd/clusterctl/internal/test/contracts.go
+++ b/cmd/clusterctl/internal/test/contracts.go
@@ -16,8 +16,10 @@ limitations under the License.
 
 package test
 
-import clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha2"
-import clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+import (
+	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha2"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
 
 // PreviousCAPIContractNotSupported define the previous Cluster API contract, not supported by this release of clusterctl.
 var PreviousCAPIContractNotSupported = clusterv1old.GroupVersion.Version

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -17,7 +17,7 @@ limitations under the License.
 package test
 
 import (
-	apiextensionslv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -29,7 +29,7 @@ import (
 	fakecontrolplane "sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test/providers/controlplane"
 	fakeexternal "sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test/providers/external"
 	fakeinfrastructure "sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test/providers/infrastructure"
-	addonsv1alpha3 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
+	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -50,8 +50,8 @@ func init() {
 	_ = clusterctlv1.AddToScheme(FakeScheme)
 	_ = clusterv1.AddToScheme(FakeScheme)
 	_ = expv1.AddToScheme(FakeScheme)
-	_ = addonsv1alpha3.AddToScheme(FakeScheme)
-	_ = apiextensionslv1.AddToScheme(FakeScheme)
+	_ = addonsv1.AddToScheme(FakeScheme)
+	_ = apiextensionsv1.AddToScheme(FakeScheme)
 
 	_ = fakebootstrap.AddToScheme(FakeScheme)
 	_ = fakecontrolplane.AddToScheme(FakeScheme)
@@ -165,4 +165,33 @@ func (f *FakeProxy) WithProviderInventory(name string, providerType clusterctlv1
 	})
 
 	return f
+}
+
+// WithFakeCAPISetup adds required objects in order to make kubeadm pass checks
+// ensuring that management cluster has a proper release of Cluster API installed.
+// NOTE: When using the fake client it is not required to install CRDs, given that type information are
+// derived from the schema. However, CheckCAPIContract looks for CRDs to be installed, so this
+// helper provide a way to get around to this difference between fake client and a real API server.
+func (f *FakeProxy) WithFakeCAPISetup() *FakeProxy {
+	f.objs = append(f.objs, FakeCAPISetupObjects()...)
+
+	return f
+}
+
+// FakeCAPISetupObjects return required objects in order to make kubeadm pass checks
+// ensuring that management cluster has a proper release of Cluster API installed.
+func FakeCAPISetupObjects() []runtime.Object {
+	return []runtime.Object{
+		&apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "clusters.cluster.x-k8s.io"},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{
+						Name:    clusterv1.GroupVersion.Version, // Current Cluster API contract
+						Storage: true,
+					},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a backport of https://github.com/kubernetes-sigs/cluster-api/pull/4199

Cluster API v1alpha4 is introducing changes in how providers are deployed (see e.g webhooks running with manager).

As a consequence, clusterctl version v1alpha3 should not be allowed to run on v1alpha4 clusters

NB: While doing the change, also clusterctl version v1alpha3 should not be allowed to run on v1alpha2 clusters was implemented (this is not technically possible, but we are getting this for free while backporting), and tests are now refactored in order to make changes for supporting the next contract less invasive.

**Which issue(s) this PR fixes**:
Rif https://github.com/kubernetes-sigs/cluster-api/issues/4192

/milestone v0.3.x
/hold 
for https://github.com/kubernetes-sigs/cluster-api/pull/4199 to merge