### PR TITLE
⚠️ Add --raw flag for clusterctl generate provider subcommand

### DIFF
--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -46,16 +46,11 @@ func (c *clusterctlClient) GetProvidersConfig() ([]Provider, error) {
 }
 
 func (c *clusterctlClient) GetProviderComponents(provider string, providerType clusterctlv1.ProviderType, options ComponentsOptions) (Components, error) {
-	// ComponentsOptions is an alias for repository.ComponentsOptions; this makes the conversion
-	inputOptions := repository.ComponentsOptions{
-		Version:         options.Version,
-		TargetNamespace: options.TargetNamespace,
-		SkipVariables:   options.SkipVariables,
-	}
-	components, err := c.getComponentsByName(provider, providerType, inputOptions)
+	components, err := c.getComponentsByName(provider, providerType, repository.ComponentsOptions(options))
 	if err != nil {
 		return nil, err
 	}
+
 	return components, nil
 }
 

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -220,8 +220,8 @@ func Test_getComponentsByName_withEmptyVariables(t *testing.T) {
 		WithCluster(cluster1)
 
 	options := ComponentsOptions{
-		TargetNamespace: "ns1",
-		SkipVariables:   true,
+		TargetNamespace:     "ns1",
+		SkipTemplateProcess: true,
 	}
 	components, err := client.GetProviderComponents(repository1Config.Name(), repository1Config.Type(), options)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -58,9 +58,9 @@ type InitOptions struct {
 	// LogUsageInstructions instructs the init command to print the usage instructions in case of first run.
 	LogUsageInstructions bool
 
-	// skipVariables skips variable parsing in the provider components yaml.
-	// It is set to true for listing images of provider components.
-	skipVariables bool
+	// SkipTemplateProcess allows for skipping the call to the template processor, including also variable replacement in the component YAML.
+	// NOTE this works only if the rawYaml is a valid yaml by itself, like e.g when using envsubst/the simple processor.
+	skipTemplateProcess bool
 }
 
 // Init initializes a management cluster by adding the requested list of providers.
@@ -156,7 +156,7 @@ func (c *clusterctlClient) InitImages(options InitOptions) ([]string, error) {
 	c.addDefaultProviders(clusterClient, &options)
 
 	// skip variable parsing when listing images
-	options.skipVariables = true
+	options.skipTemplateProcess = true
 
 	// create an installer service, add the requested providers to the install queue and then perform validation
 	// of the target state of the management cluster before starting the installation.
@@ -187,9 +187,9 @@ func (c *clusterctlClient) setupInstaller(cluster cluster.Client, options InitOp
 	installer := cluster.ProviderInstaller()
 
 	addOptions := addToInstallerOptions{
-		installer:       installer,
-		targetNamespace: options.TargetNamespace,
-		skipVariables:   options.skipVariables,
+		installer:           installer,
+		targetNamespace:     options.TargetNamespace,
+		skipTemplateProcess: options.skipTemplateProcess,
 	}
 
 	if options.CoreProvider != "" {
@@ -238,9 +238,9 @@ func (c *clusterctlClient) addDefaultProviders(cluster cluster.Client, options *
 }
 
 type addToInstallerOptions struct {
-	installer       cluster.ProviderInstaller
-	targetNamespace string
-	skipVariables   bool
+	installer           cluster.ProviderInstaller
+	targetNamespace     string
+	skipTemplateProcess bool
 }
 
 // addToInstaller adds the components to the install queue and checks that the actual provider type match the target group.
@@ -254,8 +254,8 @@ func (c *clusterctlClient) addToInstaller(options addToInstallerOptions, provide
 			continue
 		}
 		componentsOptions := repository.ComponentsOptions{
-			TargetNamespace: options.targetNamespace,
-			SkipVariables:   options.skipVariables,
+			TargetNamespace:     options.targetNamespace,
+			SkipTemplateProcess: options.skipTemplateProcess,
 		}
 		components, err := c.getComponentsByName(provider, providerType, componentsOptions)
 		if err != nil {

--- a/cmd/clusterctl/client/repository/components_client_test.go
+++ b/cmd/clusterctl/client/repository/components_client_test.go
@@ -114,7 +114,7 @@ func Test_componentsClient_Get(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "successfully gets the components even with SkipVariables defined",
+			name: "successfully gets the components even with SkipTemplateProcess defined",
 			fields: fields{
 				provider: p1,
 				repository: test.NewFakeRepository().
@@ -260,9 +260,9 @@ func Test_componentsClient_Get(t *testing.T) {
 			gs := NewWithT(t)
 
 			options := ComponentsOptions{
-				Version:         tt.args.version,
-				TargetNamespace: tt.args.targetNamespace,
-				SkipVariables:   tt.args.skipVariables,
+				Version:             tt.args.version,
+				TargetNamespace:     tt.args.targetNamespace,
+				SkipTemplateProcess: tt.args.skipVariables,
 			}
 			f := newComponentsClient(tt.fields.provider, tt.fields.repository, configClient)
 			if tt.fields.processor != nil {
@@ -291,7 +291,7 @@ func Test_componentsClient_Get(t *testing.T) {
 				gs.Expect(yaml).To(ContainSubstring(variableValue))
 			}
 
-			// Verify that when SkipVariables is set we have all the variables
+			// Verify that when SkipTemplateProcess is set we have all the variables
 			// in the template without the values processed.
 			if tt.args.skipVariables {
 				for _, v := range tt.want.variables {

--- a/cmd/clusterctl/cmd/config_provider.go
+++ b/cmd/clusterctl/cmd/config_provider.go
@@ -142,8 +142,8 @@ func runGetComponents() error {
 	}
 
 	options := client.ComponentsOptions{
-		TargetNamespace: cpo.targetNamespace,
-		SkipVariables:   true,
+		TargetNamespace:     cpo.targetNamespace,
+		SkipTemplateProcess: true,
 	}
 	components, err := c.GetProviderComponents(providerName, providerType, options)
 	if err != nil {

--- a/cmd/clusterctl/cmd/generate_provider.go
+++ b/cmd/clusterctl/cmd/generate_provider.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 )
@@ -30,6 +31,7 @@ type generateProvidersOptions struct {
 	infrastructureProvider string
 	targetNamespace        string
 	textOutput             bool
+	raw                    bool
 }
 
 var gpo = &generateProvidersOptions{}
@@ -60,7 +62,11 @@ var generateProviderCmd = &cobra.Command{
 		clusterctl generate provider --infrastructure aws --describe
 
 		# Displays information about a specific version of the infrastructure provider.
-		clusterctl generate provider --infrastructure aws:v0.4.1 --describe`),
+		clusterctl generate provider --infrastructure aws:v0.4.1 --describe
+
+		# Generates a yaml file for creating provider for a specific version.
+		# No variables will be processed and substituted using this flag
+		clusterctl generate provider --infrastructure aws:v0.4.1 --raw`),
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGenerateProviderComponents()
@@ -80,6 +86,8 @@ func init() {
 		"The target namespace where the provider should be deployed. If unspecified, the components default namespace is used.")
 	generateProviderCmd.Flags().BoolVar(&gpo.textOutput, "describe", false,
 		"Generate configuration without variable substitution.")
+	generateProviderCmd.Flags().BoolVar(&gpo.raw, "raw", false,
+		"Generate configuration without variable substitution in a yaml format.")
 
 	generateCmd.AddCommand(generateProviderCmd)
 }
@@ -95,8 +103,10 @@ func runGenerateProviderComponents() error {
 	}
 
 	options := client.ComponentsOptions{
-		TargetNamespace: gpo.targetNamespace,
+		TargetNamespace:     gpo.targetNamespace,
+		SkipTemplateProcess: gpo.raw,
 	}
+
 	components, err := c.GetProviderComponents(providerName, providerType, options)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
All the credits for this PR to @aayushrangwala who started this work in https://github.com/kubernetes-sigs/cluster-api/pull/4705

Add --raw flag for the `clusterctl generate provider` subcommand for returning the unprocessed yaml

While doing this change the field `SkipVariables` in the clusterctl library has been renamed into `SkipTemplateProcess` to better reflect what is really doing.

**Which issue(s) this PR fixes**:
Fixes #4650
