### PR TITLE
🌱 Updates conversion error message with reasoning

### DIFF
--- a/util/conversion/conversion.go
+++ b/util/conversion/conversion.go
@@ -76,7 +76,7 @@ func ConvertReferenceAPIContract(ctx context.Context, c client.Client, restConfi
 	// If there is no label, return early without changing the reference.
 	supportedVersions, ok := metadata.Labels[contract]
 	if !ok || supportedVersions == "" {
-		return errors.Errorf("cannot find any versions matching contract %q for CRD %v", contract, metadata.Name)
+		return errors.Errorf("cannot find any versions matching contract %q for CRD %v as contract version label(s) are either missing or empty", contract, metadata.Name)
 	}
 
 	// Pick the latest version in the slice and validate it.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds more context to error message about not being able to find versions matching contract - we burnt a few cycles with this error message, so I reckoned it'd be helpful to add a pointer for the next person :D
