### PR TITLE
⚠️ Remove unused DNSAddOnType constants from kubeadm/v1alpha4

### DIFF
--- a/bootstrap/kubeadm/api/v1alpha4/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1alpha4/kubeadm_types.go
@@ -154,17 +154,6 @@ type APIServer struct {
 	TimeoutForControlPlane *metav1.Duration `json:"timeoutForControlPlane,omitempty"`
 }
 
-// DNSAddOnType defines string identifying DNS add-on types.
-type DNSAddOnType string
-
-const (
-	// CoreDNS add-on type.
-	CoreDNS DNSAddOnType = "CoreDNS"
-
-	// KubeDNS add-on type.
-	KubeDNS DNSAddOnType = "kube-dns"
-)
-
 // DNS defines the DNS addon that should be used in the cluster.
 type DNS struct {
 	// ImageMeta allows to customize the image used for the DNS component

--- a/controlplane/kubeadm/internal/kubeadm_config_map.go
+++ b/controlplane/kubeadm/internal/kubeadm_config_map.go
@@ -36,7 +36,6 @@ const (
 	statusAPIEndpointsKey    = "apiEndpoints"
 	configVersionKey         = "kubernetesVersion"
 	dnsKey                   = "dns"
-	dnsTypeKey               = "type"
 	dnsImageRepositoryKey    = "imageRepository"
 	dnsImageTagKey           = "imageTag"
 	configImageRepositoryKey = "imageRepository"
@@ -205,7 +204,6 @@ func (k *kubeadmConfig) UpdateCoreDNSImageInfo(repository, tag string) error {
 		return errors.Wrapf(err, "unable to decode kubeadm ConfigMap's %q to Unstructured object", clusterConfigurationKey)
 	}
 	dnsMap := map[string]string{
-		dnsTypeKey:            string(bootstrapv1.CoreDNS),
 		dnsImageRepositoryKey: repository,
 		dnsImageTagKey:        tag,
 	}

--- a/controlplane/kubeadm/internal/kubeadm_config_map_test.go
+++ b/controlplane/kubeadm/internal/kubeadm_config_map_test.go
@@ -389,7 +389,6 @@ scheduler: {}`,
 
 			g.Expect(yaml.Unmarshal([]byte(kc.ConfigMap.Data[clusterConfigurationKey]), &actualClusterConfig)).To(Succeed())
 			actualDNS := actualClusterConfig.DNS
-			g.Expect(actualDNS.Type).To(BeEquivalentTo(bootstrapv1.CoreDNS))
 			g.Expect(actualDNS.ImageRepository).To(Equal(imageRepository))
 			g.Expect(actualDNS.ImageTag).To(Equal(imageTag))
 		})
@@ -576,8 +575,8 @@ kind: ClusterConfiguration
     name: mount1
   - hostPath: /a/b
     mountPath: /c/d
-    name: mount2   
-  timeoutForControlPlane: 3m0s 
+    name: mount2
+  timeoutForControlPlane: 3m0s
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
 `},
@@ -612,8 +611,8 @@ kind: ClusterConfiguration
     name: mount1
   - hostPath: /a/b
     mountPath: /c/d
-    name: mount2   
-  timeoutForControlPlane: 3m0s 
+    name: mount2
+  timeoutForControlPlane: 3m0s
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
 `,


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove unused DNSAddOnType constants from kubeadm/v1alpha4

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #4546 
