### PR TITLE
:bug: unmarshal data to a pointer when parsing kubetest config

### DIFF
--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -183,7 +183,7 @@ func parseKubetestConfig(kubetestConfigFile string) (kubetestConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to read kubetest config file %s: %w", kubetestConfigFile, err)
 	}
-	if err := yaml.Unmarshal(data, conf); err != nil {
+	if err := yaml.Unmarshal(data, &conf); err != nil {
 		return nil, fmt.Errorf("unable to parse kubetest config file %s as valid, non-nested YAML: %w", kubetestConfigFile, err)
 	}
 	return conf, nil


### PR DESCRIPTION
Cherry pick of #4774 on release-0.3.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.