### PR TITLE
🐛 Fix the observedGeneration update

### DIFF
--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -227,6 +227,7 @@ func patchKubeadmControlPlane(ctx context.Context, patchHelper *patch.Helper, kc
 			controlplanev1.AvailableCondition,
 			controlplanev1.CertificatesAvailableCondition,
 		}},
+		patch.WithStatusObservedGeneration{},
 	)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where the observedGenaration is not update correctly when deploying a new generation of KubeadmControlPlane.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4341 
