### PR TITLE
🐛 Fix the observedGeneration update

### DIFF
--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -235,6 +235,7 @@ func patchKubeadmControlPlane(ctx context.Context, patchHelper *patch.Helper, kc
 			controlplanev1.AvailableCondition,
 			controlplanev1.CertificatesAvailableCondition,
 		}},
+		patch.WithStatusObservedGeneration{},
 	)
 }
 

--- a/controlplane/kubeadm/controllers/controller_test.go
+++ b/controlplane/kubeadm/controllers/controller_test.go
@@ -174,6 +174,61 @@ func TestClusterToKubeadmControlPlaneOtherControlPlane(t *testing.T) {
 	g.Expect(got).To(BeNil())
 }
 
+func TestReconcileUpdateObservedGeneration(t *testing.T) {
+	g := NewWithT(t)
+	r := &KubeadmControlPlaneReconciler{
+		Client:            testEnv,
+		recorder:          record.NewFakeRecorder(32),
+		managementCluster: &internal.Management{Client: testEnv.Client},
+		Log:               log.NullLogger{},
+	}
+	ctx := context.TODO()
+
+	cluster, kcp, _ := createClusterWithControlPlane()
+	g.Expect(testEnv.CreateObj(ctx, cluster)).To(Succeed())
+	g.Expect(testEnv.CreateObj(ctx, kcp)).To(Succeed())
+
+	// read kcp.Generation after create
+	errGettingObject := testEnv.Get(ctx, util.ObjectKey(kcp), kcp)
+	g.Expect(errGettingObject).NotTo(HaveOccurred())
+	generation := kcp.Generation
+
+	// Set cluster.status.InfrastructureReady so we actually enter in the reconcile loop
+	patch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"status\":{\"infrastructureReady\":%t}}", true)))
+	g.Expect(testEnv.Status().Patch(ctx, cluster, patch)).To(Succeed())
+
+	// call reconcile the first time, so we can check if observedGeneration is set when adding a finalizer
+	result, err := r.Reconcile(ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Eventually(func() int64 {
+		errGettingObject = testEnv.Get(ctx, util.ObjectKey(kcp), kcp)
+		g.Expect(errGettingObject).NotTo(HaveOccurred())
+		return kcp.Status.ObservedGeneration
+	}, 10*time.Second).Should(Equal(generation))
+
+	// triggers a generation change by changing the spec
+	kcp.Spec.Replicas = pointer.Int32Ptr(*kcp.Spec.Replicas + 2)
+	g.Expect(testEnv.Update(ctx, kcp)).To(Succeed())
+
+	// read kcp.Generation after the update
+	errGettingObject = testEnv.Get(ctx, util.ObjectKey(kcp), kcp)
+	g.Expect(errGettingObject).NotTo(HaveOccurred())
+	generation = kcp.Generation
+
+	// call reconcile the second time, so we can check if observedGeneration is set when calling defer patch
+	// NB. The call to reconcile fails because KCP is not properly setup (e.g. missing InfrastructureTemplate)
+	// but this is not important because what we want is KCP to be patched
+	_, _ = r.Reconcile(ctrl.Request{NamespacedName: util.ObjectKey(kcp)})
+
+	g.Eventually(func() int64 {
+		errGettingObject = testEnv.Get(ctx, util.ObjectKey(kcp), kcp)
+		g.Expect(errGettingObject).NotTo(HaveOccurred())
+		return kcp.Status.ObservedGeneration
+	}, 10*time.Second).Should(Equal(generation))
+}
+
 func TestReconcileNoClusterOwnerRef(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Patch `.status.observedGeneration` properly for KCP objects.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4864 
