### PR TITLE
🌱  capd: print debug infos on container creation error

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -350,7 +350,7 @@ func setClusterPause(proxy Proxy, clusters []*node, value bool, dryRun bool) err
 		if err := retryWithExponentialBackoff(setClusterPauseBackoff, func() error {
 			return patchCluster(proxy, cluster, patch)
 		}); err != nil {
-			return err
+			return errors.Wrapf(err, "error setting Cluster.Spec.Paused=%t", value)
 		}
 	}
 	return nil
@@ -375,7 +375,7 @@ func patchCluster(proxy Proxy, cluster *node, patch client.Patch) error {
 	}
 
 	if err := cFrom.Patch(ctx, clusterObj, patch); err != nil {
-		return errors.Wrapf(err, "error pausing reconciliation for %q %s/%s",
+		return errors.Wrapf(err, "error patching %q %s/%s",
 			clusterObj.GroupVersionKind(), clusterObj.GetNamespace(), clusterObj.GetName())
 	}
 

--- a/test/infrastructure/docker/docker/machine.go
+++ b/test/infrastructure/docker/docker/machine.go
@@ -28,14 +28,15 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
-	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha4"
-	"sigs.k8s.io/cluster-api/test/infrastructure/docker/cloudinit"
-	"sigs.k8s.io/cluster-api/test/infrastructure/docker/docker/types"
-	"sigs.k8s.io/cluster-api/util/container"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 	"sigs.k8s.io/kind/pkg/exec"
+
+	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/test/infrastructure/docker/cloudinit"
+	"sigs.k8s.io/cluster-api/test/infrastructure/docker/docker/types"
+	"sigs.k8s.io/cluster-api/util/container"
 )
 
 const (
@@ -223,7 +224,9 @@ func (m *Machine) Create(ctx context.Context, role string, version *string, moun
 			return ps.Run(ctx) == nil, nil
 		})
 		if err != nil {
-			return errors.WithStack(err)
+			log.Info("Failed running command", "command", "crictl ps")
+			logContainerDebugInfo(ctx, m.ContainerName())
+			return errors.Wrap(errors.WithStack(err), "failed to run crictl ps")
 		}
 		return nil
 	}
@@ -309,6 +312,7 @@ func (m *Machine) ExecBootstrap(ctx context.Context, data string) error {
 		err := cmd.Run(ctx)
 		if err != nil {
 			log.Info("Failed running command", "command", command, "stdout", outStd.String(), "stderr", outErr.String(), "bootstrap data", data)
+			logContainerDebugInfo(ctx, m.ContainerName())
 			return errors.Wrap(errors.WithStack(err), "failed to run cloud config")
 		}
 	}
@@ -429,4 +433,22 @@ func (m *Machine) machineImage(version *string) string {
 	versionString = container.SemverToOCIImageTag(versionString)
 
 	return fmt.Sprintf("%s:%s", defaultImageName, versionString)
+}
+
+func logContainerDebugInfo(ctx context.Context, name string) {
+	log := ctrl.LoggerFrom(ctx)
+
+	cmd := exec.CommandContext(ctx, "docker", "inspect", name)
+	output, err := exec.CombinedOutputLines(cmd)
+	if err != nil {
+		log.Error(err, "Failed inspecting the machine container", "output", output)
+	}
+	log.Info("Inspected the machine container", "output", output)
+
+	cmd = exec.CommandContext(ctx, "docker", "logs", name)
+	output, err = exec.CombinedOutputLines(cmd)
+	if err != nil {
+		log.Error(err, "Failed to get logs from the machine container", "output", output)
+	}
+	log.Info("Got logs from the machine container", "output", output)
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Adds more debug information in case the container creation does not work. For context, please see https://github.com/kubernetes-sigs/cluster-api/issues/4405#issuecomment-811075444
(supersedes #4416).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Improves observability to debug issues like #4405
