### PR TITLE
🌱 Make node drain delete timeout configurable in e2e framework

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -128,3 +128,4 @@ intervals:
   default/wait-machine-remediation: ["5m", "10s"]
   node-drain/wait-deployment-available: ["3m", "10s"]
   node-drain/wait-control-plane: ["15m", "10s"]
+  node-drain/wait-machine-deleted: ["2m", "10s"]


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Previously, we were adding 2 minutes to the nodeDrainTimeout for each node that needed to get deleted in order to come up with the interval timeout in the nodeDrainTimeout test. 2 minutes is not flexible enough for all infrastructure and providers, it should be a configurable timeout.

Now, we take a `node-drain/wait-machine-deleted` interval in the e2e config and calculate the appropriate machine deployment and control plane scale down timeout by adding the provided machine deletion timeout with the nodeDrainTimeout and multiply it by the number of machines.

_There is no behavior change for the existing docker infra node drain test (timeouts stay the same for MD and KCP)_ 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
