### PR TITLE
🐛 Use metadata.yaml in github repo to fetch latest release for older contracts

### DIFF
--- a/cmd/clusterctl/api/v1alpha3/metadata_type.go
+++ b/cmd/clusterctl/api/v1alpha3/metadata_type.go
@@ -60,3 +60,14 @@ func (m *Metadata) GetReleaseSeriesForVersion(version *version.Version) *Release
 
 	return nil
 }
+
+// GetReleaseSeriesForContract returns the release series for a given API Version, e.g. `v1alpha4`.
+func (m *Metadata) GetReleaseSeriesForContract(contract string) *ReleaseSeries {
+	for _, releaseSeries := range m.ReleaseSeries {
+		if contract == releaseSeries.Contract {
+			return &releaseSeries
+		}
+	}
+
+	return nil
+}

--- a/cmd/clusterctl/client/cluster/installer.go
+++ b/cmd/clusterctl/client/cluster/installer.go
@@ -174,7 +174,7 @@ func (i *providerInstaller) getProviderContract(providerInstanceContracts map[st
 	}
 
 	if releaseSeries.Contract != clusterv1.GroupVersion.Version {
-		return "", errors.Errorf("current version of clusterctl could install only %s providers, detected %s for provider %s", clusterv1.GroupVersion.Version, releaseSeries.Contract, provider.ManifestLabel())
+		return "", errors.Errorf("current version of clusterctl is only compatible with %s providers, detected %s for provider %s", clusterv1.GroupVersion.Version, releaseSeries.Contract, provider.ManifestLabel())
 	}
 
 	providerInstanceContracts[provider.InstanceName()] = releaseSeries.Contract

--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -26,6 +26,8 @@ import (
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
+const metadataFile = "metadata.yaml"
+
 // MetadataClient has methods to work with metadata hosted on a provider repository.
 // Metadata are yaml files providing additional information about provider's assets like e.g the version compatibility Matrix.
 type MetadataClient interface {
@@ -59,25 +61,24 @@ func (f *metadataClient) Get() (*clusterctlv1.Metadata, error) {
 
 	// gets the metadata file from the repository
 	version := f.version
-	name := "metadata.yaml"
 
 	file, err := getLocalOverride(&newOverrideInput{
 		configVariablesClient: f.configVarClient,
 		provider:              f.provider,
 		version:               version,
-		filePath:              name,
+		filePath:              metadataFile,
 	})
 	if err != nil {
 		return nil, err
 	}
 	if file == nil {
-		log.V(5).Info("Fetching", "File", name, "Provider", f.provider.Name(), "Type", f.provider.Type(), "Version", version)
-		file, err = f.repository.GetFile(version, name)
+		log.V(5).Info("Fetching", "File", metadataFile, "Provider", f.provider.Name(), "Type", f.provider.Type(), "Version", version)
+		file, err = f.repository.GetFile(version, metadataFile)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to read %q from the repository for provider %q", name, f.provider.ManifestLabel())
+			return nil, errors.Wrapf(err, "failed to read %q from the repository for provider %q", metadataFile, f.provider.ManifestLabel())
 		}
 	} else {
-		log.V(1).Info("Using", "Override", name, "Provider", f.provider.ManifestLabel(), "Version", version)
+		log.V(1).Info("Using", "Override", metadataFile, "Provider", f.provider.ManifestLabel(), "Version", version)
 	}
 
 	// Convert the yaml into a typed object
@@ -85,7 +86,7 @@ func (f *metadataClient) Get() (*clusterctlv1.Metadata, error) {
 	codecFactory := serializer.NewCodecFactory(scheme.Scheme)
 
 	if err := runtime.DecodeInto(codecFactory.UniversalDecoder(), file, obj); err != nil {
-		return nil, errors.Wrapf(err, "error decoding %q for provider %q", name, f.provider.ManifestLabel())
+		return nil, errors.Wrapf(err, "error decoding %q for provider %q", metadataFile, f.provider.ManifestLabel())
 	}
 
 	//TODO: consider if to add metadata validation (TBD)

--- a/cmd/clusterctl/client/repository/repository_github.go
+++ b/cmd/clusterctl/client/repository/repository_github.go
@@ -25,6 +25,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/scheme"
+
 	"github.com/google/go-github/v33/github"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
@@ -171,7 +178,7 @@ func newGitHubRepository(providerConfig config.Provider, configVariablesClient c
 	}
 
 	if defaultVersion == githubLatestReleaseLabel {
-		repo.defaultVersion, err = repo.getLatestRelease()
+		repo.defaultVersion, err = repo.getLatestContractRelease(clusterv1.GroupVersion.Version)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get GitHub latest version")
 		}
@@ -238,9 +245,53 @@ func (g *gitHubRepository) getVersions() ([]string, error) {
 	return versions, nil
 }
 
+// getLatestContractRelease returns the latest patch release for a github repository for the current API contract, according to
+// semantic version order of the release tag name.
+func (g *gitHubRepository) getLatestContractRelease(contract string) (string, error) {
+	latest, err := g.getLatestRelease()
+	if err != nil {
+		return latest, err
+	}
+	// Attempt to check if the latest release satisfies the API Contract
+	// This is a best-effort attempt to find the latest release for an older API contract if it's not the latest Github release.
+	// If an error occurs, we just return the latest release.
+	file, err := g.GetFile(latest, metadataFile)
+	if err != nil {
+		// if we can't get the metadata file from the release, we return latest.
+		return latest, nil // nolint:nilerr
+	}
+	latestMetadata := &clusterctlv1.Metadata{}
+	codecFactory := serializer.NewCodecFactory(scheme.Scheme)
+	if err := runtime.DecodeInto(codecFactory.UniversalDecoder(), file, latestMetadata); err != nil {
+		return latest, nil // nolint:nilerr
+	}
+
+	releaseSeries := latestMetadata.GetReleaseSeriesForContract(contract)
+	if releaseSeries == nil {
+		return latest, nil
+	}
+
+	sv, err := version.ParseSemantic(latest)
+	if err != nil {
+		return latest, nil // nolint:nilerr
+	}
+
+	// If the Major or Minor version of the latest release doesn't match the release series for the current contract,
+	// return the latest patch release of the desired Major/Minor version.
+	if sv.Major() != releaseSeries.Major || sv.Minor() != releaseSeries.Minor {
+		return g.getLatestPatchRelease(&releaseSeries.Major, &releaseSeries.Minor)
+	}
+	return latest, nil
+}
+
 // getLatestRelease returns the latest release for a github repository, according to
 // semantic version order of the release tag name.
 func (g *gitHubRepository) getLatestRelease() (string, error) {
+	return g.getLatestPatchRelease(nil, nil)
+}
+
+// getLatestRelease returns the latest patch release for a given Major and Minor version.
+func (g *gitHubRepository) getLatestPatchRelease(major, minor *uint) (string, error) {
 	versions, err := g.getVersions()
 	if err != nil {
 		return "", g.handleGithubErr(err, "failed to get the list of versions")
@@ -258,6 +309,11 @@ func (g *gitHubRepository) getLatestRelease() (string, error) {
 		sv, err := version.ParseSemantic(v)
 		if err != nil {
 			// discard releases with tags that are not a valid semantic versions (the user can point explicitly to such releases)
+			continue
+		}
+
+		if (major != nil && sv.Major() != *major) || (minor != nil && sv.Minor() != *minor) {
+			// skip versions that don't match the desired Major.Minor version.
 			continue
 		}
 

--- a/cmd/clusterctl/client/repository/repository_local.go
+++ b/cmd/clusterctl/client/repository/repository_local.go
@@ -23,6 +23,12 @@ import (
 	"runtime"
 	"strings"
 
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/scheme"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/version"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
@@ -192,7 +198,7 @@ func newLocalRepository(providerConfig config.Provider, configVariablesClient co
 	}
 
 	if defaultVersion == latestVersionTag {
-		repo.defaultVersion, err = repo.getLatestRelease()
+		repo.defaultVersion, err = repo.getLatestContractRelease(clusterv1.GroupVersion.Version)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get latest version")
 		}
@@ -200,8 +206,51 @@ func newLocalRepository(providerConfig config.Provider, configVariablesClient co
 	return repo, nil
 }
 
+// getLatestContractRelease returns the latest patch release for a local repository for the current API contract.
+func (r *localRepository) getLatestContractRelease(contract string) (string, error) {
+	latest, err := r.getLatestRelease()
+	if err != nil {
+		return latest, err
+	}
+	// Attempt to check if the latest release satisfies the API Contract
+	// This is a best-effort attempt to find the latest release for an older API contract if it's not the latest Github release.
+	// If an error occurs, we just return the latest release.
+	file, err := r.GetFile(latest, metadataFile)
+	if err != nil {
+		// if we can't get the metadata file from the release, we return latest.
+		return latest, nil // nolint:nilerr
+	}
+	latestMetadata := &clusterctlv1.Metadata{}
+	codecFactory := serializer.NewCodecFactory(scheme.Scheme)
+	if err := apiruntime.DecodeInto(codecFactory.UniversalDecoder(), file, latestMetadata); err != nil {
+		return latest, nil // nolint:nilerr
+	}
+
+	releaseSeries := latestMetadata.GetReleaseSeriesForContract(contract)
+	if releaseSeries == nil {
+		return latest, nil
+	}
+
+	sv, err := version.ParseSemantic(latest)
+	if err != nil {
+		return latest, nil // nolint:nilerr
+	}
+
+	// If the Major or Minor version of the latest release doesn't match the release series for the current contract,
+	// return the latest patch release of the desired Major/Minor version.
+	if sv.Major() != releaseSeries.Major || sv.Minor() != releaseSeries.Minor {
+		return r.getLatestPatchRelease(&releaseSeries.Major, &releaseSeries.Minor)
+	}
+	return latest, nil
+}
+
 // getLatestRelease returns the latest release for the local repository.
 func (r *localRepository) getLatestRelease() (string, error) {
+	return r.getLatestPatchRelease(nil, nil)
+}
+
+// getLatestPatchRelease returns the latest patch release for a given Major and Minor version.
+func (r *localRepository) getLatestPatchRelease(major, minor *uint) (string, error) {
 	versions, err := r.GetVersions()
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get local repository versions")
@@ -216,6 +265,11 @@ func (r *localRepository) getLatestRelease() (string, error) {
 	for _, v := range versions {
 		sv, err := version.ParseSemantic(v)
 		if err != nil {
+			continue
+		}
+
+		if (major != nil && sv.Major() != *major) || (minor != nil && sv.Minor() != *minor) {
+			// skip versions that don't match the desired Major.Minor version.
 			continue
 		}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Currently clusterctl init gets the latest release by default for each provider and then validates the provider contract using the metadata.yaml file. However, this causes `init` to fail when using an older clusterctl version (eg. v0.3.19) and a newer version is available with a different contract (eg. v0.4.0). This fix will get the latest patch release of the contract release when it does not match the latest release.

This PR targets the main branch, will open a separate cherry pick PR to release-0.3 to fix clusterctl v0.3.x.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4856 
