### PR TITLE
✨ Implement getClusterState for topology controller

### DIFF
--- a/api/v1alpha4/common_types.go
+++ b/api/v1alpha4/common_types.go
@@ -29,6 +29,10 @@ const (
 	// ClusterTopologyLabelName is the label set on all the object which are managed as part of a ClusterTopology.
 	ClusterTopologyLabelName = "cluster.x-k8s.io/topology"
 
+	// ClusterTopologyMachineDeploymentLabelName is the label set on the generated  MachineDeployment objects
+	// to track the name of the machine deployment topology it represents.
+	ClusterTopologyMachineDeploymentLabelName = "cluster.x-k8s.io/topology/deployment-name"
+
 	// ProviderLabelName is the label set on components in the provider manifest.
 	// This label allows to easily identify all the components belonging to a provider; the clusterctl
 	// tool uses this label for implementing provider's lifecycle operations.

--- a/controllers/topology/cluster_class.go
+++ b/controllers/topology/cluster_class.go
@@ -54,13 +54,13 @@ func (r *ClusterReconciler) getClass(ctx context.Context, cluster *clusterv1.Clu
 	}()
 
 	// Get ClusterClass.spec.infrastructure.
-	class.infrastructureClusterTemplate, err = r.getTemplate(ctx, class.clusterClass.Spec.Infrastructure.Ref)
+	class.infrastructureClusterTemplate, err = r.getReference(ctx, class.clusterClass.Spec.Infrastructure.Ref)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get ClusterClass.spec.controlPlane.
-	class.controlPlane.template, err = r.getTemplate(ctx, class.clusterClass.Spec.ControlPlane.Ref)
+	class.controlPlane.template, err = r.getReference(ctx, class.clusterClass.Spec.ControlPlane.Ref)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (r *ClusterReconciler) getClass(ctx context.Context, cluster *clusterv1.Clu
 	// Check if ClusterClass.spec.ControlPlane.MachineInfrastructure is set, as it's optional.
 	if class.clusterClass.Spec.ControlPlane.MachineInfrastructure != nil && class.clusterClass.Spec.ControlPlane.MachineInfrastructure.Ref != nil {
 		// Get ClusterClass.spec.controlPlane.machineInfrastructure.
-		class.controlPlane.infrastructureMachineTemplate, err = r.getTemplate(ctx, class.clusterClass.Spec.ControlPlane.MachineInfrastructure.Ref)
+		class.controlPlane.infrastructureMachineTemplate, err = r.getReference(ctx, class.clusterClass.Spec.ControlPlane.MachineInfrastructure.Ref)
 		if err != nil {
 			return nil, err
 		}
@@ -77,12 +77,12 @@ func (r *ClusterReconciler) getClass(ctx context.Context, cluster *clusterv1.Clu
 	for _, mdc := range class.clusterClass.Spec.Workers.MachineDeployments {
 		mdTopologyClass := machineDeploymentTopologyClass{}
 
-		mdTopologyClass.infrastructureMachineTemplate, err = r.getTemplate(ctx, mdc.Template.Infrastructure.Ref)
+		mdTopologyClass.infrastructureMachineTemplate, err = r.getReference(ctx, mdc.Template.Infrastructure.Ref)
 		if err != nil {
 			return nil, err
 		}
 
-		mdTopologyClass.bootstrapTemplate, err = r.getTemplate(ctx, mdc.Template.Bootstrap.Ref)
+		mdTopologyClass.bootstrapTemplate, err = r.getReference(ctx, mdc.Template.Bootstrap.Ref)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/topology/controller.go
+++ b/controllers/topology/controller.go
@@ -125,7 +125,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cl
 	}
 
 	// Gets the current state of the Cluster.
-	currentState, err := r.getCurrentState(ctx, cluster)
+	currentState, err := r.getCurrentState(ctx, cluster, class.clusterClass)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "error reading current state of the Cluster topology")
 	}

--- a/controllers/topology/current_state.go
+++ b/controllers/topology/current_state.go
@@ -18,12 +18,142 @@ package topology
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Gets the current state of the Cluster topology.
-func (r *ClusterReconciler) getCurrentState(ctx context.Context, cluster *clusterv1.Cluster) (*clusterTopologyState, error) {
-	// TODO: add get class logic; also remove nolint exception from clusterTopologyState and machineDeploymentTopologyState
-	return nil, nil
+// getCurrentState gets information about the current state of a Cluster by inspecting the state of the InfrastructureCluster,
+// the ControlPlane, and the MachineDeployments associated with the Cluster.
+func (r *ClusterReconciler) getCurrentState(ctx context.Context, cluster *clusterv1.Cluster, class *clusterv1.ClusterClass) (*clusterTopologyState, error) {
+	clusterState := clusterTopologyState{
+		cluster: cluster,
+	}
+
+	// Reference to the InfrastructureCluster can be nil and is expected to be on the first reconcile.
+	// In this case the method should still be allowed to continue.
+	if cluster.Spec.InfrastructureRef != nil {
+		infra, err := r.getCurrentInfrastructureClusterState(ctx, cluster)
+		if err != nil {
+			return nil, err
+		}
+		clusterState.infrastructureCluster = infra
+	}
+
+	// Reference to the ControlPlane can be nil, and is expected to be on the first reconcile. In this case the method
+	// should still be allowed to continue.
+	if cluster.Spec.ControlPlaneRef != nil {
+		cp, err := r.getCurrentControlPlaneState(ctx, cluster, class)
+		if err != nil {
+			return nil, err
+		}
+		clusterState.controlPlane = cp
+	}
+
+	// A Cluster may have zero or more MachineDeployments and a Cluster is expected to have zero MachineDeployments on
+	// first reconcile.
+	m, err := r.getCurrentMachineDeploymentState(ctx, cluster)
+	if err != nil {
+		return nil, err
+	}
+	clusterState.machineDeployments = m
+	return &clusterState, nil
+}
+
+// getCurrentInfrastructureClusterState looks for the state of the InfrastructureCluster. If a reference is set but not
+// found, either from an error or the object not being found, an error is thrown.
+func (r *ClusterReconciler) getCurrentInfrastructureClusterState(ctx context.Context, cluster *clusterv1.Cluster) (*unstructured.Unstructured, error) {
+	infra, err := r.getReference(ctx, cluster.Spec.InfrastructureRef)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read %s %s", cluster.Spec.InfrastructureRef.Kind, cluster.Spec.InfrastructureRef.Name)
+	}
+	return infra, nil
+}
+
+// getCurrentControlPlaneState returns information on the ControlPlane being used by the Cluster. If a reference is not found,
+// an error is thrown. If the ControlPlane requires MachineInfrastructure according to its ClusterClass an error will be
+// thrown if the ControlPlane has no MachineTemplates.
+func (r *ClusterReconciler) getCurrentControlPlaneState(ctx context.Context, cluster *clusterv1.Cluster, class *clusterv1.ClusterClass) (controlPlaneTopologyState, error) {
+	cp, err := r.getReference(ctx, cluster.Spec.ControlPlaneRef)
+	if err != nil {
+		return controlPlaneTopologyState{}, errors.Wrapf(err, "failed to read %s %s", cluster.Spec.ControlPlaneRef.Kind, cluster.Spec.ControlPlaneRef.Name)
+	}
+	// Some ControlPlane providers may not require MachineInfrastructure to run. This check returns early if the field
+	// indicating MachineInfrastructure is required is not found in the ClusterClass of the given Cluster.
+	if class.Spec.ControlPlane.MachineInfrastructure == nil {
+		return controlPlaneTopologyState{
+			cp,
+			nil,
+		}, nil
+	}
+
+	cpInfraRef, err := getNestedRef(cp, "spec", "machineTemplate", "infrastructureRef")
+	if err != nil {
+		return controlPlaneTopologyState{cp, nil}, errors.Wrapf(err, "failed to get InfrastructureMachineTemplate reference for %s, %s", cp.GetKind(), cp.GetName())
+	}
+	infra, err := r.getReference(ctx, cpInfraRef)
+	if err != nil {
+		return controlPlaneTopologyState{cp, nil}, errors.Wrapf(err, "failed to get InfrastructureMachineTemplate reference for %s, %s", cp.GetKind(), cp.GetName())
+	}
+	return controlPlaneTopologyState{
+		cp,
+		infra,
+	}, nil
+}
+
+// getCurrentMachineDeploymentState queries for all MachineDeployments and filters them for their linked Cluster and
+// whether they are managed by a ClusterClass using labels. A Cluster may have zero or more MachineDeployments. Zero is
+// expected on first reconcile. If MachineDeployments are found for the Cluster their Infrastructure and Bootstrap references
+// are inspected. Where these are not found the function will throw an error.
+func (r *ClusterReconciler) getCurrentMachineDeploymentState(ctx context.Context, cluster *clusterv1.Cluster) (map[string]machineDeploymentTopologyState, error) {
+	mDeploymentState := make(map[string]machineDeploymentTopologyState)
+
+	md := &clusterv1.MachineDeploymentList{}
+	err := r.Client.List(ctx, md, client.MatchingLabels{
+		clusterv1.ClusterLabelName:         cluster.Name,
+		clusterv1.ClusterTopologyLabelName: "",
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read MachineDeployments for managed topology")
+	}
+	for _, m := range md.Items {
+		machineDeployment := m
+		mdTopologyName, ok := m.ObjectMeta.Labels[clusterv1.ClusterTopologyMachineDeploymentLabelName]
+		if !ok {
+			return nil, fmt.Errorf("failed to find label %s in %s", clusterv1.ClusterTopologyMachineDeploymentLabelName, machineDeployment.Name)
+		}
+		if mdTopologyName == "" {
+			return nil, fmt.Errorf("no value for MachineDeploymentTopoplogyName for %s", machineDeployment.Name)
+		}
+		if _, ok := mDeploymentState[mdTopologyName]; ok {
+			return nil, fmt.Errorf("duplicate machine deployment %s found for label %s: %s", machineDeployment.Name, clusterv1.ClusterTopologyMachineDeploymentLabelName, mdTopologyName)
+		}
+		infraRef := &m.Spec.Template.Spec.InfrastructureRef
+		if infraRef == nil {
+			return nil, fmt.Errorf("MachineDeployment %s does not have a reference to a InfrastructureMachineTemplate", machineDeployment.Name)
+		}
+
+		bootstrapRef := m.Spec.Template.Spec.Bootstrap.ConfigRef
+		if bootstrapRef == nil {
+			return nil, fmt.Errorf("MachineDeployment %s does not have a reference to a Bootstrap Config", machineDeployment.Name)
+		}
+
+		i, err := r.getReference(ctx, infraRef)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("MachineDeployment %s Infrastructure reference could not be retrieved", machineDeployment.Name))
+		}
+		b, err := r.getReference(ctx, bootstrapRef)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("MachineDeployment %s Bootstrap reference could not be retrieved", machineDeployment.Name))
+		}
+		mDeploymentState[mdTopologyName] = machineDeploymentTopologyState{
+			object:                        &machineDeployment,
+			bootstrapTemplate:             b,
+			infrastructureMachineTemplate: i,
+		}
+	}
+	return mDeploymentState, nil
 }

--- a/controllers/topology/current_state_test.go
+++ b/controllers/topology/current_state_test.go
@@ -1,0 +1,348 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetCurrentState(t *testing.T) {
+	fakeScheme := runtime.NewScheme()
+	_ = apiextensionsv1.AddToScheme(fakeScheme)
+	_ = clusterv1.AddToScheme(fakeScheme)
+
+	crds := []client.Object{
+		fakeControlPlaneCRD,
+		fakeInfrastuctureClusterCRD,
+		fakeControlPlaneTemplateCRD,
+		fakeInfrastructureClusterTemplateCRD,
+		fakeBootstrapTemplateCRD,
+		fakeInfrastructureMachineTemplateCRD,
+	}
+
+	// The following is a block creating a number of fake objects for use in the test cases.
+
+	// InfrastructureCluster fake objects.
+	infraCluster := newFakeInfrastructureCluster(metav1.NamespaceDefault, "infraOne").Obj()
+	nonExistentInfraCluster := newFakeInfrastructureCluster(metav1.NamespaceDefault, "does-not-exist").Obj()
+
+	// ControlPlane and ControlPlaneInfrastructureMachineTemplate fake objects.
+	controlPlaneInfrastructureMachineTemplate := newFakeInfrastructureMachineTemplate(metav1.NamespaceDefault, "cpInfraTemplate").Obj()
+	controlPlaneTemplateWithInfrastructureMachine := newFakeControlPlaneTemplate(metav1.NamespaceDefault, "cpTemplateWithInfra1").WithInfrastructureMachineTemplate(controlPlaneInfrastructureMachineTemplate).Obj()
+	controlPlane := newFakeControlPlane(metav1.NamespaceDefault, "cp1").Obj()
+	controlPlaneWithInfra := newFakeControlPlane(metav1.NamespaceDefault, "cp1").WithInfrastructureMachineTemplate(controlPlaneInfrastructureMachineTemplate).Obj()
+
+	// ClusterClass fake objects.
+	clusterClassWithControlPlaneInfra := newFakeClusterClass(metav1.NamespaceDefault, "class1").WithControlPlaneTemplate(controlPlaneTemplateWithInfrastructureMachine).WithControlPlaneInfrastructureMachineTemplate(controlPlaneInfrastructureMachineTemplate).Obj()
+	clusterClassWithNoControlPlaneInfra := newFakeClusterClass(metav1.NamespaceDefault, "class2").Obj()
+
+	// MachineDeployment and related objects.
+	machineDeploymentInfrastructure := newFakeInfrastructureMachineTemplate(metav1.NamespaceDefault, "infra1").Obj()
+	machineDeploymentBootstrap := newFakeBootstrapTemplate(metav1.NamespaceDefault, "bootstrap1").Obj()
+	labelsInClass := map[string]string{clusterv1.ClusterLabelName: "cluster1", clusterv1.ClusterTopologyLabelName: "", clusterv1.ClusterTopologyMachineDeploymentLabelName: "md1"}
+	labelsNotInClass := map[string]string{clusterv1.ClusterLabelName: "non-existent-cluster", clusterv1.ClusterTopologyLabelName: "", clusterv1.ClusterTopologyMachineDeploymentLabelName: "md1"}
+	labelsUnmanaged := map[string]string{clusterv1.ClusterLabelName: "cluster1"}
+	labelsManagedWithoutDeploymentName := map[string]string{clusterv1.ClusterLabelName: "cluster1", clusterv1.ClusterTopologyLabelName: ""}
+	machineDeploymentInCluster := newFakeMachineDeployment(metav1.NamespaceDefault, "proper-labels").WithLabels(labelsInClass).WithBootstrapRef(machineDeploymentBootstrap).WithInfraTemplateRef(machineDeploymentInfrastructure).Obj()
+	duplicateMachineDeploymentInCluster := newFakeMachineDeployment(metav1.NamespaceDefault, "duplicate-labels").WithLabels(labelsInClass).WithBootstrapRef(machineDeploymentBootstrap).WithInfraTemplateRef(machineDeploymentInfrastructure).Obj()
+	machineDeploymentNoBootstrap := newFakeMachineDeployment(metav1.NamespaceDefault, "no-bootstrap").WithLabels(labelsInClass).WithInfraTemplateRef(machineDeploymentInfrastructure).Obj()
+	machineDeploymentNoInfrastructure := newFakeMachineDeployment(metav1.NamespaceDefault, "no-infra").WithLabels(labelsInClass).WithBootstrapRef(machineDeploymentBootstrap).Obj()
+	machineDeploymentOutsideCluster := newFakeMachineDeployment(metav1.NamespaceDefault, "wrong-cluster-label").WithLabels(labelsNotInClass).WithBootstrapRef(machineDeploymentBootstrap).WithInfraTemplateRef(machineDeploymentInfrastructure).Obj()
+	machineDeploymentUnmanaged := newFakeMachineDeployment(metav1.NamespaceDefault, "no-managed-label").WithLabels(labelsUnmanaged).WithBootstrapRef(machineDeploymentBootstrap).WithInfraTemplateRef(machineDeploymentInfrastructure).Obj()
+	machineDeploymentWithoutDeploymentName := newFakeMachineDeployment(metav1.NamespaceDefault, "missing-topology-md-labelName").WithLabels(labelsManagedWithoutDeploymentName).WithBootstrapRef(machineDeploymentBootstrap).WithInfraTemplateRef(machineDeploymentInfrastructure).Obj()
+	emptyMachineDeployments := make(map[string]machineDeploymentTopologyState)
+
+	tests := []struct {
+		name    string
+		cluster *clusterv1.Cluster
+		class   *clusterv1.ClusterClass
+		objects []client.Object
+		want    *clusterTopologyState
+		wantErr bool
+	}{
+		{
+			name:    "Cluster exists with no references",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
+			// Expecting valid return with no ControlPlane or Infrastructure state defined and empty MachineDeployment state list
+			want: &clusterTopologyState{
+				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
+				controlPlane:          controlPlaneTopologyState{},
+				infrastructureCluster: nil,
+				machineDeployments:    emptyMachineDeployments,
+			},
+		},
+		{
+			name:    "Cluster with non existent Infrastructure reference only",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").WithInfrastructureCluster(nonExistentInfraCluster).Obj(),
+			objects: []client.Object{
+				infraCluster,
+			},
+			wantErr: true, // this test fails as partial reconcile is undefined.
+		},
+		{
+			name:    "Cluster with Infrastructure reference only",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").WithInfrastructureCluster(infraCluster).Obj(),
+			objects: []client.Object{
+				infraCluster,
+			},
+			// Expecting valid return with no ControlPlane or MachineDeployment state defined but with a valid Infrastructure state.
+			want: &clusterTopologyState{
+				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").WithInfrastructureCluster(infraCluster).Obj(),
+				controlPlane:          controlPlaneTopologyState{},
+				infrastructureCluster: infraCluster,
+				machineDeployments:    emptyMachineDeployments,
+			},
+		},
+		{
+			name:    "Cluster with Infrastructure reference and ControlPlane reference, no ControlPlane Infrastructure and a ClusterClass with no Infrastructure requirement",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").WithControlPlane(controlPlane).WithInfrastructureCluster(infraCluster).Obj(),
+			class:   clusterClassWithNoControlPlaneInfra,
+			objects: []client.Object{
+				controlPlane,
+				infraCluster,
+				clusterClassWithNoControlPlaneInfra,
+			},
+			// Expecting valid return with ControlPlane, no ControlPlane Infrastructure state, InfrastructureCluster state and no defined MachineDeployment state.
+			want: &clusterTopologyState{
+				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").WithControlPlane(controlPlane).WithInfrastructureCluster(infraCluster).Obj(),
+				controlPlane:          controlPlaneTopologyState{object: controlPlane, infrastructureMachineTemplate: nil},
+				infrastructureCluster: infraCluster,
+				machineDeployments:    emptyMachineDeployments,
+			},
+		},
+		{
+			name:    "Cluster with Infrastructure reference and ControlPlane reference, no ControlPlane Infrastructure and a ClusterClass with an Infrastructure requirement",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").WithControlPlane(controlPlane).WithInfrastructureCluster(infraCluster).Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				controlPlane,
+				infraCluster,
+				clusterClassWithControlPlaneInfra,
+			},
+			// Expecting error from ControlPlane having no valid ControlPlane Infrastructure with ClusterClass requiring ControlPlane Infrastructure.
+			wantErr: true,
+		},
+		{
+			name:    "Cluster with ControlPlane reference and with ControlPlane Infrastructure, but no InfrastructureCluster",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").WithControlPlane(controlPlaneWithInfra).Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				controlPlaneWithInfra,
+				controlPlaneInfrastructureMachineTemplate,
+			},
+			// Expecting valid return with valid ControlPlane state, but no ControlPlane Infrastructure, InfrastructureCluster or MachineDeployment state defined.
+			want: &clusterTopologyState{
+				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").WithControlPlane(controlPlaneWithInfra).Obj(),
+				controlPlane:          controlPlaneTopologyState{object: controlPlaneWithInfra, infrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate},
+				infrastructureCluster: nil,
+				machineDeployments:    emptyMachineDeployments,
+			},
+		},
+		{
+			name:    "Cluster with InfrastructureCluster reference ControlPlane reference and ControlPlane Infrastructure",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").WithInfrastructureCluster(infraCluster).WithControlPlane(controlPlaneWithInfra).Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				infraCluster,
+				clusterClassWithControlPlaneInfra,
+				controlPlaneInfrastructureMachineTemplate,
+				controlPlaneWithInfra,
+			},
+			// Expecting valid return with valid ControlPlane state, ControlPlane Infrastructure state and InfrastructureCluster state, but no defined MachineDeployment state.
+			want: &clusterTopologyState{
+				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").WithInfrastructureCluster(infraCluster).WithControlPlane(controlPlaneWithInfra).Obj(),
+				controlPlane:          controlPlaneTopologyState{object: controlPlaneWithInfra, infrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate},
+				infrastructureCluster: infraCluster,
+				machineDeployments:    emptyMachineDeployments,
+			},
+		},
+		{
+			name:    "Cluster with MachineDeployment state but no other states defined",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				infraCluster,
+				clusterClassWithControlPlaneInfra,
+				controlPlaneInfrastructureMachineTemplate,
+				controlPlaneWithInfra,
+				machineDeploymentInfrastructure,
+				machineDeploymentBootstrap,
+				machineDeploymentInCluster,
+			},
+			// Expecting valid return with valid ControlPlane, ControlPlane Infrastructure and InfrastructureCluster state, but no defined MachineDeployment state.
+			want: &clusterTopologyState{
+				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
+				controlPlane:          controlPlaneTopologyState{},
+				infrastructureCluster: nil,
+				machineDeployments: map[string]machineDeploymentTopologyState{
+					"md1": {object: machineDeploymentInCluster, bootstrapTemplate: machineDeploymentBootstrap, infrastructureMachineTemplate: machineDeploymentInfrastructure}},
+			},
+		},
+		{
+			name:    "Class assigning ControlPlane Infrastructure and Cluster with ControlPlane reference but no ControlPlane Infrastructure",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").WithControlPlane(controlPlane).Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				clusterClassWithControlPlaneInfra,
+				controlPlane,
+			},
+			// Expecting error as ClusterClass references ControlPlane Infrastructure, but ControlPlane Infrastructure is missing in the cluster.
+			wantErr: true,
+		},
+		{
+			name:    "Cluster with no linked MachineDeployments, InfrastructureCluster reference, ControlPlane reference and ControlPlane Infrastructure",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				clusterClassWithControlPlaneInfra,
+				machineDeploymentOutsideCluster,
+				machineDeploymentUnmanaged,
+			},
+			// Expect valid return with empty MachineDeployments properly filtered by label.
+			want: &clusterTopologyState{
+				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
+				controlPlane:          controlPlaneTopologyState{},
+				infrastructureCluster: nil,
+				machineDeployments:    emptyMachineDeployments,
+			},
+		},
+		{
+			name:    "MachineDeployment with ClusterTopologyLabelName but without correct ClusterTopologyMachineDeploymentLabelName",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				clusterClassWithControlPlaneInfra,
+				machineDeploymentWithoutDeploymentName,
+			},
+			// Expect error to be thrown as no managed MachineDeployment is reconcilable unless it has a ClusterTopologyMachineDeploymentLabelName.
+			wantErr: true,
+		},
+		{
+			name:    "Multiple MachineDeployments with the same ClusterTopologyLabelName label",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				clusterClassWithControlPlaneInfra,
+				machineDeploymentInfrastructure,
+				machineDeploymentBootstrap,
+				machineDeploymentInCluster,
+				duplicateMachineDeploymentInCluster,
+			},
+			// Expect error as two MachineDeployments with the same ClusterTopologyLabelName should not exist for one cluster
+			wantErr: true,
+		},
+		{
+			name:    "Cluster with MachineDeployments, InfrastructureCluster reference, ControlPlane reference and ControlPlane Infrastructure",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").WithInfrastructureCluster(infraCluster).WithControlPlane(controlPlaneWithInfra).Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				infraCluster,
+				clusterClassWithControlPlaneInfra,
+				controlPlaneInfrastructureMachineTemplate,
+				controlPlaneWithInfra,
+				machineDeploymentInfrastructure,
+				machineDeploymentBootstrap,
+				machineDeploymentInCluster,
+				machineDeploymentOutsideCluster,
+				machineDeploymentUnmanaged,
+			},
+			// Expect valid return of full clusterTopologyState with MachineDeployments properly filtered by label.
+			want: &clusterTopologyState{
+				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").WithInfrastructureCluster(infraCluster).WithControlPlane(controlPlaneWithInfra).Obj(),
+				controlPlane:          controlPlaneTopologyState{object: controlPlaneWithInfra, infrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate},
+				infrastructureCluster: infraCluster,
+				machineDeployments: map[string]machineDeploymentTopologyState{
+					"md1": {object: machineDeploymentInCluster, bootstrapTemplate: machineDeploymentBootstrap, infrastructureMachineTemplate: machineDeploymentInfrastructure}},
+			},
+		},
+		{
+			name:    "Cluster with MachineDeployments lacking Bootstrap Template",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				infraCluster,
+				clusterClassWithControlPlaneInfra,
+				controlPlaneInfrastructureMachineTemplate,
+				controlPlaneWithInfra,
+				machineDeploymentInfrastructure,
+				machineDeploymentNoBootstrap,
+			},
+			// Expect error as Bootstrap Template not defined for MachineDeployments relevant to the Cluster.
+			wantErr: true,
+		},
+		{
+			name:    "Cluster with MachineDeployments lacking Infrastructure Template",
+			cluster: newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
+			class:   clusterClassWithControlPlaneInfra,
+			objects: []client.Object{
+				infraCluster,
+				clusterClassWithControlPlaneInfra,
+				controlPlaneInfrastructureMachineTemplate,
+				controlPlaneWithInfra,
+				machineDeploymentBootstrap,
+				machineDeploymentNoInfrastructure,
+			},
+			// Expect error as Infrastructure Template not defined for MachineDeployment relevant to the Cluster.
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			objs := []client.Object{}
+			objs = append(objs, crds...)
+			objs = append(objs, tt.objects...)
+			if tt.cluster != nil {
+				objs = append(objs, tt.cluster)
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(fakeScheme).
+				WithObjects(objs...).
+				Build()
+			r := &ClusterReconciler{
+				Client:                    fakeClient,
+				UnstructuredCachingClient: fakeClient,
+			}
+			got, err := r.getCurrentState(ctx, tt.cluster, tt.class)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			if tt.want == nil {
+				g.Expect(got).To(BeNil())
+				return
+			}
+			g.Expect(got.cluster).To(Equal(tt.want.cluster), cmp.Diff(tt.want.cluster, got.cluster))
+			g.Expect(got.infrastructureCluster).To(Equal(tt.want.infrastructureCluster), cmp.Diff(tt.want.infrastructureCluster, got.infrastructureCluster))
+			g.Expect(got.controlPlane).To(Equal(tt.want.controlPlane), cmp.Diff(tt.want.controlPlane, got.controlPlane, cmp.AllowUnexported(unstructured.Unstructured{}, controlPlaneTopologyState{})))
+			g.Expect(got.machineDeployments).To(Equal(tt.want.machineDeployments), cmp.Diff(tt.want.machineDeployments, got.machineDeployments, cmp.AllowUnexported(machineDeploymentTopologyState{})))
+		})
+	}
+}

--- a/controllers/topology/types.go
+++ b/controllers/topology/types.go
@@ -48,7 +48,7 @@ type clusterTopologyState struct {
 	cluster               *clusterv1.Cluster
 	infrastructureCluster *unstructured.Unstructured
 	controlPlane          controlPlaneTopologyState
-	machineDeployments    []machineDeploymentTopologyState //nolint:structcheck
+	machineDeployments    map[string]machineDeploymentTopologyState
 }
 
 // controlPlaneTopologyState all the objects representing the state of a managed control plane.
@@ -59,7 +59,7 @@ type controlPlaneTopologyState struct {
 
 // machineDeploymentTopologyState all the objects representing the state of a managed deployment.
 type machineDeploymentTopologyState struct {
-	object                        *clusterv1.MachineDeployment //nolint:structcheck
-	bootstrapTemplate             *unstructured.Unstructured   //nolint:structcheck
-	infrastructureMachineTemplate *unstructured.Unstructured   //nolint:structcheck
+	object                        *clusterv1.MachineDeployment
+	bootstrapTemplate             *unstructured.Unstructured
+	infrastructureMachineTemplate *unstructured.Unstructured
 }

--- a/controllers/topology/util.go
+++ b/controllers/topology/util.go
@@ -28,9 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// getTemplate gets the object referenced in ref.
+// getReference gets the object referenced in ref.
 // If necessary, it updates the ref to the latest apiVersion of the current contract.
-func (r *ClusterReconciler) getTemplate(ctx context.Context, ref *corev1.ObjectReference) (*unstructured.Unstructured, error) {
+func (r *ClusterReconciler) getReference(ctx context.Context, ref *corev1.ObjectReference) (*unstructured.Unstructured, error) {
 	if ref == nil {
 		return nil, errors.New("reference is not set")
 	}

--- a/controllers/topology/util_test.go
+++ b/controllers/topology/util_test.go
@@ -99,7 +99,7 @@ func TestGetTemplate(t *testing.T) {
 				Client:                    fakeClient,
 				UnstructuredCachingClient: fakeClient,
 			}
-			got, err := r.getTemplate(ctx, tt.ref)
+			got, err := r.getReference(ctx, tt.ref)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 				return


### PR DESCRIPTION
Implementation for reading the current state of a cluster managed
by a ClusterClass to the cluster topology controller. This will
allow the controller to see the observed state of a managed
cluster and use the information during reconcilliation.

Signed-off-by: killianmuldoon <kmuldoon@vmware.com>


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4971 
