### PR TITLE
🌱 Replace deprecated func in `getMaxUnhealthy`

### DIFF
--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -590,7 +590,7 @@ func getMaxUnhealthy(mhc *clusterv1.MachineHealthCheck) (int, error) {
 	if mhc.Spec.MaxUnhealthy == nil {
 		return 0, errors.New("spec.maxUnhealthy must be set")
 	}
-	maxUnhealthy, err := intstr.GetValueFromIntOrPercent(mhc.Spec.MaxUnhealthy, int(mhc.Status.ExpectedMachines), false)
+	maxUnhealthy, err := intstr.GetScaledValueFromIntOrPercent(mhc.Spec.MaxUnhealthy, int(mhc.Status.ExpectedMachines), false)
 	if err != nil {
 		return 0, err
 	}

--- a/controllers/machinehealthcheck_controller_test.go
+++ b/controllers/machinehealthcheck_controller_test.go
@@ -2183,7 +2183,7 @@ func TestGetMaxUnhealthy(t *testing.T) {
 			maxUnhealthy:         &intstr.IntOrString{Type: intstr.String, StrVal: "abcdef"},
 			expectedMaxUnhealthy: 0,
 			actualMachineCount:   3,
-			expectedErr:          errors.New("invalid value for IntOrString: invalid value \"abcdef\": strconv.Atoi: parsing \"abcdef\": invalid syntax"),
+			expectedErr:          errors.New("invalid value for IntOrString: invalid type: string is not a percentage"),
 		},
 		{
 			name:                 "when maxUnhealthy is an int",


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Replace deprecated func `intstr.GetValueFromIntOrPercent`  with `intstr.GetScaledValueFromIntOrPercent` for `getMaxUnhealthy` in `controllers/machinehealthcheck_controller.go`

`GetValueFromIntOrPercent` was deprecated in favor of `GetScaledValueFromIntOrPercent`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
