### PR TITLE
📖 Document `UpgradeAfter`

### DIFF
--- a/docs/book/src/tasks/upgrading-clusters.md
+++ b/docs/book/src/tasks/upgrading-clusters.md
@@ -47,6 +47,28 @@ that if a specific machine image is specified, it has to match the Kubernetes ve
 `KubeadmControlPlane` spec. In order to only trigger a single upgrade, the new `MachineTemplate` should be created first
 and then both the `Version` and `InfrastructureTemplate` should be modified in a single transaction.
 
+#### How to schedule a machine rollout
+
+A `KubeadmControlPlane` resource has a field `UpgradeAfter` that can be set to a timestamp
+(RFC-3339) after which a rollout should be triggered regardless of whether there were any changes
+to the `KubeadmControlPlane.Spec` or not. This would roll out replacement control plane nodes
+which can be useful e.g. to perform certificate rotation, reflect changes to machine templates,
+move to new machines, etc.
+
+Note that this field can only be used for triggering a rollout, not for delaying one. Specifically,
+a rollout can also happen before the time specified in `UpgradeAfter` if any changes are made to
+the spec before that time.
+
+To do the same for machines managed by a `MachineDeployment` it's enough to make an arbitrary
+change to its `Spec.Template`, one common approach is to run:
+
+``` shell
+clusterctl alpha rollout restart machinedeployment/my-md-0
+```
+
+This will modify the template by setting an `cluster.x-k8s.io/restartedAt` annotation which will
+trigger a rollout.
+
 ### Upgrading machines managed by a `MachineDeployment`
 
 Upgrades are not limited to just the control plane. This section is not related to Kubeadm control plane specifically,


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a section that documents `KubeadmControlPlane.Spec.UpgradeAfter` and
how to achieve a similar effect for machines managed by a
`MachineDeployment`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #3401
