### PR TITLE
🌱 Set the FieldOwner when updating objects

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -37,6 +37,7 @@ import (
 	kubeadmbootstrapcontrollers "sigs.k8s.io/cluster-api/bootstrap/kubeadm/controllers"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/util/fieldowner"
 	"sigs.k8s.io/cluster-api/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -168,7 +169,7 @@ func main() {
 
 func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if err := (&kubeadmbootstrapcontrollers.KubeadmConfigReconciler{
-		Client: mgr.GetClient(),
+		Client: fieldowner.Wrap(mgr.GetClient(), kubeadmbootstrapcontrollers.KubeadmConfigControllerName),
 	}).SetupWithManager(ctx, mgr, concurrency(kubeadmConfigConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeadmConfig")
 		os.Exit(1)

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	kcpv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
 	kubeadmcontrolplanecontrollers "sigs.k8s.io/cluster-api/controlplane/kubeadm/controllers"
+	"sigs.k8s.io/cluster-api/util/fieldowner"
 	"sigs.k8s.io/cluster-api/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -182,7 +183,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&kubeadmcontrolplanecontrollers.KubeadmControlPlaneReconciler{
-		Client:  mgr.GetClient(),
+		Client:  fieldowner.Wrap(mgr.GetClient(), "kubeadm-control-plane-controller"),
 		Tracker: tracker,
 	}).SetupWithManager(ctx, mgr, concurrency(kubeadmControlPlaneConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubeadmControlPlane")

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	expcontrollers "sigs.k8s.io/cluster-api/exp/controllers"
 	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/util/fieldowner"
 	"sigs.k8s.io/cluster-api/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -236,14 +237,14 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&controllers.ClusterReconciler{
-		Client:           mgr.GetClient(),
+		Client:           fieldowner.Wrap(mgr.GetClient(), "cluster-controller"),
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, concurrency(clusterConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Cluster")
 		os.Exit(1)
 	}
 	if err := (&controllers.MachineReconciler{
-		Client:           mgr.GetClient(),
+		Client:           fieldowner.Wrap(mgr.GetClient(), controllers.MachineControllerName),
 		Tracker:          tracker,
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, concurrency(machineConcurrency)); err != nil {
@@ -251,7 +252,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 	if err := (&controllers.MachineSetReconciler{
-		Client:           mgr.GetClient(),
+		Client:           fieldowner.Wrap(mgr.GetClient(), "machineset-controller"),
 		Tracker:          tracker,
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, concurrency(machineSetConcurrency)); err != nil {
@@ -259,7 +260,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 	if err := (&controllers.MachineDeploymentReconciler{
-		Client:           mgr.GetClient(),
+		Client:           fieldowner.Wrap(mgr.GetClient(), "machinedeployment-controller"),
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, concurrency(machineDeploymentConcurrency)); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MachineDeployment")
@@ -268,7 +269,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if feature.Gates.Enabled(feature.MachinePool) {
 		if err := (&expcontrollers.MachinePoolReconciler{
-			Client:           mgr.GetClient(),
+			Client:           fieldowner.Wrap(mgr.GetClient(), expcontrollers.MachinePoolControllerName),
 			WatchFilterValue: watchFilterValue,
 		}).SetupWithManager(ctx, mgr, concurrency(machinePoolConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MachinePool")
@@ -278,7 +279,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if feature.Gates.Enabled(feature.ClusterResourceSet) {
 		if err := (&addonscontrollers.ClusterResourceSetReconciler{
-			Client:           mgr.GetClient(),
+			Client:           fieldowner.Wrap(mgr.GetClient(), "cluster-resource-set-controller"),
 			Tracker:          tracker,
 			WatchFilterValue: watchFilterValue,
 		}).SetupWithManager(ctx, mgr, concurrency(clusterResourceSetConcurrency)); err != nil {
@@ -286,7 +287,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 			os.Exit(1)
 		}
 		if err := (&addonscontrollers.ClusterResourceSetBindingReconciler{
-			Client:           mgr.GetClient(),
+			Client:           fieldowner.Wrap(mgr.GetClient(), "cluster-resource-set-binding-controller"),
 			WatchFilterValue: watchFilterValue,
 		}).SetupWithManager(ctx, mgr, concurrency(clusterResourceSetConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ClusterResourceSetBinding")
@@ -295,7 +296,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&controllers.MachineHealthCheckReconciler{
-		Client:           mgr.GetClient(),
+		Client:           fieldowner.Wrap(mgr.GetClient(), "machinehealthcheck-controller"),
 		Tracker:          tracker,
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, concurrency(machineHealthCheckConcurrency)); err != nil {

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/controllers"
 	infrav1exp "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1alpha4"
 	expcontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/controllers"
+	"sigs.k8s.io/cluster-api/util/fieldowner"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -142,7 +143,7 @@ func setupChecks(mgr ctrl.Manager) {
 
 func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if err := (&controllers.DockerMachineReconciler{
-		Client: mgr.GetClient(),
+		Client: fieldowner.Wrap(mgr.GetClient(), "docker-machine-controller"),
 	}).SetupWithManager(ctx, mgr, controller.Options{
 		MaxConcurrentReconciles: concurrency,
 	}); err != nil {
@@ -151,7 +152,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 
 	if err := (&controllers.DockerClusterReconciler{
-		Client: mgr.GetClient(),
+		Client: fieldowner.Wrap(mgr.GetClient(), "docker-cluster-controller"),
 		Log:    ctrl.Log.WithName("controllers").WithName("DockerCluster"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DockerCluster")
@@ -160,7 +161,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if feature.Gates.Enabled(feature.MachinePool) {
 		if err := (&expcontrollers.DockerMachinePoolReconciler{
-			Client: mgr.GetClient(),
+			Client: fieldowner.Wrap(mgr.GetClient(), "docker-machine-pool-controller"),
 			Log:    ctrl.Log.WithName("controllers").WithName("DockerMachinePool"),
 		}).SetupWithManager(mgr, controller.Options{
 			MaxConcurrentReconciles: concurrency,

--- a/util/fieldowner/field_owner.go
+++ b/util/fieldowner/field_owner.go
@@ -1,0 +1,46 @@
+package fieldowner
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Wrap wraps a Client with one that sets the field owner.
+func Wrap(upstream client.Client, owner string) client.Client {
+	return &clientWithOwner{Client: upstream, owner: client.FieldOwner(owner)}
+}
+
+type clientWithOwner struct {
+	client.Client
+	owner client.FieldOwner
+}
+
+func (c *clientWithOwner) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return c.Client.Create(ctx, obj, append(opts, c.owner)...)
+}
+
+func (c *clientWithOwner) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return c.Client.Update(ctx, obj, append(opts, c.owner)...)
+}
+
+func (c *clientWithOwner) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.Client.Patch(ctx, obj, patch, append(opts, c.owner)...)
+}
+
+func (c *clientWithOwner) Status() client.StatusWriter {
+	return &statusWriterWithOwner{StatusWriter: c.Client.Status(), owner: c.owner}
+}
+
+type statusWriterWithOwner struct {
+	client.StatusWriter
+	owner client.FieldOwner
+}
+
+func (s *statusWriterWithOwner) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return s.StatusWriter.Update(ctx, obj, append(opts, s.owner)...)
+}
+
+func (s *statusWriterWithOwner) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return s.StatusWriter.Patch(ctx, obj, patch, append(opts, s.owner)...)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This means the controller name will show up as the `manager` in the `managedFields` of each object.

This is what I was trying to achieve in #4257, but better since we get separate identities for all the different controllers that live in one binary.

~In a couple of places I extracted an existing string out to a constant so I could re-use it.~

~I have not done `Patch()` yet as it will involve changing `PatchHelper`, so I thought I would get some reaction to this before continuing.~

I didn't change `clusterctl` as the default is to use the binary name which works well in that case.