### PR TITLE
🐛 Fix v1alpha4 conversion webhook failure

### DIFF
--- a/api/v1alpha3/webhook_suite_test.go
+++ b/api/v1alpha3/webhook_suite_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/cluster-api/test/helpers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
+)
+
+func TestMain(m *testing.M) {
+	// Bootstrapping test environment
+	utilruntime.Must(AddToScheme(scheme.Scheme))
+	testEnv = helpers.NewTestEnvironment()
+	go func() {
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+	<-testEnv.Manager.Elected()
+	testEnv.WaitForWebhooks()
+
+	// Run tests
+	code := m.Run()
+	// Tearing down the test environment
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
+	}
+
+	// Report exit code
+	os.Exit(code)
+}

--- a/api/v1alpha3/webhook_test.go
+++ b/api/v1alpha3/webhook_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/util"
+)
+
+func TestClusterConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	clusterName := fmt.Sprintf("test-cluster-%s", util.RandomString(5))
+	cluster := &Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: ns.Name,
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, cluster)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, cluster)
+}
+
+func TestMachineSetConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	clusterName := fmt.Sprintf("test-cluster-%s", util.RandomString(5))
+	machineSetName := fmt.Sprintf("test-machineset-%s", util.RandomString(5))
+	machineSet := &MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      machineSetName,
+		},
+		Spec: MachineSetSpec{
+			ClusterName:     clusterName,
+			Template:        newFakeMachineTemplate(ns.Name, clusterName),
+			MinReadySeconds: 10,
+			Replicas:        pointer.Int32Ptr(1),
+			DeletePolicy:    "Random",
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, machineSet)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, machineSet)
+}
+
+func TestMachineDeploymentConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	clusterName := fmt.Sprintf("test-cluster-%s", util.RandomString(5))
+	machineDeploymentName := fmt.Sprintf("test-machinedeployment-%s", util.RandomString(5))
+	machineDeployment := &MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machineDeploymentName,
+			Namespace: ns.Name,
+		},
+		Spec: MachineDeploymentSpec{
+			ClusterName: clusterName,
+			Template:    newFakeMachineTemplate(ns.Name, clusterName),
+			Replicas:    pointer.Int32Ptr(0),
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, machineDeployment)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, machineDeployment)
+}
+
+func newFakeMachineTemplate(namespace, clusterName string) MachineTemplateSpec {
+	return MachineTemplateSpec{
+		Spec: MachineSpec{
+			ClusterName: clusterName,
+			Bootstrap: Bootstrap{
+				ConfigRef: &corev1.ObjectReference{
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+					Kind:       "KubeadmConfigTemplate",
+					Name:       fmt.Sprintf("%s-md-0", clusterName),
+					Namespace:  namespace,
+				},
+			},
+			InfrastructureRef: corev1.ObjectReference{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+				Kind:       "FakeMachineTemplate",
+				Name:       fmt.Sprintf("%s-md-0", clusterName),
+				Namespace:  namespace,
+			},
+			Version: pointer.String("v1.20.2"),
+		},
+	}
+}

--- a/bootstrap/kubeadm/api/v1alpha3/webhook_suite_test.go
+++ b/bootstrap/kubeadm/api/v1alpha3/webhook_suite_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/cluster-api/test/helpers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
+)
+
+func TestMain(m *testing.M) {
+	// Bootstrapping test environment
+	utilruntime.Must(AddToScheme(scheme.Scheme))
+	testEnv = helpers.NewTestEnvironment()
+	go func() {
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+	<-testEnv.Manager.Elected()
+	testEnv.WaitForWebhooks()
+
+	// Run tests
+	code := m.Run()
+	// Tearing down the test environment
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
+	}
+
+	// Report exit code
+	os.Exit(code)
+}

--- a/bootstrap/kubeadm/api/v1alpha3/webhook_test.go
+++ b/bootstrap/kubeadm/api/v1alpha3/webhook_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kubeadmv1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+func TestKubeadmConfigConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	kubeadmConfigName := fmt.Sprintf("test-kubeadmconfig-%s", util.RandomString(5))
+	kubeadmConfig := &KubeadmConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeadmConfigName,
+			Namespace: ns.Name,
+		},
+		Spec: fakeKubeadmConfigSpec,
+	}
+
+	g.Expect(testEnv.Create(ctx, kubeadmConfig)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, kubeadmConfig)
+}
+
+func TestKubeadmConfigTemplateConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	kubeadmConfigTemplateName := fmt.Sprintf("test-kubeadmconfigtemplate-%s", util.RandomString(5))
+	kubeadmConfigTemplate := &KubeadmConfigTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeadmConfigTemplateName,
+			Namespace: ns.Name,
+		},
+		Spec: KubeadmConfigTemplateSpec{
+			Template: KubeadmConfigTemplateResource{
+				Spec: fakeKubeadmConfigSpec,
+			},
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, kubeadmConfigTemplate)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, kubeadmConfigTemplate)
+}
+
+var fakeKubeadmConfigSpec = KubeadmConfigSpec{
+	ClusterConfiguration: &kubeadmv1beta1.ClusterConfiguration{
+		KubernetesVersion: "v1.20.2",
+		APIServer: kubeadmv1beta1.APIServer{
+			ControlPlaneComponent: kubeadmv1beta1.ControlPlaneComponent{
+				ExtraArgs: map[string]string{
+					"foo": "bar",
+				},
+				ExtraVolumes: []kubeadmv1beta1.HostPathMount{
+					{
+						Name:      "mount-path",
+						HostPath:  "/foo",
+						MountPath: "/foo",
+						ReadOnly:  false,
+					},
+				},
+			},
+		},
+	},
+	InitConfiguration: &kubeadmv1beta1.InitConfiguration{
+		NodeRegistration: kubeadmv1beta1.NodeRegistrationOptions{
+			Name:      "foo",
+			CRISocket: "/var/run/containerd/containerd.sock",
+		},
+	},
+	JoinConfiguration: &kubeadmv1beta1.JoinConfiguration{
+		NodeRegistration: kubeadmv1beta1.NodeRegistrationOptions{
+			Name:      "foo",
+			CRISocket: "/var/run/containerd/containerd.sock",
+		},
+	},
+	Files: []File{
+		{
+			Path:        "/foo",
+			Owner:       "root:root",
+			Permissions: "0644",
+			Content:     "foo",
+		},
+		{
+			Path:        "/foobar",
+			Owner:       "root:root",
+			Permissions: "0644",
+			ContentFrom: &FileSource{
+				Secret: SecretFileSource{
+					Name: "foo",
+					Key:  "bar",
+				},
+			},
+		},
+	},
+	DiskSetup: &DiskSetup{
+		Partitions: []Partition{
+			{
+				Device:    "/dev/disk/scsi1/lun0",
+				Layout:    true,
+				Overwrite: pointer.Bool(false),
+				TableType: pointer.String("gpt"),
+			},
+		},
+		Filesystems: []Filesystem{
+			{
+				Device:     "/dev/disk/scsi2/lun0",
+				Filesystem: "ext4",
+				Label:      "disk",
+				Partition:  pointer.String("auto"),
+				Overwrite:  pointer.Bool(true),
+				ReplaceFS:  pointer.String("ntfs"),
+				ExtraOpts:  []string{"-E"},
+			},
+		},
+	},
+	Mounts: []MountPoints{
+		{
+			"LABEL=disk",
+			"/var/lib/disk",
+		},
+	},
+	PreKubeadmCommands:  []string{`echo "foo"`},
+	PostKubeadmCommands: []string{`echo "bar"`},
+	Users: []User{
+		{
+			Name:              "foo",
+			Groups:            pointer.String("foo"),
+			HomeDir:           pointer.String("/home/foo"),
+			Inactive:          pointer.Bool(false),
+			Shell:             pointer.String("/bin/bash"),
+			Passwd:            pointer.String("password"),
+			SSHAuthorizedKeys: []string{"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQD24GRNlhO+rgrseyWYrGwP0PACO/9JAsKV06W63yQ=="},
+		},
+	},
+	NTP: &NTP{
+		Servers: []string{"ntp.server.local"},
+		Enabled: pointer.Bool(true),
+	},
+	Format:                   Format("cloud-config"),
+	Verbosity:                pointer.Int32(3),
+	UseExperimentalRetryJoin: true,
+}

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	kubeadmbootstrapv1old "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	kubeadmbootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
 	kubeadmbootstrapcontrollers "sigs.k8s.io/cluster-api/bootstrap/kubeadm/controllers"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
@@ -55,6 +56,7 @@ func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
 	_ = expv1.AddToScheme(scheme)
+	_ = kubeadmbootstrapv1old.AddToScheme(scheme)
 	_ = kubeadmbootstrapv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }

--- a/controlplane/kubeadm/api/v1alpha3/webhook_suite_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/webhook_suite_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/cluster-api/test/helpers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
+)
+
+func TestMain(m *testing.M) {
+	// Bootstrapping test environment
+	utilruntime.Must(AddToScheme(scheme.Scheme))
+	testEnv = helpers.NewTestEnvironment()
+	go func() {
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+	<-testEnv.Manager.Elected()
+	testEnv.WaitForWebhooks()
+
+	// Run tests
+	code := m.Run()
+	// Tearing down the test environment
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
+	}
+
+	// Report exit code
+	os.Exit(code)
+}

--- a/controlplane/kubeadm/api/v1alpha3/webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/webhook_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cabpkv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
+	kubeadmv1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+func TestKubeadmControlPlaneConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	infraMachineTemplateName := fmt.Sprintf("test-machinetemplate-%s", util.RandomString(5))
+	controlPlaneName := fmt.Sprintf("test-controlpane-%s", util.RandomString(5))
+	controlPane := &KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controlPlaneName,
+			Namespace: ns.Name,
+		},
+		Spec: KubeadmControlPlaneSpec{
+			Replicas: pointer.Int32(3),
+			Version:  "v1.20.2",
+			InfrastructureTemplate: corev1.ObjectReference{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
+				Kind:       "TestMachineTemplate",
+				Namespace:  ns.Name,
+				Name:       infraMachineTemplateName,
+			},
+			KubeadmConfigSpec: cabpkv1.KubeadmConfigSpec{
+				ClusterConfiguration: &kubeadmv1beta1.ClusterConfiguration{
+					APIServer: kubeadmv1beta1.APIServer{
+						ControlPlaneComponent: kubeadmv1beta1.ControlPlaneComponent{
+							ExtraArgs: map[string]string{
+								"foo": "bar",
+							},
+							ExtraVolumes: []kubeadmv1beta1.HostPathMount{
+								{
+									Name:      "mount-path",
+									HostPath:  "/foo",
+									MountPath: "/foo",
+									ReadOnly:  false,
+								},
+							},
+						},
+					},
+				},
+				InitConfiguration: &kubeadmv1beta1.InitConfiguration{
+					NodeRegistration: kubeadmv1beta1.NodeRegistrationOptions{
+						Name:      "foo",
+						CRISocket: "/var/run/containerd/containerd.sock",
+					},
+				},
+				JoinConfiguration: &kubeadmv1beta1.JoinConfiguration{
+					NodeRegistration: kubeadmv1beta1.NodeRegistrationOptions{
+						Name:      "foo",
+						CRISocket: "/var/run/containerd/containerd.sock",
+					},
+				},
+			},
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, controlPane)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, controlPane)
+}

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -35,7 +35,8 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	kubeadmbootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/remote"
-	kcpv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
+	kubeadmcontrolplanev1old "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
+	kubeadmcontrolplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
 	kubeadmcontrolplanecontrollers "sigs.k8s.io/cluster-api/controlplane/kubeadm/controllers"
 	"sigs.k8s.io/cluster-api/version"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -54,7 +55,8 @@ func init() {
 
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
-	_ = kcpv1.AddToScheme(scheme)
+	_ = kubeadmcontrolplanev1old.AddToScheme(scheme)
+	_ = kubeadmcontrolplanev1.AddToScheme(scheme)
 	_ = kubeadmbootstrapv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
@@ -191,7 +193,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := (&kcpv1.KubeadmControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&kubeadmcontrolplanev1.KubeadmControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "KubeadmControlPlane")
 		os.Exit(1)
 	}

--- a/exp/addons/api/v1alpha3/webhook_suite_test.go
+++ b/exp/addons/api/v1alpha3/webhook_suite_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/cluster-api/test/helpers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
+)
+
+func TestMain(m *testing.M) {
+	// Bootstrapping test environment
+	utilruntime.Must(AddToScheme(scheme.Scheme))
+	testEnv = helpers.NewTestEnvironment()
+	go func() {
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+	<-testEnv.Manager.Elected()
+	testEnv.WaitForWebhooks()
+
+	// Run tests
+	code := m.Run()
+	// Tearing down the test environment
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
+	}
+
+	// Report exit code
+	os.Exit(code)
+}

--- a/exp/addons/api/v1alpha3/webhook_test.go
+++ b/exp/addons/api/v1alpha3/webhook_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestClusterResourceSetConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	clusterName := fmt.Sprintf("test-cluster-%s", util.RandomString(5))
+	crsName := fmt.Sprintf("test-clusterresourceset-%s", util.RandomString(5))
+	crs := &ClusterResourceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crsName,
+			Namespace: ns.Name,
+		},
+		Spec: ClusterResourceSetSpec{
+			Strategy: "ApplyOnce",
+			ClusterSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"cni": fmt.Sprintf("%s-crs-cni", clusterName),
+				},
+			},
+			Resources: []ResourceRef{
+				{
+					Name: fmt.Sprintf("%s-crs-cni", clusterName),
+					Kind: "ConfigMap",
+				},
+			},
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, crs)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, crs)
+}
+
+func TestClusterResourceSetBindingConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	crsbindingName := fmt.Sprintf("test-clusterresourcesetbinding-%s", util.RandomString(5))
+	crsbinding := &ClusterResourceSetBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      crsbindingName,
+			Namespace: ns.Name,
+		},
+		Spec: ClusterResourceSetBindingSpec{
+			Bindings: []*ResourceSetBinding{
+				{
+					ClusterResourceSetName: "test-clusterresourceset",
+					Resources: []ResourceBinding{
+						{
+							ResourceRef: ResourceRef{
+								Name: "ApplySucceeded",
+								Kind: "Secret",
+							},
+							Applied:         true,
+							Hash:            "xyz",
+							LastAppliedTime: &metav1.Time{Time: time.Now().UTC()},
+						},
+						{
+							ResourceRef: ResourceRef{
+								Name: "applyFailed",
+								Kind: "Secret",
+							},
+							Applied:         false,
+							Hash:            "",
+							LastAppliedTime: &metav1.Time{Time: time.Now().UTC()},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, crsbinding)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, crsbinding)
+}

--- a/exp/api/v1alpha3/webhook_suite_test.go
+++ b/exp/api/v1alpha3/webhook_suite_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/cluster-api/test/helpers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	testEnv *helpers.TestEnvironment
+	ctx     = ctrl.SetupSignalHandler()
+)
+
+func TestMain(m *testing.M) {
+	// Bootstrapping test environment
+	utilruntime.Must(AddToScheme(scheme.Scheme))
+	testEnv = helpers.NewTestEnvironment()
+	go func() {
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
+	}()
+	<-testEnv.Manager.Elected()
+	testEnv.WaitForWebhooks()
+
+	// Run tests
+	code := m.Run()
+	// Tearing down the test environment
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
+	}
+
+	// Report exit code
+	os.Exit(code)
+}

--- a/exp/api/v1alpha3/webhook_test.go
+++ b/exp/api/v1alpha3/webhook_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestMachinePoolConversion(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := testEnv.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
+	g.Expect(err).ToNot(HaveOccurred())
+	clusterName := fmt.Sprintf("test-cluster-%s", util.RandomString(5))
+	machinePoolName := fmt.Sprintf("test-machinepool-%s", util.RandomString(5))
+	machinePool := &MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machinePoolName,
+			Namespace: ns.Name,
+		},
+		Spec: MachinePoolSpec{
+			ClusterName: clusterName,
+			Replicas:    pointer.Int32(3),
+			Template:    newFakeMachineTemplate(ns.Name, clusterName),
+			Strategy: &clusterv1alpha3.MachineDeploymentStrategy{
+				Type: clusterv1alpha3.RollingUpdateMachineDeploymentStrategyType,
+			},
+			MinReadySeconds: pointer.Int32(60),
+			ProviderIDList:  []string{"cloud:////1111", "cloud:////1112", "cloud:////1113"},
+			FailureDomains:  []string{"1", "3"},
+		},
+	}
+
+	g.Expect(testEnv.Create(ctx, machinePool)).To(Succeed())
+	defer func(do ...client.Object) {
+		g.Expect(testEnv.Cleanup(ctx, do...)).To(Succeed())
+	}(ns, machinePool)
+}
+
+func newFakeMachineTemplate(namespace, clusterName string) clusterv1alpha3.MachineTemplateSpec {
+	return clusterv1alpha3.MachineTemplateSpec{
+		Spec: clusterv1alpha3.MachineSpec{
+			ClusterName: clusterName,
+			Bootstrap: clusterv1alpha3.Bootstrap{
+				ConfigRef: &corev1.ObjectReference{
+					APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+					Kind:       "KubeadmConfigTemplate",
+					Name:       fmt.Sprintf("%s-md-0", clusterName),
+					Namespace:  namespace,
+				},
+			},
+			InfrastructureRef: corev1.ObjectReference{
+				APIVersion: "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
+				Kind:       "FakeMachinePool",
+				Name:       fmt.Sprintf("%s-md-0", clusterName),
+				Namespace:  namespace,
+			},
+			Version: pointer.String("v1.20.2"),
+		},
+	}
+}

--- a/main.go
+++ b/main.go
@@ -33,11 +33,14 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
+	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	addonsv1old "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha4"
 	addonscontrollers "sigs.k8s.io/cluster-api/exp/addons/controllers"
+	expv1old "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	expcontrollers "sigs.k8s.io/cluster-api/exp/controllers"
 	"sigs.k8s.io/cluster-api/feature"
@@ -79,8 +82,11 @@ func init() {
 	klog.InitFlags(nil)
 
 	_ = clientgoscheme.AddToScheme(scheme)
+	_ = clusterv1old.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
+	_ = expv1old.AddToScheme(scheme)
 	_ = expv1.AddToScheme(scheme)
+	_ = addonsv1old.AddToScheme(scheme)
 	_ = addonsv1.AddToScheme(scheme)
 	_ = apiextensionsv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -176,6 +176,9 @@ func NewTestEnvironment() *TestEnvironment {
 	if err := (&crs.ClusterResourceSet{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("unable to create webhook for crs: %+v", err)
 	}
+	if err := (&expv1.MachinePool{}).SetupWebhookWithManager(mgr); err != nil {
+		klog.Fatalf("unable to create webhook for machinepool: %+v", err)
+	}
 
 	return &TestEnvironment{
 		Manager: mgr,

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -34,9 +34,11 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/feature"
+	infrav1old "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/controllers"
-	infrav1exp "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1alpha4"
+	infraexpv1old "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1alpha3"
+	infraexpv1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1alpha4"
 	expcontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/controllers"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -62,8 +64,10 @@ func init() {
 	klog.InitFlags(nil)
 
 	_ = scheme.AddToScheme(myscheme)
+	_ = infrav1old.AddToScheme(myscheme)
 	_ = infrav1.AddToScheme(myscheme)
-	_ = infrav1exp.AddToScheme(myscheme)
+	_ = infraexpv1old.AddToScheme(myscheme)
+	_ = infraexpv1.AddToScheme(myscheme)
 	_ = clusterv1.AddToScheme(myscheme)
 	_ = expv1.AddToScheme(myscheme)
 	// +kubebuilder:scaffold:scheme


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR fixes v1alpha4 conversion webhook failure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4401
