### PR TITLE
🌱 test/framework: improve the way we inject the ci-artifacts script

### DIFF
--- a/test/framework/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
+++ b/test/framework/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
@@ -22,6 +22,22 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
+function retry {
+  attempt=0
+  max_attempts=$${1}
+  interval=$${2}
+  shift; shift
+  until [[ $${attempt} -ge "$${max_attempts}" ]] ; do
+    attempt=$((attempt+1))
+    set +e
+    eval "$*" && return || echo "failed $${attempt} times: $*"
+    set -e
+    sleep "$${interval}"
+  done
+  echo "error: reached max attempts at retry($*)"
+  return 1
+}
+
 [[ $(id -u) != 0 ]] && SUDO="sudo" || SUDO=""
 
 USE_CI_ARTIFACTS=${USE_CI_ARTIFACTS:=false}
@@ -30,19 +46,6 @@ if [ ! "${USE_CI_ARTIFACTS}" = true ]; then
   echo "No CI Artifacts installation, exiting"
   exit 0
 fi
-
-GSUTIL=gsutil
-
-if ! command -v $${GSUTIL} >/dev/null; then
-  apt-get update
-  apt-get install -y apt-transport-https ca-certificates gnupg curl
-  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | $${SUDO} tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | $${SUDO} apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-  apt-get update
-  apt-get install -y google-cloud-sdk
-fi
-
-$${GSUTIL} version
 
 # This test installs release packages or binaries that are a result of the CI and release builds.
 # It runs '... --version' commands to verify that the binaries are correctly installed
@@ -62,14 +65,21 @@ if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
   CI_DIR=/tmp/k8s-ci
   mkdir -p "$${CI_DIR}"
   declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
+  {{- if .IsControlPlaneMachine }}
   declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+  {{- else }}
+  declare -a CONTAINERS_TO_TEST=("kube-proxy")
+  {{- end }}
   CONTAINER_EXT="tar"
   echo "* testing CI version $${KUBERNETES_VERSION}"
   # Check for semver
   if [[ "$${KUBERNETES_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    CI_URL="gs://kubernetes-release/release/$${KUBERNETES_VERSION}/bin/linux/amd64"
+    CI_URL="https://storage.googleapis.com/kubernetes-release/release/$${KUBERNETES_VERSION}/bin/linux/amd64"
     VERSION_WITHOUT_PREFIX="$${KUBERNETES_VERSION#v}"
-    DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+    export DEBIAN_FRONTEND=noninteractive
+    # sometimes the network is not immediately available, so we have to retry the apt-get update
+    retry 10 5 "apt-get update"
+    apt-get install -y apt-transport-https ca-certificates curl
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
     echo 'deb https://apt.kubernetes.io/ kubernetes-xenial main' >/etc/apt/sources.list.d/kubernetes.list
     apt-get update
@@ -78,24 +88,28 @@ if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
     PACKAGE_VERSION="$(apt-cache madison kubelet | grep "$${VERSION_REGEX}-" | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
     for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
       echo "* installing package: $${CI_PACKAGE} $${PACKAGE_VERSION}"
-      DEBIAN_FRONTEND=noninteractive apt-get install -y "$${CI_PACKAGE}=$${PACKAGE_VERSION}"
+      apt-get install -y "$${CI_PACKAGE}=$${PACKAGE_VERSION}"
     done
   else
-    CI_URL="gs://kubernetes-release-dev/ci/$${KUBERNETES_VERSION}/bin/linux/amd64"
+    CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${KUBERNETES_VERSION}/bin/linux/amd64"
     for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
+      # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
+      # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
       echo "* downloading binary: $${CI_URL}/$${CI_PACKAGE}"
-      $${GSUTIL} cp "$${CI_URL}/$${CI_PACKAGE}" "$${CI_DIR}/$${CI_PACKAGE}"
+      wget "$${CI_URL}/$${CI_PACKAGE}" -O "$${CI_DIR}/$${CI_PACKAGE}"
       chmod +x "$${CI_DIR}/$${CI_PACKAGE}"
       mv "$${CI_DIR}/$${CI_PACKAGE}" "/usr/bin/$${CI_PACKAGE}"
     done
     systemctl restart kubelet
   fi
   for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
+    # Browser: https://console.cloud.google.com/storage/browser/kubernetes-release?project=kubernetes-release
+    # e.g.: https://storage.googleapis.com/kubernetes-release/release/v1.20.4/bin/linux/amd64/kube-apiserver.tar
     echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-    $${GSUTIL} cp "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
+    wget "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
     $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
     $${SUDO} ctr -n k8s.io images tag "k8s.gcr.io/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "k8s.gcr.io/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
-    $${SUDO} ctr -n k8s.io images tag "k8s.gcr.io/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/kubernetes-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
+    $${SUDO} ctr -n k8s.io images tag "k8s.gcr.io/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
   done
 fi
 echo "* checking binary versions"

--- a/test/framework/kubernetesversions/data/kustomization.yaml
+++ b/test/framework/kubernetesversions/data/kustomization.yaml
@@ -2,7 +2,19 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 resources:
-  - ci-artifacts-source-template.yaml
+- ci-artifacts-source-template.yaml
 patchesStrategicMerge:
-  - kustomizeversions.yaml
-  - platform-kustomization.yaml
+- platform-kustomization.yaml
+patchesJson6902:
+- path: kubeadmcontrolplane-patch.yaml
+  target:
+    group: controlplane.cluster.x-k8s.io
+    kind: KubeadmControlPlane
+    name: ".*-control-plane"
+    version: v1alpha4
+- path: kubeadmconfigtemplate-patch.yaml
+  target:
+    group: bootstrap.cluster.x-k8s.io
+    kind: KubeadmConfigTemplate
+    name: ".*-md-0"
+    version: v1alpha4


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR changes the way we patch the `ci-artifacts.sh` script. Up until now we used strategic merge patch. This overwrote the `files` and `preKubeadmCommands` arrays. That was the reason this functionality could not be reused in CAPO and CAPZ (https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/1018#discussion_r515363781). The new version is implemented with JSON patch and just appends the script to the arrays. Because we append the script, it's also possible to run some provider-specific scripts before.

Further improvements:
* only download control plane images on control plane nodes
* use wget to download artifacts instead of gsutil so save a few minutes because we don't have to install gsutil

Some more details on the linked issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4386

Notes:
* I removed the bindata the same way as in https://github.com/kubernetes-sigs/cluster-api/pull/4378, as it lead to test errors because it got out of sync.