### PR TITLE
🌱 clusterctl move should consider Secrets from provider's namespace

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -60,7 +60,7 @@ func (o *objectMover) Move(namespace string, toCluster Client, dryRun bool) erro
 		log.Info("********************************************************")
 	}
 
-	objectGraph := newObjectGraph(o.fromProxy)
+	objectGraph := newObjectGraph(o.fromProxy, o.fromProviderInventory)
 
 	// checks that all the required providers in place in the target cluster.
 	if !o.dryRun {

--- a/cmd/clusterctl/internal/test/fake_objects.go
+++ b/cmd/clusterctl/internal/test/fake_objects.go
@@ -1143,6 +1143,22 @@ func (f *FakeExternalObject) Objs() []client.Object {
 	return []client.Object{externalObj}
 }
 
+// NewSecret generates a new secret with the given namespace and name.
+func NewSecret(namespace, name string) *corev1.Secret {
+	s := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	setUID(s)
+	return s
+}
+
 // SelectClusterObj finds and returns a Cluster with the given name and namespace, if any.
 func SelectClusterObj(objs []client.Object, namespace, name string) *clusterv1.Cluster {
 	for _, o := range objs {

--- a/docs/book/src/clusterctl/provider-contract.md
+++ b/docs/book/src/clusterctl/provider-contract.md
@@ -311,10 +311,18 @@ functioning of `clusterctl` when using non-compliant component YAML or cluster t
 
 Provider authors should be aware that `clusterctl move` command implements a discovery mechanism that considers:
 
-* All the objects of Kind defined in one of the CRDs installed by clusterctl using `clusterctl init`.
-* `Secret` and `ConfigMap` objects.
-* The `OwnerReference` chain of the above objects.
-* Any object of Kind in which its CRD has the "move" label (`clusterctl.cluster.x-k8s.io/move`) attached to it.
+* All the objects of Kind defined in one of the CRDs installed by clusterctl using `clusterctl init` from the namespace being moved.
+* `ConfigMap` objects from the namespace being moved.
+* `Secret` objects from the namespace being moved and from the namespaces where infrastructure providers are installed.
+
+`clusterctl move` does NOT consider any objects:
+
+* Not included in the set of objects defined above.
+* Included in the set of objects defined above, but not:
+  * Directly or indirectly linked to a `Cluster` object through the `OwnerReference` chain.
+  * Directly or indirectly linked to a `ClusterResourceSet` object through the `OwnerReference` chain.
+  * Explicitly required to move via the "move" label (`clusterctl.cluster.x-k8s.io/move`) attached to the object or to
+    the CRD definition.
 
 <aside class="note warning">
 
@@ -324,15 +332,8 @@ When using the "move" label, if the CRD is a global resource, the object is copi
 
 </aside>
 
-`clusterctl move` does NOT consider any objects:
-
-* Not included in the set of objects defined above.
-* Included in the set of objects defined above, but not:
-  * Directly or indirectly linked to a `Cluster` object through the `OwnerReference` chain.
-  * Directly or indirectly linked to a `ClusterResourceSet` object through the `OwnerReference` chain.
-
 If moving some of excluded object is required, the provider authors should create documentation describing the
-the exact move sequence to be executed by the user.
+exact move sequence to be executed by the user.
 
 Additionally, provider authors should be aware that `clusterctl move` assumes all the provider's Controllers respect the
 `Cluster.Spec.Paused` field introduced in the v1alpha3 Cluster API specification.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements the first of a set of changes meant to allow clusterctl move to deal properly with the new model for managing credentials being implemented by providers in v1alpha4.

More specifically this PR makes clusterctl move to consider Secrets from the infrastructure provider's namespace (in addition to secrets from the namespace being moved).

**Which issue(s) this PR fixes**:
Fixes: #3042

/assign @randomvariable 
/assign @yastij 