### PR TITLE
🌱 Make RegisterClusterResourceSetConfigMapTransformation to be general (not only for CNI)

### DIFF
--- a/test/framework/clusterctl/repository.go
+++ b/test/framework/clusterctl/repository.go
@@ -45,24 +45,24 @@ type CreateRepositoryInput struct {
 	FileTransformations []RepositoryFileTransformation
 }
 
-// RegisterClusterResourceSetConfigMapTransformation registers a FileTransformations that injects a CNI file into
+// RegisterClusterResourceSetConfigMapTransformation registers a FileTransformations that injects a manifests file into
 // a ConfigMap that defines a ClusterResourceSet resource.
 //
 // NOTE: this transformation is specifically designed for replacing "data: ${envSubstVar}".
-func (i *CreateRepositoryInput) RegisterClusterResourceSetConfigMapTransformation(cniManifestPath, envSubstVar string) {
-	By(fmt.Sprintf("Reading the CNI manifest %s", cniManifestPath))
-	cniData, err := ioutil.ReadFile(cniManifestPath)
-	Expect(err).ToNot(HaveOccurred(), "Failed to read the e2e test CNI file")
-	Expect(cniData).ToNot(BeEmpty(), "CNI file should not be empty")
+func (i *CreateRepositoryInput) RegisterClusterResourceSetConfigMapTransformation(manifestPath, envSubstVar string) {
+	By(fmt.Sprintf("Reading the ClusterResourceSet manifest %s", manifestPath))
+	manifestData, err := ioutil.ReadFile(manifestPath)
+	Expect(err).ToNot(HaveOccurred(), "Failed to read the ClusterResourceSet manifest file")
+	Expect(manifestData).ToNot(BeEmpty(), "ClusterResourceSet manifest file should not be empty")
 
 	i.FileTransformations = append(i.FileTransformations, func(template []byte) ([]byte, error) {
 		old := fmt.Sprintf("data: ${%s}", envSubstVar)
 		new := "data:\n"
 		new += "  resources: |\n"
-		for _, l := range strings.Split(string(cniData), "\n") {
+		for _, l := range strings.Split(string(manifestData), "\n") {
 			new += strings.Repeat(" ", 4) + l + "\n"
 		}
-		return bytes.Replace(template, []byte(old), []byte(new), -1), nil
+		return bytes.ReplaceAll(template, []byte(old), []byte(new)), nil
 	})
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR make `RegisterClusterResourceSetConfigMapTransformation` clusterctl e2e framework to be general. In the case infrastructure provider can use this function for installing an external Cloud Controller Manager via CRS in their e2e test
Actually, the functionality already working, this PR just changes `CNI` with `manifests` in the ginkgo message.

**Which issue(s) this PR fixes** 
None
