### PR TITLE
🔨  Add tests (💚) and chores (🔨) categories to release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
-<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->
+<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 💚 (:green_heart:, adding, fixing, or improving tests), 📖 (:book:, documentation or proposals), 🔨 (:hammer:, chore or maintenance tasks), or 🌱 (:seedling:, minor or other) -->
 
 **What this PR does / why we need it**:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,13 @@ come up, including gaps in documentation!
 1. Fork the desired repo, develop and test your code changes.
 1. Submit a pull request.
     1. All code PR must be labeled with one of
-        - ⚠️ (:warning:, major or breaking changes)
-        - ✨ (:sparkles:, feature additions)
-        - 🐛 (:bug:, patch and bugfixes)
-        - 📖 (:book:, documentation or proposals)
-        - 🌱 (:seedling:, minor or other)
+        - ⚠️ (`:warning:`, major or breaking changes)
+        - ✨ (`:sparkles:`, feature additions)
+        - 🐛 (`:bug:`, patch and bugfixes)
+        - 📖 (`:book:`, documentation or proposals)
+        - 🌱 (`:seedling:`, minor or other)
+        - 💚 (`:green_heart:`, tests)
+        - 🔨 (`:hammer:` chores, infra, maintenance - these will _not_ appear in release notes)
 
 All changes must be code reviewed. Coding conventions and standards are explained in the official [developer
 docs](https://git.k8s.io/community/contributors/devel). Expect reviewers to request that you

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -61,7 +61,9 @@ a:
 - Non-breaking feature: :sparkles: (`:sparkles:`)
 - Patch fix: :bug: (`:bug:`)
 - Docs: :book: (`:book:`)
-- Infra/Tests/Other: :seedling: (`:seedling:`)
+- Tests: :green_heart: (`:green_heart:`)
+- Minor/Other: :seedling: (`:seedling:`)
+- Chores/Infra/Maintenance: :hammer: (`:hammer:`) - these will _not_ appear in release notes
 
 You can also use the equivalent emoji directly, since GitHub doesn't
 render the `:xyz:` aliases in PR titles.

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -40,6 +40,7 @@ const (
 	documentation = ":book: Documentation"
 	proposals     = ":memo: Proposals"
 	warning       = ":warning: Breaking Changes"
+	tests         = ":green_heart: Testing"
 	other         = ":seedling: Others"
 	unknown       = ":question: Sort these by hand"
 )
@@ -50,6 +51,7 @@ var (
 		warning,
 		features,
 		bugs,
+		tests,
 		other,
 		documentation,
 		unknown,
@@ -91,6 +93,7 @@ func run() int {
 	merges := map[string][]string{
 		features:      {},
 		bugs:          {},
+		tests:         {},
 		documentation: {},
 		warning:       {},
 		other:         {},
@@ -124,6 +127,9 @@ func run() int {
 		body := strings.TrimSpace(c.body)
 		var key, prNumber, fork string
 		switch {
+		case strings.HasPrefix(body, ":hammer:"), strings.HasPrefix(body, "🔨"):
+			// do nothing for chores, we exclude them from release notes
+			continue
 		case strings.HasPrefix(body, ":sparkles:"), strings.HasPrefix(body, "✨"):
 			key = features
 			body = strings.TrimPrefix(body, ":sparkles:")
@@ -147,6 +153,10 @@ func run() int {
 			key = warning
 			body = strings.TrimPrefix(body, ":warning:")
 			body = strings.TrimPrefix(body, "⚠️")
+		case strings.HasPrefix(body, ":green_heart:"), strings.HasPrefix(body, "💚"):
+			key = tests
+			body = strings.TrimPrefix(body, ":green_heart:")
+			body = strings.TrimPrefix(body, "💚")
 		default:
 			key = unknown
 		}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Improvements following the v0.4.0 release process, there were too many PRs categorized "others", a lot of them not user-facing and irrelevant for release notes. This adds two new categories:

- 💚 (`:green_heart:`, tests)
- 🔨 (`:hammer:` chores, infra, maintenance - these will _not_ appear in release notes)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
