### PR TITLE
🌱 Include metadata for the CAPI v0.3 releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,6 +476,8 @@ release-manifests: $(RELEASE_DIR) $(KUSTOMIZE) ## Builds the manifests to publis
 	cat $(RELEASE_DIR)/bootstrap-components.yaml >> $(RELEASE_DIR)/cluster-api-components.yaml
 	echo "---" >> $(RELEASE_DIR)/cluster-api-components.yaml
 	cat $(RELEASE_DIR)/control-plane-components.yaml >> $(RELEASE_DIR)/cluster-api-components.yaml
+	# Add metadata to the release artifacts
+	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
 
 .PHONY: release-manifests-dev
 release-manifests-dev: ## Builds the development manifests and copies them in the release folder

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,10 @@
+# maps release series of major.minor to cluster-api contract version
+# the contract version may change between minor or major versions, but *not*
+# between patch versions.
+#
+# update this file only when a new major or minor version is released
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+releaseSeries:
+  - major: 0
+    minor: 3
+    contract: v1alpha3


### PR DESCRIPTION
**What this PR does / why we need it**:
In cluster API v1alpha4 we removed the embedded metadata, but most of the providers are already doing this for the v1alpha3 releases.

This PR is a backport of https://github.com/kubernetes-sigs/cluster-api/pull/4167 that adds metadata.yaml in the CAPI release assets, thus aligning CAPI with the other providers and making it easier v1alpha3 --> v1alpha4 upgrades.