### PR TITLE
🌱  Upgrade quickstart and e2e tests to Kubernetes v1.22.0

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -593,7 +593,7 @@ For the purpose of this tutorial, we'll name our cluster capi-quickstart.
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.21.2 \
+  --kubernetes-version v1.22.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -612,7 +612,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.21.2 \
+  --kubernetes-version v1.22.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -110,11 +110,11 @@ providers:
 variables:
   # default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
-  KUBERNETES_VERSION: "v1.21.2"
-  ETCD_VERSION_UPGRADE_TO: "3.4.13-0"
+  KUBERNETES_VERSION: "v1.22.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.0-0"
   COREDNS_VERSION_UPGRADE_TO: "1.8.4"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.21.2"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.20.7"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.22.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.21.2"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "IPv4"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// DefaultNodeImage is the default node image to be used for for testing.
-	DefaultNodeImage = "kindest/node:v1.21.2"
+	DefaultNodeImage = "kindest/node:v1.22.0"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Gets additional CAPD dependencies
 WORKDIR /tmp
 
-RUN curl -LO https://dl.k8s.io/release/v1.21.2/bin/linux/amd64/kubectl && \
+RUN curl -LO https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl
 

--- a/test/infrastructure/docker/docker/machine.go
+++ b/test/infrastructure/docker/docker/machine.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.21.2"
+	defaultImageTag  = "v1.22.0"
 )
 
 type nodeCreator interface {

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -29,7 +29,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.21.2
+  version: v1.22.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -86,7 +86,7 @@ spec:
         kind: DockerMachinePool
         name: worker-dmp-0
         namespace: default
-      version: v1.21.2
+      version: v1.22.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: DockerMachinePool

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.21.2
+  version: v1.22.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -120,7 +120,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.21.2
+      version: v1.22.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -38,7 +38,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.21.2
+  version: v1.22.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -106,7 +106,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.21.2
+      version: v1.22.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.21.2
+  version: v1.22.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -105,7 +105,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.21.2
+      version: v1.22.0
       clusterName: my-cluster
       bootstrap:
         configRef:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Regular update to the latest stable Kubernetes release

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
