### PR TITLE
⚠️ remove clusterctl delete --namespace flag

### DIFF
--- a/cmd/clusterctl/client/delete_test.go
+++ b/cmd/clusterctl/client/delete_test.go
@@ -51,7 +51,6 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 					Kubeconfig:              Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					IncludeNamespace:        false,
 					IncludeCRDs:             false,
-					Namespace:               "",
 					CoreProvider:            "",
 					BootstrapProviders:      nil,
 					InfrastructureProviders: nil,
@@ -63,30 +62,6 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name: "Delete single provider",
-			fields: fields{
-				client: fakeClusterForDelete(),
-			},
-			args: args{
-				options: DeleteOptions{
-					Kubeconfig:              Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
-					IncludeNamespace:        false,
-					IncludeCRDs:             false,
-					Namespace:               "capbpk-system",
-					CoreProvider:            "",
-					BootstrapProviders:      []string{bootstrapProviderConfig.Name()},
-					InfrastructureProviders: nil,
-					ControlPlaneProviders:   nil,
-					DeleteAll:               false,
-				},
-			},
-			wantProviders: sets.NewString(
-				capiProviderConfig.Name(),
-				clusterctlv1.ManifestLabel(controlPlaneProviderConfig.Name(), controlPlaneProviderConfig.Type()),
-				clusterctlv1.ManifestLabel(infraProviderConfig.Name(), infraProviderConfig.Type())),
-			wantErr: false,
-		},
-		{
 			name: "Delete single provider auto-detect namespace",
 			fields: fields{
 				client: fakeClusterForDelete(),
@@ -96,7 +71,6 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 					Kubeconfig:              Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					IncludeNamespace:        false,
 					IncludeCRDs:             false,
-					Namespace:               "", // empty namespace triggers namespace auto detection
 					CoreProvider:            "",
 					BootstrapProviders:      []string{bootstrapProviderConfig.Name()},
 					InfrastructureProviders: nil,
@@ -120,7 +94,6 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 					Kubeconfig:              Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
 					IncludeNamespace:        false,
 					IncludeCRDs:             false,
-					Namespace:               "", // empty namespace triggers namespace auto detection
 					CoreProvider:            capiProviderConfig.Name(),
 					BootstrapProviders:      []string{bootstrapProviderConfig.Name()},
 					InfrastructureProviders: nil,
@@ -131,29 +104,6 @@ func Test_clusterctlClient_Delete(t *testing.T) {
 			wantProviders: sets.NewString(
 				clusterctlv1.ManifestLabel(controlPlaneProviderConfig.Name(), controlPlaneProviderConfig.Type()),
 				clusterctlv1.ManifestLabel(infraProviderConfig.Name(), infraProviderConfig.Type())),
-			wantErr: false,
-		},
-		{
-			name: "Delete all providers in a namespace",
-			fields: fields{
-				client: fakeClusterForDelete(),
-			},
-			args: args{
-				options: DeleteOptions{
-					Kubeconfig:              Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
-					IncludeNamespace:        false,
-					IncludeCRDs:             false,
-					Namespace:               namespace,
-					CoreProvider:            "",
-					BootstrapProviders:      nil,
-					InfrastructureProviders: nil,
-					ControlPlaneProviders:   nil,
-					DeleteAll:               true,
-				},
-			},
-			wantProviders: sets.NewString(
-				capiProviderConfig.Name(),
-				clusterctlv1.ManifestLabel(bootstrapProviderConfig.Name(), bootstrapProviderConfig.Type())),
 			wantErr: false,
 		},
 	}

--- a/cmd/clusterctl/cmd/delete.go
+++ b/cmd/clusterctl/cmd/delete.go
@@ -25,7 +25,6 @@ import (
 type deleteOptions struct {
 	kubeconfig              string
 	kubeconfigContext       string
-	targetNamespace         string
 	coreProvider            string
 	bootstrapProviders      []string
 	controlPlaneProviders   []string
@@ -49,29 +48,10 @@ var deleteCmd = &cobra.Command{
 		# and the CRDs.
 		clusterctl delete --infrastructure aws
 
-		# Deletes the instance of the AWS infrastructure provider hosted in the "foo" namespace
-		# Please note, if there are multiple instances of the AWS provider installed in the cluster,
-		# global/shared resources (e.g. ClusterRoles), are not deleted in order to preserve
-		# the functioning of the remaining instances.
-		#
-		# WARNING: There is a known bug where deleting an infrastructure component from a namespace that share
-		# the same prefix with other namespaces (e.g. 'foo' and 'foo-bar') will result
-		# in erroneous deletion of cluster scoped objects such as 'ClusterRole' and
-		# 'ClusterRoleBindings' that share the same namespace prefix.
-		# This is true if the prefix before a dash '-' is same. That is, namespaces such
-		# as 'foo' and 'foobar' are fine however namespaces such as 'foo' and 'foo-bar'
-		# are not. See CAPI issue 3119 for more details.
-		clusterctl delete --infrastructure aws --namespace=foo
-
 		# Deletes all the providers
 		# Important! As a consequence of this operation, all the corresponding resources managed by
 		# Cluster API Providers are orphaned and there might be ongoing costs incurred as a result of this.
 		clusterctl delete --all
-
-		# Deletes all the providers in a namespace
-		# Important! As a consequence of this operation, all the corresponding resources managed by
-		# Cluster API Providers are orphaned and there might be ongoing costs incurred as a result of this.
-		clusterctl delete --all --namespace=foo
 
 		# Delete the AWS infrastructure provider and Core provider. This will leave behind Bootstrap and ControlPlane
 		# providers
@@ -107,7 +87,6 @@ func init() {
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
 	deleteCmd.Flags().StringVar(&dd.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
-	deleteCmd.Flags().StringVar(&dd.targetNamespace, "namespace", "", "The namespace where the provider to be deleted lives. If unspecified, the namespace name will be inferred from the current configuration")
 
 	deleteCmd.Flags().BoolVar(&dd.includeNamespace, "include-namespace", false,
 		"Forces the deletion of the namespace where the providers are hosted (and of all the contained objects)")
@@ -152,7 +131,6 @@ func runDelete() error {
 		Kubeconfig:              client.Kubeconfig{Path: dd.kubeconfig, Context: dd.kubeconfigContext},
 		IncludeNamespace:        dd.includeNamespace,
 		IncludeCRDs:             dd.includeCRDs,
-		Namespace:               dd.targetNamespace,
 		CoreProvider:            dd.coreProvider,
 		BootstrapProviders:      dd.bootstrapProviders,
 		InfrastructureProviders: dd.infrastructureProviders,

--- a/docs/book/src/clusterctl/commands/delete.md
+++ b/docs/book/src/clusterctl/commands/delete.md
@@ -33,39 +33,6 @@ the aws provider, it deletes all the `AWSCluster`, `AWSMachine` etc.
 
 </aside>
 
-<aside class="note warning">
-
-<h1>Warning</h1>
-
-KNOWN BUG:
-
-Deleting an infrastructure component from a namespace _that shares
-the same prefix_ with other namespaces (e.g. `foo` and `foo-bar`) will result
-in erroneous deletion of cluster scoped objects such as `ClusterRole` and
-`ClusterRoleBindings` that share the same namespace prefix.
-
-This is true if the prefix before a dash `-` is the same. That is, namespaces such
-as `foo` and `foobar` are fine however namespaces such as `foo` and `foo-bar`
-are not.
-
-For example,
-
-1. Init an infrastructure provider in namespace `foo` and `foo-bar`.
-    ```
-    clusterctl init --infrastructure aws --watching-namespace foo --target-namespace foo
-    clusterctl init --infrastructure aws --watching-namespace foo-bar --target-namespace foo-bar
-    ```
-1. Delete infrastructure components from namespace `foo`
-    ```
-    clusterctl delete --infrastructure aws --namespace foo
-    ```
-
-`ClusterRole` and `ClusterRoleBindings` for both the namespaces are deleted.
-
-See [issue 3119] for more details.
-
-</aside>
-
 If you want to delete all the providers in a single operation , you can use the `--all` flag.
 
 ```shell


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the --namespace flag from clusterctl delete, not necessary anymore given that having many instances of a provider into a management cluster is not supported anymore. 

Please note that more cleanup should follow, as described in https://github.com/kubernetes-sigs/cluster-api/issues/4056#issuecomment-796752547, but I'm breaking down the change in smaller PRs in order to make review easier

**Which issue(s) this PR fixes**:
Rif #4056

