### PR TITLE
🌱 Divide KCPUpgrade E2E test suite

### DIFF
--- a/test/e2e/kcp_upgrade_test.go
+++ b/test/e2e/kcp_upgrade_test.go
@@ -22,18 +22,48 @@ import (
 	"context"
 
 	. "github.com/onsi/ginkgo"
+
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 )
 
-var _ = Describe("When testing KCP upgrade", func() {
-
+var _ = Describe("When testing KCP upgrade in a single control plane cluster", func() {
 	KCPUpgradeSpec(context.TODO(), func() KCPUpgradeSpecInput {
 		return KCPUpgradeSpecInput{
-			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			ArtifactFolder:        artifactFolder,
-			SkipCleanup:           skipCleanup,
+			E2EConfig:                e2eConfig,
+			ClusterctlConfigPath:     clusterctlConfigPath,
+			BootstrapClusterProxy:    bootstrapClusterProxy,
+			ArtifactFolder:           artifactFolder,
+			SkipCleanup:              skipCleanup,
+			ControlPlaneMachineCount: 1,
+			Flavor:                   clusterctl.DefaultFlavor,
 		}
 	})
+})
 
+var _ = Describe("When testing KCP upgrade in a HA cluster", func() {
+	KCPUpgradeSpec(context.TODO(), func() KCPUpgradeSpecInput {
+		return KCPUpgradeSpecInput{
+			E2EConfig:                e2eConfig,
+			ClusterctlConfigPath:     clusterctlConfigPath,
+			BootstrapClusterProxy:    bootstrapClusterProxy,
+			ArtifactFolder:           artifactFolder,
+			SkipCleanup:              skipCleanup,
+			ControlPlaneMachineCount: 3,
+			Flavor:                   clusterctl.DefaultFlavor,
+		}
+	})
+})
+
+var _ = Describe("When testing KCP upgrade in a HA cluster using scale in rollout", func() {
+	KCPUpgradeSpec(context.TODO(), func() KCPUpgradeSpecInput {
+		return KCPUpgradeSpecInput{
+			E2EConfig:                e2eConfig,
+			ClusterctlConfigPath:     clusterctlConfigPath,
+			BootstrapClusterProxy:    bootstrapClusterProxy,
+			ArtifactFolder:           artifactFolder,
+			SkipCleanup:              skipCleanup,
+			ControlPlaneMachineCount: 3,
+			Flavor:                   "kcp-scale-in",
+		}
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Separate KCP scale in rollout test to improve test parallelization.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4672
