### PR TITLE
🌱  explicitly ignore command injection (in tests)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,7 +73,6 @@ issues:
   exclude:
   # The following are being worked on to remove their exclusion. This list should be reduced or go away all together over time.
   # If it is decided they will not be addressed they should be moved above this comment.
-  - Subprocess launch(ed with variable|ing should be audited)
   - 'G307: Deferring unsafe method "Close" on type "\*os.File"'
   exclude-rules:
   - linters:

--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -94,7 +94,7 @@ func InitWithBinary(_ context.Context, binary string, input InitInput) {
 		strings.Join(input.InfrastructureProviders, ","),
 	)
 
-	cmd := exec.Command(binary, "init",
+	cmd := exec.Command(binary, "init", //nolint:gosec // We don't care about command injection here.
 		"--core", input.CoreProvider,
 		"--bootstrap", strings.Join(input.BootstrapProviders, ","),
 		"--control-plane", strings.Join(input.ControlPlaneProviders, ","),
@@ -202,7 +202,7 @@ func ConfigClusterWithBinary(_ context.Context, clusterctlBinaryPath string, inp
 		valueOrDefault(input.Flavor),
 	)
 
-	cmd := exec.Command(clusterctlBinaryPath, "config", "cluster",
+	cmd := exec.Command(clusterctlBinaryPath, "config", "cluster", //nolint:gosec // We don't care about command injection here.
 		input.ClusterName,
 		"--infrastructure", input.InfrastructureProvider,
 		"--kubernetes-version", input.KubernetesVersion,

--- a/test/framework/docker_logcollector.go
+++ b/test/framework/docker_logcollector.go
@@ -111,7 +111,7 @@ func (k DockerLogCollector) collectLogsFromNode(ctx context.Context, outputPath 
 				return err
 			}
 
-			return osExec.Command("tar", "--extract", "--file", tempfileName, "--directory", outputDir).Run()
+			return osExec.Command("tar", "--extract", "--file", tempfileName, "--directory", outputDir).Run() //nolint:gosec // We don't care about command injection here.
 		}
 	}
 	return errors.AggregateConcurrent([]func() error{

--- a/test/framework/kubernetesversions/template.go
+++ b/test/framework/kubernetesversions/template.go
@@ -125,7 +125,7 @@ func GenerateCIArtifactsInjectedTemplateForDebian(input GenerateCIArtifactsInjec
 	if err := os.WriteFile(path.Join(overlayDir, "platform-kustomization.yaml"), input.PlatformKustomization, 0o600); err != nil {
 		return "", err
 	}
-	cmd := exec.Command("kustomize", "build", overlayDir)
+	cmd := exec.Command("kustomize", "build", overlayDir) //nolint:gosec // We don't care about command injection here.
 	data, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Let's rather ignore the individual cases of this finding in our tests then the whole finding.

For details, please see: https://github.com/kubernetes-sigs/cluster-api/issues/4622#issuecomment-876262757

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4622
