### PR TITLE
🌱 fallback on build if kindest images are missing

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -40,27 +40,35 @@ capi:buildDockerImages () {
   fi
 }
 
-# k8s::resolveAllVersions checks all the e2e test variables representing a Kubernetes version,
-# and resolves kubernetes version labels (e.g. latest) to the corresponding version numbers.
-k8s::resolveAllVersions() {
+# k8s::prepareKindestImages checks all the e2e test variables representing a Kubernetes version,
+# and makes sure a corresponding kindest/node image is available locally.
+k8s::prepareKindestImages() {
   if [ -n "${KUBERNETES_VERSION:-}" ]; then
     k8s::resolveVersion "KUBERNETES_VERSION" "$KUBERNETES_VERSION"
     export KUBERNETES_VERSION=$resolveVersion
+
+    kind::prepareKindestImage $resolveVersion
   fi
 
   if [ -n "${KUBERNETES_VERSION_UPGRADE_TO:-}" ]; then
     k8s::resolveVersion "KUBERNETES_VERSION_UPGRADE_TO" "$KUBERNETES_VERSION_UPGRADE_TO"
     export KUBERNETES_VERSION_UPGRADE_TO=$resolveVersion
+
+    kind::prepareKindestImage $resolveVersion
   fi
 
   if [ -n "${KUBERNETES_VERSION_UPGRADE_FROM:-}" ]; then
     k8s::resolveVersion "KUBERNETES_VERSION_UPGRADE_FROM" "$KUBERNETES_VERSION_UPGRADE_FROM"
     export KUBERNETES_VERSION_UPGRADE_FROM=$resolveVersion
+
+    kind::prepareKindestImage $resolveVersion
   fi
 
   if [ -n "${BUILD_NODE_IMAGE_TAG:-}" ]; then
     k8s::resolveVersion "BUILD_NODE_IMAGE_TAG" "$BUILD_NODE_IMAGE_TAG"
     export BUILD_NODE_IMAGE_TAG=$resolveVersion
+
+    kind::prepareKindestImage $resolveVersion
   fi
 }
 
@@ -86,6 +94,84 @@ k8s::resolveVersion() {
   echo "+ $variableName=\"$version\" resolved to \"$resolveVersion\""
 }
 
+# kind::prepareKindestImage check if a kindest/image exist, and if yes, pre-pull it; otherwise it builds
+# the kindest image locally
+kind::prepareKindestImage() {
+  local version=$1
+
+  # Try to pre-pull the image
+  kind::prepullImage "kindest/node:$version"
+
+  # if pre-pull failed, falling back to local build
+  if [[ "$retVal" != 0 ]]; then
+    echo "+ image for Kuberentes $version is not available in docker hub, trying local build"
+    kind::buildNodeImage $version
+  fi
+}
+
+# kind::buildNodeImage builds a kindest/node images starting from Kubernetes sources.
+# the func expect an input parameter defining the image tag to be used.
+kind::buildNodeImage() {
+  local version=$1
+
+  # move to the Kubernetes repository.
+  echo "KUBE_ROOT $GOPATH/src/k8s.io/kubernetes"
+  cd $GOPATH/src/k8s.io/kubernetes
+
+  # checkouts the Kubernetes branch for the given version.
+  k8s::checkoutBranch "$version"
+
+  # sets the build version that will be applied by the Kubernetes build command called during kind build node-image.
+  k8s::setBuildVersion "$version"
+
+  # build the node image
+  version="${version//+/_}"
+  echo "+ Building kindest/node:$version"
+  kind build node-image --type docker --image "kindest/node:$version"
+
+  # move back to Cluster API
+  cd $REPO_ROOT
+}
+
+# k8s::checkoutBranch checkouts the Kubernetes branch for the given version.
+k8s::checkoutBranch() {
+  local version=$1
+  echo "+ Checkout branch for Kubernetes $version"
+
+  # checkout the required tag/branch.
+  local buildMetadata
+  buildMetadata=$(echo "${version#v}" | awk '{split($0,a,"+"); print a[2]}')
+  if [[ "$buildMetadata" == "" ]]; then
+    # if there are no release metadata, it means we are looking for a Kubernetes version that
+    # should be already been tagged.
+    echo "+ checkout tag $version"
+    git fetch --all --tags
+    git checkout tags/$version -b $version-branch
+  else
+    # otherwise we are requiring a Kubernetes version that should be built from HEAD
+    # of one of the existing branches
+    echo "+ checking for existing branches"
+    git fetch --all
+
+    local major
+    local minor
+    major=$(echo "${version#v}" | awk '{split($0,a,"."); print a[1]}')
+    minor=$(echo "${version#v}" | awk '{split($0,a,"."); print a[2]}')
+
+    local releaseBranch
+    releaseBranch="$(git branch -r | grep release-$major.$minor$ || true)"
+    if [[ "$releaseBranch" != "" ]]; then
+      # if there is already a release branch for the required Kubernetes branch, use it
+      echo "+ checkout $releaseBranch branch"
+      git checkout $releaseBranch -b release-$major.$minor
+    else
+      # otherwise, we should build from master, which is the branch for the next release
+      echo "+ checkout master branch"
+      git checkout master
+    fi
+  fi
+}
+
 # k8s::setBuildVersion sets the build version that will be applied by the Kubernetes build command.
 # the func expect an input parameter defining the version to be used.
 k8s::setBuildVersion() {
@@ -108,61 +194,25 @@ EOL
   export KUBE_GIT_VERSION_FILE=$PWD/build-version
 }
 
-# kind::buildNodeImage builds a kindest/node images starting from Kubernetes sources.
-# the func expect an input parameter defining the image tag to be used.
-kind::buildNodeImage() {
-  local version=$1
-  version="${version//+/_}"
-
-  # return early if the image already exists
-  if [[ "$(docker images -q kindest/node:"$version" 2> /dev/null)" != "" ]]; then
-    echo "+ image kindest/node:$version already present in the system, skipping build"
-    return
-  fi
-
-  # sets the build version that will be applied by the Kubernetes build command called during .
-  k8s::setBuildVersion "$1"
-
-  # build the node image
-  echo "+ Building kindest/node:$version"
-  kind build node-image --type docker --image "kindest/node:$version"
-}
-
-# kind:prepullImages pre-pull all the images that will be used in the e2e, thus making
+# kind:prepullAdditionalImages pre-pull all the additional (not Kindest/node) images that will be used in the e2e, thus making
 # the actual test run less sensible to the network speed.
-kind:prepullImages () {
+kind:prepullAdditionalImages () {
   # Pulling cert manager images so we can pre-load in kind nodes
   kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.1.0"
   kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.1.0"
   kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.1.0"
-
-  # Pulling kindest/node images used by tests
-  # NB. some of those versions might be the same
-  if [ -n "${KUBERNETES_VERSION:-}" ]; then
-    kind::prepullImage "kindest/node:$KUBERNETES_VERSION"
-  fi
-
-  if [ -n "${KUBERNETES_VERSION_UPGRADE_TO:-}" ]; then
-    kind::prepullImage "kindest/node:$KUBERNETES_VERSION_UPGRADE_TO"
-  fi
-
-  if [ -n "${KUBERNETES_VERSION_UPGRADE_FROM:-}" ]; then
-    kind::prepullImage "kindest/node:$KUBERNETES_VERSION_UPGRADE_FROM"
-  fi
-
-  if [ -n "${BUILD_NODE_IMAGE_TAG:-}" ]; then
-    kind::prepullImage "kindest/node:$BUILD_NODE_IMAGE_TAG"
-  fi
 }
 
 # kind:prepullImage pre-pull a docker image if no already present locally.
+# The result will be available in the retVal value which is accessible from the caller.
 kind::prepullImage () {
   local image=$1
   image="${image//+/_}"
 
+  retVal=0
   if [[ "$(docker images -q "$image" 2> /dev/null)" == "" ]]; then
     echo "+ Pulling $image"
-    docker pull "$image"
+    docker pull "$image" || retVal=$?
   else
     echo "+ image $image already present in the system, skipping pre-pull"
   fi

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -38,29 +38,19 @@ export PATH="${REPO_ROOT}/hack/tools/bin:${PATH}"
 # Builds CAPI (and CAPD) images.
 capi:buildDockerImages
 
-# Checks all the e2e test variables representing a Kubernetes version,
-# and resolves kubernetes version labels (e.g. latest) to the corresponding version numbers.
+# Prepare kindest/node images for all the required Kubernetes version; this implies
+# 1. Kubernetes version labels (e.g. latest) to the corresponding version numbers.
+# 2. Pre-pulling the corresponding kindest/node image if available; if not, building the image locally.
 # Following variables are currently checked (if defined):
 # - KUBERNETES_VERSION
 # - KUBERNETES_VERSION_UPGRADE_TO
 # - KUBERNETES_VERSION_UPGRADE_FROM
-# - BUILD_NODE_IMAGE_TAG
-k8s::resolveAllVersions
-
-# If it is required to build a kindest/node image, build it ensuring the generated binary gets
-# the expected version.
-if [ -n "${BUILD_NODE_IMAGE_TAG:-}" ]; then
-  kind::buildNodeImage "$BUILD_NODE_IMAGE_TAG"
-fi
+k8s::prepareKindestImages
 
 # pre-pull all the images that will be used in the e2e, thus making the actual test run
 # less sensible to the network speed. This includes:
 # - cert-manager images
-# - kindest/node:KUBERNETES_VERSION (if defined)
-# - kindest/node:KUBERNETES_VERSION_UPGRADE_TO (if defined)
-# - kindest/node:KUBERNETES_VERSION_UPGRADE_FROM (if defined)
-# - kindest/node:BUILD_NODE_IMAGE_TAG (if defined)
-kind:prepullImages
+kind:prepullAdditionalImages
 
 # Configure e2e tests
 export GINKGO_NODES=3


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a problem in our E2E test, where test will fail if the kindest/node image for the requested Kubernetes version is not published yet.

With this PR instead we are changing our prePull sequence, and if a kindest image is not available on gitHub, we build it locally.

As a niece side effect, we are also dropping the BUILD_NODE_IMAGE_TAG env variable for our tests configuration...

/assign @srm09 