### PR TITLE
🌱  Add v1alpha4 to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,5 +6,8 @@
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 releaseSeries:
   - major: 0
+    minor: 4
+    contract: v1alpha4
+  - major: 0
     minor: 3
     contract: v1alpha3


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Adds the v1alpha4 info to the metadata.yaml for clusterctl in release-0.3. Without this change, any new v0.3.x release will be detected as the "latest" Github release which will cause clusterctl v0.4.x to fetch its artifacts and then fail to find the right release series to use as the metadata doesn't contain useful information about the release series for the v1alpha4 contract.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #4856 