### PR TITLE
🐛 Fixes panic when ControlPlaneRef is nil

### DIFF
--- a/cmd/clusterctl/client/tree/discovery_test.go
+++ b/cmd/clusterctl/client/tree/discovery_test.go
@@ -268,6 +268,26 @@ func Test_Discovery(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Discovery with no control plane or machine deployments",
+			args: args{
+				discoverOptions: DiscoverOptions{},
+				objs:            test.NewFakeCluster("ns1", "cluster1").Objs(),
+			},
+			wantTree: map[string][]string{
+				// Cluster should be parent of InfrastructureCluster
+				"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns1/cluster1": {
+					"infrastructure.cluster.x-k8s.io/v1alpha4, Kind=GenericInfrastructureCluster, ns1/cluster1",
+				},
+				"infrastructure.cluster.x-k8s.io/v1alpha4, Kind=GenericInfrastructureCluster, ns1/cluster1": {},
+			},
+			wantNodeCheck: map[string]nodeCheck{
+				// InfrastructureCluster should have a meta name
+				"infrastructure.cluster.x-k8s.io/v1alpha4, Kind=GenericInfrastructureCluster, ns1/cluster1": func(g *WithT, obj client.Object) {
+					g.Expect(GetMetaName(obj)).To(Equal("ClusterInfrastructure"))
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Fixes panic when `cluster.Spec.ControlPlaneRef` is `nil` - e.g: when calling `clusterctl describe cluster` on a cluster without a control plane ref in the spec.
