### PR TITLE
🐛  fix golangci-lint nolint:ifshort

### DIFF
--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -273,7 +273,7 @@ func (r *MachineReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 	log := ctrl.LoggerFrom(ctx, "cluster", cluster.Name)
 
 	err := r.isDeleteNodeAllowed(ctx, cluster, m)
-	isDeleteNodeAllowed := err == nil // nolint:ifshort
+	isDeleteNodeAllowed := err == nil //nolint:ifshort
 	if err != nil {
 		switch err {
 		case errNoControlPlaneNodes, errLastControlPlaneNode, errNilNodeRef, errClusterIsBeingDeleted, errControlPlaneIsBeingDeleted:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

**What this PR does / why we need it**:
I just set up my local environment on mac and got the following error:
```bash
controllers/machine_controller.go:276:36: directive `// nolint:ifshort` is unused for linter "ifshort" (nolintlint)
isDeleteNodeAllowed := err == nil // nolint:ifshort
```
When I remove the `nolint` I get a finding of the `ifshort` linter, so we definitely need the `nolint`. I'm not sure why we don't get the error in CI but apparently all our other `nolint`'s don't have a space between `//` and `nolint`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
