### PR TITLE
⚠️ Accept options in remote.NewClusterCacheTracker

### DIFF
--- a/controllers/remote/cluster_cache_healthcheck_test.go
+++ b/controllers/remote/cluster_cache_healthcheck_test.go
@@ -71,7 +71,7 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 			k8sClient = mgr.GetClient()
 
 			t.Log("Setting up a ClusterCacheTracker")
-			cct, err = NewClusterCacheTracker(klogr.New(), mgr)
+			cct, err = NewClusterCacheTracker(mgr, ClusterCacheTrackerOptions{Log: klogr.New()})
 			g.Expect(err).NotTo(HaveOccurred())
 
 			t.Log("Creating a namespace for the test")

--- a/controllers/remote/cluster_cache_reconciler_test.go
+++ b/controllers/remote/cluster_cache_reconciler_test.go
@@ -85,7 +85,7 @@ func TestClusterCacheReconciler(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			t.Log("Setting up a ClusterCacheTracker")
-			cct, err = NewClusterCacheTracker(log.NullLogger{}, mgr)
+			cct, err = NewClusterCacheTracker(mgr, ClusterCacheTrackerOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 
 			t.Log("Creating the ClusterCacheReconciler")

--- a/controllers/remote/cluster_cache_tracker_test.go
+++ b/controllers/remote/cluster_cache_tracker_test.go
@@ -31,7 +31,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -86,7 +85,7 @@ func TestClusterCacheTracker(t *testing.T) {
 			k8sClient = mgr.GetClient()
 
 			t.Log("Setting up a ClusterCacheTracker")
-			cct, err = NewClusterCacheTracker(log.NullLogger{}, mgr)
+			cct, err = NewClusterCacheTracker(mgr, ClusterCacheTrackerOptions{})
 			g.Expect(err).NotTo(HaveOccurred())
 
 			t.Log("Creating a namespace for the test")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -52,8 +52,8 @@ func TestMain(m *testing.M) {
 	// Set up a ClusterCacheTracker and ClusterCacheReconciler to provide to controllers
 	// requiring a connection to a remote cluster
 	tracker, err := remote.NewClusterCacheTracker(
-		log.Log,
 		env.Manager,
+		remote.ClusterCacheTrackerOptions{Log: log.Log},
 	)
 	if err != nil {
 		panic(fmt.Sprintf("unable to create cluster cache tracker: %v", err))

--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -107,8 +107,8 @@ func TestGetWorkloadCluster(t *testing.T) {
 	badCrtEtcdSecret := etcdSecret.DeepCopy()
 	badCrtEtcdSecret.Data[secret.TLSCrtDataName] = []byte("bad cert")
 	tracker, err := remote.NewClusterCacheTracker(
-		log.Log,
 		env.Manager,
+		remote.ClusterCacheTrackerOptions{Log: log.Log},
 	)
 	g.Expect(err).ToNot(HaveOccurred())
 

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -185,10 +185,7 @@ func setupChecks(mgr ctrl.Manager) {
 func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	// Set up a ClusterCacheTracker to provide to controllers
 	// requiring a connection to a remote cluster
-	tracker, err := remote.NewClusterCacheTracker(
-		ctrl.Log.WithName("remote").WithName("ClusterCacheTracker"),
-		mgr,
-	)
+	tracker, err := remote.NewClusterCacheTracker(mgr, remote.ClusterCacheTrackerOptions{})
 	if err != nil {
 		setupLog.Error(err, "unable to create cluster cache tracker")
 		os.Exit(1)

--- a/exp/addons/controllers/suite_test.go
+++ b/exp/addons/controllers/suite_test.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/cluster-api/internal/envtest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -38,7 +37,7 @@ func TestMain(m *testing.M) {
 	fmt.Println("Creating new test environment")
 	env = envtest.New()
 
-	trckr, err := remote.NewClusterCacheTracker(log.NullLogger{}, env.Manager)
+	trckr, err := remote.NewClusterCacheTracker(env.Manager, remote.ClusterCacheTrackerOptions{})
 	if err != nil {
 		panic(fmt.Sprintf("Failed to create new cluster cache tracker: %v", err))
 	}

--- a/main.go
+++ b/main.go
@@ -225,8 +225,8 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	// Set up a ClusterCacheTracker and ClusterCacheReconciler to provide to controllers
 	// requiring a connection to a remote cluster
 	tracker, err := remote.NewClusterCacheTracker(
-		ctrl.Log.WithName("remote").WithName("ClusterCacheTracker"),
 		mgr,
+		remote.ClusterCacheTrackerOptions{Log: ctrl.Log.WithName("remote").WithName("ClusterCacheTracker")},
 	)
 	if err != nil {
 		setupLog.Error(err, "unable to create cluster cache tracker")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR add an new optional `options` argument to the `NewClusterCacheTracker` function.
This new options argument can be used to control the objects that the client should not cache. Defaults to:
```
corev1.ConfigMap{}
corev1.Secret{}
```
It can also be used to pass a desired logger. Defaults to `ctrl.Log.WithName("remote").WithName("ClusterCacheTracker")`


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4146 
