### PR TITLE
🌱  Extend the ControlPlane contract defining version and infrastructure machine fields for ClusterClass compat

### DIFF
--- a/docs/book/src/developer/architecture/controllers/control-plane.md
+++ b/docs/book/src/developer/architecture/controllers/control-plane.md
@@ -63,6 +63,35 @@ status: {}
 More information about the [scale subresource can be found in the Kubernetes
 documentation][scale].
 
+#### Required `spec` fields for implementations using version
+
+* `version` - is a string representing the Kubernetes version to be used
+  by the control plane machines. The value must be a valid semantic version;
+  also if the value provided by the user does not start with the v prefix, it
+  must be added.
+
+#### Required `spec` fields for implementations using Machines
+
+* `machineTemplate` - is a struct containing details of the control plane 
+  machine template.
+
+* `machineTemplate.metadata` - is a struct containing info about metadata for control plane
+  machines.
+
+* `machineTemplate.metadata.labels` - is a map of string keys and values that can be used 
+  to organize and categorize control plane machines.
+
+* `machineTemplate.metadata.annotations` - is a map of string keys and values containing
+  arbitrary metadata to be applied to control plane machines.
+
+* `machineTemplate.infrastructureRef` - is a corev1.ObjectReference to a custom resource
+  offered by an infrastructure provider. The namespace in the ObjectReference must
+  be in the same namespace of the control plane object. 
+
+* `machineTemplate.nodeDrainTimeout` - is a *metav1.Duration defining the total amount of time
+  that the controller will spend on draining a control plane node.
+  The default value is 0, meaning that the node can be drained without any time limitations.
+  
 #### Required `status` fields
 
 The `ImplementationControlPlane` object **must** have a `status` object.
@@ -168,6 +197,15 @@ following fields defined:
   </tr>
 </table>
 
+#### Required `status` fields for implementations using version
+
+* `version` - is a string representing the minimum Kubernetes version for the
+  control plane machines in the cluster.
+  NOTE: The minimum Kubernetes version, and more specifically the API server
+  version, will be used to determine when a control plane is fully upgraded
+  (`spec.version == status.version`) and for enforcing [Kubernetes version
+  skew policies](https://kubernetes.io/releases/version-skew-policy/) in managed topologies.
+  
 #### Optional `status` fields
 
 The `status` object **may** define several fields:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures the control plane contract documents fields that will be used by the ClusterClass for handling
- the Kubernetes version for control plane machines
- control plane machines metadata
- control plane infrastructure templates.

NOTE: This field is a requirement for ClusterClass compatibility and doesn't necessarily apply to current provider offerings.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4948

