### PR TITLE
🌱 Sets InfraReady condition for MachinePool for incorrect external reference

### DIFF
--- a/api/v1alpha4/condition_consts.go
+++ b/api/v1alpha4/condition_consts.go
@@ -35,6 +35,9 @@ const (
 
 	// DeletedReason (Severity=Info) documents an condition not in Status=True because the underlying object was deleted.
 	DeletedReason = "Deleted"
+
+	// IncorrectExternalRefReason (Severity=Error) documents a CAPI object with an incorrect external object reference.
+	IncorrectExternalRefReason = "IncorrectExternalRef"
 )
 
 const (

--- a/exp/controllers/machinepool_controller_phases.go
+++ b/exp/controllers/machinepool_controller_phases.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	"sigs.k8s.io/cluster-api/util"
@@ -232,12 +231,16 @@ func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, clu
 	// Call generic external reconciler.
 	infraReconcileResult, err := r.reconcileExternal(ctx, cluster, mp, &mp.Spec.Template.Spec.InfrastructureRef)
 	if err != nil {
-		if mp.Status.InfrastructureReady && strings.Contains(err.Error(), "could not find") {
-			// Infra object went missing after the machine pool was up and running
-			log.Error(err, "MachinePool infrastructure reference has been deleted after being ready, setting failure state")
-			mp.Status.FailureReason = capierrors.MachinePoolStatusErrorPtr(capierrors.InvalidConfigurationMachinePoolError)
-			mp.Status.FailureMessage = pointer.StringPtr(fmt.Sprintf("MachinePool infrastructure resource %v with name %q has been deleted after being ready",
-				mp.Spec.Template.Spec.InfrastructureRef.GroupVersionKind(), mp.Spec.Template.Spec.InfrastructureRef.Name))
+		if apierrors.IsNotFound(errors.Cause(err)) {
+			log.Error(err, "infrastructure reference could not be found")
+			if mp.Status.InfrastructureReady {
+				// Infra object went missing after the machine pool was up and running
+				log.Error(err, "infrastructure reference has been deleted after being ready, setting failure state")
+				mp.Status.FailureReason = capierrors.MachinePoolStatusErrorPtr(capierrors.InvalidConfigurationMachinePoolError)
+				mp.Status.FailureMessage = pointer.StringPtr(fmt.Sprintf("MachinePool infrastructure resource %v with name %q has been deleted after being ready",
+					mp.Spec.Template.Spec.InfrastructureRef.GroupVersionKind(), mp.Spec.Template.Spec.InfrastructureRef.Name))
+			}
+			conditions.MarkFalse(mp, clusterv1.InfrastructureReadyCondition, clusterv1.IncorrectExternalRefReason, clusterv1.ConditionSeverityError, fmt.Sprintf("could not find infra reference of kind %s with name %s", mp.Spec.Template.Spec.InfrastructureRef.Kind, mp.Spec.Template.Spec.InfrastructureRef.Name))
 		}
 		return ctrl.Result{}, err
 	}

--- a/exp/controllers/machinepool_controller_test.go
+++ b/exp/controllers/machinepool_controller_test.go
@@ -709,6 +709,7 @@ func TestMachinePoolConditions(t *testing.T) {
 		name                string
 		bootstrapReady      bool
 		infrastructureReady bool
+		expectError         bool
 		beforeFunc          func(bootstrap, infra *unstructured.Unstructured, mp *expv1.MachinePool, nodeList *corev1.NodeList)
 		conditionAssertFunc func(t *testing.T, getter conditions.Getter)
 	}{
@@ -813,6 +814,25 @@ func TestMachinePoolConditions(t *testing.T) {
 				g.Expect(readyCondition.Status).To(Equal(corev1.ConditionFalse))
 			},
 		},
+		{
+			name:           "incorrect infrastructure reference",
+			bootstrapReady: true,
+			expectError:    true,
+			beforeFunc: func(bootstrap, infra *unstructured.Unstructured, mp *expv1.MachinePool, nodeList *corev1.NodeList) {
+				mp.Spec.Template.Spec.InfrastructureRef = corev1.ObjectReference{
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+					Kind:       "InfrastructureConfig",
+					Name:       "does-not-exist",
+				}
+			},
+			conditionAssertFunc: func(t *testing.T, getter conditions.Getter) {
+				g := NewWithT(t)
+
+				g.Expect(conditions.Has(getter, clusterv1.InfrastructureReadyCondition)).To(BeTrue())
+				infraReadyCondition := conditions.Get(getter, clusterv1.InfrastructureReadyCondition)
+				g.Expect(infraReadyCondition.Status).To(Equal(corev1.ConditionFalse))
+			},
+		},
 	}
 
 	for _, tt := range testcases {
@@ -845,7 +865,9 @@ func TestMachinePoolConditions(t *testing.T) {
 			}
 
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(machinePool)})
-			g.Expect(err).NotTo(HaveOccurred())
+			if !tt.expectError {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
 
 			m := &expv1.MachinePool{}
 			machinePoolKey := client.ObjectKeyFromObject(machinePool)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This patch sets the `InfrastructureReadyCondition` as `false` if the external reference set on the MachinePool object is incorrect/does not exist. 

**Which issue(s) this PR fixes**:
Fixes #4311
