### PR TITLE
🐛 make manifest to use cert-manager.io/v1alpha2

### DIFF
--- a/bootstrap/kubeadm/config/certmanager/certificate.yaml
+++ b/bootstrap/kubeadm/config/certmanager/certificate.yaml
@@ -1,7 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for breaking changes
-apiVersion: cert-manager.io/v1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -9,7 +9,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/bootstrap/kubeadm/config/webhook/kustomization.yaml
+++ b/bootstrap/kubeadm/config/webhook/kustomization.yaml
@@ -19,7 +19,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
@@ -27,7 +27,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: cert-manager.io/v1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -19,7 +19,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
@@ -27,7 +27,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:

--- a/controlplane/kubeadm/config/certmanager/certificate.yaml
+++ b/controlplane/kubeadm/config/certmanager/certificate.yaml
@@ -1,7 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for breaking changes
-apiVersion: cert-manager.io/v1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -9,7 +9,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/controlplane/kubeadm/config/webhook/kustomization.yaml
+++ b/controlplane/kubeadm/config/webhook/kustomization.yaml
@@ -19,7 +19,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
@@ -27,7 +27,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1
+    version: v1alpha2
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:

--- a/test/infrastructure/docker/config/certmanager/certificate.yaml
+++ b/test/infrastructure/docker/config/certmanager/certificate.yaml
@@ -1,6 +1,6 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
-apiVersion: cert-manager.io/v1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/test/infrastructure/docker/config/webhook/kustomization.yaml
+++ b/test/infrastructure/docker/config/webhook/kustomization.yaml
@@ -33,7 +33,7 @@ vars:
     objref:
       kind: Certificate
       group: cert-manager.io
-      version: v1
+      version: v1alpha2
       name: serving-cert # this name should match the one in certificate.yaml
     fieldref:
       fieldpath: metadata.namespace
@@ -41,5 +41,5 @@ vars:
     objref:
       kind: Certificate
       group: cert-manager.io
-      version: v1
+      version: v1alpha2
       name: serving-cert # this name should match the one in certificate.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api/pull/4225 made clustectl to deploy cert manager v1.1.0. and updated manifests generation in order to generate Certificate objects using `cert-manager.io/v1` apiVersion.

Unfortunately this is creating a problem for people using old versions of clusterctl for doing `clusterctl init` because e.g.:
- `clusterctl init` with clusterctl v0.3.14 installs cert manager v0.16.1
- `clusterctl init` then installs the latest version of providers, that now is v0.3.15 which creates `cert-manager.io/v1` objects.

This makes init to fail with older version of clusterctl.

This PR fixes this problem by changing our manifests in order to generate Certificate objects using `cert-manager.io/v1alpha2` apiVersion, which can be processed either by v0.16.1 and v1.1.0 version of cert manager

**Note**
As a temporary workaround it is possible to pin version of the installed providers
```
clusterctl init \
	--core cluster-api:v0.3.14 \
	--bootstrap kubeadm:v0.3.14 \
	--control-plane kubeadm:v0.3.14 \
	--infrastructure vsphere:v0.3.14
```

