### PR TITLE
📖 doc: add linter fix hint to migration doc

### DIFF
--- a/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
+++ b/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
@@ -277,3 +277,10 @@ MachinePool is today an experiment, and the API group we originally decided to p
 All InfraMachinePool implementations should be moved to `infrastructure.cluster.x-k8s.io`. See `DockerMachinePool` for an example.
 
 Note that MachinePools are still experimental after this change and should still be feature gated.
+
+## Golangci-lint configuration
+
+There were a lot of new useful linters added to `.golangci.yml`. Of course it's not mandatory to use `golangci-lint` or 
+a similar configuration, but it might make sense regardless. Please note there was previously an error in 
+the `exclude` configuration which has been fixed in [#4657](https://github.com/kubernetes-sigs/cluster-api/pull/4657). As 
+this configuration has been duplicated in a few other providers, it could be that you're also affected.


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to https://github.com/kubernetes-sigs/cluster-api/pull/4657. Adds a hint about new linters we added and the bugfix which is at least relevant to CAPA/CAPG/CAPO and probably a few other providers.

Some more context:
* https://github.com/kubernetes-sigs/cluster-api/pull/4649#issuecomment-847142876
* https://kubernetes.slack.com/archives/C8TSNPY4T/p1621871864043200

Related issues:
* CAPA: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2414
* CAPO: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/878
* CAPG: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/issues/368
* CAPDO: https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/issues/258
* CAPN: https://github.com/kubernetes-sigs/cluster-api-provider-nested/issues/80

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
