### PR TITLE
🌱 Refactor tests to plain go in controlplane/kubeadm/controllers

### DIFF
--- a/api/v1alpha3/webhook_suite_test.go
+++ b/api/v1alpha3/webhook_suite_test.go
@@ -28,9 +28,6 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
 var (
 	testEnv *helpers.TestEnvironment
 	ctx     = ctrl.SetupSignalHandler()

--- a/bootstrap/kubeadm/api/v1alpha3/webhook_suite_test.go
+++ b/bootstrap/kubeadm/api/v1alpha3/webhook_suite_test.go
@@ -28,9 +28,6 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
 var (
 	testEnv *helpers.TestEnvironment
 	ctx     = ctrl.SetupSignalHandler()

--- a/bootstrap/kubeadm/api/v1alpha4/kubeadmconfig_types_test.go
+++ b/bootstrap/kubeadm/api/v1alpha4/kubeadmconfig_types_test.go
@@ -24,9 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// These tests are written in BDD-style using Ginkgo framework. Refer to
-// http://onsi.github.io/ginkgo to learn more.
-
 func TestClusterValidate(t *testing.T) {
 	cases := map[string]struct {
 		in        *KubeadmConfig

--- a/controlplane/kubeadm/api/v1alpha3/webhook_suite_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/webhook_suite_test.go
@@ -28,9 +28,6 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
 var (
 	testEnv *helpers.TestEnvironment
 	ctx     = ctrl.SetupSignalHandler()

--- a/controlplane/kubeadm/controllers/suite_test.go
+++ b/controlplane/kubeadm/controllers/suite_test.go
@@ -21,30 +21,15 @@ import (
 	"os"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"sigs.k8s.io/cluster-api/test/helpers"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	// +kubebuilder:scaffold:imports
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
 	testEnv *helpers.TestEnvironment
 	ctx     = ctrl.SetupSignalHandler()
 )
-
-func TestAPIs(t *testing.T) {
-	RegisterFailHandler(Fail)
-
-	RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
-		[]Reporter{printer.NewlineReporter{}})
-}
 
 func TestMain(m *testing.M) {
 	// Bootstrapping test environment

--- a/exp/addons/api/v1alpha3/webhook_suite_test.go
+++ b/exp/addons/api/v1alpha3/webhook_suite_test.go
@@ -28,9 +28,6 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
 var (
 	testEnv *helpers.TestEnvironment
 	ctx     = ctrl.SetupSignalHandler()

--- a/exp/api/v1alpha3/webhook_suite_test.go
+++ b/exp/api/v1alpha3/webhook_suite_test.go
@@ -28,9 +28,6 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
-
 var (
 	testEnv *helpers.TestEnvironment
 	ctx     = ctrl.SetupSignalHandler()


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors the tests in the controlplane/kubeadm/controllers package to use plain Go testing instead of ginkgo. There were no ginkgo tests here, so `TestAPIs` was a no-op as far as I can tell.

Also removes dangling comments about "these tests use Ginkgo," because no, they don't. Just the ones under `test/`.

**Which issue(s) this PR fixes**:

Refs #4588

**Notes**:

With the other two open PRs, this should complete #4588 ("Refactor tests using plain go tests + envtest instead of Ginkgo").

Also in case anyone cares, I quite like `ginkgo` and have used it successfully in several Go projects. Ginkgo 2.0 looks like it makes some nice improvements and I'm excited to use it, just not in these tests. ☮️ 