### PR TITLE
🐛 fix TestReconcileEtcdMembers flakes

### DIFF
--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -185,7 +185,7 @@ func TestGetWorkloadCluster(t *testing.T) {
 			g := NewWithT(t)
 
 			for _, o := range tt.objs {
-				g.Expect(testEnv.CreateObj(ctx, o)).To(Succeed())
+				g.Expect(testEnv.Client.Create(ctx, o)).To(Succeed())
 				defer func(do client.Object) {
 					g.Expect(testEnv.Cleanup(ctx, do)).To(Succeed())
 				}(o)

--- a/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_etcd_test.go
@@ -578,9 +578,9 @@ func TestReconcileEtcdMembers(t *testing.T) {
 			g := NewWithT(t)
 
 			for _, o := range tt.objs {
-				g.Expect(testEnv.CreateObj(ctx, o)).To(Succeed())
+				g.Expect(testEnv.CreateAndWait(ctx, o)).To(Succeed())
 				defer func(do client.Object) {
-					g.Expect(testEnv.Cleanup(ctx, do)).To(Succeed())
+					g.Expect(testEnv.CleanupAndWait(ctx, do)).To(Succeed())
 				}(o)
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
CAPI unit test are being flaky lately and one of the errors is 

```
=== Failed
=== FAIL: controlplane/kubeadm/internal TestReconcileEtcdMembers/successfully_removes_the_etcd_member_without_a_node_for_Kubernetes_version_>=_1.22.0 (0.02s)
    workload_cluster_etcd_test.go:559: 
        Expected success, but got an error:
            <*errors.StatusError | 0xc00083dae0>: {
                ErrStatus: {
                    TypeMeta: {Kind: "", APIVersion: ""},
skipped 16 lines unfold_more
                    },
                    Code: 404,
                },
            }
            ConfigMap "kubeadm-config" not found
    --- FAIL: TestReconcileEtcdMembers/successfully_removes_the_etcd_member_without_a_node_for_Kubernetes_version_>=_1.22.0 (0.02s)
=== FAIL: controlplane/kubeadm/internal TestReconcileEtcdMembers (0.20s)
```

This PR attempts to fix this error by providing new testenv primitives, `CreateAndWait` and `CleanupAndWait`, both ensuring the client cache is updated according to the operation.
This is required especially in cases like the failing test, when the same object (the kubeadm-config map) is being created and deleted several times during the same test.

Also, `testenv.CreateObj` method is deprecated given that it is a plain wrapper on `testenv.Create` (`testenv.Client.Create`)

**Which issue(s) this PR fixes**:
Fixes #
