### PR TITLE
🌱 Refactor tests to plain go in bootstrap/kubeadm/controllers

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller_reconciler_test.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller_reconciler_test.go
@@ -17,7 +17,8 @@ limitations under the License.
 package controllers
 
 import (
-	. "github.com/onsi/ginkgo"
+	"testing"
+
 	. "github.com/onsi/gomega"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -26,36 +27,35 @@ import (
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
 )
 
-var _ = Describe("KubeadmConfigReconciler", func() {
-	BeforeEach(func() {})
-	AfterEach(func() {})
+func TestKubeadmConfigReconciler(t *testing.T) {
+	t.Run("Reconcile a KubeadmConfig", func(t *testing.T) {
+		t.Run("should wait until infrastructure is ready", func(t *testing.T) {
+			g := NewWithT(t)
 
-	Context("Reconcile a KubeadmConfig", func() {
-		It("should wait until infrastructure is ready", func() {
 			cluster := newCluster("cluster1")
-			Expect(testEnv.Create(ctx, cluster)).To(Succeed())
+			g.Expect(testEnv.Create(ctx, cluster)).To(Succeed())
 
 			machine := newMachine(cluster, "my-machine")
-			Expect(testEnv.Create(ctx, machine)).To(Succeed())
+			g.Expect(testEnv.Create(ctx, machine)).To(Succeed())
 
 			config := newKubeadmConfig(machine, "my-machine-config")
-			Expect(testEnv.Create(ctx, config)).To(Succeed())
+			g.Expect(testEnv.Create(ctx, config)).To(Succeed())
 
 			reconciler := KubeadmConfigReconciler{
 				Client: testEnv,
 			}
-			By("Calling reconcile should requeue")
+			t.Log("Calling reconcile should requeue")
 			result, err := reconciler.Reconcile(ctx, ctrl.Request{
 				NamespacedName: client.ObjectKey{
 					Namespace: "default",
 					Name:      "my-machine-config",
 				},
 			})
-			Expect(err).To(Succeed())
-			Expect(result.Requeue).To(BeFalse())
+			g.Expect(err).To(Succeed())
+			g.Expect(result.Requeue).To(BeFalse())
 		})
 	})
-})
+}
 
 // getKubeadmConfig returns a KubeadmConfig object from the cluster.
 func getKubeadmConfig(c client.Client, name string) (*bootstrapv1.KubeadmConfig, error) {

--- a/bootstrap/kubeadm/controllers/suite_test.go
+++ b/bootstrap/kubeadm/controllers/suite_test.go
@@ -17,49 +17,39 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
+	"os"
 	"testing"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/cluster-api/test/helpers"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	// +kubebuilder:scaffold:imports
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
 	testEnv *helpers.TestEnvironment
 	ctx     = ctrl.SetupSignalHandler()
 )
 
-func TestAPIs(t *testing.T) {
-	RegisterFailHandler(Fail)
-
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
-}
-
-var _ = BeforeSuite(func() {
-	By("bootstrapping test environment")
+func TestMain(m *testing.M) {
+	fmt.Println("Creating new test environment")
 	testEnv = helpers.NewTestEnvironment()
 
-	By("starting the manager")
 	go func() {
-		defer GinkgoRecover()
-		Expect(testEnv.StartManager(ctx)).To(Succeed())
+		fmt.Println("Starting the manager")
+		if err := testEnv.StartManager(ctx); err != nil {
+			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
+		}
 	}()
 	<-testEnv.Manager.Elected()
 	testEnv.WaitForWebhooks()
-}, 60)
 
-var _ = AfterSuite(func() {
-	if testEnv != nil {
-		By("tearing down the test environment")
-		Expect(testEnv.Stop()).To(Succeed())
+	code := m.Run()
+
+	fmt.Println("Tearing down test suite")
+	if err := testEnv.Stop(); err != nil {
+		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
 	}
-})
+
+	os.Exit(code)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors the tests in the bootstrap/kubeadm/controllers package to use plain Go testing instead of ginkgo.

**Which issue(s) this PR fixes**:

Refs #4588
