### PR TITLE
🌱 Update operator to use certmanager v1 resources

### DIFF
--- a/exp/operator/config/certmanager/certificate.yaml
+++ b/exp/operator/config/certmanager/certificate.yaml
@@ -1,8 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-# WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
-# breaking changes
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -10,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
@@ -23,4 +21,4 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/exp/operator/config/certmanager/kustomization.yaml
+++ b/exp/operator/config/certmanager/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - certificate.yaml
 

--- a/exp/operator/config/certmanager/kustomizeconfig.yaml
+++ b/exp/operator/config/certmanager/kustomizeconfig.yaml
@@ -1,4 +1,4 @@
-# This configuration is for teaching kustomize how to update name ref and var substitution 
+# This configuration is for teaching kustomize how to update name ref and var substitution
 nameReference:
 - kind: Issuer
   group: cert-manager.io
@@ -14,3 +14,6 @@ varReference:
 - kind: Certificate
   group: cert-manager.io
   path: spec/dnsNames
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/secretName


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Aligning the cert-manager config with master. 

towards https://github.com/kubernetes-sigs/cluster-api/issues/4246
