### PR TITLE
🐛 test/e2e: upgrade 1.18/1.19 kindest/node images to latest patch version

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -110,11 +110,11 @@ providers:
 variables:
   # default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
-  KUBERNETES_VERSION: "v1.19.1"
+  KUBERNETES_VERSION: "v1.19.11"
   ETCD_VERSION_UPGRADE_TO: "3.4.9-0"
   COREDNS_VERSION_UPGRADE_TO: "1.7.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.19.1"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.18.2"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.19.11"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.18.19"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "IPv4"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// DefaultNodeImage is the default node image to be used for for testing.
-	DefaultNodeImage = "kindest/node:v1.19.1"
+	DefaultNodeImage = "kindest/node:v1.19.11"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/infrastructure/docker/docker/machine.go
+++ b/test/infrastructure/docker/docker/machine.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.19.1"
+	defaultImageTag  = "v1.19.11"
 )
 
 type nodeCreator interface {

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -29,7 +29,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.19.1
+  version: v1.19.11
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -86,7 +86,7 @@ spec:
         kind: DockerMachinePool
         name: worker-dmp-0
         namespace: default
-      version: v1.19.1
+      version: v1.19.11
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: DockerMachinePool

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.19.1
+  version: v1.19.11
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -120,7 +120,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.19.1
+      version: v1.19.11
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -38,7 +38,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.19.1
+  version: v1.19.11
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -106,7 +106,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.19.1
+      version: v1.19.11
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.19.1
+  version: v1.19.11
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -105,7 +105,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.19.1
+      version: v1.19.11
       clusterName: my-cluster
       bootstrap:
         configRef:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR upgrade to the latest Kubernetes patch versions. Those images are built with kind v0.11.0 (or a kind version very close to the release). Goal is to finally only uses images with the new entrypoint script without the PIPEFAIL issue.

For more context please see https://github.com/kubernetes-sigs/cluster-api/issues/4405#issuecomment-847571154

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes (hopefully) #4405
