### PR TITLE
🐛 ClusterResourceSet controller: fix reconciliation triggered by resource changes

### DIFF
--- a/exp/addons/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/controllers/clusterresourceset_controller_test.go
@@ -304,20 +304,17 @@ metadata:
 			},
 			Data: map[string]string{},
 		}
+
+		// Let's wait until the initial reconciliations are *all* done, so we can test
+		// if the ConfigMap creation triggers a reconciliation. Otherwise a previous change
+		// of another resource triggers the reconciliation and we cannot verify if we react
+		// correctly to the ConfigMap creation
+		time.Sleep(5 * time.Second)
+
 		g.Expect(testEnv.Create(ctx, newConfigmap)).To(Succeed())
 		defer func() {
 			g.Expect(testEnv.Delete(ctx, newConfigmap)).To(Succeed())
 		}()
-
-		cmKey := client.ObjectKey{
-			Namespace: defaultNamespaceName,
-			Name:      newCMName,
-		}
-		g.Eventually(func() bool {
-			m := &corev1.ConfigMap{}
-			err := testEnv.Get(ctx, cmKey, m)
-			return err == nil
-		}, timeout).Should(BeTrue())
 
 		// When the ConfigMap resource is created, CRS should get reconciled immediately.
 		g.Eventually(func() error {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The ClusterResourceSet controller did not react to changes on
ConfigMaps and Secrets (except when OwnerReferences were already set).

The problem was that we use OnlyMetadata on the watches and we tried to
get the kind of ConfigMap/Secret from the TypeMeta of an PartialObjectMetadata.
The TypeMeta of a PartialObjectMetadata is empty so apiutil.GVKForObject(o,
r.Client.Scheme()) always returned an error and the reconciliation was
not triggered.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4486

Additional context:
* https://kubernetes.slack.com/archives/C8TSNPY4T/p1618606088075900
* branch to reproduce the issue easily: https://github.com/kubernetes-sigs/cluster-api/pull/4490
  * explanations on how to do that are in the Slack thread
