### PR TITLE
🌱 Migrate envtest setup to envtest.Run, add CAPI_DISABLE_TEST_ENV option

### DIFF
--- a/api/v1alpha3/suite_test.go
+++ b/api/v1alpha3/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -34,24 +33,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// Bootstrapping test environment
 	utilruntime.Must(AddToScheme(scheme.Scheme))
-	env = envtest.New()
-	go func() {
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
 
-	// Run tests
-	code := m.Run()
-	// Tearing down the test environment
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
-	}
-
-	// Report exit code
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/bootstrap/kubeadm/api/v1alpha3/suite_test.go
+++ b/bootstrap/kubeadm/api/v1alpha3/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -34,24 +33,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// Bootstrapping test environment
 	utilruntime.Must(AddToScheme(scheme.Scheme))
-	env = envtest.New()
-	go func() {
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
 
-	// Run tests
-	code := m.Run()
-	// Tearing down the test environment
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
-	}
-
-	// Report exit code
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/bootstrap/kubeadm/controllers/suite_test.go
+++ b/bootstrap/kubeadm/controllers/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -32,24 +31,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	fmt.Println("Creating new test environment")
-	env = envtest.New()
-
-	go func() {
-		fmt.Println("Starting the manager")
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
-
-	code := m.Run()
-
-	fmt.Println("Tearing down test suite")
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
-	}
-
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/bootstrap/util/suite_test.go
+++ b/bootstrap/util/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -32,23 +31,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// Bootstrapping test environment
-	env = envtest.New()
-	go func() {
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
-
-	// Run tests
-	code := m.Run()
-	// Tearing down the test environment
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
-	}
-
-	// Report exit code
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/controllers/remote/suite_test.go
+++ b/controllers/remote/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package remote
 
 import (
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -37,24 +36,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	fmt.Println("Creating a new test environment")
-	env = envtest.New()
-
-	go func() {
-		fmt.Println("Starting the test environment manager")
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the test environment manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
-
-	code := m.Run()
-
-	fmt.Println("Stopping the test environment")
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop the test environment: %v", err))
-	}
-
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/controlplane/kubeadm/api/v1alpha3/suite_test.go
+++ b/controlplane/kubeadm/api/v1alpha3/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -34,24 +33,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// Bootstrapping test environment
 	utilruntime.Must(AddToScheme(scheme.Scheme))
-	env = envtest.New()
-	go func() {
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
 
-	// Run tests
-	code := m.Run()
-	// Tearing down the test environment
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
-	}
-
-	// Report exit code
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/controlplane/kubeadm/controllers/suite_test.go
+++ b/controlplane/kubeadm/controllers/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -32,23 +31,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// Bootstrapping test environment
-	env = envtest.New()
-	go func() {
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
-
-	// Run tests
-	code := m.Run()
-	// Tearing down the test environment
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
-	}
-
-	// Report exit code
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/controlplane/kubeadm/internal/suite_test.go
+++ b/controlplane/kubeadm/internal/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package internal
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -31,20 +30,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	env = envtest.New()
-	go func() {
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
-
-	code := m.Run()
-
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
-	}
-
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/exp/addons/api/v1alpha3/suite_test.go
+++ b/exp/addons/api/v1alpha3/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -34,24 +33,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// Bootstrapping test environment
 	utilruntime.Must(AddToScheme(scheme.Scheme))
-	env = envtest.New()
-	go func() {
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
 
-	// Run tests
-	code := m.Run()
-	// Tearing down the test environment
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
-	}
-
-	// Report exit code
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/exp/api/v1alpha3/suite_test.go
+++ b/exp/api/v1alpha3/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -34,24 +33,10 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// Bootstrapping test environment
 	utilruntime.Must(AddToScheme(scheme.Scheme))
-	env = envtest.New()
-	go func() {
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
 
-	// Run tests
-	code := m.Run()
-	// Tearing down the test environment
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
-	}
-
-	// Report exit code
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/util/collections/suite_test.go
+++ b/util/collections/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package collections_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -31,23 +30,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// Bootstrapping test environment
-	env = envtest.New()
-	go func() {
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
-
-	// Run tests
-	code := m.Run()
-	// Tearing down the test environment
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop the envtest: %v", err))
-	}
-
-	// Report exit code
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }

--- a/util/patch/suite_test.go
+++ b/util/patch/suite_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package patch
 
 import (
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -37,24 +36,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	fmt.Println("Creating new test environment")
-	env = envtest.New()
-
-	go func() {
-		fmt.Println("Starting the manager")
-		if err := env.Start(ctx); err != nil {
-			panic(fmt.Sprintf("Failed to start the envtest manager: %v", err))
-		}
-	}()
-	<-env.Manager.Elected()
-	env.WaitForWebhooks()
-
-	code := m.Run()
-
-	fmt.Println("Tearing down test suite")
-	if err := env.Stop(); err != nil {
-		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
-	}
-
-	os.Exit(code)
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:        m,
+		SetupEnv: func(e *envtest.Environment) { env = e },
+	}))
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5029
