### PR TITLE
🐛 Drop aggressive requeue=true and find machines to nodes by providerID

### DIFF
--- a/api/v1alpha4/common_types.go
+++ b/api/v1alpha4/common_types.go
@@ -102,6 +102,10 @@ var (
 const (
 	// MachineNodeNameIndex is used by the Machine Controller to index Machines by Node name, and add a watch on Nodes.
 	MachineNodeNameIndex = "status.nodeRef.name"
+
+	// MachineProviderIDIndex is used to index Machines by ProviderID. It's useful to find Machines
+	// in a management cluster from Nodes in a workload cluster.
+	MachineProviderIDIndex = "spec.providerID"
 )
 
 // MachineAddressType describes a valid MachineAddress type.

--- a/controllers/machine_controller_noderef.go
+++ b/controllers/machine_controller_noderef.go
@@ -70,7 +70,8 @@ func (r *MachineReconciler) reconcileNode(ctx context.Context, cluster *clusterv
 				return ctrl.Result{}, errors.Wrapf(err, "no matching Node for Machine %q in namespace %q", machine.Name, machine.Namespace)
 			}
 			conditions.MarkFalse(machine, clusterv1.MachineNodeHealthyCondition, clusterv1.NodeProvisioningReason, clusterv1.ConditionSeverityWarning, "")
-			return ctrl.Result{Requeue: true}, nil
+			// No need to requeue here. Nodes emit an event that triggers reconciliation.
+			return ctrl.Result{}, nil
 		}
 		log.Error(err, "Failed to retrieve Node by ProviderID")
 		r.recorder.Event(machine, corev1.EventTypeWarning, "Failed to retrieve Node by ProviderID", err.Error())

--- a/controllers/noderefutil/indexer.go
+++ b/controllers/noderefutil/indexer.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,7 +42,7 @@ func AddMachineNodeIndex(ctx context.Context, mgr ctrl.Manager) error {
 		clusterv1.MachineNodeNameIndex,
 		indexMachineByNodeName,
 	); err != nil {
-		return errors.Wrap(err, "error setting index fields")
+		return errors.Wrap(err, "error setting index field")
 	}
 
 	return nil
@@ -65,14 +66,46 @@ func IndexNodeByProviderID(o client.Object) []string {
 		panic(fmt.Sprintf("Expected a Node but got a %T", o))
 	}
 
-	if node.Spec.ProviderID != "" {
-		providerID, err := NewProviderID(node.Spec.ProviderID)
-		if err != nil {
-			// Failed to create providerID, skipping.
-			return nil
-		}
-		return []string{providerID.IndexKey()}
+	if node.Spec.ProviderID == "" {
+		return nil
+	}
+
+	providerID, err := NewProviderID(node.Spec.ProviderID)
+	if err != nil {
+		// Failed to create providerID, skipping.
+		return nil
+	}
+	return []string{providerID.IndexKey()}
+}
+
+// AddMachineProviderIDIndex adds the machine providerID index to the
+// managers cache.
+func AddMachineProviderIDIndex(ctx context.Context, mgr ctrl.Manager) error {
+	if err := mgr.GetCache().IndexField(ctx, &clusterv1.Machine{},
+		clusterv1.MachineProviderIDIndex,
+		IndexMachineByProviderID,
+	); err != nil {
+		return errors.Wrap(err, "error setting index field")
 	}
 
 	return nil
+}
+
+// IndexMachineByProviderID contains the logic to index Machines by ProviderID.
+func IndexMachineByProviderID(o client.Object) []string {
+	machine, ok := o.(*clusterv1.Machine)
+	if !ok {
+		panic(fmt.Sprintf("Expected a Machine but got a %T", o))
+	}
+
+	if pointer.StringDeref(machine.Spec.ProviderID, "") == "" {
+		return nil
+	}
+
+	providerID, err := NewProviderID(*machine.Spec.ProviderID)
+	if err != nil {
+		// Failed to create providerID, skipping.
+		return nil
+	}
+	return []string{providerID.IndexKey()}
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -53,7 +53,12 @@ func TestMain(m *testing.M) {
 
 	// Set up the MachineNodeIndex
 	if err := noderefutil.AddMachineNodeIndex(ctx, env.Manager); err != nil {
-		panic(fmt.Sprintf("undable to setup machine node index: %v", err))
+		panic(fmt.Sprintf("unable to setup machine node index: %v", err))
+	}
+
+	// Set up the MachineProviderIDIndex
+	if err := noderefutil.AddMachineProviderIDIndex(ctx, env.Manager); err != nil {
+		panic(fmt.Sprintf("unable to setup machine providerID index: %v", err))
 	}
 
 	// Set up a ClusterCacheTracker and ClusterCacheReconciler to provide to controllers

--- a/exp/addons/controllers/suite_test.go
+++ b/exp/addons/controllers/suite_test.go
@@ -43,7 +43,12 @@ func TestMain(m *testing.M) {
 
 	// Set up the MachineNodeIndex
 	if err := noderefutil.AddMachineNodeIndex(ctx, env.Manager); err != nil {
-		panic(fmt.Sprintf("undable to setup machine node index: %v", err))
+		panic(fmt.Sprintf("unable to setup machine node index: %v", err))
+	}
+
+	// Set up the MachineProviderIDIndex
+	if err := noderefutil.AddMachineProviderIDIndex(ctx, env.Manager); err != nil {
+		panic(fmt.Sprintf("unable to setup machine providerID index: %v", err))
 	}
 
 	trckr, err := remote.NewClusterCacheTracker(env.Manager, remote.ClusterCacheTrackerOptions{})

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -39,7 +39,12 @@ func TestMain(m *testing.M) {
 
 	// Set up the MachineNodeIndex
 	if err := noderefutil.AddMachineNodeIndex(ctx, env.Manager); err != nil {
-		panic(fmt.Sprintf("undable to setup machine node index: %v", err))
+		panic(fmt.Sprintf("unable to setup machine node index: %v", err))
+	}
+
+	// Set up the MachineProviderIDIndex
+	if err := noderefutil.AddMachineProviderIDIndex(ctx, env.Manager); err != nil {
+		panic(fmt.Sprintf("unable to setup machine providerID index: %v", err))
 	}
 
 	machinePoolReconciler := MachinePoolReconciler{

--- a/main.go
+++ b/main.go
@@ -230,6 +230,11 @@ func setupIndexes(ctx context.Context, mgr ctrl.Manager) {
 		setupLog.Error(err, "unable to setup index")
 		os.Exit(1)
 	}
+
+	if err := noderefutil.AddMachineProviderIDIndex(ctx, mgr); err != nil {
+		setupLog.Error(err, "unable to setup index")
+		os.Exit(1)
+	}
 }
 
 func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Problem:
There's a lag between the nodes coming up and the machine nodeRef being set.

Causes:
The aggressive requeue=true whe a node is not found [1] results in exponential backoff for the controller.
The nodeToMachine function relies on the nodeRef [2] resulting in a chicken-egg issue.

Solution:
Stop aggressive requeue=true.
Let nodeToMachine find machines to nodes by providerID.

Result:
When the node shows up, it triggers a an event.
machineToNode maps the Node to a Machine.
The nodeRef is set immediately after the Node shows up.

[1] https://github.com/kubernetes-sigs/cluster-api/blob/70e959802aa7722efefe69158e868d7ff3eec4be/controllers/machine_controller_noderef.go#L74
[2] https://github.com/kubernetes-sigs/cluster-api/blob/37c862b5c9256d7ae65cd8ee8ddd7a103d51fe90/controllers/machine_controller.go#L643

Fixes #4946
Fixes #4447

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
