### PR TITLE
🐛 Return error instead of panic if controlPlaneRef is nil

### DIFF
--- a/cmd/clusterctl/client/tree/discovery.go
+++ b/cmd/clusterctl/client/tree/discovery.go
@@ -18,6 +18,7 @@ package tree
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
@@ -67,11 +68,11 @@ func Discovery(ctx context.Context, c client.Client, namespace, name string, opt
 
 	// Adds control plane
 	if cluster.Spec.ControlPlaneRef == nil {
-		return nil, errors.New("controlplane ref cannot be nil")
+		return nil, errors.New(fmt.Sprintf("spec.controlPlaneRef for Cluster %v is nil, this is unexpected", client.ObjectKeyFromObject(cluster)))
 	}
 	controlPlane, err := external.Get(ctx, c, cluster.Spec.ControlPlaneRef, cluster.Namespace)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get controlplane")
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to get controlplane for cluster %v", client.ObjectKeyFromObject(cluster)))
 	}
 	tree.Add(cluster, controlPlane, ObjectMetaName("ControlPlane"), GroupingObject(true))
 

--- a/cmd/clusterctl/client/tree/discovery.go
+++ b/cmd/clusterctl/client/tree/discovery.go
@@ -18,7 +18,6 @@ package tree
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
@@ -68,11 +67,11 @@ func Discovery(ctx context.Context, c client.Client, namespace, name string, opt
 
 	// Adds control plane
 	if cluster.Spec.ControlPlaneRef == nil {
-		return nil, errors.New(fmt.Sprintf("spec.controlPlaneRef for Cluster %v is nil, this is unexpected", client.ObjectKeyFromObject(cluster)))
+		return nil, errors.Errorf("spec.controlPlaneRef for Cluster %v is nil, this is unexpected", client.ObjectKeyFromObject(cluster))
 	}
 	controlPlane, err := external.Get(ctx, c, cluster.Spec.ControlPlaneRef, cluster.Namespace)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to get controlplane for cluster %v", client.ObjectKeyFromObject(cluster)))
+		return nil, errors.Wrapf(err, "failed to get controlplane for cluster %v", client.ObjectKeyFromObject(cluster))
 	}
 	tree.Add(cluster, controlPlane, ObjectMetaName("ControlPlane"), GroupingObject(true))
 

--- a/cmd/clusterctl/client/tree/discovery.go
+++ b/cmd/clusterctl/client/tree/discovery.go
@@ -67,11 +67,11 @@ func Discovery(ctx context.Context, c client.Client, namespace, name string, opt
 
 	// Adds control plane
 	if cluster.Spec.ControlPlaneRef == nil {
-		return nil, errors.Errorf("controlplane ref cannot be nil")
+		return nil, errors.New("controlplane ref cannot be nil")
 	}
 	controlPlane, err := external.Get(ctx, c, cluster.Spec.ControlPlaneRef, cluster.Namespace)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to get controlplane")
 	}
 	tree.Add(cluster, controlPlane, ObjectMetaName("ControlPlane"), GroupingObject(true))
 

--- a/cmd/clusterctl/client/tree/discovery_test.go
+++ b/cmd/clusterctl/client/tree/discovery_test.go
@@ -268,6 +268,26 @@ func Test_Discovery(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Discovery with no control plane or machine deployments",
+			args: args{
+				discoverOptions: DiscoverOptions{},
+				objs:            test.NewFakeCluster("ns1", "cluster1").Objs(),
+			},
+			wantTree: map[string][]string{
+				// Cluster should be parent of InfrastructureCluster
+				"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns1/cluster1": {
+					"infrastructure.cluster.x-k8s.io/v1alpha4, Kind=GenericInfrastructureCluster, ns1/cluster1",
+				},
+				"infrastructure.cluster.x-k8s.io/v1alpha4, Kind=GenericInfrastructureCluster, ns1/cluster1": {},
+			},
+			wantNodeCheck: map[string]nodeCheck{
+				// InfrastructureCluster should have a meta name
+				"infrastructure.cluster.x-k8s.io/v1alpha4, Kind=GenericInfrastructureCluster, ns1/cluster1": func(g *WithT, obj client.Object) {
+					g.Expect(GetMetaName(obj)).To(Equal("ClusterInfrastructure"))
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**: Return error instead of panic when calling `clusterctl describe cluster` on a Cluster without `controlPlaneRef`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4580

