### PR TITLE
✨ Compute ControlPlane version for a managed topology

### DIFF
--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -402,34 +402,66 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 			wantErr:             true,
 		},
 		{
-			name:                "ControlPlane does exist, with same version (no-op)",
-			topologyVersion:     "v1.21.0",
-			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").WithVersion("v1.21.0").Obj(),
-			want:                "v1.21.0",
+			name:            "ControlPlane does exist, with same version (no-op)",
+			topologyVersion: "v1.21.0",
+			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").
+				WithVersion("v1.21.0").
+				WithStatusVersion("v1.21.0").
+				Obj(),
+			want: "v1.21.0",
 		},
 		{
-			name:                "ControlPlane does exist, with newer version (downgrade)",
-			topologyVersion:     "v1.21.0",
-			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").WithVersion("v1.22.0").Obj(),
-			wantErr:             true,
+			name:            "ControlPlane does exist, with newer version (downgrade)",
+			topologyVersion: "v1.21.0",
+			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").
+				WithVersion("v1.22.0").
+				WithStatusVersion("v1.22.0").
+				Obj(),
+			wantErr: true,
 		},
 		{
-			name:                "ControlPlane does exist, with invalid version",
-			topologyVersion:     "v1.21.0",
-			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").WithVersion("invalid-version").Obj(),
-			wantErr:             true,
+			name:            "ControlPlane does exist, with invalid version",
+			topologyVersion: "v1.21.0",
+			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").
+				WithVersion("invalid-version").
+				WithStatusVersion("invalid-version").
+				Obj(),
+			wantErr: true,
 		},
 		{
-			name:                "ControlPlane does exist, with valid version but invalid topology version",
-			topologyVersion:     "invalid-version",
-			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").WithVersion("v1.21.0").Obj(),
-			wantErr:             true,
+			name:            "ControlPlane does exist, with valid version but invalid topology version",
+			topologyVersion: "invalid-version",
+			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").
+				WithVersion("v1.21.0").
+				WithStatusVersion("v1.21.0").
+				Obj(),
+			wantErr: true,
 		},
 		{
-			name:                "ControlPlane does exist, with older version (upgrade)",
-			topologyVersion:     "v1.21.0",
-			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").WithVersion("v1.20.0").Obj(),
-			want:                "v1.21.0",
+			name:            "ControlPlane does exist, with older version (upgrade)",
+			topologyVersion: "v1.21.0",
+			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").
+				WithVersion("v1.20.0").
+				WithStatusVersion("v1.20.0").
+				Obj(),
+			want: "v1.21.0",
+		},
+		{
+			name:            "ControlPlane does exist, with older version (upgrade) but another upgrade is already in progress (.status.version has older version)",
+			topologyVersion: "v1.22.0",
+			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").
+				WithVersion("v1.21.0").
+				WithStatusVersion("v1.20.0").
+				Obj(),
+			want: "v1.21.0",
+		},
+		{
+			name:            "ControlPlane does exist, with older version (upgrade) but another upgrade is already in progress (.status.version is not set)",
+			topologyVersion: "v1.22.0",
+			currentControlPlane: newFakeControlPlane(metav1.NamespaceDefault, "cp").
+				WithVersion("v1.21.0").
+				Obj(),
+			want: "v1.21.0",
 		},
 	}
 

--- a/controllers/topology/object_builders_test.go
+++ b/controllers/topology/object_builders_test.go
@@ -395,6 +395,7 @@ type fakeControlPlane struct {
 	namespace                     string
 	name                          string
 	infrastructureMachineTemplate *unstructured.Unstructured
+	version                       *string
 }
 
 func newFakeControlPlane(namespace, name string) *fakeControlPlane {
@@ -406,6 +407,11 @@ func newFakeControlPlane(namespace, name string) *fakeControlPlane {
 
 func (f *fakeControlPlane) WithInfrastructureMachineTemplate(t *unstructured.Unstructured) *fakeControlPlane {
 	f.infrastructureMachineTemplate = t
+	return f
+}
+
+func (f *fakeControlPlane) WithVersion(version string) *fakeControlPlane {
+	f.version = &version
 	return f
 }
 
@@ -425,6 +431,12 @@ func (f *fakeControlPlane) Obj() *unstructured.Unstructured {
 
 	if f.infrastructureMachineTemplate != nil {
 		if err := setNestedRef(obj, f.infrastructureMachineTemplate, "spec", "machineTemplate", "infrastructureRef"); err != nil {
+			panic(err)
+		}
+	}
+
+	if f.version != nil {
+		if err := unstructured.SetNestedField(obj.UnstructuredContent(), *f.version, "spec", "version"); err != nil {
 			panic(err)
 		}
 	}

--- a/controllers/topology/object_builders_test.go
+++ b/controllers/topology/object_builders_test.go
@@ -396,6 +396,7 @@ type fakeControlPlane struct {
 	name                          string
 	infrastructureMachineTemplate *unstructured.Unstructured
 	version                       *string
+	statusVersion                 *string
 }
 
 func newFakeControlPlane(namespace, name string) *fakeControlPlane {
@@ -412,6 +413,11 @@ func (f *fakeControlPlane) WithInfrastructureMachineTemplate(t *unstructured.Uns
 
 func (f *fakeControlPlane) WithVersion(version string) *fakeControlPlane {
 	f.version = &version
+	return f
+}
+
+func (f *fakeControlPlane) WithStatusVersion(version string) *fakeControlPlane {
+	f.statusVersion = &version
 	return f
 }
 
@@ -437,6 +443,11 @@ func (f *fakeControlPlane) Obj() *unstructured.Unstructured {
 
 	if f.version != nil {
 		if err := unstructured.SetNestedField(obj.UnstructuredContent(), *f.version, "spec", "version"); err != nil {
+			panic(err)
+		}
+	}
+	if f.statusVersion != nil {
+		if err := unstructured.SetNestedField(obj.UnstructuredContent(), *f.statusVersion, "status", "version"); err != nil {
 			panic(err)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

I intentionally did not implement the more complicated cases when a previous rollout is not completely done and the next upgrade is triggered. The idea behind this is to get the base case stable and tested (including e2e) before we expand the implementation to more advanced use cases.

Notes:
* This only implements upgrade for ControlPlane based on #5002
* MachineDeployment upgrade will be implemented in a separate PR after the corresponding `computeMachineDeployments` code has been implemented in #4999.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially implements #5016
