### PR TITLE
🐛 Allow clusterctl config cluster --from on empty clusters

### DIFF
--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -228,11 +228,6 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 		return nil, err
 	}
 
-	// Ensure this command only runs against management clusters with the current Cluster API contract.
-	if err := cluster.ProviderInventory().CheckCAPIContract(); err != nil {
-		return nil, err
-	}
-
 	// If the option specifying the targetNamespace is empty, try to detect it.
 	if options.TargetNamespace == "" {
 		currentNamespace, err := cluster.Proxy().CurrentNamespace()
@@ -252,6 +247,10 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 
 	// Gets the workload cluster template from the selected source
 	if options.ProviderRepositorySource != nil {
+		// Ensure this command only runs against management clusters with the current Cluster API contract.
+		if err := cluster.ProviderInventory().CheckCAPIContract(); err != nil {
+			return nil, err
+		}
 		return c.getTemplateFromRepository(cluster, options)
 	}
 	if options.ConfigMapSource != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fix a version check too much restrictive preventing to run `clusterctl config cluster --from` on an empty cluster.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4552

/assign @vincepri 