### PR TITLE
🌱 Refactor tests to plain go in exp/addons/controllers

### DIFF
--- a/exp/addons/controllers/suite_test.go
+++ b/exp/addons/controllers/suite_test.go
@@ -17,61 +17,60 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
+	"os"
 	"testing"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/test/helpers"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	// +kubebuilder:scaffold:imports
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
 	testEnv *helpers.TestEnvironment
 	ctx     = ctrl.SetupSignalHandler()
 )
 
-func TestAPIs(t *testing.T) {
-	RegisterFailHandler(Fail)
-
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
-}
-
-var _ = BeforeSuite(func() {
-	By("bootstrapping test environment")
+func TestMain(m *testing.M) {
+	fmt.Println("Creating new test environment")
 	testEnv = helpers.NewTestEnvironment()
+
 	trckr, err := remote.NewClusterCacheTracker(log.NullLogger{}, testEnv.Manager)
-	Expect(err).NotTo(HaveOccurred())
-	Expect((&ClusterResourceSetReconciler{
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create new cluster cache tracker: %v", err))
+	}
+	reconciler := ClusterResourceSetReconciler{
 		Client:  testEnv,
 		Tracker: trckr,
-	}).SetupWithManager(ctx, testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
-	Expect((&ClusterResourceSetBindingReconciler{
+	}
+	if err = reconciler.SetupWithManager(ctx, testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		panic(fmt.Sprintf("Failed to set up cluster resource set reconciler: %v", err))
+	}
+	bindingReconciler := ClusterResourceSetBindingReconciler{
 		Client: testEnv,
-	}).SetupWithManager(ctx, testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
+	}
+	if err = bindingReconciler.SetupWithManager(ctx, testEnv.Manager, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		panic(fmt.Sprintf("Failed to set up cluster resource set binding reconciler: %v", err))
+	}
 
-	By("starting the manager")
 	go func() {
-		defer GinkgoRecover()
-		Expect(testEnv.StartManager(ctx)).To(Succeed())
+		fmt.Println("Starting the manager")
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
 	}()
 	<-testEnv.Manager.Elected()
 	testEnv.WaitForWebhooks()
-}, 60)
 
-var _ = AfterSuite(func() {
-	if testEnv != nil {
-		By("tearing down the test environment")
-		Expect(testEnv.Stop()).To(Succeed())
+	code := m.Run()
+
+	fmt.Println("Tearing down test suite")
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
 	}
-})
+
+	os.Exit(code)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors the tests in the exp/addons/controllers package to use plain Go testing instead of ginkgo.

**Which issue(s) this PR fixes**:

Refs #4588
