### PR TITLE
[WIP] 🌱 capd: inspect container when container bootstrap fails

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -350,7 +350,7 @@ func setClusterPause(proxy Proxy, clusters []*node, value bool, dryRun bool) err
 		if err := retryWithExponentialBackoff(setClusterPauseBackoff, func() error {
 			return patchCluster(proxy, cluster, patch)
 		}); err != nil {
-			return err
+			return errors.Wrapf(err, "error setting Cluster.Spec.Paused=%t", value)
 		}
 	}
 	return nil
@@ -375,7 +375,7 @@ func patchCluster(proxy Proxy, cluster *node, patch client.Patch) error {
 	}
 
 	if err := cFrom.Patch(ctx, clusterObj, patch); err != nil {
-		return errors.Wrapf(err, "error pausing reconciliation for %q %s/%s",
+		return errors.Wrapf(err, "error patching %q %s/%s",
 			clusterObj.GroupVersionKind(), clusterObj.GetNamespace(), clusterObj.GetName())
 	}
 

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -21,7 +21,7 @@ set -o pipefail
 set -x
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KIND_VERSION=v0.9.0
+MINIMUM_KIND_VERSION=v0.10.0
 
 # Ensure the kind tool exists and is a viable version, or installs it
 verify_kind_version() {

--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -96,5 +96,10 @@ ctr -n moby events > "${ARTIFACTS_LOCAL}/containerd-events.txt" 2>&1 &
 
 # Run e2e tests
 mkdir -p "$ARTIFACTS"
-echo "+ run tests!"
-make -C test/e2e/ run
+
+# run the tests more often, so do they don't have to be re-triggered every hour
+for i in {1..20};
+do
+  echo "+ run tests! ${i}"
+  make -C test/e2e/ run
+done

--- a/test/infrastructure/docker/docker/machine.go
+++ b/test/infrastructure/docker/docker/machine.go
@@ -40,8 +40,8 @@ import (
 )
 
 const (
-	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.19.1"
+	defaultImageName = "sbueringer/kindest-node"
+	defaultImageTag  = "v1.19.1-verbose"
 )
 
 type nodeCreator interface {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adds more debug information in case the container creation does not work. For context, please see https://github.com/kubernetes-sigs/cluster-api/issues/4405#issuecomment-811075444


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Improves observability to debug #4405
