### PR TITLE
 🌱 E2E test: Allow extra args to be passed during kubectl apply

### DIFF
--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -64,7 +64,7 @@ type ClusterProxy interface {
 	GetRESTConfig() *rest.Config
 
 	// Apply to apply YAML to the Kubernetes cluster, `kubectl apply`.
-	Apply(context.Context, []byte) error
+	Apply(ctx context.Context, resources []byte, args ...string) error
 
 	// GetWorkloadCluster returns a proxy to a workload cluster defined in the Kubernetes cluster.
 	GetWorkloadCluster(ctx context.Context, namespace, name string) ClusterProxy
@@ -179,20 +179,12 @@ func (p *clusterProxy) GetClientSet() *kubernetes.Clientset {
 	return cs
 }
 
-// Apply wraps `kubectl apply` and prints the output so we can see what gets applied to the cluster.
-func (p *clusterProxy) Apply(ctx context.Context, resources []byte) error {
-	Expect(ctx).NotTo(BeNil(), "ctx is required for Apply")
-	Expect(resources).NotTo(BeNil(), "resources is required for Apply")
-
-	return exec.KubectlApply(ctx, p.kubeconfigPath, resources)
-}
-
 // Apply wraps `kubectl apply ...` and prints the output so we can see what gets applied to the cluster.
-func (p *clusterProxy) ApplyWithArgs(ctx context.Context, resources []byte, args ...string) error {
+func (p *clusterProxy) Apply(ctx context.Context, resources []byte, args ...string) error {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for Apply")
 	Expect(resources).NotTo(BeNil(), "resources is required for Apply")
 
-	return exec.KubectlApplyWithArgs(ctx, p.kubeconfigPath, resources, args...)
+	return exec.KubectlApply(ctx, p.kubeconfigPath, resources, args...)
 }
 
 func (p *clusterProxy) GetRESTConfig() *rest.Config {

--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -111,6 +111,7 @@ type ApplyClusterTemplateAndWaitInput struct {
 	WaitForControlPlaneIntervals []interface{}
 	WaitForMachineDeployments    []interface{}
 	WaitForMachinePools          []interface{}
+	Args                         []string // extra args to be used during `kubectl apply`
 }
 
 type ApplyClusterTemplateAndWaitResult struct {
@@ -153,7 +154,7 @@ func ApplyClusterTemplateAndWait(ctx context.Context, input ApplyClusterTemplate
 	Expect(workloadClusterTemplate).ToNot(BeNil(), "Failed to get the cluster template")
 
 	log.Logf("Applying the cluster template yaml to the cluster")
-	Expect(input.ClusterProxy.Apply(ctx, workloadClusterTemplate)).To(Succeed())
+	Expect(input.ClusterProxy.Apply(ctx, workloadClusterTemplate, input.Args...)).To(Succeed())
 
 	log.Logf("Waiting for the cluster infrastructure to be provisioned")
 	result.Cluster = framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{

--- a/test/framework/exec/kubectl.go
+++ b/test/framework/exec/kubectl.go
@@ -23,11 +23,7 @@ import (
 )
 
 // TODO: Remove this usage of kubectl and replace with a function from apply.go using the controller-runtime client.
-func KubectlApply(ctx context.Context, kubeconfigPath string, resources []byte) error {
-	return KubectlApplyWithArgs(ctx, kubeconfigPath, resources)
-}
-
-func KubectlApplyWithArgs(ctx context.Context, kubeconfigPath string, resources []byte, args ...string) error {
+func KubectlApply(ctx context.Context, kubeconfigPath string, resources []byte, args ...string) error {
 	aargs := append([]string{"apply", "--kubeconfig", kubeconfigPath, "-f", "-"}, args...)
 	rbytes := bytes.NewReader(resources)
 	applyCmd := NewCommand(


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Recently in capz, we were working on integrating gpu-operator with capz's nvidia-gpu flavor [#1254](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1254). As part of it, a CRS is created which refers to a config map that contains the ClusterPolicy CRD (provided by gpu-opertor). But when this config map is applied, it fails with error `The ConfigMap "$cm_name$" is invalid: metadata.annotations: Too long: must have at most 262144 characters`. This is because `kubectl apply` tracks the current version of the resource in `last-applied` annotation thus causing it to exceed the limit.

The solution is to use [server side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) which requires an extra arg `--server-side` to be passed in `kubectl apply`.

This PR adds an `ApplyClusterTemplateAndWaitWithArgs` method to e2e test framework that allows extra args to be passed for kubectl apply. This will help in running e2e tests for nvidia-gpu-flavor by passing `--server-side` flag to kubectl apply.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
