### PR TITLE
🌱 gate DockerClusterTemplate usage with ClusterTopology feature gate

### DIFF
--- a/test/infrastructure/docker/api/v1alpha4/dockerclustertemplate_webhook.go
+++ b/test/infrastructure/docker/api/v1alpha4/dockerclustertemplate_webhook.go
@@ -23,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -50,6 +51,15 @@ var _ webhook.Validator = &DockerClusterTemplate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *DockerClusterTemplate) ValidateCreate() error {
+	// NOTE: DockerClusterTemplate is behind ClusterTopology feature gate flag; the web hook
+	// must prevent creating new objects in case the feature flag is disabled.
+	if !feature.Gates.Enabled(feature.ClusterTopology) {
+		return field.Forbidden(
+			field.NewPath("spec"),
+			"can be set only if the ClusterTopology feature flag is enabled",
+		)
+	}
+
 	allErrs := validateDockerClusterSpec(r.Spec.Template.Spec)
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(GroupVersion.WithKind("DockerClusterTemplate").GroupKind(), r.Name, allErrs)

--- a/test/infrastructure/docker/api/v1alpha4/dockerclustertemplate_webhook_test.go
+++ b/test/infrastructure/docker/api/v1alpha4/dockerclustertemplate_webhook_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/component-base/featuregate/testing"
+	"sigs.k8s.io/cluster-api/feature"
+)
+
+func TestDockerClusterTemplateValidationFeatureGateEnabled(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
+
+	t.Run("create dockerclustertemplate should pass if gate enabled and valid dockerclustertemplate", func(t *testing.T) {
+		g := NewWithT(t)
+		dct := &DockerClusterTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dockerclustertemplate-test",
+				Namespace: "test-namespace",
+			},
+			Spec: DockerClusterTemplateSpec{
+				Template: DockerClusterTemplateResource{
+					Spec: DockerClusterSpec{},
+				},
+			},
+		}
+		g.Expect(dct.ValidateCreate()).To(Succeed())
+	})
+}
+
+func TestDockerClusterTemplateValidationFeatureGateDisabled(t *testing.T) {
+	// NOTE: ClusterTopology feature flag is disabled by default, thus preventing to create DockerClusterTemplate.
+	t.Run("create dockerclustertemplate should not pass if gate disabled and valid dockerclustertemplate", func(t *testing.T) {
+		g := NewWithT(t)
+		dct := &DockerClusterTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dockerclustertemplate-test",
+				Namespace: "test-namespace",
+			},
+			Spec: DockerClusterTemplateSpec{
+				Template: DockerClusterTemplateResource{
+					Spec: DockerClusterSpec{},
+				},
+			},
+		}
+		g.Expect(dct.ValidateCreate()).NotTo(Succeed())
+	})
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Prevent DockerClusterTemplate to be used if ClusterTopology feature flag is false.
This PR is part of [ClusterClass proposal](https://github.com/kubernetes-sigs/cluster-api/blob/master/docs/proposals/202105256-cluster-class-and-managed-topologies.md) implementation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5066 
