### PR TITLE
🌱 Use dl.k8s.io instead of hardcoded GCS URIs

### DIFF
--- a/docs/book/src/developer/providers/implementers-guide/overview.md
+++ b/docs/book/src/developer/providers/implementers-guide/overview.md
@@ -33,8 +33,8 @@ brew install kustomize
 
 ```bash
 # Install kubectl
-KUBECTL_VERSION=$(curl -sf https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-curl -fLO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+KUBECTL_VERSION=$(curl -sf https://dl.k8s.io/release/stable.txt)
+curl -fLO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 
 # Install kustomize
 OS_TYPE=linux

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -31,7 +31,7 @@ verify_kubectl_version() {
         mkdir -p "${GOPATH_BIN}"
       fi
       echo 'kubectl not found, installing'
-      curl -sLo "${GOPATH_BIN}/kubectl" https://storage.googleapis.com/kubernetes-release/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
+      curl -sLo "${GOPATH_BIN}/kubectl" https://dl.k8s.io/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
       chmod +x "${GOPATH_BIN}/kubectl"
     else
       echo "Missing required binary in path: kubectl"

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -87,9 +87,9 @@ k8s::resolveVersion() {
   fi
 
   if [[ "$version" =~ ^ci/ ]]; then
-    resolveVersion=$(curl -LsS "http://gcsweb.k8s.io/gcs/kubernetes-release-dev/ci/${version#ci/}.txt")
+    resolveVersion=$(curl -LsS "http://dl.k8s.io/ci/${version#ci/}.txt")
   else
-    resolveVersion=$(curl -LsS "http://gcsweb.k8s.io/gcs/kubernetes-release/release/${version}.txt")
+    resolveVersion=$(curl -LsS "http://dl.k8s.io/release/${version}.txt")
   fi
   echo "+ $variableName=\"$version\" resolved to \"$resolveVersion\""
 }

--- a/test/framework/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
+++ b/test/framework/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
@@ -74,7 +74,7 @@ if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
   echo "* testing CI version $${KUBERNETES_VERSION}"
   # Check for semver
   if [[ "$${KUBERNETES_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    CI_URL="https://storage.googleapis.com/kubernetes-release/release/$${KUBERNETES_VERSION}/bin/linux/amd64"
+    CI_URL="https://dl.k8s.io/release/$${KUBERNETES_VERSION}/bin/linux/amd64"
     VERSION_WITHOUT_PREFIX="$${KUBERNETES_VERSION#v}"
     export DEBIAN_FRONTEND=noninteractive
     # sometimes the network is not immediately available, so we have to retry the apt-get update
@@ -91,7 +91,7 @@ if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
       apt-get install -y "$${CI_PACKAGE}=$${PACKAGE_VERSION}"
     done
   else
-    CI_URL="https://storage.googleapis.com/k8s-release-dev/ci/$${KUBERNETES_VERSION}/bin/linux/amd64"
+    CI_URL="https://dl.k8s.io/ci/$${KUBERNETES_VERSION}/bin/linux/amd64"
     for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
       # Browser: https://console.cloud.google.com/storage/browser/k8s-release-dev?project=k8s-release-dev
       # e.g.: https://storage.googleapis.com/k8s-release-dev/ci/v1.21.0-beta.1.378+cf3374e43491c5/bin/linux/amd64/kubectl
@@ -103,8 +103,10 @@ if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
     systemctl restart kubelet
   fi
   for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-    # Browser: https://console.cloud.google.com/storage/browser/kubernetes-release?project=kubernetes-release
-    # e.g.: https://storage.googleapis.com/kubernetes-release/release/v1.20.4/bin/linux/amd64/kube-apiserver.tar
+    # Redirect: https://dl.k8s.io/release/{path}
+    # e.g. https://dl.k8s.io/release/v1.20.4/bin/linux/amd64/kube-apiserver.tar
+    # Browser: https://gcsweb.k8s.io/gcs/kubernetes-release/
+    # e.g. https://gcsweb.k8s.io/gcs/kubernetes-release/release/v1.20.4/bin/linux/amd64
     echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
     wget "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
     $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"

--- a/test/framework/kubernetesversions/versions.go
+++ b/test/framework/kubernetesversions/versions.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	ciVersionURL     = "https://dl.k8s.io/ci/latest.txt"
-	stableVersionURL = "https://storage.googleapis.com/kubernetes-release/release/stable-%d.%d.txt"
+	stableVersionURL = "https://dl.k8s.io/release/stable-%d.%d.txt"
 	tagPrefix        = "v"
 )
 

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Gets additional CAPD dependencies
 WORKDIR /tmp
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.2/bin/linux/amd64/kubectl && \
+RUN curl -LO https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Sort of a follow-on to https://github.com/kubernetes-sigs/cluster-api/pull/4420

The only time a kubernetes GCS bucket name should be showing up in a
hardcoded URI is if gsutil is being used (e.g. gsutil cp gs://foo/bar .)

Otherwise, for tools like curl or wget, dl.k8s.io is much nicer for us
as a project, since we can transparently change where that redirects to
without having to change code everywhere

These changes will mean no changes will be necessary to accommodate a
gs://kubernetes-release -> gs://k8s-release migration equivalent of the
CI migration we're going through right now
(https://github.com/kubernetes/k8s.io/issues/2318)

EDIT: this also catches one last mention of `kubernetes-release-dev` which I've called out in a review comment below

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #