### PR TITLE
🌱Add SpokeBeforeMutation() to FuzzTest to accept data loss from spoke to hub

### DIFF
--- a/util/conversion/conversion.go
+++ b/util/conversion/conversion.go
@@ -164,6 +164,7 @@ type FuzzTestFuncInput struct {
 	HubAfterMutation func(conversion.Hub)
 
 	Spoke                      conversion.Convertible
+	SpokeBeforeMutation        func(convertible conversion.Convertible)
 	SpokeAfterMutation         func(convertible conversion.Convertible)
 	SkipSpokeAnnotationCleanup bool
 
@@ -182,7 +183,9 @@ func FuzzTestFunc(input FuzzTestFuncInput) func(*testing.T) {
 				// Create the spoke and fuzz it
 				spokeBefore := input.Spoke.DeepCopyObject().(conversion.Convertible)
 				fuzzer.Fuzz(spokeBefore)
-
+				if input.SpokeBeforeMutation != nil {
+					input.SpokeBeforeMutation(spokeBefore)
+				}
 				// First convert spoke to hub
 				hubCopy := input.Hub.DeepCopyObject().(conversion.Hub)
 				g.Expect(spokeBefore.ConvertTo(hubCopy)).To(gomega.Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4655
