### PR TITLE
:bug: Use unstructured for conversion utils tests, and fix how we set annotations

### DIFF
--- a/util/conversion/conversion.go
+++ b/util/conversion/conversion.go
@@ -108,23 +108,27 @@ func MarshalData(src metav1.Object, dst metav1.Object) error {
 	if err != nil {
 		return err
 	}
-	if dst.GetAnnotations() == nil {
-		dst.SetAnnotations(map[string]string{})
+	annotations := dst.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
 	}
-	dst.GetAnnotations()[DataAnnotation] = string(data)
+	annotations[DataAnnotation] = string(data)
+	dst.SetAnnotations(annotations)
 	return nil
 }
 
 // UnmarshalData tries to retrieve the data from the annotation and unmarshals it into the object passed as input.
 func UnmarshalData(from metav1.Object, to interface{}) (bool, error) {
-	data, ok := from.GetAnnotations()[DataAnnotation]
+	annotations := from.GetAnnotations()
+	data, ok := annotations[DataAnnotation]
 	if !ok {
 		return false, nil
 	}
 	if err := json.Unmarshal([]byte(data), to); err != nil {
 		return false, err
 	}
-	delete(from.GetAnnotations(), DataAnnotation)
+	delete(annotations, DataAnnotation)
+	from.SetAnnotations(annotations)
 	return true, nil
 }
 


### PR DESCRIPTION

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:


During a rewrite of the tests for the conversion util codebase which
sets and resets the annotation to retain data when doing conversion,
opted to use unstructured objects with a generic old "Machine" type
instead of importing multiple API packages.

The switch to unstructured showed that we weren't setting annotation
properly by calling SetAnnotations, but rather we opted to change the
map coming from GetAnnotations() directly in some cases.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4632

/kind release-blocking
/milestone v0.4
