### PR TITLE
📖  Revise CAPI book introduction

### DIFF
--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -1,8 +1,8 @@
-# The Cluster API project<div style="float: right; position: relative; display: inline;"><img src="images/introduction.png" width="160px" /></div>
+# Kubernetes Cluster API<div style="float: right; position: relative; display: inline;"><img src="images/introduction.png" width="160px" /></div>
 
 Cluster API is a Kubernetes sub-project focused on providing declarative APIs and tooling to simplify provisioning, upgrading, and operating multiple Kubernetes clusters.
 
-Started by the Kubernetes Special Interest Group (SIG) Cluster Lifecycle, the Cluster API project uses Kubernetes-style APIs and patterns to automate cluster lifecycle management for platform operators. The supporting infrastructure, like virtual machines, networks, load balancers, and VPCs, as well as the Kubernetes cluster configuration are all defined in the same way that application developers operate deploying and managing their workloads. This enables consistent and repeatable cluster deployments across a wide variety of infrastructure environments.
+Started by the Kubernetes Special Interest Group (SIG) [Cluster Lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle#readme), the Cluster API project uses Kubernetes-style APIs and patterns to automate cluster lifecycle management for platform operators. The supporting infrastructure, like virtual machines, networks, load balancers, and VPCs, as well as the Kubernetes cluster configuration are all defined in the same way that application developers operate deploying and managing their workloads. This enables consistent and repeatable cluster deployments across a wide variety of infrastructure environments.
 
 ## Getting started
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- New title, “Kubernetes Cluster API”, for https://cluster-api.sigs.k8s.io/
- hyperlink to [SIG Cluster Lifecycle](https://github.com/kubernetes/community/tree/master/sig-cluster-lifecycle#readme) in the introduction

I suggested the new title because although CAPI _is_ a project, the book is about the outcome of the project more than it is about the work to deliver that outcome.

/kind documentation