### PR TITLE
🌱  Add fabriziopandini to cluster-api-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -21,6 +21,7 @@ aliases:
   # non-admin folks who have write-access and can approve any PRs in the repo
   cluster-api-maintainers:
   - CecileRobertMichon
+  - fabriziopandini
   - detiber
   - justinsb
   - vincepri

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,10 +2,10 @@
 
 aliases:
   sig-cluster-lifecycle-leads:
-  - neolit123
-  - justinsb
-  - timothysc
   - fabriziopandini
+  - justinsb
+  - neolit123
+  - timothysc
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for Cluster API
@@ -14,22 +14,22 @@ aliases:
   # active folks who can be contacted to perform admin-related
   # tasks on the repo, or otherwise approve any PRS.
   cluster-api-admins:
-  - justinsb
   - detiber
+  - justinsb
   - vincepri
 
   # non-admin folks who have write-access and can approve any PRs in the repo
   cluster-api-maintainers:
-  - justinsb
-  - detiber
-  - vincepri
   - CecileRobertMichon
+  - detiber
+  - justinsb
+  - vincepri
 
   # folks who can review and LGTM any PRs in the repo
   cluster-api-reviewers:
   - CecileRobertMichon
-  - vincepri
   - JoelSpeed
+  - vincepri
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for docs/book
@@ -37,8 +37,8 @@ aliases:
 
   # folks who can review and LGTM any PRs under docs/book
   cluster-api-book-reviewers:
-  - randomvariable
   - moshloop
+  - randomvariable
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for test/infrastructure/docker


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Adds @fabriziopandini to cluster-api-maintainers. Fabrizio already has approver rights via his role as sig-cluster-lifecycle-lead and has essentially been acting as a cluster-api maintainer for a while so this makes it explicit.

Also alphabetized the OWNERS_ALIASES file (kept as separate commit).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
