### PR TITLE
🌱  Ease local CAPD e2e test execution

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -10,13 +10,13 @@
 images:
 # Use local dev images built source tree;
 - name: gcr.io/k8s-staging-cluster-api/cluster-api-controller-amd64:dev
-  loadBehavior: mustLoad
+  loadBehavior: tryLoad
 - name: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller-amd64:dev
-  loadBehavior: mustLoad
+  loadBehavior: tryLoad
 - name: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-amd64:dev
-  loadBehavior: mustLoad
+  loadBehavior: tryLoad
 - name: gcr.io/k8s-staging-cluster-api/capd-manager-amd64:dev
-  loadBehavior: mustLoad
+  loadBehavior: tryLoad
 - name: quay.io/jetstack/cert-manager-cainjector:v1.1.0
   loadBehavior: tryLoad
 - name: quay.io/jetstack/cert-manager-webhook:v1.1.0

--- a/test/infrastructure/docker/config/default/manager_image_patch.yaml
+++ b/test/infrastructure/docker/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/k8s-staging-cluster-api/capd-manager:dev
+      - image: gcr.io/k8s-staging-cluster-api/capd-manager:master
         name: manager


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->
Follow-up to: https://github.com/kubernetes-sigs/cluster-api/pull/4515#issuecomment-825147782

Some additional context:
* when running the e2e-test.sh script locally it only builds the CAPD image when it doesn't already exist
* as a side effect the `docker-build` target changes the image pull policy and image patches 
* the e2e tests then rely on the changed image name and image pull policy

When I'm now running the tests either with an already existing CAPD image (which is pretty common locally) or directly via the IDE I have to manually modify the patch files and have to be careful so I don't check in and push this change.

With this PR the test framework takes care of the image and image pull policy. When the test is run via the script (e.g. via Prow) the replacements are no-ops.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/cc @fabriziopandini 
