### PR TITLE
✨ Add ipv6 support to capd

### DIFF
--- a/api/v1alpha4/cluster_types.go
+++ b/api/v1alpha4/cluster_types.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -213,6 +214,87 @@ func (c *Cluster) GetConditions() Conditions {
 
 func (c *Cluster) SetConditions(conditions Conditions) {
 	c.Status.Conditions = conditions
+}
+
+func (c *Cluster) GetIPFamily() (ClusterIPFamily, error) {
+	var podCIDRs, serviceCIDRs []string
+	if c.Spec.ClusterNetwork != nil {
+		if c.Spec.ClusterNetwork.Pods != nil {
+			podCIDRs = c.Spec.ClusterNetwork.Pods.CIDRBlocks
+		}
+		if c.Spec.ClusterNetwork.Services != nil {
+			serviceCIDRs = c.Spec.ClusterNetwork.Services.CIDRBlocks
+		}
+	}
+	if len(podCIDRs) == 0 && len(serviceCIDRs) == 0 {
+		return IPv4IPFamily, nil
+	}
+
+	podsIPFamily, err := ipFamilyForCIDRStrings(podCIDRs)
+	if err != nil {
+		return InvalidIPFamily, fmt.Errorf("pods: %s", err)
+	}
+	if len(serviceCIDRs) == 0 {
+		return podsIPFamily, nil
+	}
+
+	servicesIPFamily, err := ipFamilyForCIDRStrings(serviceCIDRs)
+	if err != nil {
+		return InvalidIPFamily, fmt.Errorf("services: %s", err)
+	}
+	if len(podCIDRs) == 0 {
+		return servicesIPFamily, nil
+	}
+
+	if podsIPFamily == DualStackIPFamily {
+		return DualStackIPFamily, nil
+	} else if podsIPFamily != servicesIPFamily {
+		return InvalidIPFamily, errors.New("pods and services IP family mismatch")
+	}
+
+	return podsIPFamily, nil
+}
+
+func ipFamilyForCIDRStrings(cidrs []string) (ClusterIPFamily, error) {
+	if len(cidrs) > 2 {
+		return InvalidIPFamily, errors.New("too many CIDRs specified")
+	}
+	var foundIPv4 bool
+	var foundIPv6 bool
+	for _, cidr := range cidrs {
+		ip, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return InvalidIPFamily, fmt.Errorf("could not parse CIDR: %s", err)
+		}
+		if ip.To4() != nil {
+			foundIPv4 = true
+		} else {
+			foundIPv6 = true
+		}
+	}
+	switch {
+	case foundIPv4 && foundIPv6:
+		return DualStackIPFamily, nil
+	case foundIPv4:
+		return IPv4IPFamily, nil
+	case foundIPv6:
+		return IPv6IPFamily, nil
+	default:
+		return InvalidIPFamily, nil
+	}
+}
+
+type ClusterIPFamily int
+
+const (
+	InvalidIPFamily ClusterIPFamily = iota
+	IPv4IPFamily
+	IPv6IPFamily
+	DualStackIPFamily
+)
+
+func (f ClusterIPFamily) String() string {
+	return [...]string{"InvalidIPFamily", "IPv4IPFamily", "IPv6IPFamily", "DualStackIPFamily"}[f]
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha4/cluster_types_test.go
+++ b/api/v1alpha4/cluster_types_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestClusterIPFamily(t *testing.T) {
+	clusterWithNetwork := func(podCIDRs, serviceCIDRs []string) *Cluster {
+		return &Cluster{
+			Spec: ClusterSpec{
+				ClusterNetwork: &ClusterNetwork{
+					Pods: &NetworkRanges{
+						CIDRBlocks: podCIDRs,
+					},
+					Services: &NetworkRanges{
+						CIDRBlocks: serviceCIDRs,
+					},
+				},
+			},
+		}
+	}
+
+	validAndUnambiguous := []struct {
+		name      string
+		expectRes ClusterIPFamily
+		c         *Cluster
+	}{
+		{
+			name:      "pods: ipv4, services: ipv4",
+			expectRes: IPv4IPFamily,
+			c:         clusterWithNetwork([]string{"192.168.0.0/16"}, []string{"10.128.0.0/12"}),
+		},
+		{
+			name:      "pods: ipv4, services: nil",
+			expectRes: IPv4IPFamily,
+			c:         clusterWithNetwork([]string{"192.168.0.0/16"}, nil),
+		},
+		{
+			name:      "pods: ipv6, services: nil",
+			expectRes: IPv6IPFamily,
+			c:         clusterWithNetwork([]string{"fd00:100:96::/48"}, nil),
+		},
+		{
+			name:      "pods: ipv6, services: ipv6",
+			expectRes: IPv6IPFamily,
+			c:         clusterWithNetwork([]string{"fd00:100:96::/48"}, []string{"fd00:100:64::/108"}),
+		},
+		{
+			name:      "pods: dual-stack, services: nil",
+			expectRes: DualStackIPFamily,
+			c:         clusterWithNetwork([]string{"192.168.0.0/16", "fd00:100:96::/48"}, nil),
+		},
+		{
+			name:      "pods: dual-stack, services: ipv4",
+			expectRes: DualStackIPFamily,
+			c:         clusterWithNetwork([]string{"192.168.0.0/16", "fd00:100:96::/48"}, []string{"10.128.0.0/12"}),
+		},
+		{
+			name:      "pods: dual-stack, services: ipv6",
+			expectRes: DualStackIPFamily,
+			c:         clusterWithNetwork([]string{"192.168.0.0/16", "fd00:100:96::/48"}, []string{"fd00:100:64::/108"}),
+		},
+		{
+			name:      "pods: dual-stack, services: dual-stack",
+			expectRes: DualStackIPFamily,
+			c:         clusterWithNetwork([]string{"192.168.0.0/16", "fd00:100:96::/48"}, []string{"10.128.0.0/12", "fd00:100:64::/108"}),
+		},
+		{
+			name:      "pods: nil, services: dual-stack",
+			expectRes: DualStackIPFamily,
+			c:         clusterWithNetwork(nil, []string{"10.128.0.0/12", "fd00:100:64::/108"}),
+		},
+	}
+
+	for _, tt := range validAndUnambiguous {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ipFamily, err := tt.c.GetIPFamily()
+			g.Expect(ipFamily).To(Equal(tt.expectRes))
+			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+
+	validButAmbiguous := []struct {
+		name      string
+		expectRes ClusterIPFamily
+		c         *Cluster
+	}{
+		{
+			name: "pods: nil, services: nil",
+			// this could  be ipv4, ipv6, or dual-stack; assume ipv4 for now though
+			expectRes: IPv4IPFamily,
+			c:         clusterWithNetwork(nil, nil),
+		},
+		{
+			name: "pods: nil, services: ipv4",
+			// this could be a dual-stack; assume ipv4 for now though
+			expectRes: IPv4IPFamily,
+			c:         clusterWithNetwork(nil, []string{"10.128.0.0/12"}),
+		},
+		{
+			name: "pods: nil, services: ipv6",
+			// this could be dual-stack; assume ipv6 for now though
+			expectRes: IPv6IPFamily,
+			c:         clusterWithNetwork(nil, []string{"fd00:100:64::/108"}),
+		},
+	}
+
+	for _, tt := range validButAmbiguous {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ipFamily, err := tt.c.GetIPFamily()
+			g.Expect(ipFamily).To(Equal(tt.expectRes))
+			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+
+	invalid := []struct {
+		name      string
+		expectErr string
+		c         *Cluster
+	}{
+		{
+			name:      "pods: ipv4, services: ipv6",
+			expectErr: "pods and services IP family mismatch",
+			c:         clusterWithNetwork([]string{"192.168.0.0/16"}, []string{"fd00:100:64::/108"}),
+		},
+		{
+			name:      "pods: ipv6, services: ipv4",
+			expectErr: "pods and services IP family mismatch",
+			c:         clusterWithNetwork([]string{"fd00:100:96::/48"}, []string{"10.128.0.0/12"}),
+		},
+		{
+			name:      "pods: ipv6, services: dual-stack",
+			expectErr: "pods and services IP family mismatch",
+			c:         clusterWithNetwork([]string{"fd00:100:96::/48"}, []string{"10.128.0.0/12", "fd00:100:64::/108"}),
+		},
+		{
+			name:      "pods: ipv4, services: dual-stack",
+			expectErr: "pods and services IP family mismatch",
+			c:         clusterWithNetwork([]string{"192.168.0.0/16"}, []string{"10.128.0.0/12", "fd00:100:64::/108"}),
+		},
+		{
+			name:      "pods: ipv4, services: dual-stack",
+			expectErr: "pods and services IP family mismatch",
+			c:         clusterWithNetwork([]string{"192.168.0.0/16"}, []string{"10.128.0.0/12", "fd00:100:64::/108"}),
+		},
+		{
+			name:      "pods: bad cidr",
+			expectErr: "pods: could not parse CIDR",
+			c:         clusterWithNetwork([]string{"foo"}, nil),
+		},
+		{
+			name:      "services: bad cidr",
+			expectErr: "services: could not parse CIDR",
+			c:         clusterWithNetwork([]string{"192.168.0.0/16"}, []string{"foo"}),
+		},
+		{
+			name:      "pods: too many cidrs",
+			expectErr: "pods: too many CIDRs specified",
+			c:         clusterWithNetwork([]string{"192.168.0.0/16", "fd00:100:96::/48", "10.128.0.0/12"}, nil),
+		},
+		{
+			name:      "services: too many cidrs",
+			expectErr: "services: too many CIDRs specified",
+			c:         clusterWithNetwork(nil, []string{"192.168.0.0/16", "fd00:100:96::/48", "10.128.0.0/12"}),
+		},
+	}
+
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ipFamily, err := tt.c.GetIPFamily()
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err).To(MatchError(ContainSubstring(tt.expectErr)))
+			g.Expect(ipFamily).To(Equal(InvalidIPFamily))
+		})
+	}
+}

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -69,6 +69,7 @@ cluster-templates-v1alpha4: $(KUSTOMIZE) ## Generate cluster templates for v1alp
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-node-drain --load_restrictor none > $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-node-drain.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-upgrades --load_restrictor none > $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-upgrades.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-kcp-scale-in --load_restrictor none > $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-kcp-scale-in.yaml
+	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-ipv6 --load_restrictor none > $(DOCKER_TEMPLATES)/v1alpha4/cluster-template-ipv6.yaml
 ## --------------------------------------
 ## Testing
 ## --------------------------------------

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -40,6 +40,7 @@ const (
 	KubernetesVersionUpgradeTo   = "KUBERNETES_VERSION_UPGRADE_TO"
 	EtcdVersionUpgradeTo         = "ETCD_VERSION_UPGRADE_TO"
 	CoreDNSVersionUpgradeTo      = "COREDNS_VERSION_UPGRADE_TO"
+	IPFamily                     = "IP_FAMILY"
 )
 
 func Byf(format string, a ...interface{}) {

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -104,6 +104,7 @@ providers:
     - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-node-drain.yaml"
     - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-upgrades.yaml"
     - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-kcp-scale-in.yaml"
+    - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template-ipv6.yaml"
     - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
 
 variables:
@@ -115,8 +116,8 @@ variables:
   KUBERNETES_VERSION_UPGRADE_TO: "v1.19.1"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.18.2"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
+  IP_FAMILY: "IPv4"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"
-  # IMPORTANT! This values should match the one used by the CNI provider
   DOCKER_POD_CIDRS: "192.168.0.0/16"
   CNI: "./data/cni/kindnet/kindnet.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"

--- a/test/e2e/data/cni/kindnet/kindnet.yaml
+++ b/test/e2e/data/cni/kindnet/kindnet.yaml
@@ -78,7 +78,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: POD_SUBNET
-              value: "192.168.0.0/16"
+              value: '${DOCKER_POD_CIDRS}'
           volumeMounts:
             - name: cni-cfg
               mountPath: /etc/cni/net.d

--- a/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-ipv6/kcp-ipv6.yaml
+++ b/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-ipv6/kcp-ipv6.yaml
@@ -1,0 +1,22 @@
+---
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        # host.docker.internal is required by kubetest when running on MacOS because of the way ports are proxied.
+        certSANs: [localhost, "::", "::1", host.docker.internal]
+    initConfiguration:
+      localAPIEndpoint:
+        advertiseAddress: '::'
+        bindPort: 6443
+      nodeRegistration:
+        kubeletExtraArgs:
+          node-ip: "::"
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          node-ip: "::"

--- a/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-ipv6/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-ipv6/kustomization.yaml
@@ -1,0 +1,8 @@
+bases:
+  - ../bases/cluster-with-kcp.yaml
+  - ../bases/md.yaml
+  - ../bases/crs.yaml
+
+patchesStrategicMerge:
+  - ./md-ipv6.yaml
+  - ./kcp-ipv6.yaml

--- a/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-ipv6/md-ipv6.yaml
+++ b/test/e2e/data/infrastructure-docker/v1alpha4/cluster-template-ipv6/md-ipv6.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+spec:
+  template:
+    spec:
+      initConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-ip: "::"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-ip: "::"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -185,6 +185,7 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 			Name:               config.ManagementClusterName,
 			RequiresDockerSock: config.HasDockerProvider(),
 			Images:             config.Images,
+			IPFamily:           config.GetVariable(IPFamily),
 		})
 		Expect(clusterProvider).ToNot(BeNil(), "Failed to create a bootstrap cluster")
 

--- a/test/e2e/quick_start.go
+++ b/test/e2e/quick_start.go
@@ -72,6 +72,11 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 	It("Should create a workload cluster", func() {
 		By("Creating a workload cluster")
 
+		flavor := clusterctl.DefaultFlavor
+		if input.E2EConfig.GetVariable(IPFamily) == "IPv6" {
+			flavor = "ipv6"
+		}
+
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: input.BootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{
@@ -79,7 +84,7 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 				ClusterctlConfigPath:     input.ClusterctlConfigPath,
 				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
 				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
-				Flavor:                   clusterctl.DefaultFlavor,
+				Flavor:                   flavor,
 				Namespace:                namespace.Name,
 				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
 				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),

--- a/test/framework/bootstrap/kind_util.go
+++ b/test/framework/bootstrap/kind_util.go
@@ -42,6 +42,9 @@ type CreateKindBootstrapClusterAndLoadImagesInput struct {
 
 	// Images to be loaded in the cluster (this is kind specific)
 	Images []clusterctl.ContainerImage
+
+	// IPFamily is either ipv4 or ipv6. Default is ipv4.
+	IPFamily string
 }
 
 // CreateKindBootstrapClusterAndLoadImages returns a new Kubernetes cluster with pre-loaded images.
@@ -55,6 +58,10 @@ func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKi
 	if input.RequiresDockerSock {
 		options = append(options, WithDockerSockMount())
 	}
+	if input.IPFamily == "IPv6" {
+		options = append(options, WithIPv6Family())
+	}
+
 	clusterProvider := NewKindClusterProvider(input.Name, options...)
 	Expect(clusterProvider).ToNot(BeNil(), "Failed to create a kind cluster")
 

--- a/test/infrastructure/docker/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/controllers/dockercluster_controller.go
@@ -72,7 +72,7 @@ func (r *DockerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	log = log.WithValues("cluster", cluster.Name)
 
 	// Create a helper for managing a docker container hosting the loadbalancer.
-	externalLoadBalancer, err := docker.NewLoadBalancer(cluster.Name)
+	externalLoadBalancer, err := docker.NewLoadBalancer(cluster)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the externalLoadBalancer")
 	}
@@ -141,14 +141,14 @@ func (r *DockerClusterReconciler) reconcileNormal(ctx context.Context, dockerClu
 	}
 
 	// Set APIEndpoints with the load balancer IP so the Cluster API Cluster Controller can pull it
-	lbip4, err := externalLoadBalancer.IP(ctx)
+	lbIP, err := externalLoadBalancer.IP(ctx)
 	if err != nil {
 		conditions.MarkFalse(dockerCluster, infrav1.LoadBalancerAvailableCondition, infrav1.LoadBalancerProvisioningFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
 		return ctrl.Result{}, errors.Wrap(err, "failed to get ip for the load balancer")
 	}
 
 	dockerCluster.Spec.ControlPlaneEndpoint = infrav1.APIEndpoint{
-		Host: lbip4,
+		Host: lbIP,
 		Port: 6443,
 	}
 

--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
@@ -138,7 +138,7 @@ func (r *DockerMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Create a helper for managing the docker container hosting the machine.
-	externalMachine, err := docker.NewMachine(cluster.Name, machine.Name, dockerMachine.Spec.CustomImage, nil)
+	externalMachine, err := docker.NewMachine(cluster, machine.Name, dockerMachine.Spec.CustomImage, nil)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the externalMachine")
 	}
@@ -147,7 +147,7 @@ func (r *DockerMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// NB. the machine controller has to manage the cluster load balancer because the current implementation of the
 	// docker load balancer does not support auto-discovery of control plane nodes, so CAPD should take care of
 	// updating the cluster load balancer configuration when control plane machines are added/removed
-	externalLoadBalancer, err := docker.NewLoadBalancer(cluster.Name)
+	externalLoadBalancer, err := docker.NewLoadBalancer(cluster)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the externalLoadBalancer")
 	}

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -1,0 +1,132 @@
+# Creates a cluster with one control-plane node and one worker node
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: DockerCluster
+metadata:
+  name: my-cluster
+  namespace: default
+---
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: Cluster
+metadata:
+  name: my-cluster
+  namespace: default
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ["fd00:100:64::/108"]
+    pods:
+      cidrBlocks: ["fd00:100:96::/48"]
+    serviceDomain: "cluster.local"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    kind: KubeadmControlPlane
+    name: controlplane
+    namespace: default
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    kind: DockerCluster
+    name: my-cluster
+    namespace: default
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: DockerMachineTemplate
+metadata:
+  name: controlplane
+  namespace: default
+spec:
+  template:
+    spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+kind: KubeadmControlPlane
+metadata:
+  name: controlplane
+  namespace: default
+spec:
+  replicas: 1
+  version: v1.19.1
+  infrastructureTemplate:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    kind: DockerMachineTemplate
+    name: controlplane
+    namespace: default
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+        - localhost
+        - 127.0.0.1
+        - 0.0.0.0
+        - "::"
+        - "::1"
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+    initConfiguration:
+      localAPIEndpoint:
+        advertiseAddress: '::'
+        bindPort: 6443
+      nodeRegistration:
+        kubeletExtraArgs:
+          # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+          # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+          node-ip: "::"
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          node-ip: "::"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+kind: DockerMachineTemplate
+metadata:
+  name: worker
+  namespace: default
+spec:
+  template:
+    spec: {}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+kind: KubeadmConfigTemplate
+metadata:
+  name: worker
+spec:
+  template:
+    spec:
+      initConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-ip: "::"
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+            cgroup-driver: cgroupfs
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+            node-ip: "::"
+---
+apiVersion: cluster.x-k8s.io/v1alpha4
+kind: MachineDeployment
+metadata:
+  name: worker-md-0
+spec:
+  clusterName: my-cluster
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: my-cluster
+  template:
+    spec:
+      version: v1.19.1
+      clusterName: my-cluster
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+          kind: KubeadmConfigTemplate
+          name: worker
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        kind: DockerMachineTemplate
+        name: worker

--- a/test/infrastructure/docker/exp/docker/nodepool.go
+++ b/test/infrastructure/docker/exp/docker/nodepool.go
@@ -83,7 +83,7 @@ func (np *NodePool) ReconcileMachines(ctx context.Context) (ctrl.Result, error) 
 	for _, machine := range np.machines {
 		totalNumberOfMachines++
 		if totalNumberOfMachines > desiredReplicas || !np.isMachineMatchingInfrastructureSpec(machine) {
-			externalMachine, err := docker.NewMachine(np.cluster.Name, machine.Name(), np.dockerMachinePool.Spec.Template.CustomImage, np.labelFilters)
+			externalMachine, err := docker.NewMachine(np.cluster, machine.Name(), np.dockerMachinePool.Spec.Template.CustomImage, np.labelFilters)
 			if err != nil {
 				return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the externalMachine named %s", machine.Name())
 			}
@@ -148,7 +148,7 @@ func (np *NodePool) ReconcileMachines(ctx context.Context) (ctrl.Result, error) 
 // Delete will delete all of the machines in the node pool.
 func (np *NodePool) Delete(ctx context.Context) error {
 	for _, machine := range np.machines {
-		externalMachine, err := docker.NewMachine(np.cluster.Name, machine.Name(), np.dockerMachinePool.Spec.Template.CustomImage, np.labelFilters)
+		externalMachine, err := docker.NewMachine(np.cluster, machine.Name(), np.dockerMachinePool.Spec.Template.CustomImage, np.labelFilters)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create helper for managing the externalMachine named %s", machine.Name())
 		}
@@ -180,7 +180,7 @@ func (np *NodePool) machinesMatchingInfrastructureSpec() []*docker.Machine {
 // addMachine will add a new machine to the node pool and update the docker machine pool status.
 func (np *NodePool) addMachine(ctx context.Context) error {
 	instanceName := fmt.Sprintf("worker-%s", util.RandomString(6))
-	externalMachine, err := docker.NewMachine(np.cluster.Name, instanceName, np.dockerMachinePool.Spec.Template.CustomImage, np.labelFilters)
+	externalMachine, err := docker.NewMachine(np.cluster, instanceName, np.dockerMachinePool.Spec.Template.CustomImage, np.labelFilters)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create helper for managing the externalMachine named %s", instanceName)
 	}
@@ -194,7 +194,7 @@ func (np *NodePool) addMachine(ctx context.Context) error {
 // refresh asks docker to list all the machines matching the node pool label and updates the cached list of node pool
 // machines.
 func (np *NodePool) refresh() error {
-	machines, err := docker.ListMachinesByCluster(np.cluster.Name, np.labelFilters)
+	machines, err := docker.ListMachinesByCluster(np.cluster, np.labelFilters)
 	if err != nil {
 		return errors.Wrapf(err, "failed to list all machines in the cluster")
 	}
@@ -241,7 +241,7 @@ func (np *NodePool) reconcileMachine(ctx context.Context, machine *docker.Machin
 		}
 	}()
 
-	externalMachine, err := docker.NewMachine(np.cluster.Name, machine.Name(), np.dockerMachinePool.Spec.Template.CustomImage, np.labelFilters)
+	externalMachine, err := docker.NewMachine(np.cluster, machine.Name(), np.dockerMachinePool.Spec.Template.CustomImage, np.labelFilters)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the externalMachine named %s", machine.Name())
 	}


### PR DESCRIPTION
quickstart e2e test can be run with:
```
IP_FAMILY=IPv6 \
DOCKER_SERVICE_CIDRS="fd00:100:64::/108" \
DOCKER_POD_CIDRS="fd00:100:96::/48" \
make test-e2e
```
Note: `POD_SUBNET` in kindnet.yaml is now set automatically based on `DOCKER_POD_CIDRS`

`IPFamily()` method on `Cluster` determines the ip family based on the service CIDRs and pod CIDRs. This is used by the docker provider to configure the docker machines accordingly.

Related feature request: https://github.com/kubernetes-sigs/cluster-api/issues/4557

cc @christianang
