### PR TITLE
⚠️ Machine status.phase should be `provisioned` when there is a ProviderID and no Node yet

### DIFF
--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -58,8 +58,8 @@ func (r *MachineReconciler) reconcilePhase(_ context.Context, m *clusterv1.Machi
 		m.Status.SetTypedPhase(clusterv1.MachinePhaseProvisioning)
 	}
 
-	// Set the phase to "provisioned" if there is a NodeRef.
-	if m.Status.NodeRef != nil {
+	// Set the phase to "provisioned" if there is a provider ID.
+	if m.Spec.ProviderID != nil {
 		m.Status.SetTypedPhase(clusterv1.MachinePhaseProvisioned)
 	}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

We're currently in a situation where the "provisioned" phase would never
show up given the sequence of events between the controllers. The
proposal expects "provisioned" to be set whenever a Machine has
a spec.providerID field populated, the infrastructure provider is
reporting ready, and there is no Node associated with the Machine.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4779 

/assign @fabriziopandini @CecileRobertMichon 
/cc @onesolpark
