### PR TITLE
📖 update supported Kubernetes versions

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-The Cluster API team maintains release branches for **(v1alpha3) v0.3** and **(v1alpha2) v0.2**, the two most recent releases.
+The Cluster API team maintains release branches for **(v1alpha4) v0.4** and **(v1alpha3) v0.3**, the two most recent releases.
 
 Releases include these components:
 
@@ -23,11 +23,11 @@ See the [following section](#kubernetes-version-support-as-a-function-of-cluster
 
 The Core Provider, Kubeadm Bootstrap Provider, and Kubeadm Control Plane Provider run on the Management Cluster, and clusterctl talks to that cluster's API server.
 
-In some cases, the Management Cluster is separate from the Workload Clusters. The Kubernetes version of the Management and Workload Clusters are allowed to be different. For example, the current Cluster API release is compatible with Kubernetes versions 1.16 through 1.18. For example, the Management Cluster can run v1.18.2, and two Workload Clusters can run v1.16.9 and v1.17.5.
+In some cases, the Management Cluster is separate from the Workload Clusters. The Kubernetes version of the Management and Workload Clusters are allowed to be different.
 
 Management Clusters and Workload Clusters can be upgraded independently and in any order, however, if you are additionally moving from
-v1alpha2 (v0.2.x) to v1alpha3 (v0.3.x) as part of the upgrade roll out, the management cluster will need to be upgraded to at least v1.16.x,
-prior to upgrading any workload cluster using Cluster API v1alpha3 (v0.3.x)
+v1alpha3 (v0.3.x) to v1alpha4 (v0.4.x) as part of the upgrade roll out, the management cluster will need to be upgraded to at least v1.19.x,
+prior to upgrading any workload cluster using Cluster API v1alpha4 (v0.4.x)
 
 These diagrams show the relationships between components in a Cluster API release (yellow), and other components (white).
 
@@ -43,47 +43,43 @@ These diagrams show the relationships between components in a Cluster API releas
 
 #### Core Provider (`cluster-api-controller`)
 
-|                  | Cluster API v1alpha2 (v0.2) | Cluster API v1alpha3 (v0.3) |
-| ---------------- | --------------------------- | --------------------------- |
-| Kubernetes v1.13 | ✓                           |                             |
-| Kubernetes v1.14 | ✓                           |                             |
-| Kubernetes v1.15 | ✓                           |                             |
-| Kubernetes v1.16 | ✓                           | ✓                           |
-| Kubernetes v1.17 |                             | ✓                           |
-| Kubernetes v1.18 |                             | ✓                           |
-| Kubernetes v1.19 |                             | ✓                           |
-| Kubernetes v1.20 |                             | ✓                           |
+|                  |  CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload |  CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload |
+| ---------------- | -------------------------------- | ----------------------------- | -------------------------------- | ----------------------------- |
+| Kubernetes v1.16 | ✓                                | ✓                             |                                  |                               |
+| Kubernetes v1.17 | ✓                                | ✓                             |                                  |                               |
+| Kubernetes v1.18 | ✓                                | ✓                             |                                  | ✓                             |
+| Kubernetes v1.19 | ✓                                | ✓                             | ✓                                | ✓                             |
+| Kubernetes v1.20 | ✓                                | ✓                             | ✓                                | ✓                             |
+| Kubernetes v1.21 | ✓                                | ✓                             | ✓                                | ✓                             |
+| Kubernetes v1.22 |                                  | ✓                             | ✓                                | ✓                             |
 
 The Core Provider also talks to API server of every Workload Cluster. Therefore, the Workload Cluster's Kubernetes version must also be compatible.
 
 #### Kubeadm Bootstrap Provider (`kubeadm-bootstrap-controller`)
 
-|                                    | Cluster API v1alpha2 (v0.2) | Cluster API v1alpha3 (v0.3) |
-| ---------------------------------- | --------------------------- | --------------------------- |
-| Kubernetes v1.13                   |                             |                             |
-| Kubernetes v1.14 + kubeadm/v1beta1 | ✓                           |                             |
-| Kubernetes v1.15 + kubeadm/v1beta2 | ✓                           |                             |
-| Kubernetes v1.16 + kubeadm/v1beta2 | ✓                           | ✓                           |
-| Kubernetes v1.17 + kubeadm/v1beta2 |                             | ✓                           |
-| Kubernetes v1.18 + kubeadm/v1beta2 |                             | ✓                           |
-| Kubernetes v1.19 + kubeadm/v1beta2 |                             | ✓                           |
-| Kubernetes v1.20 + kubeadm/v1beta2 |                             | ✓                           |
+|                                    |  CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload | CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload |
+| ---------------------------------- | -------------------------------- | ----------------------------- | ------------------------------- | ----------------------------- |
+| Kubernetes v1.16 + kubeadm/v1beta2 | ✓                                | ✓                             |                                 |                               |
+| Kubernetes v1.17 + kubeadm/v1beta2 | ✓                                | ✓                             |                                 |                               |
+| Kubernetes v1.18 + kubeadm/v1beta2 | ✓                                | ✓                             |                                 | ✓                             |
+| Kubernetes v1.19 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             |
+| Kubernetes v1.20 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             |
+| Kubernetes v1.21 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             |
+| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4) |                                  | ✓                             | ✓                               | ✓                             |
 
-The Kubeadm Bootstrap Provider generates configuration using the v1beta1 or v1beta2 kubeadm API
-according to the target Kubernetes version.
+The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
-|                            | Cluster API v1alpha2 (v0.2) | Cluster API v1alpha3 (v0.3) |
-| -------------------------- | --------------------------- | --------------------------- |
-| Kubernetes v1.13           |                             |                             |
-| Kubernetes v1.14           |                             |                             |
-| Kubernetes v1.15           |                             |                             |
-| Kubernetes v1.16 + etcd/v3 |                             | ✓                           |
-| Kubernetes v1.17 + etcd/v3 |                             | ✓                           |
-| Kubernetes v1.18 + etcd/v3 |                             | ✓                           |
-| Kubernetes v1.19 + etcd/v3 |                             | ✓                           |
-| Kubernetes v1.20 + etcd/v3 |                             | ✓                           |
+|                            | CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload | CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload |
+| -------------------------- | ------------------------------- | ----------------------------- | ------------------------------- | ----------------------------- |
+| Kubernetes v1.16 + etcd/v3 | ✓                               | ✓                             |                                 |                               |
+| Kubernetes v1.17 + etcd/v3 | ✓                               | ✓                             |                                 |                               |
+| Kubernetes v1.18 + etcd/v3 | ✓                               | ✓                             |                                 | ✓                             |
+| Kubernetes v1.19 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             |
+| Kubernetes v1.20 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             |
+| Kubernetes v1.21 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             |
+| Kubernetes v1.22 + etcd/v3 |                                 | ✓                             | ✓                               | ✓                             |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
See issue.

I think we should only try to keep the supported versions of the current book up-to-date (it's hard enough). So I wouldn't fix the old 0.3 book. Or at least as we're currently referencing the current and the last release series in our matrix and I wouldn't maintain it in both books.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4988
