### PR TITLE
🌱  test/framework: disable metrics collection should not disable watching deployment logs

### DIFF
--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -109,15 +109,14 @@ func InitManagementClusterAndWatchControllerLogs(ctx context.Context, input Init
 			LogPath:    filepath.Join(input.LogFolder, "controllers"),
 		})
 
-		if input.DisableMetricsCollection {
-			return
+		if !input.DisableMetricsCollection {
+			framework.WatchPodMetrics(ctx, framework.WatchPodMetricsInput{
+				GetLister:   client,
+				ClientSet:   input.ClusterProxy.GetClientSet(),
+				Deployment:  deployment,
+				MetricsPath: filepath.Join(input.LogFolder, "controllers"),
+			})
 		}
-		framework.WatchPodMetrics(ctx, framework.WatchPodMetricsInput{
-			GetLister:   client,
-			ClientSet:   input.ClusterProxy.GetClientSet(),
-			Deployment:  deployment,
-			MetricsPath: filepath.Join(input.LogFolder, "controllers"),
-		})
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently, the `DisableMetricsCollection` also disables watching logs of all deployments except the first one. I assume that's not intended.


Note: this field is not used by any of our e2e tests in the `cluster-api` repo

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
