### PR TITLE
🌱 Drop 420 dec default for secrets

### DIFF
--- a/bootstrap/kubeadm/config/default/manager_webhook_patch.yaml
+++ b/bootstrap/kubeadm/config/default/manager_webhook_patch.yaml
@@ -19,5 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          defaultMode: 420
           secretName: $(SERVICE_NAME)-cert

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -19,5 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          defaultMode: 420
           secretName: $(SERVICE_NAME)-cert

--- a/controlplane/kubeadm/config/default/manager_webhook_patch.yaml
+++ b/controlplane/kubeadm/config/default/manager_webhook_patch.yaml
@@ -19,5 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          defaultMode: 420
           secretName: $(SERVICE_NAME)-cert

--- a/test/infrastructure/docker/config/default/manager_webhook_patch.yaml
+++ b/test/infrastructure/docker/config/default/manager_webhook_patch.yaml
@@ -19,6 +19,5 @@ spec:
       volumes:
       - name: cert
         secret:
-          defaultMode: 420
           secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Using dec to set permissions is not intuitive. 420 dec is equivalent to 0644 octal which is already the default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
