### PR TITLE
:seedling: Include 'edited' to the list of PR types for golangci action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,6 +1,7 @@
 name: golangci-lint
 on:
   pull_request:
+    types: [opened, edited, synchronize, reopened]
     branches:
       - main
       - master


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

By default
(see https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request)
github actions are only triggered on opened, syncroize, and reopened.
This PR adds edited to the mix for older PRs.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/milestone v0.4
/assign @fabriziopandini @CecileRobertMichon 
