### PR TITLE
✨ Add a MemoryReader for the operator to place config from a secret

### DIFF
--- a/cmd/clusterctl/client/config/reader_memory.go
+++ b/cmd/clusterctl/client/config/reader_memory.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/pkg/errors"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/yaml"
+)
+
+// MemoryReader provides a reader implementation backed by a map.
+// This is to be used by the operator to place config from a secret
+// and the ProviderSpec.Fetchconfig.
+type MemoryReader struct {
+	variables map[string]string
+	providers []configProvider
+}
+
+var _ Reader = &MemoryReader{}
+
+// NewMemoryReader return a new MemoryReader.
+func NewMemoryReader() *MemoryReader {
+	return &MemoryReader{
+		variables: map[string]string{},
+		providers: []configProvider{},
+	}
+}
+
+// Init initialize the reader.
+func (f *MemoryReader) Init(_ string) error {
+	data, err := yaml.Marshal(f.providers)
+	if err != nil {
+		return err
+	}
+	f.variables["providers"] = string(data)
+
+	// images is not used by the operator, but it is read by the clusterctrl
+	// code, so we need a correct empty "images".
+	data, err = yaml.Marshal(map[string]imageMeta{})
+	if err != nil {
+		return err
+	}
+	f.variables["images"] = string(data)
+	return nil
+}
+
+// Get gets a value for the given key.
+func (f *MemoryReader) Get(key string) (string, error) {
+	if val, ok := f.variables[key]; ok {
+		return val, nil
+	}
+	return "", errors.Errorf("value for variable %q is not set", key)
+}
+
+// Set sets a value for the given key.
+func (f *MemoryReader) Set(key, value string) {
+	f.variables[key] = value
+}
+
+// UnmarshalKey gets a value for the given key, then unmarshal it.
+func (f *MemoryReader) UnmarshalKey(key string, rawval interface{}) error {
+	data, err := f.Get(key)
+	if err != nil {
+		return nil // nolint:nilerr // We expect to not error if the key is not present
+	}
+	return yaml.Unmarshal([]byte(data), rawval)
+}
+
+// AddProvider adds the given provider to the "providers" map entry and returns any errors.
+func (f *MemoryReader) AddProvider(name string, ttype clusterctlv1.ProviderType, url string) (*MemoryReader, error) {
+	f.providers = append(f.providers, configProvider{
+		Name: name,
+		URL:  url,
+		Type: ttype,
+	})
+
+	yaml, err := yaml.Marshal(f.providers)
+	if err != nil {
+		return f, err
+	}
+	f.variables["providers"] = string(yaml)
+
+	return f, nil
+}

--- a/cmd/clusterctl/client/config/reader_memory_test.go
+++ b/cmd/clusterctl/client/config/reader_memory_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+)
+
+func TestMemoryReader(t *testing.T) {
+	tests := []struct {
+		name       string
+		variables  map[string]string
+		providers  []configProvider
+		imageMetas map[string]imageMeta
+		wantErr    bool
+	}{
+		{
+			name: "providers",
+			providers: []configProvider{
+				{
+					Name: "foo",
+					Type: v1alpha3.BootstrapProviderType,
+					URL:  "url",
+				},
+			},
+			imageMetas: map[string]imageMeta{},
+			variables: map[string]string{
+				"one":   "1",
+				"two":   "2",
+				"three": "3",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			f := NewMemoryReader()
+			g.Expect(f.Init("")).To(Succeed())
+			for _, p := range tt.providers {
+				_, err := f.AddProvider(p.Name, p.Type, p.URL)
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			for n, v := range tt.variables {
+				f.Set(n, v)
+			}
+
+			providersOut := []configProvider{}
+			g.Expect(f.UnmarshalKey("providers", &providersOut)).To(Succeed())
+			g.Expect(providersOut).To(Equal(tt.providers))
+
+			imagesOut := map[string]imageMeta{}
+			g.Expect(f.UnmarshalKey("images", &imagesOut)).To(Succeed())
+			g.Expect(imagesOut).To(Equal(tt.imageMetas))
+
+			for n, v := range tt.variables {
+				outV, err := f.Get(n)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(outV).To(Equal(v))
+			}
+			val, err := f.Get("notfound")
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(val).To(Equal(""))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The operator needs to be able to read configuration (normally in files locally) from a secret into a Reader.
see https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/20201020-capi-provider-operator.md
This can be easily done by the operator reading in the secret and Setting the variables on new MemoryReader.

Note that the secret is to not be writable so we don't need to push the ability to write the secret into the Reader.
This has been split out of https://github.com/kubernetes-sigs/cluster-api/pull/4926 for ease of reviewing.
/cc @fabriziopandini @alexander-demichev 

This is how it is used: https://github.com/kubernetes-sigs/cluster-api/pull/4926/files#diff-c580f31a2ccfe402ca2335b20daeeaf9b4862b22662a49e5bffff938295d36acR109

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4978
/area operator
