### PR TITLE
🐛 fix panic in clusterctl backup

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -366,7 +366,7 @@ func (o *objectMover) backup(graph *objectGraph, directory string) error {
 	moveSequence := getMoveSequence(graph)
 
 	// Save all objects group by group
-	log.Info("Saving files to %s", directory)
+	log.Info(fmt.Sprintf("Saving files to %s", directory))
 	for groupIndex := 0; groupIndex < len(moveSequence.groups); groupIndex++ {
 		if err := o.backupGroup(moveSequence.getGroup(groupIndex), directory); err != nil {
 			return err


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Without this change clusterctl backup panics because of an uneven amount of key-value arguments. The unit test didn't catch this as it's using the `NullLogger`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
