### PR TITLE
✨Add CI script for running make verify

### DIFF
--- a/scripts/ci-verify.sh
+++ b/scripts/ci-verify.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+cd "${REPO_ROOT}" || exit 1
+
+echo "*** Verifying Cluster API ***"
+make verify


### PR DESCRIPTION
**What this PR does / why we need it**:
Add CI script for running `make verify`. This change is needed for having one common CI job for verifying operator and CAPI.
Currently, the prow job runs `make verify` without this script. See: https://github.com/kubernetes/test-infra/pull/21182/files#diff-acb2ca5ac5bdc0e994bdab32ff57c18d2a3b4d8d51e29773c1bb226f1ee7090aR83

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
