### PR TITLE
🌱 deduplicate linters, move exclude to exclude-rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ linters:
   - deadcode
   - depguard
   - dogsled
-  - exportloopref
   - errcheck
   - exportloopref
   - goconst
@@ -19,8 +18,8 @@ linters:
   - gosec
   - gosimple
   - govet
-  - importas
   - ifshort
+  - importas
   - ineffassign
   - misspell
   - nakedret
@@ -72,15 +71,21 @@ issues:
   exclude-use-default: false
   # List of regexps of issue texts to exclude, empty list by default.
   exclude:
-  - "G108: Profiling endpoint is automatically exposed on /debug/pprof"
-  - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-  - "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
   # The following are being worked on to remove their exclusion. This list should be reduced or go away all together over time.
   # If it is decided they will not be addressed they should be moved above this comment.
   - Subprocess launch(ed with variable|ing should be audited)
   - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
   - (G104|G307)
   exclude-rules:
+  - linters:
+    - gosec
+    text: "G108: Profiling endpoint is automatically exposed on /debug/pprof"
+  - linters:
+    - revive
+    text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
+  - linters:
+    - errcheck
+    text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
   # With Go 1.16, the new embed directive can be used with an un-named import,
   # revive (previously, golint) only allows these to be imported in a main.go, which wouldn't work for us.
   # This directive allows the embed package to be imported with an underscore everywhere.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Deduplicates linter list (and I took the chance to sort it a bit more). Moves excludes to exclude-rules. Reasoning behind this is to reduce the "blast radius" of the regex matches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially implements #4622
