### PR TITLE
🐛 Release-0.3: Allow clusterctl config cluster --from on empty clusters

### DIFF
--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -229,11 +229,6 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 		return nil, err
 	}
 
-	// Ensure this command only runs against management clusters with the current Cluster API contract.
-	if err := cluster.ProviderInventory().CheckCAPIContract(); err != nil {
-		return nil, err
-	}
-
 	// If the option specifying the targetNamespace is empty, try to detect it.
 	if options.TargetNamespace == "" {
 		currentNamespace, err := cluster.Proxy().CurrentNamespace()
@@ -253,6 +248,10 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 
 	// Gets the workload cluster template from the selected source
 	if options.ProviderRepositorySource != nil {
+		// Ensure this command only runs against management clusters with the current Cluster API contract.
+		if err := cluster.ProviderInventory().CheckCAPIContract(); err != nil {
+			return nil, err
+		}
 		return c.getTemplateFromRepository(cluster, options)
 	}
 	if options.ConfigMapSource != nil {

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -615,6 +615,137 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 	}
 }
 
+func Test_clusterctlClient_GetClusterTemplate_onEmptyCluster(t *testing.T) {
+	g := NewWithT(t)
+
+	rawTemplate := templateYAML("ns3", "${ CLUSTER_NAME }")
+
+	// Template on a file
+	tmpDir, err := ioutil.TempDir("", "cc")
+	g.Expect(err).NotTo(HaveOccurred())
+	defer os.RemoveAll(tmpDir)
+
+	path := filepath.Join(tmpDir, "cluster-template.yaml")
+	g.Expect(ioutil.WriteFile(path, rawTemplate, 0600)).To(Succeed())
+
+	// Template in a ConfigMap in a cluster not initialized
+	configMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns1",
+			Name:      "my-template",
+		},
+		Data: map[string]string{
+			"prod": string(rawTemplate),
+		},
+	}
+
+	config1 := newFakeConfig().
+		WithProvider(infraProviderConfig)
+
+	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1).
+		WithObjs(configMap)
+
+	client := newFakeClient(config1).
+		WithCluster(cluster1)
+
+	type args struct {
+		options GetClusterTemplateOptions
+	}
+
+	type templateValues struct {
+		variables       []string
+		targetNamespace string
+		yaml            []byte
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    templateValues
+		wantErr bool
+	}{
+		{
+			name: "repository source - fails because the cluster is not initialized/not v1alpha3",
+			args: args{
+				options: GetClusterTemplateOptions{
+					Kubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
+					ProviderRepositorySource: &ProviderRepositorySourceOptions{
+						InfrastructureProvider: "infra:v3.0.0",
+						Flavor:                 "",
+					},
+					ClusterName:              "test",
+					TargetNamespace:          "ns1",
+					ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "URL source - pass",
+			args: args{
+				options: GetClusterTemplateOptions{
+					Kubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
+					URLSource: &URLSourceOptions{
+						URL: path,
+					},
+					ClusterName:              "test",
+					TargetNamespace:          "ns1",
+					ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				},
+			},
+			want: templateValues{
+				variables:       []string{"CLUSTER_NAME"}, // variable detected
+				targetNamespace: "ns1",
+				yaml:            templateYAML("ns1", "test"), // original template modified with target namespace and variable replacement
+			},
+		},
+		{
+			name: "ConfigMap source - pass",
+			args: args{
+				options: GetClusterTemplateOptions{
+					Kubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
+					ConfigMapSource: &ConfigMapSourceOptions{
+						Namespace: "ns1",
+						Name:      "my-template",
+						DataKey:   "prod",
+					},
+					ClusterName:              "test",
+					TargetNamespace:          "ns1",
+					ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				},
+			},
+			want: templateValues{
+				variables:       []string{"CLUSTER_NAME"}, // variable detected
+				targetNamespace: "ns1",
+				yaml:            templateYAML("ns1", "test"), // original template modified with target namespace and variable replacement
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
+			got, err := client.GetClusterTemplate(tt.args.options)
+			if tt.wantErr {
+				gs.Expect(err).To(HaveOccurred())
+				return
+			}
+			gs.Expect(err).NotTo(HaveOccurred())
+
+			gs.Expect(got.Variables()).To(Equal(tt.want.variables))
+			gs.Expect(got.TargetNamespace()).To(Equal(tt.want.targetNamespace))
+
+			gotYaml, err := got.Yaml()
+			gs.Expect(err).NotTo(HaveOccurred())
+			gs.Expect(gotYaml).To(Equal(tt.want.yaml))
+		})
+	}
+}
+
 func Test_clusterctlClient_ProcessYAML(t *testing.T) {
 	g := NewWithT(t)
 	template := `v1: ${VAR1:=default1}


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR backports https://github.com/kubernetes-sigs/cluster-api/pull/4553 to `release-0.3`

**Which issue(s) this PR fixes**
Fixes #4556 
