### PR TITLE
🌱 Refactor MachineSet scaling code and add more tests

### DIFF
--- a/controllers/machinedeployment_sync_test.go
+++ b/controllers/machinedeployment_sync_test.go
@@ -17,13 +17,21 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/controllers/mdutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCalculateStatus(t *testing.T) {
@@ -216,6 +224,176 @@ func TestCalculateStatus(t *testing.T) {
 
 			actualStatus := calculateStatus(test.machineSets, test.newMachineSet, test.deployment)
 			g.Expect(actualStatus).To(Equal(test.expectedStatus))
+		})
+	}
+}
+
+func TestScaleMachineSet(t *testing.T) {
+	testCases := []struct {
+		name              string
+		machineDeployment *clusterv1.MachineDeployment
+		machineSet        *clusterv1.MachineSet
+		newScale          int32
+		error             error
+	}{
+		{
+			name: "It fails when new MachineSet has no replicas",
+			machineDeployment: &clusterv1.MachineDeployment{
+				Spec: clusterv1.MachineDeploymentSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+			},
+			machineSet: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+			},
+			error: errors.Errorf("spec.replicas for MachineSet foo/bar is nil, this is unexpected"),
+		},
+		{
+			name: "It fails when new MachineDeployment has no replicas",
+			machineDeployment: &clusterv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				Spec: clusterv1.MachineDeploymentSpec{},
+			},
+			machineSet: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+			},
+			error: errors.Errorf("spec.replicas for MachineDeployment foo/bar is nil, this is unexpected"),
+		},
+		{
+			name: "Scale up",
+			machineDeployment: &clusterv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					Strategy: &clusterv1.MachineDeploymentStrategy{
+						Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+						RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+							MaxUnavailable: intOrStrPtr(0),
+							MaxSurge:       intOrStrPtr(2),
+						},
+					},
+					Replicas: pointer.Int32Ptr(2),
+				},
+			},
+			machineSet: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(0),
+				},
+			},
+			newScale: 2,
+		},
+		{
+			name: "Scale down",
+			machineDeployment: &clusterv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					Strategy: &clusterv1.MachineDeploymentStrategy{
+						Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+						RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+							MaxUnavailable: intOrStrPtr(0),
+							MaxSurge:       intOrStrPtr(2),
+						},
+					},
+					Replicas: pointer.Int32Ptr(2),
+				},
+			},
+			machineSet: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(4),
+				},
+			},
+			newScale: 2,
+		},
+		{
+			name: "Same replicas does not scale",
+			machineDeployment: &clusterv1.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				Spec: clusterv1.MachineDeploymentSpec{
+					Strategy: &clusterv1.MachineDeploymentStrategy{
+						Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+						RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+							MaxUnavailable: intOrStrPtr(0),
+							MaxSurge:       intOrStrPtr(2),
+						},
+					},
+					Replicas: pointer.Int32Ptr(2),
+				},
+			},
+			machineSet: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Name:      "bar",
+				},
+				Spec: clusterv1.MachineSetSpec{
+					Replicas: pointer.Int32Ptr(2),
+				},
+			},
+			newScale: 2,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+			resources := []client.Object{
+				tc.machineDeployment,
+				tc.machineSet,
+			}
+
+			r := &MachineDeploymentReconciler{
+				Client:   fake.NewClientBuilder().WithObjects(resources...).Build(),
+				recorder: record.NewFakeRecorder(32),
+			}
+
+			err := r.scaleMachineSet(context.Background(), tc.machineSet, tc.newScale, tc.machineDeployment)
+			if tc.error != nil {
+				g.Expect(err.Error()).To(BeEquivalentTo(tc.error.Error()))
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			freshMachineSet := &clusterv1.MachineSet{}
+			err = r.Client.Get(ctx, client.ObjectKeyFromObject(tc.machineSet), freshMachineSet)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(*freshMachineSet.Spec.Replicas).To(BeEquivalentTo(tc.newScale))
+
+			expectedMachineSetAnnotations := map[string]string{
+				clusterv1.DesiredReplicasAnnotation: fmt.Sprintf("%d", *tc.machineDeployment.Spec.Replicas),
+				clusterv1.MaxReplicasAnnotation:     fmt.Sprintf("%d", (*tc.machineDeployment.Spec.Replicas)+mdutil.MaxSurge(*tc.machineDeployment)),
+			}
+			g.Expect(freshMachineSet.GetAnnotations()).To(BeEquivalentTo(expectedMachineSetAnnotations))
 		})
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This drops the presumably unncessary split between scaleMachineSet and scaleMachineSetOperation and cover scaleMachineSet with unit tests.

Follow up for https://github.com/kubernetes-sigs/cluster-api/pull/4495, https://github.com/kubernetes-sigs/cluster-api/pull/4505, https://github.com/kubernetes-sigs/cluster-api/pull/4498. Related to #4457

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
