### PR TITLE
✨ Add E2E for scale in rollout

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -68,7 +68,7 @@ cluster-templates-v1alpha4: $(KUSTOMIZE) ## Generate cluster templates for v1alp
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-machine-pool --load_restrictor none > $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-machine-pool.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-node-drain --load_restrictor none > $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-node-drain.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-upgrades --load_restrictor none > $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-upgrades.yaml
-
+	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-kcp-scale-in --load_restrictor none > $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-kcp-scale-in.yaml
 ## --------------------------------------
 ## Testing
 ## --------------------------------------

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -80,6 +80,7 @@ providers:
     - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-machine-pool.yaml"
     - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-node-drain.yaml"
     - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-upgrades.yaml"
+    - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-kcp-scale-in.yaml"
     - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
 
 variables:

--- a/test/e2e/data/infrastructure-docker/v1alpha4/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1alpha4/bases/cluster-with-kcp.yaml
@@ -72,3 +72,4 @@ spec:
         criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs: {eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'}
   version: "${KUBERNETES_VERSION}"
+  

--- a/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-kcp-scale-in/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-kcp-scale-in/cluster-with-kcp.yaml
@@ -1,0 +1,9 @@
+# KubeadmControlPlane referenced by the Cluster object with
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 0

--- a/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-kcp-scale-in/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-kcp-scale-in/kustomization.yaml
@@ -1,0 +1,7 @@
+bases:
+- ../bases/crs.yaml
+- ../bases/md.yaml
+- ../bases/cluster-with-kcp.yaml
+
+patchesStrategicMerge:
+- ./cluster-with-kcp.yaml

--- a/test/e2e/kcp_upgrade.go
+++ b/test/e2e/kcp_upgrade.go
@@ -108,7 +108,6 @@ func KCPUpgradeSpec(ctx context.Context, inputGetter func() KCPUpgradeSpecInput)
 
 	It("Should successfully upgrade Kubernetes, DNS, kube-proxy, and etcd in a HA cluster", func() {
 		By("Creating a workload cluster")
-
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: input.BootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{
@@ -117,6 +116,43 @@ func KCPUpgradeSpec(ctx context.Context, inputGetter func() KCPUpgradeSpecInput)
 				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
 				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
 				Flavor:                   clusterctl.DefaultFlavor,
+				Namespace:                namespace.Name,
+				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
+				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersionUpgradeFrom),
+				ControlPlaneMachineCount: pointer.Int64Ptr(3),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, clusterResources)
+
+		By("Upgrading Kubernetes, DNS, kube-proxy, and etcd versions")
+		framework.UpgradeControlPlaneAndWaitForUpgrade(ctx, framework.UpgradeControlPlaneAndWaitForUpgradeInput{
+			ClusterProxy:                input.BootstrapClusterProxy,
+			Cluster:                     clusterResources.Cluster,
+			ControlPlane:                clusterResources.ControlPlane,
+			EtcdImageTag:                input.E2EConfig.GetVariable(EtcdVersionUpgradeTo),
+			DNSImageTag:                 input.E2EConfig.GetVariable(CoreDNSVersionUpgradeTo),
+			KubernetesUpgradeVersion:    input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
+			WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
+			WaitForDNSUpgrade:           input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
+			WaitForEtcdUpgrade:          input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
+		})
+
+		By("PASSED!")
+	})
+
+	It("Should successfully upgrade Kubernetes, DNS, kube-proxy, and etcd in a HA cluster using scale in rollout", func() {
+		By("Creating a workload cluster")
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: input.BootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   "kcp-scale-in",
 				Namespace:                namespace.Name,
 				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
 				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersionUpgradeFrom),


### PR DESCRIPTION
This PR implements E2E test for KCP scale in rollout. 
Feature is added to master [4073](https://github.com/kubernetes-sigs/cluster-api/pull/4073#pullrequestreview-595150434) and will be part of the v1alpha4 release. 
Related to issue [4282](https://github.com/kubernetes-sigs/cluster-api/issues/4282#event-4450251288)
