### PR TITLE
⚠️   clusterctl init: wait for deployments to be ready

### DIFF
--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"sort"
+	"time"
 
 	"github.com/pkg/errors"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
@@ -57,6 +58,12 @@ type InitOptions struct {
 
 	// LogUsageInstructions instructs the init command to print the usage instructions in case of first run.
 	LogUsageInstructions bool
+
+	// WaitProviders instructs the init command to wait till the providers are installed.
+	WaitProviders bool
+
+	// WaitProviderTimeout sets the timeout per provider wait installation
+	WaitProviderTimeout time.Duration
 
 	// SkipTemplateProcess allows for skipping the call to the template processor, including also variable replacement in the component YAML.
 	// NOTE this works only if the rawYaml is a valid yaml by itself, like e.g when using envsubst/the simple processor.
@@ -109,7 +116,11 @@ func (c *clusterctlClient) Init(options InitOptions) ([]Components, error) {
 		return nil, err
 	}
 
-	components, err := installer.Install()
+	installOpts := cluster.InstallOptions{
+		WaitProviders:       options.WaitProviders,
+		WaitProviderTimeout: options.WaitProviderTimeout,
+	}
+	components, err := installer.Install(installOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
@@ -32,6 +33,8 @@ type initOptions struct {
 	infrastructureProviders []string
 	targetNamespace         string
 	listImages              bool
+	waitProviders           bool
+	waitProviderTimeout     int
 }
 
 var initOpts = &initOptions{}
@@ -100,6 +103,10 @@ func init() {
 		"Control plane providers and versions (e.g. kubeadm:v0.3.0) to add to the management cluster. If unspecified, the Kubeadm control plane provider's latest release is used.")
 	initCmd.Flags().StringVar(&initOpts.targetNamespace, "target-namespace", "",
 		"The target namespace where the providers should be deployed. If unspecified, the provider components' default namespace is used.")
+	initCmd.Flags().BoolVar(&initOpts.waitProviders, "wait-providers", false,
+		"Wait for providers to be installed.")
+	initCmd.Flags().IntVar(&initOpts.waitProviderTimeout, "wait-provider-timeout", 5*60,
+		"Wait timeout per provider installation in seconds. This value is ignored if --wait-providers is false")
 
 	// TODO: Move this to a sub-command or similar, it shouldn't really be a flag.
 	initCmd.Flags().BoolVar(&initOpts.listImages, "list-images", false,
@@ -122,6 +129,8 @@ func runInit() error {
 		InfrastructureProviders: initOpts.infrastructureProviders,
 		TargetNamespace:         initOpts.targetNamespace,
 		LogUsageInstructions:    true,
+		WaitProviders:           initOpts.waitProviders,
+		WaitProviderTimeout:     time.Duration(initOpts.waitProviderTimeout) * time.Second,
 	}
 
 	if initOpts.listImages {

--- a/cmd/clusterctl/internal/util/objs_test.go
+++ b/cmd/clusterctl/internal/util/objs_test.go
@@ -22,7 +22,11 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func Test_inspectImages(t *testing.T) {
@@ -267,6 +271,95 @@ func TestFixImages(t *testing.T) {
 			gotImages, err := InspectImages(got)
 			g.Expect(err).NotTo(HaveOccurred())
 			g.Expect(gotImages).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestIsDeploymentWithManager(t *testing.T) {
+	convertor := runtime.DefaultUnstructuredConverter
+
+	depManagerContainer := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "manager-deployment",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: controllerContainerName}},
+				},
+			},
+		},
+	}
+	depManagerContainerObj, err := convertor.ToUnstructured(depManagerContainer)
+	if err != nil {
+		t.Fatalf("failed to construct unstructured object of %v: %v", depManagerContainer, err)
+	}
+
+	depNOManagerContainer := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "not-manager-deployment",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "not-manager"}},
+				},
+			},
+		},
+	}
+	depNOManagerContainerObj, err := convertor.ToUnstructured(depNOManagerContainer)
+	if err != nil {
+		t.Fatalf("failed to construct unstructured object of %v : %v", depNOManagerContainer, err)
+	}
+
+	svc := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-service",
+		},
+	}
+	svcObj, err := convertor.ToUnstructured(svc)
+	if err != nil {
+		t.Fatalf("failed to construct unstructured object of %v : %v", svc, err)
+	}
+
+	tests := []struct {
+		name     string
+		obj      unstructured.Unstructured
+		expected bool
+	}{
+		{
+			name:     "deployment with manager container",
+			obj:      unstructured.Unstructured{Object: depManagerContainerObj},
+			expected: true,
+		},
+		{
+			name:     "deployment without manager container",
+			obj:      unstructured.Unstructured{Object: depNOManagerContainerObj},
+			expected: false,
+		},
+		{
+			name:     "not a deployment",
+			obj:      unstructured.Unstructured{Object: svcObj},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+			actual := IsDeploymentWithManager(test.obj)
+			g.Expect(actual).To(Equal(test.expected))
 		})
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
`clusterctl init` should wait for the cluster to be 'ready' before exiting.
This includes:
- [x] All the CAP* deployments should be ready
- [ ] ~All the CAP* services should be ready~ (NOT implementing this - kind of addressed in https://github.com/kubernetes-sigs/cluster-api/pull/4989)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4474 
