### PR TITLE
🌱 Refactor tests to plain go in controllers

### DIFF
--- a/controllers/machinedeployment_controller_test.go
+++ b/controllers/machinedeployment_controller_test.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
@@ -39,27 +38,31 @@ import (
 
 var _ reconcile.Reconciler = &MachineDeploymentReconciler{}
 
-var _ = Describe("MachineDeployment Reconciler", func() {
+func TestMachineDeploymentReconciler(t *testing.T) {
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "md-test"}}
 	testCluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: namespace.Name, Name: "test-cluster"}}
 
-	BeforeEach(func() {
-		By("Creating the namespace")
-		Expect(testEnv.Create(ctx, namespace)).To(Succeed())
-		By("Creating the Cluster")
-		Expect(testEnv.Create(ctx, testCluster)).To(Succeed())
-		By("Creating the Cluster Kubeconfig Secret")
-		Expect(testEnv.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
-	})
+	setup := func(t *testing.T, g *WithT) {
+		t.Log("Creating the namespace")
+		g.Expect(testEnv.Create(ctx, namespace)).To(Succeed())
+		t.Log("Creating the Cluster")
+		g.Expect(testEnv.Create(ctx, testCluster)).To(Succeed())
+		t.Log("Creating the Cluster Kubeconfig Secret")
+		g.Expect(testEnv.CreateKubeconfigSecret(ctx, testCluster)).To(Succeed())
+	}
 
-	AfterEach(func() {
-		By("Deleting the Cluster")
-		Expect(testEnv.Delete(ctx, testCluster)).To(Succeed())
-		By("Deleting the namespace")
-		Expect(testEnv.Delete(ctx, namespace)).To(Succeed())
-	})
+	teardown := func(t *testing.T, g *WithT) {
+		t.Log("Deleting the Cluster")
+		g.Expect(testEnv.Delete(ctx, testCluster)).To(Succeed())
+		t.Log("Deleting the namespace")
+		g.Expect(testEnv.Delete(ctx, namespace)).To(Succeed())
+	}
 
-	It("Should reconcile a MachineDeployment", func() {
+	t.Run("Should reconcile a MachineDeployment", func(t *testing.T) {
+		g := NewWithT(t)
+		setup(t, g)
+		defer teardown(t, g)
+
 		labels := map[string]string{
 			"foo":                      "bar",
 			clusterv1.ClusterLabelName: testCluster.Name,
@@ -135,19 +138,19 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		infraTmpl.SetAPIVersion("infrastructure.cluster.x-k8s.io/v1alpha4")
 		infraTmpl.SetName("md-template")
 		infraTmpl.SetNamespace(namespace.Name)
-		By("Creating the infrastructure template")
-		Expect(testEnv.Create(ctx, infraTmpl)).To(Succeed())
+		t.Log("Creating the infrastructure template")
+		g.Expect(testEnv.Create(ctx, infraTmpl)).To(Succeed())
 
 		// Create the MachineDeployment object and expect Reconcile to be called.
-		By("Creating the MachineDeployment")
-		Expect(testEnv.Create(ctx, deployment)).To(Succeed())
+		t.Log("Creating the MachineDeployment")
+		g.Expect(testEnv.Create(ctx, deployment)).To(Succeed())
 		defer func() {
-			By("Deleting the MachineDeployment")
-			Expect(testEnv.Delete(ctx, deployment)).To(Succeed())
+			t.Log("Deleting the MachineDeployment")
+			g.Expect(testEnv.Delete(ctx, deployment)).To(Succeed())
 		}()
 
-		By("Verifying the MachineDeployment has a cluster label and ownerRef")
-		Eventually(func() bool {
+		t.Log("Verifying the MachineDeployment has a cluster label and ownerRef")
+		g.Eventually(func() bool {
 			key := client.ObjectKey{Name: deployment.Name, Namespace: deployment.Namespace}
 			if err := testEnv.Get(ctx, key, deployment); err != nil {
 				return false
@@ -162,21 +165,20 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		}, timeout).Should(BeTrue())
 
 		// Verify that the MachineSet was created.
-		By("Verifying the MachineSet was created")
+		t.Log("Verifying the MachineSet was created")
 		machineSets := &clusterv1.MachineSetList{}
-		Eventually(func() int {
+		g.Eventually(func() int {
 			if err := testEnv.List(ctx, machineSets, msListOpts...); err != nil {
 				return -1
 			}
 			return len(machineSets.Items)
 		}, timeout).Should(BeEquivalentTo(1))
 
-		By("Verifying that the deployment's deletePolicy was propagated to the machineset", func() {
-			Expect(machineSets.Items[0].Spec.DeletePolicy).Should(Equal("Oldest"))
-		})
+		t.Log("Verifying that the deployment's deletePolicy was propagated to the machineset")
+		g.Expect(machineSets.Items[0].Spec.DeletePolicy).To(Equal("Oldest"))
 
-		By("Verifying the linked infrastructure template has a cluster owner reference")
-		Eventually(func() bool {
+		t.Log("Verifying the linked infrastructure template has a cluster owner reference")
+		g.Eventually(func() bool {
 			obj, err := external.Get(ctx, testEnv, &deployment.Spec.Template.Spec.InfrastructureRef, deployment.Namespace)
 			if err != nil {
 				return false
@@ -188,13 +190,12 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 				Name:       testCluster.Name,
 				UID:        testCluster.UID,
 			})
-
 		}, timeout).Should(BeTrue())
 
 		// Verify that expected number of machines are created
-		By("Verify expected number of machines are created")
+		t.Log("Verify expected number of machines are created")
 		machines := &clusterv1.MachineList{}
-		Eventually(func() int {
+		g.Eventually(func() int {
 			if err := testEnv.List(ctx, machines, client.InNamespace(namespace.Name)); err != nil {
 				return -1
 			}
@@ -202,21 +203,21 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		}, timeout).Should(BeEquivalentTo(*deployment.Spec.Replicas))
 
 		// Verify that machines has MachineSetLabelName and MachineDeploymentLabelName labels
-		By("Verify machines have expected MachineSetLabelName and MachineDeploymentLabelName")
+		t.Log("Verify machines have expected MachineSetLabelName and MachineDeploymentLabelName")
 		for _, m := range machines.Items {
-			Expect(m.Labels[clusterv1.ClusterLabelName]).To(Equal(testCluster.Name))
+			g.Expect(m.Labels[clusterv1.ClusterLabelName]).To(Equal(testCluster.Name))
 		}
 
 		firstMachineSet := machineSets.Items[0]
-		Expect(*firstMachineSet.Spec.Replicas).To(BeEquivalentTo(2))
-		Expect(*firstMachineSet.Spec.Template.Spec.Version).To(BeEquivalentTo("v1.10.3"))
+		g.Expect(*firstMachineSet.Spec.Replicas).To(BeEquivalentTo(2))
+		g.Expect(*firstMachineSet.Spec.Template.Spec.Version).To(BeEquivalentTo("v1.10.3"))
 
 		//
 		// Delete firstMachineSet and expect Reconcile to be called to replace it.
 		//
-		By("Deleting the initial MachineSet")
-		Expect(testEnv.Delete(ctx, &firstMachineSet)).To(Succeed())
-		Eventually(func() bool {
+		t.Log("Deleting the initial MachineSet")
+		g.Expect(testEnv.Delete(ctx, &firstMachineSet)).To(Succeed())
+		g.Eventually(func() bool {
 			if err := testEnv.List(ctx, machineSets, msListOpts...); err != nil {
 				return false
 			}
@@ -232,10 +233,10 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		// Scale the MachineDeployment and expect Reconcile to be called.
 		//
 		secondMachineSet := machineSets.Items[0]
-		By("Scaling the MachineDeployment to 3 replicas")
+		t.Log("Scaling the MachineDeployment to 3 replicas")
 		modifyFunc := func(d *clusterv1.MachineDeployment) { d.Spec.Replicas = pointer.Int32Ptr(3) }
-		Expect(updateMachineDeployment(ctx, testEnv, deployment, modifyFunc)).To(Succeed())
-		Eventually(func() int {
+		g.Expect(updateMachineDeployment(ctx, testEnv, deployment, modifyFunc)).To(Succeed())
+		g.Eventually(func() int {
 			key := client.ObjectKey{Name: secondMachineSet.Name, Namespace: secondMachineSet.Namespace}
 			if err := testEnv.Get(ctx, key, &secondMachineSet); err != nil {
 				return -1
@@ -246,34 +247,34 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		//
 		// Update a MachineDeployment, expect Reconcile to be called and a new MachineSet to appear.
 		//
-		By("Setting a label on the MachineDeployment")
+		t.Log("Setting a label on the MachineDeployment")
 		modifyFunc = func(d *clusterv1.MachineDeployment) { d.Spec.Template.Labels["updated"] = "true" }
-		Expect(updateMachineDeployment(ctx, testEnv, deployment, modifyFunc)).To(Succeed())
-		Eventually(func() int {
+		g.Expect(updateMachineDeployment(ctx, testEnv, deployment, modifyFunc)).To(Succeed())
+		g.Eventually(func() int {
 			if err := testEnv.List(ctx, machineSets, msListOpts...); err != nil {
 				return -1
 			}
 			return len(machineSets.Items)
 		}, timeout).Should(BeEquivalentTo(2))
 
-		By("Updating deletePolicy on the MachineDeployment")
+		t.Log("Updating deletePolicy on the MachineDeployment")
 		modifyFunc = func(d *clusterv1.MachineDeployment) {
 			d.Spec.Strategy.RollingUpdate.DeletePolicy = pointer.StringPtr("Newest")
 		}
-		Expect(updateMachineDeployment(ctx, testEnv, deployment, modifyFunc)).To(Succeed())
-		Eventually(func() string {
+		g.Expect(updateMachineDeployment(ctx, testEnv, deployment, modifyFunc)).To(Succeed())
+		g.Eventually(func() string {
 			if err := testEnv.List(ctx, machineSets, msListOpts...); err != nil {
 				return ""
 			}
 			return machineSets.Items[0].Spec.DeletePolicy
 		}, timeout).Should(Equal("Newest"))
 
-		//Verify that the old machine set retains its delete policy
-		Expect(machineSets.Items[1].Spec.DeletePolicy).Should(Equal("Oldest"))
+		// Verify that the old machine set retains its delete policy
+		g.Expect(machineSets.Items[1].Spec.DeletePolicy).To(Equal("Oldest"))
 
 		// Verify that all the MachineSets have the expected OwnerRef.
-		By("Verifying MachineSet owner references")
-		Eventually(func() bool {
+		t.Log("Verifying MachineSet owner references")
+		g.Eventually(func() bool {
 			if err := testEnv.List(ctx, machineSets, msListOpts...); err != nil {
 				return false
 			}
@@ -286,7 +287,7 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 			return true
 		}, timeout).Should(BeTrue())
 
-		By("Locating the newest MachineSet")
+		t.Log("Locating the newest MachineSet")
 		var thirdMachineSet *clusterv1.MachineSet
 		for i := range machineSets.Items {
 			ms := &machineSets.Items[i]
@@ -295,14 +296,14 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 				break
 			}
 		}
-		Expect(thirdMachineSet).NotTo(BeNil())
+		g.Expect(thirdMachineSet).NotTo(BeNil())
 
-		By("Verifying the initial MachineSet is deleted")
-		Eventually(func() int {
+		t.Log("Verifying the initial MachineSet is deleted")
+		g.Eventually(func() int {
 			// Set the all non-deleted machines as ready with a NodeRef, so the MachineSet controller can proceed
 			// to properly set AvailableReplicas.
 			foundMachines := &clusterv1.MachineList{}
-			Expect(testEnv.List(ctx, foundMachines, client.InNamespace(namespace.Name))).To(Succeed())
+			g.Expect(testEnv.List(ctx, foundMachines, client.InNamespace(namespace.Name))).To(Succeed())
 			for i := 0; i < len(foundMachines.Items); i++ {
 				m := foundMachines.Items[i]
 				// Skip over deleted Machines
@@ -313,8 +314,8 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 				if !metav1.IsControlledBy(&m, thirdMachineSet) {
 					continue
 				}
-				providerID := fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource)
-				fakeMachineNodeRef(&m, providerID)
+				providerID := fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource, g)
+				fakeMachineNodeRef(&m, providerID, g)
 			}
 
 			if err := testEnv.List(ctx, machineSets, msListOpts...); err != nil {
@@ -336,15 +337,15 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 			clusterv1.ClusterLabelName: testCluster.Name,
 		}
 
-		By("Updating MachineDeployment label")
+		t.Log("Updating MachineDeployment label")
 		modifyFunc = func(d *clusterv1.MachineDeployment) {
 			d.Spec.Selector.MatchLabels = newLabels
 			d.Spec.Template.Labels = newLabels
 		}
-		Expect(updateMachineDeployment(ctx, testEnv, deployment, modifyFunc)).To(Succeed())
+		g.Expect(updateMachineDeployment(ctx, testEnv, deployment, modifyFunc)).To(Succeed())
 
-		By("Verifying if a new MachineSet with updated labels are created")
-		Eventually(func() int {
+		t.Log("Verifying if a new MachineSet with updated labels are created")
+		g.Eventually(func() int {
 			listOpts := client.MatchingLabels(newLabels)
 			if err := testEnv.List(ctx, machineSets, listOpts); err != nil {
 				return -1
@@ -353,12 +354,12 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		}, timeout).Should(BeEquivalentTo(1))
 		newms := machineSets.Items[0]
 
-		By("Verifying new MachineSet has desired number of replicas")
-		Eventually(func() bool {
+		t.Log("Verifying new MachineSet has desired number of replicas")
+		g.Eventually(func() bool {
 			// Set the all non-deleted machines as ready with a NodeRef, so the MachineSet controller can proceed
 			// to properly set AvailableReplicas.
 			foundMachines := &clusterv1.MachineList{}
-			Expect(testEnv.List(ctx, foundMachines, client.InNamespace(namespace.Name))).To(Succeed())
+			g.Expect(testEnv.List(ctx, foundMachines, client.InNamespace(namespace.Name))).To(Succeed())
 			for i := 0; i < len(foundMachines.Items); i++ {
 				m := foundMachines.Items[i]
 				if !m.DeletionTimestamp.IsZero() {
@@ -368,8 +369,8 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 				if !metav1.IsControlledBy(&m, &newms) {
 					continue
 				}
-				providerID := fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource)
-				fakeMachineNodeRef(&m, providerID)
+				providerID := fakeInfrastructureRefReady(m.Spec.InfrastructureRef, infraResource, g)
+				fakeMachineNodeRef(&m, providerID, g)
 			}
 
 			listOpts := client.MatchingLabels(newLabels)
@@ -379,8 +380,8 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 			return machineSets.Items[0].Status.Replicas == *deployment.Spec.Replicas
 		}, timeout*5).Should(BeTrue())
 
-		By("Verifying MachineSets with old labels are deleted")
-		Eventually(func() int {
+		t.Log("Verifying MachineSets with old labels are deleted")
+		g.Eventually(func() int {
 			listOpts := client.MatchingLabels(oldLabels)
 			if err := testEnv.List(ctx, machineSets, listOpts); err != nil {
 				return -1
@@ -390,9 +391,9 @@ var _ = Describe("MachineDeployment Reconciler", func() {
 		}, timeout*5).Should(BeEquivalentTo(0))
 
 		// Validate that the controller set the cluster name label in selector.
-		Expect(deployment.Status.Selector).To(ContainSubstring(testCluster.Name))
+		g.Expect(deployment.Status.Selector).To(ContainSubstring(testCluster.Name))
 	})
-})
+}
 
 func TestMachineSetToDeployments(t *testing.T) {
 	g := NewWithT(t)
@@ -713,7 +714,6 @@ func TestGetMachineSetsForDeployment(t *testing.T) {
 
 			got, err := r.getMachineSetsForDeployment(ctx, &tc.machineDeployment)
 			g.Expect(err).NotTo(HaveOccurred())
-
 			g.Expect(got).To(HaveLen(len(tc.expected)))
 
 			for idx, res := range got {

--- a/controllers/suite_util_test.go
+++ b/controllers/suite_util_test.go
@@ -38,9 +38,9 @@ func intOrStrPtr(i int32) *intstr.IntOrString {
 	return &res
 }
 
-func fakeBootstrapRefReady(ref corev1.ObjectReference, base map[string]interface{}) {
+func fakeBootstrapRefReady(ref corev1.ObjectReference, base map[string]interface{}, g *WithT) {
 	bref := (&unstructured.Unstructured{Object: base}).DeepCopy()
-	Eventually(func() error {
+	g.Eventually(func() error {
 		return testEnv.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, bref)
 	}).Should(Succeed())
 
@@ -53,33 +53,33 @@ func fakeBootstrapRefReady(ref corev1.ObjectReference, base map[string]interface
 			"value": "data",
 		},
 	}
-	Expect(testEnv.Create(ctx, bdataSecret)).To(Succeed())
+	g.Expect(testEnv.Create(ctx, bdataSecret)).To(Succeed())
 
 	brefPatch := client.MergeFrom(bref.DeepCopy())
-	Expect(unstructured.SetNestedField(bref.Object, true, "status", "ready")).To(Succeed())
-	Expect(unstructured.SetNestedField(bref.Object, bdataSecret.Name, "status", "dataSecretName")).To(Succeed())
-	Expect(testEnv.Status().Patch(ctx, bref, brefPatch)).To(Succeed())
+	g.Expect(unstructured.SetNestedField(bref.Object, true, "status", "ready")).To(Succeed())
+	g.Expect(unstructured.SetNestedField(bref.Object, bdataSecret.Name, "status", "dataSecretName")).To(Succeed())
+	g.Expect(testEnv.Status().Patch(ctx, bref, brefPatch)).To(Succeed())
 }
 
-func fakeInfrastructureRefReady(ref corev1.ObjectReference, base map[string]interface{}) string {
+func fakeInfrastructureRefReady(ref corev1.ObjectReference, base map[string]interface{}, g *WithT) string {
 	iref := (&unstructured.Unstructured{Object: base}).DeepCopy()
-	Eventually(func() error {
+	g.Eventually(func() error {
 		return testEnv.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, iref)
 	}).Should(Succeed())
 
 	irefPatch := client.MergeFrom(iref.DeepCopy())
 	providerID := fmt.Sprintf("test:////%v", uuid.NewUUID())
-	Expect(unstructured.SetNestedField(iref.Object, providerID, "spec", "providerID")).To(Succeed())
-	Expect(testEnv.Patch(ctx, iref, irefPatch)).To(Succeed())
+	g.Expect(unstructured.SetNestedField(iref.Object, providerID, "spec", "providerID")).To(Succeed())
+	g.Expect(testEnv.Patch(ctx, iref, irefPatch)).To(Succeed())
 
 	irefPatch = client.MergeFrom(iref.DeepCopy())
-	Expect(unstructured.SetNestedField(iref.Object, true, "status", "ready")).To(Succeed())
-	Expect(testEnv.Status().Patch(ctx, iref, irefPatch)).To(Succeed())
+	g.Expect(unstructured.SetNestedField(iref.Object, true, "status", "ready")).To(Succeed())
+	g.Expect(testEnv.Status().Patch(ctx, iref, irefPatch)).To(Succeed())
 	return providerID
 }
 
-func fakeMachineNodeRef(m *clusterv1.Machine, pid string) {
-	Eventually(func() error {
+func fakeMachineNodeRef(m *clusterv1.Machine, pid string, g *WithT) {
+	g.Eventually(func() error {
 		key := client.ObjectKey{Name: m.Name, Namespace: m.Namespace}
 		return testEnv.Get(ctx, key, &clusterv1.Machine{})
 	}).Should(Succeed())
@@ -97,9 +97,9 @@ func fakeMachineNodeRef(m *clusterv1.Machine, pid string) {
 			ProviderID: pid,
 		},
 	}
-	Expect(testEnv.Create(ctx, node)).To(Succeed())
+	g.Expect(testEnv.Create(ctx, node)).To(Succeed())
 
-	Eventually(func() error {
+	g.Eventually(func() error {
 		key := client.ObjectKey{Name: node.Name, Namespace: node.Namespace}
 		return testEnv.Get(ctx, key, &corev1.Node{})
 	}).Should(Succeed())
@@ -107,12 +107,12 @@ func fakeMachineNodeRef(m *clusterv1.Machine, pid string) {
 	// Patch the node and make it look like ready.
 	patchNode := client.MergeFrom(node.DeepCopy())
 	node.Status.Conditions = append(node.Status.Conditions, corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue})
-	Expect(testEnv.Status().Patch(ctx, node, patchNode)).To(Succeed())
+	g.Expect(testEnv.Status().Patch(ctx, node, patchNode)).To(Succeed())
 
 	// Patch the Machine.
 	patchMachine := client.MergeFrom(m.DeepCopy())
 	m.Spec.ProviderID = pointer.StringPtr(pid)
-	Expect(testEnv.Patch(ctx, m, patchMachine)).To(Succeed())
+	g.Expect(testEnv.Patch(ctx, m, patchMachine)).To(Succeed())
 
 	patchMachine = client.MergeFrom(m.DeepCopy())
 	m.Status.NodeRef = &corev1.ObjectReference{
@@ -120,5 +120,5 @@ func fakeMachineNodeRef(m *clusterv1.Machine, pid string) {
 		Kind:       node.Kind,
 		Name:       node.Name,
 	}
-	Expect(testEnv.Status().Patch(ctx, m, patchMachine)).To(Succeed())
+	g.Expect(testEnv.Status().Patch(ctx, m, patchMachine)).To(Succeed())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors the tests in the controllers package to use plain Go testing instead of ginkgo.

**Which issue(s) this PR fixes**:

Fixes #4588

**Notes**:

This is a big PR, although I think the changes fall into obvious patterns. But please let me know if I should break it up to make reviewing easier.
