### PR TITLE
🐛 fix DefaultValidateTest ensuring old object gets defaulted too

### DIFF
--- a/util/defaulting/defaulting.go
+++ b/util/defaulting/defaulting.go
@@ -49,6 +49,7 @@ func DefaultValidateTest(object DefaultingValidator) func(*testing.T) {
 		t.Run("validate-on-update", func(t *testing.T) {
 			g := gomega.NewWithT(t)
 			defaultingUpdateCopy.Default()
+			updateCopy.Default()
 			g.Expect(defaultingUpdateCopy.ValidateUpdate(updateCopy)).To(gomega.Succeed())
 		})
 		t.Run("validate-on-delete", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
fix DefaultValidateTest ensuring that defauting web hooks are consistent with validation web hooks.

In order to do so, the func takes an object and passes it to the defaulting and validation web hooks; for the upgrade web hook the object is used both as current and old value, however old value is not defaulted (as it will happen in the real system).

This PR fixes this ensuring that both  current and old value are defaulted before calling the validate upgrade webhook

**Which issue(s) this PR fixes**:
Fixes #
