### PR TITLE
🌱 Deprecate partial upgrade tests

### DIFF
--- a/test/e2e/kcp_upgrade.go
+++ b/test/e2e/kcp_upgrade.go
@@ -44,7 +44,7 @@ type KCPUpgradeSpecInput struct {
 	Flavor                   string
 }
 
-// KCPUpgradeSpec implements a test that verifies KCP to properly upgrade a control plane with 3 machines.
+// KCPUpgradeSpec implements a test that verifies KCP to properly upgrade a control plane.
 func KCPUpgradeSpec(ctx context.Context, inputGetter func() KCPUpgradeSpecInput) {
 	var (
 		specName         = "kcp-upgrade"

--- a/test/e2e/machine_pool.go
+++ b/test/e2e/machine_pool.go
@@ -44,7 +44,7 @@ type MachinePoolInput struct {
 	SkipCleanup           bool
 }
 
-// MachinePoolSpec implements a test that verifies MachinePool scale up, down and version update
+// MachinePoolSpec implements a test that verifies MachinePool create, scale up and scale down.
 func MachinePoolSpec(ctx context.Context, inputGetter func() MachinePoolInput) {
 	var (
 		specName         = "machine-pool"
@@ -107,15 +107,6 @@ func MachinePoolSpec(ctx context.Context, inputGetter func() MachinePoolInput) {
 			Replicas:                  workerMachineCount - 1,
 			MachinePools:              clusterResources.MachinePools,
 			WaitForMachinePoolToScale: input.E2EConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
-		})
-
-		By("Upgrading the instances")
-		framework.UpgradeMachinePoolAndWait(ctx, framework.UpgradeMachinePoolAndWaitInput{
-			ClusterProxy:                   input.BootstrapClusterProxy,
-			Cluster:                        clusterResources.Cluster,
-			UpgradeVersion:                 input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
-			WaitForMachinePoolToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-machine-pool-upgrade"),
-			MachinePools:                   clusterResources.MachinePools,
 		})
 
 		By("PASSED!")

--- a/test/e2e/md_rollout.go
+++ b/test/e2e/md_rollout.go
@@ -33,8 +33,8 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-// MachineDeploymentUpgradesSpecInput is the input for MachineDeploymentUpgradesSpec.
-type MachineDeploymentUpgradesSpecInput struct {
+// MachineDeploymentRolloutSpecInput is the input for MachineDeploymentRolloutSpec.
+type MachineDeploymentRolloutSpecInput struct {
 	E2EConfig             *clusterctl.E2EConfig
 	ClusterctlConfigPath  string
 	BootstrapClusterProxy framework.ClusterProxy
@@ -42,11 +42,11 @@ type MachineDeploymentUpgradesSpecInput struct {
 	SkipCleanup           bool
 }
 
-// MachineDeploymentUpgradesSpec implements a test that verifies that MachineDeployment upgrades are successful.
-func MachineDeploymentUpgradesSpec(ctx context.Context, inputGetter func() MachineDeploymentUpgradesSpecInput) {
+// MachineDeploymentRolloutSpec implements a test that verifies that MachineDeployment rolling updates are successful.
+func MachineDeploymentRolloutSpec(ctx context.Context, inputGetter func() MachineDeploymentRolloutSpecInput) {
 	var (
-		specName         = "md-upgrades"
-		input            MachineDeploymentUpgradesSpecInput
+		specName         = "md-rollout"
+		input            MachineDeploymentRolloutSpecInput
 		namespace        *corev1.Namespace
 		cancelWatches    context.CancelFunc
 		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
@@ -89,15 +89,6 @@ func MachineDeploymentUpgradesSpec(ctx context.Context, inputGetter func() Machi
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 		}, clusterResources)
-
-		By("Upgrading MachineDeployment's Kubernetes version to a valid version")
-		framework.UpgradeMachineDeploymentsAndWait(ctx, framework.UpgradeMachineDeploymentsAndWaitInput{
-			ClusterProxy:                input.BootstrapClusterProxy,
-			Cluster:                     clusterResources.Cluster,
-			UpgradeVersion:              input.E2EConfig.GetVariable(KubernetesVersion),
-			WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
-			MachineDeployments:          clusterResources.MachineDeployments,
-		})
 
 		By("Upgrading MachineDeployment Infrastructure ref and wait for rolling upgrade")
 		framework.UpgradeMachineDeploymentInfrastructureRefAndWait(ctx, framework.UpgradeMachineDeploymentInfrastructureRefAndWaitInput{

--- a/test/e2e/md_rollout_test.go
+++ b/test/e2e/md_rollout_test.go
@@ -22,10 +22,10 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = Describe("When testing MachineDeployment upgrades", func() {
+var _ = Describe("When testing MachineDeployment rolling upgrades", func() {
 
-	MachineDeploymentUpgradesSpec(ctx, func() MachineDeploymentUpgradesSpecInput {
-		return MachineDeploymentUpgradesSpecInput{
+	MachineDeploymentRolloutSpec(ctx, func() MachineDeploymentRolloutSpecInput {
+		return MachineDeploymentRolloutSpecInput{
 			E2EConfig:             e2eConfig,
 			ClusterctlConfigPath:  clusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Originally in our E2E test we implemented upgrade tests for single CAPI resources:

- KCPUpgradeSpec
- MachineDeploymentUpgradesSpec
- MachinePoolSpec

This is now superseded by ClusterUpgradeConformanceSpec, which upgrades all the resources, makes sure CP is upgraded before nodes (thus being compliant with K8s recommendations) and runs conformance on the resulting test.

This PR refactors the legacy test to remove partial upgrade as described in the issue:

- KCPUpgradeSpec might still have sense, because it tries different topologies of control plane vs what we usually have in KCPUpgradeSpec
- MachineDeploymentUpgradesSpec should be re-focused to test rollout when the infrastructure template changes.
- MachinePoolSpec should be re-focused on test MachinePool machinery (except upgrades)

It also adds a flag to skip conformance in ClusterUpgradeConformanceSpec for providers to be able to test upgrade without the hour+ conformance job.

Future work: adding a quick smoke test that always run for basic validation as described in https://github.com/kubernetes-sigs/cluster-api/issues/4896#issuecomment-876364145.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4896 
