### PR TITLE
🐛 e2e tests: fix fix-kubeconfig for mac

### DIFF
--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -317,7 +317,8 @@ func (p *clusterProxy) fixConfig(ctx context.Context, name string, config *api.C
 	containerRuntime, err := container.NewDockerClient()
 	Expect(err).ToNot(HaveOccurred(), "Failed to get Docker runtime client")
 
-	port, err := containerRuntime.GetHostPort(ctx, name, "6443/tcp")
+	lbContainerName := name + "-lb"
+	port, err := containerRuntime.GetHostPort(ctx, lbContainerName, "6443/tcp")
 	Expect(err).ToNot(HaveOccurred(), "Failed to get load balancer port")
 
 	controlPlaneURL := &url.URL{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
I guess this got lost during the refactoring. We have to calculate the lb container name based on the cluster name by appending `-lb`. This only affected certain e2e tests on MacOS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/cc @stmcginnis (just fyi)
