### PR TITLE
⚠️ Unexport MachineHealthCheck `patchUnhealthyTargets` method

### DIFF
--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -287,8 +287,8 @@ func (r *MachineHealthCheckReconciler) reconcile(ctx context.Context, logger log
 	m.Status.RemediationsAllowed = remediationCount
 	conditions.MarkTrue(m, clusterv1.RemediationAllowedCondition)
 
-	errList := r.PatchUnhealthyTargets(ctx, logger, unhealthy, cluster, m)
-	errList = append(errList, r.PatchHealthyTargets(ctx, logger, healthy, cluster, m)...)
+	errList := r.patchUnhealthyTargets(ctx, logger, unhealthy, cluster, m)
+	errList = append(errList, r.patchHealthyTargets(ctx, logger, healthy, m)...)
 
 	// handle update errors
 	if len(errList) > 0 {
@@ -306,8 +306,8 @@ func (r *MachineHealthCheckReconciler) reconcile(ctx context.Context, logger log
 	return ctrl.Result{}, nil
 }
 
-// PatchHealthyTargets patches healthy machines with MachineHealthCheckSuccededCondition.
-func (r *MachineHealthCheckReconciler) PatchHealthyTargets(ctx context.Context, logger logr.Logger, healthy []healthCheckTarget, cluster *clusterv1.Cluster, m *clusterv1.MachineHealthCheck) []error {
+// patchHealthyTargets patches healthy machines with MachineHealthCheckSucceededCondition.
+func (r *MachineHealthCheckReconciler) patchHealthyTargets(ctx context.Context, logger logr.Logger, healthy []healthCheckTarget, m *clusterv1.MachineHealthCheck) []error {
 	errList := []error{}
 	for _, t := range healthy {
 		if m.Spec.RemediationTemplate != nil {
@@ -337,8 +337,8 @@ func (r *MachineHealthCheckReconciler) PatchHealthyTargets(ctx context.Context, 
 	return errList
 }
 
-// PatchUnhealthyTargets patches machines with MachineOwnerRemediatedCondition for remediation.
-func (r *MachineHealthCheckReconciler) PatchUnhealthyTargets(ctx context.Context, logger logr.Logger, unhealthy []healthCheckTarget, cluster *clusterv1.Cluster, m *clusterv1.MachineHealthCheck) []error {
+// patchUnhealthyTargets patches machines with MachineOwnerRemediatedCondition for remediation.
+func (r *MachineHealthCheckReconciler) patchUnhealthyTargets(ctx context.Context, logger logr.Logger, unhealthy []healthCheckTarget, cluster *clusterv1.Cluster, m *clusterv1.MachineHealthCheck) []error {
 	// mark for remediation
 	errList := []error{}
 	for _, t := range unhealthy {

--- a/controllers/machinehealthcheck_controller_test.go
+++ b/controllers/machinehealthcheck_controller_test.go
@@ -2617,10 +2617,10 @@ func TestPatchTargets(t *testing.T) {
 	}
 
 	// Target with wrong patch helper will fail but the other one will be patched.
-	g.Expect(len(r.PatchUnhealthyTargets(context.TODO(), log.NullLogger{}, []healthCheckTarget{target1, target3}, defaultCluster, mhc))).To(BeNumerically(">", 0))
+	g.Expect(len(r.patchUnhealthyTargets(context.TODO(), log.NullLogger{}, []healthCheckTarget{target1, target3}, defaultCluster, mhc))).To(BeNumerically(">", 0))
 	g.Expect(cl.Get(ctx, client.ObjectKey{Name: machine2.Name, Namespace: machine2.Namespace}, machine2)).NotTo(HaveOccurred())
 	g.Expect(conditions.Get(machine2, clusterv1.MachineOwnerRemediatedCondition).Status).To(Equal(corev1.ConditionFalse))
 
 	// Target with wrong patch helper will fail but the other one will be patched.
-	g.Expect(len(r.PatchHealthyTargets(context.TODO(), log.NullLogger{}, []healthCheckTarget{target1, target3}, defaultCluster, mhc))).To(BeNumerically(">", 0))
+	g.Expect(len(r.patchHealthyTargets(context.TODO(), log.NullLogger{}, []healthCheckTarget{target1, target3}, mhc))).To(BeNumerically(">", 0))
 }


### PR DESCRIPTION
Tidy: changed empty slice declaration, modified var name that collides with pkg name, fixed typo and removed unused func variable

Signed-off-by: Michael Shitrit <mshitrit@redhat.com>

**Not much just a bit of tidy up fixing couple of minor cosmetic stuff**:

