### PR TITLE
📖 Add replace instructions to v1alpha4 provider doc

### DIFF
--- a/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
+++ b/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
@@ -20,6 +20,10 @@
 - The module is going to be tagged and versioned as part of the release.
 - Folks importing the test e2e framework or the docker infrastructure provider need to import the new module.
   - When imported, the test module version should always match the Cluster API one.
+  - Add the following line in `go.mod` to replace the cluster-api dependency in the test module (change the version to your current Cluster API version):
+  ```
+  replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v0.4.x
+  ```
 - The CAPD go module in test/infrastructure/docker has been removed.
 
 ## Upgrade kube-rbac-proxy to v0.8.0


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Follow up from #4713. When providers import CAPI test, they need to add this replace statement to avoid getting an error `go: sigs.k8s.io/cluster-api/test@v0.0.0-20210607195256-55f064d1b9fc requires
	sigs.k8s.io/cluster-api@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000`. Since the replace statement in https://github.com/kubernetes-sigs/cluster-api/blob/55f064d1b9fcf3f0a7b1a32e43559bdff4d3c2cb/test/go.mod#L5 only applies locally, the solution is to add a replace statement in the provider's `go.mod`.

See also discussion in [this slack thread](https://kubernetes.slack.com/archives/C8TSNPY4T/p1623167323286000).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
