### PR TITLE
:seedling: Add IsMissingVariables

### DIFF
--- a/cmd/clusterctl/client/yamlprocessor/simple_processor.go
+++ b/cmd/clusterctl/client/yamlprocessor/simple_processor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package yamlprocessor
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -127,12 +128,23 @@ type errMissingVariables struct {
 	Missing []string
 }
 
+func (e *errMissingVariables) Is(target error) bool {
+	_, ok := target.(*errMissingVariables)
+	return ok
+}
+
 func (e *errMissingVariables) Error() string {
 	sort.Strings(e.Missing)
 	return fmt.Sprintf(
 		"value for variables [%s] is not set. Please set the value using os environment variables or the clusterctl config file",
 		strings.Join(e.Missing, ", "),
 	)
+}
+
+// IsMissingVariables returns true if the provided error indicates missing
+// variables when processing a template.
+func IsMissingVariables(err error) bool {
+	return errors.Is(err, &errMissingVariables{})
 }
 
 // inspectVariables parses through the yaml and returns a map of the variable

--- a/cmd/clusterctl/client/yamlprocessor/simple_processor_test.go
+++ b/cmd/clusterctl/client/yamlprocessor/simple_processor_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package yamlprocessor
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -272,6 +274,25 @@ func TestSimpleProcessor_Process(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestIsMissingVariables(t *testing.T) {
+	errTests := []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{desc: "normal string error", err: errors.New("test error"), want: false},
+		{desc: "missing variables error", err: &errMissingVariables{Missing: []string{"testing"}}, want: true},
+		{desc: "wrapped error", err: fmt.Errorf("wrapped error: %w", &errMissingVariables{Missing: []string{"testing"}}), want: true},
+	}
+	for _, tt := range errTests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if v := IsMissingVariables(tt.err); v != tt.want {
+				t.Errorf("IsMissingVariables got %v, want %v for %v", v, tt.want, tt.err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This implements IsMissingVariables which allows consumers to identify
the specific error for improving the errors returned upstream.