### PR TITLE
:warning: Enforce comments on most of the codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,14 +44,12 @@ issues:
   exclude:
   - "G108: Profiling endpoint is automatically exposed on /debug/pprof"
   - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-  - exported method `.*.Reconcile` should have comment or be unexported
-  - exported method `.*.SetupWithManager` should have comment or be unexported
+  - exported method `.*.(Reconcile|SetupWithManager|SetupWebhookWithManager)` should have comment or be unexported
   # The following are being worked on to remove their exclusion. This list should be reduced or go away all together over time.
   # If it is decided they will not be addressed they should be moved above this comment.
   - Subprocess launch(ed with variable|ing should be audited)
   - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
   - (G104|G307)
-  - exported (method|function|type|const) (.+) should have comment or be unexported
   exclude-rules:
   # With Go 1.16, the new embed directive can be used with an un-named import,
   # golint only allows these to be imported in a main.go, which wouldn't work for us.
@@ -59,6 +57,19 @@ issues:
   - linters:
     - golint
     source: _ "embed"
+  # Exclude some packages or code to require comments, for example test code, or fake clients.
+  - linters:
+    - golint
+    text: exported (method|function|type|const) (.+) should have comment or be unexported
+    source: (func|type).*Fake.*
+  - linters:
+    - golint
+    text: exported (method|function|type|const) (.+) should have comment or be unexported
+    path: fake_\.go
+  - linters:
+    - golint
+    text: exported (method|function|type|const) (.+) should have comment or be unexported
+    path: .*test/(providers|framework|e2e).*.go
   # Disable unparam "always receives" which might not be really
   # useful when building libraries.
   - linters:
@@ -70,9 +81,7 @@ issues:
     text: should not use dot imports
   - path: _test\.go
     text: cyclomatic complexity
-  - path: test/framework.*.go
-    text: should not use dot imports
-  - path: test/e2e.*.go
+  - path: test/(framework|e2e).*.go
     text: should not use dot imports
 
 run:

--- a/api/v1alpha3/cluster_types.go
+++ b/api/v1alpha3/cluster_types.go
@@ -213,10 +213,12 @@ type Cluster struct {
 	Status ClusterStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (c *Cluster) GetConditions() Conditions {
 	return c.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (c *Cluster) SetConditions(conditions Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/api/v1alpha3/machine_types.go
+++ b/api/v1alpha3/machine_types.go
@@ -252,10 +252,12 @@ type Machine struct {
 	Status MachineStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (m *Machine) GetConditions() Conditions {
 	return m.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (m *Machine) SetConditions(conditions Conditions) {
 	m.Status.Conditions = conditions
 }

--- a/api/v1alpha3/machinedeployment_types.go
+++ b/api/v1alpha3/machinedeployment_types.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// MachineDeploymentStrategyType defines the type of MachineDeployment rollout strategies.
 type MachineDeploymentStrategyType string
 
 const (

--- a/api/v1alpha3/machinehealthcheck_types.go
+++ b/api/v1alpha3/machinehealthcheck_types.go
@@ -132,10 +132,12 @@ type MachineHealthCheck struct {
 	Status MachineHealthCheckStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (m *MachineHealthCheck) GetConditions() Conditions {
 	return m.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (m *MachineHealthCheck) SetConditions(conditions Conditions) {
 	m.Status.Conditions = conditions
 }

--- a/api/v1alpha4/cluster_types.go
+++ b/api/v1alpha4/cluster_types.go
@@ -211,14 +211,17 @@ type Cluster struct {
 	Status ClusterStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (c *Cluster) GetConditions() Conditions {
 	return c.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (c *Cluster) SetConditions(conditions Conditions) {
 	c.Status.Conditions = conditions
 }
 
+// GetIPFamily returns a ClusterIPFamily from the configuration provided.
 func (c *Cluster) GetIPFamily() (ClusterIPFamily, error) {
 	var podCIDRs, serviceCIDRs []string
 	if c.Spec.ClusterNetwork != nil {
@@ -287,6 +290,7 @@ func ipFamilyForCIDRStrings(cidrs []string) (ClusterIPFamily, error) {
 	}
 }
 
+// ClusterIPFamily defines the types of supported IP families.
 type ClusterIPFamily int
 
 // Define the ClusterIPFamily constants.

--- a/api/v1alpha4/cluster_webhook.go
+++ b/api/v1alpha4/cluster_webhook.go
@@ -36,6 +36,7 @@ func (c *Cluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Defaulter = &Cluster{}
 var _ webhook.Validator = &Cluster{}
 
+// Default satisfies the defaulting webhook interface.
 func (c *Cluster) Default() {
 	if c.Spec.InfrastructureRef != nil && len(c.Spec.InfrastructureRef.Namespace) == 0 {
 		c.Spec.InfrastructureRef.Namespace = c.Namespace

--- a/api/v1alpha4/machine_types.go
+++ b/api/v1alpha4/machine_types.go
@@ -245,10 +245,12 @@ type Machine struct {
 	Status MachineStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (m *Machine) GetConditions() Conditions {
 	return m.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (m *Machine) SetConditions(conditions Conditions) {
 	m.Status.Conditions = conditions
 }

--- a/api/v1alpha4/machinedeployment_types.go
+++ b/api/v1alpha4/machinedeployment_types.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// MachineDeploymentStrategyType defines the type of MachineDeployment rollout strategies.
 type MachineDeploymentStrategyType string
 
 const (

--- a/api/v1alpha4/machinehealthcheck_types.go
+++ b/api/v1alpha4/machinehealthcheck_types.go
@@ -144,10 +144,12 @@ type MachineHealthCheck struct {
 	Status MachineHealthCheckStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (m *MachineHealthCheck) GetConditions() Conditions {
 	return m.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (m *MachineHealthCheck) SetConditions(conditions Conditions) {
 	m.Status.Conditions = conditions
 }

--- a/bootstrap/kubeadm/api/v1alpha3/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1alpha3/kubeadmconfig_types.go
@@ -143,10 +143,12 @@ type KubeadmConfig struct {
 	Status KubeadmConfigStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (c *KubeadmConfig) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (c *KubeadmConfig) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/bootstrap/kubeadm/api/v1alpha4/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1alpha4/kubeadmconfig_types.go
@@ -136,10 +136,12 @@ type KubeadmConfig struct {
 	Status KubeadmConfigStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (c *KubeadmConfig) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (c *KubeadmConfig) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -77,6 +77,7 @@ type KubeadmConfigReconciler struct {
 	remoteClientGetter remote.ClusterClientGetter
 }
 
+// Scope is a scoped struct used during reconciliation.
 type Scope struct {
 	logr.Logger
 	Config      *bootstrapv1.KubeadmConfig

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -77,6 +77,7 @@ var (
 	healthAddr                  string
 )
 
+// InitFlags initializes this manager's flags.
 func InitFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&metricsBindAddr, "metrics-bind-addr", ":8080",
 		"The address the metric endpoint binds to.")

--- a/bootstrap/kubeadm/types/utils.go
+++ b/bootstrap/kubeadm/types/utils.go
@@ -55,6 +55,7 @@ var (
 	}
 )
 
+// KubeVersionToKubeadmAPIGroupVersion maps a Kubernetes version to the correct Kubeadm API Group supported.
 func KubeVersionToKubeadmAPIGroupVersion(version semver.Version) (schema.GroupVersion, error) {
 	switch {
 	case version.LT(v1beta1KubeadmVersion):

--- a/cmd/clusterctl/api/v1alpha3/provider_type.go
+++ b/cmd/clusterctl/api/v1alpha3/provider_type.go
@@ -151,30 +151,35 @@ type ProviderList struct {
 	Items           []Provider `json:"items"`
 }
 
+// FilterByNamespace returns a new list of providers that reside in the namespace provided.
 func (l *ProviderList) FilterByNamespace(namespace string) []Provider {
 	return l.filterBy(func(p Provider) bool {
 		return p.Namespace == namespace
 	})
 }
 
+// FilterByProviderNameAndType returns a new list of provider that match the name and type.
 func (l *ProviderList) FilterByProviderNameAndType(provider string, providerType ProviderType) []Provider {
 	return l.filterBy(func(p Provider) bool {
 		return p.ProviderName == provider && p.Type == string(providerType)
 	})
 }
 
+// FilterByType returns a new list of providers that match the given type.
 func (l *ProviderList) FilterByType(providerType ProviderType) []Provider {
 	return l.filterBy(func(p Provider) bool {
 		return p.GetProviderType() == providerType
 	})
 }
 
+// FilterCore returns a new list of providers that are in the core.
 func (l *ProviderList) FilterCore() []Provider {
 	return l.filterBy(func(p Provider) bool {
 		return p.GetProviderType() == CoreProviderType
 	})
 }
 
+// FilterNonCore returns a new list of providers that are not in the core.
 func (l *ProviderList) FilterNonCore() []Provider {
 	return l.filterBy(func(p Provider) bool {
 		return p.GetProviderType() != CoreProviderType

--- a/cmd/clusterctl/client/alpha/rollout.go
+++ b/cmd/clusterctl/client/alpha/rollout.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 )
 
+// MachineDeployment is a resource type.
 const MachineDeployment = "machinedeployment"
 
 var validResourceTypes = []string{MachineDeployment}

--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -105,20 +105,22 @@ type clusterctlClient struct {
 	alphaClient             alpha.Client
 }
 
-// RepositoryClientFactoryInput represents the inputs required by the
-// RepositoryClientFactory.
+// RepositoryClientFactoryInput represents the inputs required by the factory.
 type RepositoryClientFactoryInput struct {
 	Provider  Provider
 	Processor Processor
 }
+
+// RepositoryClientFactory is a factory of repository.Client from a given input.
 type RepositoryClientFactory func(RepositoryClientFactoryInput) (repository.Client, error)
 
-// ClusterClientFactoryInput reporesents the inputs required by the
-// ClusterClientFactory.
+// ClusterClientFactoryInput reporesents the inputs required by the factory.
 type ClusterClientFactoryInput struct {
 	Kubeconfig Kubeconfig
 	Processor  Processor
 }
+
+// ClusterClientFactory is a factory of cluster.Client from a given input.
 type ClusterClientFactory func(ClusterClientFactoryInput) (cluster.Client, error)
 
 // Ensure clusterctlClient implements Client.

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -104,6 +104,7 @@ type clusterClient struct {
 	processor               yaml.Processor
 }
 
+// RepositoryClientFactory defines a function that returns a new repository.Client.
 type RepositoryClientFactory func(provider config.Provider, configClient config.Client, options ...repository.Option) (repository.Client, error)
 
 // ensure clusterClient implements Client.
@@ -218,6 +219,7 @@ func newClusterClient(kubeconfig Kubeconfig, configClient config.Client, options
 	return client
 }
 
+// Proxy defines a client proxy interface.
 type Proxy interface {
 	// GetConfig returns the rest.Config
 	GetConfig() (*rest.Config, error)

--- a/cmd/clusterctl/client/cluster/components.go
+++ b/cmd/clusterctl/client/cluster/components.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// DeleteOptions defines delete options.
 type DeleteOptions struct {
 	Provider         clusterctlv1.Provider
 	IncludeNamespace bool

--- a/cmd/clusterctl/client/cluster/proxy.go
+++ b/cmd/clusterctl/client/cluster/proxy.go
@@ -217,14 +217,17 @@ func listObjByGVK(c client.Client, groupVersion, kind string, options []client.L
 	return objList, nil
 }
 
+// ProxyOption defines a function that can change proxy options.
 type ProxyOption func(p *proxy)
 
+// InjectProxyTimeout sets the proxy timeout.
 func InjectProxyTimeout(t time.Duration) ProxyOption {
 	return func(p *proxy) {
 		p.timeout = t
 	}
 }
 
+// InjectKubeconfigPaths sets the kubeconfig paths loading rules.
 func InjectKubeconfigPaths(paths []string) ProxyOption {
 	return func(p *proxy) {
 		p.configLoadingRules.Precedence = paths

--- a/cmd/clusterctl/client/cluster/template.go
+++ b/cmd/clusterctl/client/cluster/template.go
@@ -54,6 +54,7 @@ type templateClient struct {
 // ensure templateClient implements TemplateClient.
 var _ TemplateClient = &templateClient{}
 
+// TemplateClientInput is an input struct for newTemplateClient.
 type TemplateClientInput struct {
 	proxy        Proxy
 	configClient config.Client

--- a/cmd/clusterctl/client/config/provider.go
+++ b/cmd/clusterctl/client/config/provider.go
@@ -83,6 +83,7 @@ func (p *provider) Less(other Provider) bool {
 		(p.providerType.Order() == other.Type().Order() && p.name < other.Name())
 }
 
+// NewProvider creates a new Provider with the given input.
 func NewProvider(name string, url string, ttype clusterctlv1.ProviderType) Provider {
 	return &provider{
 		name:         name,

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -27,6 +27,7 @@ import (
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
+// NoopProvider determines if a provider passed in should behave as a no-op.
 const NoopProvider = "-"
 
 // InitOptions carries the options supported by Init.

--- a/cmd/clusterctl/client/repository/template.go
+++ b/cmd/clusterctl/client/repository/template.go
@@ -70,6 +70,7 @@ func (t *template) Yaml() ([]byte, error) {
 	return utilyaml.FromUnstructured(t.objs)
 }
 
+// TemplateInput is an input struct for NewTemplate.
 type TemplateInput struct {
 	RawArtifact           []byte
 	ConfigVariablesClient config.VariablesClient

--- a/cmd/clusterctl/client/repository/template_client.go
+++ b/cmd/clusterctl/client/repository/template_client.go
@@ -38,6 +38,7 @@ type templateClient struct {
 	processor             yaml.Processor
 }
 
+// TemplateClientInput is an input strict for newTemplateClient.
 type TemplateClientInput struct {
 	version               string
 	provider              config.Provider

--- a/cmd/clusterctl/client/tree/options.go
+++ b/cmd/clusterctl/client/tree/options.go
@@ -38,6 +38,7 @@ func (o *addObjectOptions) ApplyOptions(opts []AddObjectOption) *addObjectOption
 // e.g. control plane for KCP.
 type ObjectMetaName string
 
+// ApplyToAdd applies the given options.
 func (n ObjectMetaName) ApplyToAdd(options *addObjectOptions) {
 	options.MetaName = string(n)
 }
@@ -46,6 +47,7 @@ func (n ObjectMetaName) ApplyToAdd(options *addObjectOptions) {
 // when adding the node's children.
 type GroupingObject bool
 
+// ApplyToAdd applies the given options.
 func (n GroupingObject) ApplyToAdd(options *addObjectOptions) {
 	options.GroupingObject = bool(n)
 }
@@ -54,6 +56,7 @@ func (n GroupingObject) ApplyToAdd(options *addObjectOptions) {
 // same Status, Severity and Reason of the parent's object ready condition (it is an echo).
 type NoEcho bool
 
+// ApplyToAdd applies the given options.
 func (n NoEcho) ApplyToAdd(options *addObjectOptions) {
 	options.NoEcho = bool(n)
 }

--- a/cmd/clusterctl/client/tree/tree.go
+++ b/cmd/clusterctl/client/tree/tree.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ObjectTreeOptions defines the options for an ObjectTree.
 type ObjectTreeOptions struct {
 	// ShowOtherConditions is a list of comma separated kind or kind/name for which we should add   the ShowObjectConditionsAnnotation
 	// to signal to the presentation layer to show all the conditions for the objects.
@@ -52,6 +53,7 @@ type ObjectTree struct {
 	ownership map[types.UID]map[types.UID]bool
 }
 
+// NewObjectTree creates a new object tree with the given root and options.
 func NewObjectTree(root client.Object, options ObjectTreeOptions) *ObjectTree {
 	return &ObjectTree{
 		root:      root,
@@ -155,14 +157,18 @@ func (od ObjectTree) addInner(parent client.Object, obj client.Object) {
 	od.ownership[parent.GetUID()][obj.GetUID()] = true
 }
 
+// GetRoot returns the root of the tree.
 func (od ObjectTree) GetRoot() client.Object { return od.root }
 
+// GetObject returns the object with the given uid.
 func (od ObjectTree) GetObject(id types.UID) client.Object { return od.items[id] }
 
+// IsObjectWithChild determines if an object has dependants.
 func (od ObjectTree) IsObjectWithChild(id types.UID) bool {
 	return len(od.ownership[id]) > 0
 }
 
+// GetObjectsByParent returns all the dependant objects for the given uid.
 func (od ObjectTree) GetObjectsByParent(id types.UID) []client.Object {
 	out := make([]client.Object, 0, len(od.ownership[id]))
 	for k := range od.ownership[id] {

--- a/cmd/clusterctl/client/yamlprocessor/simple_processor.go
+++ b/cmd/clusterctl/client/yamlprocessor/simple_processor.go
@@ -34,6 +34,7 @@ type SimpleProcessor struct{}
 
 var _ Processor = &SimpleProcessor{}
 
+// NewSimpleProcessor returns a new simple template processor.
 func NewSimpleProcessor() *SimpleProcessor {
 	return &SimpleProcessor{}
 }

--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -88,6 +88,7 @@ var RootCmd = &cobra.Command{
 	},
 }
 
+// Execute executes the root command.
 func Execute() {
 	if err := RootCmd.Execute(); err != nil {
 		if verbosity != nil && *verbosity >= 5 {
@@ -134,7 +135,7 @@ func initConfig() {
 	logf.SetLogger(logf.NewLogger(logf.WithThreshold(verbosity)))
 }
 
-const Indentation = `  `
+const indentation = `  `
 
 // LongDesc normalizes a command's long description to follow the conventions.
 func LongDesc(s string) string {
@@ -172,7 +173,7 @@ func (s normalizer) indent() normalizer {
 	indentedLines := make([]string, 0, len(splitLines))
 	for _, line := range splitLines {
 		trimmed := strings.TrimSpace(line)
-		indented := Indentation + trimmed
+		indented := indentation + trimmed
 		indentedLines = append(indentedLines, indented)
 	}
 	s.string = strings.Join(indentedLines, "\n")

--- a/cmd/clusterctl/internal/test/fake_objects.go
+++ b/cmd/clusterctl/internal/test/fake_objects.go
@@ -1143,6 +1143,7 @@ func (f *FakeExternalObject) Objs() []client.Object {
 	return []client.Object{externalObj}
 }
 
+// SelectClusterObj finds and returns a Cluster with the given name and namespace, if any.
 func SelectClusterObj(objs []client.Object, namespace, name string) *clusterv1.Cluster {
 	for _, o := range objs {
 		if o.GetObjectKind().GroupVersionKind().GroupKind() != clusterv1.GroupVersion.WithKind("Cluster").GroupKind() {

--- a/cmd/clusterctl/internal/util/cmd.go
+++ b/cmd/clusterctl/internal/util/cmd.go
@@ -36,6 +36,7 @@ type Cmd struct {
 	stderr  io.Writer
 }
 
+// NewCmd returns a new Cmd with the given arguments.
 func NewCmd(command string, args ...string) *Cmd {
 	return &Cmd{
 		command: command,
@@ -43,16 +44,19 @@ func NewCmd(command string, args ...string) *Cmd {
 	}
 }
 
+// Run runs the command.
 func (c *Cmd) Run() error {
 	return c.runInnerCommand()
 }
 
+// RunWithEcho runs the command and redirects its output to stdout and stderr.
 func (c *Cmd) RunWithEcho() error {
 	c.stdout = os.Stderr
 	c.stderr = os.Stdout
 	return c.runInnerCommand()
 }
 
+// RunAndCapture runs the command and captures any output.
 func (c *Cmd) RunAndCapture() (lines []string, err error) {
 	var buff bytes.Buffer
 	c.stdout = &buff
@@ -66,6 +70,7 @@ func (c *Cmd) RunAndCapture() (lines []string, err error) {
 	return lines, err
 }
 
+// Stdin sets the stdin for the command.
 func (c *Cmd) Stdin(in io.Reader) *Cmd {
 	c.stdin = in
 	return c

--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -49,6 +49,7 @@ func Get(ctx context.Context, c client.Client, ref *corev1.ObjectReference, name
 	return obj, nil
 }
 
+// CloneTemplateInput is the input to CloneTemplate.
 type CloneTemplateInput struct {
 	// Client is the controller runtime client.
 	// +required
@@ -138,6 +139,7 @@ type GenerateTemplateInput struct {
 	Annotations map[string]string
 }
 
+// GenerateTemplate generates an object with the given template input.
 func GenerateTemplate(in *GenerateTemplateInput) (*unstructured.Unstructured, error) {
 	template, found, err := unstructured.NestedMap(in.Template.Object, "spec", "template")
 	if !found {

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -162,10 +162,12 @@ type KubeadmControlPlane struct {
 	Status KubeadmControlPlaneStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (in *KubeadmControlPlane) GetConditions() clusterv1.Conditions {
 	return in.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (in *KubeadmControlPlane) SetConditions(conditions clusterv1.Conditions) {
 	in.Status.Conditions = conditions
 }

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_types.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/cluster-api/errors"
 )
 
+// RolloutStrategyType defines the rollout strategies for a KubeadmControlPlane.
 type RolloutStrategyType string
 
 const (
@@ -87,6 +88,8 @@ type KubeadmControlPlaneSpec struct {
 	RolloutStrategy *RolloutStrategy `json:"rolloutStrategy,omitempty"`
 }
 
+// KubeadmControlPlaneMachineTemplate defines the template for Machines
+// in a KubeadmControlPlane object.
 type KubeadmControlPlaneMachineTemplate struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -209,10 +212,12 @@ type KubeadmControlPlane struct {
 	Status KubeadmControlPlaneStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (in *KubeadmControlPlane) GetConditions() clusterv1.Conditions {
 	return in.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (in *KubeadmControlPlane) SetConditions(conditions clusterv1.Conditions) {
 	in.Status.Conditions = conditions
 }

--- a/controlplane/kubeadm/internal/cluster.go
+++ b/controlplane/kubeadm/internal/cluster.go
@@ -59,7 +59,10 @@ type RemoteClusterConnectionError struct {
 	Err  error
 }
 
+// Error satisfies the error interface.
 func (e *RemoteClusterConnectionError) Error() string { return e.Name + ": " + e.Err.Error() }
+
+// Unwrap satisfies the unwrap error inteface.
 func (e *RemoteClusterConnectionError) Unwrap() error { return e.Err }
 
 // Get implements client.Reader.

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -329,6 +329,7 @@ func (c *ControlPlane) HasUnhealthyMachine() bool {
 	return len(c.UnhealthyMachines()) > 0
 }
 
+// PatchMachines patches all the machines conditions.
 func (c *ControlPlane) PatchMachines(ctx context.Context) error {
 	errList := []error{}
 	for i := range c.Machines {

--- a/controlplane/kubeadm/internal/etcd/etcd.go
+++ b/controlplane/kubeadm/internal/etcd/etcd.go
@@ -65,6 +65,7 @@ type MemberAlarm struct {
 	Type AlarmType
 }
 
+// AlarmType defines the type of alarm for etcd.
 type AlarmType int32
 
 const (

--- a/controlplane/kubeadm/internal/etcd/util/util.go
+++ b/controlplane/kubeadm/internal/etcd/util/util.go
@@ -32,6 +32,7 @@ func MemberForName(members []*etcd.Member, name string) *etcd.Member {
 	return nil
 }
 
+// MemberNames returns a list of all the etcd member names.
 func MemberNames(members []*etcd.Member) []string {
 	names := make([]string, 0, len(members))
 	for _, m := range members {
@@ -40,6 +41,10 @@ func MemberNames(members []*etcd.Member) []string {
 	return names
 }
 
+// MemberEqual returns true if the lists of members match.
+//
+// This function only checks that set of names of each member
+// within the lists is the same.
 func MemberEqual(members1, members2 []*etcd.Member) bool {
 	names1 := sets.NewString(MemberNames(members1)...)
 	names2 := sets.NewString(MemberNames(members2)...)

--- a/controlplane/kubeadm/internal/workload_cluster_coredns.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns.go
@@ -52,8 +52,10 @@ type coreDNSMigrator interface {
 	Migrate(currentVersion string, toVersion string, corefile string, deprecations bool) (string, error)
 }
 
+// CoreDNSMigrator is a shim that can be used to migrate CoreDNS files from one version to another.
 type CoreDNSMigrator struct{}
 
+// Migrate calls the CoreDNS migration library to migrate a corefile.
 func (c *CoreDNSMigrator) Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefile string, deprecations bool) (string, error) {
 	return migration.Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefile, deprecations)
 }

--- a/controlplane/kubeadm/internal/workload_cluster_etcd.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd.go
@@ -191,6 +191,7 @@ func (w *Workload) ForwardEtcdLeadership(ctx context.Context, machine *clusterv1
 	return nil
 }
 
+// EtcdMemberStatus contains status information for a single etcd member.
 type EtcdMemberStatus struct {
 	Name       string
 	Responsive bool

--- a/errors/clusters.go
+++ b/errors/clusters.go
@@ -37,6 +37,7 @@ func (e *ClusterError) Error() string {
 // value, and all arguments are Printf-style varargs fed into Sprintf to
 // construct the Message.
 
+// InvalidClusterConfiguration creates a new error for when the cluster configuration is invalid.
 func InvalidClusterConfiguration(format string, args ...interface{}) *ClusterError {
 	return &ClusterError{
 		Reason:  InvalidConfigurationClusterError,
@@ -44,6 +45,7 @@ func InvalidClusterConfiguration(format string, args ...interface{}) *ClusterErr
 	}
 }
 
+// CreateCluster creates a new error for when creating a cluster.
 func CreateCluster(format string, args ...interface{}) *ClusterError {
 	return &ClusterError{
 		Reason:  CreateClusterError,
@@ -51,6 +53,7 @@ func CreateCluster(format string, args ...interface{}) *ClusterError {
 	}
 }
 
+// DeleteCluster creates a new error for when deleting a cluster.
 func DeleteCluster(format string, args ...interface{}) *ClusterError {
 	return &ClusterError{
 		Reason:  DeleteClusterError,

--- a/errors/consts.go
+++ b/errors/consts.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package errors
 
+// MachineStatusError defines errors states for Machine objects.
 type MachineStatusError string
 
 // Constants aren't automatically generated for unversioned packages.
@@ -78,6 +79,7 @@ const (
 	JoinClusterTimeoutMachineError = "JoinClusterTimeoutError"
 )
 
+// ClusterStatusError defines errors states for Cluster objects.
 type ClusterStatusError string
 
 const (
@@ -103,6 +105,7 @@ const (
 	DeleteClusterError ClusterStatusError = "DeleteError"
 )
 
+// MachineSetStatusError defines errors states for MachineSet objects.
 type MachineSetStatusError string
 
 const (
@@ -115,6 +118,7 @@ const (
 	InvalidConfigurationMachineSetError MachineSetStatusError = "InvalidConfiguration"
 )
 
+// MachinePoolStatusFailure defines errors states for MachinePool objects.
 type MachinePoolStatusFailure string
 
 const (
@@ -127,6 +131,7 @@ const (
 	InvalidConfigurationMachinePoolError MachinePoolStatusFailure = "InvalidConfiguration"
 )
 
+// KubeadmControlPlaneStatusError defines errors states for KubeadmControlPlane objects.
 type KubeadmControlPlaneStatusError string
 
 const (

--- a/errors/kubeadmcontrolplane.go
+++ b/errors/kubeadmcontrolplane.go
@@ -25,6 +25,7 @@ type KubeadmControlPlaneError struct {
 	Message string
 }
 
+// Error satisfies the error interface.
 func (e *KubeadmControlPlaneError) Error() string {
 	return e.Message
 }

--- a/errors/machines.go
+++ b/errors/machines.go
@@ -37,6 +37,7 @@ func (e *MachineError) Error() string {
 // value, and all arguments are Printf-style varargs fed into Sprintf to
 // construct the Message.
 
+// InvalidMachineConfiguration creates a new error when a Machine has invalid configuration.
 func InvalidMachineConfiguration(msg string, args ...interface{}) *MachineError {
 	return &MachineError{
 		Reason:  InvalidConfigurationMachineError,
@@ -44,6 +45,7 @@ func InvalidMachineConfiguration(msg string, args ...interface{}) *MachineError 
 	}
 }
 
+// CreateMachine creates a new error for when creating a Machine.
 func CreateMachine(msg string, args ...interface{}) *MachineError {
 	return &MachineError{
 		Reason:  CreateMachineError,
@@ -51,6 +53,7 @@ func CreateMachine(msg string, args ...interface{}) *MachineError {
 	}
 }
 
+// UpdateMachine creates a new error for when updating a Machine.
 func UpdateMachine(msg string, args ...interface{}) *MachineError {
 	return &MachineError{
 		Reason:  UpdateMachineError,
@@ -58,6 +61,7 @@ func UpdateMachine(msg string, args ...interface{}) *MachineError {
 	}
 }
 
+// DeleteMachine creates a new error for when deleting a Machine.
 func DeleteMachine(msg string, args ...interface{}) *MachineError {
 	return &MachineError{
 		Reason:  DeleteMachineError,

--- a/exp/addons/api/v1alpha3/clusterresourceset_types.go
+++ b/exp/addons/api/v1alpha3/clusterresourceset_types.go
@@ -99,10 +99,12 @@ type ClusterResourceSetStatus struct {
 
 // ANCHOR_END: ClusterResourceSetStatus
 
+// GetConditions returns the set of conditions for this object.
 func (m *ClusterResourceSet) GetConditions() clusterv1.Conditions {
 	return m.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (m *ClusterResourceSet) SetConditions(conditions clusterv1.Conditions) {
 	m.Status.Conditions = conditions
 }

--- a/exp/addons/api/v1alpha4/clusterresourceset_types.go
+++ b/exp/addons/api/v1alpha4/clusterresourceset_types.go
@@ -99,10 +99,12 @@ type ClusterResourceSetStatus struct {
 
 // ANCHOR_END: ClusterResourceSetStatus
 
+// GetConditions returns the set of conditions for this object.
 func (m *ClusterResourceSet) GetConditions() clusterv1.Conditions {
 	return m.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (m *ClusterResourceSet) SetConditions(conditions clusterv1.Conditions) {
 	m.Status.Conditions = conditions
 }

--- a/exp/api/v1alpha3/machinepool_types.go
+++ b/exp/api/v1alpha3/machinepool_types.go
@@ -220,10 +220,12 @@ type MachinePool struct {
 	Status MachinePoolStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (m *MachinePool) GetConditions() clusterv1.Conditions {
 	return m.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (m *MachinePool) SetConditions(conditions clusterv1.Conditions) {
 	m.Status.Conditions = conditions
 }

--- a/exp/api/v1alpha4/machinepool_types.go
+++ b/exp/api/v1alpha4/machinepool_types.go
@@ -216,10 +216,12 @@ type MachinePool struct {
 	Status MachinePoolStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (m *MachinePool) GetConditions() clusterv1.Conditions {
 	return m.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (m *MachinePool) SetConditions(conditions clusterv1.Conditions) {
 	m.Status.Conditions = conditions
 }

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -264,12 +264,15 @@ func initializeWebhookInEnvironment() {
 		MutatingWebhooks:   mutatingWebhooks,
 	}
 }
+
+// StartManager starts the manager.
 func (t *TestEnvironment) StartManager(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	t.cancel = cancel
 	return t.Manager.Start(ctx)
 }
 
+// WaitForWebhooks waits for the webhook server to be available.
 func (t *TestEnvironment) WaitForWebhooks() {
 	port := env.WebhookInstallOptions.LocalServingPort
 
@@ -288,15 +291,18 @@ func (t *TestEnvironment) WaitForWebhooks() {
 	}
 }
 
+// Stop stops the test environment.
 func (t *TestEnvironment) Stop() error {
 	t.cancel()
 	return env.Stop()
 }
 
+// CreateKubeconfigSecret generates a new Kubeconfig secret from the envtest config.
 func (t *TestEnvironment) CreateKubeconfigSecret(ctx context.Context, cluster *clusterv1.Cluster) error {
 	return t.Create(ctx, kubeconfig.GenerateSecret(cluster, kubeconfig.FromEnvTestConfig(t.Config, cluster)))
 }
 
+// Cleanup deletes all the given objects.
 func (t *TestEnvironment) Cleanup(ctx context.Context, objs ...client.Object) error {
 	errs := []error{}
 	for _, o := range objs {
@@ -317,6 +323,7 @@ func (t *TestEnvironment) CreateObj(ctx context.Context, obj client.Object, opts
 	return t.Client.Create(ctx, obj, opts...)
 }
 
+// CreateNamespace creates a new namespace with a generated name.
 func (t *TestEnvironment) CreateNamespace(ctx context.Context, generateName string) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/infrastructure/docker/api/v1alpha3/dockercluster_types.go
+++ b/test/infrastructure/docker/api/v1alpha3/dockercluster_types.go
@@ -80,10 +80,12 @@ type DockerCluster struct {
 	Status DockerClusterStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (c *DockerCluster) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (c *DockerCluster) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/test/infrastructure/docker/api/v1alpha3/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1alpha3/dockermachine_types.go
@@ -103,10 +103,12 @@ type DockerMachine struct {
 	Status DockerMachineStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (c *DockerMachine) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (c *DockerMachine) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/test/infrastructure/docker/api/v1alpha4/dockercluster_types.go
+++ b/test/infrastructure/docker/api/v1alpha4/dockercluster_types.go
@@ -81,10 +81,12 @@ type DockerCluster struct {
 	Status DockerClusterStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (c *DockerCluster) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (c *DockerCluster) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/test/infrastructure/docker/api/v1alpha4/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1alpha4/dockermachine_types.go
@@ -104,10 +104,12 @@ type DockerMachine struct {
 	Status DockerMachineStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (c *DockerMachine) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (c *DockerMachine) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/test/infrastructure/docker/exp/api/v1alpha3/dockermachinepool_types.go
+++ b/test/infrastructure/docker/exp/api/v1alpha3/dockermachinepool_types.go
@@ -123,10 +123,12 @@ type DockerMachinePool struct {
 	Status DockerMachinePoolStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (c *DockerMachinePool) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (c *DockerMachinePool) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/test/infrastructure/docker/exp/api/v1alpha4/dockermachinepool_types.go
+++ b/test/infrastructure/docker/exp/api/v1alpha4/dockermachinepool_types.go
@@ -124,10 +124,12 @@ type DockerMachinePool struct {
 	Status DockerMachinePoolStatus `json:"status,omitempty"`
 }
 
+// GetConditions returns the set of conditions for this object.
 func (c *DockerMachinePool) GetConditions() clusterv1.Conditions {
 	return c.Status.Conditions
 }
 
+// SetConditions sets the conditions on this object.
 func (c *DockerMachinePool) SetConditions(conditions clusterv1.Conditions) {
 	c.Status.Conditions = conditions
 }

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -47,6 +47,7 @@ func HasSkipRemediationAnnotation(o metav1.Object) bool {
 	return hasAnnotation(o, clusterv1.MachineSkipRemediationAnnotation)
 }
 
+// HasWithPrefix returns true if at least one of the annotations has the prefix specified.
 func HasWithPrefix(prefix string, annotations map[string]string) bool {
 	for key := range annotations {
 		if strings.HasPrefix(key, prefix) {

--- a/util/collections/machine_filters.go
+++ b/util/collections/machine_filters.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// Func is the functon definition for a filter.
 type Func func(machine *clusterv1.Machine) bool
 
 // And returns a filter that returns true if all of the given filters returns true.

--- a/util/conditions/matchers.go
+++ b/util/conditions/matchers.go
@@ -25,17 +25,18 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
+// HaveSameStateOf matches a condition to have the same state of another.
 func HaveSameStateOf(expected *clusterv1.Condition) types.GomegaMatcher {
-	return &ConditionMatcher{
+	return &conditionMatcher{
 		Expected: expected,
 	}
 }
 
-type ConditionMatcher struct {
+type conditionMatcher struct {
 	Expected *clusterv1.Condition
 }
 
-func (matcher *ConditionMatcher) Match(actual interface{}) (success bool, err error) {
+func (matcher *conditionMatcher) Match(actual interface{}) (success bool, err error) {
 	actualCondition, ok := actual.(*clusterv1.Condition)
 	if !ok {
 		return false, errors.New("value should be a condition")
@@ -44,9 +45,9 @@ func (matcher *ConditionMatcher) Match(actual interface{}) (success bool, err er
 	return hasSameState(actualCondition, matcher.Expected), nil
 }
 
-func (matcher *ConditionMatcher) FailureMessage(actual interface{}) (message string) {
+func (matcher *conditionMatcher) FailureMessage(actual interface{}) (message string) {
 	return format.Message(actual, "to have the same state of", matcher.Expected)
 }
-func (matcher *ConditionMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+func (matcher *conditionMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	return format.Message(actual, "not to have the same state of", matcher.Expected)
 }

--- a/util/kubeconfig/testing.go
+++ b/util/kubeconfig/testing.go
@@ -25,6 +25,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
+// FromEnvTestConfig returns a new Kubeconfig in byte form when running in envtest.
 func FromEnvTestConfig(cfg *rest.Config, cluster *clusterv1.Cluster) []byte {
 	contextName := fmt.Sprintf("%s@%s", cfg.Username, cluster.Name)
 	c := api.Config{

--- a/util/retry.go
+++ b/util/retry.go
@@ -29,6 +29,7 @@ const (
 	backoffJitter   = 1.0
 )
 
+// Retry retries a given function with exponential backoff.
 func Retry(fn wait.ConditionFunc, initialBackoffSec int) error {
 	if initialBackoffSec <= 0 {
 		initialBackoffSec = backoffDuration
@@ -46,10 +47,14 @@ func Retry(fn wait.ConditionFunc, initialBackoffSec int) error {
 	return nil
 }
 
+// Poll tries a condition func until it returns true, an error, or the timeout
+// is reached.
 func Poll(interval, timeout time.Duration, condition wait.ConditionFunc) error {
 	return wait.Poll(interval, timeout, condition)
 }
 
+// PollImmediate tries a condition func until it returns true, an error, or the timeout
+// is reached.
 func PollImmediate(interval, timeout time.Duration, condition wait.ConditionFunc) error {
 	return wait.PollImmediate(interval, timeout, condition)
 }

--- a/util/secret/certificates.go
+++ b/util/secret/certificates.go
@@ -353,6 +353,7 @@ func (c *Certificate) AsFiles() []bootstrapv1.File {
 	return out
 }
 
+// Generate generates a certificate.
 func (c *Certificate) Generate() error {
 	// Do not generate the APIServerEtcdClient key pair. It is user supplied
 	if c.Purpose == APIServerEtcdClient {

--- a/util/yaml/yaml.go
+++ b/util/yaml/yaml.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// ExtractClusterReferences returns the references in a Cluster object.
 func ExtractClusterReferences(out *ParseOutput, c *clusterv1.Cluster) (res []*unstructured.Unstructured) {
 	if c.Spec.InfrastructureRef == nil {
 		return nil
@@ -46,6 +47,7 @@ func ExtractClusterReferences(out *ParseOutput, c *clusterv1.Cluster) (res []*un
 	return
 }
 
+// ExtractMachineReferences returns the references in a Machine object.
 func ExtractMachineReferences(out *ParseOutput, m *clusterv1.Machine) (res []*unstructured.Unstructured) {
 	if obj := out.FindUnstructuredReference(&m.Spec.InfrastructureRef); obj != nil {
 		res = append(res, obj)
@@ -58,10 +60,7 @@ func ExtractMachineReferences(out *ParseOutput, m *clusterv1.Machine) (res []*un
 	return
 }
 
-type ParseInput struct {
-	File string
-}
-
+// ParseOutput is the output given from the Parse function.
 type ParseOutput struct {
 	Clusters            []*clusterv1.Cluster
 	Machines            []*clusterv1.Machine
@@ -90,6 +89,11 @@ func (p *ParseOutput) FindUnstructuredReference(ref *corev1.ObjectReference) *un
 		}
 	}
 	return nil
+}
+
+// ParseInput is an input struct for the Parse function.
+type ParseInput struct {
+	File string
 }
 
 // Parse extracts runtime objects from a file.
@@ -178,6 +182,7 @@ func (d *yamlDecoder) Close() error {
 	return d.close()
 }
 
+// NewYAMLDecoder returns a new streaming Decoded that supports YAML.
 func NewYAMLDecoder(r io.ReadCloser) streaming.Decoder {
 	return &yamlDecoder{
 		reader:  apiyaml.NewYAMLReader(bufio.NewReader(r)),

--- a/version/version.go
+++ b/version/version.go
@@ -31,6 +31,7 @@ var (
 	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )
 
+// Info exposes information about the version used for the current running code.
 type Info struct {
 	Major        string `json:"major,omitempty"`
 	Minor        string `json:"minor,omitempty"`
@@ -43,6 +44,7 @@ type Info struct {
 	Platform     string `json:"platform,omitempty"`
 }
 
+// Get returns an Info object with all the information about the current running code.
 func Get() Info {
 	return Info{
 		Major:        gitMajor,


### PR DESCRIPTION


Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Marked as a breaking change because we're unexporting some previously
exported variables or structs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/milestone v0.4
/assign @CecileRobertMichon @fabriziopandini @sbueringer 
