### PR TITLE
🐛 fix metric collection in e2e test

### DIFF
--- a/bootstrap/kubeadm/config/manager/manager.yaml
+++ b/bootstrap/kubeadm/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
         - /manager
         args:
         - "--leader-elect"
+        - "--metrics-bind-addr=localhost:8080"
         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}"
         image: controller:latest
         name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,7 @@ spec:
         - /manager
         args:
         - "--leader-elect"
+        - "--metrics-bind-addr=localhost:8080"
         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=false}"
         image: controller:latest
         name: manager

--- a/controlplane/kubeadm/config/manager/manager.yaml
+++ b/controlplane/kubeadm/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
         - /manager
         args:
         - "--leader-elect"
+        - "--metrics-bind-addr=localhost:8080"
         image: controller:latest
         name: manager
         ports:

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -37,6 +37,9 @@ providers:
       new: --metrics-addr=:8080
   - name: v0.4.99 # next; use manifest from source files
     value: ../../../config/default
+    replacements:
+    - old: --metrics-bind-addr=localhost:8080
+      new: --metrics-bind-addr=:8080
     files:
     - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
 
@@ -51,6 +54,9 @@ providers:
         new: --metrics-addr=:8080
   - name: v0.4.99 # next; use manifest from source files
     value: ../../../bootstrap/kubeadm/config/default
+    replacements:
+    - old: --metrics-bind-addr=localhost:8080
+      new: --metrics-bind-addr=:8080
     files:
     - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
 
@@ -65,6 +71,9 @@ providers:
         new: --metrics-addr=:8080
   - name: v0.4.99 # next; use manifest from source files
     value: ../../../controlplane/kubeadm/config/default
+    replacements:
+    - old: --metrics-bind-addr=localhost:8080
+      new: --metrics-bind-addr=:8080
     files:
     - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
 
@@ -82,6 +91,9 @@ providers:
       - sourcePath: "../data/infrastructure-docker/v1alpha3/cluster-template.yaml"
   - name: v0.4.99 # next; use manifest from source files
     value: ../../../test/infrastructure/docker/config/default
+    replacements:
+    - old: --metrics-bind-addr=localhost:8080
+      new: --metrics-bind-addr=:8080
     files:
     # Add cluster templates
     - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template.yaml"

--- a/test/infrastructure/docker/config/manager/manager.yaml
+++ b/test/infrastructure/docker/config/manager/manager.yaml
@@ -18,6 +18,7 @@ spec:
       containers:
       - args:
         - "--leader-elect"
+        - "--metrics-bind-addr=localhost:8080"
         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}"
         image: controller:latest
         name: manager


### PR DESCRIPTION
During the removal of kube-rbac-proxy the e2e test metric collection
broke. The easiest way to fix it is to set the default value of the
metrics-bind-addr in our manager.yaml files and then replace it via our
e2e test framework.

Signed-off-by: Stefan Büringer buringerst@vmware.com

**What this PR does / why we need it**:
See linked issue

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4794
