### PR TITLE
✨ Show required and defaults in "clusterctl generate cluster <name> --list-variables"

### DIFF
--- a/cmd/clusterctl/client/yamlprocessor/processor.go
+++ b/cmd/clusterctl/client/yamlprocessor/processor.go
@@ -25,8 +25,12 @@ type Processor interface {
 	GetTemplateName(version, flavor string) string
 
 	// GetVariables parses the template blob of bytes and provides a
-	// list of variables that the template requires.
+	// list of variables that the template uses.
 	GetVariables([]byte) ([]string, error)
+
+	// GetVariables parses the template blob of bytes and provides a
+	// map of variables that the template uses with their default values.
+	GetVariableMap([]byte) (map[string]*string, error)
 
 	// Process processes the template blob of bytes and will return the final
 	// yaml with values retrieved from the values getter

--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -182,7 +182,7 @@ func runGenerateClusterTemplate(cmd *cobra.Command, name string) error {
 	}
 
 	if gc.listVariables {
-		return printVariablesOutput(template)
+		return printVariablesOutput(cmd, template)
 	}
 
 	return printYamlOutput(template)

--- a/cmd/clusterctl/internal/test/fake_processor.go
+++ b/cmd/clusterctl/internal/test/fake_processor.go
@@ -17,9 +17,10 @@ limitations under the License.
 package test
 
 type FakeProcessor struct {
-	errGetVariables error
-	errProcess      error
-	artifactName    string
+	errGetVariables   error
+	errGetVariableMap error
+	errProcess        error
+	artifactName      string
 }
 
 func NewFakeProcessor() *FakeProcessor {
@@ -47,6 +48,10 @@ func (fp *FakeProcessor) GetTemplateName(version, flavor string) string {
 
 func (fp *FakeProcessor) GetVariables(raw []byte) ([]string, error) {
 	return nil, fp.errGetVariables
+}
+
+func (fp *FakeProcessor) GetVariableMap(raw []byte) (map[string]*string, error) {
+	return nil, fp.errGetVariableMap
 }
 
 func (fp *FakeProcessor) Process(raw []byte, variablesGetter func(string) (string, error)) ([]byte, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the output of `clusterctl generate cluster <name> --list-variables` more informative:

Before:

```shell
% clusterctl generate cluster testcluster1 --list-variables
Variables:
  - AZURE_CONTROL_PLANE_MACHINE_TYPE
  - AZURE_LOCATION
  - AZURE_NODE_MACHINE_TYPE
  - AZURE_RESOURCE_GROUP
  - AZURE_SSH_PUBLIC_KEY_B64
  - AZURE_SUBSCRIPTION_ID
  - AZURE_VNET_NAME
  - CLUSTER_NAME
  - CONTROL_PLANE_MACHINE_COUNT
  - KUBERNETES_VERSION
  - WORKER_MACHINE_COUNT
```

After:

```shell
% clusterctl generate cluster testcluster1 --list-variables
Required Variables:
  - AZURE_CONTROL_PLANE_MACHINE_TYPE
  - AZURE_LOCATION
  - AZURE_NODE_MACHINE_TYPE
  - AZURE_SUBSCRIPTION_ID

Optional Variables:
  - AZURE_RESOURCE_GROUP         (defaults to "${CLUSTER_NAME}")
  - AZURE_SSH_PUBLIC_KEY_B64     (defaults to "")
  - AZURE_VNET_NAME              (defaults to "${CLUSTER_NAME}-vnet")
  - CLUSTER_NAME                 (defaults to <name> from "clusterctl config cluster <name>")
  - CONTROL_PLANE_MACHINE_COUNT  (defaults to 1)
  - KUBERNETES_VERSION           (defaults to the value of --kubernetes-version)
  - WORKER_MACHINE_COUNT         (defaults to 0)
```

**Which issue(s) this PR fixes**:

Fixes #4258
Closes #4262

**Notes**:

Credit goes to @mabikash for taking this on and showing the way forward!

I rebased #4262 but got stuck on not having a public implementation of the `yamlprocessor.VariableMetadata` interface: I wasn't sure if I should reimplement that just for the unit tests in other packages that reference variables. It's entirely possible I missed something - @mabikash let me know.

So I submitted this alternative implementation instead. This is arguably more hacky by not adding a struct to capture whether or not a variable is specifically required. Instead, if its value in the map is `nil`, it's required. If reviewers prefer the approach in #4262, I can try again to get it to pass tests instead.