### PR TITLE
⚠️ Deprecate Provider.WatchedNamespace

### DIFF
--- a/cmd/clusterctl/api/v1alpha3/provider_type.go
+++ b/cmd/clusterctl/api/v1alpha3/provider_type.go
@@ -27,7 +27,6 @@ import (
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".type"
 // +kubebuilder:printcolumn:name="Provider",type="string",JSONPath=".providerName"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".version"
-// +kubebuilder:printcolumn:name="Watch Namespace",type="string",JSONPath=".watchedNamespace"
 
 // Provider defines an entry in the provider inventory.
 type Provider struct {
@@ -49,6 +48,7 @@ type Provider struct {
 
 	// WatchedNamespace indicates the namespace where the provider controller is is watching.
 	// if empty the provider controller is watching for objects in all namespaces.
+	// Deprecated: in clusterctl v1alpha4 all the providers watch all the namespaces; this field will be removed in a future version of this API
 	// +optional
 	WatchedNamespace string `json:"watchedNamespace,omitempty"`
 }

--- a/cmd/clusterctl/config/crd/bases/clusterctl.cluster.x-k8s.io_providers.yaml
+++ b/cmd/clusterctl/config/crd/bases/clusterctl.cluster.x-k8s.io_providers.yaml
@@ -28,9 +28,6 @@ spec:
     - jsonPath: .version
       name: Version
       type: string
-    - jsonPath: .watchedNamespace
-      name: Watch Namespace
-      type: string
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -59,9 +56,11 @@ spec:
             description: Version indicates the component version.
             type: string
           watchedNamespace:
-            description: WatchedNamespace indicates the namespace where the provider
+            description: 'WatchedNamespace indicates the namespace where the provider
               controller is is watching. if empty the provider controller is watching
-              for objects in all namespaces.
+              for objects in all namespaces. Deprecated: in clusterctl v1alpha4 all
+              the providers watch all the namespaces; this field will be removed in
+              a future version of this API'
             type: string
         type: object
     served: true

--- a/cmd/clusterctl/config/manifest/clusterctl-api.yaml
+++ b/cmd/clusterctl/config/manifest/clusterctl-api.yaml
@@ -26,9 +26,6 @@ spec:
     - jsonPath: .version
       name: Version
       type: string
-    - jsonPath: .watchedNamespace
-      name: Watch Namespace
-      type: string
     name: v1alpha3
     schema:
       openAPIV3Schema:
@@ -52,7 +49,7 @@ spec:
             description: Version indicates the component version.
             type: string
           watchedNamespace:
-            description: WatchedNamespace indicates the namespace where the provider controller is is watching. if empty the provider controller is watching for objects in all namespaces.
+            description: 'WatchedNamespace indicates the namespace where the provider controller is is watching. if empty the provider controller is watching for objects in all namespaces. Deprecated: in clusterctl v1alpha4 all the providers watch all the namespaces; this field will be removed in a future version of this API'
             type: string
         type: object
     served: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow up of https://github.com/kubernetes-sigs/cluster-api/pull/4666; It deprecates the `WatchedNamespace` field in the Provider object which is not required anymore given that clusterctl v1alpha4 does not support multiple instances of a provider.

