### PR TITLE
⚠️ Clusterctl v1alpha3 should not upgrade to v1alpha4

### DIFF
--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
@@ -100,7 +101,8 @@ func (u *providerUpgrader) Plan() ([]UpgradePlan, error) {
 		// in a management group are expected to support the same API Version of Cluster API (contract).
 		// e.g if the core provider supports v1alpha3, all the providers in the same management group should support v1alpha3 as well;
 		// all the providers in the management group can upgrade to the latest release supporting v1alpha3, or if available,
-		// or if available, all the providers in the management group can upgrade to the latest release supporting v1alpha4.
+		// all the providers in the management group can upgrade to the latest release supporting v1alpha4
+		// (not supported in current clusterctl release, but upgrade plan should report these options)
 
 		// Gets the upgrade info for the core provider.
 		coreUpgradeInfo, err := u.getUpgradeInfo(managementGroup.CoreProvider)
@@ -117,8 +119,8 @@ func (u *providerUpgrader) Plan() ([]UpgradePlan, error) {
 
 		// Creates an UpgradePlan for each contract considered for upgrades; each upgrade plans contains
 		// an UpgradeItem for each provider defining the next available version with the target contract, if available.
-		// e.g. v1alpha3, cluster-api --> v0.3.2, kubeadm bootstrap --> v0.3.2, aws --> v0.5.4
-		// e.g. v1alpha4, cluster-api --> v0.4.1, kubeadm bootstrap --> v0.4.1, aws --> v0.6.2
+		// e.g. v1alpha3, cluster-api --> v0.3.2, kubeadm bootstrap --> v0.3.2, aws --> v0.5.4 (not supported in current clusterctl release, but upgrade plan should report these options).
+		// e.g. v1alpha4, cluster-api --> v0.4.1, kubeadm bootstrap --> v0.4.1, aws --> v0.X.2 (not supported in current clusterctl release, but upgrade plan should report these options).
 		for _, contract := range contractsForUpgrade {
 			upgradePlan, err := u.getUpgradePlan(managementGroup, contract)
 			if err != nil {
@@ -140,6 +142,10 @@ func (u *providerUpgrader) Plan() ([]UpgradePlan, error) {
 }
 
 func (u *providerUpgrader) ApplyPlan(coreProvider clusterctlv1.Provider, contract string) error {
+	if contract != clusterv1.GroupVersion.Version {
+		return errors.Errorf("current version of clusterctl could only upgrade to %s contract, requested %s", clusterv1.GroupVersion.Version, contract)
+	}
+
 	log := logf.Log
 	log.Info("Performing upgrade...")
 
@@ -243,6 +249,10 @@ func (u *providerUpgrader) createCustomPlan(coreProvider clusterctlv1.Provider, 
 	targetContract, err := u.getProviderContractByVersion(managementGroup.CoreProvider, targetCoreProviderVersion)
 	if err != nil {
 		return nil, err
+	}
+
+	if targetContract != clusterv1.GroupVersion.Version {
+		return nil, errors.Errorf("current version of clusterctl could only upgrade to %s contract, requested %s", clusterv1.GroupVersion.Version, targetContract)
 	}
 
 	// Builds the custom upgrade plan, by adding all the upgrade items after checking consistency with the targetContract.

--- a/cmd/clusterctl/client/cluster/upgrader_info.go
+++ b/cmd/clusterctl/client/cluster/upgrader_info.go
@@ -44,6 +44,7 @@ type upgradeInfo struct {
 }
 
 // getUpgradeInfo returns all the info required for taking upgrade decisions for a provider.
+// NOTE: This could contain also versions for the previous or next Cluster API contract (not supported in current clusterctl release, but upgrade plan should report this options).
 func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgradeInfo, error) {
 	// Gets the list of versions available in the provider repository.
 	configRepository, err := u.configClient.Providers().Get(provider.ProviderName, provider.GetProviderType())
@@ -96,6 +97,7 @@ func (u *providerUpgrader) getUpgradeInfo(provider clusterctlv1.Provider) (*upgr
 	// Filters the versions to be considered for upgrading the provider (next
 	// versions) and checks if the releaseSeries defined in metadata includes
 	// all of them.
+	// NOTE: This could contain also versions for the previous or next Cluster API contract (not supported in current clusterctl release, but upgrade plan should report this options).
 	nextVersions := []version.Version{}
 	for _, repositoryVersion := range repositoryVersions {
 		// we are ignoring the conversion error here because a first check already passed above
@@ -144,9 +146,7 @@ func newUpgradeInfo(metadata *clusterctlv1.Metadata, currentVersion *version.Ver
 	}
 }
 
-// getContractsForUpgrade return the list of API Version of Cluster API (contract) version available for a provider upgrade. e.g.
-// - If the current version of the provider support v1alpha3 contract (the latest), it returns v1alpha3
-// - If the current version of the provider support v1alpha3 contract but there is also the v1alpha4 contract available, it returns v1alpha3, v1alpha4
+// getContractsForUpgrade return the list of API Version of Cluster API (contract) version available for a provider upgrade.
 func (i *upgradeInfo) getContractsForUpgrade() []string {
 	contractsForUpgrade := sets.NewString()
 	for _, releaseSeries := range i.metadata.ReleaseSeries {

--- a/cmd/clusterctl/client/cluster/upgrader_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_test.go
@@ -40,26 +40,25 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Single Management group, no multi-tenancy, upgrade within the same contract",
+			name: "Single Management group, no multi-tenancy, upgrade within the current contract",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version in the v1alpha3 contract
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1").
 						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 					"infrastructure-infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1").
 						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 				},
@@ -69,8 +68,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases the v1alpha3 contract
-					Contract:     "v1alpha3",
+				{ // one upgrade plan with the latest releases the current contract
+					Contract:     test.CurrentCAPIContract,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 					Providers: []UpgradeItem{
 						{
@@ -93,26 +92,25 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version in the v1alpha3 contract
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1").
 						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 					"infrastructure-infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1", "v3.0.0-alpha.0").
 						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}).
 						WithMetadata("v3.0.0-alpha.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 				},
@@ -122,8 +120,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases the v1alpha3 contract
-					Contract:     "v1alpha3",
+				{ // one upgrade plan with the latest releases the current contract
+					Contract:     test.CurrentCAPIContract,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 					Providers: []UpgradeItem{
 						{
@@ -140,28 +138,27 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, no multi-tenancy, upgrade for two contracts",
+			name: "Single Management group, no multi-tenancy, upgrade for previous contract (not supported), current contract", // upgrade plan should report unsupported options
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version for current v1alpha3 contract and a new version for the v1alpha4 contract
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
+								{Major: 1, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 					"infrastructure-infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
+								{Major: 2, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 				},
@@ -171,8 +168,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 contract
-					Contract:     "v1alpha3",
+				{ // one upgrade plan with the latest releases in the previous contract (not supported, but upgrade plan should report these options)
+					Contract:     test.PreviousCAPIContractNotSupported,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 					Providers: []UpgradeItem{
 						{
@@ -185,8 +182,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 contract
-					Contract:     "v1alpha4",
+				{ // one upgrade plan with the latest releases in the current contract
+					Contract:     test.CurrentCAPIContract,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 					Providers: []UpgradeItem{
 						{
@@ -203,26 +200,87 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Infra multi-tenancy, upgrade within the same contract",
+			name: "Single Management group, no multi-tenancy, upgrade for two current contract, next contract (not supported)", // upgrade plan should report unsupported options
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version in the v1alpha3 contract
+				repository: map[string]repository.Repository{
+					"cluster-api": test.NewFakeRepository().
+						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
+						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 2, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+					"infrastructure-infra": test.NewFakeRepository().
+						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
+						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 3, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+				},
+				// two providers existing in the cluster
+				proxy: test.NewFakeProxy().
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+			},
+			want: []UpgradePlan{
+				{ // one upgrade plan with the latest releases in the current
+					Contract:     test.CurrentCAPIContract,
+					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+					Providers: []UpgradeItem{
+						{
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							NextVersion: "v1.0.1",
+						},
+						{
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+							NextVersion: "v2.0.1",
+						},
+					},
+				},
+				{ // one upgrade plan with the latest releases in the next contract (not supported, but upgrade plan should report these options)
+					Contract:     test.NextCAPIContractNotSupported,
+					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+					Providers: []UpgradeItem{
+						{
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							NextVersion: "v2.0.0",
+						},
+						{
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+							NextVersion: "v3.0.0",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Single Management group, n-Infra multi-tenancy, upgrade within the same current contract",
+			fields: fields{
+				// config for two providers
+				reader: test.NewFakeReader().
+					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
+					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1").
 						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 					"infrastructure-infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1").
 						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 				},
@@ -233,8 +291,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 contract
-					Contract:     "v1alpha3",
+				{ // one upgrade plan with the latest releases in the current contract
+					Contract:     test.CurrentCAPIContract,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 					Providers: []UpgradeItem{
 						{
@@ -255,28 +313,27 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Infra multi-tenancy, upgrade for two contracts",
+			name: "Single Management group, n-Infra multi-tenancy, upgrade for previous contract (not supported), current contract", // upgrade plan should report unsupported options
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version for current v1alpha3 contract and a new version for the v1alpha4 contract
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
+								{Major: 1, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 					"infrastructure-infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
+								{Major: 2, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 				},
@@ -287,8 +344,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 contract
-					Contract:     "v1alpha3",
+				{ // one upgrade plan with the latest releases in the previous contract (not supported, but upgrade plan should report these options)
+					Contract:     test.PreviousCAPIContractNotSupported,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 					Providers: []UpgradeItem{
 						{
@@ -305,8 +362,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 contract
-					Contract:     "v1alpha4",
+				{ // one upgrade plan with the latest releases in the current contract
+					Contract:     test.CurrentCAPIContract,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 					Providers: []UpgradeItem{
 						{
@@ -327,26 +384,96 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Core multi-tenancy, upgrade within the same contract",
+			name: "Single Management group, n-Infra multi-tenancy, upgrade for current contract, next contract (not supported)", // upgrade plan should report unsupported options
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version in the v1alpha3 contract
+				repository: map[string]repository.Repository{
+					"cluster-api": test.NewFakeRepository().
+						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
+						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 2, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+					"infrastructure-infra": test.NewFakeRepository().
+						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
+						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 3, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+				},
+				// one core and two infra providers existing in the cluster
+				proxy: test.NewFakeProxy().
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system1", "ns1").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
+			},
+			want: []UpgradePlan{
+				{ // one upgrade plan with the latest releases in the current contract
+					Contract:     test.CurrentCAPIContract,
+					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+					Providers: []UpgradeItem{
+						{
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							NextVersion: "v1.0.1",
+						},
+						{
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system1", "ns1"),
+							NextVersion: "v2.0.1",
+						},
+						{
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
+							NextVersion: "v2.0.1",
+						},
+					},
+				},
+				{ // one upgrade plan with the latest releases in the next contract (not supported, but upgrade plan should report these options)
+					Contract:     test.NextCAPIContractNotSupported,
+					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+					Providers: []UpgradeItem{
+						{
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							NextVersion: "v2.0.0",
+						},
+						{
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system1", "ns1"),
+							NextVersion: "v3.0.0",
+						},
+						{
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
+							NextVersion: "v3.0.0",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Single Management group, n-Core multi-tenancy, upgrade within the current contract",
+			fields: fields{
+				// config for two providers
+				reader: test.NewFakeReader().
+					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
+					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1").
 						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 					"infrastructure-infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1").
 						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 				},
@@ -358,8 +485,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 contract for the first management group
-					Contract:     "v1alpha3",
+				{ // one upgrade plan with the latest releases in the current contract for the first management group
+					Contract:     test.CurrentCAPIContract,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system1", "ns1"),
 					Providers: []UpgradeItem{
 						{
@@ -372,8 +499,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha3 contract for the second management group
-					Contract:     "v1alpha3",
+				{ // one upgrade plan with the latest releases in the current contract for the second management group
+					Contract:     test.CurrentCAPIContract,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2"),
 					Providers: []UpgradeItem{
 						{
@@ -390,28 +517,27 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, n-Core multi-tenancy, upgrade for two contracts",
+			name: "Single Management group, n-Core multi-tenancy, upgrade for previous contract (not supported), current contract", // upgrade plan should report unsupported options
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version for current v1alpha3 contract and a new version for the v1alpha4 contract
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
+								{Major: 1, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 					"infrastructure-infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
+								{Major: 2, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 				},
@@ -423,8 +549,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 contract for the first management group
-					Contract:     "v1alpha3",
+				{ // one upgrade plan with the latest releases in the previous contract for the first management group (not supported, but upgrade plan should report these options)
+					Contract:     test.PreviousCAPIContractNotSupported,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system1", "ns1"),
 					Providers: []UpgradeItem{
 						{
@@ -437,8 +563,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 contract for the first management group
-					Contract:     "v1alpha4",
+				{ // one upgrade plan with the latest releases in the current contract for the first management group
+					Contract:     test.CurrentCAPIContract,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system1", "ns1"),
 					Providers: []UpgradeItem{
 						{
@@ -451,8 +577,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha3 contract for the second management group
-					Contract:     "v1alpha3",
+				{ // one upgrade plan with the latest releases in the previous contract for the second management group (not supported, but upgrade plan should report these options)
+					Contract:     test.PreviousCAPIContractNotSupported,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2"),
 					Providers: []UpgradeItem{
 						{
@@ -465,8 +591,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 					},
 				},
-				{ // one upgrade plan with the latest releases in the v1alpha4 contract for the second management group
-					Contract:     "v1alpha4",
+				{ // one upgrade plan with the latest releases in the current contract for the second management group
+					Contract:     test.CurrentCAPIContract,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2"),
 					Providers: []UpgradeItem{
 						{
@@ -483,27 +609,118 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Single Management group, no multi-tenancy, upgrade for two contracts, but the upgrade for the second one is partially available",
+			name: "Single Management group, n-Core multi-tenancy, upgrade for current contract, next contract (not supported)", // upgrade plan should report unsupported options
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, the first with a new version for current v1alpha3 contract and a new version for the v1alpha4 contract, the second without new releases
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 2, Minor: 0, Contract: test.NextCAPIContractNotSupported},
 							},
 						}),
 					"infrastructure-infra": test.NewFakeRepository().
-						WithVersions("v2.0.0"). // no v1alpha3 or v1alpha3 new releases yet available for the infra provider (only the current release exists)
+						WithVersions("v2.0.0", "v2.0.1", "v3.0.0").
+						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 3, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+				},
+				// two management groups existing in the cluster
+				proxy: test.NewFakeProxy().
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system1", "ns1").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system1", "ns1").
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
+			},
+			want: []UpgradePlan{
+				{ // one upgrade plan with the latest releases in the current contract for the first management group
+					Contract:     test.CurrentCAPIContract,
+					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system1", "ns1"),
+					Providers: []UpgradeItem{
+						{
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system1", "ns1"),
+							NextVersion: "v1.0.1",
+						},
+						{
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system1", "ns1"),
+							NextVersion: "v2.0.1",
+						},
+					},
+				},
+				{ // one upgrade plan with the latest releases in the next contract for the first management group (not supported, but upgrade plan should report these options)
+					Contract:     test.NextCAPIContractNotSupported,
+					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system1", "ns1"),
+					Providers: []UpgradeItem{
+						{
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system1", "ns1"),
+							NextVersion: "v2.0.0",
+						},
+						{
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system1", "ns1"),
+							NextVersion: "v3.0.0",
+						},
+					},
+				},
+				{ // one upgrade plan with the latest releases in the current contract for the second management group
+					Contract:     test.CurrentCAPIContract,
+					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2"),
+					Providers: []UpgradeItem{
+						{
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2"),
+							NextVersion: "v1.0.1",
+						},
+						{
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
+							NextVersion: "v2.0.1",
+						},
+					},
+				},
+				{ // one upgrade plan with the latest releases in the next contract for the second management group (not supported, but upgrade plan should report these options)
+					Contract:     test.NextCAPIContractNotSupported,
+					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2"),
+					Providers: []UpgradeItem{
+						{
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system2", "ns2"),
+							NextVersion: "v2.0.0",
+						},
+						{
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system2", "ns2"),
+							NextVersion: "v3.0.0",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Single Management group, no multi-tenancy, partial upgrades for next contract", // upgrade plan should report unsupported options
+			fields: fields{
+				// config for two providers
+				reader: test.NewFakeReader().
+					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
+					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
+				repository: map[string]repository.Repository{
+					"cluster-api": test.NewFakeRepository().
+						WithVersions("v1.0.0", "v1.0.1", "v2.0.0").
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 2, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+					"infrastructure-infra": test.NewFakeRepository().
+						WithVersions("v2.0.0"). // no new releases available for the infra provider (only the current release exists)
+						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 2, Minor: 0, Contract: test.NextCAPIContractNotSupported},
 							},
 						}),
 				},
@@ -513,8 +730,8 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
 			},
 			want: []UpgradePlan{
-				{ // one upgrade plan with the latest releases in the v1alpha3 contract
-					Contract:     "v1alpha3",
+				{ // one upgrade plan with the latest releases in the current contract
+					Contract:     test.CurrentCAPIContract,
 					CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 					Providers: []UpgradeItem{
 						{
@@ -523,11 +740,11 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 						},
 						{
 							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-							NextVersion: "", // we are already to the latest version for the infra provider in the v1alpha3 contract, but this is acceptable for the current contract
+							NextVersion: "", // we are already to the latest version for the infra provider, but this is acceptable for the current contract
 						},
 					},
 				},
-				// the upgrade plan with the latest releases in the v1alpha4 contract should be dropped because all the provider are required to change the contract at the same time
+				// the upgrade plan with the latest releases in the next contract should be dropped because all the provider are required to change the contract at the same time
 			},
 			wantErr: false,
 		},
@@ -581,20 +798,19 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version in the v1alpha3 contract
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1").
 						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 					"infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1").
 						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 				},
@@ -608,12 +824,12 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				providersToUpgrade: []UpgradeItem{
 					{
 						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-						NextVersion: "v2.0.1", // upgrade to next release in the v1alpha3 contract
+						NextVersion: "v2.0.1", // upgrade to next release in the current contract
 					},
 				},
 			},
 			want: &UpgradePlan{
-				Contract:     "v1alpha3",
+				Contract:     test.CurrentCAPIContract,
 				CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 				Providers: []UpgradeItem{
 					{
@@ -631,20 +847,19 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with a new version in the v1alpha3 contract
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v1.0.1").
 						WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 					"infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v2.0.1").
 						WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 				},
@@ -658,12 +873,12 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				providersToUpgrade: []UpgradeItem{
 					{
 						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-						NextVersion: "v1.0.1", // upgrade to next release in the v1alpha3 contract
+						NextVersion: "v1.0.1", // upgrade to next release in the current contract
 					},
 				},
 			},
 			want: &UpgradePlan{
-				Contract:     "v1alpha3",
+				Contract:     test.CurrentCAPIContract,
 				CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 				Providers: []UpgradeItem{
 					{
@@ -675,71 +890,27 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "fail if upgrade infra provider, changing contract",
+			name: "pass if upgrade core and infra provider, same contract",
 			fields: fields{
 				// config for two providers
 				reader: test.NewFakeReader().
 					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
 					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with current version in v1alpha3 and a new version in the v1alpha4 contract
 				repository: map[string]repository.Repository{
 					"cluster-api": test.NewFakeRepository().
 						WithVersions("v1.0.0", "v2.0.0").
 						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 					"infra": test.NewFakeRepository().
 						WithVersions("v2.0.0", "v3.0.0").
 						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
 							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
-							},
-						}),
-				},
-				// two providers existing in the cluster
-				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-			},
-			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
-				providersToUpgrade: []UpgradeItem{
-					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-						NextVersion: "v3.0.0", // upgrade to next release in the v1alpha4 contract
-					},
-				},
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "fail if upgrade core provider, changing contract",
-			fields: fields{
-				// config for two providers
-				reader: test.NewFakeReader().
-					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
-					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with current version in v1alpha3 and a new version in the v1alpha4 contract
-				repository: map[string]repository.Repository{
-					"cluster-api": test.NewFakeRepository().
-						WithVersions("v1.0.0", "v2.0.0").
-						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
-							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
-							},
-						}),
-					"infra": test.NewFakeRepository().
-						WithVersions("v2.0.0", "v3.0.0").
-						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
-							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
 							},
 						}),
 				},
@@ -753,68 +924,298 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				providersToUpgrade: []UpgradeItem{
 					{
 						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-						NextVersion: "v2.0.0", // upgrade to next release in the v1alpha4 contract
-					},
-				},
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "pass if upgrade core and infra provider, changing contract",
-			fields: fields{
-				// config for two providers
-				reader: test.NewFakeReader().
-					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
-					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
-				// two provider repositories, each with current version in v1alpha3 and a new version in the v1alpha4 contract
-				repository: map[string]repository.Repository{
-					"cluster-api": test.NewFakeRepository().
-						WithVersions("v1.0.0", "v2.0.0").
-						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
-							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 1, Minor: 0, Contract: "v1alpha3"},
-								{Major: 2, Minor: 0, Contract: "v1alpha4"},
-							},
-						}),
-					"infra": test.NewFakeRepository().
-						WithVersions("v2.0.0", "v3.0.0").
-						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
-							ReleaseSeries: []clusterctlv1.ReleaseSeries{
-								{Major: 2, Minor: 0, Contract: "v1alpha3"},
-								{Major: 3, Minor: 0, Contract: "v1alpha4"},
-							},
-						}),
-				},
-				// two providers existing in the cluster
-				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-			},
-			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
-				providersToUpgrade: []UpgradeItem{
-					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-						NextVersion: "v2.0.0", // upgrade to next release in the v1alpha4 contract
+						NextVersion: "v2.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
 					},
 					{
 						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-						NextVersion: "v3.0.0", // upgrade to next release in the v1alpha4 contract
+						NextVersion: "v3.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
 					},
 				},
 			},
 			want: &UpgradePlan{
-				Contract:     "v1alpha4",
+				Contract:     test.CurrentCAPIContract,
 				CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
 				Providers: []UpgradeItem{
 					{
 						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-						NextVersion: "v2.0.0", // upgrade to next release in the v1alpha4 contract
+						NextVersion: "v2.0.0",
 					},
 					{
 						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
-						NextVersion: "v3.0.0", // upgrade to next release in the v1alpha4 contract
+						NextVersion: "v3.0.0",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "fail if upgrade infra provider alone from current to the next contract", // not supported in current clusterctl release.
+			fields: fields{
+				// config for two providers
+				reader: test.NewFakeReader().
+					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
+					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
+				repository: map[string]repository.Repository{
+					"cluster-api": test.NewFakeRepository().
+						WithVersions("v1.0.0", "v2.0.0").
+						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 2, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+					"infra": test.NewFakeRepository().
+						WithVersions("v2.0.0", "v3.0.0").
+						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 3, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+				},
+				// two providers existing in the cluster
+				proxy: test.NewFakeProxy().
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+			},
+			args: args{
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				providersToUpgrade: []UpgradeItem{
+					{
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						NextVersion: "v3.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "fail if upgrade infra provider alone from previous to the current contract",
+			fields: fields{
+				// config for two providers
+				reader: test.NewFakeReader().
+					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
+					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
+				repository: map[string]repository.Repository{
+					"cluster-api": test.NewFakeRepository().
+						WithVersions("v1.0.0", "v2.0.0").
+						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 1, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+							},
+						}),
+					"infra": test.NewFakeRepository().
+						WithVersions("v2.0.0", "v3.0.0").
+						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 2, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
+							},
+						}),
+				},
+				// two providers existing in the cluster
+				proxy: test.NewFakeProxy().
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+			},
+			args: args{
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				providersToUpgrade: []UpgradeItem{
+					{
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						NextVersion: "v3.0.0", // upgrade to next release in the current contract.
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "fail if upgrade core provider alone from current to the next contract", // not supported in current clusterctl release.
+			fields: fields{
+				// config for two providers
+				reader: test.NewFakeReader().
+					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
+					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
+				repository: map[string]repository.Repository{
+					"cluster-api": test.NewFakeRepository().
+						WithVersions("v1.0.0", "v2.0.0").
+						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 2, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+					"infra": test.NewFakeRepository().
+						WithVersions("v2.0.0", "v3.0.0").
+						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 3, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+				},
+				// two providers existing in the cluster
+				proxy: test.NewFakeProxy().
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+			},
+			args: args{
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				providersToUpgrade: []UpgradeItem{
+					{
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						NextVersion: "v2.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "fail if upgrade core provider alone from previous to the current contract",
+			fields: fields{
+				// config for two providers
+				reader: test.NewFakeReader().
+					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
+					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
+				repository: map[string]repository.Repository{
+					"cluster-api": test.NewFakeRepository().
+						WithVersions("v1.0.0", "v2.0.0").
+						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 1, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+							},
+						}),
+					"infra": test.NewFakeRepository().
+						WithVersions("v2.0.0", "v3.0.0").
+						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 2, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
+							},
+						}),
+				},
+				// two providers existing in the cluster
+				proxy: test.NewFakeProxy().
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+			},
+			args: args{
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				providersToUpgrade: []UpgradeItem{
+					{
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						NextVersion: "v2.0.0", // upgrade to next release in the current contract
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "fail if upgrade core and infra provider to the next contract", // not supported in current clusterctl release
+			fields: fields{
+				// config for two providers
+				reader: test.NewFakeReader().
+					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
+					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
+				repository: map[string]repository.Repository{
+					"cluster-api": test.NewFakeRepository().
+						WithVersions("v1.0.0", "v2.0.0").
+						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 2, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+					"infra": test.NewFakeRepository().
+						WithVersions("v2.0.0", "v3.0.0").
+						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+								{Major: 3, Minor: 0, Contract: test.NextCAPIContractNotSupported},
+							},
+						}),
+				},
+				// two providers existing in the cluster
+				proxy: test.NewFakeProxy().
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+			},
+			args: args{
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				providersToUpgrade: []UpgradeItem{
+					{
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						NextVersion: "v2.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
+					},
+					{
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						NextVersion: "v3.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "pass if upgrade core and infra provider from previous to current contract",
+			fields: fields{
+				// config for two providers
+				reader: test.NewFakeReader().
+					WithProvider("cluster-api", clusterctlv1.CoreProviderType, "https://somewhere.com").
+					WithProvider("infra", clusterctlv1.InfrastructureProviderType, "https://somewhere.com"),
+				repository: map[string]repository.Repository{
+					"cluster-api": test.NewFakeRepository().
+						WithVersions("v1.0.0", "v2.0.0").
+						WithMetadata("v2.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 1, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
+							},
+						}),
+					"infra": test.NewFakeRepository().
+						WithVersions("v2.0.0", "v3.0.0").
+						WithMetadata("v3.0.0", &clusterctlv1.Metadata{
+							ReleaseSeries: []clusterctlv1.ReleaseSeries{
+								{Major: 2, Minor: 0, Contract: test.PreviousCAPIContractNotSupported},
+								{Major: 3, Minor: 0, Contract: test.CurrentCAPIContract},
+							},
+						}),
+				},
+				// two providers existing in the cluster
+				proxy: test.NewFakeProxy().
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+			},
+			args: args{
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				providersToUpgrade: []UpgradeItem{
+					{
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						NextVersion: "v2.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
+					},
+					{
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						NextVersion: "v3.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
+					},
+				},
+			},
+			want: &UpgradePlan{
+				Contract:     test.CurrentCAPIContract,
+				CoreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+				Providers: []UpgradeItem{
+					{
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						NextVersion: "v2.0.0",
+					},
+					{
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						NextVersion: "v3.0.0",
 					},
 				},
 			},

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 )
@@ -50,8 +50,8 @@ func (c *clusterctlClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePla
 		return nil, err
 	}
 
-	// Ensure this command only runs against management clusters with the current Cluster API contract (default) or the previous one.
-	if err := clusterClient.ProviderInventory().CheckCAPIContract(cluster.AllowCAPIContract{Contract: clusterv1old.GroupVersion.Version}); err != nil {
+	// Ensure this command only runs against management clusters with the current Cluster API contract (default).
+	if err := clusterClient.ProviderInventory().CheckCAPIContract(); err != nil {
 		return nil, err
 	}
 
@@ -86,7 +86,7 @@ type ApplyUpgradeOptions struct {
 	// ManagementGroup that should be upgraded (e.g. capi-system/cluster-api).
 	ManagementGroup string
 
-	// Contract defines the API Version of Cluster API (contract e.g. v1alpha3) the management group should upgrade to.
+	// Contract defines the API Version of Cluster API (contract e.g. v1alpha4) the management group should upgrade to.
 	// When upgrading by contract, the latest versions available will be used for all the providers; if you want
 	// a more granular control on upgrade, use CoreProvider, BootstrapProviders, ControlPlaneProviders, InfrastructureProviders.
 	Contract string
@@ -105,14 +105,18 @@ type ApplyUpgradeOptions struct {
 }
 
 func (c *clusterctlClient) ApplyUpgrade(options ApplyUpgradeOptions) error {
+	if options.Contract != "" && options.Contract != clusterv1.GroupVersion.Version {
+		return errors.Errorf("current version of clusterctl could only upgrade to %s contract, requested %s", clusterv1.GroupVersion.Version, options.Contract)
+	}
+
 	// Get the client for interacting with the management cluster.
 	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return err
 	}
 
-	// Ensure this command only runs against management clusters with the current Cluster API contract (default) or the previous one.
-	if err := clusterClient.ProviderInventory().CheckCAPIContract(cluster.AllowCAPIContract{Contract: clusterv1old.GroupVersion.Version}); err != nil {
+	// Ensure this command only runs against management clusters with the current Cluster API contract (default).
+	if err := clusterClient.ProviderInventory().CheckCAPIContract(); err != nil {
 		return err
 	}
 

--- a/cmd/clusterctl/client/upgrade_test.go
+++ b/cmd/clusterctl/client/upgrade_test.go
@@ -166,7 +166,7 @@ func Test_clusterctlClient_ApplyUpgrade(t *testing.T) {
 				options: ApplyUpgradeOptions{
 					Kubeconfig:              Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					ManagementGroup:         "cluster-api-system/cluster-api",
-					Contract:                "v1alpha3",
+					Contract:                test.CurrentCAPIContract,
 					CoreProvider:            "",
 					BootstrapProviders:      nil,
 					ControlPlaneProviders:   nil,
@@ -324,7 +324,7 @@ func fakeClientForUpgrade() *fakeClient {
 		WithVersions("v1.0.0", "v1.0.1").
 		WithMetadata("v1.0.1", &clusterctlv1.Metadata{
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
-				{Major: 1, Minor: 0, Contract: "v1alpha3"},
+				{Major: 1, Minor: 0, Contract: test.CurrentCAPIContract},
 			},
 		})
 	repository2 := newFakeRepository(infra, config1).
@@ -334,7 +334,7 @@ func fakeClientForUpgrade() *fakeClient {
 		WithVersions("v2.0.0", "v2.0.1").
 		WithMetadata("v2.0.1", &clusterctlv1.Metadata{
 			ReleaseSeries: []clusterctlv1.ReleaseSeries{
-				{Major: 2, Minor: 0, Contract: "v1alpha3"},
+				{Major: 2, Minor: 0, Contract: test.CurrentCAPIContract},
 			},
 		})
 

--- a/cmd/clusterctl/cmd/upgrade_plan.go
+++ b/cmd/clusterctl/cmd/upgrade_plan.go
@@ -22,6 +22,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 )
 
@@ -116,9 +117,13 @@ func runUpgradePlan() error {
 		fmt.Println("")
 
 		if upgradeAvailable {
-			fmt.Println("You can now apply the upgrade by executing the following command:")
-			fmt.Println("")
-			fmt.Printf("   upgrade apply --management-group %s --contract %s\n", plan.CoreProvider.InstanceName(), plan.Contract)
+			if plan.Contract == clusterv1.GroupVersion.Version {
+				fmt.Println("You can now apply the upgrade by executing the following command:")
+				fmt.Println("")
+				fmt.Printf(" clusterctl upgrade upgrade apply --management-group %s --contract %s\n", plan.CoreProvider.InstanceName(), plan.Contract)
+			} else {
+				fmt.Printf("The current version of clusterctl could not upgrade to %s contract (only %s supported).\n", plan.Contract, clusterv1.GroupVersion.Version)
+			}
 		} else {
 			fmt.Println("You are already up to date!")
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a backport of https://github.com/kubernetes-sigs/cluster-api/pull/4202

Cluster API v1alpha4 is introducing changes in how providers are deployed (see e.g webhooks running with manager).

As a consequence, clusterctl version v1alpha3 should not be allowed to upgrade to v1alpha3 clusters

**Which issue(s) this PR fixes**:
Rif #4192 

/milestone v0.3.x
/hold 
for https://github.com/kubernetes-sigs/cluster-api/pull/4202 to merge 
