### PR TITLE
✨ Implements Backup and Restore for objectMover

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -51,6 +51,12 @@ type Client interface {
 	// Move moves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target management cluster.
 	Move(options MoveOptions) error
 
+	// Backup saves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target management cluster.
+	Backup(options BackupOptions) error
+
+	// Restore restores all the Cluster API objects existing in a configured directory based on a glob to a target management cluster.
+	Restore(options RestoreOptions) error
+
 	// PlanUpgrade returns a set of suggested Upgrade plans for the cluster, and more specifically:
 	// - Upgrade to the latest version in the the v1alpha3 series: ....
 	// - Upgrade to the latest version in the the v1alpha4 series: ....

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -104,6 +104,14 @@ func (f fakeClient) Move(options MoveOptions) error {
 	return f.internalClient.Move(options)
 }
 
+func (f fakeClient) Backup(options BackupOptions) error {
+	return f.internalClient.Backup(options)
+}
+
+func (f fakeClient) Restore(options RestoreOptions) error {
+	return f.internalClient.Restore(options)
+}
+
 func (f fakeClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePlan, error) {
 	return f.internalClient.PlanUpgrade(options)
 }

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -17,7 +17,13 @@ limitations under the License.
 package cluster
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -480,6 +486,457 @@ var moveTests = []struct {
 	},
 }
 
+var backupRestoreTests = []struct {
+	name    string
+	fields  moveTestsFields
+	files   map[string]string
+	wantErr bool
+}{
+	{
+		name: "Cluster",
+		fields: moveTestsFields{
+			objs: test.NewFakeCluster("ns1", "foo").Objs(),
+		},
+		files: map[string]string{
+			"Cluster_ns1_foo.yaml":                      `{"apiVersion":"cluster.x-k8s.io/v1alpha4","kind":"Cluster","metadata":{"creationTimestamp":null,"name":"foo","namespace":"ns1","resourceVersion":"999","uid":"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns1/foo"},"spec":{"controlPlaneEndpoint":{"host":"","port":0},"infrastructureRef":{"apiVersion":"infrastructure.cluster.x-k8s.io/v1alpha4","kind":"GenericInfrastructureCluster","name":"foo","namespace":"ns1"}},"status":{"infrastructureReady":false}}` + "\n",
+			"Secret_ns1_foo-kubeconfig.yaml":            `{"apiVersion":"v1","kind":"Secret","metadata":{"creationTimestamp":null,"name":"foo-kubeconfig","namespace":"ns1","ownerReferences":[{"apiVersion":"cluster.x-k8s.io/v1alpha4","kind":"Cluster","name":"foo","uid":"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns1/foo"}],"resourceVersion":"999","uid":"/v1, Kind=Secret, ns1/foo-kubeconfig"}}` + "\n",
+			"Secret_ns1_foo-ca.yaml":                    `{"apiVersion":"v1","kind":"Secret","metadata":{"creationTimestamp":null,"name":"foo-ca","namespace":"ns1","resourceVersion":"999","uid":"/v1, Kind=Secret, ns1/foo-ca"}}` + "\n",
+			"GenericInfrastructureCluster_ns1_foo.yaml": `{"apiVersion":"infrastructure.cluster.x-k8s.io/v1alpha4","kind":"GenericInfrastructureCluster","metadata":{"creationTimestamp":null,"labels":{"cluster.x-k8s.io/cluster-name":"foo"},"name":"foo","namespace":"ns1","ownerReferences":[{"apiVersion":"cluster.x-k8s.io/v1alpha4","kind":"Cluster","name":"foo","uid":"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns1/foo"}],"resourceVersion":"999","uid":"infrastructure.cluster.x-k8s.io/v1alpha4, Kind=GenericInfrastructureCluster, ns1/foo"}}` + "\n",
+		},
+		wantErr: false,
+	},
+	{
+		name: "Many namespace cluster",
+		fields: moveTestsFields{
+			objs: func() []client.Object {
+				objs := []client.Object{}
+				objs = append(objs, test.NewFakeCluster("ns1", "foo").Objs()...)
+				objs = append(objs, test.NewFakeCluster("ns2", "bar").Objs()...)
+				return objs
+			}(),
+		},
+		files: map[string]string{
+			"Cluster_ns1_foo.yaml":                      `{"apiVersion":"cluster.x-k8s.io/v1alpha4","kind":"Cluster","metadata":{"creationTimestamp":null,"name":"foo","namespace":"ns1","resourceVersion":"999","uid":"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns1/foo"},"spec":{"controlPlaneEndpoint":{"host":"","port":0},"infrastructureRef":{"apiVersion":"infrastructure.cluster.x-k8s.io/v1alpha4","kind":"GenericInfrastructureCluster","name":"foo","namespace":"ns1"}},"status":{"infrastructureReady":false}}` + "\n",
+			"Secret_ns1_foo-kubeconfig.yaml":            `{"apiVersion":"v1","kind":"Secret","metadata":{"creationTimestamp":null,"name":"foo-kubeconfig","namespace":"ns1","ownerReferences":[{"apiVersion":"cluster.x-k8s.io/v1alpha4","kind":"Cluster","name":"foo","uid":"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns1/foo"}],"resourceVersion":"999","uid":"/v1, Kind=Secret, ns1/foo-kubeconfig"}}` + "\n",
+			"Secret_ns1_foo-ca.yaml":                    `{"apiVersion":"v1","kind":"Secret","metadata":{"creationTimestamp":null,"name":"foo-ca","namespace":"ns1","resourceVersion":"999","uid":"/v1, Kind=Secret, ns1/foo-ca"}}` + "\n",
+			"GenericInfrastructureCluster_ns1_foo.yaml": `{"apiVersion":"infrastructure.cluster.x-k8s.io/v1alpha4","kind":"GenericInfrastructureCluster","metadata":{"creationTimestamp":null,"labels":{"cluster.x-k8s.io/cluster-name":"foo"},"name":"foo","namespace":"ns1","ownerReferences":[{"apiVersion":"cluster.x-k8s.io/v1alpha4","kind":"Cluster","name":"foo","uid":"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns1/foo"}],"resourceVersion":"999","uid":"infrastructure.cluster.x-k8s.io/v1alpha4, Kind=GenericInfrastructureCluster, ns1/foo"}}` + "\n",
+			"Cluster_ns2_bar.yaml":                      `{"apiVersion":"cluster.x-k8s.io/v1alpha4","kind":"Cluster","metadata":{"creationTimestamp":null,"name":"bar","namespace":"ns2","resourceVersion":"999","uid":"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns2/bar"},"spec":{"controlPlaneEndpoint":{"host":"","port":0},"infrastructureRef":{"apiVersion":"infrastructure.cluster.x-k8s.io/v1alpha4","kind":"GenericInfrastructureCluster","name":"bar","namespace":"ns2"}},"status":{"infrastructureReady":false}}` + "\n",
+			"Secret_ns2_bar-kubeconfig.yaml":            `{"apiVersion":"v1","kind":"Secret","metadata":{"creationTimestamp":null,"name":"bar-kubeconfig","namespace":"ns2","ownerReferences":[{"apiVersion":"cluster.x-k8s.io/v1alpha4","kind":"Cluster","name":"bar","uid":"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns2/bar"}],"resourceVersion":"999","uid":"/v1, Kind=Secret, ns2/bar-kubeconfig"}}` + "\n",
+			"Secret_ns2_bar-ca.yaml":                    `{"apiVersion":"v1","kind":"Secret","metadata":{"creationTimestamp":null,"name":"bar-ca","namespace":"ns2","resourceVersion":"999","uid":"/v1, Kind=Secret, ns2/bar-ca"}}` + "\n",
+			"GenericInfrastructureCluster_ns2_bar.yaml": `{"apiVersion":"infrastructure.cluster.x-k8s.io/v1alpha4","kind":"GenericInfrastructureCluster","metadata":{"creationTimestamp":null,"labels":{"cluster.x-k8s.io/cluster-name":"bar"},"name":"bar","namespace":"ns2","ownerReferences":[{"apiVersion":"cluster.x-k8s.io/v1alpha4","kind":"Cluster","name":"bar","uid":"cluster.x-k8s.io/v1alpha4, Kind=Cluster, ns2/bar"}],"resourceVersion":"999","uid":"infrastructure.cluster.x-k8s.io/v1alpha4, Kind=GenericInfrastructureCluster, ns2/bar"}}` + "\n",
+		},
+		wantErr: false,
+	},
+}
+
+func Test_objectMover_backupTargetObject(t *testing.T) {
+	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
+	for _, tt := range backupRestoreTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Create an objectGraph bound a source cluster with all the CRDs for the types involved in the test.
+			graph := getObjectGraphWithObjs(tt.fields.objs)
+
+			// Get all the types to be considered for discovery
+			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
+
+			// trigger discovery the content of the source cluster
+			g.Expect(graph.Discovery("")).To(Succeed())
+
+			// Run backupTargetObject on nodes in graph
+			mover := objectMover{
+				fromProxy: graph.proxy,
+			}
+
+			dir, err := ioutil.TempDir("/tmp", "cluster-api")
+			if err != nil {
+				t.Error(err)
+			}
+			defer os.RemoveAll(dir)
+
+			for _, node := range graph.uidToNode {
+				err = mover.backupTargetObject(node, dir)
+				if tt.wantErr {
+					g.Expect(err).To(HaveOccurred())
+					return
+				}
+
+				g.Expect(err).NotTo(HaveOccurred())
+
+				// objects are stored and serialized correctly in the temporary directory
+				expectedFilename := node.getFilename()
+				expectedFileContents, ok := tt.files[expectedFilename]
+				if !ok {
+					t.Errorf("Could not access file map: %v\n", expectedFilename)
+				}
+
+				path := filepath.Join(dir, expectedFilename)
+				fileContents, err := os.ReadFile(path)
+				if err != nil {
+					g.Expect(err).NotTo(HaveOccurred())
+					return
+				}
+
+				firstFileStat, err := os.Stat(path)
+				if err != nil {
+					g.Expect(err).NotTo(HaveOccurred())
+					return
+				}
+
+				fmt.Printf("Actual file content %v\n", string(fileContents))
+				g.Expect(string(fileContents)).To(Equal(expectedFileContents))
+
+				// Add delay so we ensure the file ModTime of updated files is different from old ones in the original files
+				time.Sleep(time.Millisecond * 5)
+
+				// Running backupTargetObject should override any existing files since it represents a new backup
+				err = mover.backupTargetObject(node, dir)
+				if tt.wantErr {
+					g.Expect(err).To(HaveOccurred())
+					return
+				}
+
+				g.Expect(err).NotTo(HaveOccurred())
+
+				secondFileStat, err := os.Stat(path)
+				if err != nil {
+					g.Expect(err).NotTo(HaveOccurred())
+					return
+				}
+
+				g.Expect(firstFileStat.ModTime()).To(BeTemporally("<", secondFileStat.ModTime()))
+			}
+		})
+	}
+}
+
+func Test_objectMover_restoreTargetObject(t *testing.T) {
+	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
+	for _, tt := range backupRestoreTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// temporary directory
+			dir, err := ioutil.TempDir("/tmp", "cluster-api")
+			if err != nil {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			defer os.RemoveAll(dir)
+
+			// Create an objectGraph bound a source cluster with all the CRDs for the types involved in the test.
+			graph := getObjectGraph()
+
+			// Get all the types to be considered for discovery
+			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
+
+			// trigger discovery the content of the source cluster
+			g.Expect(graph.Discovery("")).To(Succeed())
+
+			// gets a fakeProxy to an empty cluster with all the required CRDs
+			toProxy := getFakeProxyWithCRDs()
+
+			// Run restoreTargetObject
+			mover := objectMover{
+				fromProxy: graph.proxy,
+			}
+
+			// Write go string slice to directory
+			for _, file := range tt.files {
+				tempFile, err := ioutil.TempFile(dir, "obj")
+				g.Expect(err).NotTo(HaveOccurred())
+
+				_, err = tempFile.Write([]byte(file))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(tempFile.Close()).To(Succeed())
+			}
+
+			objs, err := mover.filesToObjs(dir)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			for i := range objs {
+				g.Expect(graph.addRestoredObj(&objs[i])).NotTo(HaveOccurred())
+			}
+
+			for _, node := range graph.uidToNode {
+				err = mover.restoreTargetObject(node, toProxy)
+				if tt.wantErr {
+					g.Expect(err).To(HaveOccurred())
+					return
+				}
+
+				g.Expect(err).NotTo(HaveOccurred())
+
+				// Check objects are in new restored cluster
+				csTo, err := toProxy.NewClient()
+				g.Expect(err).NotTo(HaveOccurred())
+
+				key := client.ObjectKey{
+					Namespace: node.identity.Namespace,
+					Name:      node.identity.Name,
+				}
+
+				// objects are created in the target cluster
+				oTo := &unstructured.Unstructured{}
+				oTo.SetAPIVersion(node.identity.APIVersion)
+				oTo.SetKind(node.identity.Kind)
+
+				if err := csTo.Get(ctx, key, oTo); err != nil {
+					t.Errorf("error = %v when checking for %v created in target cluster", err, key)
+					continue
+				}
+
+				// Re-running restoreTargetObjects won't override existing objects
+				err = mover.restoreTargetObject(node, toProxy)
+				if tt.wantErr {
+					g.Expect(err).To(HaveOccurred())
+					return
+				}
+
+				g.Expect(err).NotTo(HaveOccurred())
+
+				// Check objects are in new restored cluster
+				csAfter, err := toProxy.NewClient()
+				g.Expect(err).NotTo(HaveOccurred())
+
+				keyAfter := client.ObjectKey{
+					Namespace: node.identity.Namespace,
+					Name:      node.identity.Name,
+				}
+
+				// objects are created in the target cluster
+				oAfter := &unstructured.Unstructured{}
+				oAfter.SetAPIVersion(node.identity.APIVersion)
+				oAfter.SetKind(node.identity.Kind)
+
+				if err := csAfter.Get(ctx, keyAfter, oAfter); err != nil {
+					t.Errorf("error = %v when checking for %v created in target cluster", err, key)
+					continue
+				}
+
+				g.Expect(oAfter.GetAPIVersion()).Should(Equal(oTo.GetAPIVersion()))
+				g.Expect(oAfter.GetName()).Should(Equal(oTo.GetName()))
+				g.Expect(oAfter.GetCreationTimestamp()).Should(Equal(oTo.GetCreationTimestamp()))
+				g.Expect(oAfter.GetUID()).Should(Equal(oTo.GetUID()))
+				g.Expect(oAfter.GetOwnerReferences()).Should(Equal(oTo.GetOwnerReferences()))
+			}
+		})
+	}
+}
+
+func Test_objectMover_backup(t *testing.T) {
+	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
+	for _, tt := range backupRestoreTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// Create an objectGraph bound a source cluster with all the CRDs for the types involved in the test.
+			graph := getObjectGraphWithObjs(tt.fields.objs)
+
+			// Get all the types to be considered for discovery
+			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
+
+			// trigger discovery the content of the source cluster
+			g.Expect(graph.Discovery("")).To(Succeed())
+
+			// Run backup
+			mover := objectMover{
+				fromProxy: graph.proxy,
+			}
+
+			dir, err := ioutil.TempDir("/tmp", "cluster-api")
+			if err != nil {
+				t.Error(err)
+			}
+			defer os.RemoveAll(dir)
+
+			err = mover.backup(graph, dir)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// check that the objects are stored in the temporary directory but not deleted from the source cluster
+			csFrom, err := graph.proxy.NewClient()
+			g.Expect(err).NotTo(HaveOccurred())
+
+			missingFiles := []string{}
+			for _, node := range graph.uidToNode {
+				key := client.ObjectKey{
+					Namespace: node.identity.Namespace,
+					Name:      node.identity.Name,
+				}
+
+				// objects are not deleted from the source cluster
+				oFrom := &unstructured.Unstructured{}
+				oFrom.SetAPIVersion(node.identity.APIVersion)
+				oFrom.SetKind(node.identity.Kind)
+
+				err := csFrom.Get(ctx, key, oFrom)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				// objects are stored in the temporary directory with the expected filename
+				files, err := ioutil.ReadDir(dir)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				expectedFilename := node.getFilename()
+				found := false
+				for _, f := range files {
+					if strings.Contains(f.Name(), expectedFilename) {
+						found = true
+					}
+				}
+
+				if !found {
+					missingFiles = append(missingFiles, expectedFilename)
+				}
+			}
+
+			g.Expect(missingFiles).To(BeEmpty())
+		})
+	}
+}
+
+func Test_objectMover_filesToObjs(t *testing.T) {
+	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
+	for _, tt := range backupRestoreTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			dir, err := ioutil.TempDir("/tmp", "cluster-api")
+			if err != nil {
+				t.Error(err)
+			}
+			defer os.RemoveAll(dir)
+
+			for _, fileName := range tt.files {
+				path := filepath.Join(dir, fileName)
+				file, err := os.Create(path)
+				if err != nil {
+					return
+				}
+
+				_, err = file.WriteString(tt.files[fileName])
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(file.Close()).To(Succeed())
+			}
+
+			// Create an objectGraph bound a source cluster with all the CRDs for the types involved in the test.
+			graph := getObjectGraphWithObjs(tt.fields.objs)
+
+			// Run filesToObjs
+			mover := objectMover{
+				fromProxy: graph.proxy,
+			}
+
+			objs, err := mover.filesToObjs(dir)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+
+			missingObjs := []unstructured.Unstructured{}
+			for _, obj := range objs {
+				found := false
+				for _, expected := range tt.fields.objs {
+					if expected.GetName() == obj.GetName() && expected.GetObjectKind() == obj.GetObjectKind() {
+						found = true
+					}
+				}
+
+				if !found {
+					missingObjs = append(missingObjs, obj)
+				}
+			}
+
+			g.Expect(missingObjs).To(BeEmpty())
+		})
+	}
+}
+
+func Test_objectMover_restore(t *testing.T) {
+	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
+	for _, tt := range backupRestoreTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			// temporary directory
+			dir, err := ioutil.TempDir("/tmp", "cluster-api")
+			if err != nil {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			defer os.RemoveAll(dir)
+
+			// Create an objectGraph bound a source cluster with all the CRDs for the types involved in the test.
+			graph := getObjectGraph()
+
+			// Get all the types to be considered for discovery
+			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
+
+			// gets a fakeProxy to an empty cluster with all the required CRDs
+			toProxy := getFakeProxyWithCRDs()
+
+			// Run restore
+			mover := objectMover{
+				fromProxy: graph.proxy,
+			}
+
+			// Write go string slice to directory
+			for _, file := range tt.files {
+				tempFile, err := ioutil.TempFile(dir, "obj")
+				g.Expect(err).NotTo(HaveOccurred())
+
+				_, err = tempFile.Write([]byte(file))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(tempFile.Close()).To(Succeed())
+			}
+
+			objs, err := mover.filesToObjs(dir)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			for i := range objs {
+				g.Expect(graph.addRestoredObj(&objs[i])).NotTo(HaveOccurred())
+			}
+
+			// trigger discovery the content of the source cluster
+			g.Expect(graph.Discovery("")).To(Succeed())
+
+			err = mover.restore(graph, toProxy)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+
+			// Check objects are in new restored cluster
+			csTo, err := toProxy.NewClient()
+			g.Expect(err).NotTo(HaveOccurred())
+
+			for _, node := range graph.uidToNode {
+				key := client.ObjectKey{
+					Namespace: node.identity.Namespace,
+					Name:      node.identity.Name,
+				}
+
+				// objects are created in the target cluster
+				oTo := &unstructured.Unstructured{}
+				oTo.SetAPIVersion(node.identity.APIVersion)
+				oTo.SetKind(node.identity.Kind)
+
+				if err := csTo.Get(ctx, key, oTo); err != nil {
+					t.Errorf("error = %v when checking for %v created in target cluster", err, key)
+					continue
+				}
+			}
+		})
+	}
+}
+
 func Test_getMoveSequence(t *testing.T) {
 	// NB. we are testing the move and move sequence using the same set of moveTests, but checking the results at different stages of the move process
 	for _, tt := range moveTests {
@@ -490,8 +947,7 @@ func Test_getMoveSequence(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			err := getFakeDiscoveryTypes(graph)
-			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery("")).To(Succeed())
@@ -522,8 +978,7 @@ func Test_objectMover_move_dryRun(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			err := getFakeDiscoveryTypes(graph)
-			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery("")).To(Succeed())
@@ -537,7 +992,7 @@ func Test_objectMover_move_dryRun(t *testing.T) {
 				dryRun:    true,
 			}
 
-			err = mover.move(graph, toProxy)
+			err := mover.move(graph, toProxy)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return
@@ -596,8 +1051,7 @@ func Test_objectMover_move(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			err := getFakeDiscoveryTypes(graph)
-			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery("")).To(Succeed())
@@ -610,7 +1064,7 @@ func Test_objectMover_move(t *testing.T) {
 				fromProxy: graph.proxy,
 			}
 
-			err = mover.move(graph, toProxy)
+			err := mover.move(graph, toProxy)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return
@@ -868,8 +1322,7 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			err := getFakeDiscoveryTypes(graph)
-			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery("")).To(Succeed())
@@ -877,7 +1330,7 @@ func Test_objectMover_checkProvisioningCompleted(t *testing.T) {
 			o := &objectMover{
 				fromProxy: graph.proxy,
 			}
-			err = o.checkProvisioningCompleted(graph)
+			err := o.checkProvisioningCompleted(graph)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {
@@ -1109,8 +1562,7 @@ func Test_objectMoverService_ensureNamespaces(t *testing.T) {
 			graph := getObjectGraphWithObjs(tt.fields.objs)
 
 			// Get all the types to be considered for discovery
-			err := getFakeDiscoveryTypes(graph)
-			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(getFakeDiscoveryTypes(graph)).To(Succeed())
 
 			// Trigger discovery the content of the source cluster
 			g.Expect(graph.Discovery("")).To(Succeed())
@@ -1119,7 +1571,7 @@ func Test_objectMoverService_ensureNamespaces(t *testing.T) {
 				fromProxy: graph.proxy,
 			}
 
-			err = mover.ensureNamespaces(graph, tt.args.toProxy)
+			err := mover.ensureNamespaces(graph, tt.args.toProxy)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			// Check that the namespaces either existed or were created in the

--- a/cmd/clusterctl/client/cluster/objectgraph_test.go
+++ b/cmd/clusterctl/client/cluster/objectgraph_test.go
@@ -1378,6 +1378,16 @@ func getObjectGraphWithObjs(objs []client.Object) *objectGraph {
 	return newObjectGraph(fromProxy, inventory)
 }
 
+func getObjectGraph() *objectGraph {
+	// build object graph from file
+	fromProxy := getFakeProxyWithCRDs()
+
+	fromProxy.WithProviderInventory("infra1", clusterctlv1.InfrastructureProviderType, "v1.2.3", "infra1-system")
+	inventory := newInventoryClient(fromProxy, fakePollImmediateWaiter)
+
+	return newObjectGraph(fromProxy, inventory)
+}
+
 func getFakeProxyWithCRDs() *test.FakeProxy {
 	proxy := test.NewFakeProxy()
 	for _, o := range test.FakeCRDList() {

--- a/cmd/clusterctl/cmd/backup.go
+++ b/cmd/clusterctl/cmd/backup.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+type backupOptions struct {
+	fromKubeconfig        string
+	fromKubeconfigContext string
+	namespace             string
+	directory             string
+}
+
+var buo = &backupOptions{}
+
+var backupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Backup Cluster API objects and all dependencies from a management cluster.",
+	Long: LongDesc(`
+		Backup Cluster API objects and all dependencies from a management cluster.`),
+
+	Example: Examples(`
+		Backup Cluster API objects and all dependencies from a management cluster.
+		clusterctl backup --directory=/tmp/backup-directory`),
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runBackup()
+	},
+}
+
+func init() {
+	backupCmd.Flags().StringVar(&buo.fromKubeconfig, "kubeconfig", "",
+		"Path to the kubeconfig file for the source management cluster to backup. If unspecified, default discovery rules apply.")
+	backupCmd.Flags().StringVar(&buo.fromKubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file for the source management cluster. If empty, current context will be used.")
+	backupCmd.Flags().StringVarP(&buo.namespace, "namespace", "n", "",
+		"The namespace where the workload cluster is hosted. If unspecified, the current context's namespace is used.")
+	backupCmd.Flags().StringVar(&buo.directory, "directory", "",
+		"The directory to save Cluster API objects to as yaml files")
+
+	RootCmd.AddCommand(backupCmd)
+}
+
+func runBackup() error {
+	if buo.directory == "" {
+		return errors.New("please specify a directory to backup cluster API objects to using the --directory flag")
+	}
+
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	return c.Backup(client.BackupOptions{
+		FromKubeconfig: client.Kubeconfig{Path: buo.fromKubeconfig, Context: buo.fromKubeconfigContext},
+		Namespace:      buo.namespace,
+		Directory:      buo.directory,
+	})
+}

--- a/cmd/clusterctl/cmd/restore.go
+++ b/cmd/clusterctl/cmd/restore.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+type restoreOptions struct {
+	toKubeconfig        string
+	toKubeconfigContext string
+	directory           string
+}
+
+var ro = &restoreOptions{}
+
+var restoreCmd = &cobra.Command{
+	Use:   "restore",
+	Short: "Restore Cluster API objects from file by glob. Object files are searched in config directory",
+	Long: LongDesc(`
+		Restore Cluster API objects from file by glob. Object files are searched in the default config directory
+		or in the provided directory.`),
+	Example: Examples(`
+		Restore Cluster API objects from file by glob. Object files are searched in config directory.
+		clusterctl restore my-cluster`),
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runRestore()
+	},
+}
+
+func init() {
+	restoreCmd.Flags().StringVar(&ro.toKubeconfig, "kubeconfig", "",
+		"Path to the kubeconfig file for the target management cluster to restore objects to. If unspecified, default discovery rules apply.")
+	restoreCmd.Flags().StringVar(&ro.toKubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file for the target management cluster. If empty, current context will be used.")
+	restoreCmd.Flags().StringVar(&ro.directory, "directory", "",
+		"The directory to target when restoring Cluster API object yaml files")
+
+	RootCmd.AddCommand(restoreCmd)
+}
+
+func runRestore() error {
+	if ro.directory == "" {
+		return errors.New("please specify a directory to restore cluster API objects from using the --directory flag")
+	}
+
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	return c.Restore(client.RestoreOptions{
+		ToKubeconfig: client.Kubeconfig{Path: ro.toKubeconfig, Context: ro.toKubeconfigContext},
+		Directory:    ro.directory,
+	})
+}


### PR DESCRIPTION
### What this PR does / why we need it:

Implements the Backup and Restore methods on the objectMover

Backup will iterate objects in a given namespace, building the object graph, to then save them to a provided directory as a set of json files. These files will appear as:
```
{configured-directory}/object-kind_object-name_object-namespace.yaml
```
Restore will iterate object files using a given glob in a configured directory to re-build an object graph. Once all files are iterated and the object graph is created, re-applies those objects to a given management / bootstrap cluster with provided client.

These methods can then be used to create a "backup / restore" cycle where a clusters objects are saved and restored latter.

Fixes #3441

This PR supersedes #4786 which was based on the 0.3 branching. Hope to get this into the 0.4.0 release. Since a previous build of my testing code / environment was based on 0.3, I wasn't able to test this out as fully as I'd like and would like guidance on testing this more. Definitely want feedback on this and open to any proposed changes!
cc: @fabriziopandini @vincepri 
