### PR TITLE
✨ Add annotation support to util.CloneTemplate to pass them down from templates to machines

### DIFF
--- a/controllers/external/util_test.go
+++ b/controllers/external/util_test.go
@@ -130,7 +130,12 @@ func TestCloneTemplateResourceFound(t *testing.T) {
 				"template": map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"annotations": map[string]interface{}{
-							"test": "annotations",
+							"test-template": "annotations",
+							"precedence":    "template",
+						},
+						"labels": map[string]interface{}{
+							"test-template": "label",
+							"precedence":    "template",
 						},
 					},
 					"spec": map[string]interface{}{
@@ -175,7 +180,12 @@ func TestCloneTemplateResourceFound(t *testing.T) {
 		ClusterName: testClusterName,
 		OwnerRef:    owner.DeepCopy(),
 		Labels: map[string]string{
-			"test-label-1": "value-1",
+			"precedence":               "input",
+			clusterv1.ClusterLabelName: "should-be-overwritten",
+		},
+		Annotations: map[string]string{
+			"precedence": "input",
+			clusterv1.TemplateClonedFromNameAnnotation: "should-be-overwritten",
 		},
 	})
 	g.Expect(err).NotTo(HaveOccurred())
@@ -201,10 +211,12 @@ func TestCloneTemplateResourceFound(t *testing.T) {
 
 	cloneLabels := clone.GetLabels()
 	g.Expect(cloneLabels).To(HaveKeyWithValue(clusterv1.ClusterLabelName, testClusterName))
-	g.Expect(cloneLabels).To(HaveKeyWithValue("test-label-1", "value-1"))
+	g.Expect(cloneLabels).To(HaveKeyWithValue("test-template", "label"))
+	g.Expect(cloneLabels).To(HaveKeyWithValue("precedence", "input"))
 
 	cloneAnnotations := clone.GetAnnotations()
-	g.Expect(cloneAnnotations).To(HaveKeyWithValue("test", "annotations"))
+	g.Expect(cloneAnnotations).To(HaveKeyWithValue("test-template", "annotations"))
+	g.Expect(cloneAnnotations).To(HaveKeyWithValue("precedence", "input"))
 
 	g.Expect(cloneAnnotations).To(HaveKeyWithValue(clusterv1.TemplateClonedFromNameAnnotation, templateRef.Name))
 	g.Expect(cloneAnnotations).To(HaveKeyWithValue(clusterv1.TemplateClonedFromGroupKindAnnotation, templateRef.GroupVersionKind().GroupKind().String()))

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -361,6 +361,7 @@ func (r *MachineSetReconciler) syncReplicas(ctx context.Context, ms *clusterv1.M
 				Namespace:   machine.Namespace,
 				ClusterName: machine.Spec.ClusterName,
 				Labels:      machine.Labels,
+				Annotations: machine.Annotations,
 			})
 			if err != nil {
 				return errors.Wrapf(err, "failed to clone infrastructure configuration for MachineSet %q in namespace %q", ms.Name, ms.Namespace)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds support for annotations to the `util.CloneTemplate` and `util.GenerateTemplate` functions. This is used to pass down annotations from `MachineDeployments`/`MachineSets` to the infrastructure machine resources.

It also extends the tests of the MachineSet controller to verify that labels and annotations are passed down correctly.

**Which issue(s) this PR fixes**:
Fixes #4543 
