### PR TITLE
🐛 unmarshal data to a pointer when parsing kubetest config

### DIFF
--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -183,7 +183,7 @@ func parseKubetestConfig(kubetestConfigFile string) (kubetestConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to read kubetest config file %s: %w", kubetestConfigFile, err)
 	}
-	if err := yaml.Unmarshal(data, conf); err != nil {
+	if err := yaml.Unmarshal(data, &conf); err != nil {
 		return nil, fmt.Errorf("unable to parse kubetest config file %s as valid, non-nested YAML: %w", kubetestConfigFile, err)
 	}
 	return conf, nil


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Follow-up PR for https://github.com/kubernetes-sigs/cluster-api/pull/4761. kubetest configs were not translated properly when unmarshaling to a non-pointer (e.g. https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/1421/pull-cluster-api-provider-azure-conformance-with-ci-artifacts/1402316758991245312).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
