### PR TITLE
🐛 Use unstructured to extract data from Secret/ConfigMap in CRS

### DIFF
--- a/exp/addons/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/controllers/clusterresourceset_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
@@ -260,7 +261,7 @@ metadata:
 		setup(t, g)
 		defer teardown(t, g)
 
-		newCMName := fmt.Sprintf("test-configmap-%s", util.RandomString(6))
+		newCMName := fmt.Sprintf("flaky-test-configmap-%s", util.RandomString(6))
 
 		crsInstance := &addonsv1.ClusterResourceSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -341,7 +342,7 @@ metadata:
 			if len(binding.Spec.Bindings[0].Resources) > 0 && binding.Spec.Bindings[0].Resources[0].Name == newCMName {
 				return nil
 			}
-			return errors.Errorf("ClusterResourceSet binding does not have any resources matching %q: %v", newCMName, binding.Spec.Bindings)
+			return errors.Errorf("ClusterResourceSet binding does not have any resources matching %q: %v", newCMName, spew.Sprint(binding.Spec.Bindings))
 		}, timeout).Should(Succeed())
 
 		t.Log("Verifying ClusterResourceSetBinding is deleted when its cluster owner reference is deleted")
@@ -359,7 +360,7 @@ metadata:
 		setup(t, g)
 		defer teardown(t, g)
 
-		newSecretName := fmt.Sprintf("test-secret-%s", util.RandomString(6))
+		newSecretName := fmt.Sprintf("flaky-test-secret-%s", util.RandomString(6))
 
 		crsInstance := &addonsv1.ClusterResourceSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -441,7 +442,7 @@ metadata:
 			if len(binding.Spec.Bindings[0].Resources) > 0 && binding.Spec.Bindings[0].Resources[0].Name == newSecretName {
 				return nil
 			}
-			return errors.Errorf("ClusterResourceSet binding does not have any resources matching %q: %v", newSecretName, binding.Spec.Bindings)
+			return errors.Errorf("ClusterResourceSet binding does not have any resources matching %q: %v", newSecretName, spew.Sprint(binding.Spec.Bindings))
 		}, timeout).Should(Succeed())
 
 		t.Log("Verifying ClusterResourceSetBinding is deleted when its cluster owner reference is deleted")

--- a/exp/addons/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/controllers/clusterresourceset_controller_test.go
@@ -343,7 +343,7 @@ metadata:
 				return nil
 			}
 			return errors.Errorf("ClusterResourceSet binding does not have any resources matching %q: %v", newCMName, spew.Sprint(binding.Spec.Bindings))
-		}, timeout).Should(Succeed())
+		}, timeout*5).Should(Succeed())
 
 		t.Log("Verifying ClusterResourceSetBinding is deleted when its cluster owner reference is deleted")
 		g.Expect(env.Delete(ctx, testCluster)).To(Succeed())
@@ -443,7 +443,7 @@ metadata:
 				return nil
 			}
 			return errors.Errorf("ClusterResourceSet binding does not have any resources matching %q: %v", newSecretName, spew.Sprint(binding.Spec.Bindings))
-		}, timeout).Should(Succeed())
+		}, timeout*5).Should(Succeed())
 
 		t.Log("Verifying ClusterResourceSetBinding is deleted when its cluster owner reference is deleted")
 		g.Expect(env.Delete(ctx, testCluster)).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
While investigating CRS flakes I noticed "failed to get data field from the resource" error in the logs; being generated in https://github.com/kubernetes-sigs/cluster-api/blob/55f064d1b9fcf3f0a7b1a32e43559bdff4d3c2cb/exp/addons/controllers/clusterresourceset_controller.go#L306

Those error could preventing the binding to be created.
This PR uses unstructured the unstructured library to get the data field in a more resilient way