### PR TITLE
🌱 Rename ListVariableOnly flag in TemplateInput

### DIFF
--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
+
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
@@ -477,7 +478,7 @@ type fakeTemplateClient struct {
 	processor             yaml.Processor
 }
 
-func (f *fakeTemplateClient) Get(flavor, targetNamespace string, listVariablesOnly bool) (repository.Template, error) {
+func (f *fakeTemplateClient) Get(flavor, targetNamespace string, skipTemplateProcess bool) (repository.Template, error) {
 	name := "cluster-template"
 	if flavor != "" {
 		name = fmt.Sprintf("%s-%s", name, flavor)
@@ -493,7 +494,7 @@ func (f *fakeTemplateClient) Get(flavor, targetNamespace string, listVariablesOn
 		ConfigVariablesClient: f.configVariablesClient,
 		Processor:             f.processor,
 		TargetNamespace:       targetNamespace,
-		ListVariablesOnly:     listVariablesOnly,
+		SkipTemplateProcess:   skipTemplateProcess,
 	})
 }
 

--- a/cmd/clusterctl/client/cluster/template.go
+++ b/cmd/clusterctl/client/cluster/template.go
@@ -37,10 +37,10 @@ import (
 // TemplateClient has methods to work with templates stored in the cluster/out of the provider repository.
 type TemplateClient interface {
 	// GetFromConfigMap returns a workload cluster template from the given ConfigMap.
-	GetFromConfigMap(namespace, name, dataKey, targetNamespace string, listVariablesOnly bool) (repository.Template, error)
+	GetFromConfigMap(namespace, name, dataKey, targetNamespace string, skipTemplateProcess bool) (repository.Template, error)
 
 	// GetFromURL returns a workload cluster template from the given URL.
-	GetFromURL(templateURL, targetNamespace string, listVariablesOnly bool) (repository.Template, error)
+	GetFromURL(templateURL, targetNamespace string, skipTemplateProcess bool) (repository.Template, error)
 }
 
 // templateClient implements TemplateClient.
@@ -71,7 +71,7 @@ func newTemplateClient(input TemplateClientInput) *templateClient {
 	}
 }
 
-func (t *templateClient) GetFromConfigMap(configMapNamespace, configMapName, configMapDataKey, targetNamespace string, listVariablesOnly bool) (repository.Template, error) {
+func (t *templateClient) GetFromConfigMap(configMapNamespace, configMapName, configMapDataKey, targetNamespace string, skipTemplateProcess bool) (repository.Template, error) {
 	if configMapNamespace == "" {
 		return nil, errors.New("invalid GetFromConfigMap operation: missing configMapNamespace value")
 	}
@@ -104,11 +104,11 @@ func (t *templateClient) GetFromConfigMap(configMapNamespace, configMapName, con
 		ConfigVariablesClient: t.configClient.Variables(),
 		Processor:             t.processor,
 		TargetNamespace:       targetNamespace,
-		ListVariablesOnly:     listVariablesOnly,
+		SkipTemplateProcess:   skipTemplateProcess,
 	})
 }
 
-func (t *templateClient) GetFromURL(templateURL, targetNamespace string, listVariablesOnly bool) (repository.Template, error) {
+func (t *templateClient) GetFromURL(templateURL, targetNamespace string, skipTemplateProcess bool) (repository.Template, error) {
 	if templateURL == "" {
 		return nil, errors.New("invalid GetFromURL operation: missing templateURL value")
 	}
@@ -123,7 +123,7 @@ func (t *templateClient) GetFromURL(templateURL, targetNamespace string, listVar
 		ConfigVariablesClient: t.configClient.Variables(),
 		Processor:             t.processor,
 		TargetNamespace:       targetNamespace,
-		ListVariablesOnly:     listVariablesOnly,
+		SkipTemplateProcess:   skipTemplateProcess,
 	})
 }
 

--- a/cmd/clusterctl/client/cluster/template_test.go
+++ b/cmd/clusterctl/client/cluster/template_test.go
@@ -67,11 +67,11 @@ func Test_templateClient_GetFromConfigMap(t *testing.T) {
 		configClient config.Client
 	}
 	type args struct {
-		configMapNamespace string
-		configMapName      string
-		configMapDataKey   string
-		targetNamespace    string
-		listVariablesOnly  bool
+		configMapNamespace  string
+		configMapName       string
+		configMapDataKey    string
+		targetNamespace     string
+		skipTemplateProcess bool
 	}
 	tests := []struct {
 		name    string
@@ -87,11 +87,11 @@ func Test_templateClient_GetFromConfigMap(t *testing.T) {
 				configClient: configClient,
 			},
 			args: args{
-				configMapNamespace: "ns1",
-				configMapName:      "my-template",
-				configMapDataKey:   "prod",
-				targetNamespace:    "",
-				listVariablesOnly:  false,
+				configMapNamespace:  "ns1",
+				configMapName:       "my-template",
+				configMapDataKey:    "prod",
+				targetNamespace:     "",
+				skipTemplateProcess: false,
 			},
 			want:    template,
 			wantErr: false,
@@ -103,11 +103,11 @@ func Test_templateClient_GetFromConfigMap(t *testing.T) {
 				configClient: configClient,
 			},
 			args: args{
-				configMapNamespace: "ns1",
-				configMapName:      "something-else",
-				configMapDataKey:   "prod",
-				targetNamespace:    "",
-				listVariablesOnly:  false,
+				configMapNamespace:  "ns1",
+				configMapName:       "something-else",
+				configMapDataKey:    "prod",
+				targetNamespace:     "",
+				skipTemplateProcess: false,
 			},
 			want:    "",
 			wantErr: true,
@@ -119,11 +119,11 @@ func Test_templateClient_GetFromConfigMap(t *testing.T) {
 				configClient: configClient,
 			},
 			args: args{
-				configMapNamespace: "ns1",
-				configMapName:      "my-template",
-				configMapDataKey:   "something-else",
-				targetNamespace:    "",
-				listVariablesOnly:  false,
+				configMapNamespace:  "ns1",
+				configMapName:       "my-template",
+				configMapDataKey:    "something-else",
+				targetNamespace:     "",
+				skipTemplateProcess: false,
 			},
 			want:    "",
 			wantErr: true,
@@ -135,7 +135,7 @@ func Test_templateClient_GetFromConfigMap(t *testing.T) {
 
 			processor := yaml.NewSimpleProcessor()
 			tc := newTemplateClient(TemplateClientInput{tt.fields.proxy, tt.fields.configClient, processor})
-			got, err := tc.GetFromConfigMap(tt.args.configMapNamespace, tt.args.configMapName, tt.args.configMapDataKey, tt.args.targetNamespace, tt.args.listVariablesOnly)
+			got, err := tc.GetFromConfigMap(tt.args.configMapNamespace, tt.args.configMapName, tt.args.configMapDataKey, tt.args.targetNamespace, tt.args.skipTemplateProcess)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return
@@ -147,7 +147,7 @@ func Test_templateClient_GetFromConfigMap(t *testing.T) {
 				ConfigVariablesClient: configClient.Variables(),
 				Processor:             processor,
 				TargetNamespace:       tt.args.targetNamespace,
-				ListVariablesOnly:     tt.args.listVariablesOnly,
+				SkipTemplateProcess:   tt.args.skipTemplateProcess,
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(got).To(Equal(wantTemplate))
@@ -308,9 +308,9 @@ func Test_templateClient_GetFromURL(t *testing.T) {
 	g.Expect(os.WriteFile(path, []byte(template), 0600)).To(Succeed())
 
 	type args struct {
-		templateURL       string
-		targetNamespace   string
-		listVariablesOnly bool
+		templateURL         string
+		targetNamespace     string
+		skipTemplateProcess bool
 	}
 	tests := []struct {
 		name    string
@@ -321,9 +321,9 @@ func Test_templateClient_GetFromURL(t *testing.T) {
 		{
 			name: "Get from local file system",
 			args: args{
-				templateURL:       path,
-				targetNamespace:   "",
-				listVariablesOnly: false,
+				templateURL:         path,
+				targetNamespace:     "",
+				skipTemplateProcess: false,
 			},
 			want:    template,
 			wantErr: false,
@@ -331,9 +331,9 @@ func Test_templateClient_GetFromURL(t *testing.T) {
 		{
 			name: "Get from GitHub",
 			args: args{
-				templateURL:       "https://github.com/kubernetes-sigs/cluster-api/blob/master/config/default/cluster-template.yaml",
-				targetNamespace:   "",
-				listVariablesOnly: false,
+				templateURL:         "https://github.com/kubernetes-sigs/cluster-api/blob/master/config/default/cluster-template.yaml",
+				targetNamespace:     "",
+				skipTemplateProcess: false,
 			},
 			want:    template,
 			wantErr: false,
@@ -351,7 +351,7 @@ func Test_templateClient_GetFromURL(t *testing.T) {
 			// override the github client factory
 			c.gitHubClientFactory = gitHubClientFactory
 
-			got, err := c.GetFromURL(tt.args.templateURL, tt.args.targetNamespace, tt.args.listVariablesOnly)
+			got, err := c.GetFromURL(tt.args.templateURL, tt.args.targetNamespace, tt.args.skipTemplateProcess)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return
@@ -364,7 +364,7 @@ func Test_templateClient_GetFromURL(t *testing.T) {
 				ConfigVariablesClient: configClient.Variables(),
 				Processor:             processor,
 				TargetNamespace:       tt.args.targetNamespace,
-				ListVariablesOnly:     tt.args.listVariablesOnly,
+				SkipTemplateProcess:   tt.args.skipTemplateProcess,
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(got).To(Equal(wantTemplate))

--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -20,10 +20,10 @@ import (
 	"io"
 	"strconv"
 
-	"k8s.io/utils/pointer"
-
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/utils/pointer"
+
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
@@ -66,9 +66,9 @@ type ProcessYAMLOptions struct {
 	// URLSource to be used for reading the template
 	URLSource *URLSourceOptions
 
-	// ListVariablesOnly return the list of variables expected by the template
+	// SkipTemplateProcess return the list of variables expected by the template
 	// without executing any further processing.
-	ListVariablesOnly bool
+	SkipTemplateProcess bool
 }
 
 func (c *clusterctlClient) ProcessYAML(options ProcessYAMLOptions) (YamlPrinter, error) {
@@ -84,7 +84,7 @@ func (c *clusterctlClient) ProcessYAML(options ProcessYAMLOptions) (YamlPrinter,
 			ConfigVariablesClient: c.configClient.Variables(),
 			Processor:             yaml.NewSimpleProcessor(),
 			TargetNamespace:       "",
-			ListVariablesOnly:     options.ListVariablesOnly,
+			SkipTemplateProcess:   options.SkipTemplateProcess,
 		})
 	}
 
@@ -92,7 +92,7 @@ func (c *clusterctlClient) ProcessYAML(options ProcessYAMLOptions) (YamlPrinter,
 	// leveraging the template client which exposes GetFromURL() is available
 	// on the cluster client so we create a cluster client with default
 	// configs to access it.
-	cluster, err := c.clusterClientFactory(
+	clstr, err := c.clusterClientFactory(
 		ClusterClientFactoryInput{
 			// use the default kubeconfig
 			Kubeconfig: Kubeconfig{},
@@ -103,7 +103,7 @@ func (c *clusterctlClient) ProcessYAML(options ProcessYAMLOptions) (YamlPrinter,
 	}
 
 	if options.URLSource != nil {
-		return c.getTemplateFromURL(cluster, *options.URLSource, "", options.ListVariablesOnly)
+		return c.getTemplateFromURL(clstr, *options.URLSource, "", options.SkipTemplateProcess)
 	}
 
 	return nil, errors.New("unable to read custom template. Please specify a template source")

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
@@ -904,7 +905,7 @@ v3: ${VAR3:-default3}`
 				URLSource: &URLSourceOptions{
 					URL: templateFile,
 				},
-				ListVariablesOnly: false,
+				SkipTemplateProcess: false,
 			},
 			expectErr: false,
 			expectedYaml: `v1: default1
@@ -913,12 +914,12 @@ v3: default3`,
 			expectedVars: []string{"VAR1", "VAR2", "VAR3"},
 		},
 		{
-			name: "returns the expected variables only if ListVariablesOnly is set",
+			name: "returns the expected variables only if SkipTemplateProcess is set",
 			options: ProcessYAMLOptions{
 				URLSource: &URLSourceOptions{
 					URL: templateFile,
 				},
-				ListVariablesOnly: true,
+				SkipTemplateProcess: true,
 			},
 			expectErr:    false,
 			expectedYaml: ``,
@@ -935,7 +936,7 @@ v3: default3`,
 				ReaderSource: &ReaderSourceOptions{
 					Reader: inputReader,
 				},
-				ListVariablesOnly: false,
+				SkipTemplateProcess: false,
 			},
 			expectErr: false,
 			expectedYaml: `v1: default1
@@ -949,7 +950,7 @@ v3: default3`,
 				ReaderSource: &ReaderSourceOptions{
 					Reader: &errReader{},
 				},
-				ListVariablesOnly: false,
+				SkipTemplateProcess: false,
 			},
 			expectErr: true,
 		},

--- a/cmd/clusterctl/client/repository/template.go
+++ b/cmd/clusterctl/client/repository/template.go
@@ -19,6 +19,7 @@ package repository
 import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	yaml "sigs.k8s.io/cluster-api/cmd/clusterctl/client/yamlprocessor"
 	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
@@ -34,7 +35,7 @@ type Template interface {
 	// This value is derived from the template YAML.
 	Variables() []string
 
-	// Variables used by the template with their default values. If the value is `nil`, there is no
+	// VariableMap used by the template with their default values. If the value is `nil`, there is no
 	// default and the variable is required.
 	// This value is derived from the template YAML.
 	VariableMap() map[string]*string
@@ -86,7 +87,7 @@ type TemplateInput struct {
 	ConfigVariablesClient config.VariablesClient
 	Processor             yaml.Processor
 	TargetNamespace       string
-	ListVariablesOnly     bool
+	SkipTemplateProcess   bool
 }
 
 // NewTemplate returns a new objects embedding a cluster template YAML file.
@@ -101,7 +102,7 @@ func NewTemplate(input TemplateInput) (Template, error) {
 		return nil, err
 	}
 
-	if input.ListVariablesOnly {
+	if input.SkipTemplateProcess {
 		return &template{
 			variables:       variables,
 			variableMap:     variableMap,

--- a/cmd/clusterctl/client/repository/template_client.go
+++ b/cmd/clusterctl/client/repository/template_client.go
@@ -65,7 +65,7 @@ func newTemplateClient(input TemplateClientInput) *templateClient {
 // Get return the template for the flavor specified.
 // In case the template does not exists, an error is returned.
 // Get assumes the following naming convention for templates: cluster-template[-<flavor_name>].yaml.
-func (c *templateClient) Get(flavor, targetNamespace string, listVariablesOnly bool) (Template, error) {
+func (c *templateClient) Get(flavor, targetNamespace string, skipTemplateProcess bool) (Template, error) {
 	log := logf.Log
 
 	if targetNamespace == "" {
@@ -96,5 +96,11 @@ func (c *templateClient) Get(flavor, targetNamespace string, listVariablesOnly b
 		log.V(1).Info("Using", "Override", name, "Provider", c.provider.ManifestLabel(), "Version", version)
 	}
 
-	return NewTemplate(TemplateInput{rawArtifact, c.configVariablesClient, c.processor, targetNamespace, listVariablesOnly})
+	return NewTemplate(TemplateInput{
+		rawArtifact,
+		c.configVariablesClient,
+		c.processor,
+		targetNamespace,
+		skipTemplateProcess,
+	})
 }

--- a/cmd/clusterctl/client/repository/template_client_test.go
+++ b/cmd/clusterctl/client/repository/template_client_test.go
@@ -139,7 +139,7 @@ func Test_templates_Get(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "pass if variables does not exists but listVariablesOnly flag is set",
+			name: "pass if variables does not exists but skipTemplateProcess flag is set",
 			fields: fields{
 				version:  "v1.0",
 				provider: p1,

--- a/cmd/clusterctl/client/repository/template_test.go
+++ b/cmd/clusterctl/client/repository/template_test.go
@@ -42,7 +42,7 @@ func Test_newTemplate(t *testing.T) {
 		configVariablesClient config.VariablesClient
 		processor             yaml.Processor
 		targetNamespace       string
-		listVariablesOnly     bool
+		skipTemplateProcess   bool
 	}
 	type want struct {
 		variables       []string
@@ -61,7 +61,7 @@ func Test_newTemplate(t *testing.T) {
 				configVariablesClient: test.NewFakeVariableClient().WithVar(variableName, variableValue),
 				processor:             yaml.NewSimpleProcessor(),
 				targetNamespace:       "ns1",
-				listVariablesOnly:     false,
+				skipTemplateProcess:   false,
 			},
 			want: want{
 				variables:       []string{variableName},
@@ -76,7 +76,7 @@ func Test_newTemplate(t *testing.T) {
 				configVariablesClient: test.NewFakeVariableClient(),
 				processor:             yaml.NewSimpleProcessor(),
 				targetNamespace:       "ns1",
-				listVariablesOnly:     true,
+				skipTemplateProcess:   true,
 			},
 			want: want{
 				variables:       []string{variableName},
@@ -94,7 +94,7 @@ func Test_newTemplate(t *testing.T) {
 				ConfigVariablesClient: tt.args.configVariablesClient,
 				Processor:             tt.args.processor,
 				TargetNamespace:       tt.args.targetNamespace,
-				ListVariablesOnly:     tt.args.listVariablesOnly,
+				SkipTemplateProcess:   tt.args.skipTemplateProcess,
 			})
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
@@ -105,14 +105,14 @@ func Test_newTemplate(t *testing.T) {
 			g.Expect(got.Variables()).To(Equal(tt.want.variables))
 			g.Expect(got.TargetNamespace()).To(Equal(tt.want.targetNamespace))
 
-			if tt.args.listVariablesOnly {
+			if tt.args.skipTemplateProcess {
 				return
 			}
 
 			// check variable replaced in components
-			yaml, err := got.Yaml()
+			yml, err := got.Yaml()
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(yaml).To(ContainSubstring((fmt.Sprintf("variable: %s", variableValue))))
+			g.Expect(yml).To(ContainSubstring(fmt.Sprintf("variable: %s", variableValue)))
 		})
 	}
 }

--- a/cmd/clusterctl/cmd/generate_yaml.go
+++ b/cmd/clusterctl/cmd/generate_yaml.go
@@ -83,7 +83,7 @@ func generateYAML(r io.Reader, w io.Writer) error {
 		return err
 	}
 	options := client.ProcessYAMLOptions{
-		ListVariablesOnly: gyOpts.listVariables,
+		SkipTemplateProcess: gyOpts.listVariables,
 	}
 	if gyOpts.url != "" {
 		if gyOpts.url == "-" {


### PR DESCRIPTION
**What this PR does / why we need it**:

- As the part of adding --raw flag to clusterctl, the requirements to rename these flags which allows skipping the processing of template using variables

- renamed the variable ListVariableOnly to SkipTemplateProcess in all the files using it including test files and comments

Signed-off-by: Ayush Rangwala <arangwala@vmware.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4784 
