### PR TITLE
✨ Implements Save and Restore for objectMover

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -50,6 +50,12 @@ type Client interface {
 	// Move moves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target management cluster.
 	Move(options MoveOptions) error
 
+	// Save saves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target management cluster.
+	Save(options SaveOptions) error
+
+	// Restore restores all the Cluster API objects existing in a configured directory based on a glob to a target management cluster.
+	Restore(options RestoreOptions) error
+
 	// PlanUpgrade returns a set of suggested Upgrade plans for the cluster, and more specifically:
 	// - Each management group gets separated upgrade plans.
 	// - For each management group, an upgrade plan is generated for each API Version of Cluster API (contract) available, e.g.

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -102,6 +102,14 @@ func (f fakeClient) Move(options MoveOptions) error {
 	return f.internalClient.Move(options)
 }
 
+func (f fakeClient) Save(options SaveOptions) error {
+	return f.internalClient.Save(options)
+}
+
+func (f fakeClient) Restore(options RestoreOptions) error {
+	return f.internalClient.Restore(options)
+}
+
 func (f fakeClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePlan, error) {
 	return f.internalClient.PlanUpgrade(options)
 }

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -17,6 +17,9 @@ limitations under the License.
 package client
 
 import (
+	"os"
+	"path/filepath"
+
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 )
 
@@ -36,6 +39,37 @@ type MoveOptions struct {
 
 	// DryRun means the move action is a dry run, no real action will be performed
 	DryRun bool
+}
+
+// SaveOptions holds options supported by save
+type SaveOptions struct {
+	// FromKubeconfig defines the kubeconfig to use for accessing the source management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	FromKubeconfig Kubeconfig
+
+	// Namespace where the objects describing the workload cluster exists. If unspecified, the current
+	// namespace will be used.
+	Namespace string
+
+	// DirectoryLocation defines the local directory to store the cluster objects
+	DirectoryLocation string
+}
+
+// RestoreOptions holds options supported by restore
+type RestoreOptions struct {
+	// FromKubeconfig defines the kubeconfig to use for accessing the target management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	ToKubeconfig Kubeconfig
+
+	// Namespace where the objects describing the workload cluster exists. If unspecified, the current
+	// namespace will be used.
+	Namespace string
+
+	// Glob for finding files in defined directory
+	Glob string
+
+	// DirectoryLocation defines the local directory to store the cluster objects
+	DirectoryLocation string
 }
 
 func (c *clusterctlClient) Move(options MoveOptions) error {
@@ -74,6 +108,94 @@ func (c *clusterctlClient) Move(options MoveOptions) error {
 	}
 
 	if err := fromCluster.ObjectMover().Move(options.Namespace, toCluster, options.DryRun); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *clusterctlClient) Save(options SaveOptions) error {
+	// Get the client for interacting with the source management cluster.
+	fromCluster, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.FromKubeconfig})
+	if err != nil {
+		return err
+	}
+
+	// Ensures the custom resource definitions required by clusterctl are in place.
+	if err := fromCluster.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
+		return err
+	}
+
+	// If the option specifying the Namespace is empty, try to detect it.
+	if options.Namespace == "" {
+		currentNamespace, err := fromCluster.Proxy().CurrentNamespace()
+		if err != nil {
+			return err
+		}
+		options.Namespace = currentNamespace
+	}
+
+	// If directory location specified is empty, use a default directory
+	if options.DirectoryLocation == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+
+		directoryBin := filepath.Join(homeDir, ".cluster-api", "objects")
+		err = os.MkdirAll(directoryBin, 0755)
+		if err != nil {
+			return err
+		}
+
+		options.DirectoryLocation = directoryBin
+	}
+
+	if err := fromCluster.ObjectMover().Save(options.Namespace, options.DirectoryLocation); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *clusterctlClient) Restore(options RestoreOptions) error {
+	// Get the client for interacting with the source management cluster.
+	fromCluster, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.ToKubeconfig})
+	if err != nil {
+		return err
+	}
+
+	// Ensures the custom resource definitions required by clusterctl are in place.
+	if err := fromCluster.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
+		return err
+	}
+
+	// If the option specifying the Namespace is empty, try to detect it.
+	if options.Namespace == "" {
+		currentNamespace, err := fromCluster.Proxy().CurrentNamespace()
+		if err != nil {
+			return err
+		}
+		options.Namespace = currentNamespace
+	}
+
+	// If directory location specified is empty, use a default directory
+	if options.DirectoryLocation == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+
+		directoryBin := filepath.Join(homeDir, ".cluster-api", "objects")
+		err = os.MkdirAll(directoryBin, 0755)
+		if err != nil {
+			return err
+		}
+
+		options.DirectoryLocation = directoryBin
+	}
+
+	if err := fromCluster.ObjectMover().Restore(options.Namespace, options.Glob, options.DirectoryLocation); err != nil {
 		return err
 	}
 

--- a/cmd/clusterctl/client/move_test.go
+++ b/cmd/clusterctl/client/move_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package client
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -93,6 +95,128 @@ func Test_clusterctlClient_Move(t *testing.T) {
 	}
 }
 
+func Test_clusterctlClient_Save(t *testing.T) {
+	dir, err := ioutil.TempDir("/tmp", "cluster-api")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(dir)
+
+	type fields struct {
+		client *fakeClient
+	}
+	type args struct {
+		options SaveOptions
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "does not return error if cluster client is found",
+			fields: fields{
+				client: fakeClientForMove(), // core v1.0.0 (v1.0.1 available), infra v2.0.0 (v2.0.1 available)
+			},
+			args: args{
+				options: SaveOptions{
+					FromKubeconfig:    Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
+					DirectoryLocation: dir,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns an error if from cluster client is not found",
+			fields: fields{
+				client: fakeClientForMove(), // core v1.0.0 (v1.0.1 available), infra v2.0.0 (v2.0.1 available)
+			},
+			args: args{
+				options: SaveOptions{
+					FromKubeconfig:    Kubeconfig{Path: "kubeconfig", Context: "does-not-exist"},
+					DirectoryLocation: dir,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			err := tt.fields.client.Save(tt.args.options)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+}
+
+func Test_clusterctlClient_Restore(t *testing.T) {
+	dir, err := ioutil.TempDir("/tmp", "cluster-api")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(dir)
+
+	type fields struct {
+		client *fakeClient
+	}
+	type args struct {
+		options RestoreOptions
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "does not return error if cluster client is found",
+			fields: fields{
+				client: fakeClientForMove(), // core v1.0.0 (v1.0.1 available), infra v2.0.0 (v2.0.1 available)
+			},
+			args: args{
+				options: RestoreOptions{
+					ToKubeconfig:      Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
+					DirectoryLocation: dir,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns an error if to cluster client is not found",
+			fields: fields{
+				client: fakeClientForMove(), // core v1.0.0 (v1.0.1 available), infra v2.0.0 (v2.0.1 available)
+			},
+			args: args{
+				options: RestoreOptions{
+					ToKubeconfig:      Kubeconfig{Path: "kubeconfig", Context: "does-not-exist"},
+					DirectoryLocation: dir,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			err := tt.fields.client.Restore(tt.args.options)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+}
+
 func fakeClientForMove() *fakeClient {
 	core := config.NewProvider("cluster-api", "https://somewhere.com", clusterctlv1.CoreProviderType)
 	infra := config.NewProvider("infra", "https://somewhere.com", clusterctlv1.InfrastructureProviderType)
@@ -119,9 +243,19 @@ func fakeClientForMove() *fakeClient {
 }
 
 type fakeObjectMover struct {
-	moveErr error
+	moveErr    error
+	saveErr    error
+	restoerErr error
 }
 
 func (f *fakeObjectMover) Move(namespace string, toCluster cluster.Client, dryRun bool) error {
 	return f.moveErr
+}
+
+func (f *fakeObjectMover) Save(namespace string, directory string) error {
+	return f.saveErr
+}
+
+func (f *fakeObjectMover) Restore(namespace string, glob string, directory string) error {
+	return f.restoerErr
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements the `Save` and `Restore` methods on the `objectMover`

Save will iterate objects in a given namespace, building the object graph, to then save them to a provided directory as a set of json files. These files will appear as:
```
{configured-directory}/object-kind_object-name_object-namespace
```

Restore will iterate object files using a given glob in a configured directory to re-build an object graph. Once all files are iterated and the object graph is created, re-apply those objects to a given management / bootstrap cluster with provided client.

These methods can then be used to create a "backup / restore" cycle where a clusters objects are saved and restored latter.

Fixes #3441

---
Definitely want feedback on this and open to any proposed changes!
cc: @fabriziopandini 
