### PR TITLE
:book: CRS API does not allow empty selectors

### DIFF
--- a/docs/proposals/20200220-cluster-resource-set.md
+++ b/docs/proposals/20200220-cluster-resource-set.md
@@ -96,7 +96,7 @@ None. We are planning to implement this feature without modifying any of the exi
 
 #### ClusterResourceSet Object Definition
 
-This is the CRD that has a set of components (resources) to be applied to clusters that match the label selector in it.
+This is the CRD that has a set of components (resources) to be applied to clusters that match the label selector in it. The label selector cannot be empty.
 
 The resources field is a list of `Secrets`/`ConfigMaps` which should be in the same namespace with `ClusterResourceSet`. The clusterSelector field is a Kubernetes [label selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements) that matches against labels on clusters (only the clusters in the same namespace with the ClusterResourceSet resource).
 ClusterResourceSet is namespace-scoped, all resources and clusters needs to be in the same namespace as the ClusterResourceSet.

--- a/exp/addons/api/v1alpha4/clusterresourceset_types.go
+++ b/exp/addons/api/v1alpha4/clusterresourceset_types.go
@@ -37,6 +37,7 @@ type ClusterResourceSetSpec struct {
 	// Label selector for Clusters. The Clusters that are
 	// selected by this will be the ones affected by this ClusterResourceSet.
 	// It must match the Cluster labels. This field is immutable.
+	// Label selector cannot be empty.
 	ClusterSelector metav1.LabelSelector `json:"clusterSelector"`
 
 	// Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Updated CRS API and documentation that label selector can not be empty.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4635 
