### PR TITLE
🐛 Add validation testing for defaulting

### DIFF
--- a/api/v1alpha4/cluster_webhook_test.go
+++ b/api/v1alpha4/cluster_webhook_test.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestClusterDefault(t *testing.T) {
@@ -37,6 +38,8 @@ func TestClusterDefault(t *testing.T) {
 			ControlPlaneRef:   &corev1.ObjectReference{},
 		},
 	}
+
+	t.Run("for Cluster", utildefaulting.DefaultValidateTest(c))
 	c.Default()
 
 	g.Expect(c.Spec.InfrastructureRef.Namespace).To(Equal(c.Namespace))

--- a/api/v1alpha4/machine_webhook_test.go
+++ b/api/v1alpha4/machine_webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +39,7 @@ func TestMachineDefault(t *testing.T) {
 			Version:   pointer.StringPtr("1.17.5"),
 		},
 	}
-
+	t.Run("for Machine", utildefaulting.DefaultValidateTest(m))
 	m.Default()
 
 	g.Expect(m.Labels[ClusterLabelName]).To(Equal(m.Spec.ClusterName))

--- a/api/v1alpha4/machinedeployment_webhook_test.go
+++ b/api/v1alpha4/machinedeployment_webhook_test.go
@@ -23,6 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestMachineDeploymentDefault(t *testing.T) {
@@ -32,7 +33,7 @@ func TestMachineDeploymentDefault(t *testing.T) {
 			Name: "test-md",
 		},
 	}
-
+	t.Run("for MachineDeployment", utildefaulting.DefaultValidateTest(md))
 	md.Default()
 
 	g.Expect(md.Labels[ClusterLabelName]).To(Equal(md.Spec.ClusterName))

--- a/api/v1alpha4/machinehealthcheck_webhook_test.go
+++ b/api/v1alpha4/machinehealthcheck_webhook_test.go
@@ -24,12 +24,19 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestMachineHealthCheckDefault(t *testing.T) {
 	g := NewWithT(t)
-	mhc := &MachineHealthCheck{}
-
+	mhc := &MachineHealthCheck{
+		Spec: MachineHealthCheckSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+		},
+	}
+	t.Run("for MachineHealthCheck", utildefaulting.DefaultValidateTest(mhc))
 	mhc.Default()
 
 	g.Expect(mhc.Labels[ClusterLabelName]).To(Equal(mhc.Spec.ClusterName))

--- a/api/v1alpha4/machineset_webhook_test.go
+++ b/api/v1alpha4/machineset_webhook_test.go
@@ -22,22 +22,23 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestMachineSetDefault(t *testing.T) {
 	g := NewWithT(t)
-	md := &MachineSet{
+	ms := &MachineSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-ms",
 		},
 	}
+	t.Run("for MachineSet", utildefaulting.DefaultValidateTest(ms))
+	ms.Default()
 
-	md.Default()
-
-	g.Expect(md.Labels[ClusterLabelName]).To(Equal(md.Spec.ClusterName))
-	g.Expect(md.Spec.DeletePolicy).To(Equal(string(RandomMachineSetDeletePolicy)))
-	g.Expect(md.Spec.Selector.MatchLabels).To(HaveKeyWithValue(MachineSetLabelName, "test-ms"))
-	g.Expect(md.Spec.Template.Labels).To(HaveKeyWithValue(MachineSetLabelName, "test-ms"))
+	g.Expect(ms.Labels[ClusterLabelName]).To(Equal(ms.Spec.ClusterName))
+	g.Expect(ms.Spec.DeletePolicy).To(Equal(string(RandomMachineSetDeletePolicy)))
+	g.Expect(ms.Spec.Selector.MatchLabels).To(HaveKeyWithValue(MachineSetLabelName, "test-ms"))
+	g.Expect(ms.Spec.Template.Labels).To(HaveKeyWithValue(MachineSetLabelName, "test-ms"))
 }
 
 func TestMachineSetLabelSelectorMatchValidation(t *testing.T) {

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
+	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestKubeadmControlPlaneDefault(t *testing.T) {
@@ -36,11 +37,17 @@ func TestKubeadmControlPlaneDefault(t *testing.T) {
 			Namespace: "foo",
 		},
 		Spec: KubeadmControlPlaneSpec{
-			Version:                "1.18.3",
+			Version:                "v1.18.3",
 			InfrastructureTemplate: corev1.ObjectReference{},
 			RolloutStrategy:        &RolloutStrategy{},
 		},
 	}
+	updateDefaultingValidationKCP := kcp.DeepCopy()
+	updateDefaultingValidationKCP.Spec.Version = "v1.18.3"
+	updateDefaultingValidationKCP.Spec.InfrastructureTemplate = corev1.ObjectReference{
+		Namespace: "foo",
+	}
+	t.Run("for KubeadmControlPLane", utildefaulting.DefaultValidateTest(updateDefaultingValidationKCP))
 	kcp.Default()
 
 	g.Expect(kcp.Spec.InfrastructureTemplate.Namespace).To(Equal(kcp.Namespace))

--- a/exp/addons/api/v1alpha4/clusterresourceset_webhook.go
+++ b/exp/addons/api/v1alpha4/clusterresourceset_webhook.go
@@ -87,7 +87,7 @@ func (m *ClusterResourceSet) validate(old *ClusterResourceSet) error {
 		)
 	}
 
-	if old != nil && old.Spec.Strategy != m.Spec.Strategy {
+	if old != nil && old.Spec.Strategy != "" && old.Spec.Strategy != m.Spec.Strategy {
 		allErrs = append(
 			allErrs,
 			field.Invalid(field.NewPath("spec", "strategy"), m.Spec.Strategy, "field is immutable"),

--- a/exp/addons/api/v1alpha4/clusterresourceset_webhook_test.go
+++ b/exp/addons/api/v1alpha4/clusterresourceset_webhook_test.go
@@ -22,12 +22,17 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestClusterResourcesetDefault(t *testing.T) {
 	g := NewWithT(t)
 	clusterResourceSet := &ClusterResourceSet{}
-
+	defaultingValidationCRS := clusterResourceSet.DeepCopy()
+	defaultingValidationCRS.Spec.ClusterSelector = metav1.LabelSelector{
+		MatchLabels: map[string]string{"foo": "bar"},
+	}
+	t.Run("for ClusterResourceSet", utildefaulting.DefaultValidateTest(defaultingValidationCRS))
 	clusterResourceSet.Default()
 
 	g.Expect(clusterResourceSet.Spec.Strategy).To(Equal(string(ClusterResourceSetStrategyApplyOnce)))

--- a/exp/api/v1alpha4/machinepool_webhook_test.go
+++ b/exp/api/v1alpha4/machinepool_webhook_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
 )
 
 func TestMachinePoolDefault(t *testing.T) {
@@ -42,7 +43,7 @@ func TestMachinePoolDefault(t *testing.T) {
 			},
 		},
 	}
-
+	t.Run("for MachinePool", utildefaulting.DefaultValidateTest(m))
 	m.Default()
 
 	g.Expect(m.Labels[clusterv1.ClusterLabelName]).To(Equal(m.Spec.ClusterName))

--- a/util/defaulting/defaulting.go
+++ b/util/defaulting/defaulting.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaulting
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// DefaultingValidator interface is for objects that define both defaulting
+// and validating webhooks.
+type DefaultingValidator interface {
+	admission.Defaulter
+	admission.Validator
+}
+
+// DefaultValidateTest returns a new testing function to be used in tests to
+// make sure defaulting webhooks also pass validation tests on create,
+// update and delete.
+func DefaultValidateTest(object DefaultingValidator) func(*testing.T) {
+	return func(t *testing.T) {
+		createCopy := object.DeepCopyObject().(DefaultingValidator)
+		updateCopy := object.DeepCopyObject().(DefaultingValidator)
+		deleteCopy := object.DeepCopyObject().(DefaultingValidator)
+		defaultingUpdateCopy := updateCopy.DeepCopyObject().(DefaultingValidator)
+
+		t.Run("validate-on-create", func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			createCopy.Default()
+			g.Expect(createCopy.ValidateCreate()).To(gomega.Succeed())
+		})
+		t.Run("validate-on-update", func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			defaultingUpdateCopy.Default()
+			g.Expect(defaultingUpdateCopy.ValidateUpdate(updateCopy)).To(gomega.Succeed())
+		})
+		t.Run("validate-on-delete", func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			deleteCopy.Default()
+			g.Expect(deleteCopy.ValidateDelete()).To(gomega.Succeed())
+		})
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Intended to prevent regressions in webhooks when additive changes are made to the API, add generic tests to all of the controllers with defaulting webhooks to ensure that they pass validations.

As a result, found an edge case in CRS on update which is the second commit here (rather than squashing into a single commit).


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
