### PR TITLE
🌱 Minor CAPD Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,9 @@ $(KUSTOMIZE): # Build kustomize from tools folder.
 
 envsubst: $(ENVSUBST) ## Build a local copy of envsubst.
 kustomize: $(KUSTOMIZE) ## Build a local copy of kustomize.
+controller-gen: $(CONTROLLER_GEN) ## Build a local copy of controller-gen.
+conversion-gen: $(CONVERSION_GEN) ## Build a local copy of conversion-gen.
+gotestsum: $(GOTESTSUM) ## Build a local copy of gotestsum.
 
 .PHONY: e2e-framework
 e2e-framework: ## Builds the CAPI e2e framework

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -102,11 +102,14 @@ test-junit: $(GOTESTSUM) ## Run tests with verbose setting and generate a junit 
 manager: ## Build manager binary
 	go build -o $(BIN_DIR)/manager sigs.k8s.io/cluster-api/test/infrastructure/docker
 
-$(CONTROLLER_GEN): $(TOOLS_DIR)/go.mod # Build controller-gen from tools folder.
-	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen
+$(CONTROLLER_GEN):
+	$(MAKE) -C $(ROOT) controller-gen
 
-$(CONVERSION_GEN): $(TOOLS_DIR)/go.mod
-	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/conversion-gen k8s.io/code-generator/cmd/conversion-gen
+$(CONVERSION_GEN):
+	$(MAKE) -C $(ROOT) conversion-gen
+
+$(GOTESTSUM):
+	$(MAKE) -C $(ROOT) gotestsum
 
 ## --------------------------------------
 ## Generate / Manifests


### PR DESCRIPTION

**What this PR does / why we need it**:
A minor cleanup to use the main Makefile targets for CAPD controller-gen and conversion-gen.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #4407

/kind cleanup