### PR TITLE
:seedling: upgrade kube-rbac-proxy to v0.8.0

### DIFF
--- a/bootstrap/kubeadm/config/manager/manager_auth_proxy_patch.yaml
+++ b/bootstrap/kubeadm/config/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/cmd/clusterctl/client/init_test.go
+++ b/cmd/clusterctl/client/init_test.go
@@ -75,7 +75,7 @@ func Test_clusterctlClient_InitImages(t *testing.T) {
 				kubeconfigContext:      "mgmt-context",
 			},
 			expectedImages: []string{
-				"gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1",
+				"gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0",
 				"us.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller:v0.5.3",
 			},
 			wantErr: false,
@@ -894,7 +894,7 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+      - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
       - image: us.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller:v0.5.3
         name: manager

--- a/cmd/clusterctl/internal/util/objs_test.go
+++ b/cmd/clusterctl/internal/util/objs_test.go
@@ -80,7 +80,7 @@ func Test_inspectImages(t *testing.T) {
 											},
 											{
 												"name":  "kube-rbac-proxy",
-												"image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1",
+												"image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0",
 											},
 										},
 									},
@@ -90,7 +90,7 @@ func Test_inspectImages(t *testing.T) {
 					},
 				},
 			},
-			want:    []string{"gcr.io/k8s-staging-cluster-api/cluster-api-controller:master", "gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1"},
+			want:    []string{"gcr.io/k8s-staging-cluster-api/cluster-api-controller:master", "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"},
 			wantErr: false,
 		},
 		{

--- a/config/ci/manager/manager_auth_proxy_patch.yaml
+++ b/config/ci/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/controlplane/kubeadm/config/manager/manager_auth_proxy_patch.yaml
+++ b/controlplane/kubeadm/config/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.1
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/test/infrastructure/docker/config/manager/manager_auth_proxy_patch.yaml
+++ b/test/infrastructure/docker/config/manager/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will update kube-rbac-proxy for the release-0.3 branch. This
helps ensure that the CAPI v0.3.x series can be deployed multi-arch. It is a
straight backport from the commit mentioned below with the exception of
fixing merge conflicts around docs.

(cherry picked from commit aa51850504544661eead1685479341bccf9dd39e)
Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
