### PR TITLE
📖 Add a warning that only CoreDNS is supported in KCP

### DIFF
--- a/docs/book/src/tasks/kubeadm-control-plane.md
+++ b/docs/book/src/tasks/kubeadm-control-plane.md
@@ -2,6 +2,14 @@
 
 Using the Kubeadm control plane type to manage a control plane provides several ways to upgrade control plane machines.
 
+<aside class="note warning">
+
+<h1>Warning</h1>
+
+KubeadmControlPlane is solely supporting CoreDNS as a DNS server at this time.
+
+</aside>
+
 ### Kubeconfig management
 
 KCP will generate and manage the admin Kubeconfig for clusters. The client certificate for the admin user is created


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to address #4026 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This adds a warning message in the Cluster API Book Section 1.5
Fixes #4026 
