### PR TITLE
🐛 clusterctl: use newest release series of same contract

### DIFF
--- a/cmd/clusterctl/api/v1alpha3/metadata_type_test.go
+++ b/cmd/clusterctl/api/v1alpha3/metadata_type_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1alpha3
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetReleaseSeriesForContract(t *testing.T) {
+	rsSinglePerContract := []ReleaseSeries{
+		{Major: 0, Minor: 4, Contract: "v1alpha4"},
+		{Major: 0, Minor: 3, Contract: "v1alpha3"},
+	}
+
+	rsMultiplePerContract := []ReleaseSeries{
+		{Major: 0, Minor: 4, Contract: "v1alpha4"},
+		{Major: 0, Minor: 5, Contract: "v1alpha4"},
+		{Major: 0, Minor: 3, Contract: "v1alpha3"},
+	}
+
+	tests := []struct {
+		name                  string
+		contract              string
+		releaseSeries         []ReleaseSeries
+		expectedReleaseSeries *ReleaseSeries
+	}{
+		{
+			name:                  "Should get the release series with matching contract",
+			contract:              "v1alpha4",
+			releaseSeries:         rsSinglePerContract,
+			expectedReleaseSeries: &rsMultiplePerContract[0],
+		},
+		{
+			name:                  "Should get the newest release series with matching contract",
+			contract:              "v1alpha4",
+			releaseSeries:         rsMultiplePerContract,
+			expectedReleaseSeries: &rsMultiplePerContract[1],
+		},
+		{
+			name:                  "Should return nil if no release series with matching contract is found",
+			contract:              "v1alpha5",
+			releaseSeries:         rsMultiplePerContract,
+			expectedReleaseSeries: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			m := &Metadata{ReleaseSeries: test.releaseSeries}
+			g.Expect(m.GetReleaseSeriesForContract(test.contract)).To(Equal(test.expectedReleaseSeries))
+		})
+	}
+}

--- a/cmd/clusterctl/client/repository/repository_github_test.go
+++ b/cmd/clusterctl/client/repository/repository_github_test.go
@@ -291,16 +291,17 @@ func Test_gitHubRepository_getLatestContractRelease(t *testing.T) {
 	mux.HandleFunc("/repos/o/r1/releases", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[`)
-		fmt.Fprint(w, `{"id":1, "tag_name": "v0.4.0", "assets": [{"id": 1, "name": "metadata.yaml"}]},`)
-		fmt.Fprint(w, `{"id":2, "tag_name": "v0.3.2", "assets": [{"id": 1, "name": "metadata.yaml"}]},`)
-		fmt.Fprint(w, `{"id":3, "tag_name": "v0.3.1", "assets": [{"id": 1, "name": "metadata.yaml"}]}`)
+		fmt.Fprint(w, `{"id":1, "tag_name": "v0.5.0", "assets": [{"id": 1, "name": "metadata.yaml"}]},`)
+		fmt.Fprint(w, `{"id":2, "tag_name": "v0.4.0", "assets": [{"id": 1, "name": "metadata.yaml"}]},`)
+		fmt.Fprint(w, `{"id":3, "tag_name": "v0.3.2", "assets": [{"id": 1, "name": "metadata.yaml"}]},`)
+		fmt.Fprint(w, `{"id":4, "tag_name": "v0.3.1", "assets": [{"id": 1, "name": "metadata.yaml"}]}`)
 		fmt.Fprint(w, `]`)
 	})
 
 	// test.NewFakeGitHub and handler for returning a fake release
-	mux.HandleFunc("/repos/o/r1/releases/tags/v0.4.0", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/repos/o/r1/releases/tags/v0.5.0", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		fmt.Fprint(w, `{"id":13, "tag_name": "v0.4.0", "assets": [{"id": 1, "name": "metadata.yaml"}] }`)
+		fmt.Fprint(w, `{"id":13, "tag_name": "v0.5.0", "assets": [{"id": 1, "name": "metadata.yaml"}] }`)
 	})
 
 	// test.NewFakeGitHub an handler for returning a fake release metadata file
@@ -308,7 +309,7 @@ func Test_gitHubRepository_getLatestContractRelease(t *testing.T) {
 		testMethod(t, r, "GET")
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Disposition", "attachment; filename=metadata.yaml")
-		fmt.Fprint(w, "apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3\nreleaseSeries:\n  - major: 0\n    minor: 4\n    contract: v1alpha4\n  - major: 0\n    minor: 3\n    contract: v1alpha3\n")
+		fmt.Fprint(w, "apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3\nreleaseSeries:\n  - major: 0\n    minor: 4\n    contract: v1alpha4\n  - major: 0\n    minor: 5\n    contract: v1alpha4\n  - major: 0\n    minor: 3\n    contract: v1alpha3\n")
 	})
 
 	configVariablesClient := test.NewFakeVariableClient()
@@ -329,7 +330,7 @@ func Test_gitHubRepository_getLatestContractRelease(t *testing.T) {
 				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/latest/path", clusterctlv1.CoreProviderType),
 			},
 			contract: "v1alpha4",
-			want:     "v0.4.0",
+			want:     "v0.5.0",
 			wantErr:  false,
 		},
 		{
@@ -346,7 +347,7 @@ func Test_gitHubRepository_getLatestContractRelease(t *testing.T) {
 			field: field{
 				providerConfig: config.NewProvider("test", "https://github.com/o/r1/releases/latest/path", clusterctlv1.CoreProviderType),
 			},
-			want:     "v0.4.0",
+			want:     "v0.5.0",
 			contract: "foo",
 			wantErr:  false,
 		},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Backport https://github.com/kubernetes-sigs/cluster-api/pull/4912 to release-0.3

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4889 
