### PR TITLE
🌱 upgrade cloudbuild to use gcb-docker-gcloud with go 1.16

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200619-68869a4'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +13,7 @@ steps:
     - DOCKER_BUILDKIT=1
     args:
     - release-staging-nightly
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200619-68869a4'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
     dir: 'test/infrastructure/docker'
     entrypoint: make
     env:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200619-68869a4'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +13,7 @@ steps:
     - DOCKER_BUILDKIT=1
     args:
     - release-staging
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200619-68869a4'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
     dir: 'test/infrastructure/docker'
     entrypoint: make
     env:

--- a/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
+++ b/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
@@ -3,6 +3,8 @@
 ## Minimum Go version
 
 - The Go version used by Cluster API is now Go 1.16+
+  - In case cloudbuild is used to push images, please upgrade to `gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583` 
+    in the cloudbuild YAML files.  
 
 ## Controller Runtime version
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Upgrades cloudbuild to the newest gcb-docker-gcloud image which uses Go 1.16. I already upgraded the image in CAPO and it worked flawlessly: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/commit/a0467f27b8de8a018e5fbad77d45abbf7581738f 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4383

I'm not sure about what the best way is to propagate this change to other providers:
* open PRs in the other provider repos
* add it to the migration doc
* both

Any thoughts?
