### PR TITLE
📖 Update links for kustomize installation

### DIFF
--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -53,7 +53,7 @@ If you choose not to use GCR, you'll need to set the `REGISTRY` environment vari
 You'll need to [install `kustomize`][kustomize].
 There is a version of `kustomize` built into kubectl, but it does not have all the features of `kustomize` v3 and will not work.
 
-[kustomize]: https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md
+[kustomize]: https://kubectl.docs.kubernetes.io/installation/kustomize/
 
 ### Kubebuilder
 

--- a/docs/book/src/developer/providers/implementers-guide/overview.md
+++ b/docs/book/src/developer/providers/implementers-guide/overview.md
@@ -66,5 +66,5 @@ export PATH=$PATH:/usr/local/kubebuilder/bin
 
 [kubebuilder-book]: https://book.kubebuilder.io/
 [kubectl-install]: http://kubernetes.io/docs/user-guide/prereqs/
-[install-kustomize]: https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md
+[install-kustomize]: https://kubectl.docs.kubernetes.io/installation/kustomize/
 [install-kubebuilder]:  https://book.kubebuilder.io/quick-start.html#installation

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -10,7 +10,7 @@ workflow that offers easy deployments and rapid iterative builds.
 1. [Docker](https://docs.docker.com/install/) v19.03 or newer
 1. [kind](https://kind.sigs.k8s.io) v0.9 or newer (other clusters can be
    used if `preload_images_for_kind` is set to false)
-1. [kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md)
+1. [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)
    standalone (`kubectl kustomize` does not work because it is missing
    some features of kustomize v3)
 1. [Tilt](https://docs.tilt.dev/install.html) v0.16.0 or newer


### PR DESCRIPTION
**What this PR does / why we need it**:

The installation instructions for kustomize have moved. This updates
references to that documentation to point to the new home.