### PR TITLE
🌱 Add envtest binaries to operator makefile

### DIFF
--- a/exp/operator/Makefile
+++ b/exp/operator/Makefile
@@ -79,7 +79,7 @@ help:  ## Display this help
 
 .PHONY: test
 test: ## Run tests.
-	go test ./... $(TEST_ARGS)
+	source $(ROOT)/scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; go test ./... $(TEST_ARGS)
 
 .PHONY: test-verbose
 test-verbose: ## Run tests with verbose settings.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Add envtest binaries to operator makefile. This should help when someone executes tests from the operator directory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
