### PR TITLE
 🐛 Change KCP upgrade to use machinelist for scaling decision

### DIFF
--- a/controlplane/kubeadm/controllers/upgrade.go
+++ b/controlplane/kubeadm/controllers/upgrade.go
@@ -105,17 +105,12 @@ func (r *KubeadmControlPlaneReconciler) upgradeControlPlane(
 		return ctrl.Result{}, errors.Wrap(err, "failed to upgrade kubelet config map")
 	}
 
-	status, err := workloadCluster.ClusterStatus(ctx)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	switch kcp.Spec.RolloutStrategy.Type {
 	case controlplanev1.RollingUpdateStrategyType:
 		// RolloutStrategy is currently defaulted and validated to be RollingUpdate
 		// We can ignore MaxUnavailable because we are enforcing health checks before we get here.
 		maxNodes := *kcp.Spec.Replicas + int32(kcp.Spec.RolloutStrategy.RollingUpdate.MaxSurge.IntValue())
-		if status.Nodes < maxNodes {
+		if int32(controlPlane.Machines.Len()) < maxNodes {
 			// scaleUp ensures that we don't continue scaling up while waiting for Machines to have NodeRefs
 			return r.scaleUpControlPlane(ctx, cluster, kcp, controlPlane)
 		}


### PR DESCRIPTION
status.Nodes is not the resource status. Method which is populating this field is using the cached client,
which is not ideal when taking decision about scale up or down. This PR change KCP to use list of machines in the controlPlane object for making scaling decision.

Fix issue commented here  [#4293 (comment)](https://github.com/kubernetes-sigs/cluster-api/pull/4293#discussion_r600604240) 