### PR TITLE
📖 Improve links to main Kubernetes docs

### DIFF
--- a/docs/book/src/user/concepts.md
+++ b/docs/book/src/user/concepts.md
@@ -26,7 +26,7 @@ The Bootstrap Provider is responsible for:
 
 ## Control plane
 
-The control plane is a set of [services](https://kubernetes.io/docs/concepts/#kubernetes-control-plane) that serve the Kubernetes API and continuously reconcile desired state using control loops.
+The [control plane](https://kubernetes.io/docs/concepts/overview/components/) is a set of components that serve the Kubernetes API and continuously reconcile desired state using [control loops](https://kubernetes.io/docs/concepts/architecture/controller/).
 
 * __Machine-based__ control planes are the most common type. Dedicated machines are provisioned, running [static pods](https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/) for components such as [kube-apiserver](https://kubernetes.io/docs/admin/kube-apiserver/), [kube-controller-manager](https://kubernetes.io/docs/admin/kube-controller-manager/) and [kube-scheduler](https://kubernetes.io/docs/admin/kube-scheduler/).
 
@@ -39,6 +39,8 @@ As of v1alpha2, __Machine-Based__ is the only control plane type that Cluster AP
 The default provider uses kubeadm to bootstrap the control plane. As of v1alpha3, it exposes the configuration via the `KubeadmControlPlane` object. The controller, `capi-kubeadm-control-plane-controller-manager`, can then create Machine and BootstrapConfig objects based on the requested replicas in the `KubeadmControlPlane` object.
 
 ## Custom Resource Definitions (CRDs)
+
+A [CustomResourceDefinition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) is a built-in resource that lets you extend the Kubernetes API. Each CustomResourceDefinition represents a customization of a Kubernetes installation. The Cluster API provides and relies on several CustomResourceDefinitions:
 
 ### Machine
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix / add links to:
- _control plane_
- _controller_
- `CustomResourceDefinition`

in the main Kubernetes docs.
/kind cleanup