### PR TITLE
:seedling: dependabot: Disable automatic PRs for gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,14 @@
 version: 2
 updates:
-  # Daily updates for main go.mod
+  # Check daily for go.mod
   - package-ecosystem: "gomod"
+    # Unfortunately, we don't want automatic PRs until such a time
+    # that `make modules` and `make generate` can be run to update all
+    # of the go modules in one go and get passing PRs.
+    #
+    # Maintainers can continue to look at the log in
+    # https://github.com/kubernetes-sigs/cluster-api/network/updates/
+    open-pull-requests-limit: 0
     directory: "/"
     schedule:
       interval: "daily"
@@ -25,6 +32,7 @@ updates:
 
   - package-ecosystem: "gomod"
     directory: "/hack/tools"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
     commit_message:
@@ -32,6 +40,7 @@ updates:
 
   - package-ecosystem: "gomod"
     directory: "/test"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
     commit_message:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Disable automatic PRs from dependabot for gomod as it doesn't work well across modules in the same repo. Maintainers will continue to be able to read the log at https://github.com/kubernetes-sigs/cluster-api/network/updates/ 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
