### PR TITLE
🌱 Randomly generated namespace in controllers pkg tests

### DIFF
--- a/controllers/cluster_controller_test.go
+++ b/controllers/cluster_controller_test.go
@@ -23,25 +23,40 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	clusterReconcileNamespace = "test-cluster-reconcile"
 )
 
 func TestClusterReconciler(t *testing.T) {
+	ns, err := env.CreateNamespace(ctx, clusterReconcileNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := env.Delete(ctx, ns); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
 	t.Run("Should create a Cluster", func(t *testing.T) {
 		g := NewWithT(t)
 
 		instance := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test1-",
-				Namespace:    "default",
+				Namespace:    ns.Name,
 			},
 			Spec: clusterv1.ClusterSpec{},
 		}
@@ -70,7 +85,7 @@ func TestClusterReconciler(t *testing.T) {
 		cluster := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test2-",
-				Namespace:    "default",
+				Namespace:    ns.Name,
 			},
 		}
 		g.Expect(env.Create(ctx, cluster)).To(Succeed())
@@ -116,7 +131,7 @@ func TestClusterReconciler(t *testing.T) {
 		cluster := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test3-",
-				Namespace:    "default",
+				Namespace:    ns.Name,
 			},
 		}
 		g.Expect(env.Create(ctx, cluster)).To(Succeed())
@@ -160,7 +175,7 @@ func TestClusterReconciler(t *testing.T) {
 		cluster := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test4-",
-				Namespace:    "default",
+				Namespace:    ns.Name,
 			},
 		}
 
@@ -208,7 +223,7 @@ func TestClusterReconciler(t *testing.T) {
 		cluster := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test5-",
-				Namespace:    "default",
+				Namespace:    ns.Name,
 			},
 		}
 		g.Expect(env.Create(ctx, cluster)).To(Succeed())
@@ -253,7 +268,7 @@ func TestClusterReconciler(t *testing.T) {
 		cluster := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test6-",
-				Namespace:    corev1.NamespaceDefault,
+				Namespace:    ns.Name,
 			},
 		}
 
@@ -289,7 +304,7 @@ func TestClusterReconciler(t *testing.T) {
 		machine := &clusterv1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test6-",
-				Namespace:    corev1.NamespaceDefault,
+				Namespace:    ns.Name,
 				Labels: map[string]string{
 					clusterv1.MachineControlPlaneLabelName: "",
 				},

--- a/controllers/machine_controller_node_labels_test.go
+++ b/controllers/machine_controller_node_labels_test.go
@@ -110,7 +110,7 @@ func TestReconcileInterruptibleNodeLabel(t *testing.T) {
 
 	defer func(do ...client.Object) {
 		g.Expect(env.Cleanup(ctx, do...)).To(Succeed())
-	}(cluster, node, infraMachine, machine)
+	}(cluster, ns, node, infraMachine, machine)
 
 	r := &MachineReconciler{
 		Client:   env.Client,

--- a/controllers/machine_controller_phases_test.go
+++ b/controllers/machine_controller_phases_test.go
@@ -30,15 +30,16 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func init() {
@@ -59,7 +60,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 	defaultMachine := clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine-test",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
 				clusterv1.MachineControlPlaneLabelName: "",
 			},
@@ -87,7 +88,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 			"metadata": map[string]interface{}{
 				"name":      "bootstrap-config1",
-				"namespace": "default",
+				"namespace": metav1.NamespaceDefault,
 			},
 			"spec":   map[string]interface{}{},
 			"status": map[string]interface{}{},
@@ -100,7 +101,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha4",
 			"metadata": map[string]interface{}{
 				"name":      "infra-config1",
-				"namespace": "default",
+				"namespace": metav1.NamespaceDefault,
 			},
 			"spec":   map[string]interface{}{},
 			"status": map[string]interface{}{},
@@ -593,7 +594,7 @@ func TestReconcileBootstrap(t *testing.T) {
 	defaultMachine := clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine-test",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
 				clusterv1.ClusterLabelName: "test-cluster",
 			},
@@ -612,7 +613,7 @@ func TestReconcileBootstrap(t *testing.T) {
 	defaultCluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 		},
 	}
 
@@ -631,7 +632,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 				},
 				"spec": map[string]interface{}{},
 				"status": map[string]interface{}{
@@ -654,7 +655,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 				},
 				"spec": map[string]interface{}{},
 				"status": map[string]interface{}{
@@ -675,7 +676,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 				},
 				"spec":   map[string]interface{}{},
 				"status": map[string]interface{}{},
@@ -726,7 +727,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 				},
 				"spec": map[string]interface{}{},
 				"status": map[string]interface{}{
@@ -737,7 +738,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bootstrap-test-existing",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
@@ -767,7 +768,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 					"ownerReferences": []interface{}{
 						map[string]interface{}{
 							"apiVersion": clusterv1.GroupVersion.String(),
@@ -786,7 +787,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bootstrap-test-existing",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
@@ -814,7 +815,7 @@ func TestReconcileBootstrap(t *testing.T) {
 				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 					"ownerReferences": []interface{}{
 						map[string]interface{}{
 							"apiVersion": "cluster.x-k8s.io/v1alpha2",
@@ -833,7 +834,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bootstrap-test-existing",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
@@ -893,7 +894,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 	defaultMachine := clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine-test",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
 				clusterv1.ClusterLabelName: "test-cluster",
 			},
@@ -917,7 +918,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 	defaultCluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 		},
 	}
 
@@ -938,7 +939,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "infra-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 					"ownerReferences": []interface{}{
 						map[string]interface{}{
 							"apiVersion": clusterv1.GroupVersion.String(),
@@ -979,7 +980,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "machine-test",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
@@ -1006,7 +1007,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 				},
 				"spec": map[string]interface{}{},
 				"status": map[string]interface{}{
@@ -1035,7 +1036,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "infra-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 					"annotations": map[string]interface{}{
 						"cluster.x-k8s.io/paused": "true",
 					},

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -28,17 +28,18 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestWatches(t *testing.T) {
@@ -178,13 +179,17 @@ func TestWatches(t *testing.T) {
 
 func TestMachine_Reconcile(t *testing.T) {
 	g := NewWithT(t)
+
+	ns, err := env.CreateNamespace(ctx, "test-machine-reconcile")
+	g.Expect(err).ToNot(HaveOccurred())
+
 	infraMachine := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "InfrastructureMachine",
 			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha4",
 			"metadata": map[string]interface{}{
 				"name":      "infra-config1",
-				"namespace": "default",
+				"namespace": ns.Name,
 			},
 			"spec": map[string]interface{}{
 				"providerID": "test://id-1",
@@ -198,7 +203,7 @@ func TestMachine_Reconcile(t *testing.T) {
 			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 			"metadata": map[string]interface{}{
 				"name":      "bootstrap-config-machinereconcile",
-				"namespace": "default",
+				"namespace": ns.Name,
 			},
 			"spec":   map[string]interface{}{},
 			"status": map[string]interface{}{},
@@ -208,7 +213,7 @@ func TestMachine_Reconcile(t *testing.T) {
 	testCluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "machine-reconcile-",
-			Namespace:    "default",
+			Namespace:    ns.Name,
 		},
 	}
 
@@ -218,12 +223,12 @@ func TestMachine_Reconcile(t *testing.T) {
 
 	defer func(do ...client.Object) {
 		g.Expect(env.Cleanup(ctx, do...)).To(Succeed())
-	}(testCluster)
+	}(ns, testCluster, defaultBootstrap)
 
 	machine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "machine-created-",
-			Namespace:    "default",
+			Namespace:    ns.Name,
 			Finalizers:   []string{clusterv1.MachineFinalizer},
 		},
 		Spec: clusterv1.MachineSpec{
@@ -318,15 +323,15 @@ func TestMachineFinalizer(t *testing.T) {
 	bootstrapData := "some valid data"
 	clusterCorrectMeta := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
 			Name:      "valid-cluster",
+			Namespace: metav1.NamespaceDefault,
 		},
 	}
 
 	machineValidCluster := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine1",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.MachineSpec{
 			Bootstrap: clusterv1.Bootstrap{
@@ -339,7 +344,7 @@ func TestMachineFinalizer(t *testing.T) {
 	machineWithFinalizer := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "machine2",
-			Namespace:  "default",
+			Namespace:  metav1.NamespaceDefault,
 			Finalizers: []string{"some-other-finalizer"},
 		},
 		Spec: clusterv1.MachineSpec{
@@ -405,13 +410,13 @@ func TestMachineOwnerReference(t *testing.T) {
 	bootstrapData := "some valid data"
 	testCluster := &clusterv1.Cluster{
 		TypeMeta:   metav1.TypeMeta{Kind: "Cluster", APIVersion: clusterv1.GroupVersion.String()},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-cluster"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test-cluster"},
 	}
 
 	machineInvalidCluster := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine1",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.MachineSpec{
 			ClusterName: "invalid",
@@ -421,7 +426,7 @@ func TestMachineOwnerReference(t *testing.T) {
 	machineValidCluster := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine2",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.MachineSpec{
 			Bootstrap: clusterv1.Bootstrap{
@@ -434,7 +439,7 @@ func TestMachineOwnerReference(t *testing.T) {
 	machineValidMachine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine3",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
 				clusterv1.ClusterLabelName: "valid-cluster",
 			},
@@ -458,7 +463,7 @@ func TestMachineOwnerReference(t *testing.T) {
 	machineValidControlled := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine4",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
 				clusterv1.ClusterLabelName:             "valid-cluster",
 				clusterv1.MachineControlPlaneLabelName: "",
@@ -576,7 +581,7 @@ func TestReconcileRequest(t *testing.T) {
 			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha4",
 			"metadata": map[string]interface{}{
 				"name":      "infra-config1",
-				"namespace": "default",
+				"namespace": metav1.NamespaceDefault,
 			},
 			"spec": map[string]interface{}{
 				"providerID": "test://id-1",
@@ -598,14 +603,14 @@ func TestReconcileRequest(t *testing.T) {
 	testCluster := clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 		},
 	}
 
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: corev1.NodeSpec{ProviderID: "test://id-1"},
 	}
@@ -622,7 +627,7 @@ func TestReconcileRequest(t *testing.T) {
 			machine: clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "created",
-					Namespace:  "default",
+					Namespace:  metav1.NamespaceDefault,
 					Finalizers: []string{clusterv1.MachineFinalizer},
 				},
 				Spec: clusterv1.MachineSpec{
@@ -650,7 +655,7 @@ func TestReconcileRequest(t *testing.T) {
 			machine: clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "updated",
-					Namespace:  "default",
+					Namespace:  metav1.NamespaceDefault,
 					Finalizers: []string{clusterv1.MachineFinalizer},
 				},
 				Spec: clusterv1.MachineSpec{
@@ -678,7 +683,7 @@ func TestReconcileRequest(t *testing.T) {
 			machine: clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "deleted",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 					Labels: map[string]string{
 						clusterv1.MachineControlPlaneLabelName: "",
 					},
@@ -739,7 +744,7 @@ func TestMachineConditions(t *testing.T) {
 				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "infra-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 				},
 				"spec": map[string]interface{}{
 					"providerID": "test://id-1",
@@ -770,7 +775,7 @@ func TestMachineConditions(t *testing.T) {
 				"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
-					"namespace": "default",
+					"namespace": metav1.NamespaceDefault,
 				},
 				"status": status,
 			},
@@ -780,14 +785,14 @@ func TestMachineConditions(t *testing.T) {
 	testCluster := clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 		},
 	}
 
 	machine := clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "blah",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
 				clusterv1.MachineControlPlaneLabelName: "",
 			},
@@ -977,7 +982,7 @@ func TestMachineConditions(t *testing.T) {
 
 func TestReconcileDeleteExternal(t *testing.T) {
 	testCluster := &clusterv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-cluster"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test-cluster"},
 	}
 
 	bootstrapConfig := &unstructured.Unstructured{
@@ -986,7 +991,7 @@ func TestReconcileDeleteExternal(t *testing.T) {
 			"apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha4",
 			"metadata": map[string]interface{}{
 				"name":      "delete-bootstrap",
-				"namespace": "default",
+				"namespace": metav1.NamespaceDefault,
 			},
 		},
 	}
@@ -994,7 +999,7 @@ func TestReconcileDeleteExternal(t *testing.T) {
 	machine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "delete",
-			Namespace: "default",
+			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.MachineSpec{
 			ClusterName: "test-cluster",
@@ -1023,7 +1028,7 @@ func TestReconcileDeleteExternal(t *testing.T) {
 					"kind":       "BootstrapConfig",
 					"metadata": map[string]interface{}{
 						"name":            "delete-bootstrap",
-						"namespace":       "default",
+						"namespace":       metav1.NamespaceDefault,
 						"resourceVersion": "999",
 					},
 				},
@@ -1069,13 +1074,13 @@ func TestRemoveMachineFinalizerAfterDeleteReconcile(t *testing.T) {
 	dt := metav1.Now()
 
 	testCluster := &clusterv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-cluster"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test-cluster"},
 	}
 
 	m := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "delete123",
-			Namespace:         "default",
+			Namespace:         metav1.NamespaceDefault,
 			Finalizers:        []string{clusterv1.MachineFinalizer, "test"},
 			DeletionTimestamp: &dt,
 		},
@@ -1104,7 +1109,7 @@ func TestRemoveMachineFinalizerAfterDeleteReconcile(t *testing.T) {
 func TestIsNodeDrainedAllowed(t *testing.T) {
 	testCluster := &clusterv1.Cluster{
 		TypeMeta:   metav1.TypeMeta{Kind: "Cluster", APIVersion: clusterv1.GroupVersion.String()},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-cluster"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "test-cluster"},
 	}
 
 	tests := []struct {
@@ -1117,7 +1122,7 @@ func TestIsNodeDrainedAllowed(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test-machine",
-					Namespace:   "default",
+					Namespace:   metav1.NamespaceDefault,
 					Finalizers:  []string{clusterv1.MachineFinalizer},
 					Annotations: map[string]string{clusterv1.ExcludeNodeDrainingAnnotation: "existed!!"},
 				},
@@ -1135,7 +1140,7 @@ func TestIsNodeDrainedAllowed(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-machine",
-					Namespace:  "default",
+					Namespace:  metav1.NamespaceDefault,
 					Finalizers: []string{clusterv1.MachineFinalizer},
 				},
 				Spec: clusterv1.MachineSpec{
@@ -1162,7 +1167,7 @@ func TestIsNodeDrainedAllowed(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-machine",
-					Namespace:  "default",
+					Namespace:  metav1.NamespaceDefault,
 					Finalizers: []string{clusterv1.MachineFinalizer},
 				},
 				Spec: clusterv1.MachineSpec{
@@ -1188,7 +1193,7 @@ func TestIsNodeDrainedAllowed(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-machine",
-					Namespace:  "default",
+					Namespace:  metav1.NamespaceDefault,
 					Finalizers: []string{clusterv1.MachineFinalizer},
 				},
 				Spec: clusterv1.MachineSpec{
@@ -1240,13 +1245,13 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 			},
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "created",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 					Labels: map[string]string{
 						clusterv1.ClusterLabelName: "test-cluster",
 					},
@@ -1266,13 +1271,13 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 			},
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "created",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 					Labels: map[string]string{
 						clusterv1.ClusterLabelName: "test-cluster",
 					},
@@ -1296,13 +1301,13 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 			},
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "created",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 					Labels: map[string]string{
 						clusterv1.ClusterLabelName:             "test-cluster",
 						clusterv1.MachineControlPlaneLabelName: "",
@@ -1328,13 +1333,13 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 			},
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "created",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 					Labels: map[string]string{
 						clusterv1.ClusterLabelName: "test-cluster",
 					},
@@ -1358,7 +1363,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "test-cluster",
-					Namespace:         "default",
+					Namespace:         metav1.NamespaceDefault,
 					DeletionTimestamp: &deletionts,
 				},
 			},
@@ -1370,7 +1375,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: clusterv1.ClusterSpec{
 					ControlPlaneRef: &corev1.ObjectReference{
@@ -1384,7 +1389,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "created",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 					Labels: map[string]string{
 						clusterv1.ClusterLabelName: "test-cluster",
 					},
@@ -1408,7 +1413,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: clusterv1.ClusterSpec{
 					ControlPlaneRef: &corev1.ObjectReference{
@@ -1422,7 +1427,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "created",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 					Labels: map[string]string{
 						clusterv1.ClusterLabelName: "test-cluster",
 					},
@@ -1446,7 +1451,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 				},
 				Spec: clusterv1.ClusterSpec{
 					ControlPlaneRef: &corev1.ObjectReference{
@@ -1460,7 +1465,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			machine: &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "created",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 					Labels: map[string]string{
 						clusterv1.ClusterLabelName: "test-cluster",
 					},
@@ -1522,7 +1527,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			m1 := &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cp1",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 					Labels: map[string]string{
 						clusterv1.ClusterLabelName: "test-cluster",
 					},
@@ -1542,7 +1547,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 			m2 := &clusterv1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "cp2",
-					Namespace: "default",
+					Namespace: metav1.NamespaceDefault,
 					Labels: map[string]string{
 						clusterv1.ClusterLabelName: "test-cluster",
 					},

--- a/controllers/mdutil/util_test.go
+++ b/controllers/mdutil/util_test.go
@@ -767,7 +767,7 @@ func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
 		{
 			name: "test Annotations nil",
 			machineSet: &clusterv1.MachineSet{
-				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: "test"},
+				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: metav1.NamespaceDefault},
 				Spec: clusterv1.MachineSetSpec{
 					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
 				},
@@ -779,7 +779,7 @@ func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
 			machineSet: &clusterv1.MachineSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "hello",
-					Namespace:   "test",
+					Namespace:   metav1.NamespaceDefault,
 					Annotations: map[string]string{clusterv1.DesiredReplicasAnnotation: "8", clusterv1.MaxReplicasAnnotation: maxReplicas},
 				},
 				Spec: clusterv1.MachineSetSpec{
@@ -793,7 +793,7 @@ func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
 			machineSet: &clusterv1.MachineSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "hello",
-					Namespace:   "test",
+					Namespace:   metav1.NamespaceDefault,
 					Annotations: map[string]string{clusterv1.DesiredReplicasAnnotation: desiredReplicas, clusterv1.MaxReplicasAnnotation: "16"},
 				},
 				Spec: clusterv1.MachineSetSpec{
@@ -807,7 +807,7 @@ func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
 			machineSet: &clusterv1.MachineSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "hello",
-					Namespace:   "test",
+					Namespace:   metav1.NamespaceDefault,
 					Annotations: map[string]string{clusterv1.DesiredReplicasAnnotation: desiredReplicas, clusterv1.MaxReplicasAnnotation: maxReplicas},
 				},
 				Spec: clusterv1.MachineSetSpec{

--- a/controllers/remote/cluster_cache_healthcheck_test.go
+++ b/controllers/remote/cluster_cache_healthcheck_test.go
@@ -43,7 +43,6 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 		var mgrCancel context.CancelFunc
 		var k8sClient client.Client
 
-		var testNamespace *corev1.Namespace
 		var testClusterKey client.ObjectKey
 		var cct *ClusterCacheTracker
 		var cc *stoppableCache
@@ -52,7 +51,7 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 		var testPollTimeout = 50 * time.Millisecond
 		var testUnhealthyThreshold = 3
 
-		setup := func(t *testing.T, g *WithT) {
+		setup := func(t *testing.T, g *WithT) *corev1.Namespace {
 			t.Log("Setting up a new manager")
 			var err error
 			mgr, err = manager.New(env.Config, manager.Options{
@@ -75,14 +74,14 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			t.Log("Creating a namespace for the test")
-			testNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "cluster-cache-test-"}}
-			g.Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+			ns, err := env.CreateNamespace(ctx, "cluster-cache-health-test")
+			g.Expect(err).To(BeNil())
 
 			t.Log("Creating a test cluster")
 			testCluster := &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
-					Namespace: testNamespace.GetName(),
+					Namespace: ns.GetName(),
 				},
 			}
 			g.Expect(k8sClient.Create(ctx, testCluster)).To(Succeed())
@@ -98,13 +97,17 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 			_, cancel := context.WithCancel(ctx)
 			cc = &stoppableCache{cancelFunc: cancel}
 			cct.clusterAccessors[testClusterKey] = &clusterAccessor{cache: cc}
+
+			return ns
 		}
 
-		teardown := func(t *testing.T, g *WithT) {
+		teardown := func(t *testing.T, g *WithT, ns *corev1.Namespace) {
 			t.Log("Deleting any Secrets")
 			g.Expect(cleanupTestSecrets(ctx, k8sClient)).To(Succeed())
 			t.Log("Deleting any Clusters")
 			g.Expect(cleanupTestClusters(ctx, k8sClient)).To(Succeed())
+			t.Log("Deleting Namespace")
+			g.Expect(env.Delete(ctx, ns)).To(Succeed())
 			t.Log("Stopping the manager")
 			cc.cancelFunc()
 			mgrCancel()
@@ -112,20 +115,19 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 
 		t.Run("with a healthy cluster", func(t *testing.T) {
 			g := NewWithT(t)
-			setup(t, g)
-			defer teardown(t, g)
+			ns := setup(t, g)
+			defer teardown(t, g, ns)
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			// TODO(community): Fill in these field names.
 			go cct.healthCheckCluster(ctx, &healthCheckInput{
-				testClusterKey,
-				env.Config,
-				testPollInterval,
-				testPollTimeout,
-				testUnhealthyThreshold,
-				"/",
+				cluster:            testClusterKey,
+				cfg:                env.Config,
+				interval:           testPollInterval,
+				requestTimeout:     testPollTimeout,
+				unhealthyThreshold: testUnhealthyThreshold,
+				path:               "/",
 			})
 
 			// Make sure this passes for at least two seconds, to give the health check goroutine time to run.
@@ -134,21 +136,20 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 
 		t.Run("with an invalid path", func(t *testing.T) {
 			g := NewWithT(t)
-			setup(t, g)
-			defer teardown(t, g)
+			ns := setup(t, g)
+			defer teardown(t, g, ns)
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			// TODO(community): Fill in these field names.
 			go cct.healthCheckCluster(ctx,
 				&healthCheckInput{
-					testClusterKey,
-					env.Config,
-					testPollInterval,
-					testPollTimeout,
-					testUnhealthyThreshold,
-					"/clusterAccessor",
+					cluster:            testClusterKey,
+					cfg:                env.Config,
+					interval:           testPollInterval,
+					requestTimeout:     testPollTimeout,
+					unhealthyThreshold: testUnhealthyThreshold,
+					path:               "/clusterAccessor",
 				})
 
 			// This should succeed after N consecutive failed requests.
@@ -157,8 +158,8 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 
 		t.Run("with an invalid config", func(t *testing.T) {
 			g := NewWithT(t)
-			setup(t, g)
-			defer teardown(t, g)
+			ns := setup(t, g)
+			defer teardown(t, g, ns)
 
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -173,14 +174,13 @@ func TestClusterCacheHealthCheck(t *testing.T) {
 			config := rest.CopyConfig(env.Config)
 			config.Host = fmt.Sprintf("http://127.0.0.1:%d", l.Addr().(*net.TCPAddr).Port)
 
-			// TODO(community): Fill in these field names.
 			go cct.healthCheckCluster(ctx, &healthCheckInput{
-				testClusterKey,
-				config,
-				testPollInterval,
-				testPollTimeout,
-				testUnhealthyThreshold,
-				"/",
+				cluster:            testClusterKey,
+				cfg:                config,
+				interval:           testPollInterval,
+				requestTimeout:     testPollTimeout,
+				unhealthyThreshold: testUnhealthyThreshold,
+				path:               "/",
 			})
 
 			// This should succeed after N consecutive failed requests.

--- a/controllers/remote/cluster_cache_tracker_test.go
+++ b/controllers/remote/cluster_cache_tracker_test.go
@@ -49,18 +49,17 @@ func mapper(i client.Object) []reconcile.Request {
 func TestClusterCacheTracker(t *testing.T) {
 	t.Run("watching", func(t *testing.T) {
 		var (
-			mgr           manager.Manager
-			mgrContext    context.Context
-			mgrCancel     context.CancelFunc
-			cct           *ClusterCacheTracker
-			k8sClient     client.Client
-			testNamespace *corev1.Namespace
-			c             *testController
-			w             Watcher
-			clusterA      *clusterv1.Cluster
+			mgr        manager.Manager
+			mgrContext context.Context
+			mgrCancel  context.CancelFunc
+			cct        *ClusterCacheTracker
+			k8sClient  client.Client
+			c          *testController
+			w          Watcher
+			clusterA   *clusterv1.Cluster
 		)
 
-		setup := func(t *testing.T, g *WithT) {
+		setup := func(t *testing.T, g *WithT) *corev1.Namespace {
 			t.Log("Setting up a new manager")
 			var err error
 			mgr, err = manager.New(env.Config, manager.Options{
@@ -89,13 +88,13 @@ func TestClusterCacheTracker(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			t.Log("Creating a namespace for the test")
-			testNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "cluster-cache-test-"}}
-			g.Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+			ns, err := env.CreateNamespace(ctx, "cluster-cache-tracker-test")
+			g.Expect(err).To(BeNil())
 
 			t.Log("Creating a test cluster")
 			clusterA = &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:   testNamespace.GetName(),
+					Namespace:   ns.GetName(),
 					Name:        "test-cluster",
 					Annotations: make(map[string]string),
 				},
@@ -107,21 +106,25 @@ func TestClusterCacheTracker(t *testing.T) {
 
 			t.Log("Creating a test cluster kubeconfig")
 			g.Expect(env.CreateKubeconfigSecret(ctx, clusterA)).To(Succeed())
+
+			return ns
 		}
 
-		teardown := func(t *testing.T, g *WithT) {
+		teardown := func(t *testing.T, g *WithT, ns *corev1.Namespace) {
 			t.Log("Deleting any Secrets")
 			g.Expect(cleanupTestSecrets(ctx, k8sClient)).To(Succeed())
 			t.Log("Deleting any Clusters")
 			g.Expect(cleanupTestClusters(ctx, k8sClient)).To(Succeed())
+			t.Log("Deleting Namespace")
+			g.Expect(env.Delete(ctx, ns)).To(Succeed())
 			t.Log("Stopping the manager")
 			mgrCancel()
 		}
 
 		t.Run("with the same name should succeed and not have duplicates", func(t *testing.T) {
 			g := NewWithT(t)
-			setup(t, g)
-			defer teardown(t, g)
+			ns := setup(t, g)
+			defer teardown(t, g, ns)
 
 			t.Log("Creating the watch")
 			g.Expect(cct.Watch(ctx, WatchInput{

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -34,17 +34,17 @@ import (
 var (
 	clusterWithValidKubeConfig = client.ObjectKey{
 		Name:      "test1",
-		Namespace: "test",
+		Namespace: metav1.NamespaceDefault,
 	}
 
 	clusterWithInvalidKubeConfig = client.ObjectKey{
 		Name:      "test2",
-		Namespace: "test",
+		Namespace: metav1.NamespaceDefault,
 	}
 
 	clusterWithNoKubeConfig = client.ObjectKey{
 		Name:      "test3",
-		Namespace: "test",
+		Namespace: metav1.NamespaceDefault,
 	}
 
 	validKubeConfig = `
@@ -67,7 +67,7 @@ users:
 	validSecret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test1-kubeconfig",
-			Namespace: "test",
+			Namespace: metav1.NamespaceDefault,
 		},
 		Data: map[string][]byte{
 			secret.KubeconfigDataName: []byte(validKubeConfig),
@@ -77,7 +77,7 @@ users:
 	invalidSecret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test2-kubeconfig",
-			Namespace: "test",
+			Namespace: metav1.NamespaceDefault,
 		},
 		Data: map[string][]byte{
 			secret.KubeconfigDataName: []byte("Not valid!!1"),

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,18 +27,20 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/internal/envtest"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	// +kubebuilder:scaffold:imports
 )
 
 const (
-	timeout = time.Second * 30
+	timeout         = time.Second * 30
+	testClusterName = "test-cluster"
 )
 
 var (


### PR DESCRIPTION
Partly solves https://github.com/kubernetes-sigs/cluster-api/issues/4629. Only `controllers` pkg is updated.

Use of randomly generated namespaces was started in https://github.com/kubernetes-sigs/cluster-api/pull/4698. This PR continues it's work in the same manner. `env.CreateNamespace` is used everywhere internal `envtest` package is used for testing. And everywhere else(for example tests that use `fake.Client` from `controller-runtime`) it replaces `"default"` and `"test"` namespace names with constant `metav1.NamespaceDefault`.
