### PR TITLE
🐛 validate namespace of MHC remediation template

### DIFF
--- a/api/v1alpha4/machinehealthcheck_webhook.go
+++ b/api/v1alpha4/machinehealthcheck_webhook.go
@@ -77,6 +77,10 @@ func (m *MachineHealthCheck) Default() {
 	if m.Spec.NodeStartupTimeout == nil {
 		m.Spec.NodeStartupTimeout = &DefaultNodeStartupTimeout
 	}
+
+	if m.Spec.RemediationTemplate != nil && len(m.Spec.RemediationTemplate.Namespace) == 0 {
+		m.Spec.RemediationTemplate.Namespace = m.Namespace
+	}
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
@@ -147,6 +151,17 @@ func (m *MachineHealthCheck) validate(old *MachineHealthCheck) error {
 				field.Invalid(field.NewPath("spec", "maxUnhealthy"), m.Spec.MaxUnhealthy, fmt.Sprintf("must be either an int or a percentage: %v", err.Error())),
 			)
 		}
+	}
+
+	if m.Spec.RemediationTemplate != nil && m.Spec.RemediationTemplate.Namespace != m.Namespace {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				field.NewPath("spec", "remediationTemplate", "namespace"),
+				m.Spec.RemediationTemplate.Namespace,
+				"must match metadata.namespace",
+			),
+		)
 	}
 
 	if len(allErrs) == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Extends the validation webhook of MachineHealthCheck to ensure that the namespace of the MHC and its RemediationWebhook are identical.
It also defaults the namespace of the RemediationWebhook to the namespace of the MHC so it can be omitted (same as a lot of other resources).

The namespace set in the reference [is ignored](https://github.com/kubernetes-sigs/cluster-api/blob/master/controllers/machinehealthcheck_controller.go#L370), that's why it shouldn't be allowed to be different from the MHC's namespace.

**Which issue(s) this PR fixes**:
Fixes #4943 
