### PR TITLE
✨ v0.3.x: block clusterctl init and move on Kubernetes v1.22

### DIFF
--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -33,6 +33,9 @@ import (
 
 const (
 	minimumKubernetesVersion = "v1.16.0"
+	// managementClusterVersionCeiling is the first version we don't support as management cluster.
+	// We cannot support v1.22.0 as it's not compatible with our controller-runtime version and WebhookConfigurations v1beta1.
+	managementClusterVersionCeiling = "v1.22.0"
 )
 
 var (
@@ -227,6 +230,9 @@ type Proxy interface {
 
 	// ValidateKubernetesVersion returns an error if management cluster version less than minimumKubernetesVersion
 	ValidateKubernetesVersion() error
+
+	// ValidateKubernetesMaxVersion returns an error if management cluster version is greater than or equal to managementClusterVersionCeiling
+	ValidateKubernetesMaxVersion() error
 
 	// NewClient returns a new controller runtime Client object for working on the management cluster
 	NewClient() (client.Client, error)

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -76,6 +76,10 @@ func (c *clusterctlClient) Init(options InitOptions) ([]Components, error) {
 		return nil, err
 	}
 
+	if err := clusterClient.Proxy().ValidateKubernetesMaxVersion(); err != nil {
+		return nil, err
+	}
+
 	// ensure the custom resource definitions required by clusterctl are in place
 	if err := clusterClient.ProviderInventory().EnsureCustomResourceDefinitions(); err != nil {
 		return nil, err

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -62,6 +62,9 @@ func (c *clusterctlClient) Move(options MoveOptions) error {
 		if err != nil {
 			return err
 		}
+		if err := toCluster.Proxy().ValidateKubernetesMaxVersion(); err != nil {
+			return err
+		}
 
 		// Ensure this command only runs against management clusters with the current Cluster API contract.
 		if err := toCluster.ProviderInventory().CheckCAPIContract(); err != nil {

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -67,6 +67,10 @@ func (f *FakeProxy) ValidateKubernetesVersion() error {
 	return nil
 }
 
+func (f *FakeProxy) ValidateKubernetesMaxVersion() error {
+	return nil
+}
+
 func (f *FakeProxy) GetConfig() (*rest.Config, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
See issue for details.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially implements #4966 (1., only clusterctl in this PR)
