### PR TITLE
:seedling: Provide more information in clusterctl move logs

### DIFF
--- a/cmd/clusterctl/client/alpha/machinedeployment.go
+++ b/cmd/clusterctl/client/alpha/machinedeployment.go
@@ -39,8 +39,8 @@ func getMachineDeployment(proxy cluster.Proxy, name, namespace string) (*cluster
 		Name:      name,
 	}
 	if err := c.Get(ctx, mdObjKey, mdObj); err != nil {
-		return nil, errors.Wrapf(err, "error reading %q %s/%s",
-			mdObj.GroupVersionKind(), mdObjKey.Namespace, mdObjKey.Name)
+		return nil, errors.Wrapf(err, "error reading MachineDeployment %s/%s",
+			mdObjKey.Namespace, mdObjKey.Name)
 	}
 	return mdObj, nil
 }
@@ -57,11 +57,11 @@ func patchMachineDeployemt(proxy cluster.Proxy, name, namespace string, patch cl
 		Name:      name,
 	}
 	if err := cFrom.Get(ctx, mdObjKey, mdObj); err != nil {
-		return errors.Wrapf(err, "error reading %s/%s", mdObj.GetNamespace(), mdObj.GetName())
+		return errors.Wrapf(err, "error reading MachineDeployment %s/%s", mdObj.GetNamespace(), mdObj.GetName())
 	}
 
 	if err := cFrom.Patch(ctx, mdObj, patch); err != nil {
-		return errors.Wrapf(err, "error while patching %s/%s", mdObj.GetNamespace(), mdObj.GetName())
+		return errors.Wrapf(err, "error while patching MachineDeployment %s/%s", mdObj.GetNamespace(), mdObj.GetName())
 	}
 	return nil
 }
@@ -95,11 +95,11 @@ func findMachineDeploymentRevision(toRevision int64, allMSs []*clusterv1.Machine
 	}
 
 	if toRevision > 0 {
-		return nil, errors.Errorf("unable to find specified revision: %v", toRevision)
+		return nil, errors.Errorf("unable to find specified MachineDeployment revision: %v", toRevision)
 	}
 
 	if previousMachineSet == nil {
-		return nil, errors.Errorf("no rollout history found")
+		return nil, errors.Errorf("no rollout history found for MachineDeployment")
 	}
 	return previousMachineSet, nil
 }


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Some minor changes to logs to get more information, related to #4816