### PR TITLE
🐛 Invoke ginkgo in kubetest through entrypoint

### DIFF
--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -153,13 +153,13 @@ func Run(ctx context.Context, input RunInput) error {
 		return errors.Wrap(err, "unable to determine current user")
 	}
 	userArg := user.Uid + ":" + user.Gid
+	entrypointArg := "--entrypoint=/usr/local/bin/ginkgo"
 	networkArg := "--network=kind"
-	e2eCmd := exec.Command("docker", "run", "--user", userArg, kubeConfigVolumeMount, outputVolumeMount, viperVolumeMount, "-t", networkArg)
+	e2eCmd := exec.Command("docker", "run", "--user", userArg, entrypointArg, kubeConfigVolumeMount, outputVolumeMount, viperVolumeMount, "-t", networkArg)
 	if len(testRepoListVolumeArgs) > 0 {
 		e2eCmd.Args = append(e2eCmd.Args, testRepoListVolumeArgs...)
 	}
 	e2eCmd.Args = append(e2eCmd.Args, input.ConformanceImage)
-	e2eCmd.Args = append(e2eCmd.Args, "/usr/local/bin/ginkgo")
 	e2eCmd.Args = append(e2eCmd.Args, ginkgoArgs...)
 	e2eCmd.Args = append(e2eCmd.Args, "/usr/local/bin/e2e.test")
 	e2eCmd.Args = append(e2eCmd.Args, "--")


### PR DESCRIPTION
Signed-off-by: Wilson E. Husin <wilson@husin.dev>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This change is necessary due to kubernetes/kubernetes#99178 where the
conformance image now defines ENTRYPOINT (previously only CMD) which
refers to conformance runner.

Since this test would like to invoke ginkgo directly, overriding
entrypoint is necessary to preserve existing behavior.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #4660
