### PR TITLE
✨ Add the ability to specify name of cluster to move

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -37,7 +37,7 @@ import (
 // ObjectMover defines methods for moving Cluster API objects to another management cluster.
 type ObjectMover interface {
 	// Move moves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target management cluster.
-	Move(namespace string, toCluster Client, dryRun bool) error
+	Move(namespace, cluster string, toCluster Client, dryRun bool) error
 }
 
 // objectMover implements the ObjectMover interface.
@@ -50,7 +50,7 @@ type objectMover struct {
 // ensure objectMover implements the ObjectMover interface.
 var _ ObjectMover = &objectMover{}
 
-func (o *objectMover) Move(namespace string, toCluster Client, dryRun bool) error {
+func (o *objectMover) Move(namespace, cluster string, toCluster Client, dryRun bool) error {
 	log := logf.Log
 	log.Info("Performing move...")
 	o.dryRun = dryRun
@@ -78,7 +78,7 @@ func (o *objectMover) Move(namespace string, toCluster Client, dryRun bool) erro
 	// Discovery the object graph for the selected types:
 	// - Nodes are defined the Kubernetes objects (Clusters, Machines etc.) identified during the discovery process.
 	// - Edges are derived by the OwnerReferences between nodes.
-	if err := objectGraph.Discovery(namespace); err != nil {
+	if err := objectGraph.Discovery(namespace, cluster); err != nil {
 		return err
 	}
 

--- a/cmd/clusterctl/client/cluster/objectgraph.go
+++ b/cmd/clusterctl/client/cluster/objectgraph.go
@@ -289,13 +289,19 @@ func getCRDList(proxy Proxy, crdList *apiextensionsv1.CustomResourceDefinitionLi
 
 // Discovery reads all the Kubernetes objects existing in a namespace (or in all namespaces if empty) for the types received in input, and then adds
 // everything to the objects graph.
-func (o *objectGraph) Discovery(namespace string) error {
+func (o *objectGraph) Discovery(namespace, cluster string) error {
 	log := logf.Log
 	log.Info("Discovering Cluster API objects")
 
 	selectors := []client.ListOption{}
 	if namespace != "" {
 		selectors = append(selectors, client.InNamespace(namespace))
+	}
+
+	if cluster != "" {
+		selectors = append(selectors, client.MatchingLabels(map[string]string{
+			clusterv1.ClusterLabelName: cluster,
+		}))
 	}
 
 	discoveryBackoff := newReadBackoff()

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -36,6 +36,9 @@ type MoveOptions struct {
 
 	// DryRun means the move action is a dry run, no real action will be performed
 	DryRun bool
+
+	// Cluster means the name of the cluster to move
+	Cluster string
 }
 
 func (c *clusterctlClient) Move(options MoveOptions) error {
@@ -83,7 +86,7 @@ func (c *clusterctlClient) Move(options MoveOptions) error {
 		options.Namespace = currentNamespace
 	}
 
-	if err := fromCluster.ObjectMover().Move(options.Namespace, toCluster, options.DryRun); err != nil {
+	if err := fromCluster.ObjectMover().Move(options.Namespace, options.Cluster, toCluster, options.DryRun); err != nil {
 		return err
 	}
 

--- a/cmd/clusterctl/client/move_test.go
+++ b/cmd/clusterctl/client/move_test.go
@@ -125,6 +125,6 @@ type fakeObjectMover struct {
 	moveErr error
 }
 
-func (f *fakeObjectMover) Move(namespace string, toCluster cluster.Client, dryRun bool) error {
+func (f *fakeObjectMover) Move(namespace, cluster string, toCluster cluster.Client, dryRun bool) error {
 	return f.moveErr
 }

--- a/cmd/clusterctl/cmd/move.go
+++ b/cmd/clusterctl/cmd/move.go
@@ -29,6 +29,7 @@ type moveOptions struct {
 	toKubeconfigContext   string
 	namespace             string
 	dryRun                bool
+	cluster               string
 }
 
 var mo = &moveOptions{}
@@ -63,6 +64,8 @@ func init() {
 		"The namespace where the workload cluster is hosted. If unspecified, the current context's namespace is used.")
 	moveCmd.Flags().BoolVar(&mo.dryRun, "dry-run", false,
 		"Enable dry run, don't really perform the move actions")
+	moveCmd.Flags().StringVarP(&mo.cluster, "cluster", "c", "",
+		"The cluster name to move. If not specified, moves all clusters in the namespace, falling back to default behavior.")
 
 	RootCmd.AddCommand(moveCmd)
 }
@@ -83,6 +86,7 @@ func runMove() error {
 		ToKubeconfig:   client.Kubeconfig{Path: mo.toKubeconfig, Context: mo.toKubeconfigContext},
 		Namespace:      mo.namespace,
 		DryRun:         mo.dryRun,
+		Cluster:        mo.cluster,
 	}); err != nil {
 		return err
 	}

--- a/cmd/clusterctl/internal/test/fake_objects.go
+++ b/cmd/clusterctl/internal/test/fake_objects.go
@@ -100,7 +100,7 @@ func (f *FakeCluster) Objs() []client.Object {
 			Name:      f.name,
 			Namespace: f.namespace,
 			// OwnerReferences: cluster, Added by the cluster controller (see below) -- RECONCILED
-			// Labels: cluster.x-k8s.io/cluster-name=cluster, Added by the cluster controller (see below) -- RECONCILED
+			Labels: map[string]string{clusterv1.ClusterLabelName: f.name},
 		},
 	}
 
@@ -147,6 +147,7 @@ func (f *FakeCluster) Objs() []client.Object {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f.name + "-ca",
 			Namespace: f.namespace,
+			Labels:    map[string]string{clusterv1.ClusterLabelName: f.name},
 		},
 	}
 
@@ -165,6 +166,7 @@ func (f *FakeCluster) Objs() []client.Object {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      f.name + "-cloud-config",
 				Namespace: f.namespace,
+				Labels:    map[string]string{clusterv1.ClusterLabelName: f.name},
 			},
 		}
 
@@ -196,7 +198,7 @@ func (f *FakeCluster) Objs() []client.Object {
 						UID:        cluster.UID,
 					},
 				},
-				// Labels: cluster.x-k8s.io/cluster-name=cluster MISSING??
+				Labels: map[string]string{clusterv1.ClusterLabelName: f.name},
 			},
 		}
 		objs = append(objs, kubeconfigSecret)
@@ -392,7 +394,7 @@ func (f *FakeMachinePool) Objs(cluster *clusterv1.Cluster) []client.Object {
 					UID:        cluster.UID,
 				},
 			},
-			// Labels: MISSING
+			Labels: map[string]string{clusterv1.ClusterLabelName: cluster.Name},
 		},
 	}
 
@@ -412,7 +414,7 @@ func (f *FakeMachinePool) Objs(cluster *clusterv1.Cluster) []client.Object {
 					UID:        cluster.UID,
 				},
 			},
-			// Labels: MISSING
+			Labels: map[string]string{clusterv1.ClusterLabelName: cluster.Name},
 		},
 	}
 
@@ -544,7 +546,7 @@ func (f *FakeMachineDeployment) Objs(cluster *clusterv1.Cluster) []client.Object
 					UID:        cluster.UID,
 				},
 			},
-			// Labels: MISSING
+			Labels: map[string]string{clusterv1.ClusterLabelName: cluster.Name},
 		},
 	}
 
@@ -720,7 +722,7 @@ func (f *FakeMachineSet) Objs(cluster *clusterv1.Cluster, machineDeployment *clu
 						UID:        cluster.UID,
 					},
 				},
-				// Labels: MISSING
+				Labels: map[string]string{clusterv1.ClusterLabelName: cluster.Name},
 			},
 		}
 
@@ -772,7 +774,7 @@ func (f *FakeMachine) Objs(cluster *clusterv1.Cluster, generateCerts bool, machi
 			Name:      f.name,
 			Namespace: cluster.Namespace,
 			// OwnerReferences: machine, Added by the machine controller (see below) -- RECONCILED
-			// Labels: cluster.x-k8s.io/cluster-name=cluster, Added by the machine controller (see  below) -- RECONCILED
+			Labels: map[string]string{clusterv1.ClusterLabelName: cluster.Name},
 		},
 	}
 
@@ -787,7 +789,7 @@ func (f *FakeMachine) Objs(cluster *clusterv1.Cluster, generateCerts bool, machi
 			Name:      f.name,
 			Namespace: cluster.Namespace,
 			// OwnerReferences: machine, Added by the machine controller (see below) -- RECONCILED
-			// Labels: cluster.x-k8s.io/cluster-name=cluster, Added by the machine controller (see below) -- RECONCILED
+			Labels: map[string]string{clusterv1.ClusterLabelName: cluster.Name},
 		},
 		Status: fakebootstrap.GenericBootstrapConfigStatus{
 			DataSecretName: &bootstrapDataSecretName,
@@ -880,7 +882,7 @@ func (f *FakeMachine) Objs(cluster *clusterv1.Cluster, generateCerts bool, machi
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      cluster.GetName() + "-sa",
 					Namespace: cluster.GetNamespace(),
-					// Labels: cluster.x-k8s.io/cluster-name=cluster MISSING??
+					Labels:    map[string]string{clusterv1.ClusterLabelName: cluster.Name},
 				},
 			}
 			// Set controlled by the machineBootstrap / ownership set by the bootstrap config controller -- ** NOT RECONCILED ?? **


### PR DESCRIPTION
## What this PR does:

It allows for users using `clusterctl` to specify a `cluster` by name when performing the `move` action. It makes use of the `cluster.x-k8s.io/cluster-name` label to identify resources as part of discovery.

## Why this PR is needed

In a scenario where you are running multiple `production` clusters within the same namespace, you want to be able to reduce the risk of moving both clusters at the same time to a new management cluster. We do this by adding the ability to specify which cluster by name we would like to move. If no cluster name is provided, the default logic applies, move all clusters in a namespace if namespace is specified, move all clusters if neither namespace or cluster name is supplied.

## Proven results

We faced the above scenario recently, and with these changes we were able to move multiple clusters, safely and individually, to an array of different CAPI management clusters.

## Which issue(s) this PR fixes

This PR does not fix any issues, however it does relate to the redesign/scope re-define of `clusterctl` - #3354
