### PR TITLE
🌱Add leases to leader election role in operator

### DIFF
--- a/exp/operator/config/rbac/leader_election_role.yaml
+++ b/exp/operator/config/rbac/leader_election_role.yaml
@@ -30,3 +30,15 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Add leases to leader election role in operator. Similar to what is done here https://github.com/kubernetes-sigs/cluster-api/blob/master/config/rbac/leader_election_role.yaml#L34

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
