### PR TITLE
 🌱  Upgrade quickstart and e2e tests to Kubernetes v1.21.2

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -593,7 +593,7 @@ For the purpose of this tutorial, we'll name our cluster capi-quickstart.
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.19.11 \
+  --kubernetes-version v1.21.2 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -612,7 +612,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.19.11 \
+  --kubernetes-version v1.21.2 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -672,7 +672,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                            INITIALIZED   API SERVER AVAILABLE   VERSION   REPLICAS   READY   UPDATED   UNAVAILABLE
-capi-quickstart-control-plane   true                                 v1.19.11   3                  3         3
+capi-quickstart-control-plane   true                                 v1.21.2   3                  3         3
 ```
 
 <aside class="note warning">

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -110,11 +110,11 @@ providers:
 variables:
   # default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
-  KUBERNETES_VERSION: "v1.19.11"
-  ETCD_VERSION_UPGRADE_TO: "3.4.9-0"
-  COREDNS_VERSION_UPGRADE_TO: "1.7.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.19.11"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.18.19"
+  KUBERNETES_VERSION: "v1.21.2"
+  ETCD_VERSION_UPGRADE_TO: "3.4.13-0"
+  COREDNS_VERSION_UPGRADE_TO: "1.8.4"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.21.2"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.20.7"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "IPv4"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// DefaultNodeImage is the default node image to be used for for testing.
-	DefaultNodeImage = "kindest/node:v1.19.11"
+	DefaultNodeImage = "kindest/node:v1.21.2"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/framework/machine_helpers.go
+++ b/test/framework/machine_helpers.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/test/framework/internal/log"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -114,7 +115,7 @@ type WaitForControlPlaneMachinesToBeUpgradedInput struct {
 	MachineCount             int
 }
 
-// WaitForControlPlaneMachinesToBeUpgraded waits until all machines are upgraded to the correct kubernetes version.
+// WaitForControlPlaneMachinesToBeUpgraded waits until all machines are upgraded to the correct Kubernetes version.
 func WaitForControlPlaneMachinesToBeUpgraded(ctx context.Context, input WaitForControlPlaneMachinesToBeUpgradedInput, intervals ...interface{}) {
 	Expect(ctx).NotTo(BeNil(), "ctx is required for WaitForControlPlaneMachinesToBeUpgraded")
 	Expect(input.Lister).ToNot(BeNil(), "Invalid argument. input.Lister can't be nil when calling WaitForControlPlaneMachinesToBeUpgraded")
@@ -132,7 +133,8 @@ func WaitForControlPlaneMachinesToBeUpgraded(ctx context.Context, input WaitForC
 
 		upgraded := 0
 		for _, machine := range machines {
-			if *machine.Spec.Version == input.KubernetesUpgradeVersion {
+			m := machine
+			if *m.Spec.Version == input.KubernetesUpgradeVersion && conditions.IsTrue(&m, clusterv1.MachineNodeHealthyCondition) {
 				upgraded++
 			}
 		}

--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -482,6 +482,15 @@ func (d *docker) RunContainer(ctx context.Context, runConfig *RunContainerInput,
 		}
 	}
 
+	containerJSON, err := d.dockerClient.ContainerInspect(ctx, resp.ID)
+	if err != nil {
+		return fmt.Errorf("error inspecting container %s: %v", resp.ID, err)
+	}
+
+	if containerJSON.ContainerJSONBase.State.ExitCode != 0 {
+		return fmt.Errorf("error container run failed with exit code %d", containerJSON.ContainerJSONBase.State.ExitCode)
+	}
+
 	return nil
 }
 

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -29,7 +29,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.19.11
+  version: v1.21.2
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -86,7 +86,7 @@ spec:
         kind: DockerMachinePool
         name: worker-dmp-0
         namespace: default
-      version: v1.19.11
+      version: v1.21.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: DockerMachinePool

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.19.11
+  version: v1.21.2
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -120,7 +120,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.19.11
+      version: v1.21.2
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -38,7 +38,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.19.11
+  version: v1.21.2
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -106,7 +106,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.19.11
+      version: v1.21.2
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.19.11
+  version: v1.21.2
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -105,7 +105,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.19.11
+      version: v1.21.2
       clusterName: my-cluster
       bootstrap:
         configRef:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
> I'm +1 to jump to a newer releases in the quick-start and in the e2e; ideally we should stay in lockstep with K8s.
If we are going for 1.21 let's jump to the .2 path release, because it contains the fix for CoreDNS image and for etcd ephemeral storage.
> https://github.com/kubernetes-sigs/cluster-api/pull/4898#discussion_r666776466

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
