### PR TITLE
:seedling: Backport of conformance updates for Kubernetes 1.22

### DIFF
--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -151,12 +151,12 @@ func Run(input RunInput) error {
 		return errors.Wrap(err, "unable to determine current user")
 	}
 	userArg := user.Uid + ":" + user.Gid
-	e2eCmd := exec.Command("docker", "run", "--user", userArg, kubeConfigVolumeMount, outputVolumeMount, viperVolumeMount, "-t")
+	entrypointArg := "--entrypoint=/usr/local/bin/ginkgo"
+	e2eCmd := exec.Command("docker", "run", "--user", userArg, entrypointArg, kubeConfigVolumeMount, outputVolumeMount, viperVolumeMount, "-t")
 	if len(testRepoListVolumeArgs) > 0 {
 		e2eCmd.Args = append(e2eCmd.Args, testRepoListVolumeArgs...)
 	}
 	e2eCmd.Args = append(e2eCmd.Args, input.ConformanceImage)
-	e2eCmd.Args = append(e2eCmd.Args, "/usr/local/bin/ginkgo")
 	e2eCmd.Args = append(e2eCmd.Args, ginkgoArgs...)
 	e2eCmd.Args = append(e2eCmd.Args, "/usr/local/bin/e2e.test")
 	e2eCmd.Args = append(e2eCmd.Args, "--")

--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubetest
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -31,6 +32,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -109,12 +111,11 @@ func Run(input RunInput) error {
 		"slowSpecThreshold": strconv.Itoa(input.GinkgoSlowSpecThreshold),
 	}
 
-	// Copy configuration files for kubetest into the artifacts directory
-	// to avoid issues with volume mounts on MacOS
-	tmpConfigFilePath := path.Join(kubetestConfigDir, "viper-config.yaml")
-	if err := copyFile(input.ConfigFilePath, tmpConfigFilePath); err != nil {
+	config, err := parseKubetestConfig(input.ConfigFilePath)
+	if err != nil {
 		return err
 	}
+
 	tmpKubeConfigPath, err := dockeriseKubeconfig(kubetestConfigDir, input.ClusterProxy.GetKubeconfigPath())
 	if err != nil {
 		return err
@@ -136,7 +137,6 @@ func Run(input RunInput) error {
 		"dump-logs-on-failure": "false",
 		"report-prefix":        "kubetest.",
 		"num-nodes":            strconv.FormatInt(int64(input.NumberOfNodes), 10),
-		"viper-config":         "/tmp/viper-config.yaml",
 	}
 	ginkgoArgs := buildArgs(ginkgoVars, "-")
 	e2eArgs := buildArgs(e2eVars, "--")
@@ -145,14 +145,13 @@ func Run(input RunInput) error {
 	}
 	kubeConfigVolumeMount := volumeArg(tmpKubeConfigPath, "/tmp/kubeconfig")
 	outputVolumeMount := volumeArg(reportDir, "/output")
-	viperVolumeMount := volumeArg(tmpConfigFilePath, "/tmp/viper-config.yaml")
 	user, err := user.Current()
 	if err != nil {
 		return errors.Wrap(err, "unable to determine current user")
 	}
 	userArg := user.Uid + ":" + user.Gid
 	entrypointArg := "--entrypoint=/usr/local/bin/ginkgo"
-	e2eCmd := exec.Command("docker", "run", "--user", userArg, entrypointArg, kubeConfigVolumeMount, outputVolumeMount, viperVolumeMount, "-t")
+	e2eCmd := exec.Command("docker", "run", "--user", userArg, entrypointArg, kubeConfigVolumeMount, outputVolumeMount, "-t")
 	if len(testRepoListVolumeArgs) > 0 {
 		e2eCmd.Args = append(e2eCmd.Args, testRepoListVolumeArgs...)
 	}
@@ -161,6 +160,7 @@ func Run(input RunInput) error {
 	e2eCmd.Args = append(e2eCmd.Args, "/usr/local/bin/e2e.test")
 	e2eCmd.Args = append(e2eCmd.Args, "--")
 	e2eCmd.Args = append(e2eCmd.Args, e2eArgs...)
+	e2eCmd.Args = append(e2eCmd.Args, config.toFlags()...)
 	e2eCmd = framework.CompleteCommand(e2eCmd, "Running e2e test", false)
 	if err := e2eCmd.Run(); err != nil {
 		return errors.Wrap(err, "Unable to run conformance tests")
@@ -169,6 +169,24 @@ func Run(input RunInput) error {
 		return err
 	}
 	return nil
+}
+
+type kubetestConfig map[string]string
+
+func (c kubetestConfig) toFlags() []string {
+	return buildArgs(c, "-")
+}
+
+func parseKubetestConfig(kubetestConfigFile string) (kubetestConfig, error) {
+	conf := make(kubetestConfig)
+	data, err := ioutil.ReadFile(kubetestConfigFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read kubetest config file %s: %w", kubetestConfigFile, err)
+	}
+	if err := yaml.Unmarshal(data, conf); err != nil {
+		return nil, fmt.Errorf("unable to parse kubetest config file %s as valid, non-nested YAML: %w", kubetestConfigFile, err)
+	}
+	return conf, nil
 }
 
 func isUsingCIArtifactsVersion(k8sVersion string) bool {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Backport of #4761 and #4662

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
