### PR TITLE
✨ Refactor clusterctl config to clusterctl generate

### DIFF
--- a/cmd/clusterctl/cmd/config.go
+++ b/cmd/clusterctl/cmd/config.go
@@ -22,8 +22,8 @@ import (
 
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Display provider configuration and templates to create workload clusters.",
-	Long:  `Display provider configuration and templates to create workload clusters.`,
+	Short: "Display clusterctl configuration.",
+	Long:  `Display clusterctl configuration.`,
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/config_cluster.go
+++ b/cmd/clusterctl/cmd/config_cluster.go
@@ -25,6 +25,11 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 )
 
+/*
+NOTE: This command is deprecated in favor of `clusterctl generate cluster`. The source code is located at `cmd/clusterctl/cmd/generate_cluster.go`.
+This file will be removed in 0.5.x. Do not make any changes to this file.
+*/
+
 type configClusterOptions struct {
 	kubeconfig             string
 	kubeconfigContext      string
@@ -90,6 +95,7 @@ var configClusterClusterCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGetClusterTemplate(cmd, args[0])
 	},
+	Deprecated: "use `clusterctl generate cluster` instead",
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/config_provider.go
+++ b/cmd/clusterctl/cmd/config_provider.go
@@ -28,6 +28,11 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 )
 
+/*
+NOTE: This command is deprecated in favor of `clusterctl generate provider`. The source code is located at `cmd/clusterctl/cmd/generate_provider.go`.
+This file will be removed in 0.5.x. Do not make any changes to this file.
+*/
+
 const (
 	// ComponentsOutputYaml is an option used to print the components in yaml format.
 	ComponentsOutputYaml = "yaml"
@@ -79,6 +84,7 @@ var configProviderCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGetComponents()
 	},
+	Deprecated: "use `clusterctl generate provider` instead",
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+type generateClusterOptions struct {
+	kubeconfig             string
+	kubeconfigContext      string
+	flavor                 string
+	infrastructureProvider string
+
+	targetNamespace          string
+	kubernetesVersion        string
+	controlPlaneMachineCount int64
+	workerMachineCount       int64
+
+	url                string
+	configMapNamespace string
+	configMapName      string
+	configMapDataKey   string
+
+	listVariables bool
+}
+
+var gc = &generateClusterOptions{}
+
+var generateClusterClusterCmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Generate templates for creating workload clusters.",
+	Long: LongDesc(`
+		Generate templates for creating workload clusters.
+
+		clusterctl ships with a list of known providers; if necessary, edit
+		$HOME/.cluster-api/clusterctl.yaml to add new provider or to customize existing ones.
+
+		Each provider configuration links to a repository; clusterctl uses this information
+		to fetch templates when creating a new cluster.`),
+
+	Example: Examples(`
+		# Generates a yaml file for creating workload clusters using
+		# the pre-installed infrastructure and bootstrap providers.
+		clusterctl generate cluster my-cluster
+
+		# Generates a yaml file for creating workload clusters using
+		# a specific version of the AWS infrastructure provider.
+		clusterctl generate cluster my-cluster --infrastructure=aws:v0.4.1
+
+		# Generates a yaml file for creating workload clusters in a custom namespace.
+		clusterctl generate cluster my-cluster --target-namespace=foo
+
+		# Generates a yaml file for creating workload clusters with a specific Kubernetes version.
+		clusterctl generate cluster my-cluster --kubernetes-version=v1.19.1
+
+		# Generates a yaml file for creating workload clusters with a
+		# custom number of nodes (if supported by the provider's templates).
+		clusterctl generate cluster my-cluster --control-plane-machine-count=3 --worker-machine-count=10
+
+		# Generates a yaml file for creating workload clusters using a template stored in a ConfigMap.
+		clusterctl generate cluster my-cluster --from-config-map MyTemplates
+
+		# Generates a yaml file for creating workload clusters using a template from a specific URL.
+		clusterctl generate cluster my-cluster --from https://github.com/foo-org/foo-repository/blob/master/cluster-template.yaml
+
+		# Generates a yaml file for creating workload clusters using a template stored locally.
+		clusterctl generate cluster my-cluster --from ~/workspace/cluster-template.yaml
+
+		# Prints the list of variables required by the yaml file for creating workload cluster.
+		clusterctl generate cluster my-cluster --list-variables`),
+
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGenerateClusterTemplate(cmd, args[0])
+	},
+}
+
+func init() {
+	generateClusterClusterCmd.Flags().StringVar(&gc.kubeconfig, "kubeconfig", "",
+		"Path to a kubeconfig file to use for the management cluster. If empty, default discovery rules apply.")
+	generateClusterClusterCmd.Flags().StringVar(&gc.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
+
+	// flags for the template variables
+	generateClusterClusterCmd.Flags().StringVarP(&gc.targetNamespace, "target-namespace", "n", "",
+		"The namespace to use for the workload cluster. If unspecified, the current namespace will be used.")
+	generateClusterClusterCmd.Flags().StringVar(&gc.kubernetesVersion, "kubernetes-version", "",
+		"The Kubernetes version to use for the workload cluster. If unspecified, the value from OS environment variables or the .cluster-api/clusterctl.yaml config file will be used.")
+	generateClusterClusterCmd.Flags().Int64Var(&gc.controlPlaneMachineCount, "control-plane-machine-count", 1,
+		"The number of control plane machines for the workload cluster.")
+	generateClusterClusterCmd.Flags().Int64Var(&gc.workerMachineCount, "worker-machine-count", 0,
+		"The number of worker machines for the workload cluster.")
+
+	// flags for the repository source
+	generateClusterClusterCmd.Flags().StringVarP(&gc.infrastructureProvider, "infrastructure", "i", "",
+		"The infrastructure provider to read the workload cluster template from. If unspecified, the default infrastructure provider will be used.")
+	generateClusterClusterCmd.Flags().StringVarP(&gc.flavor, "flavor", "f", "",
+		"The workload cluster template variant to be used when reading from the infrastructure provider repository. If unspecified, the default cluster template will be used.")
+
+	// flags for the url source
+	generateClusterClusterCmd.Flags().StringVar(&gc.url, "from", "",
+		"The URL to read the workload cluster template from. If unspecified, the infrastructure provider repository URL will be used")
+
+	// flags for the config map source
+	generateClusterClusterCmd.Flags().StringVar(&gc.configMapName, "from-config-map", "",
+		"The ConfigMap to read the workload cluster template from. This can be used as alternative to read from the provider repository or from an URL")
+	generateClusterClusterCmd.Flags().StringVar(&gc.configMapNamespace, "from-config-map-namespace", "",
+		"The namespace where the ConfigMap exists. If unspecified, the current namespace will be used")
+	generateClusterClusterCmd.Flags().StringVar(&gc.configMapDataKey, "from-config-map-key", "",
+		fmt.Sprintf("The ConfigMap.Data key where the workload cluster template is hosted. If unspecified, %q will be used", client.DefaultCustomTemplateConfigMapKey))
+
+	// other flags
+	generateClusterClusterCmd.Flags().BoolVar(&gc.listVariables, "list-variables", false,
+		"Returns the list of variables expected by the template instead of the template yaml")
+
+	generateCmd.AddCommand(generateClusterClusterCmd)
+}
+
+func runGenerateClusterTemplate(cmd *cobra.Command, name string) error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	templateOptions := client.GetClusterTemplateOptions{
+		Kubeconfig:        client.Kubeconfig{Path: gc.kubeconfig, Context: gc.kubeconfigContext},
+		ClusterName:       name,
+		TargetNamespace:   gc.targetNamespace,
+		KubernetesVersion: gc.kubernetesVersion,
+		ListVariablesOnly: gc.listVariables,
+	}
+
+	if cmd.Flags().Changed("control-plane-machine-count") {
+		templateOptions.ControlPlaneMachineCount = &gc.controlPlaneMachineCount
+	}
+	if cmd.Flags().Changed("worker-machine-count") {
+		templateOptions.WorkerMachineCount = &gc.workerMachineCount
+	}
+
+	if gc.url != "" {
+		templateOptions.URLSource = &client.URLSourceOptions{
+			URL: gc.url,
+		}
+	}
+
+	if gc.configMapNamespace != "" || gc.configMapName != "" || gc.configMapDataKey != "" {
+		templateOptions.ConfigMapSource = &client.ConfigMapSourceOptions{
+			Namespace: gc.configMapNamespace,
+			Name:      gc.configMapName,
+			DataKey:   gc.configMapDataKey,
+		}
+	}
+
+	if gc.infrastructureProvider != "" || gc.flavor != "" {
+		templateOptions.ProviderRepositorySource = &client.ProviderRepositorySourceOptions{
+			InfrastructureProvider: gc.infrastructureProvider,
+			Flavor:                 gc.flavor,
+		}
+	}
+
+	template, err := c.GetClusterTemplate(templateOptions)
+	if err != nil {
+		return err
+	}
+
+	if gc.listVariables {
+		return printVariablesOutput(template)
+	}
+
+	return printYamlOutput(template)
+}

--- a/cmd/clusterctl/cmd/generate_provider.go
+++ b/cmd/clusterctl/cmd/generate_provider.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+type generateProvidersOptions struct {
+	coreProvider           string
+	bootstrapProvider      string
+	controlPlaneProvider   string
+	infrastructureProvider string
+	targetNamespace        string
+	watchingNamespace      string
+	textOutput             bool
+}
+
+var gpo = &generateProvidersOptions{}
+
+var generateProviderCmd = &cobra.Command{
+	Use:   "provider",
+	Args:  cobra.NoArgs,
+	Short: "Generate templates for provider components.",
+	Long: LongDesc(`
+		Generate templates for provider components.
+
+		clusterctl fetches the provider components from the provider repository and performs variable substitution.
+		
+		Variable values are either sourced from the clusterctl config file or
+		from environment variables`),
+
+	Example: Examples(`
+		# Generates a yaml file for creating provider with variable values using
+        # components defined in the provider repository.
+		clusterctl generate provider --infrastructure aws
+
+		# Generates a yaml file for creating provider for a specific version with variable values using
+        # components defined in the provider repository.
+		clusterctl generate provider --infrastructure aws:v0.4.1
+
+		# Displays information about a specific infrastructure provider.
+		# If applicable, prints out the list of required environment variables.
+		clusterctl generate provider --infrastructure aws --describe
+
+		# Displays information about a specific version of the infrastructure provider.
+		clusterctl generate provider --infrastructure aws:v0.4.1 --describe`),
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGenerateProviderComponents()
+	},
+}
+
+func init() {
+	generateProviderCmd.Flags().StringVar(&gpo.coreProvider, "core", "",
+		"Core provider and version (e.g. cluster-api:v0.3.0)")
+	generateProviderCmd.Flags().StringVarP(&gpo.infrastructureProvider, "infrastructure", "i", "",
+		"Infrastructure provider and version (e.g. aws:v0.5.0)")
+	generateProviderCmd.Flags().StringVarP(&gpo.bootstrapProvider, "bootstrap", "b", "",
+		"Bootstrap provider and version (e.g. kubeadm:v0.3.0)")
+	generateProviderCmd.Flags().StringVarP(&gpo.controlPlaneProvider, "control-plane", "c", "",
+		"ControlPlane provider and version (e.g. kubeadm:v0.3.0)")
+	generateProviderCmd.Flags().StringVar(&gpo.targetNamespace, "target-namespace", "",
+		"The target namespace where the provider should be deployed. If unspecified, the components default namespace is used.")
+	generateProviderCmd.Flags().StringVar(&gpo.watchingNamespace, "watching-namespace", "",
+		"Namespace the provider should watch when reconciling objects. If unspecified, all namespaces are watched.")
+	generateProviderCmd.Flags().BoolVar(&gpo.textOutput, "describe", false,
+		"Generate configuration without variable substitution.")
+
+	generateCmd.AddCommand(generateProviderCmd)
+}
+
+func runGenerateProviderComponents() error {
+	providerName, providerType, err := parseProvider()
+	if err != nil {
+		return err
+	}
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	options := client.ComponentsOptions{
+		TargetNamespace:   gpo.targetNamespace,
+		WatchingNamespace: gpo.watchingNamespace,
+	}
+	components, err := c.GetProviderComponents(providerName, providerType, options)
+	if err != nil {
+		return err
+	}
+
+	if gpo.textOutput {
+		return printComponentsAsText(components)
+	}
+
+	return printYamlOutput(components)
+}
+
+// parseProvider parses command line flags and returns the provider name and type.
+func parseProvider() (string, clusterctlv1.ProviderType, error) {
+	providerName := gpo.coreProvider
+	providerType := clusterctlv1.CoreProviderType
+	if gpo.bootstrapProvider != "" {
+		if providerName != "" {
+			return "", "", errors.New("only one of --core, --bootstrap, --control-plane, --infrastructure should be set")
+		}
+		providerName = gpo.bootstrapProvider
+		providerType = clusterctlv1.BootstrapProviderType
+	}
+	if gpo.controlPlaneProvider != "" {
+		if providerName != "" {
+			return "", "", errors.New("only one of --core, --bootstrap, --control-plane, --infrastructure should be set")
+		}
+		providerName = gpo.controlPlaneProvider
+		providerType = clusterctlv1.ControlPlaneProviderType
+	}
+	if gpo.infrastructureProvider != "" {
+		if providerName != "" {
+			return "", "", errors.New("only one of --core, --bootstrap, --control-plane, --infrastructure should be set")
+		}
+		providerName = gpo.infrastructureProvider
+		providerType = clusterctlv1.InfrastructureProviderType
+	}
+	if providerName == "" {
+		return "", "", errors.New("at least one of --core, --bootstrap, --control-plane, --infrastructure should be set")
+	}
+
+	return providerName, providerType, nil
+}

--- a/cmd/clusterctl/cmd/util.go
+++ b/cmd/clusterctl/cmd/util.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+// printYamlOutput prints the yaml content of a generated template to stdout.
+func printYamlOutput(printer client.YamlPrinter) error {
+	yaml, err := printer.Yaml()
+	if err != nil {
+		return err
+	}
+	yaml = append(yaml, '\n')
+
+	if _, err := os.Stdout.Write(yaml); err != nil {
+		return errors.Wrap(err, "failed to write yaml to Stdout")
+	}
+	return nil
+}
+
+// printVariablesOutput prints the expected variables in the template to stdout.
+func printVariablesOutput(printer client.YamlPrinter) error {
+	if len(printer.Variables()) > 0 {
+		fmt.Println("Variables:")
+		for _, v := range printer.Variables() {
+			fmt.Printf("  - %s\n", v)
+		}
+	}
+	fmt.Println()
+	return nil
+}
+
+// printComponentsAsText prints information about the components to stdout.
+func printComponentsAsText(c client.Components) error {
+	dir, file := filepath.Split(c.URL())
+	// Remove the version suffix from the URL since we already display it
+	// separately.
+	baseURL, _ := filepath.Split(strings.TrimSuffix(dir, "/"))
+	fmt.Printf("Name:               %s\n", c.Name())
+	fmt.Printf("Type:               %s\n", c.Type())
+	fmt.Printf("URL:                %s\n", baseURL)
+	fmt.Printf("Version:            %s\n", c.Version())
+	fmt.Printf("File:               %s\n", file)
+	fmt.Printf("TargetNamespace:    %s\n", c.TargetNamespace())
+	fmt.Printf("WatchingNamespace:  %s\n", c.WatchingNamespace())
+	if len(c.Variables()) > 0 {
+		fmt.Println("Variables:")
+		for _, v := range c.Variables() {
+			fmt.Printf("  - %s\n", v)
+		}
+	}
+	if len(c.Images()) > 0 {
+		fmt.Println("Images:")
+		for _, v := range c.Images() {
+			fmt.Printf("  - %s\n", v)
+		}
+	}
+	fmt.Println()
+
+	return nil
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This pr refactors `clusterct config cluster` and `cluster config provider` to `clusterctl generate cluster` and `clusterctl generate provider` respectively. Some changes to be noted:
- `clusterctl generate provider` -> generates a yaml template of the provider, this is equivalent to `clusterctl config provider -o yaml`
- `clusterctl generate provider --describe` -> displays information about the provider in text, this is equivalent to `clusterctl config provider`
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3360 

** There was an earlier [PR](#4467) that aimed to fix the same issue. Based on the [discussion](https://github.com/kubernetes-sigs/cluster-api/pull/4467#issuecomment-833719760), we're splitting it into two prs, this is the first one.