### PR TITLE
🐛 fix clusterctl config cluster regression

### DIFF
--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -223,14 +223,14 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 	}
 
 	// Gets  the client for the current management cluster
-	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{options.Kubeconfig, options.YamlProcessor})
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{options.Kubeconfig, options.YamlProcessor})
 	if err != nil {
 		return nil, err
 	}
 
 	// If the option specifying the targetNamespace is empty, try to detect it.
 	if options.TargetNamespace == "" {
-		currentNamespace, err := cluster.Proxy().CurrentNamespace()
+		currentNamespace, err := clusterClient.Proxy().CurrentNamespace()
 		if err != nil {
 			return nil, err
 		}
@@ -248,16 +248,21 @@ func (c *clusterctlClient) GetClusterTemplate(options GetClusterTemplateOptions)
 	// Gets the workload cluster template from the selected source
 	if options.ProviderRepositorySource != nil {
 		// Ensure this command only runs against management clusters with the current Cluster API contract.
-		if err := cluster.ProviderInventory().CheckCAPIContract(); err != nil {
-			return nil, err
+		// NOTE: This command tolerates also not existing cluster (Kubeconfig.Path=="") or clusters not yet initialized in order to allow
+		// users to dry-run the command and take a look at what the cluster will look like; in both scenarios, it is required
+		// to pass provider:version given that auto-discovery can't work without a provider inventory installed in a cluster.
+		if options.Kubeconfig.Path != "" {
+			if err := clusterClient.ProviderInventory().CheckCAPIContract(cluster.AllowCAPINotInstalled{}); err != nil {
+				return nil, err
+			}
 		}
-		return c.getTemplateFromRepository(cluster, options)
+		return c.getTemplateFromRepository(clusterClient, options)
 	}
 	if options.ConfigMapSource != nil {
-		return c.getTemplateFromConfigMap(cluster, *options.ConfigMapSource, options.TargetNamespace, options.ListVariablesOnly)
+		return c.getTemplateFromConfigMap(clusterClient, *options.ConfigMapSource, options.TargetNamespace, options.ListVariablesOnly)
 	}
 	if options.URLSource != nil {
-		return c.getTemplateFromURL(cluster, *options.URLSource, options.TargetNamespace, options.ListVariablesOnly)
+		return c.getTemplateFromURL(clusterClient, *options.URLSource, options.TargetNamespace, options.ListVariablesOnly)
 	}
 
 	return nil, errors.New("unable to read custom template. Please specify a template source")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a clusterctl regression preventing to use the clusterctl library for clusterctl config cluster before the management cluster is created or when the management cluster is not yet initialised. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4569

/assign @vincepri 