### PR TITLE
⚠️ Drop usage of GetValueFromIntOrPercent in favour of GetScaledValueFromIntOrPercent

### DIFF
--- a/api/v1alpha4/machinehealthcheck_webhook.go
+++ b/api/v1alpha4/machinehealthcheck_webhook.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -138,18 +137,11 @@ func (m *MachineHealthCheck) validate(old *MachineHealthCheck) error {
 	}
 
 	if m.Spec.MaxUnhealthy != nil {
-		if _, err := intstr.GetValueFromIntOrPercent(m.Spec.MaxUnhealthy, 0, false); err != nil {
+		if _, err := intstr.GetScaledValueFromIntOrPercent(m.Spec.MaxUnhealthy, 0, false); err != nil {
 			allErrs = append(
 				allErrs,
-				field.Invalid(field.NewPath("spec", "maxUnhealthy"), m.Spec.MaxUnhealthy, "must be either an int or a percentage"),
+				field.Invalid(field.NewPath("spec", "maxUnhealthy"), m.Spec.MaxUnhealthy, fmt.Sprintf("must be either an int or a percentage: %v", err.Error())),
 			)
-		} else if m.Spec.MaxUnhealthy.Type == intstr.String {
-			if len(validation.IsValidPercent(m.Spec.MaxUnhealthy.StrVal)) != 0 {
-				allErrs = append(
-					allErrs,
-					field.Invalid(field.NewPath("spec", "maxUnhealthy"), m.Spec.MaxUnhealthy, "must be either an int or a percentage"),
-				)
-			}
 		}
 	}
 

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -590,7 +590,7 @@ func getMaxUnhealthy(mhc *clusterv1.MachineHealthCheck) (int, error) {
 	if mhc.Spec.MaxUnhealthy == nil {
 		return 0, errors.New("spec.maxUnhealthy must be set")
 	}
-	maxUnhealthy, err := intstr.GetValueFromIntOrPercent(mhc.Spec.MaxUnhealthy, int(mhc.Status.ExpectedMachines), false)
+	maxUnhealthy, err := intstr.GetScaledValueFromIntOrPercent(mhc.Spec.MaxUnhealthy, int(mhc.Status.ExpectedMachines), false)
 	if err != nil {
 		return 0, err
 	}

--- a/controllers/machinehealthcheck_controller_test.go
+++ b/controllers/machinehealthcheck_controller_test.go
@@ -2183,7 +2183,7 @@ func TestGetMaxUnhealthy(t *testing.T) {
 			maxUnhealthy:         &intstr.IntOrString{Type: intstr.String, StrVal: "abcdef"},
 			expectedMaxUnhealthy: 0,
 			actualMachineCount:   3,
-			expectedErr:          errors.New("invalid value for IntOrString: invalid value \"abcdef\": strconv.Atoi: parsing \"abcdef\": invalid syntax"),
+			expectedErr:          errors.New("invalid value for IntOrString: invalid type: string is not a percentage"),
 		},
 		{
 			name:                 "when maxUnhealthy is an int",

--- a/controllers/mdutil/util.go
+++ b/controllers/mdutil/util.go
@@ -533,7 +533,7 @@ func NewMSNewReplicas(deployment *clusterv1.MachineDeployment, allMSs []*cluster
 	switch deployment.Spec.Strategy.Type {
 	case clusterv1.RollingUpdateMachineDeploymentStrategyType:
 		// Check if we can scale up.
-		maxSurge, err := intstrutil.GetValueFromIntOrPercent(deployment.Spec.Strategy.RollingUpdate.MaxSurge, int(*(deployment.Spec.Replicas)), true)
+		maxSurge, err := intstrutil.GetScaledValueFromIntOrPercent(deployment.Spec.Strategy.RollingUpdate.MaxSurge, int(*(deployment.Spec.Replicas)), true)
 		if err != nil {
 			return 0, err
 		}
@@ -593,11 +593,11 @@ func IsSaturated(deployment *clusterv1.MachineDeployment, ms *clusterv1.MachineS
 // 2 desired, max unavailable 0%, surge 1% - should scale new(+1), then old(-1), then new(+1), then old(-1)
 // 1 desired, max unavailable 0%, surge 1% - should scale new(+1), then old(-1).
 func ResolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired int32) (int32, int32, error) {
-	surge, err := intstrutil.GetValueFromIntOrPercent(maxSurge, int(desired), true)
+	surge, err := intstrutil.GetScaledValueFromIntOrPercent(maxSurge, int(desired), true)
 	if err != nil {
 		return 0, 0, err
 	}
-	unavailable, err := intstrutil.GetValueFromIntOrPercent(maxUnavailable, int(desired), false)
+	unavailable, err := intstrutil.GetScaledValueFromIntOrPercent(maxUnavailable, int(desired), false)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/controllers/mdutil/util_test.go
+++ b/controllers/mdutil/util_test.go
@@ -492,6 +492,14 @@ func TestResolveFenceposts(t *testing.T) {
 			expectUnavailable: 0,
 			expectError:       true,
 		},
+		{
+			maxSurge:          "5",
+			maxUnavailable:    "1",
+			desired:           7,
+			expectSurge:       0,
+			expectUnavailable: 0,
+			expectError:       true,
+		},
 	}
 
 	for _, test := range tests {

--- a/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
+++ b/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
@@ -245,3 +245,10 @@ with `cert-manager.io/v1`
   ```yaml
   serviceAccountName: manager
   ```
+
+## Percentage String or Int API input will fail with a string different from an integer with % appended.
+
+`MachineDeployment.Spec.Strategy.RollingUpdate.MaxSurge`, `MachineDeployment.Spec.Strategy.RollingUpdate.MaxUnavailable` and `MachineHealthCheck.Spec.MaxUnhealthy` would have previously taken a String value with an integer character in it e.g "3" as a valid input and process it as a percentage value.
+Only String values like "3%" or Int values e.g 3 are valid input values now. A string not matching the percentage format will fail, e.g "3".
+
+

--- a/docs/book/src/tasks/upgrading-clusters.md
+++ b/docs/book/src/tasks/upgrading-clusters.md
@@ -80,6 +80,17 @@ transparently manage `MachineSet`s and `Machine`s to allow for a seamless scalin
 [these instructions](./change-machine-template.md) for changing the
 template for an existing `MachineDeployment`.
 
+`MachineDeployment`s support different strategies for rolling out changes to `Machines`:
+
+- RollingUpdate
+
+Changes are rolled out by honouring `MaxUnavailable` and `MaxSurge` values.
+Only values allowed are of type Int or Strings with an integer and percentage symbol e.g "5%".
+
+- OnDelete
+
+Changes are rolled out driven by the user or any entity deleting the old `Machines`. Only when a `Machine` is fully deleted a new one will come up.
+
 For a more in-depth look at how `MachineDeployments` manage scaling events, take a look at the [`MachineDeployment`
 controller documentation](../developer/architecture/controllers/machine-deployment.md) and the [`MachineSet` controller
 documentation](../developer/architecture/controllers/machine-set.md).


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Because we rely on [1] in this func [2] a string such as "2" would be treated as a percentage for this fields.
[1] https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go#L164-L168
[2] https://github.com/kubernetes-sigs/cluster-api/blob/3bc596eea96cb27e23c8f2d6c758f6bd56db67b1/controllers/mdutil/util.go#L595-L600

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4531
