### PR TITLE
✨ Switch to non-alpine kindest/haproxy version

### DIFF
--- a/test/infrastructure/docker/third_party/forked/loadbalancer/const.go
+++ b/test/infrastructure/docker/third_party/forked/loadbalancer/const.go
@@ -17,7 +17,7 @@ limitations under the License.
 package loadbalancer
 
 // Image defines the loadbalancer image:tag
-const Image = "kindest/haproxy:2.1.1-alpine"
+const Image = "kindest/haproxy:v20210715-a6da3463"
 
 // ConfigPath defines the path to the config file in the image
 const ConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
Alpine has several challenges, so there's a long running effort in
upstream kubernetes to switch to distroless/debian based images.

Kind recently moved to a non-alpine image, so let us please switch to
the same as well:
https://github.com/kubernetes-sigs/kind/pull/2373

Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
