### PR TITLE
🌱 Remove redundant judgment condition in controlplane/kubeadm/internal/workload_cluster_coredns_test.go

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
@@ -416,7 +416,7 @@ kind: ClusterConfiguration
 					for _, o := range tt.objs {
 						o := o.DeepCopyObject().(client.Object)
 						err := testEnv.Get(ctx, client.ObjectKeyFromObject(o), o)
-						if err == nil || (err != nil && !apierrors.IsNotFound(err)) {
+						if err == nil || !apierrors.IsNotFound(err) {
 							return false
 						}
 					}


### PR DESCRIPTION


<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Remove redundant judgment condition in controlplane/kubeadm/internal/workload_cluster_coredns_test.go

```go
if err == nil || (err != nil && !apierrors.IsNotFound(err)) {
   return false
 }
```

if `err == nil`, the conditions after `||` will be not executed, so `err != nil` is redundant.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
