### PR TITLE
🐛 Fix annotations.AddAnnotations (if annotations has been nil before)

### DIFF
--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -52,9 +52,13 @@ func HasWithPrefix(prefix string, annotations map[string]string) bool {
 
 // AddAnnotations sets the desired annotations on the object and returns true if the annotations have changed.
 func AddAnnotations(o metav1.Object, desired map[string]string) bool {
+	if len(desired) == 0 {
+		return false
+	}
 	annotations := o.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
+		o.SetAnnotations(annotations)
 	}
 	hasChanged := false
 	for k, v := range desired {

--- a/util/annotations/helpers_test.go
+++ b/util/annotations/helpers_test.go
@@ -70,6 +70,19 @@ func TestAddAnnotations(t *testing.T) {
 			changed: false,
 		},
 		{
+			name: "should do nothing if no annotations are provided and have been nil before",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input:    map[string]string{},
+			expected: nil,
+			changed:  false,
+		},
+		{
 			name: "should return true if annotations are added",
 			obj: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -98,6 +111,23 @@ func TestAddAnnotations(t *testing.T) {
 					Annotations: map[string]string{
 						"foo": "bar",
 					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			input: map[string]string{
+				"foo": "buzz",
+			},
+			expected: map[string]string{
+				"foo": "buzz",
+			},
+			changed: true,
+		},
+		{
+			name: "should return true if annotations are changed and have been nil before",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
 				},
 				Spec:   corev1.NodeSpec{},
 				Status: corev1.NodeStatus{},


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously the `AddAnnotations` func only added the annotations in a local var in case the annotations map in the object has been nil before calling the func. 

As far as I could see this func is used in machine and machinepool controller when adding annotations to node resources. I suppose we didn't hit this bug because in those cases the annotation map is never nil.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
