### PR TITLE
🌱 Refactor tests to plain go in util/collections

### DIFF
--- a/util/collections/machine_collection_test.go
+++ b/util/collections/machine_collection_test.go
@@ -17,62 +17,42 @@ limitations under the License.
 package collections_test
 
 import (
-	"sigs.k8s.io/cluster-api/util/collections"
 	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo"
+	"sigs.k8s.io/cluster-api/util/collections"
+
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 func TestMachineCollection(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Machine Collection Suite")
-}
-
-var _ = Describe("Machine Collection", func() {
-	Describe("Machines", func() {
-		var collection collections.Machines
-		BeforeEach(func() {
-			collection = collections.Machines{
-				"machine-4": machine("machine-4", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 04, 02, 03, 04, 05, 06, time.UTC)})),
-				"machine-5": machine("machine-5", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 05, 02, 03, 04, 05, 06, time.UTC)})),
-				"machine-2": machine("machine-2", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 02, 02, 03, 04, 05, 06, time.UTC)})),
-				"machine-1": machine("machine-1", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 01, 02, 03, 04, 05, 06, time.UTC)})),
-				"machine-3": machine("machine-3", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 03, 02, 03, 04, 05, 06, time.UTC)})),
-			}
-		})
-		Describe("SortedByAge", func() {
-			It("should return the same number of machines as are in the collection", func() {
-				sortedMachines := collection.SortedByCreationTimestamp()
-				Expect(sortedMachines).To(HaveLen(len(collection)))
-				Expect(sortedMachines[0].Name).To(Equal("machine-1"))
-				Expect(sortedMachines[len(sortedMachines)-1].Name).To(Equal("machine-5"))
-			})
-		})
-		Describe("Difference", func() {
-			It("returns the collection with elements of the second collection removed", func() {
-				c2 := collection.Filter(func(m *clusterv1.Machine) bool {
-					return m.Name != "machine-1"
-				})
-				c3 := collection.Difference(c2)
-
-				// does not mutate
-				Expect(collection.Names()).To(ContainElement("machine-1"))
-				Expect(c3.Names()).To(ConsistOf("machine-1"))
-			})
-		})
-
-		Describe("Names", func() {
-			It("returns a slice of names of each machine in the collection", func() {
-				Expect(collections.New().Names()).To(BeEmpty())
-				Expect(collections.FromMachines(machine("1"), machine("2")).Names()).To(ConsistOf("1", "2"))
-			})
-		})
+	t.Run("should return the same number of machines as are in the collection", func(t *testing.T) {
+		g := NewWithT(t)
+		collection := machines()
+		sortedMachines := collection.SortedByCreationTimestamp()
+		g.Expect(sortedMachines).To(HaveLen(len(collection)))
+		g.Expect(sortedMachines[0].Name).To(Equal("machine-1"))
+		g.Expect(sortedMachines[len(sortedMachines)-1].Name).To(Equal("machine-5"))
 	})
-})
+	t.Run("returns the collection with elements of the second collection removed", func(t *testing.T) {
+		g := NewWithT(t)
+		collection := machines()
+		c2 := collection.Filter(func(m *clusterv1.Machine) bool {
+			return m.Name != "machine-1"
+		})
+		c3 := collection.Difference(c2)
+		// does not mutate
+		g.Expect(collection.Names()).To(ContainElement("machine-1"))
+		g.Expect(c3.Names()).To(ConsistOf("machine-1"))
+	})
+	t.Run("returns a slice of names of each machine in the collection", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(collections.New().Names()).To(BeEmpty())
+		g.Expect(collections.FromMachines(machine("1"), machine("2")).Names()).To(ConsistOf("1", "2"))
+	})
+}
 
 /* Helper functions to build machine objects for tests */
 
@@ -94,4 +74,14 @@ func machine(name string, opts ...machineOpt) *clusterv1.Machine {
 		opt(m)
 	}
 	return m
+}
+
+func machines() collections.Machines {
+	return collections.Machines{
+		"machine-4": machine("machine-4", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 04, 02, 03, 04, 05, 06, time.UTC)})),
+		"machine-5": machine("machine-5", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 05, 02, 03, 04, 05, 06, time.UTC)})),
+		"machine-2": machine("machine-2", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 02, 02, 03, 04, 05, 06, time.UTC)})),
+		"machine-1": machine("machine-1", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 01, 02, 03, 04, 05, 06, time.UTC)})),
+		"machine-3": machine("machine-3", withCreationTimestamp(metav1.Time{Time: time.Date(2018, 03, 02, 03, 04, 05, 06, time.UTC)})),
+	}
 }

--- a/util/collections/machine_collection_test.go
+++ b/util/collections/machine_collection_test.go
@@ -27,29 +27,35 @@ import (
 )
 
 func TestMachineCollection(t *testing.T) {
-	t.Run("should return the same number of machines as are in the collection", func(t *testing.T) {
-		g := NewWithT(t)
-		collection := machines()
-		sortedMachines := collection.SortedByCreationTimestamp()
-		g.Expect(sortedMachines).To(HaveLen(len(collection)))
-		g.Expect(sortedMachines[0].Name).To(Equal("machine-1"))
-		g.Expect(sortedMachines[len(sortedMachines)-1].Name).To(Equal("machine-5"))
-	})
-	t.Run("should return the collection with elements of the second collection removed", func(t *testing.T) {
-		g := NewWithT(t)
-		collection := machines()
-		c2 := collection.Filter(func(m *clusterv1.Machine) bool {
-			return m.Name != "machine-1"
+	t.Run("SortedByAge", func(t *testing.T) {
+		t.Run("should return the same number of machines as are in the collection", func(t *testing.T) {
+			g := NewWithT(t)
+			collection := machines()
+			sortedMachines := collection.SortedByCreationTimestamp()
+			g.Expect(sortedMachines).To(HaveLen(len(collection)))
+			g.Expect(sortedMachines[0].Name).To(Equal("machine-1"))
+			g.Expect(sortedMachines[len(sortedMachines)-1].Name).To(Equal("machine-5"))
 		})
-		c3 := collection.Difference(c2)
-		// does not mutate
-		g.Expect(collection.Names()).To(ContainElement("machine-1"))
-		g.Expect(c3.Names()).To(ConsistOf("machine-1"))
 	})
-	t.Run("should return a slice of names of each machine in the collection", func(t *testing.T) {
-		g := NewWithT(t)
-		g.Expect(collections.New().Names()).To(BeEmpty())
-		g.Expect(collections.FromMachines(machine("1"), machine("2")).Names()).To(ConsistOf("1", "2"))
+	t.Run("Difference", func(t *testing.T) {
+		t.Run("should return the collection with elements of the second collection removed", func(t *testing.T) {
+			g := NewWithT(t)
+			collection := machines()
+			c2 := collection.Filter(func(m *clusterv1.Machine) bool {
+				return m.Name != "machine-1"
+			})
+			c3 := collection.Difference(c2)
+			// does not mutate
+			g.Expect(collection.Names()).To(ContainElement("machine-1"))
+			g.Expect(c3.Names()).To(ConsistOf("machine-1"))
+		})
+	})
+	t.Run("Names", func(t *testing.T) {
+		t.Run("should return a slice of names of each machine in the collection", func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(collections.New().Names()).To(BeEmpty())
+			g.Expect(collections.FromMachines(machine("1"), machine("2")).Names()).To(ConsistOf("1", "2"))
+		})
 	})
 }
 

--- a/util/collections/machine_collection_test.go
+++ b/util/collections/machine_collection_test.go
@@ -20,11 +20,10 @@ import (
 	"testing"
 	"time"
 
-	"sigs.k8s.io/cluster-api/util/collections"
-
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/util/collections"
 )
 
 func TestMachineCollection(t *testing.T) {
@@ -36,7 +35,7 @@ func TestMachineCollection(t *testing.T) {
 		g.Expect(sortedMachines[0].Name).To(Equal("machine-1"))
 		g.Expect(sortedMachines[len(sortedMachines)-1].Name).To(Equal("machine-5"))
 	})
-	t.Run("returns the collection with elements of the second collection removed", func(t *testing.T) {
+	t.Run("should return the collection with elements of the second collection removed", func(t *testing.T) {
 		g := NewWithT(t)
 		collection := machines()
 		c2 := collection.Filter(func(m *clusterv1.Machine) bool {
@@ -47,7 +46,7 @@ func TestMachineCollection(t *testing.T) {
 		g.Expect(collection.Names()).To(ContainElement("machine-1"))
 		g.Expect(c3.Names()).To(ConsistOf("machine-1"))
 	})
-	t.Run("returns a slice of names of each machine in the collection", func(t *testing.T) {
+	t.Run("should return a slice of names of each machine in the collection", func(t *testing.T) {
 		g := NewWithT(t)
 		g.Expect(collections.New().Names()).To(BeEmpty())
 		g.Expect(collections.FromMachines(machine("1"), machine("2")).Names()).To(ConsistOf("1", "2"))


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors the tests in util/collections/machine_collection_test.go to use plain Go testing instead of ginkgo. The other tests in this package were already there.

**Which issue(s) this PR fixes**:
Refs #4588