### PR TITLE
🌱  Add sbueringer to cluster-api-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -29,7 +29,7 @@ aliases:
   # folks who can review and LGTM any PRs in the repo
   cluster-api-reviewers:
   - JoelSpeed
-  - vincepri
+  - sbueringer
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for docs/book

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -28,7 +28,6 @@ aliases:
 
   # folks who can review and LGTM any PRs in the repo
   cluster-api-reviewers:
-  - CecileRobertMichon
   - JoelSpeed
   - vincepri
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: @sbueringer has made quality [reviews](https://github.com/kubernetes-sigs/cluster-api/pulls?q=is%3Apr+assignee%3Asbueringer+is%3Aclosed), [contributions](https://github.com/kubernetes-sigs/cluster-api/pulls?q=is%3Apr+is%3Aclosed+author%3Asbueringer), and [investigations](https://github.com/kubernetes-sigs/cluster-api/issues?q=is%3Aissue+author%3Asbueringer+) to CAPI for past few months. This PR adds him to the reviewers for CAPI. 

Thank you all your contributions so far @sbueringer!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
