### PR TITLE
⚠️  Add --raw flag for clusterctl generate provider subcommand 

### DIFF
--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -46,16 +46,11 @@ func (c *clusterctlClient) GetProvidersConfig() ([]Provider, error) {
 }
 
 func (c *clusterctlClient) GetProviderComponents(provider string, providerType clusterctlv1.ProviderType, options ComponentsOptions) (Components, error) {
-	// ComponentsOptions is an alias for repository.ComponentsOptions; this makes the conversion
-	inputOptions := repository.ComponentsOptions{
-		Version:         options.Version,
-		TargetNamespace: options.TargetNamespace,
-		SkipVariables:   options.SkipVariables,
-	}
-	components, err := c.getComponentsByName(provider, providerType, inputOptions)
+	components, err := c.getComponentsByName(provider, providerType, repository.ComponentsOptions(options))
 	if err != nil {
 		return nil, err
 	}
+
 	return components, nil
 }
 

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -220,8 +220,8 @@ func Test_getComponentsByName_withEmptyVariables(t *testing.T) {
 		WithCluster(cluster1)
 
 	options := ComponentsOptions{
-		TargetNamespace: "ns1",
-		SkipVariables:   true,
+		TargetNamespace:     "ns1",
+		SkipVariableProcess: true,
 	}
 	components, err := client.GetProviderComponents(repository1Config.Name(), repository1Config.Type(), options)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -254,8 +254,8 @@ func (c *clusterctlClient) addToInstaller(options addToInstallerOptions, provide
 			continue
 		}
 		componentsOptions := repository.ComponentsOptions{
-			TargetNamespace: options.targetNamespace,
-			SkipVariables:   options.skipVariables,
+			TargetNamespace:     options.targetNamespace,
+			SkipVariableProcess: options.skipVariables,
 		}
 		components, err := c.getComponentsByName(provider, providerType, componentsOptions)
 		if err != nil {

--- a/cmd/clusterctl/client/repository/components.go
+++ b/cmd/clusterctl/client/repository/components.go
@@ -161,7 +161,7 @@ type ComponentsOptions struct {
 	Version         string
 	TargetNamespace string
 	// Allows for skipping variable replacement in the component YAML
-	SkipVariables bool
+	SkipVariableProcess bool
 }
 
 // ComponentsInput represents all the inputs required by NewComponents.
@@ -178,7 +178,7 @@ type ComponentsInput struct {
 // It is important to notice that clusterctl applies a set of processing steps to the “raw” component YAML read
 // from the provider repositories:
 // 1. Checks for all the variables in the component YAML file and replace with corresponding config values
-// 2. The variables replacement can be skipped using the SkipVariables flag in the input options
+// 2. The variables replacement can be skipped using the SkipVariableProcess flag in the input options
 // 3. Ensure all the provider components are deployed in the target namespace (apply only to namespaced objects)
 // 4. Ensure all the ClusterRoleBinding which are referencing namespaced objects have the name prefixed with the namespace name
 // 5. Adds labels to all the components in order to allow easy identification of the provider objects.
@@ -189,7 +189,7 @@ func NewComponents(input ComponentsInput) (Components, error) {
 	}
 
 	processedYaml := input.RawYaml
-	if !input.Options.SkipVariables {
+	if !input.Options.SkipVariableProcess {
 		processedYaml, err = input.Processor.Process(input.RawYaml, input.ConfigClient.Variables().Get)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to perform variable substitution")

--- a/cmd/clusterctl/client/repository/components_client_test.go
+++ b/cmd/clusterctl/client/repository/components_client_test.go
@@ -114,7 +114,7 @@ func Test_componentsClient_Get(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "successfully gets the components even with SkipVariables defined",
+			name: "successfully gets the components even with SkipVariableProcess defined",
 			fields: fields{
 				provider: p1,
 				repository: test.NewFakeRepository().
@@ -260,9 +260,9 @@ func Test_componentsClient_Get(t *testing.T) {
 			gs := NewWithT(t)
 
 			options := ComponentsOptions{
-				Version:         tt.args.version,
-				TargetNamespace: tt.args.targetNamespace,
-				SkipVariables:   tt.args.skipVariables,
+				Version:             tt.args.version,
+				TargetNamespace:     tt.args.targetNamespace,
+				SkipVariableProcess: tt.args.skipVariables,
 			}
 			f := newComponentsClient(tt.fields.provider, tt.fields.repository, configClient)
 			if tt.fields.processor != nil {
@@ -291,7 +291,7 @@ func Test_componentsClient_Get(t *testing.T) {
 				gs.Expect(yaml).To(ContainSubstring(variableValue))
 			}
 
-			// Verify that when SkipVariables is set we have all the variables
+			// Verify that when SkipVariableProcess is set we have all the variables
 			// in the template without the values processed.
 			if tt.args.skipVariables {
 				for _, v := range tt.want.variables {

--- a/cmd/clusterctl/cmd/config_provider.go
+++ b/cmd/clusterctl/cmd/config_provider.go
@@ -142,8 +142,8 @@ func runGetComponents() error {
 	}
 
 	options := client.ComponentsOptions{
-		TargetNamespace: cpo.targetNamespace,
-		SkipVariables:   true,
+		TargetNamespace:     cpo.targetNamespace,
+		SkipVariableProcess: true,
 	}
 	components, err := c.GetProviderComponents(providerName, providerType, options)
 	if err != nil {

--- a/cmd/clusterctl/cmd/generate_provider.go
+++ b/cmd/clusterctl/cmd/generate_provider.go
@@ -103,8 +103,8 @@ func runGenerateProviderComponents() error {
 	}
 
 	options := client.ComponentsOptions{
-		TargetNamespace: gpo.targetNamespace,
-		SkipVariables:   gpo.raw,
+		TargetNamespace:     gpo.targetNamespace,
+		SkipVariableProcess: gpo.raw,
 	}
 
 	components, err := c.GetProviderComponents(providerName, providerType, options)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add --raw flag for clusterctl generate provider subcommand  for unprocessed yaml

  - Added a New flag --raw of type bool in the provider subcommand 
  - If flag provided, the variables processing will be skipped while generating provider yaml

Signed-off-by: Ayush Rangwala <arangwala@vmware.com>
 
Since we are in the process to deprecate `clusterctl config provider --infrastructure aws` commands and migrating to `clusterctl generate provider`, based on [this](https://github.com/kubernetes-sigs/cluster-api/issues/3360#issuecomment-662677592) discussion, we decided to have a `--raw` flag to give the same functionality as of the `config` subcommand

Fixes #4650 
