### PR TITLE
✨ CAPD: set container restartPolicy to unless-stopped

### DIFF
--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -383,11 +383,12 @@ func (d *docker) RunContainer(ctx context.Context, runConfig *RunContainerInput,
 		// privileges, but this flag also changes some mounts that are necessary
 		// including some ones docker would otherwise do by default.
 		// for now this is what we want. in the future we may revisit this.
-		Privileged:   true,
-		SecurityOpt:  []string{"seccomp=unconfined"}, // ignore seccomp
-		NetworkMode:  dockercontainer.NetworkMode(runConfig.Network),
-		Tmpfs:        runConfig.Tmpfs,
-		PortBindings: nat.PortMap{},
+		Privileged:    true,
+		SecurityOpt:   []string{"seccomp=unconfined"}, // ignore seccomp
+		NetworkMode:   dockercontainer.NetworkMode(runConfig.Network),
+		Tmpfs:         runConfig.Tmpfs,
+		PortBindings:  nat.PortMap{},
+		RestartPolicy: dockercontainer.RestartPolicy{Name: "unless-stopped"},
 	}
 	networkConfig := network.NetworkingConfig{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

If the docker engine is restarted, either through a service restart or a
full system reboot, the containers created by CAPD are left in a stopped
state.

This adds the restartPolicy setting to the Docker container creation so
that containers will be automatically restarted on service restart
unless the user has explicitly stopped the container prior to the
restart.

**Which issue(s) this PR fixes**:
Fixes #5020 
