### PR TITLE
🌱 Reconcile infrastructure cluster for managed topologies

### DIFF
--- a/controllers/topology/cluster_class_test.go
+++ b/controllers/topology/cluster_class_test.go
@@ -213,8 +213,14 @@ func TestGetClass(t *testing.T) {
 			cluster := newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj()
 
 			if tt.clusterClass != nil {
-				cluster.Spec.Topology.Class = tt.clusterClass.Name
+				cluster.Spec.Topology = &clusterv1.Topology{
+					Class: tt.clusterClass.Name,
+				}
 				objs = append(objs, tt.clusterClass)
+			} else {
+				cluster.Spec.Topology = &clusterv1.Topology{
+					Class: "foo",
+				}
 			}
 
 			fakeClient := fake.NewClientBuilder().

--- a/controllers/topology/reconcile_state.go
+++ b/controllers/topology/reconcile_state.go
@@ -16,10 +16,120 @@ limitations under the License.
 
 package topology
 
-import "context"
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // reconcileState reconciles the current and desired state of the managed Cluster topology.
+// NOTE: We are assuming all the required objects are provided as input; also, in case of any error,
+// the entire reconcile operation will fail. This might be improved in the future if support for reconciling
+// subset of a topology will be implemented.
 func (r *ClusterReconciler) reconcileState(ctx context.Context, current, desired *clusterTopologyState) error {
-	// TODO: add reconcile logic
+	// Reconcile desired state of the InfrastructureCluster object.
+	if err := r.reconcileInfrastructureCluster(ctx, current, desired); err != nil {
+		return err
+	}
+
+	// TODO: reconcile control plane
+
+	// Reconcile desired state of the InfrastructureCluster object.
+	if err := r.reconcileCluster(ctx, current, desired); err != nil {
+		return err
+	}
+
+	// TODO: reconcile machine deployments
+
 	return nil
+}
+
+// reconcileInfrastructureCluster reconciles the desired state of the InfrastructureCluster object.
+func (r *ClusterReconciler) reconcileInfrastructureCluster(ctx context.Context, current, desired *clusterTopologyState) error {
+	return r.reconcileReferencedObject(ctx, current.infrastructureCluster, desired.infrastructureCluster)
+}
+
+// reconcileCluster reconciles the desired state of the Cluster object.
+// NOTE: this assumes reconcileInfrastructureCluster and reconcileControlPlane being already completed;
+// most specifically, after a Cluster is created it is assumed that the reference to the InfrastructureCluster /
+// ControlPlane objects should never change (only the content of the objects can change).
+func (r *ClusterReconciler) reconcileCluster(ctx context.Context, current, desired *clusterTopologyState) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Check differences between current and desired state, and eventually patch the current object.
+	patchHelper, err := newMergePatchHelper(current.cluster, desired.cluster, r.Client)
+	if err != nil {
+		return errors.Wrap(err, "failed to create patch helper for the Cluster object")
+	}
+	if patchHelper.HasChanges() {
+		log.Info("updating Cluster")
+		if err := patchHelper.Patch(ctx); err != nil {
+			return errors.Wrap(err, "failed to patch the Cluster object")
+		}
+	}
+	return nil
+}
+
+// reconcileReferencedObject reconciles the desired state of the referenced object.
+// NOTE: After a referenced object is created it is assumed that the reference should
+// never change (only the content of the object can eventually change). Thus, we are checking for strict compatibility.
+func (r *ClusterReconciler) reconcileReferencedObject(ctx context.Context, current, desired *unstructured.Unstructured) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// If there is no current object, create it.
+	if current == nil {
+		log.Info("creating", desired.GroupVersionKind().String(), desired.GetName())
+		if err := r.Client.Create(ctx, desired.DeepCopy()); err != nil {
+			return errors.Wrapf(err, "failed to create the %s object", desired.GetKind())
+		}
+		return nil
+	}
+
+	// Check if the current and desired referenced object are compatible.
+	if err := checkReferencedObjectsAreStrictlyCompatible(current, desired); err != nil {
+		return err
+	}
+
+	// Check differences between current and desired state, and eventually patch the current object.
+	patchHelper, err := newMergePatchHelper(current, desired, r.Client)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create patch helper for the %s object", current.GetKind())
+	}
+	if patchHelper.HasChanges() {
+		log.Info("updating", current.GroupVersionKind().String(), current.GetName())
+		if err := patchHelper.Patch(ctx); err != nil {
+			return errors.Wrapf(err, "failed to patch the %s object", current.GetKind())
+		}
+	}
+	return nil
+}
+
+// checkReferencedObjectsAreCompatible check if two referenced objects are compatible, meaning that
+// they are of the same GroupKind.
+func checkReferencedObjectsAreCompatible(current, desired client.Object) error {
+	currentGK := current.GetObjectKind().GroupVersionKind().GroupKind()
+	desiredGK := desired.GetObjectKind().GroupVersionKind().GroupKind()
+
+	if currentGK.String() != desiredGK.String() {
+		return errors.Errorf("invalid operation: it is not possible to change GroupKind from %s to %s", currentGK.String(), desiredGK.String())
+	}
+
+	// NOTE: this should never happen (webhooks prevent it), but checking for extra safety.
+	if current.GetNamespace() != desired.GetNamespace() {
+		return errors.Errorf("invalid operation: it is not possible to change namespace from %s to %s", current.GetNamespace(), desired.GetNamespace())
+	}
+
+	return nil
+}
+
+// checkReferencedObjectsAreStrictlyCompatible check if two referenced objects are strictly compatible, meaning that
+// they are compatible and the name of the objects does not change.
+func checkReferencedObjectsAreStrictlyCompatible(current, desired client.Object) error {
+	if current.GetName() != desired.GetName() {
+		return errors.Errorf("invalid operation: it is not possible to change names from %s to %s", current.GetName(), desired.GetName())
+	}
+	return checkReferencedObjectsAreCompatible(current, desired)
 }

--- a/controllers/topology/reconcile_state_test.go
+++ b/controllers/topology/reconcile_state_test.go
@@ -1,0 +1,361 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcileCluster(t *testing.T) {
+	cluster1 := newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj()
+	cluster1WithReferences := newFakeCluster(metav1.NamespaceDefault, "cluster1").
+		WithInfrastructureCluster(newFakeInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster1").Obj()).
+		WithControlPlane(newFakeControlPlane(metav1.NamespaceDefault, "control-plane1").Obj()).
+		Obj()
+	cluster2WithReferences := cluster1WithReferences.DeepCopy()
+	cluster2WithReferences.SetGroupVersionKind(cluster1WithReferences.GroupVersionKind())
+	cluster2WithReferences.Name = "cluster2"
+
+	tests := []struct {
+		name    string
+		current *clusterv1.Cluster
+		desired *clusterv1.Cluster
+		want    *clusterv1.Cluster
+		wantErr bool
+	}{
+		{
+			name:    "Should update the cluster if infrastructure and control plane references are not set",
+			current: cluster1,
+			desired: cluster1WithReferences,
+			want:    cluster1WithReferences,
+			wantErr: false,
+		},
+		{
+			name:    "Should be a no op if infrastructure and control plane references are already set",
+			current: cluster2WithReferences,
+			desired: cluster2WithReferences,
+			want:    cluster2WithReferences,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			fakeObjs := make([]client.Object, 0)
+			if tt.current != nil {
+				fakeObjs = append(fakeObjs, tt.current)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(fakeScheme).
+				WithObjects(fakeObjs...).
+				Build()
+
+			currentState := &clusterTopologyState{cluster: tt.current}
+
+			// TODO: stop setting ResourceVersion when building objects
+			tt.desired.SetResourceVersion("")
+			desiredState := &clusterTopologyState{cluster: tt.desired}
+
+			r := ClusterReconciler{
+				Client: fakeClient,
+			}
+			err := r.reconcileCluster(ctx, currentState, desiredState)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			got := tt.want.DeepCopy()
+			err = fakeClient.Get(ctx, client.ObjectKeyFromObject(tt.want), got)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(got.Spec.InfrastructureRef).To(Equal(tt.want.Spec.InfrastructureRef), cmp.Diff(got, tt.want))
+			g.Expect(got.Spec.ControlPlaneRef).To(Equal(tt.want.Spec.ControlPlaneRef), cmp.Diff(got, tt.want))
+		})
+	}
+}
+
+func TestReconcileInfrastructureCluster(t *testing.T) {
+	g := NewWithT(t)
+
+	clusterInfrastructure1 := newFakeInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster1").Obj()
+	clusterInfrastructure2 := newFakeInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster2").Obj()
+	clusterInfrastructure3 := newFakeInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster3").Obj()
+	clusterInfrastructure3WithInstanceSpecificChanges := clusterInfrastructure3.DeepCopy()
+	clusterInfrastructure3WithInstanceSpecificChanges.SetLabels(map[string]string{"foo": "bar"})
+	clusterInfrastructure4 := newFakeInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster4").Obj()
+	clusterInfrastructure4WithTemplateOverridingChanges := clusterInfrastructure4.DeepCopy()
+	err := unstructured.SetNestedField(clusterInfrastructure4WithTemplateOverridingChanges.UnstructuredContent(), false, "spec", "fakeSetting")
+	g.Expect(err).ToNot(HaveOccurred())
+	clusterInfrastructure5 := newFakeInfrastructureCluster(metav1.NamespaceDefault, "infrastructure-cluster5").Obj()
+
+	tests := []struct {
+		name    string
+		current *unstructured.Unstructured
+		desired *unstructured.Unstructured
+		want    *unstructured.Unstructured
+		wantErr bool
+	}{
+		{
+			name:    "Should create desired InfrastructureCluster if the current does not exists yet",
+			current: nil,
+			desired: clusterInfrastructure1,
+			want:    clusterInfrastructure1,
+			wantErr: false,
+		},
+		{
+			name:    "No-op if current InfrastructureCluster is equal to desired",
+			current: clusterInfrastructure2,
+			desired: clusterInfrastructure2,
+			want:    clusterInfrastructure2,
+			wantErr: false,
+		},
+		{
+			name:    "Should preserve instance specific changes",
+			current: clusterInfrastructure3WithInstanceSpecificChanges,
+			desired: clusterInfrastructure3,
+			want:    clusterInfrastructure3WithInstanceSpecificChanges,
+			wantErr: false,
+		},
+		{
+			name:    "Should restore template values if overridden",
+			current: clusterInfrastructure4WithTemplateOverridingChanges,
+			desired: clusterInfrastructure4,
+			want:    clusterInfrastructure4,
+			wantErr: false,
+		},
+		{
+			name:    "Fails for incompatible changes",
+			current: clusterInfrastructure5,
+			desired: clusterInfrastructure1,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			fakeObjs := make([]client.Object, 0)
+			if tt.current != nil {
+				fakeObjs = append(fakeObjs, tt.current)
+			}
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(fakeScheme).
+				WithObjects(fakeObjs...).
+				Build()
+
+			currentState := &clusterTopologyState{infrastructureCluster: tt.current}
+
+			// TODO: stop setting ResourceVersion when building objects
+			tt.desired.SetResourceVersion("")
+			desiredState := &clusterTopologyState{infrastructureCluster: tt.desired}
+
+			r := ClusterReconciler{
+				Client: fakeClient,
+			}
+			err := r.reconcileInfrastructureCluster(ctx, currentState, desiredState)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			got := tt.want.DeepCopy() // this is required otherwise Get will modify tt.want
+			err = fakeClient.Get(ctx, client.ObjectKeyFromObject(tt.want), got)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Spec
+			wantSpec, ok, err := unstructured.NestedMap(tt.want.UnstructuredContent(), "spec")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(ok).To(BeTrue())
+
+			gotSpec, ok, err := unstructured.NestedMap(got.UnstructuredContent(), "spec")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(ok).To(BeTrue())
+			for k, v := range wantSpec {
+				g.Expect(gotSpec).To(HaveKeyWithValue(k, v))
+			}
+		})
+	}
+}
+
+type referencedObjectsCompatibilityTestCase struct {
+	name    string
+	current *unstructured.Unstructured
+	desired *unstructured.Unstructured
+	wantErr bool
+}
+
+var referencedObjectsCompatibilityTestCases = []referencedObjectsCompatibilityTestCase{
+	{
+		name: "Fails if group changes",
+		current: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "foo/v1alpha4",
+			},
+		},
+		desired: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "bar/v1alpha4",
+			},
+		},
+		wantErr: true,
+	},
+	{
+		name: "Fails if kind changes",
+		current: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"kind": "foo",
+			},
+		},
+		desired: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"kind": "bar",
+			},
+		},
+		wantErr: true,
+	},
+	{
+		name: "Pass if gvk remains the same",
+		current: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "infrastructure.cluster.x-k8s.io/foo",
+				"kind":       "foo",
+			},
+		},
+		desired: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "infrastructure.cluster.x-k8s.io/foo",
+				"kind":       "foo",
+			},
+		},
+		wantErr: false,
+	},
+	{
+		name: "Pass if version changes but group and kind remains the same",
+		current: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "infrastructure.cluster.x-k8s.io/foo",
+				"kind":       "foo",
+			},
+		},
+		desired: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "infrastructure.cluster.x-k8s.io/bar",
+				"kind":       "foo",
+			},
+		},
+		wantErr: false,
+	},
+	{
+		name: "Fails if namespace changes",
+		current: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"namespace": "foo",
+				},
+			},
+		},
+		desired: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"namespace": "bar",
+				},
+			},
+		},
+		wantErr: true,
+	},
+}
+
+func TestCheckReferencedObjectsAreCompatible(t *testing.T) {
+	for _, tt := range referencedObjectsCompatibilityTestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			err := checkReferencedObjectsAreCompatible(tt.current, tt.desired)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+		})
+	}
+}
+
+func TestCheckReferencedObjectsAreStrictlyCompatible(t *testing.T) {
+	referencedObjectsStrictCompatibilityTestCases := append(referencedObjectsCompatibilityTestCases, []referencedObjectsCompatibilityTestCase{
+		{
+			name: "Fails if name changes",
+			current: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "foo",
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "bar",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Pass if name remains the same",
+			current: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "foo",
+					},
+				},
+			},
+			desired: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"name": "foo",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}...)
+
+	for _, tt := range referencedObjectsStrictCompatibilityTestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			err := checkReferencedObjectsAreStrictlyCompatible(tt.current, tt.desired)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is part of the activities for the implementation of the [ClusterClass proposal](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/202105256-cluster-class-and-managed-topologies.md). 

This PR is about implementing reconcile current and desired state for the infrastructureCluster object in a managed topology.

NOTE: this PR will wait for https://github.com/kubernetes-sigs/cluster-api/issues/5038 to be implemented first

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5036
