### PR TITLE
:seedling: kubetest: Remove usage of Viper, converting config files to kubetest arguments

### DIFF
--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -19,6 +19,7 @@ package kubetest
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"os/user"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -111,12 +113,11 @@ func Run(ctx context.Context, input RunInput) error {
 		"slowSpecThreshold": strconv.Itoa(input.GinkgoSlowSpecThreshold),
 	}
 
-	// Copy configuration files for kubetest into the artifacts directory
-	// to avoid issues with volume mounts on MacOS
-	tmpConfigFilePath := path.Join(kubetestConfigDir, "viper-config.yaml")
-	if err := copyFile(input.ConfigFilePath, tmpConfigFilePath); err != nil {
+	config, err := parseKubetestConfig(input.ConfigFilePath)
+	if err != nil {
 		return err
 	}
+
 	tmpKubeConfigPath, err := dockeriseKubeconfig(kubetestConfigDir, input.ClusterProxy.GetKubeconfigPath())
 	if err != nil {
 		return err
@@ -138,7 +139,6 @@ func Run(ctx context.Context, input RunInput) error {
 		"dump-logs-on-failure": "false",
 		"report-prefix":        "kubetest.",
 		"num-nodes":            strconv.FormatInt(int64(input.NumberOfNodes), 10),
-		"viper-config":         "/tmp/viper-config.yaml",
 	}
 	ginkgoArgs := buildArgs(ginkgoVars, "-")
 	e2eArgs := buildArgs(e2eVars, "--")
@@ -147,7 +147,6 @@ func Run(ctx context.Context, input RunInput) error {
 	}
 	kubeConfigVolumeMount := volumeArg(tmpKubeConfigPath, "/tmp/kubeconfig")
 	outputVolumeMount := volumeArg(reportDir, "/output")
-	viperVolumeMount := volumeArg(tmpConfigFilePath, "/tmp/viper-config.yaml")
 	user, err := user.Current()
 	if err != nil {
 		return errors.Wrap(err, "unable to determine current user")
@@ -155,7 +154,7 @@ func Run(ctx context.Context, input RunInput) error {
 	userArg := user.Uid + ":" + user.Gid
 	entrypointArg := "--entrypoint=/usr/local/bin/ginkgo"
 	networkArg := "--network=kind"
-	e2eCmd := exec.Command("docker", "run", "--user", userArg, entrypointArg, kubeConfigVolumeMount, outputVolumeMount, viperVolumeMount, "-t", networkArg)
+	e2eCmd := exec.Command("docker", "run", "--user", userArg, entrypointArg, kubeConfigVolumeMount, outputVolumeMount, "-t", networkArg)
 	if len(testRepoListVolumeArgs) > 0 {
 		e2eCmd.Args = append(e2eCmd.Args, testRepoListVolumeArgs...)
 	}
@@ -164,11 +163,30 @@ func Run(ctx context.Context, input RunInput) error {
 	e2eCmd.Args = append(e2eCmd.Args, "/usr/local/bin/e2e.test")
 	e2eCmd.Args = append(e2eCmd.Args, "--")
 	e2eCmd.Args = append(e2eCmd.Args, e2eArgs...)
+	e2eCmd.Args = append(e2eCmd.Args, config.toFlags()...)
 	e2eCmd = framework.CompleteCommand(e2eCmd, "Running e2e test", false)
 	if err := e2eCmd.Run(); err != nil {
 		return errors.Wrap(err, "Unable to run conformance tests")
 	}
 	return framework.GatherJUnitReports(reportDir, input.ArtifactsDirectory)
+}
+
+type kubetestConfig map[string]string
+
+func (c kubetestConfig) toFlags() []string {
+	return buildArgs(c, "-")
+}
+
+func parseKubetestConfig(kubetestConfigFile string) (kubetestConfig, error) {
+	conf := make(kubetestConfig)
+	data, err := os.ReadFile(kubetestConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read kubetest config file %s: %w", kubetestConfigFile, err)
+	}
+	if err := yaml.Unmarshal(data, conf); err != nil {
+		return nil, fmt.Errorf("unable to parse kubetest config file %s as valid, non-nested YAML: %w", kubetestConfigFile, err)
+	}
+	return conf, nil
 }
 
 func isUsingCIArtifactsVersion(k8sVersion string) bool {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4729 


