### PR TITLE
🌱 improve clusterctl generate cluster --list-variables

### DIFF
--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -182,7 +182,7 @@ func runGenerateClusterTemplate(cmd *cobra.Command, name string) error {
 	}
 
 	if gc.listVariables {
-		return printVariablesOutput(cmd, template)
+		return printVariablesOutput(template, templateOptions)
 	}
 
 	return printYamlOutput(template)

--- a/cmd/clusterctl/cmd/util.go
+++ b/cmd/clusterctl/cmd/util.go
@@ -26,8 +26,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 )
 
@@ -50,38 +48,66 @@ func stringPtr(s string) *string {
 }
 
 // printVariablesOutput prints the expected variables in the template to stdout.
-func printVariablesOutput(cmd *cobra.Command, template client.Template) error {
+func printVariablesOutput(template client.Template, options client.GetClusterTemplateOptions) error {
 	// Decorate the variable map for printing
 	variableMap := template.VariableMap()
-	for name, defaultValue := range variableMap {
-		if defaultValue != nil {
-			v := *defaultValue
+	var requiredVariables []string
+	var optionalVariables []string
+	for name := range variableMap {
+		if variableMap[name] != nil {
+			v := *variableMap[name]
 			// Add quotes around any unquoted strings
 			if len(v) > 0 && !strings.HasPrefix(v, "\"") {
 				v = fmt.Sprintf("\"%s\"", v)
 				variableMap[name] = &v
 			}
 		}
-	}
-	// Add variables that are defaulted from clusterctl
-	controlPlaneMachineCount, err := cmd.Flags().GetInt64("control-plane-machine-count")
-	if err != nil {
-		return err
-	}
-	variableMap["CONTROL_PLANE_MACHINE_COUNT"] = stringPtr(strconv.FormatInt(controlPlaneMachineCount, 10))
-	workerMachineCount, err := cmd.Flags().GetInt64("worker-machine-count")
-	if err != nil {
-		return err
-	}
-	variableMap["WORKER_MACHINE_COUNT"] = stringPtr(strconv.FormatInt(workerMachineCount, 10))
-	variableMap["KUBERNETES_VERSION"] = stringPtr("the value of --kubernetes-version")
-	variableMap["CLUSTER_NAME"] = stringPtr("<name> from \"clusterctl config cluster <name>\"")
 
-	// transform variable map into required and optional lists
-	var requiredVariables []string
-	var optionalVariables []string
-	for name, defaultValue := range variableMap {
-		if defaultValue != nil {
+		// Fix up default for well-know variables that have a special logic implemented in clusterctl.
+		// NOTE: this logic mimics the defaulting rules implemented in client.GetClusterTemplate;
+		switch name {
+		case "CLUSTER_NAME":
+			// Cluster name from the cmd arguments is used instead of template default.
+			variableMap[name] = stringPtr(options.ClusterName)
+		case "NAMESPACE":
+			// Namespace name from the cmd flags or from the kubeconfig is used instead of template default.
+			if options.TargetNamespace != "" {
+				variableMap[name] = stringPtr(options.TargetNamespace)
+			} else {
+				variableMap[name] = stringPtr("current Namespace in the KubeConfig file")
+			}
+		case "CONTROL_PLANE_MACHINE_COUNT":
+			// Control plane machine count uses the cmd flag, env variable or a constant is used instead of template default.
+			if options.ControlPlaneMachineCount == nil {
+				if val, ok := os.LookupEnv("CONTROL_PLANE_MACHINE_COUNT"); ok {
+					variableMap[name] = stringPtr(val)
+				} else {
+					variableMap[name] = stringPtr("1")
+				}
+			} else {
+				variableMap[name] = stringPtr(strconv.FormatInt(*options.ControlPlaneMachineCount, 10))
+			}
+		case "WORKER_MACHINE_COUNT":
+			// Worker machine count uses the cmd flag, env variable or a constant is used instead of template default.
+			if options.WorkerMachineCount == nil {
+				if val, ok := os.LookupEnv("WORKER_MACHINE_COUNT"); ok {
+					variableMap[name] = stringPtr(val)
+				} else {
+					variableMap[name] = stringPtr("0")
+				}
+			} else {
+				variableMap[name] = stringPtr(strconv.FormatInt(*options.WorkerMachineCount, 10))
+			}
+		case "KUBERNETES_VERSION":
+			// Kubernetes version uses the cmd flag, env variable, or the template default.
+			if options.KubernetesVersion != "" {
+				variableMap[name] = stringPtr(options.KubernetesVersion)
+			} else if val, ok := os.LookupEnv("KUBERNETES_VERSION"); ok {
+				variableMap[name] = stringPtr(val)
+			}
+		}
+
+		if variableMap[name] != nil {
 			optionalVariables = append(optionalVariables, name)
 		} else {
 			requiredVariables = append(requiredVariables, name)


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/cluster-api/pull/4645 recently introduced the visualisation of default values for template variables.

This PR slightly improves this by ensuring that for well know variables:
- if the template defines defaults, those are considered
- if variables are provided with env vars, those are considered
- if a default value is provided (no matter if in the template or by other means), the variable is listed a optional; otherwise the variable is listed as required.

/cc @mboersma 

