### PR TITLE
🌱 Move registering field indexes to the `noderefutil` package

### DIFF
--- a/api/v1alpha4/common_types.go
+++ b/api/v1alpha4/common_types.go
@@ -99,6 +99,11 @@ var (
 	ZeroDuration = metav1.Duration{}
 )
 
+const (
+	// MachineNodeNameIndex is used by the Machine Controller to index Machines by Node name, and add a watch on Nodes.
+	MachineNodeNameIndex = "status.nodeRef.name"
+)
+
 // MachineAddressType describes a valid MachineAddress type.
 type MachineAddressType string
 
@@ -109,11 +114,6 @@ const (
 	MachineInternalIP  MachineAddressType = "InternalIP"
 	MachineExternalDNS MachineAddressType = "ExternalDNS"
 	MachineInternalDNS MachineAddressType = "InternalDNS"
-)
-
-const (
-	// MachineNodeNameIndex is used by the Machine Controller to index Machines by Node name, and add a watch on Nodes.
-	MachineNodeNameIndex = "status.nodeRef.name"
 )
 
 // MachineAddress contains information for the node's address.

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -109,14 +109,6 @@ func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		return errors.Wrap(err, "failed to add Watch for Clusters to controller manager")
 	}
 
-	// Add index to Machine for listing by Node reference.
-	if err := mgr.GetCache().IndexField(ctx, &clusterv1.Machine{},
-		clusterv1.MachineNodeNameIndex,
-		r.indexMachineByNodeName,
-	); err != nil {
-		return errors.Wrap(err, "error setting index fields")
-	}
-
 	r.controller = controller
 
 	r.recorder = mgr.GetEventRecorderFor("machine-controller")
@@ -687,19 +679,6 @@ func (r *MachineReconciler) nodeToMachine(o client.Object) []reconcile.Request {
 	}
 
 	return []reconcile.Request{{NamespacedName: util.ObjectKey(&machineList.Items[0])}}
-}
-
-func (r *MachineReconciler) indexMachineByNodeName(o client.Object) []string {
-	machine, ok := o.(*clusterv1.Machine)
-	if !ok {
-		panic(fmt.Sprintf("Expected a Machine but got a %T", o))
-	}
-
-	if machine.Status.NodeRef != nil {
-		return []string{machine.Status.NodeRef.Name}
-	}
-
-	return nil
 }
 
 // writer implements io.Writer interface as a pass-through for klog.

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -176,40 +176,6 @@ func TestWatches(t *testing.T) {
 	}, timeout).Should(BeTrue())
 }
 
-func TestIndexMachineByNodeName(t *testing.T) {
-	r := &MachineReconciler{}
-	testCases := []struct {
-		name     string
-		object   client.Object
-		expected []string
-	}{
-		{
-			name:     "when the machine has no NodeRef",
-			object:   &clusterv1.Machine{},
-			expected: []string{},
-		},
-		{
-			name: "when the machine has valid a NodeRef",
-			object: &clusterv1.Machine{
-				Status: clusterv1.MachineStatus{
-					NodeRef: &corev1.ObjectReference{
-						Name: "node1",
-					},
-				},
-			},
-			expected: []string{"node1"},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			g := NewWithT(t)
-			got := r.indexMachineByNodeName(tc.object)
-			g.Expect(got).To(ConsistOf(tc.expected))
-		})
-	}
-}
-
 func TestMachine_Reconcile(t *testing.T) {
 	g := NewWithT(t)
 	infraMachine := &unstructured.Unstructured{

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/external"
+	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
@@ -488,36 +489,12 @@ func (r *MachineHealthCheckReconciler) nodeToMachineHealthCheck(o client.Object)
 		panic(fmt.Sprintf("Expected a corev1.Node, got %T", o))
 	}
 
-	machine, err := r.getMachineFromNode(context.TODO(), node.Name)
+	machine, err := noderefutil.GetMachineFromNode(context.TODO(), r.Client, node.Name)
 	if machine == nil || err != nil {
 		return nil
 	}
 
 	return r.machineToMachineHealthCheck(machine)
-}
-
-func (r *MachineHealthCheckReconciler) getMachineFromNode(ctx context.Context, nodeName string) (*clusterv1.Machine, error) {
-	machineList := &clusterv1.MachineList{}
-	if err := r.Client.List(
-		ctx,
-		machineList,
-		client.MatchingFields{clusterv1.MachineNodeNameIndex: nodeName},
-	); err != nil {
-		return nil, errors.Wrap(err, "failed getting machine list")
-	}
-	// TODO(vincepri): Remove this loop once controller runtime fake client supports
-	// adding indexes on objects.
-	items := []*clusterv1.Machine{}
-	for i := range machineList.Items {
-		machine := &machineList.Items[i]
-		if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name == nodeName {
-			items = append(items, machine)
-		}
-	}
-	if len(items) != 1 {
-		return nil, errors.Errorf("expecting one machine for node %v, got %v", nodeName, machineNames(items))
-	}
-	return items[0], nil
 }
 
 func (r *MachineHealthCheckReconciler) watchClusterNodes(ctx context.Context, cluster *clusterv1.Cluster) error {
@@ -603,14 +580,6 @@ func getMaxUnhealthy(mhc *clusterv1.MachineHealthCheck) (int, error) {
 // ie the delta between the expected number of machines and the current number deemed healthy.
 func unhealthyMachineCount(mhc *clusterv1.MachineHealthCheck) int {
 	return int(mhc.Status.ExpectedMachines - mhc.Status.CurrentHealthy)
-}
-
-func machineNames(machines []*clusterv1.Machine) []string {
-	result := make([]string, 0, len(machines))
-	for _, m := range machines {
-		result = append(result, m.Name)
-	}
-	return result
 }
 
 // getExternalRemediationRequest gets reference to External Remediation Request, unstructured object.

--- a/controllers/noderefutil/indexer.go
+++ b/controllers/noderefutil/indexer.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package noderefutil implements NodeRef utils.
+package noderefutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AddMachineNodeIndex adds the machine node name index to the
+// managers cache.
+func AddMachineNodeIndex(ctx context.Context, mgr ctrl.Manager) error {
+	if err := mgr.GetCache().IndexField(ctx, &clusterv1.Machine{},
+		clusterv1.MachineNodeNameIndex,
+		indexMachineByNodeName,
+	); err != nil {
+		return errors.Wrap(err, "error setting index fields")
+	}
+
+	return nil
+}
+
+func indexMachineByNodeName(o client.Object) []string {
+	machine, ok := o.(*clusterv1.Machine)
+	if !ok {
+		panic(fmt.Sprintf("Expected a Machine but got a %T", o))
+	}
+	if machine.Status.NodeRef != nil {
+		return []string{machine.Status.NodeRef.Name}
+	}
+	return nil
+}

--- a/controllers/noderefutil/indexer_test.go
+++ b/controllers/noderefutil/indexer_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderefutil
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestIndexMachineByNodeName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		object   client.Object
+		expected []string
+	}{
+		{
+			name:     "when the machine has no NodeRef",
+			object:   &clusterv1.Machine{},
+			expected: []string{},
+		},
+		{
+			name: "when the machine has valid a NodeRef",
+			object: &clusterv1.Machine{
+				Status: clusterv1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{
+						Name: "node1",
+					},
+				},
+			},
+			expected: []string{"node1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := indexMachineByNodeName(tc.object)
+			g.Expect(got).To(ConsistOf(tc.expected))
+		})
+	}
+}

--- a/controllers/noderefutil/machine.go
+++ b/controllers/noderefutil/machine.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderefutil
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetMachineFromNode retrieves the machine with a nodeRef to nodeName
+// There should at most one machine with a given nodeRef, returns an error otherwise.
+func GetMachineFromNode(ctx context.Context, c client.Client, nodeName string) (*clusterv1.Machine, error) {
+	machineList := &clusterv1.MachineList{}
+	if err := c.List(
+		ctx,
+		machineList,
+		client.MatchingFields{clusterv1.MachineNodeNameIndex: nodeName},
+	); err != nil {
+		return nil, errors.Wrap(err, "failed getting machine list")
+	}
+	// TODO(vincepri): Remove this loop once controller runtime fake client supports
+	// adding indexes on objects.
+	items := []*clusterv1.Machine{}
+	for i := range machineList.Items {
+		machine := &machineList.Items[i]
+		if machine.Status.NodeRef != nil && machine.Status.NodeRef.Name == nodeName {
+			items = append(items, machine)
+		}
+	}
+	if len(items) != 1 {
+		return nil, errors.Errorf("expecting one machine for node %v, got %v", nodeName, machineNames(items))
+	}
+	return items[0], nil
+}
+
+func machineNames(machines []*clusterv1.Machine) []string {
+	result := make([]string, 0, len(machines))
+	for _, m := range machines {
+		result = append(result, m.Name)
+	}
+	return result
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/internal/envtest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,6 +49,11 @@ var (
 func TestMain(m *testing.M) {
 	fmt.Println("Creating a new test environment")
 	env = envtest.New()
+
+	// Set up the MachineNodeIndex
+	if err := noderefutil.AddMachineNodeIndex(ctx, env.Manager); err != nil {
+		panic(fmt.Sprintf("undable to setup machine node index: %v", err))
+	}
 
 	// Set up a ClusterCacheTracker and ClusterCacheReconciler to provide to controllers
 	// requiring a connection to a remote cluster

--- a/exp/addons/controllers/suite_test.go
+++ b/exp/addons/controllers/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/exp/addons/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/internal/envtest"
@@ -39,6 +40,11 @@ var (
 func TestMain(m *testing.M) {
 	fmt.Println("Creating new test environment")
 	env = envtest.New([]client.Object{&corev1.ConfigMap{}, &corev1.Secret{}, &v1alpha4.ClusterResourceSetBinding{}}...)
+
+	// Set up the MachineNodeIndex
+	if err := noderefutil.AddMachineNodeIndex(ctx, env.Manager); err != nil {
+		panic(fmt.Sprintf("undable to setup machine node index: %v", err))
+	}
 
 	trckr, err := remote.NewClusterCacheTracker(env.Manager, remote.ClusterCacheTrackerOptions{})
 	if err != nil {

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"testing"
 
+	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/internal/envtest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -35,6 +36,11 @@ var (
 func TestMain(m *testing.M) {
 	fmt.Println("Creating new test environment")
 	env = envtest.New()
+
+	// Set up the MachineNodeIndex
+	if err := noderefutil.AddMachineNodeIndex(ctx, env.Manager); err != nil {
+		panic(fmt.Sprintf("undable to setup machine node index: %v", err))
+	}
 
 	machinePoolReconciler := MachinePoolReconciler{
 		Client:   env,

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers"
+	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	addonsv1old "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha3"
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha4"
@@ -200,6 +201,7 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	setupChecks(mgr)
+	setupIndexes(ctx, mgr)
 	setupReconcilers(ctx, mgr)
 	setupWebhooks(mgr)
 
@@ -219,6 +221,13 @@ func setupChecks(mgr ctrl.Manager) {
 
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to create health check")
+		os.Exit(1)
+	}
+}
+
+func setupIndexes(ctx context.Context, mgr ctrl.Manager) {
+	if err := noderefutil.AddMachineNodeIndex(ctx, mgr); err != nil {
+		setupLog.Error(err, "unable to setup index")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Moves the logic to register the field indexes out of the controller and into the api package. The indexes are api specific and make more sense in the api package.  
The main block now calls a `setupIndexes` to register the indexes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3778 
