### PR TITLE
🌱ClusterResourceSet: use generic predicates for secrets

### DIFF
--- a/exp/addons/controllers/predicates/resource_predicates.go
+++ b/exp/addons/controllers/predicates/resource_predicates.go
@@ -35,6 +35,7 @@ func ResourceCreate(logger logr.Logger) predicate.Funcs {
 }
 
 // AddonsSecretCreate returns a predicate that returns true for a Secret create event if in addons Secret type
+// DEPRECATED: use ResourceCreate() predicate instead because Secret type is not reachable when Secrets are cached as PartialObjectMetadata.
 func AddonsSecretCreate(logger logr.Logger) predicate.Funcs {
 	log := logger.WithValues("predicate", "SecretCreateOrUpdate")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of https://github.com/kubernetes-sigs/cluster-api/pull/4723

This is not a bug in this version because we were not filtering by predicates.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
