### PR TITLE
:book: Add v1alpha3 to v1alpha4 migration guide to the book summary

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -50,6 +50,7 @@
     - [Provider Implementers](./developer/providers/implementers.md)
         - [v1alpha1 to v1alpha2](./developer/providers/v1alpha1-to-v1alpha2.md)
         - [v1alpha2 to v1alpha3](./developer/providers/v1alpha2-to-v1alpha3.md)
+        - [v1alpha3 to v1alpha4](./developer/providers/v1alpha3-to-v1alpha4.md)
         - [Cluster Infrastructure](./developer/providers/cluster-infrastructure.md)
         - [Machine Infrastructure](./developer/providers/machine-infrastructure.md)
         - [Bootstrap](./developer/providers/bootstrap.md)

--- a/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
+++ b/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
@@ -4,7 +4,7 @@
 
 - The Go version used by Cluster API is now Go 1.16+
   - In case cloudbuild is used to push images, please upgrade to `gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583`
-    in the cloudbuild YAML files.  
+    in the cloudbuild YAML files.
 
 ## Controller Runtime version
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Noticed it was missing.

/milestone v0.4
/assign @fabriziopandini @sbueringer 

