### PR TITLE
🌱 Allow e2e tests to install more than one infra provider

### DIFF
--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -482,8 +482,8 @@ func (c *E2EConfig) validateProviders() error {
 	}
 
 	// There should be one InfraProvider (pick your own).
-	if len(providersByType[clusterctlv1.InfrastructureProviderType]) != 1 {
-		return errInvalidArg("invalid config: it is required to have exactly one infrastructure-provider")
+	if len(providersByType[clusterctlv1.InfrastructureProviderType]) < 1 {
+		return errInvalidArg("invalid config: it is required to have at least one infrastructure-provider")
 	}
 	return nil
 }


### PR DESCRIPTION
We are developing a new provider,  and we would like to use CAPD and our provider together in the E2E tests while our provider is still Work in Progress. 

We reuse the Cluster API e2e tests in our code so as to avoid duplication. 

**What this PR does / why we need it**:
Fixes #4790
