### PR TITLE
🌱 Implement twoWayPatchHelper for ClusterClass reconciliation

### DIFF
--- a/controllers/clustertopology_controller_mergepatch.go
+++ b/controllers/clustertopology_controller_mergepatch.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mergePatchHelper struct {
+	client client.Client
+
+	// original holds the object to which the patch should apply to, to be used in the Patch method.
+	original client.Object
+
+	// data holds the raw merge patch in json format.
+	data []byte
+}
+
+// newMergePatchHelper will return a patch that yields the modified document when applied to the original document.
+// NOTE: In the case of ClusterTopologyReconciler, original is the current object, modified is the desired object, and
+// the patch returns all the changes required to align current to what is defined in desired; fields not defined in desired
+// are going to be preserved without changes.
+func newMergePatchHelper(original, modified client.Object, c client.Client) (*mergePatchHelper, error) {
+	originalJSON, err := json.Marshal(original)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal original object to json")
+	}
+
+	modifiedJSON, err := json.Marshal(modified)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal modified object to json")
+	}
+
+	originalWithModifiedJSON, err := jsonpatch.MergePatch(originalJSON, modifiedJSON)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to apply modified json to original json")
+	}
+
+	data, err := jsonpatch.CreateMergePatch(originalJSON, originalWithModifiedJSON)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create merge patch")
+	}
+
+	return &mergePatchHelper{
+		client:   c,
+		data:     data,
+		original: original,
+	}, nil
+}
+
+// HasChanges return true if the patch has changes.
+func (h *mergePatchHelper) HasChanges() bool {
+	return !bytes.Equal(h.data, []byte("{}"))
+}
+
+// Patch will attempt to apply the twoWaysPatch to the original object.
+func (h *mergePatchHelper) Patch(ctx context.Context) error {
+	if !h.HasChanges() {
+		return nil
+	}
+	return h.client.Patch(ctx, h.original, client.RawPatch(types.MergePatchType, h.data))
+}

--- a/controllers/clustertopology_controller_mergepatch_test.go
+++ b/controllers/clustertopology_controller_mergepatch_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestNewMergePatchHelper(t *testing.T) {
+	tests := []struct {
+		name           string
+		original       *unstructured.Unstructured // current
+		modified       *unstructured.Unstructured // desired
+		wantHasChanges bool
+		wantPatch      []byte
+	}{
+		// Field both in original and in modified --> align to modified
+
+		{
+			name: "Field both in original and in modified, no-op when equal",
+			original: &unstructured.Unstructured{ // current
+				Object: map[string]interface{}{
+					"A": "A",
+				},
+			},
+			modified: &unstructured.Unstructured{ // desired
+				Object: map[string]interface{}{
+					"A": "A",
+				},
+			},
+			wantHasChanges: false,
+			wantPatch:      []byte("{}"),
+		},
+		{
+			name: "Field both in original and in modified, align to modified when different",
+			original: &unstructured.Unstructured{ // current
+				Object: map[string]interface{}{
+					"A": "A-changed",
+				},
+			},
+			modified: &unstructured.Unstructured{ // desired
+				Object: map[string]interface{}{
+					"A": "A",
+				},
+			},
+			wantHasChanges: true,
+			wantPatch:      []byte("{\"A\":\"A\"}"),
+		},
+		{
+			name: "Nested field both in original and in modified, no-op when equal",
+			original: &unstructured.Unstructured{ // current
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"A": "A",
+							},
+						},
+					},
+				},
+			},
+			modified: &unstructured.Unstructured{ // desired
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"A": "A",
+							},
+						},
+					},
+				},
+			},
+			wantHasChanges: false,
+			wantPatch:      []byte("{}"),
+		},
+		{
+			name: "Nested field both in original and in modified, align to modified when different",
+			original: &unstructured.Unstructured{ // current
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"A": "A-Changed",
+							},
+						},
+					},
+				},
+			},
+			modified: &unstructured.Unstructured{ // desired
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"A": "A",
+							},
+						},
+					},
+				},
+			},
+			wantHasChanges: true,
+			wantPatch:      []byte("{\"spec\":{\"template\":{\"spec\":{\"A\":\"A\"}}}}"),
+		},
+		{
+			name: "Value of type map, enforces entries from modified, preserve entries only in original",
+			original: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"map": map[string]string{
+						"A": "A-changed",
+						"B": "B",
+						// C missing
+					},
+				},
+			},
+			modified: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"map": map[string]string{
+						"A": "A",
+						// B missing
+						"C": "C",
+					},
+				},
+			},
+			wantHasChanges: true,
+			wantPatch:      []byte("{\"map\":{\"A\":\"A\",\"C\":\"C\"}}"),
+		},
+		{
+			name: "Value of type Array or Slice, align to modified",
+			original: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"slice": []string{
+						"D",
+						"C",
+						"B",
+					},
+				},
+			},
+			modified: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"slice": []string{
+						"A",
+						"B",
+						"C",
+					},
+				},
+			},
+			wantHasChanges: true,
+			wantPatch:      []byte("{\"slice\":[\"A\",\"B\",\"C\"]}"),
+		},
+
+		// Field only in modified (not existing in original) --> align to modified
+
+		{
+			name: "Field only in modified, align to modified",
+			original: &unstructured.Unstructured{ // current
+				Object: map[string]interface{}{},
+			},
+			modified: &unstructured.Unstructured{ // desired
+				Object: map[string]interface{}{
+					"A": "A",
+				},
+			},
+			wantHasChanges: true,
+			wantPatch:      []byte("{\"A\":\"A\"}"),
+		},
+		{
+			name: "Nested field only in modified, align to modified",
+			original: &unstructured.Unstructured{ // current
+				Object: map[string]interface{}{},
+			},
+			modified: &unstructured.Unstructured{ // desired
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"A": "A",
+							},
+						},
+					},
+				},
+			},
+			wantHasChanges: true,
+			wantPatch:      []byte("{\"spec\":{\"template\":{\"spec\":{\"A\":\"A\"}}}}"),
+		},
+
+		// Field only in original (not existing in modified) --> preserve original
+
+		{
+			name: "Field only in original, align to modified",
+			original: &unstructured.Unstructured{ // current
+				Object: map[string]interface{}{
+					"A": "A",
+				},
+			},
+			modified: &unstructured.Unstructured{ // desired
+				Object: map[string]interface{}{},
+			},
+			wantHasChanges: false,
+			wantPatch:      []byte("{}"),
+		},
+		{
+			name: "Nested field only in original, align to modified",
+			original: &unstructured.Unstructured{ // current
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"A": "A",
+							},
+						},
+					},
+				},
+			},
+			modified: &unstructured.Unstructured{ // desired
+				Object: map[string]interface{}{},
+			},
+			wantHasChanges: false,
+			wantPatch:      []byte("{}"),
+		},
+
+		// More tests
+		{
+			name: "No changes",
+			original: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"A": "A",
+						"B": "B",
+						"C": "C", // C only in modified
+					},
+				},
+			},
+			modified: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"A": "A",
+						"B": "B",
+					},
+				},
+			},
+			wantHasChanges: false,
+			wantPatch:      []byte("{}"),
+		},
+		{
+			name: "Many changes",
+			original: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"A": "A",
+						// B missing
+						"C": "C", // C only in modified
+					},
+				},
+			},
+			modified: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"A": "A",
+						"B": "B",
+					},
+				},
+			},
+			wantHasChanges: true,
+			wantPatch:      []byte("{\"spec\":{\"B\":\"B\"}}"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			patch, err := newMergePatchHelper(tt.original, tt.modified, nil)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(patch.HasChanges()).To(Equal(tt.wantHasChanges))
+			g.Expect(patch.data).To(Equal(tt.wantPatch))
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr implements a twoWaysPatchHelper for ClusterClass reconciliation ensuring that

- enforces that all the fields in the desired object for which a value is defined are reflected in the current object.
- all the other values in the current object are preserved

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5032
