### PR TITLE
🌱 Refactor tests to plain go in controllers/remote

### DIFF
--- a/controllers/remote/cluster_cache_reconciler_test.go
+++ b/controllers/remote/cluster_cache_reconciler_test.go
@@ -19,8 +19,8 @@ package remote
 import (
 	"context"
 	"fmt"
+	"testing"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,8 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-var _ = Describe("ClusterCache Reconciler suite", func() {
-	Context("When running the ClusterCacheReconciler", func() {
+func TestClusterCacheReconciler(t *testing.T) {
+	t.Run("When running the ClusterCacheReconciler", func(t *testing.T) {
 		var (
 			mgr           manager.Manager
 			mgrContext    context.Context
@@ -45,99 +45,103 @@ var _ = Describe("ClusterCache Reconciler suite", func() {
 		)
 
 		// createAndWatchCluster creates a new cluster and ensures the clusterCacheTracker has a clusterAccessor for it
-		createAndWatchCluster := func(clusterName string) {
-			By(fmt.Sprintf("Creating a cluster %q", clusterName))
+		createAndWatchCluster := func(clusterName string, g *WithT) {
+			t.Log(fmt.Sprintf("Creating a cluster %q", clusterName))
 			testCluster := &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      clusterName,
 					Namespace: testNamespace.GetName(),
 				},
 			}
-			Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
+			g.Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
 
 			// Check the cluster can be fetched from the API server
 			testClusterKey := util.ObjectKey(testCluster)
-			Eventually(func() error {
+			g.Eventually(func() error {
 				return k8sClient.Get(ctx, testClusterKey, &clusterv1.Cluster{})
 			}, timeout).Should(Succeed())
 
-			By("Creating a test cluster kubeconfig")
-			Expect(testEnv.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
+			t.Log("Creating a test cluster kubeconfig")
+			g.Expect(testEnv.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
 
 			// Check the secret can be fetched from the API server
 			secretKey := client.ObjectKey{Namespace: testNamespace.GetName(), Name: fmt.Sprintf("%s-kubeconfig", testCluster.GetName())}
-			Eventually(func() error {
+			g.Eventually(func() error {
 				return k8sClient.Get(ctx, secretKey, &corev1.Secret{})
 			}, timeout).Should(Succeed())
 
-			By("Creating a clusterAccessor for the cluster")
+			t.Log("Creating a clusterAccessor for the cluster")
 			_, err := cct.GetClient(ctx, testClusterKey)
-			Expect(err).To(BeNil())
+			g.Expect(err).NotTo(HaveOccurred())
 		}
 
-		BeforeEach(func() {
-			By("Setting up a new manager")
+		setup := func(t *testing.T, g *WithT) {
+			t.Log("Setting up a new manager")
 			var err error
 			mgr, err = manager.New(testEnv.Config, manager.Options{
 				Scheme:             scheme.Scheme,
 				MetricsBindAddress: "0",
 			})
-			Expect(err).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
 
-			By("Setting up a ClusterCacheTracker")
+			t.Log("Setting up a ClusterCacheTracker")
 			cct, err = NewClusterCacheTracker(log.NullLogger{}, mgr)
-			Expect(err).NotTo(HaveOccurred())
+			g.Expect(err).NotTo(HaveOccurred())
 
-			By("Creating the ClusterCacheReconciler")
+			t.Log("Creating the ClusterCacheReconciler")
 			r := &ClusterCacheReconciler{
 				Log:     log.NullLogger{},
 				Client:  mgr.GetClient(),
 				Tracker: cct,
 			}
-			Expect(r.SetupWithManager(ctx, mgr, controller.Options{})).To(Succeed())
+			g.Expect(r.SetupWithManager(ctx, mgr, controller.Options{})).To(Succeed())
 
-			By("Starting the manager")
+			t.Log("Starting the manager")
 			mgrContext, mgrCancel = context.WithCancel(ctx)
 			go func() {
-				Expect(mgr.Start(mgrContext)).To(Succeed())
+				g.Expect(mgr.Start(mgrContext)).To(Succeed())
 			}()
 			<-testEnv.Manager.Elected()
 
 			k8sClient = mgr.GetClient()
 
-			By("Creating a namespace for the test")
+			t.Log("Creating a namespace for the test")
 			testNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "cluster-cache-test-"}}
-			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+			g.Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
 
-			By("Creating clusters to test with")
-			createAndWatchCluster("cluster-1")
-			createAndWatchCluster("cluster-2")
-			createAndWatchCluster("cluster-3")
-		})
+			t.Log("Creating clusters to test with")
+			createAndWatchCluster("cluster-1", g)
+			createAndWatchCluster("cluster-2", g)
+			createAndWatchCluster("cluster-3", g)
+		}
 
-		AfterEach(func() {
-			By("Deleting any Secrets")
-			Expect(cleanupTestSecrets(ctx, k8sClient)).To(Succeed())
-			By("Deleting any Clusters")
-			Expect(cleanupTestClusters(ctx, k8sClient)).To(Succeed())
-			By("Stopping the manager")
+		teardown := func(t *testing.T, g *WithT) {
+			t.Log("Deleting any Secrets")
+			g.Expect(cleanupTestSecrets(ctx, k8sClient)).To(Succeed())
+			t.Log("Deleting any Clusters")
+			g.Expect(cleanupTestClusters(ctx, k8sClient)).To(Succeed())
+			t.Log("Stopping the manager")
 			mgrCancel()
-		})
+		}
 
-		It("should remove clusterAccessors when clusters are deleted", func() {
+		t.Run("should remove clusterAccessors when clusters are deleted", func(t *testing.T) {
+			g := NewWithT(t)
+			setup(t, g)
+			defer teardown(t, g)
+
 			for _, clusterName := range []string{"cluster-1", "cluster-2", "cluster-3"} {
-				By(fmt.Sprintf("Deleting cluster %q", clusterName))
+				t.Log(fmt.Sprintf("Deleting cluster %q", clusterName))
 				obj := &clusterv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNamespace.Name,
 						Name:      clusterName,
 					},
 				}
-				Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
+				g.Expect(k8sClient.Delete(ctx, obj)).To(Succeed())
 
-				By(fmt.Sprintf("Checking cluster %q's clusterAccessor is removed", clusterName))
-				Eventually(func() bool { return cct.clusterAccessorExists(util.ObjectKey(obj)) }, timeout).Should(BeFalse())
+				t.Log(fmt.Sprintf("Checking cluster %q's clusterAccessor is removed", clusterName))
+				g.Eventually(func() bool { return cct.clusterAccessorExists(util.ObjectKey(obj)) }, timeout).Should(BeFalse())
 			}
 		})
 	})
-})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors the tests in the controllers/remote package to use plain Go testing instead of ginkgo.

**Which issue(s) this PR fixes**:

Refs #4588
