### PR TITLE
🌱 Follow-up on the removal of clusterctl watching namespace

### DIFF
--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -314,8 +314,8 @@ func (f *fakeClusterClient) WithObjs(objs ...client.Object) *fakeClusterClient {
 	return f
 }
 
-func (f *fakeClusterClient) WithProviderInventory(name string, providerType clusterctlv1.ProviderType, version, targetNamespace, watchingNamespace string) *fakeClusterClient {
-	f.fakeProxy.WithProviderInventory(name, providerType, version, targetNamespace, watchingNamespace)
+func (f *fakeClusterClient) WithProviderInventory(name string, providerType clusterctlv1.ProviderType, version, targetNamespace string) *fakeClusterClient {
+	f.fakeProxy.WithProviderInventory(name, providerType, version, targetNamespace)
 	return f
 }
 

--- a/cmd/clusterctl/client/cluster/installer_test.go
+++ b/cmd/clusterctl/client/cluster/installer_test.go
@@ -109,8 +109,8 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			fields: fields{
 				proxy: test.NewFakeProxy(), // empty cluster
 				installQueue: []repository.Components{
-					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra1-system", ""),
+					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra1-system"),
 				},
 			},
 			wantErr: false,
@@ -119,10 +119,10 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			name: "install infra2/current contract on a cluster already initialized with core/current contract + infra1/current contract",
 			fields: fields{
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra1-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra1-system"),
 				installQueue: []repository.Components{
-					newFakeComponents("infra2", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra2-system", ""),
+					newFakeComponents("infra2", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra2-system"),
 				},
 			},
 			wantErr: false,
@@ -131,10 +131,10 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			name: "install another instance of infra1/current contract on a cluster already initialized with core/current contract + infra1/current contract",
 			fields: fields{
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "ns1", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "ns1"),
 				installQueue: []repository.Components{
-					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "ns2", ""),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "ns2"),
 				},
 			},
 			wantErr: true,
@@ -143,10 +143,10 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			name: "install another instance of infra1/current contract on a cluster already initialized with core/current contract + infra1/current contract, same namespace of the existing infra1",
 			fields: fields{
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "n1", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "n1"),
 				installQueue: []repository.Components{
-					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "n1", ""),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "n1"),
 				},
 			},
 			wantErr: true,
@@ -155,10 +155,10 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			name: "install another instance of infra1/current contract on a cluster already initialized with core/current contract + infra1/current contract, different namespace of the existing infra1",
 			fields: fields{
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "n1", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "n1"),
 				installQueue: []repository.Components{
-					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "n2", ""),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "n2"),
 				},
 			},
 			wantErr: true,
@@ -168,8 +168,8 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			fields: fields{
 				proxy: test.NewFakeProxy(), // empty cluster
 				installQueue: []repository.Components{
-					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v0.9.0", "cluster-api-system", ""),
-					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v0.9.0", "infra1-system", ""),
+					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v0.9.0", "cluster-api-system"),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v0.9.0", "infra1-system"),
 				},
 			},
 			wantErr: true,
@@ -179,8 +179,8 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			fields: fields{
 				proxy: test.NewFakeProxy(), // empty cluster
 				installQueue: []repository.Components{
-					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v0.9.0", "cluster-api-system", ""),
-					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra1-system", ""),
+					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v0.9.0", "cluster-api-system"),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "infra1-system"),
 				},
 			},
 			wantErr: true,
@@ -189,9 +189,9 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			name: "install infra1/previous contract (not supported) on a cluster already initialized with core/current contract",
 			fields: fields{
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "ns1", "ns1"),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "ns1"),
 				installQueue: []repository.Components{
-					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v0.9.0", "infra1-system", ""),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v0.9.0", "infra1-system"),
 				},
 			},
 			wantErr: true,
@@ -201,8 +201,8 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			fields: fields{
 				proxy: test.NewFakeProxy(), // empty cluster
 				installQueue: []repository.Components{
-					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v2.0.0", "cluster-api-system", ""),
-					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra1-system", ""),
+					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v2.0.0", "cluster-api-system"),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra1-system"),
 				},
 			},
 			wantErr: true,
@@ -212,8 +212,8 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			fields: fields{
 				proxy: test.NewFakeProxy(), // empty cluster
 				installQueue: []repository.Components{
-					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
-					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra1-system", ""),
+					newFakeComponents("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra1-system"),
 				},
 			},
 			wantErr: true,
@@ -222,9 +222,9 @@ func Test_providerInstaller_Validate(t *testing.T) {
 			name: "install infra1/next contract (not supported) on a cluster already initialized with core/current contract",
 			fields: fields{
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "ns1", "ns1"),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "ns1"),
 				installQueue: []repository.Components{
-					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra1-system", ""),
+					newFakeComponents("infra1", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra1-system"),
 				},
 			},
 			wantErr: true,
@@ -278,10 +278,6 @@ func (c *fakeComponents) TargetNamespace() string {
 	panic("not implemented")
 }
 
-func (c *fakeComponents) WatchingNamespace() string {
-	panic("not implemented")
-}
-
 func (c *fakeComponents) InventoryObject() clusterctlv1.Provider {
 	return c.inventoryObject
 }
@@ -298,8 +294,8 @@ func (c *fakeComponents) Yaml() ([]byte, error) {
 	panic("not implemented")
 }
 
-func newFakeComponents(name string, providerType clusterctlv1.ProviderType, version, targetNamespace, watchingNamespace string) repository.Components {
-	inventoryObject := fakeProvider(name, providerType, version, targetNamespace, watchingNamespace)
+func newFakeComponents(name string, providerType clusterctlv1.ProviderType, version, targetNamespace string) repository.Components {
+	inventoryObject := fakeProvider(name, providerType, version, targetNamespace)
 	return &fakeComponents{
 		Provider:        config.NewProvider(inventoryObject.ProviderName, "", clusterctlv1.ProviderType(inventoryObject.Type)),
 		inventoryObject: inventoryObject,
@@ -321,7 +317,7 @@ func Test_shouldInstallSharedComponents(t *testing.T) {
 			name: "First instance of the provider, must install shared components",
 			args: args{
 				providerList: &clusterctlv1.ProviderList{Items: []clusterctlv1.Provider{}}, // no core provider installed
-				provider:     fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", "", ""),
+				provider:     fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", ""),
 			},
 			want:    true,
 			wantErr: false,
@@ -330,9 +326,9 @@ func Test_shouldInstallSharedComponents(t *testing.T) {
 			name: "Second instance of the provider, same version, must NOT install shared components",
 			args: args{
 				providerList: &clusterctlv1.ProviderList{Items: []clusterctlv1.Provider{
-					fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", "", ""),
+					fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", ""),
 				}},
-				provider: fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", "", ""),
+				provider: fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", ""),
 			},
 			want:    false,
 			wantErr: false,
@@ -341,9 +337,9 @@ func Test_shouldInstallSharedComponents(t *testing.T) {
 			name: "Second instance of the provider, older version, must NOT install shared components",
 			args: args{
 				providerList: &clusterctlv1.ProviderList{Items: []clusterctlv1.Provider{
-					fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", "", ""),
+					fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", ""),
 				}},
-				provider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", "", ""),
+				provider: fakeProvider("core", clusterctlv1.CoreProviderType, "v1.0.0", ""),
 			},
 			want:    false,
 			wantErr: false,
@@ -352,9 +348,9 @@ func Test_shouldInstallSharedComponents(t *testing.T) {
 			name: "Second instance of the provider, newer version, must install shared components",
 			args: args{
 				providerList: &clusterctlv1.ProviderList{Items: []clusterctlv1.Provider{
-					fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", "", ""),
+					fakeProvider("core", clusterctlv1.CoreProviderType, "v2.0.0", ""),
 				}},
-				provider: fakeProvider("core", clusterctlv1.CoreProviderType, "v3.0.0", "", ""),
+				provider: fakeProvider("core", clusterctlv1.CoreProviderType, "v3.0.0", ""),
 			},
 			want:    true,
 			wantErr: false,

--- a/cmd/clusterctl/client/cluster/inventory_test.go
+++ b/cmd/clusterctl/client/cluster/inventory_test.go
@@ -131,10 +131,10 @@ func Test_inventoryClient_Create(t *testing.T) {
 	type args struct {
 		m clusterctlv1.Provider
 	}
-	providerV2 := fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v0.2.0", "", "")
+	providerV2 := fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v0.2.0", "")
 	// since this test object is used in a Create request, wherein setting ResourceVersion should no be set
 	providerV2.ResourceVersion = ""
-	providerV3 := fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v0.3.0", "", "")
+	providerV3 := fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v0.3.0", "")
 
 	tests := []struct {
 		name          string

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -852,8 +852,7 @@ func Test_objectsMoverService_checkTargetProviders(t *testing.T) {
 		fromProxy Proxy
 	}
 	type args struct {
-		toProxy   Proxy
-		namespace string
+		toProxy Proxy
 	}
 	tests := []struct {
 		name    string
@@ -862,87 +861,41 @@ func Test_objectsMoverService_checkTargetProviders(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "move objects in single namespace, all the providers in place (lazy matching)",
+			name: "all the providers in place (lazy matching)",
 			fields: fields{
 				fromProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v1.0.0", "capi-system", "").
-					WithProviderInventory("kubeadm", clusterctlv1.BootstrapProviderType, "v1.0.0", "cabpk-system", "").
-					WithProviderInventory("capa", clusterctlv1.InfrastructureProviderType, "v1.0.0", "capa-system", ""),
+					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v1.0.0", "capi-system").
+					WithProviderInventory("kubeadm", clusterctlv1.BootstrapProviderType, "v1.0.0", "cabpk-system").
+					WithProviderInventory("capa", clusterctlv1.InfrastructureProviderType, "v1.0.0", "capa-system"),
 			},
 			args: args{
-				namespace: "ns1", // a single namespaces
 				toProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v1.0.0", "capi-system", "ns1").
-					WithProviderInventory("kubeadm", clusterctlv1.BootstrapProviderType, "v1.0.0", "cabpk-system", "ns1").
-					WithProviderInventory("capa", clusterctlv1.InfrastructureProviderType, "v1.0.0", "capa-system", "ns1"),
+					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v1.0.0", "capi-system").
+					WithProviderInventory("kubeadm", clusterctlv1.BootstrapProviderType, "v1.0.0", "cabpk-system").
+					WithProviderInventory("capa", clusterctlv1.InfrastructureProviderType, "v1.0.0", "capa-system"),
 			},
 			wantErr: false,
 		},
 		{
-			name: "move objects in single namespace, all the providers in place but with a newer version (lazy matching)",
+			name: "all the providers in place but with a newer version (lazy matching)",
 			fields: fields{
 				fromProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.0.0", "capi-system", ""),
+					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.0.0", "capi-system"),
 			},
 			args: args{
-				namespace: "ns1", // a single namespaces
 				toProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.1.0", "capi-system", "ns1"), // Lazy matching
+					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.1.0", "capi-system"), // Lazy matching
 			},
 			wantErr: false,
-		},
-		{
-			name: "move objects in all namespaces, all the providers in place (exact matching)",
-			fields: fields{
-				fromProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v1.0.0", "capi-system", "").
-					WithProviderInventory("kubeadm", clusterctlv1.BootstrapProviderType, "v1.0.0", "cabpk-system", "").
-					WithProviderInventory("capa", clusterctlv1.InfrastructureProviderType, "v1.0.0", "capa-system", ""),
-			},
-			args: args{
-				namespace: "", // all namespaces
-				toProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v1.0.0", "capi-system", "").
-					WithProviderInventory("kubeadm", clusterctlv1.BootstrapProviderType, "v1.0.0", "cabpk-system", "").
-					WithProviderInventory("capa", clusterctlv1.InfrastructureProviderType, "v1.0.0", "capa-system", ""),
-			},
-			wantErr: false,
-		},
-		{
-			name: "move objects in all namespaces, all the providers in place but with a newer version (exact matching)",
-			fields: fields{
-				fromProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.0.0", "capi-system", ""),
-			},
-			args: args{
-				namespace: "", // all namespaces
-				toProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.1.0", "capi-system", ""),
-			},
-			wantErr: false,
-		},
-		{
-			name: "move objects in all namespaces, not exact matching",
-			fields: fields{
-				fromProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.0.0", "capi-system", ""),
-			},
-			args: args{
-				namespace: "", // all namespaces
-				toProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.1.0", "capi-system", "ns1"), // Lazy matching only
-			},
-			wantErr: true,
 		},
 		{
 			name: "fails if a provider is missing",
 			fields: fields{
 				fromProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.0.0", "capi-system", ""),
+					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.0.0", "capi-system"),
 			},
 			args: args{
-				namespace: "", // all namespaces
-				toProxy:   test.NewFakeProxy(),
+				toProxy: test.NewFakeProxy(),
 			},
 			wantErr: true,
 		},
@@ -950,12 +903,11 @@ func Test_objectsMoverService_checkTargetProviders(t *testing.T) {
 			name: "fails if a provider version is older than expected",
 			fields: fields{
 				fromProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.0.0", "capi-system", ""),
+					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v2.0.0", "capi-system"),
 			},
 			args: args{
-				namespace: "", // all namespaces
 				toProxy: test.NewFakeProxy().
-					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v1.0.0", "capi1-system", ""),
+					WithProviderInventory("capi", clusterctlv1.CoreProviderType, "v1.0.0", "capi1-system"),
 			},
 			wantErr: true,
 		},
@@ -967,7 +919,7 @@ func Test_objectsMoverService_checkTargetProviders(t *testing.T) {
 			o := &objectMover{
 				fromProviderInventory: newInventoryClient(tt.fields.fromProxy, nil),
 			}
-			err := o.checkTargetProviders(tt.args.namespace, newInventoryClient(tt.args.toProxy, nil))
+			err := o.checkTargetProviders(newInventoryClient(tt.args.toProxy, nil))
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -269,10 +269,6 @@ func (u *providerUpgrader) createCustomPlan(upgradeItems []UpgradeItem) (*Upgrad
 			return nil, errors.Errorf("unable to complete that upgrade: the target version for the provider %s supports the %s API Version of Cluster API (contract), while the management cluster is using %s", upgradeItem.InstanceName(), contract, targetContract)
 		}
 
-		// Migrate the additional provider attributes to the upgrade item
-		// such as watching namespace.
-		upgradeItem.WatchedNamespace = provider.WatchedNamespace
-
 		upgradePlan.Providers = append(upgradePlan.Providers, upgradeItem)
 		upgradeInstanceNames.Insert(upgradeItem.InstanceName())
 	}

--- a/cmd/clusterctl/client/cluster/upgrader_info_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_info_test.go
@@ -59,7 +59,7 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 					}),
 			},
 			args: args{
-				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.1", "p1-system", ""),
+				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.1", "p1-system"),
 			},
 			want: &upgradeInfo{
 				metadata: &clusterctlv1.Metadata{
@@ -97,7 +97,7 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 					}),
 			},
 			args: args{
-				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.1", "p1-system", ""),
+				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.1", "p1-system"),
 			},
 			want: &upgradeInfo{
 				metadata: &clusterctlv1.Metadata{
@@ -135,7 +135,7 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 					}),
 			},
 			args: args{
-				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.1", "p1-system", ""),
+				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.1", "p1-system"),
 			},
 			want: &upgradeInfo{
 				metadata: &clusterctlv1.Metadata{
@@ -167,7 +167,7 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 									WithVersions("v1.0.0", "v1.0.1"),
 			},
 			args: args{
-				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "p1-system", ""),
+				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "p1-system"),
 			},
 			want:    nil,
 			wantErr: true,
@@ -182,7 +182,7 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 									WithMetadata("v1.0.0", &clusterctlv1.Metadata{}),
 			},
 			args: args{
-				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "p1-system", ""),
+				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "p1-system"),
 			},
 			want:    nil,
 			wantErr: true,
@@ -197,7 +197,7 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 									WithMetadata("v1.0.1", &clusterctlv1.Metadata{}),
 			},
 			args: args{
-				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "p1-system", ""),
+				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "p1-system"),
 			},
 			want:    nil,
 			wantErr: true,
@@ -217,7 +217,7 @@ func Test_providerUpgrader_getUpgradeInfo(t *testing.T) {
 					}),
 			},
 			args: args{
-				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "p1-system", ""),
+				provider: fakeProvider("p1", clusterctlv1.InfrastructureProviderType, "v1.0.0", "p1-system"),
 			},
 			want:    nil,
 			wantErr: true,
@@ -434,7 +434,7 @@ func toSemanticVersions(versions []string) []version.Version {
 	return semanticVersions
 }
 
-func fakeProvider(name string, providerType clusterctlv1.ProviderType, version, targetNamespace, watchingNamespace string) clusterctlv1.Provider {
+func fakeProvider(name string, providerType clusterctlv1.ProviderType, version, targetNamespace string) clusterctlv1.Provider {
 	return clusterctlv1.Provider{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: clusterctlv1.GroupVersion.String(),
@@ -450,9 +450,8 @@ func fakeProvider(name string, providerType clusterctlv1.ProviderType, version, 
 				clusterctlv1.ClusterctlCoreLabelName: "inventory",
 			},
 		},
-		ProviderName:     name,
-		Type:             string(providerType),
-		Version:          version,
-		WatchedNamespace: watchingNamespace,
+		ProviderName: name,
+		Type:         string(providerType),
+		Version:      version,
 	}
 }

--- a/cmd/clusterctl/client/cluster/upgrader_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_test.go
@@ -64,19 +64,19 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			want: []UpgradePlan{
 				{ // one upgrade plan with the latest releases the current contract
 					Contract: test.CurrentCAPIContract,
 					Providers: []UpgradeItem{
 						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 							NextVersion: "v1.0.1",
 						},
 						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 							NextVersion: "v2.0.1",
 						},
 					},
@@ -115,19 +115,19 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			want: []UpgradePlan{
 				{ // one upgrade plan with the latest releases the current contract
 					Contract: test.CurrentCAPIContract,
 					Providers: []UpgradeItem{
 						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 							NextVersion: "v1.0.1",
 						},
 						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 							NextVersion: "v2.0.1",
 						},
 					},
@@ -162,19 +162,19 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			want: []UpgradePlan{
 				{ // one upgrade plan with the latest releases in the previous contract (not supported, but upgrade plan should report these options)
 					Contract: test.PreviousCAPIContractNotSupported,
 					Providers: []UpgradeItem{
 						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 							NextVersion: "v1.0.1",
 						},
 						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 							NextVersion: "v2.0.1",
 						},
 					},
@@ -183,11 +183,11 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					Contract: test.CurrentCAPIContract,
 					Providers: []UpgradeItem{
 						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 							NextVersion: "v2.0.0",
 						},
 						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 							NextVersion: "v3.0.0",
 						},
 					},
@@ -222,19 +222,19 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			want: []UpgradePlan{
 				{ // one upgrade plan with the latest releases in the current
 					Contract: test.CurrentCAPIContract,
 					Providers: []UpgradeItem{
 						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 							NextVersion: "v1.0.1",
 						},
 						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 							NextVersion: "v2.0.1",
 						},
 					},
@@ -243,11 +243,11 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 					Contract: test.NextCAPIContractNotSupported,
 					Providers: []UpgradeItem{
 						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 							NextVersion: "v2.0.0",
 						},
 						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 							NextVersion: "v3.0.0",
 						},
 					},
@@ -281,19 +281,19 @@ func Test_providerUpgrader_Plan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			want: []UpgradePlan{
 				{ // one upgrade plan with the latest releases in the current contract
 					Contract: test.CurrentCAPIContract,
 					Providers: []UpgradeItem{
 						{
-							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+							Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 							NextVersion: "v1.0.1",
 						},
 						{
-							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+							Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 							NextVersion: "", // we are already to the latest version for the infra provider, but this is acceptable for the current contract
 						},
 					},
@@ -370,14 +370,14 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system"),
 				providersToUpgrade: []UpgradeItem{
 					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 						NextVersion: "v2.0.1", // upgrade to next release in the current contract
 					},
 				},
@@ -386,7 +386,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				Contract: test.CurrentCAPIContract,
 				Providers: []UpgradeItem{
 					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 						NextVersion: "v2.0.1",
 					},
 				},
@@ -418,14 +418,14 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system"),
 				providersToUpgrade: []UpgradeItem{
 					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 						NextVersion: "v1.0.1", // upgrade to next release in the current contract
 					},
 				},
@@ -434,7 +434,7 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				Contract: test.CurrentCAPIContract,
 				Providers: []UpgradeItem{
 					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 						NextVersion: "v1.0.1",
 					},
 				},
@@ -468,18 +468,18 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system"),
 				providersToUpgrade: []UpgradeItem{
 					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 						NextVersion: "v2.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
 					},
 					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 						NextVersion: "v3.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
 					},
 				},
@@ -488,11 +488,11 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				Contract: test.CurrentCAPIContract,
 				Providers: []UpgradeItem{
 					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 						NextVersion: "v2.0.0",
 					},
 					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 						NextVersion: "v3.0.0",
 					},
 				},
@@ -526,14 +526,14 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system"),
 				providersToUpgrade: []UpgradeItem{
 					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 						NextVersion: "v3.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
 					},
 				},
@@ -568,14 +568,14 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system"),
 				providersToUpgrade: []UpgradeItem{
 					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 						NextVersion: "v3.0.0", // upgrade to next release in the current contract.
 					},
 				},
@@ -610,14 +610,14 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system"),
 				providersToUpgrade: []UpgradeItem{
 					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 						NextVersion: "v2.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
 					},
 				},
@@ -652,14 +652,14 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system"),
 				providersToUpgrade: []UpgradeItem{
 					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 						NextVersion: "v2.0.0", // upgrade to next release in the current contract
 					},
 				},
@@ -694,18 +694,18 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system"),
 				providersToUpgrade: []UpgradeItem{
 					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 						NextVersion: "v2.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
 					},
 					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 						NextVersion: "v3.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
 					},
 				},
@@ -740,18 +740,18 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				},
 				// two providers existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			args: args{
-				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system", ""),
+				coreProvider: fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "", "cluster-api-system"),
 				providersToUpgrade: []UpgradeItem{
 					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 						NextVersion: "v2.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
 					},
 					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 						NextVersion: "v3.0.0", // upgrade to next release in the next contract; not supported in current clusterctl release.
 					},
 				},
@@ -760,11 +760,11 @@ func Test_providerUpgrader_createCustomPlan(t *testing.T) {
 				Contract: test.CurrentCAPIContract,
 				Providers: []UpgradeItem{
 					{
-						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+						Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 						NextVersion: "v2.0.0",
 					},
 					{
-						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+						Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 						NextVersion: "v3.0.0",
 					},
 				},
@@ -840,9 +840,9 @@ func Test_providerUpgrader_ApplyPlan(t *testing.T) {
 				},
 				// two providers with multiple instances existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "default").
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system-1", "default-1").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", "default"),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system-1").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			contract: test.CurrentCAPIContract,
 			wantErr:  true,
@@ -876,9 +876,9 @@ func Test_providerUpgrader_ApplyPlan(t *testing.T) {
 				},
 				// two providers with multiple instances existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "default").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", "default").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system-1", "default-1"),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system-1"),
 			},
 			contract: test.CurrentCAPIContract,
 			wantErr:  true,
@@ -954,17 +954,17 @@ func Test_providerUpgrader_ApplyCustomPlan(t *testing.T) {
 				},
 				// two providers with multiple instances existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "default").
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system-1", "default-1").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", "default"),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system-1").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 			},
 			providersToUpgrade: []UpgradeItem{
 				{
-					Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+					Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 					NextVersion: "v2.0.0",
 				},
 				{
-					Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 					NextVersion: "v3.0.0",
 				},
 			},
@@ -999,21 +999,21 @@ func Test_providerUpgrader_ApplyCustomPlan(t *testing.T) {
 				},
 				// two providers with multiple instances existing in the cluster
 				proxy: test.NewFakeProxy().
-					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", "default").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", "default").
-					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system-1", "default-1"),
+					WithProviderInventory("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system").
+					WithProviderInventory("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system-1"),
 			},
 			providersToUpgrade: []UpgradeItem{
 				{
-					Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system", ""),
+					Provider:    fakeProvider("cluster-api", clusterctlv1.CoreProviderType, "v1.0.0", "cluster-api-system"),
 					NextVersion: "v2.0.0",
 				},
 				{
-					Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system", ""),
+					Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system"),
 					NextVersion: "v3.0.0",
 				},
 				{
-					Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system-1", ""),
+					Provider:    fakeProvider("infra", clusterctlv1.InfrastructureProviderType, "v2.0.0", "infra-system-1"),
 					NextVersion: "v3.0.0",
 				},
 			},

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -463,7 +463,7 @@ func Test_clusterctlClient_GetClusterTemplate(t *testing.T) {
 		WithFile("v3.0.0", "cluster-template.yaml", rawTemplate)
 
 	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1).
-		WithProviderInventory(infraProviderConfig.Name(), infraProviderConfig.Type(), "v3.0.0", "foo", "bar").
+		WithProviderInventory(infraProviderConfig.Name(), infraProviderConfig.Type(), "v3.0.0", "foo").
 		WithObjs(configMap).
 		WithObjs(test.FakeCAPISetupObjects()...)
 

--- a/cmd/clusterctl/client/delete_test.go
+++ b/cmd/clusterctl/client/delete_test.go
@@ -151,10 +151,10 @@ func fakeClusterForDelete() *fakeClient {
 	repository4 := newFakeRepository(infraProviderConfig, config1)
 
 	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1)
-	cluster1.fakeProxy.WithProviderInventory(capiProviderConfig.Name(), capiProviderConfig.Type(), "v1.0.0", "capi-system", "")
-	cluster1.fakeProxy.WithProviderInventory(bootstrapProviderConfig.Name(), bootstrapProviderConfig.Type(), "v1.0.0", "capbpk-system", "")
-	cluster1.fakeProxy.WithProviderInventory(controlPlaneProviderConfig.Name(), controlPlaneProviderConfig.Type(), "v1.0.0", namespace, "")
-	cluster1.fakeProxy.WithProviderInventory(infraProviderConfig.Name(), infraProviderConfig.Type(), "v1.0.0", namespace, "")
+	cluster1.fakeProxy.WithProviderInventory(capiProviderConfig.Name(), capiProviderConfig.Type(), "v1.0.0", "capi-system")
+	cluster1.fakeProxy.WithProviderInventory(bootstrapProviderConfig.Name(), bootstrapProviderConfig.Type(), "v1.0.0", "capbpk-system")
+	cluster1.fakeProxy.WithProviderInventory(controlPlaneProviderConfig.Name(), controlPlaneProviderConfig.Type(), "v1.0.0", namespace)
+	cluster1.fakeProxy.WithProviderInventory(infraProviderConfig.Name(), infraProviderConfig.Type(), "v1.0.0", namespace)
 	cluster1.fakeProxy.WithFakeCAPISetup()
 
 	client := newFakeClient(config1).

--- a/cmd/clusterctl/client/init_test.go
+++ b/cmd/clusterctl/client/init_test.go
@@ -749,7 +749,7 @@ func fakeInitializedCluster() *fakeClient {
 	p := client.clusters[input].Proxy()
 	fp := p.(*test.FakeProxy)
 
-	fp.WithProviderInventory(capiProviderConfig.Name(), capiProviderConfig.Type(), "v1.0.0", "capi-system", "")
+	fp.WithProviderInventory(capiProviderConfig.Name(), capiProviderConfig.Type(), "v1.0.0", "capi-system")
 
 	return client
 }

--- a/cmd/clusterctl/client/move_test.go
+++ b/cmd/clusterctl/client/move_test.go
@@ -103,15 +103,15 @@ func fakeClientForMove() *fakeClient {
 		WithProvider(infra)
 
 	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1).
-		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "").
-		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "").
+		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system").
+		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system").
 		WithObjectMover(&fakeObjectMover{}).
 		WithObjs(test.FakeCAPISetupObjects()...)
 
 	// Creating this cluster for move_test
 	cluster2 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "worker-context"}, config1).
-		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "").
-		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "").
+		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system").
+		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system").
 		WithObjs(test.FakeCAPISetupObjects()...)
 
 	client := newFakeClient(config1).

--- a/cmd/clusterctl/client/repository/components.go
+++ b/cmd/clusterctl/client/repository/components.go
@@ -54,8 +54,7 @@ const (
 // 1. Checks for all the variables in the component YAML file and replace with corresponding config values
 // 2. Ensure all the provider components are deployed in the target namespace (apply only to namespaced objects)
 // 3. Ensure all the ClusterRoleBinding which are referencing namespaced objects have the name prefixed with the namespace name
-// 4. Set the watching namespace for the provider controller
-// 5. Adds labels to all the components in order to allow easy identification of the provider objects.
+// 4. Adds labels to all the components in order to allow easy identification of the provider objects.
 type Components interface {
 	// configuration of the provider the provider components belongs to.
 	config.Provider
@@ -182,8 +181,7 @@ type ComponentsInput struct {
 // 2. The variables replacement can be skipped using the SkipVariables flag in the input options
 // 3. Ensure all the provider components are deployed in the target namespace (apply only to namespaced objects)
 // 4. Ensure all the ClusterRoleBinding which are referencing namespaced objects have the name prefixed with the namespace name
-// 5. Set the watching namespace for the provider controller
-// 6. Adds labels to all the components in order to allow easy identification of the provider objects.
+// 5. Adds labels to all the components in order to allow easy identification of the provider objects.
 func NewComponents(input ComponentsInput) (Components, error) {
 	variables, err := input.Processor.GetVariables(input.RawYaml)
 	if err != nil {

--- a/cmd/clusterctl/client/rollout_test.go
+++ b/cmd/clusterctl/client/rollout_test.go
@@ -129,8 +129,8 @@ func fakeClientForRollout() *fakeClient {
 		WithProvider(infra)
 
 	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1).
-		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "").
-		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "").
+		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system").
+		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system").
 		WithObjs(md1).
 		WithObjs(md2)
 

--- a/cmd/clusterctl/client/upgrade_test.go
+++ b/cmd/clusterctl/client/upgrade_test.go
@@ -337,8 +337,8 @@ func fakeClientForUpgrade() *fakeClient {
 	cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config1).
 		WithRepository(repository1).
 		WithRepository(repository2).
-		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system", "").
-		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system", "").
+		WithProviderInventory(core.Name(), core.Type(), "v1.0.0", "cluster-api-system").
+		WithProviderInventory(infra.Name(), infra.Type(), "v2.0.0", "infra-system").
 		WithObjs(test.FakeCAPISetupObjects()...)
 
 	client := newFakeClient(config1).

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -142,7 +142,7 @@ func (f *FakeProxy) WithNamespace(n string) *FakeProxy {
 // NB. this method adds an items to the Provider inventory, but it doesn't install the corresponding provider; if the
 // test case requires the actual provider to be installed, use the the fake client to install both the provider
 // components and the corresponding inventory item.
-func (f *FakeProxy) WithProviderInventory(name string, providerType clusterctlv1.ProviderType, version, targetNamespace, watchingNamespace string) *FakeProxy {
+func (f *FakeProxy) WithProviderInventory(name string, providerType clusterctlv1.ProviderType, version, targetNamespace string) *FakeProxy {
 	f.objs = append(f.objs, &clusterctlv1.Provider{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: clusterctlv1.GroupVersion.String(),
@@ -158,10 +158,9 @@ func (f *FakeProxy) WithProviderInventory(name string, providerType clusterctlv1
 				clusterctlv1.ClusterctlCoreLabelName: "inventory",
 			},
 		},
-		ProviderName:     name,
-		Type:             string(providerType),
-		Version:          version,
-		WatchedNamespace: watchingNamespace,
+		ProviderName: name,
+		Type:         string(providerType),
+		Version:      version,
 	})
 
 	return f


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow up of #4666; it removes watching namespace from fakeObjects & tests.
It includes also two leftover cleanups from the above PR
