### PR TITLE
🌱  Enable exportloopref, ifshort, and nilerr linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,10 +39,9 @@ linters:
   - whitespace
 
 linters-settings:
-  staticcheck:
-    go: "1.16"
-  stylecheck:
-    go: "1.16"
+  ifshort:
+    # Maximum length of variable declaration measured in number of characters, after which linter won't suggest using short syntax.
+    max-decl-chars: 50
   importas:
     no-unaliased: true
     alias:
@@ -60,6 +59,10 @@ linters-settings:
       # Controller Runtime
       - pkg: sigs.k8s.io/controller-runtime
         alias: ctrl
+  staticcheck:
+    go: "1.16"
+  stylecheck:
+    go: "1.16"
 
 issues:
   max-same-issues: 0
@@ -114,6 +117,12 @@ issues:
   - linters:
     - gocritic
     text: "appendAssign: append result not assigned to the same slice"
+  # ifshort flags variables that are only used in the if-statement even though there is
+  # already a SimpleStmt being used in the if-statement in question.
+  - linters:
+    - ifshort
+    text: "variable .* is only used in the if-statement"
+    path: controllers/mdutil/util.go
 
 run:
   timeout: 10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
   - ineffassign
   - misspell
   - nakedret
+  - nilerr
   - nolintlint
   - prealloc
   - revive

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   - dogsled
   - exportloopref
   - errcheck
+  - exportloopref
   - goconst
   - gocritic
   - gocyclo
@@ -19,6 +20,7 @@ linters:
   - gosimple
   - govet
   - importas
+  - ifshort
   - ineffassign
   - misspell
   - nakedret

--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -128,7 +128,7 @@ func (cm *certManagerClient) Images() ([]string, error) {
 	// Gets the cert-manager objects from the embedded assets.
 	objs, err := cm.getManifestObjs()
 	if err != nil {
-		return []string{}, nil
+		return []string{}, nil // nolint:nilerr // If there are no manifests we don't want to error, just return
 	}
 
 	images, err := util.InspectImages(objs)

--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -114,8 +114,7 @@ func newCertManagerClient(configClient config.Client, proxy Proxy, pollImmediate
 		proxy:               proxy,
 		pollImmediateWaiter: pollImmediateWaiter,
 	}
-	err := cm.setManifestVersion()
-	if err != nil {
+	if err := cm.setManifestVersion(); err != nil {
 		return nil, err
 	}
 

--- a/cmd/clusterctl/client/cluster/objectgraph_test.go
+++ b/cmd/clusterctl/client/cluster/objectgraph_test.go
@@ -1101,8 +1101,7 @@ func getFakeProxyWithCRDs() *test.FakeProxy {
 }
 
 func getFakeDiscoveryTypes(graph *objectGraph) error {
-	err := graph.getDiscoveryTypes()
-	if err != nil {
+	if err := graph.getDiscoveryTypes(); err != nil {
 		return err
 	}
 

--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -273,8 +273,7 @@ func validateProvider(r Provider) error {
 		return errors.New("provider URL value cannot be empty")
 	}
 
-	_, err := url.Parse(r.URL())
-	if err != nil {
+	if _, err := url.Parse(r.URL()); err != nil {
 		return errors.Wrap(err, "error parsing provider URL")
 	}
 

--- a/cmd/clusterctl/cmd/version_checker.go
+++ b/cmd/clusterctl/cmd/version_checker.go
@@ -145,7 +145,7 @@ func (v *versionChecker) getLatestRelease() (*ReleaseInfo, error) {
 			log.V(1).Info("⚠️ Unable to get latest github release for clusterctl")
 			// failing silently here so we don't error out in air-gapped
 			// environments.
-			return nil, nil
+			return nil, nil // nolint:nilerr
 		}
 
 		vs = &VersionState{

--- a/cmd/clusterctl/internal/test/fake_reader.go
+++ b/cmd/clusterctl/internal/test/fake_reader.go
@@ -64,7 +64,7 @@ func (f *FakeReader) Set(key, value string) {
 func (f *FakeReader) UnmarshalKey(key string, rawval interface{}) error {
 	data, err := f.Get(key)
 	if err != nil {
-		return nil
+		return nil // nolint:nilerr // We expect to not error if the key is not present
 	}
 	return yaml.Unmarshal([]byte(data), rawval)
 }

--- a/cmd/clusterctl/internal/util/cmd.go
+++ b/cmd/clusterctl/internal/util/cmd.go
@@ -91,8 +91,7 @@ func (c *Cmd) runInnerCommand() error {
 		cmd.Stderr = io.MultiWriter(&b1, c.stderr)
 	}
 
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, "failed to run: %s %s\n%s", c.command, strings.Join(c.args, " "), b1.String())
 	}
 

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -422,7 +422,7 @@ func (c clusterDescendants) filterOwnedDescendants(cluster *clusterv1.Cluster) (
 		obj := o.(client.Object)
 		acc, err := meta.Accessor(obj)
 		if err != nil {
-			return nil
+			return nil // nolint:nilerr // We don't want to exit the EachListItem loop, just continue
 		}
 
 		if util.IsOwnedByObject(acc, cluster) {

--- a/controllers/external/tracker.go
+++ b/controllers/external/tracker.go
@@ -45,8 +45,7 @@ func (o *ObjectTracker) Watch(log logr.Logger, obj runtime.Object, handler handl
 
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	key := gvk.GroupKind().String()
-	_, loaded := o.m.LoadOrStore(key, struct{}{})
-	if loaded {
+	if _, loaded := o.m.LoadOrStore(key, struct{}{}); loaded {
 		return nil
 	}
 

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -281,7 +281,7 @@ func (r *MachineReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 	log := ctrl.LoggerFrom(ctx, "cluster", cluster.Name)
 
 	err := r.isDeleteNodeAllowed(ctx, cluster, m)
-	isDeleteNodeAllowed := err == nil
+	isDeleteNodeAllowed := err == nil // nolint:ifshort
 	if err != nil {
 		switch err {
 		case errNoControlPlaneNodes, errLastControlPlaneNode, errNilNodeRef, errClusterIsBeingDeleted, errControlPlaneIsBeingDeleted:

--- a/controllers/machine_controller_noderef.go
+++ b/controllers/machine_controller_noderef.go
@@ -132,7 +132,7 @@ func (r *MachineReconciler) reconcileNode(ctx context.Context, cluster *clusterv
 // if all conditions are unknown,  summarized status = Unknown.
 // (semantically true conditions: NodeMemoryPressure/NodeDiskPressure/NodePIDPressure == false or Ready == true.)
 func summarizeNodeConditions(node *corev1.Node) (corev1.ConditionStatus, string) {
-	totalNumOfConditionsChecked := 4
+	// totalNumOfConditionsChecked := 4
 	semanticallyFalseStatus := 0
 	unknownStatus := 0
 
@@ -162,7 +162,7 @@ func summarizeNodeConditions(node *corev1.Node) (corev1.ConditionStatus, string)
 	if semanticallyFalseStatus > 0 {
 		return corev1.ConditionFalse, message
 	}
-	if semanticallyFalseStatus+unknownStatus < totalNumOfConditionsChecked {
+	if semanticallyFalseStatus+unknownStatus < 4 {
 		return corev1.ConditionTrue, message
 	}
 	return corev1.ConditionUnknown, message

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -46,7 +46,7 @@ var (
 )
 
 func (r *MachineReconciler) reconcilePhase(_ context.Context, m *clusterv1.Machine) {
-	originalPhase := m.Status.Phase
+	originalPhase := m.Status.Phase // nolint:ifshort
 
 	// Set the phase to "pending" if nil.
 	if m.Status.Phase == "" {

--- a/controllers/machinedeployment_rolling.go
+++ b/controllers/machinedeployment_rolling.go
@@ -162,7 +162,7 @@ func (r *MachineDeploymentReconciler) reconcileOldMachineSets(ctx context.Contex
 	// and cause timeout. See https://github.com/kubernetes/kubernetes/issues/16737
 	oldMSs, cleanupCount, err := r.cleanupUnhealthyReplicas(ctx, oldMSs, deployment, maxScaledDown)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	log.V(4).Info("Cleaned up unhealthy replicas from old MachineSets", "count", cleanupCount)

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -209,7 +209,7 @@ func (r *MachineHealthCheckReconciler) reconcile(ctx context.Context, logger log
 	// do sort to avoid keep changing m.Status as the returned machines are not in order
 	sort.Strings(m.Status.Targets)
 
-	nodeStartupTimeout := m.Spec.NodeStartupTimeout
+	nodeStartupTimeout := m.Spec.NodeStartupTimeout // nolint:ifshort
 	if nodeStartupTimeout == nil {
 		nodeStartupTimeout = &clusterv1.DefaultNodeStartupTimeout
 	}

--- a/controllers/machinehealthcheck_targets.go
+++ b/controllers/machinehealthcheck_targets.go
@@ -262,9 +262,9 @@ func (r *MachineHealthCheckReconciler) getNodeFromMachine(ctx context.Context, c
 	nodeKey := types.NamespacedName{
 		Name: machine.Status.NodeRef.Name,
 	}
-	err := clusterClient.Get(ctx, nodeKey, node)
+
 	// if it cannot find a node, send a nil node back...
-	if err != nil {
+	if err := clusterClient.Get(ctx, nodeKey, node); err != nil {
 		return nil, err
 	}
 	return node, nil

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -142,7 +142,7 @@ func (matcher *refGroupKindMatcher) Match(actual interface{}) (success bool, err
 	for _, ref := range ownerRefs {
 		gv, err := schema.ParseGroupVersion(ref.APIVersion)
 		if err != nil {
-			return false, nil
+			return false, nil // nolint:nilerr // If we can't get the group version we can't match, but it's not a failure
 		}
 		if ref.Kind == matcher.kind && gv.Group == clusterv1.GroupVersion.Group {
 			return true, nil

--- a/exp/addons/controllers/clusterresourceset_controller.go
+++ b/exp/addons/controllers/clusterresourceset_controller.go
@@ -407,8 +407,8 @@ func (r *ClusterResourceSetReconciler) patchOwnerRefToResource(ctx context.Conte
 		UID:        clusterResourceSet.GetUID(),
 	}
 
-	refs := resource.GetOwnerReferences()
 	if !util.IsOwnedByObject(resource, clusterResourceSet) {
+		refs := resource.GetOwnerReferences()
 		patch := client.MergeFrom(resource.DeepCopy())
 		refs = append(refs, newRef)
 		resource.SetOwnerReferences(refs)

--- a/test/e2e/custom_assertions.go
+++ b/test/e2e/custom_assertions.go
@@ -35,7 +35,7 @@ func (m *controllerMatch) Match(actual interface{}) (success bool, err error) {
 		return false, fmt.Errorf("unable to read meta for %T: %w", actual, err)
 	}
 
-	owner := metav1.GetControllerOf(actualMeta)
+	owner := metav1.GetControllerOf(actualMeta) // nolint:ifshort
 	if owner == nil {
 		return false, fmt.Errorf("no controller found (owner ref with controller = true) for object %#v", actual)
 	}

--- a/test/framework/kubetest/setup.go
+++ b/test/framework/kubetest/setup.go
@@ -24,8 +24,7 @@ import (
 )
 
 func copyFile(srcFilePath, destFilePath string) error {
-	err := os.MkdirAll(path.Dir(destFilePath), 0o750)
-	if err != nil {
+	if err := os.MkdirAll(path.Dir(destFilePath), 0o750); err != nil {
 		return err
 	}
 	srcFile, err := os.Open(filepath.Clean(srcFilePath))

--- a/test/infrastructure/docker/exp/docker/nodepool.go
+++ b/test/infrastructure/docker/exp/docker/nodepool.go
@@ -282,7 +282,7 @@ func (np *NodePool) reconcileMachine(ctx context.Context, machine *docker.Machin
 		if err != nil {
 			// Requeue if there is an error, as this is likely momentary load balancer
 			// state changes during control plane provisioning.
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{Requeue: true}, nil // nolint:nilerr
 		}
 
 		machineStatus.Addresses = []clusterv1.MachineAddress{
@@ -308,7 +308,7 @@ func (np *NodePool) reconcileMachine(ctx context.Context, machine *docker.Machin
 		// state changes during control plane provisioning.
 		if err := externalMachine.SetNodeProviderID(ctx); err != nil {
 			log.V(4).Info("transient error setting the provider id")
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{Requeue: true}, nil // nolint:nilerr
 		}
 		// Set ProviderID so the Cluster API Machine Controller can pull it
 		providerID := externalMachine.ProviderID()

--- a/util/secret/certificates.go
+++ b/util/secret/certificates.go
@@ -373,28 +373,22 @@ func (c *Certificate) Generate() error {
 
 // AsFiles converts a slice of certificates into bootstrap files.
 func (c Certificates) AsFiles() []bootstrapv1.File {
-	clusterCA := c.GetByPurpose(ClusterCA)
-	etcdCA := c.GetByPurpose(EtcdCA)
-	frontProxyCA := c.GetByPurpose(FrontProxyCA)
-	serviceAccountKey := c.GetByPurpose(ServiceAccount)
-
 	certFiles := make([]bootstrapv1.File, 0)
-	if clusterCA != nil {
+	if clusterCA := c.GetByPurpose(ClusterCA); clusterCA != nil {
 		certFiles = append(certFiles, clusterCA.AsFiles()...)
 	}
-	if etcdCA != nil {
+	if etcdCA := c.GetByPurpose(EtcdCA); etcdCA != nil {
 		certFiles = append(certFiles, etcdCA.AsFiles()...)
 	}
-	if frontProxyCA != nil {
+	if frontProxyCA := c.GetByPurpose(FrontProxyCA); frontProxyCA != nil {
 		certFiles = append(certFiles, frontProxyCA.AsFiles()...)
 	}
-	if serviceAccountKey != nil {
+	if serviceAccountKey := c.GetByPurpose(ServiceAccount); serviceAccountKey != nil {
 		certFiles = append(certFiles, serviceAccountKey.AsFiles()...)
 	}
 
 	// these will only exist if external etcd was defined and supplied by the user
-	apiserverEtcdClientCert := c.GetByPurpose(APIServerEtcdClient)
-	if apiserverEtcdClientCert != nil {
+	if apiserverEtcdClientCert := c.GetByPurpose(APIServerEtcdClient); apiserverEtcdClientCert != nil {
 		certFiles = append(certFiles, apiserverEtcdClientCert.AsFiles()...)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of our ongoing effort to enable more linters to take the human equation out of enforcing and catching minor issues.
This enables the [exportloopref](https://github.com/kyoh86/exportloopref), [ifshort](https://github.com/esimonov/ifshort), and [nilerr](https://github.com/gostaticanalysis/nilerr) linters.

- exportloopref - no issues found
- ifshort - no issues found
- nilerr - identified a few cases, most which appear to be intentional

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related #4622
