### PR TITLE
⚠️ Rename KubeadmControlPlane spec.upgradeAfter to rolloutAfter

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/conversion.go
+++ b/controlplane/kubeadm/api/v1alpha3/conversion.go
@@ -68,9 +68,11 @@ func (dest *KubeadmControlPlaneList) ConvertFrom(srcRaw conversion.Hub) error {
 }
 
 func Convert_v1alpha4_KubeadmControlPlaneSpec_To_v1alpha3_KubeadmControlPlaneSpec(in *v1alpha4.KubeadmControlPlaneSpec, out *KubeadmControlPlaneSpec, s apiconversion.Scope) error {
+	in.RolloutAfter = out.UpgradeAfter
 	return autoConvert_v1alpha4_KubeadmControlPlaneSpec_To_v1alpha3_KubeadmControlPlaneSpec(in, out, s)
 }
 
-func Convert_v1alpha3_KubeadmControlPlaneSpec_To_v1alpha4_KubeadmControlPlaneSpec(in *KubeadmControlPlaneSpec, out *v1alpha4.KubeadmControlPlaneSpec, s apiconversion.Scope) error { //nolint
+func Convert_v1alpha3_KubeadmControlPlaneSpec_To_v1alpha4_KubeadmControlPlaneSpec(in *KubeadmControlPlaneSpec, out *v1alpha4.KubeadmControlPlaneSpec, s apiconversion.Scope) error {
+	in.UpgradeAfter = out.RolloutAfter
 	return autoConvert_v1alpha3_KubeadmControlPlaneSpec_To_v1alpha4_KubeadmControlPlaneSpec(in, out, s)
 }

--- a/controlplane/kubeadm/api/v1alpha3/zz_generated.conversion.go
+++ b/controlplane/kubeadm/api/v1alpha3/zz_generated.conversion.go
@@ -164,7 +164,7 @@ func autoConvert_v1alpha3_KubeadmControlPlaneSpec_To_v1alpha4_KubeadmControlPlan
 	if err := apiv1alpha3.Convert_v1alpha3_KubeadmConfigSpec_To_v1alpha4_KubeadmConfigSpec(&in.KubeadmConfigSpec, &out.KubeadmConfigSpec, s); err != nil {
 		return err
 	}
-	out.UpgradeAfter = (*v1.Time)(unsafe.Pointer(in.UpgradeAfter))
+	// WARNING: in.UpgradeAfter requires manual conversion: does not exist in peer-type
 	out.NodeDrainTimeout = (*v1.Duration)(unsafe.Pointer(in.NodeDrainTimeout))
 	return nil
 }
@@ -176,7 +176,7 @@ func autoConvert_v1alpha4_KubeadmControlPlaneSpec_To_v1alpha3_KubeadmControlPlan
 	if err := apiv1alpha3.Convert_v1alpha4_KubeadmConfigSpec_To_v1alpha3_KubeadmConfigSpec(&in.KubeadmConfigSpec, &out.KubeadmConfigSpec, s); err != nil {
 		return err
 	}
-	out.UpgradeAfter = (*v1.Time)(unsafe.Pointer(in.UpgradeAfter))
+	// WARNING: in.RolloutAfter requires manual conversion: does not exist in peer-type
 	out.NodeDrainTimeout = (*v1.Duration)(unsafe.Pointer(in.NodeDrainTimeout))
 	// WARNING: in.RolloutStrategy requires manual conversion: does not exist in peer-type
 	return nil

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_types.go
@@ -66,11 +66,12 @@ type KubeadmControlPlaneSpec struct {
 	// to use for initializing and joining machines to the control plane.
 	KubeadmConfigSpec cabpkv1.KubeadmConfigSpec `json:"kubeadmConfigSpec"`
 
-	// UpgradeAfter is a field to indicate an upgrade should be performed
+	// RolloutAfter is a field to indicate a rollout should be performed
 	// after the specified time even if no changes have been made to the
-	// KubeadmControlPlane
+	// KubeadmControlPlane.
+	//
 	// +optional
-	UpgradeAfter *metav1.Time `json:"upgradeAfter,omitempty"`
+	RolloutAfter *metav1.Time `json:"rolloutAfter,omitempty"`
 
 	// NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
 	// The default value is 0, meaning that the node can be drained without any time limitations.

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
@@ -134,7 +134,7 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, "infrastructureTemplate", "name"},
 		{spec, "replicas"},
 		{spec, "version"},
-		{spec, "upgradeAfter"},
+		{spec, "rolloutAfter"},
 		{spec, "nodeDrainTimeout"},
 		{spec, "rolloutStrategy", "*"},
 	}

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
@@ -303,7 +303,7 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	validUpdate.Spec.InfrastructureTemplate.Name = "orange"
 	validUpdate.Spec.Replicas = pointer.Int32Ptr(5)
 	now := metav1.NewTime(time.Now())
-	validUpdate.Spec.UpgradeAfter = &now
+	validUpdate.Spec.RolloutAfter = &now
 
 	scaleToZero := before.DeepCopy()
 	scaleToZero.Spec.Replicas = pointer.Int32Ptr(0)

--- a/controlplane/kubeadm/api/v1alpha4/zz_generated.deepcopy.go
+++ b/controlplane/kubeadm/api/v1alpha4/zz_generated.deepcopy.go
@@ -96,8 +96,8 @@ func (in *KubeadmControlPlaneSpec) DeepCopyInto(out *KubeadmControlPlaneSpec) {
 	}
 	out.InfrastructureTemplate = in.InfrastructureTemplate
 	in.KubeadmConfigSpec.DeepCopyInto(&out.KubeadmConfigSpec)
-	if in.UpgradeAfter != nil {
-		in, out := &in.UpgradeAfter, &out.UpgradeAfter
+	if in.RolloutAfter != nil {
+		in, out := &in.RolloutAfter, &out.RolloutAfter
 		*out = (*in).DeepCopy()
 	}
 	if in.NodeDrainTimeout != nil {

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -2193,6 +2193,12 @@ spec:
                   This is a pointer to distinguish between explicit zero and not specified.
                 format: int32
                 type: integer
+              rolloutAfter:
+                description: RolloutAfter is a field to indicate a rollout should
+                  be performed after the specified time even if no changes have been
+                  made to the KubeadmControlPlane.
+                format: date-time
+                type: string
               rolloutStrategy:
                 description: The RolloutStrategy to use to replace control plane machines
                   with new ones.
@@ -2217,12 +2223,6 @@ spec:
                       is "RollingUpdate". Default is RollingUpdate.
                     type: string
                 type: object
-              upgradeAfter:
-                description: UpgradeAfter is a field to indicate an upgrade should
-                  be performed after the specified time even if no changes have been
-                  made to the KubeadmControlPlane
-                format: date-time
-                type: string
               version:
                 description: Version defines the desired Kubernetes version.
                 type: string

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -18,6 +18,7 @@ package internal
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -257,8 +258,8 @@ func (c *ControlPlane) MachinesNeedingRollout() collections.Machines {
 
 	// Return machines if they are scheduled for rollout or if with an outdated configuration.
 	return machines.AnyFilter(
-		// Machines that are scheduled for rollout (KCP.Spec.UpgradeAfter set, the UpgradeAfter deadline is expired, and the machine was created before the deadline).
-		collections.ShouldRolloutAfter(&c.reconciliationTime, c.KCP.Spec.UpgradeAfter),
+		// Machines that are scheduled for rollout (KCP.Spec.RolloutAfter set, the RolloutAfter deadline is expired, and the machine was created before the deadline).
+		collections.ShouldRolloutAfter(&c.reconciliationTime, c.KCP.Spec.RolloutAfter),
 		// Machines that do not match with KCP config.
 		collections.Not(MatchesKCPConfiguration(c.infraResources, c.kubeadmConfigs, c.KCP)),
 	)

--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -90,7 +90,7 @@ func MatchesKubeadmBootstrapConfig(machineConfigs map[string]*bootstrapv1.Kubead
 // NOTE: Machines that have KubeadmClusterConfigurationAnnotation will have to match with KCP ClusterConfiguration.
 // If the annotation is not present (machine is either old or adopted), we won't roll out on any possible changes
 // made in KCP's ClusterConfiguration given that we don't have enough information to make a decision.
-// Users should use KCP.Spec.UpgradeAfter field to force a rollout in this case.
+// Users should use KCP.Spec.RolloutAfter field to force a rollout in this case.
 func matchClusterConfiguration(kcp *controlplanev1.KubeadmControlPlane, machine *clusterv1.Machine) bool {
 	machineClusterConfigStr, ok := machine.GetAnnotations()[controlplanev1.KubeadmClusterConfigurationAnnotation]
 	if !ok {

--- a/docs/book/src/tasks/upgrading-clusters.md
+++ b/docs/book/src/tasks/upgrading-clusters.md
@@ -49,14 +49,14 @@ and then both the `Version` and `InfrastructureTemplate` should be modified in a
 
 #### How to schedule a machine rollout
 
-A `KubeadmControlPlane` resource has a field `UpgradeAfter` that can be set to a timestamp
+A `KubeadmControlPlane` resource has a field `RolloutAfter` that can be set to a timestamp
 (RFC-3339) after which a rollout should be triggered regardless of whether there were any changes
 to the `KubeadmControlPlane.Spec` or not. This would roll out replacement control plane nodes
 which can be useful e.g. to perform certificate rotation, reflect changes to machine templates,
 move to new machines, etc.
 
 Note that this field can only be used for triggering a rollout, not for delaying one. Specifically,
-a rollout can also happen before the time specified in `UpgradeAfter` if any changes are made to
+a rollout can also happen before the time specified in `RolloutAfter` if any changes are made to
 the spec before that time.
 
 To do the same for machines managed by a `MachineDeployment` it's enough to make an arbitrary

--- a/docs/proposals/20191017-kubeadm-based-control-plane.md
+++ b/docs/proposals/20191017-kubeadm-based-control-plane.md
@@ -49,7 +49,7 @@ status: implementable
                * [Delete of the entire KubeadmControlPlane (kubectl delete controlplane my-controlplane)](#delete-of-the-entire-kubeadmcontrolplane-kubectl-delete-controlplane-my-controlplane)
                * [KubeadmControlPlane rollout](#kubeadmcontrolplane-rollout)
                * [Rolling update strategy](#rolling-update-strategy)
-               * [Constraints and Assumptions](#constraints-and-assumptions)                
+               * [Constraints and Assumptions](#constraints-and-assumptions)
                * [Remediation (using delete-and-recreate)](#remediation-using-delete-and-recreate)
                   * [Why delete and recreate](#why-delete-and-recreate)
                   * [Scenario 1: Three replicas, one machine marked for remediation](#scenario-1-three-replicas-one-machine-marked-for-remediation)
@@ -216,7 +216,7 @@ And the following defaulting:
       // Default is RollingUpdate.
       // +optional
       Type RolloutStrategyType `json:"type,omitempty"`
-    
+
       // Rolling update config params. Present only if
       // RolloutStrategyType = RollingUpdate.
       // +optional
@@ -421,24 +421,24 @@ KubeadmControlPlane rollout is triggered by:
   - Changes to Version
   - Changes to the kubeadmConfigSpec
   - Changes to the infrastructureRef
-  - The `upgradeAfter` field, which can be set to a specific time in the future
+  - The `rolloutAfter` field, which can be set to a specific time in the future
     - Set to `nil` or the zero value of `time.Time` if no upgrades are desired
     - An upgrade will run after that timestamp is passed
     - Good for scheduling upgrades/SLOs
-    - Set `upgradeAfter` to now (in RFC3339 form) if an upgrade is required immediately
+    - Set `rolloutAfter` to now (in RFC3339 form) if an upgrade is required immediately
 
 - The controller should tolerate the manual or automatic removal of a replica during the upgrade process. A replica that fails during the upgrade may block the completion of the upgrade. Removal or other remedial action may be necessary to allow the upgrade to complete.
 
 - In order to determine if a Machine to be rolled out, KCP implements the following:
     - The infrastructureRef link used by each machine at creation time is stored in annotations at machine level.
     - The kubeadmConfigSpec used by each machine at creation time is stored in annotations at machine level.
-        - If the annotation is not present (machine is either old or adopted), we won't roll out on any possible changes made in KCP's ClusterConfiguration given that we don't have enough information to make a decision. Users should use KCP.Spec.UpgradeAfter field to force a rollout in this case.
+        - If the annotation is not present (machine is either old or adopted), we won't roll out on any possible changes made in KCP's ClusterConfiguration given that we don't have enough information to make a decision. Users should use KCP.Spec.RolloutAfter field to force a rollout in this case.
 
 ##### Rolling update strategy
 
 Currently KubeadmControlPlane supports only one rollout strategy type the `RollingUpdateStrategyType`. Rolling upgrade strategy's behavior can be modified by using `MaxSurge` field. The field values can be an absolute number 0 or 1.
 
-When `MaxSurge` is set to 1 the rollout algorithm is as follows:  
+When `MaxSurge` is set to 1 the rollout algorithm is as follows:
 
   - Find Machines that have an outdated spec
   - If there is a machine requiring rollout


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

UpgradeAfter is a bit confusing especially now that we have a RolloutStrategy for KCP with maxSurge/maxUnavailable. A rollout doesn't necessarily mean an upgrade is taking place.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4534


/kind release-blocking
/area api
/milestone v0.4

