### PR TITLE
✨ Adds clusterctl generate cluster and provider subcommands

### DIFF
--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -473,7 +473,7 @@ type fakeTemplateClient struct {
 	processor             yaml.Processor
 }
 
-func (f *fakeTemplateClient) Get(flavor, targetNamespace string, listVariablesOnly bool) (repository.Template, error) {
+func (f *fakeTemplateClient) Get(flavor, targetNamespace string, listVariablesOnly, skipVariables bool) (repository.Template, error) {
 	name := "cluster-template"
 	if flavor != "" {
 		name = fmt.Sprintf("%s-%s", name, flavor)
@@ -490,6 +490,7 @@ func (f *fakeTemplateClient) Get(flavor, targetNamespace string, listVariablesOn
 		Processor:             f.processor,
 		TargetNamespace:       targetNamespace,
 		ListVariablesOnly:     listVariablesOnly,
+		SkipProcess:           skipVariables,
 	})
 }
 

--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -51,7 +51,7 @@ func (c *clusterctlClient) GetProviderComponents(provider string, providerType c
 		Version:           options.Version,
 		TargetNamespace:   options.TargetNamespace,
 		WatchingNamespace: options.WatchingNamespace,
-		SkipVariables:     options.SkipVariables,
+		SkipProcess:       options.SkipProcess,
 	}
 	components, err := c.getComponentsByName(provider, providerType, inputOptions)
 	if err != nil {
@@ -158,6 +158,9 @@ type GetClusterTemplateOptions struct {
 	// YamlProcessor defines the yaml processor to use for the cluster
 	// template processing. If not defined, SimpleProcessor will be used.
 	YamlProcessor Processor
+
+	// Allows for skipping variable replacement in the component YAML.
+	SkipVariables bool
 }
 
 // numSources return the number of template sources currently set on a GetClusterTemplateOptions.
@@ -269,6 +272,7 @@ func (c *clusterctlClient) getTemplateFromRepository(cluster cluster.Client, opt
 	source := *options.ProviderRepositorySource
 	targetNamespace := options.TargetNamespace
 	listVariablesOnly := options.ListVariablesOnly
+	skipVariables := options.SkipVariables
 	processor := options.YamlProcessor
 
 	// If the option specifying the name of the infrastructure provider to get templates from is empty, try to detect it.
@@ -329,7 +333,7 @@ func (c *clusterctlClient) getTemplateFromRepository(cluster cluster.Client, opt
 		return nil, err
 	}
 
-	template, err := repo.Templates(version).Get(source.Flavor, targetNamespace, listVariablesOnly)
+	template, err := repo.Templates(version).Get(source.Flavor, targetNamespace, listVariablesOnly, skipVariables)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -226,7 +226,7 @@ func Test_getComponentsByName_withEmptyVariables(t *testing.T) {
 	options := ComponentsOptions{
 		TargetNamespace:   "ns1",
 		WatchingNamespace: "",
-		SkipVariables:     true,
+		SkipProcess:       true,
 	}
 	components, err := client.GetProviderComponents(repository1Config.Name(), repository1Config.Type(), options)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -264,7 +264,7 @@ func (c *clusterctlClient) addToInstaller(options addToInstallerOptions, provide
 		componentsOptions := repository.ComponentsOptions{
 			TargetNamespace:   options.targetNamespace,
 			WatchingNamespace: options.watchingNamespace,
-			SkipVariables:     options.skipVariables,
+			SkipProcess:       options.skipVariables,
 		}
 		components, err := c.getComponentsByName(provider, providerType, componentsOptions)
 		if err != nil {

--- a/cmd/clusterctl/client/repository/template.go
+++ b/cmd/clusterctl/client/repository/template.go
@@ -76,6 +76,7 @@ type TemplateInput struct {
 	Processor             yaml.Processor
 	TargetNamespace       string
 	ListVariablesOnly     bool
+	SkipProcess           bool
 }
 
 // NewTemplate returns a new objects embedding a cluster template YAML file.
@@ -92,9 +93,12 @@ func NewTemplate(input TemplateInput) (*template, error) {
 		}, nil
 	}
 
-	processedYaml, err := input.Processor.Process(input.RawArtifact, input.ConfigVariablesClient.Get)
-	if err != nil {
-		return nil, err
+	processedYaml := input.RawArtifact
+	if !input.SkipProcess {
+		processedYaml, err = input.Processor.Process(input.RawArtifact, input.ConfigVariablesClient.Get)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Transform the yaml in a list of objects, so following transformation can work on typed objects (instead of working on a string/slice of bytes).

--- a/cmd/clusterctl/client/repository/template_client.go
+++ b/cmd/clusterctl/client/repository/template_client.go
@@ -26,7 +26,7 @@ import (
 // TemplateClient has methods to work with cluster templates hosted on a provider repository.
 // Templates are yaml files to be used for creating a guest cluster.
 type TemplateClient interface {
-	Get(flavor, targetNamespace string, listVariablesOnly bool) (Template, error)
+	Get(flavor, targetNamespace string, listVariablesOnly, skipVariables bool) (Template, error)
 }
 
 // templateClient implements TemplateClient.
@@ -64,7 +64,7 @@ func newTemplateClient(input TemplateClientInput) *templateClient {
 // Get return the template for the flavor specified.
 // In case the template does not exists, an error is returned.
 // Get assumes the following naming convention for templates: cluster-template[-<flavor_name>].yaml.
-func (c *templateClient) Get(flavor, targetNamespace string, listVariablesOnly bool) (Template, error) {
+func (c *templateClient) Get(flavor, targetNamespace string, listVariablesOnly, skipVariables bool) (Template, error) {
 	log := logf.Log
 
 	if targetNamespace == "" {
@@ -95,5 +95,5 @@ func (c *templateClient) Get(flavor, targetNamespace string, listVariablesOnly b
 		log.V(1).Info("Using", "Override", name, "Provider", c.provider.ManifestLabel(), "Version", version)
 	}
 
-	return NewTemplate(TemplateInput{rawArtifact, c.configVariablesClient, c.processor, targetNamespace, listVariablesOnly})
+	return NewTemplate(TemplateInput{rawArtifact, c.configVariablesClient, c.processor, targetNamespace, listVariablesOnly, skipVariables})
 }

--- a/cmd/clusterctl/cmd/config.go
+++ b/cmd/clusterctl/cmd/config.go
@@ -21,9 +21,9 @@ import (
 )
 
 var configCmd = &cobra.Command{
-	Use:   "config",
-	Short: "Display provider configuration and templates to create workload clusters.",
-	Long:  `Display provider configuration and templates to create workload clusters.`,
+	Use:        "config",
+	Short:      "Display clusterctl configuration.",
+	Long:       `Display clusterctl configuration.`,
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/config_cluster.go
+++ b/cmd/clusterctl/cmd/config_cluster.go
@@ -90,6 +90,7 @@ var configClusterClusterCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGetClusterTemplate(cmd, args[0])
 	},
+	Deprecated: "use `clusterctl generate cluster` instead",
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/config_provider.go
+++ b/cmd/clusterctl/cmd/config_provider.go
@@ -79,6 +79,7 @@ var configProviderCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGetComponents()
 	},
+	Deprecated: "use `clusterctl generate provider` instead",
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/config_provider.go
+++ b/cmd/clusterctl/cmd/config_provider.go
@@ -141,7 +141,7 @@ func runGetComponents() error {
 	options := client.ComponentsOptions{
 		TargetNamespace:   cpo.targetNamespace,
 		WatchingNamespace: cpo.watchingNamespace,
-		SkipVariables:     true,
+		SkipProcess:       true,
 	}
 	components, err := c.GetProviderComponents(providerName, providerType, options)
 	if err != nil {

--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+type generateClusterOptions struct {
+	kubeconfig             string
+	kubeconfigContext      string
+	flavor                 string
+	infrastructureProvider string
+
+	targetNamespace          string
+	kubernetesVersion        string
+	controlPlaneMachineCount int64
+	workerMachineCount       int64
+
+	url                string
+	configMapNamespace string
+	configMapName      string
+	configMapDataKey   string
+
+	listVariables bool
+	skipVariables bool
+}
+
+var gc = &generateClusterOptions{}
+
+var generateClusterClusterCmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Generate templates for creating workload clusters.",
+	Long: LongDesc(`
+		Generate templates for creating workload clusters.
+
+		clusterctl ships with a list of known providers; if necessary, edit
+		$HOME/.cluster-api/clusterctl.yaml to add new provider or to customize existing ones.
+
+		Each provider configuration links to a repository; clusterctl uses this information
+		to fetch templates when creating a new cluster.`),
+
+	Example: Examples(`
+		# Generates a yaml file for creating workload clusters using
+		# the pre-installed infrastructure and bootstrap providers.
+		clusterctl generate cluster my-cluster
+
+		# Generates a yaml file for creating workload clusters using
+		# a specific version of the AWS infrastructure provider.
+		clusterctl generate cluster my-cluster --infrastructure=aws:v0.4.1
+
+		# Generates a yaml file for creating workload clusters in a custom namespace.
+		clusterctl generate cluster my-cluster --target-namespace=foo
+
+		# Generates a yaml file for creating workload clusters with a specific Kubernetes version.
+		clusterctl generate cluster my-cluster --kubernetes-version=v1.19.1
+
+		# Generates a yaml file for creating workload clusters with a
+		# custom number of nodes (if supported by the provider's templates).
+		clusterctl generate cluster my-cluster --control-plane-machine-count=3 --worker-machine-count=10
+
+		# Generates a yaml file for creating workload clusters using a template stored in a ConfigMap.
+		clusterctl generate cluster my-cluster --from-config-map MyTemplates
+
+		# Generates a yaml file for creating workload clusters using a template from a specific URL.
+		clusterctl generate cluster my-cluster --from https://github.com/foo-org/foo-repository/blob/master/cluster-template.yaml
+
+		# Generates a yaml file for creating workload clusters using a template stored locally.
+		clusterctl generate cluster my-cluster --from ~/workspace/cluster-template.yaml
+
+		# Generates a raw yaml file for creating a cluster without variable substitution.
+		clusterctl generate cluster my-cluster --raw`),
+
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGenerateClusterTemplate(cmd, args[0])
+	},
+}
+
+func init() {
+	generateClusterClusterCmd.Flags().StringVar(&gc.kubeconfig, "kubeconfig", "",
+		"Path to a kubeconfig file to use for the management cluster. If empty, default discovery rules apply.")
+	generateClusterClusterCmd.Flags().StringVar(&gc.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
+
+	// flags for the template variables
+	generateClusterClusterCmd.Flags().StringVarP(&gc.targetNamespace, "target-namespace", "n", "",
+		"The namespace to use for the workload cluster. If unspecified, the current namespace will be used.")
+	generateClusterClusterCmd.Flags().StringVar(&gc.kubernetesVersion, "kubernetes-version", "",
+		"The Kubernetes version to use for the workload cluster. If unspecified, the value from OS environment variables or the .cluster-api/clusterctl.yaml config file will be used.")
+	generateClusterClusterCmd.Flags().Int64Var(&gc.controlPlaneMachineCount, "control-plane-machine-count", 1,
+		"The number of control plane machines for the workload cluster.")
+	generateClusterClusterCmd.Flags().Int64Var(&gc.workerMachineCount, "worker-machine-count", 0,
+		"The number of worker machines for the workload cluster.")
+
+	// flags for the repository source
+	generateClusterClusterCmd.Flags().StringVarP(&gc.infrastructureProvider, "infrastructure", "i", "",
+		"The infrastructure provider to read the workload cluster template from. If unspecified, the default infrastructure provider will be used.")
+	generateClusterClusterCmd.Flags().StringVarP(&gc.flavor, "flavor", "f", "",
+		"The workload cluster template variant to be used when reading from the infrastructure provider repository. If unspecified, the default cluster template will be used.")
+
+	// flags for the url source
+	generateClusterClusterCmd.Flags().StringVar(&gc.url, "from", "",
+		"The URL to read the workload cluster template from. If unspecified, the infrastructure provider repository URL will be used")
+
+	// flags for the config map source
+	generateClusterClusterCmd.Flags().StringVar(&gc.configMapName, "from-config-map", "",
+		"The ConfigMap to read the workload cluster template from. This can be used as alternative to read from the provider repository or from an URL")
+	generateClusterClusterCmd.Flags().StringVar(&gc.configMapNamespace, "from-config-map-namespace", "",
+		"The namespace where the ConfigMap exists. If unspecified, the current namespace will be used")
+	generateClusterClusterCmd.Flags().StringVar(&gc.configMapDataKey, "from-config-map-key", "",
+		fmt.Sprintf("The ConfigMap.Data key where the workload cluster template is hosted. If unspecified, %q will be used", client.DefaultCustomTemplateConfigMapKey))
+
+	// other flags
+	generateClusterClusterCmd.Flags().BoolVar(&gc.listVariables, "list-variables", false,
+		"Returns the list of variables expected by the template instead of the template yaml")
+	generateClusterClusterCmd.Flags().BoolVar(&gc.skipVariables, "raw", false,
+		"Generate configuration without variable substitution.")
+
+	generateCmd.AddCommand(generateClusterClusterCmd)
+}
+
+func runGenerateClusterTemplate(cmd *cobra.Command, name string) error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	templateOptions := client.GetClusterTemplateOptions{
+		Kubeconfig:        client.Kubeconfig{Path: gc.kubeconfig, Context: gc.kubeconfigContext},
+		ClusterName:       name,
+		TargetNamespace:   gc.targetNamespace,
+		KubernetesVersion: gc.kubernetesVersion,
+		ListVariablesOnly: gc.listVariables,
+		SkipVariables:     gc.skipVariables,
+	}
+
+	if cmd.Flags().Changed("control-plane-machine-count") {
+		templateOptions.ControlPlaneMachineCount = &gc.controlPlaneMachineCount
+	}
+	if cmd.Flags().Changed("worker-machine-count") {
+		templateOptions.WorkerMachineCount = &gc.workerMachineCount
+	}
+
+	if gc.url != "" {
+		templateOptions.URLSource = &client.URLSourceOptions{
+			URL: gc.url,
+		}
+	}
+
+	if gc.configMapNamespace != "" || gc.configMapName != "" || gc.configMapDataKey != "" {
+		templateOptions.ConfigMapSource = &client.ConfigMapSourceOptions{
+			Namespace: gc.configMapNamespace,
+			Name:      gc.configMapName,
+			DataKey:   gc.configMapDataKey,
+		}
+	}
+
+	if gc.infrastructureProvider != "" || gc.flavor != "" {
+		templateOptions.ProviderRepositorySource = &client.ProviderRepositorySourceOptions{
+			InfrastructureProvider: gc.infrastructureProvider,
+			Flavor:                 gc.flavor,
+		}
+	}
+
+	template, err := c.GetClusterTemplate(templateOptions)
+	if err != nil {
+		return err
+	}
+
+	if gc.listVariables {
+		return printVariablesOutput(template)
+	}
+
+	return printYamlOutput(template)
+}

--- a/cmd/clusterctl/cmd/util.go
+++ b/cmd/clusterctl/cmd/util.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+// printYamlOutput prints the yaml content of a generated template to stdout.
+func printYamlOutput(printer client.YamlPrinter) error {
+	yaml, err := printer.Yaml()
+	if err != nil {
+		return err
+	}
+	yaml = append(yaml, '\n')
+
+	if _, err := os.Stdout.Write(yaml); err != nil {
+		return errors.Wrap(err, "failed to write yaml to Stdout")
+	}
+	return nil
+}
+
+// printVariablesOutput prints the expected variables in the template to stdout.
+func printVariablesOutput(printer client.YamlPrinter) error {
+	if len(printer.Variables()) > 0 {
+		fmt.Println("Variables:")
+		for _, v := range printer.Variables() {
+			fmt.Printf("  - %s\n", v)
+		}
+	}
+	fmt.Println()
+	return nil
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR 
- Refactors `cluster config [cluster|provider]` to `clusterct generate [cluster|provider]`
- Adds `--raw` option to both subcommands
- deprecates `clusterctl config`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3360 

There are still a few things that needs to be addressed, which I think, can be done as a followup, namely:
refactor 
- `ListVariables` logic in `generate provider` subcommand ( it still fetches the yaml and does variable substitution)
- add --from option to `clusterctl generate provider` - `clusterctl generate cluster` has --from option to generate cluster config from a template file. But this is very similar to `clusterctl generate yaml --from`. So either we add --from option to `clusterctl generate provider` or remove from `clusterctl generate cluster`.