### PR TITLE
fix: provider ID should use full ID for comparison

### DIFF
--- a/controllers/noderefutil/providerid_test.go
+++ b/controllers/noderefutil/providerid_test.go
@@ -22,7 +22,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const aws = "aws"
+const (
+	aws   = "aws"
+	azure = "azure"
+)
 
 func TestNewProviderID(t *testing.T) {
 	tests := []struct {
@@ -115,7 +118,7 @@ func TestInvalidProviderID(t *testing.T) {
 func TestProviderIDEquals(t *testing.T) {
 	g := NewWithT(t)
 
-	input1 := "aws:////instance-id1"
+	input1 := "aws:////us-west-1/instance-id1"
 	parsed1, err := NewProviderID(input1)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(parsed1.String()).To(Equal(input1))
@@ -129,5 +132,32 @@ func TestProviderIDEquals(t *testing.T) {
 	g.Expect(parsed2.ID()).To(Equal("instance-id1"))
 	g.Expect(parsed2.CloudProvider()).To(Equal(aws))
 
+	input3 := "aws:////instance-id1"
+	parsed3, err := NewProviderID(input3)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(parsed3.String()).To(Equal(input3))
+	g.Expect(parsed3.ID()).To(Equal("instance-id1"))
+	g.Expect(parsed3.CloudProvider()).To(Equal(aws))
+
 	g.Expect(parsed1.Equals(parsed2)).To(BeTrue())
+	g.Expect(parsed1.Equals(parsed3)).To(BeFalse())
+	g.Expect(parsed2.Equals(parsed3)).To(BeFalse())
+
+	input4 := "azure:///subscriptions/foo/resourceGroups/bar/providers/Microsoft.Compute/virtualMachineScaleSets/agentpool0/virtualMachines/0"
+	parsed4, err := NewProviderID(input4)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(parsed4.String()).To(Equal(input4))
+	g.Expect(parsed4.ID()).To(Equal("0"))
+	g.Expect(parsed4.Normalized()).To(Equal("subscriptions/foo/resourceGroups/bar/providers/Microsoft.Compute/virtualMachineScaleSets/agentpool0/virtualMachines/0"))
+	g.Expect(parsed4.CloudProvider()).To(Equal(azure))
+
+	input5 := "azure:///subscriptions/foo/resourceGroups/bar/providers/Microsoft.Compute/virtualMachineScaleSets/agentpool1/virtualMachines/0"
+	parsed5, err := NewProviderID(input2)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(parsed5.String()).To(Equal(input5))
+	g.Expect(parsed5.ID()).To(Equal("0"))
+	g.Expect(parsed5.Normalized()).To(Equal("subscriptions/foo/resourceGroups/bar/providers/Microsoft.Compute/virtualMachineScaleSets/agentpool1/virtualMachines/0"))
+	g.Expect(parsed5.CloudProvider()).To(Equal(azure))
+
+	g.Expect(parsed4.Equals(parsed5)).To(BeFalse())
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Provider ID comparisons for machine pools work a bit poorly right now. 1 Azure VMSS (read: ASG) corresponds to 1 CAPI MachinePool. Within a VMSS, instance IDs are numeric and unique. Between multiple VMSS, instance IDs are reused.

The current logic in machinepool node ref controller (below) lists **all** nodes, and then compares them using the provider ID package to the list of providerIDs from a specific machine pool. 

Because instance IDs are not unique across VMSS, and the noderef controller doesn't filter nodes first to only those in the machine pools, the logic matches node refs to VMs from the wrong VMSS. 

This PR fixes the provider ID logic to perform a comparison on the **full** provider ID, removing all leading slashes and the colon, but keeping everything else.

n.b.: this changed behavior for one of the AWS providerID tests, where one providerID included region and one didn't, but I think that is correct (they should only be equal if they differ in number of slashes). Would appreciate input from CAPA folks there.

https://github.com/kubernetes-sigs/cluster-api/blob/37c862b5c9256d7ae65cd8ee8ddd7a103d51fe90/exp/controllers/machinepool_controller_noderef.go#L179-L221

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1503
