### PR TITLE
🌱 KCP: stop caching ConfigMap, Secret, Pod, Deployment and DaemonSet of workload clusters

### DIFF
--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -199,6 +200,13 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 				Field:        noderefutil.NodeProviderIDIndex,
 				ExtractValue: noderefutil.IndexNodeByProviderID,
 			},
+		},
+		ClientUncachedObjects: []client.Object{
+			&corev1.ConfigMap{},
+			&corev1.Secret{},
+			&corev1.Pod{},
+			&appsv1.Deployment{},
+			&appsv1.DaemonSet{},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR configures the KCP ClusterCacheTracker to stop caching: ConfigMaps, Secrets, Pods, Deployments and DaemonSets of workload clusters.

> It might make more sense for KCP to always use a live client to read the status of a Cluster during reconciliation. Caching all these kind of objects increases memory usage of our controllers by a large factor, especially with management clusters that are in charge of a high number of workload clusters.
> Vince in https://github.com/kubernetes-sigs/cluster-api/pull/5033#issuecomment-889214342

Originally the plan was to implement it as a follow-up to: https://github.com/kubernetes-sigs/cluster-api/pull/4104#discussion_r566180107. But I guess we lost track of it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
