### PR TITLE
🌱 gather more Docker and containerd data/logs in ci-e2e.sh

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -71,6 +71,39 @@ export ARTIFACTS="${ARTIFACTS:-${REPO_ROOT}/_artifacts}"
 export SKIP_RESOURCE_CLEANUP=false
 export USE_EXISTING_CLUSTER=false
 
+# Setup local output directory
+ARTIFACTS_LOCAL="${ARTIFACTS}/localhost"
+mkdir -p "${ARTIFACTS_LOCAL}"
+echo "This folder contains logs from the local host where the tests ran." > "${ARTIFACTS_LOCAL}/README.md"
+
+# Configure the containerd socket, otherwise 'ctr' would not work
+export CONTAINERD_ADDRESS=/var/run/docker/containerd/containerd.sock
+
+# ensure we retrieve additional info for debugging when we leave the script
+cleanup() {
+  # shellcheck disable=SC2046
+  kill $(pgrep -f 'docker events') || true
+  # shellcheck disable=SC2046
+  kill $(pgrep -f 'ctr -n moby events') || true
+
+  cp /var/log/docker.log "${ARTIFACTS_LOCAL}/docker.log" || true
+  docker ps -a > "${ARTIFACTS_LOCAL}/docker-ps.txt" || true
+  docker images > "${ARTIFACTS_LOCAL}/docker-images.txt" || true
+  docker info > "${ARTIFACTS_LOCAL}/docker-info.txt" || true
+  docker system df > "${ARTIFACTS_LOCAL}/docker-system-df.txt" || true
+  docker version > "${ARTIFACTS_LOCAL}/docker-version.txt" || true
+
+  ctr namespaces list > "${ARTIFACTS_LOCAL}/containerd-namespaces.txt" || true
+  ctr -n moby tasks list > "${ARTIFACTS_LOCAL}/containerd-tasks.txt" || true
+  ctr -n moby containers list > "${ARTIFACTS_LOCAL}/containerd-containers.txt" || true
+  ctr -n moby images list > "${ARTIFACTS_LOCAL}/containerd-images.txt" || true
+  ctr -n moby version > "${ARTIFACTS_LOCAL}/containerd-version.txt" || true
+}
+trap "cleanup" EXIT SIGINT
+
+docker events > "${ARTIFACTS_LOCAL}/docker-events.txt" 2>&1 &
+ctr -n moby events > "${ARTIFACTS_LOCAL}/containerd-events.txt" 2>&1 &
+
 # Run e2e tests
 mkdir -p "$ARTIFACTS"
 echo "+ run tests!"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Gathers more logs and data from Docker and containerd, to be able to fix #4405 mid-term.

Maybe a bit hacky, but I suppose it works, let's see. Should provide a lot more information. The most promising new logs are:
* containerd event logs: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/4414/pull-cluster-api-e2e-main/1377189073852043264/artifacts/local/containerd-events.txt
* docker event logs: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/4414/pull-cluster-api-e2e-main/1377189073852043264/artifacts/local/docker-events.txt
* docker / containerd logs: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/4414/pull-cluster-api-e2e-main/1377189073852043264/artifacts/local/docker.log

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Prereq to fix #4405
