### PR TITLE
🐛 Check Strategy is not nil to avoid panic

### DIFF
--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -195,7 +195,14 @@ func (r *MachineDeploymentReconciler) reconcile(ctx context.Context, cluster *cl
 		return ctrl.Result{}, r.sync(ctx, d, msList)
 	}
 
+	if d.Spec.Strategy == nil {
+		return ctrl.Result{}, errors.Errorf("missing MachineDeployment strategy")
+	}
+
 	if d.Spec.Strategy.Type == clusterv1.RollingUpdateMachineDeploymentStrategyType {
+		if d.Spec.Strategy.RollingUpdate == nil {
+			return ctrl.Result{}, errors.Errorf("missing MachineDeployment settings for strategy type: %s", d.Spec.Strategy.Type)
+		}
 		return ctrl.Result{}, r.rolloutRolling(ctx, d, msList)
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Regardless of API UX via default/validation our backend should cover all possible scenarios and error appropriately without panics.

~~I'm also including structural schema defaulting to get feedback on why are we not using it rather than webhooks when possible.~~

Also why are we setting this field as optional? I'd consider any field which prevents the backend from operating successfully to be required, regardless of we choose to default it for UX. Do you agree? @vincepri @CecileRobertMichon @fabriziopandini @JoelSpeed @sbueringer 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4509
