### PR TITLE
🌱 Adds topology check to cluster controller

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -178,6 +178,16 @@ func patchCluster(ctx context.Context, patchHelper *patch.Helper, cluster *clust
 
 // reconcile handles cluster reconciliation.
 func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx, "cluster", cluster.Name)
+
+	if cluster.Spec.Topology != nil {
+		if cluster.Spec.ControlPlaneRef == nil || cluster.Spec.InfrastructureRef == nil {
+			// TODO: add a condition to surface this scenario
+			log.Info("Waiting for the topology to be generated")
+			return ctrl.Result{}, nil
+		}
+	}
+
 	phases := []func(context.Context, *clusterv1.Cluster) (ctrl.Result, error){
 		r.reconcileInfrastructure,
 		r.reconcileControlPlane,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->
**What this PR does / why we need it**:
This patch makes the cluster controller tolerant to the missing control plane and infrastructure references in the case of a cluster with `spec.Topology != nil` (cluster with topology definition)
The existing behavior would continue if the topology definition is absent.

**Which issue(s) this PR fixes**:
Fixes #4909
