### PR TITLE
🌱  Enable godoc linter checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ issues:
     - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
     # The following are being worked on to remove their exclusion. This list should be reduced or go away all together over time.
     # If it is decided they will not be addressed they should be moved above this comment.
-    - (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
     - package comment should be of the form "Package (.+) ..."
     - Subprocess launch(ed with variable|ing should be audited)
     - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,6 @@ issues:
     - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
     # The following are being worked on to remove their exclusion. This list should be reduced or go away all together over time.
     # If it is decided they will not be addressed they should be moved above this comment.
-    - package comment should be of the form "Package (.+) ..."
     - Subprocess launch(ed with variable|ing should be audited)
     - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
     - (G104|G307)

--- a/api/v1alpha3/doc.go
+++ b/api/v1alpha3/doc.go
@@ -14,5 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/api/v1alpha4
 package v1alpha3

--- a/bootstrap/kubeadm/controllers/doc.go
+++ b/bootstrap/kubeadm/controllers/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllers implements the Kubeadm controllers.
+package controllers

--- a/bootstrap/kubeadm/internal/cloudinit/doc.go
+++ b/bootstrap/kubeadm/internal/cloudinit/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cloudinit implements kubeadm cloudinit functionality.
+package cloudinit

--- a/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
+++ b/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package locking implements locking functionality.
 package locking
 
 import (

--- a/bootstrap/kubeadm/types/doc.go
+++ b/bootstrap/kubeadm/types/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha3 contains the v1alpha3 API implementation.
-// +k8s:conversion-gen=sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4
-package v1alpha3
+// Package utils contains Kubeadm utility types.
+package utils

--- a/bootstrap/kubeadm/types/utils.go
+++ b/bootstrap/kubeadm/types/utils.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package utils contains Kubeadm utility types.
 package utils
 
 import (

--- a/bootstrap/kubeadm/types/v1beta1/doc.go
+++ b/bootstrap/kubeadm/types/v1beta1/doc.go
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-This packages contains a mirror of kubeadm API v1beta1 API, required because it is not possible to import k/K.
-
-IMPORTANT: Do not change these files!
-IMPORTANT: only for KubeadmConfig serialization/deserialization, and should not be used for other purposes.
-*/
-
+// Package v1beta1 contains a mirror of kubeadm API v1beta1 API, required because it is not possible to import k/K.
+//
+// IMPORTANT: Do not change these files!
+// IMPORTANT: only for KubeadmConfig serialization/deserialization, and should not be used for other purposes.
+//
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4
 // +k8s:deepcopy-gen=package
 package v1beta1 // import "sigs.k8s.io/cluster-api/bootstrap/kubeadm/kubeadm/v1beta1"

--- a/bootstrap/kubeadm/types/v1beta2/doc.go
+++ b/bootstrap/kubeadm/types/v1beta2/doc.go
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-This packages contains a mirror of kubeadm API v1beta2 API, required because it is not possible to import k/K.
-
-IMPORTANT: Do not change these files!
-IMPORTANT: only for KubeadmConfig serialization/deserialization, and should not be used for other purposes.
-*/
-
+// Package v1beta2 contains a mirror of kubeadm API v1beta2 API, required because it is not possible to import k/K.
+//
+// IMPORTANT: Do not change these files!
+// IMPORTANT: only for KubeadmConfig serialization/deserialization, and should not be used for other purposes.
+//
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4
 // +k8s:deepcopy-gen=package
 package v1beta2 // import "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta2"

--- a/bootstrap/util/configowner.go
+++ b/bootstrap/util/configowner.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package util implements kubeadm utility functionality.
 package util
 
 import (

--- a/cmd/clusterctl/client/alpha/doc.go
+++ b/cmd/clusterctl/client/alpha/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package alpha implements clusterctl alpha functionality.
+package alpha

--- a/cmd/clusterctl/client/cluster/doc.go
+++ b/cmd/clusterctl/client/cluster/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cluster implements clusterctl cluster functionality.
+package cluster

--- a/cmd/clusterctl/client/config/doc.go
+++ b/cmd/clusterctl/client/config/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config implements clusterctl config functionality.
+package config

--- a/cmd/clusterctl/client/doc.go
+++ b/cmd/clusterctl/client/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package client implements clusterctl client functionality.
+package client

--- a/cmd/clusterctl/client/repository/doc.go
+++ b/cmd/clusterctl/client/repository/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package repository implements clusterctl repository functionality.
+package repository

--- a/cmd/clusterctl/client/tree/doc.go
+++ b/cmd/clusterctl/client/tree/doc.go
@@ -14,10 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tree
-
 /*
-This package support the generation of an "at glance" view of a Cluster API cluster designed to help the user in quickly
+Package tree supports the generation of an "at glance" view of a Cluster API cluster designed to help the user in quickly
 understanding if there are problems and where.
 
 The "at glance" view is based on the idea that we should avoid to overload the user with information, but instead
@@ -53,3 +51,4 @@ e.g is virtual node, is group node, meta name etc.
 
 The Discovery object uses the ObjectTree to build the "at glance" view of a Cluster API.
 */
+package tree

--- a/cmd/clusterctl/client/yamlprocessor/processor.go
+++ b/cmd/clusterctl/client/yamlprocessor/processor.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package yamlprocessor implements YAML processing.
 package yamlprocessor
 
 // Processor defines the methods necessary for creating a specific yaml

--- a/cmd/clusterctl/cmd/doc.go
+++ b/cmd/clusterctl/cmd/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cmd implements clusterctl commands.
+package cmd

--- a/cmd/clusterctl/cmd/rollout/pause.go
+++ b/cmd/clusterctl/cmd/rollout/pause.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package rollout implements the clusterctl rollout command.
 package rollout
 
 import (

--- a/cmd/clusterctl/config/embedded_manifest.go
+++ b/cmd/clusterctl/config/embedded_manifest.go
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package config implements clusterctl config functionality.
 package config
 
 import _ "embed"

--- a/cmd/clusterctl/internal/scheme/scheme.go
+++ b/cmd/clusterctl/internal/scheme/scheme.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package scheme implements clusterctl scheme functionality.
 package scheme
 
 import (

--- a/cmd/clusterctl/internal/test/doc.go
+++ b/cmd/clusterctl/internal/test/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package test implements test functionality.
+package test

--- a/cmd/clusterctl/internal/test/providers/bootstrap/generic_types.go
+++ b/cmd/clusterctl/internal/test/providers/bootstrap/generic_types.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-package bootstrap defines the types for a generic bootstrap provider used for tests
-*/
 package bootstrap
 
 import (

--- a/cmd/clusterctl/internal/test/providers/bootstrap/groupversion_info.go
+++ b/cmd/clusterctl/internal/test/providers/bootstrap/groupversion_info.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package bootstrap defines the types for a generic bootstrap provider used for tests.
 // +kubebuilder:object:generate=true
 // +groupName=bootstrap.cluster.x-k8s.io
 package bootstrap

--- a/cmd/clusterctl/internal/test/providers/controlplane/generic_types.go
+++ b/cmd/clusterctl/internal/test/providers/controlplane/generic_types.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-package controlplane defines the types for a generic control plane provider used for tests
-*/
 package controlplane
 
 import (

--- a/cmd/clusterctl/internal/test/providers/controlplane/groupversion_info.go
+++ b/cmd/clusterctl/internal/test/providers/controlplane/groupversion_info.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package controlplane defines the types for a generic control plane provider used for tests.
 // +kubebuilder:object:generate=true
 // +groupName=controlplane.cluster.x-k8s.io
 package controlplane

--- a/cmd/clusterctl/internal/test/providers/external/generic_types.go
+++ b/cmd/clusterctl/internal/test/providers/external/generic_types.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-package external defines the types for a generic external provider used for tests
-*/
 package external
 
 import (

--- a/cmd/clusterctl/internal/test/providers/external/groupversion_info.go
+++ b/cmd/clusterctl/internal/test/providers/external/groupversion_info.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package external defines the types for a generic external provider used for tests.
 // +kubebuilder:object:generate=true
 // +groupName=custom.cluster.x-k8s.io
 package external

--- a/cmd/clusterctl/internal/test/providers/infrastructure/generic_types.go
+++ b/cmd/clusterctl/internal/test/providers/infrastructure/generic_types.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-package infrastructure defines the types for a generic infrastructure provider used for tests
-*/
 package infrastructure
 
 import (

--- a/cmd/clusterctl/internal/test/providers/infrastructure/groupversion_info.go
+++ b/cmd/clusterctl/internal/test/providers/infrastructure/groupversion_info.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package infrastructure defines the types for a generic infrastructure provider used for tests.
 // +kubebuilder:object:generate=true
 // +groupName=infrastructure.cluster.x-k8s.io
 package infrastructure

--- a/cmd/clusterctl/internal/util/doc.go
+++ b/cmd/clusterctl/internal/util/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package util implements clusterctl utilty functions.
+package util

--- a/controllers/doc.go
+++ b/controllers/doc.go
@@ -14,4 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package controllers implements controllers.
 package controllers

--- a/controllers/external/doc.go
+++ b/controllers/external/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package external implements external controller types.
+package external

--- a/controllers/mdutil/doc.go
+++ b/controllers/mdutil/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha3 contains the v1alpha3 API implementation.
-// +k8s:conversion-gen=sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4
-package v1alpha3
+// Package mdutil implements MachineDeployment utilities.
+package mdutil

--- a/controllers/mdutil/util.go
+++ b/controllers/mdutil/util.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package mdutil implements MachineDeployment utilities.
 package mdutil
 
 import (
@@ -701,7 +702,7 @@ func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
 		DisableMethods: true,
 		SpewKeys:       true,
 	}
-	printer.Fprintf(hasher, "%#v", objectToWrite)
+	_, _ = printer.Fprintf(hasher, "%#v", objectToWrite)
 }
 
 func ComputeHash(template *clusterv1.MachineTemplateSpec) uint32 {

--- a/controllers/mdutil/util.go
+++ b/controllers/mdutil/util.go
@@ -702,7 +702,7 @@ func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
 		DisableMethods: true,
 		SpewKeys:       true,
 	}
-	_, _ = printer.Fprintf(hasher, "%#v", objectToWrite)
+	printer.Fprintf(hasher, "%#v", objectToWrite)
 }
 
 func ComputeHash(template *clusterv1.MachineTemplateSpec) uint32 {

--- a/controllers/noderefutil/providerid.go
+++ b/controllers/noderefutil/providerid.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package noderefutil implements NodeRef utils.
 package noderefutil
 
 import (

--- a/controllers/remote/doc.go
+++ b/controllers/remote/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package remote implements remote controllers.
+package remote

--- a/controllers/remote/fake/cluster.go
+++ b/controllers/remote/fake/cluster.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package fake implements testing fakes.
 package fake
 
 import (

--- a/controlplane/kubeadm/api/v1alpha3/doc.go
+++ b/controlplane/kubeadm/api/v1alpha3/doc.go
@@ -14,5 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4
 package v1alpha3

--- a/controlplane/kubeadm/controllers/doc.go
+++ b/controlplane/kubeadm/controllers/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllers implements the Kubeadm controllers.
+package controllers

--- a/controlplane/kubeadm/internal/doc.go
+++ b/controlplane/kubeadm/internal/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package internal contains internal implementation details for the Kubeadm Control Plane.
+package internal

--- a/controlplane/kubeadm/internal/etcd/fake/client.go
+++ b/controlplane/kubeadm/internal/etcd/fake/client.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package fake implements testing fakes.
 package fake
 
 import (

--- a/controlplane/kubeadm/internal/etcd/util/util.go
+++ b/controlplane/kubeadm/internal/etcd/util/util.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package util implements etcd utility functions.
 package util
 
 import (

--- a/controlplane/kubeadm/internal/proxy/addr.go
+++ b/controlplane/kubeadm/internal/proxy/addr.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package proxy implements kubeadm proxy functionality.
 package proxy
 
 import (

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package errors implements error functionality.
+package errors

--- a/exp/addons/api/v1alpha3/doc.go
+++ b/exp/addons/api/v1alpha3/doc.go
@@ -14,5 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/exp/addons/api/v1alpha4
 package v1alpha3

--- a/exp/addons/controllers/doc.go
+++ b/exp/addons/controllers/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllers implements experimental addon controllers.
+package controllers

--- a/exp/addons/controllers/predicates/resource_predicates.go
+++ b/exp/addons/controllers/predicates/resource_predicates.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package predicates implements predicate functionality.
 package predicates
 
 import (

--- a/exp/api/v1alpha3/doc.go
+++ b/exp/api/v1alpha3/doc.go
@@ -14,5 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/exp/api/v1alpha4
 package v1alpha3

--- a/exp/controllers/doc.go
+++ b/exp/controllers/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllers implements experimental controllers.
+package controllers

--- a/exp/doc.go
+++ b/exp/doc.go
@@ -14,6 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha3 contains the v1alpha3 API implementation.
-// +k8s:conversion-gen=sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4
-package v1alpha3
+// Package exp implements experimental code.
+package exp

--- a/exp/util/util.go
+++ b/exp/util/util.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package util implements utility functions.
 package util
 
 import (

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package feature implements feature functionality.
 package feature
 
 import (

--- a/hack/boilerplate/test/fail.go
+++ b/hack/boilerplate/test/fail.go
@@ -1,6 +1,8 @@
 /*
 Copyright 2014 The Kubernetes Authors.
 
+fail
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/hack/boilerplate/test/fail.go
+++ b/hack/boilerplate/test/fail.go
@@ -1,8 +1,6 @@
 /*
 Copyright 2014 The Kubernetes Authors.
 
-fail
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -16,4 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package test contains test boilerplate.
 package test

--- a/test/e2e/doc.go
+++ b/test/e2e/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package e2e implements end to end testing.
+package e2e

--- a/test/e2e/internal/log/doc.go
+++ b/test/e2e/internal/log/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package log implements log handling.
+package log

--- a/test/framework/bootstrap/interfaces.go
+++ b/test/framework/bootstrap/interfaces.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package bootstrap implements bootstrap functionality for e2e testing.
 package bootstrap
 
 import "context"

--- a/test/framework/clusterctl/doc.go
+++ b/test/framework/clusterctl/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package clusterctl implements clusterctl interaction.
+package clusterctl

--- a/test/framework/clusterctl/logger/logger.go
+++ b/test/framework/clusterctl/logger/logger.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package logger implements clusterctl logging functionality.
 package logger
 
 import (

--- a/test/framework/doc.go
+++ b/test/framework/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package framework implements the test framework.
+package framework

--- a/test/framework/exec/command.go
+++ b/test/framework/exec/command.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package exec implements command execution functionality.
 package exec
 
 import (

--- a/test/framework/ginkgoextensions/output.go
+++ b/test/framework/ginkgoextensions/output.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package ginkgoextensions extends ginko.
 package ginkgoextensions
 
 import (

--- a/test/framework/internal/log/log.go
+++ b/test/framework/internal/log/log.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package log implements test framework logging.
 package log
 
 import (

--- a/test/framework/kubernetesversions/template.go
+++ b/test/framework/kubernetesversions/template.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package kubernetesversions implements kubernetes version functions.
 package kubernetesversions
 
 import (

--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package kubetest implmements kubetest functionality.
 package kubetest
 
 import (

--- a/test/helpers/client.go
+++ b/test/helpers/client.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package helpers implements test helpers.
 package helpers
 
 import (

--- a/test/infrastructure/docker/api/v1alpha3/doc.go
+++ b/test/infrastructure/docker/api/v1alpha3/doc.go
@@ -14,5 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha4
 package v1alpha3

--- a/test/infrastructure/docker/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/controllers/dockercluster_controller.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package controllers implements controller functionality.
 package controllers
 
 import (

--- a/test/infrastructure/docker/docker/doc.go
+++ b/test/infrastructure/docker/docker/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package docker implements docker functionality.
+package docker

--- a/test/infrastructure/docker/docker/types/node.go
+++ b/test/infrastructure/docker/docker/types/node.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package types implements type functionality.
 package types
 
 import (

--- a/test/infrastructure/docker/exp/api/v1alpha3/doc.go
+++ b/test/infrastructure/docker/exp/api/v1alpha3/doc.go
@@ -14,5 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1alpha4
 package v1alpha3

--- a/test/infrastructure/docker/exp/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/controllers/dockermachinepool_controller.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package controllers implements controller functionality.
 package controllers
 
 import (

--- a/test/infrastructure/docker/exp/docker/nodepool.go
+++ b/test/infrastructure/docker/exp/docker/nodepool.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package docker implements docker functionality.
 package docker
 
 import (

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package annotations implements annotation helper functions.
 package annotations
 
 import (

--- a/util/certs/certs.go
+++ b/util/certs/certs.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package certs implements cert handling utilities.
 package certs
 
 import (

--- a/util/collections/helpers.go
+++ b/util/collections/helpers.go
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package collections implements collection utilities.
 package collections
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/util/conditions/doc.go
+++ b/util/conditions/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,4 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package exp
+// Package conditions implements condition utilities.
+package conditions

--- a/util/conditions/unstructured.go
+++ b/util/conditions/unstructured.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package conditions
 
 import (

--- a/util/container/image.go
+++ b/util/container/image.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package container implements container utility functionality.
 package container
 
 import (

--- a/util/conversion/conversion.go
+++ b/util/conversion/conversion.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package conversion implements conversion utilities.
 package conversion
 
 import (

--- a/util/defaulting/defaulting.go
+++ b/util/defaulting/defaulting.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package defaulting implements defaulting webook functionality.
 package defaulting
 
 import (

--- a/util/deprecated.go
+++ b/util/deprecated.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package util implements utilities.
 package util
 
 import (

--- a/util/failuredomains/failure_domains.go
+++ b/util/failuredomains/failure_domains.go
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package failuredomains implements FailureDomain utility functions.
 package failuredomains
 
 import (
-	"k8s.io/klog/v2/klogr"
 	"sort"
 
+	"k8s.io/klog/v2/klogr"
 	"k8s.io/utils/pointer"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"

--- a/util/kubeconfig/kubeconfig.go
+++ b/util/kubeconfig/kubeconfig.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package kubeconfig implements utilities for working with kubeconfigs.
 package kubeconfig
 
 import (

--- a/util/labels/helpers.go
+++ b/util/labels/helpers.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package labels implements label utility functions.
 package labels
 
 import (

--- a/util/patch/doc.go
+++ b/util/patch/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package patch implements patch utilities.
+package patch

--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package predicates implements predicate utilities.
 package predicates
 
 import (

--- a/util/record/recorder.go
+++ b/util/record/recorder.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package record implements recording functionality.
 package record
 
 import (

--- a/util/resource/resource.go
+++ b/util/resource/resource.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package resource implements resource utilites.
 package resource
 
 import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/util/secret/doc.go
+++ b/util/secret/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package secret implements utilities for secret handling.
+package secret

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -14,13 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package version implements version handling.
 package version
 
 import (
-	"github.com/blang/semver"
-	"github.com/pkg/errors"
 	"regexp"
 	"strconv"
+
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/util/yaml/yaml.go
+++ b/util/yaml/yaml.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package yaml implements yaml utility functions.
 package yaml
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package version implements version handling code.
 package version
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a continuation of the work being done to enable some of the excluded linters we use.

This change removes the exclusions related to enforcing godoc comments for packages and
functions, variables, and other things that are public. It makes they all have associated doc
strings and that any package comments are in the expected format of `Package x...`.

For package docs, if a given package was less than five separate files the comments were just
added to the `package` statement in the first file. If there were five or more, a `doc.go` file was
added to keep it separate and easy to find.

**Which issue(s) this PR fixes**:
Related #4622
