### PR TITLE
📖 🌱  Minor improvements to Cluster Api book  

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -40,6 +40,7 @@ First, make sure you have a kind cluster and that your `KUBECONFIG` is set up co
 ``` bash
 kind create cluster
 ```
+IMPORTANT, if you are planning to use the CAPD provider, check that you created the required mounts for allowing the provider to access the Docker socket on the host; see [quick start](https://cluster-api.sigs.k8s.io/user/quick-start.html#usage) for instructions.
 
 ### Create a tilt-settings.json file
 

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -738,7 +738,11 @@ kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
 Delete workload cluster.
 ```bash
 kubectl delete cluster capi-quickstart
-```
+```        
+<aside class="note warning">
+
+IMPORTANT: In order to ensure a proper cleanup of your infrastructure you must always delete the cluster object. Deleting the entire cluster template with `kubectl delete -f capi-quickstart.yaml` might lead to pending resources to be cleaned up manually.
+</aside>
 
 Delete management cluster
 ```bash

--- a/docs/book/src/user/troubleshooting.md
+++ b/docs/book/src/user/troubleshooting.md
@@ -36,4 +36,17 @@ For convenience, here is an example one-liner to do this post installation
 
 ```
 kubectl get nodes --no-headers -l '!node-role.kubernetes.io/master' -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | xargs -I{} kubectl label node {} node-role.kubernetes.io/worker=''
-```
+```                  
+
+## Cluster API with Docker
+
+When provisioning workload clusters using Cluster API with Docker infrastructure,
+provisioning might be stuck: 
+ 
+1. if there are stopped containers on your machine from previous runs. Clean unused containers with [docker rm -f ](https://docs.docker.com/engine/reference/commandline/rm/). 
+
+2. if the docker space on your disk is being exhausted 
+    * Run [docker system df](https://docs.docker.com/engine/reference/commandline/system_df/) to inspect the disk space consumed by Docker resources.
+    * Run [docker system prune --volumes](https://docs.docker.com/engine/reference/commandline/system_prune/) to prune dangling images, containers, volumes and networks.
+
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds minor improvements to the cluster api docs based on my recent onboarding

        1. Add a troubleshooting section for CAPD when docker runs out of space and has hanging containers
        2. Document that `kubectl apply -f capi-quickstart.yaml` might have issues when deleting a cluster
        3. Adds a note in Tilt documentation for creating kind with docker settings (required for CAPD)
