### PR TITLE
⚠️  ClusterResourceSet should not use a predicate on secret Type with metadata objects

### DIFF
--- a/exp/addons/controllers/clusterresourceset_controller.go
+++ b/exp/addons/controllers/clusterresourceset_controller.go
@@ -86,7 +86,7 @@ func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr
 			handler.EnqueueRequestsFromMapFunc(r.resourceToClusterResourceSet),
 			builder.OnlyMetadata,
 			builder.WithPredicates(
-				resourcepredicates.AddonsSecretCreate(ctrl.LoggerFrom(ctx)),
+				resourcepredicates.ResourceCreate(ctrl.LoggerFrom(ctx)),
 			),
 		).
 		WithOptions(options).

--- a/exp/addons/controllers/predicates/resource_predicates.go
+++ b/exp/addons/controllers/predicates/resource_predicates.go
@@ -19,8 +19,6 @@ package predicates
 
 import (
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1alpha4"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -29,31 +27,6 @@ import (
 func ResourceCreate(logger logr.Logger) predicate.Funcs {
 	return predicate.Funcs{
 		CreateFunc:  func(e event.CreateEvent) bool { return true },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
-		GenericFunc: func(e event.GenericEvent) bool { return false },
-	}
-}
-
-// AddonsSecretCreate returns a predicate that returns true for a Secret create event if in addons Secret type.
-func AddonsSecretCreate(logger logr.Logger) predicate.Funcs {
-	log := logger.WithValues("predicate", "SecretCreateOrUpdate")
-
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			log = log.WithValues("eventType", "create")
-			s, ok := e.Object.(*corev1.Secret)
-			if !ok {
-				log.V(4).Info("Expected Secret", "secret", e.Object.GetObjectKind().GroupVersionKind().String())
-				return false
-			}
-			if string(s.Type) != string(addonsv1.ClusterResourceSetSecretType) {
-				log.V(4).Info("Expected Secret Type", "type", addonsv1.SecretClusterResourceSetResourceKind,
-					"got", string(s.Type))
-				return false
-			}
-			return true
-		},
 		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
 		GenericFunc: func(e event.GenericEvent) bool { return false },


### PR DESCRIPTION
**What this PR does / why we need it**:
When only metadata is cached for secrets, CRS predicates do not have the `type` info and hence does not trigger reconcile when a Secret with CRS secret type (`addons.cluster.x-k8s.io/resource-set`) is created.

This PR caches full Secret object in CRS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4218
