### PR TITLE
:seedling: Dependabot: Change to weekly, enable auto commit of generated code

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,13 @@ updates:
     #
     # Maintainers can continue to look at the log in
     # https://github.com/kubernetes-sigs/cluster-api/network/updates/
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 1
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit_message:
       prefix: "🌱"
 
-  # Weekly updates for everything else
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -32,7 +31,7 @@ updates:
 
   - package-ecosystem: "gomod"
     directory: "/hack/tools"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
     commit_message:
@@ -40,7 +39,7 @@ updates:
 
   - package-ecosystem: "gomod"
     directory: "/test"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
     commit_message:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,43 @@
+name: dependabot
+
+on:
+  pull_request:
+    branches:
+      - dependabot/**
+  push:
+    branches:
+      - dependabot/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      name: Restore go cache
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Update all modules
+      run: make modules
+    - name: Update generated code
+      run: make generate
+    - uses: EndBug/add-and-commit@v7
+      name: Commit changes
+      with:
+        author_name: dependabot[bot]
+        author_email: 49699333+dependabot[bot]@users.noreply.github.com
+        default_author: github_actor
+        message: 'Update generated code'


### PR DESCRIPTION
Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
For some reason, attempts to turn off dependabot automatic PRs have failed, so instead, here we configure it.

Also adds a Github action that Cluster API Provider AWS is using such that all of the generated code is updated.

Finally, attempt to limit to a single PR at a time...

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
