### PR TITLE
✨ Add CAPN to glossary & clusterctl provider

### DIFF
--- a/docs/book/src/clusterctl/provider-contract.md
+++ b/docs/book/src/clusterctl/provider-contract.md
@@ -183,10 +183,12 @@ providers.
 |CAPI          | cluster.x-k8s.io/provider=cluster-api                  |
 |CABPK         | cluster.x-k8s.io/provider=bootstrap-kubeadm            |
 |CACPK         | cluster.x-k8s.io/provider=control-plane-kubeadm        |
+|CACPN         | cluster.x-k8s.io/provider=control-plane-nested        |
 |CAPA          | cluster.x-k8s.io/provider=infrastructure-aws           |
 |CAPV          | cluster.x-k8s.io/provider=infrastructure-vsphere       |
 |CAPD          | cluster.x-k8s.io/provider=infrastructure-docker        |
 |CAPM3         | cluster.x-k8s.io/provider=infrastructure-metal3        |
+|CAPN          | cluster.x-k8s.io/provider=infrastructure-nested        |
 |CAPP          | cluster.x-k8s.io/provider=infrastructure-packet        |
 |CAPZ          | cluster.x-k8s.io/provider=infrastructure-azure         |
 |CAPO          | cluster.x-k8s.io/provider=infrastructure-openstack     |

--- a/docs/book/src/reference/glossary.md
+++ b/docs/book/src/reference/glossary.md
@@ -50,6 +50,9 @@ Cluster API Google Cloud Provider
 ### CAPIBM
 Cluster API Provider IBM Cloud
 
+### CAPN
+Cluster API Provider Nested
+
 ### CAPO
 Cluster API Provider OpenStack
 

--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -21,6 +21,7 @@ updated info about which API version they are supporting.
 - [Exoscale](https://github.com/exoscale/cluster-api-provider-exoscale)
 - [GCP](https://github.com/kubernetes-sigs/cluster-api-provider-gcp)
 - [IBM Cloud](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud)
+- [Nested](https://github.com/kubernetes-sigs/cluster-api-provider-nested)
 - [OpenStack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack)
 - [Packet](https://github.com/kubernetes-sigs/cluster-api-provider-packet)
 - [Sidero](https://github.com/talos-systems/sidero)


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds `cluster-api-provider-nested` to the glossary and provider constructs.

Signed-off-by: Chris Hein <me@chrishein.com>