### PR TITLE
📖 Fix version support doc

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -52,6 +52,7 @@ These diagrams show the relationships between components in a Cluster API releas
 | Kubernetes v1.17 |                             | ✓                           |
 | Kubernetes v1.18 |                             | ✓                           |
 | Kubernetes v1.19 |                             | ✓                           |
+| Kubernetes v1.20 |                             | ✓                           |
 
 The Core Provider also talks to API server of every Workload Cluster. Therefore, the Workload Cluster's Kubernetes version must also be compatible.
 
@@ -61,13 +62,15 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 | ---------------------------------- | --------------------------- | --------------------------- |
 | Kubernetes v1.13                   |                             |                             |
 | Kubernetes v1.14 + kubeadm/v1beta1 | ✓                           |                             |
-| Kubernetes v1.15 + kubeadm/v1beta1 | ✓                           |                             |
-| Kubernetes v1.16 + kubeadm/v1beta1 | ✓                           | ✓                           |
-| Kubernetes v1.17 + kubeadm/v1beta1 |                             | ✓                           |
-| Kubernetes v1.18 + kubeadm/v1beta1 |                             | ✓                           |
-| Kubernetes v1.19 + kubeadm/v1beta1 |                             | ✓                           |
+| Kubernetes v1.15 + kubeadm/v1beta2 | ✓                           |                             |
+| Kubernetes v1.16 + kubeadm/v1beta2 | ✓                           | ✓                           |
+| Kubernetes v1.17 + kubeadm/v1beta2 |                             | ✓                           |
+| Kubernetes v1.18 + kubeadm/v1beta2 |                             | ✓                           |
+| Kubernetes v1.19 + kubeadm/v1beta2 |                             | ✓                           |
+| Kubernetes v1.20 + kubeadm/v1beta2 |                             | ✓                           |
 
-The Kubeadm Bootstrap Provider generates configuration using the v1beta1 kubeadm API.
+The Kubeadm Bootstrap Provider generates configuration using the v1beta1 or v1beta2 kubeadm API
+according to the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
@@ -80,6 +83,7 @@ The Kubeadm Bootstrap Provider generates configuration using the v1beta1 kubeadm
 | Kubernetes v1.17 + etcd/v3 |                             | ✓                           |
 | Kubernetes v1.18 + etcd/v3 |                             | ✓                           |
 | Kubernetes v1.19 + etcd/v3 |                             | ✓                           |
+| Kubernetes v1.20 + etcd/v3 |                             | ✓                           |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the version support doc by adding Kubernetes v1.20 and updating the CABPK support matrix according to latest changes for kubeadm v1beta1 types removal

**Which issue(s) this PR fixes**:
Fixes #
