### PR TITLE
:seedling: go.mod: Add comment about etcd versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module sigs.k8s.io/cluster-api
 
 go 1.16
 
+// Imported version of etcd is v3.4.13 with an additional patch matching
+// the imported version in Kubernetes v1.21.x
+
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/pull/4769#discussion_r647720262 
