### PR TITLE
🌱  e2e tests: make the management cluster Kubernetes version configurable

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -43,6 +43,13 @@ capi:buildDockerImages () {
 # k8s::prepareKindestImages checks all the e2e test variables representing a Kubernetes version,
 # and makes sure a corresponding kindest/node image is available locally.
 k8s::prepareKindestImages() {
+  if [ -n "${MANAGEMENT_KUBERNETES_VERSION:-}" ]; then
+    k8s::resolveVersion "MANAGEMENT_KUBERNETES_VERSION" "$MANAGEMENT_KUBERNETES_VERSION"
+    export MANAGEMENT_KUBERNETES_VERSION=$resolveVersion
+
+    kind::prepareKindestImage "$resolveVersion"
+  fi
+
   if [ -n "${KUBERNETES_VERSION:-}" ]; then
     k8s::resolveVersion "KUBERNETES_VERSION" "$KUBERNETES_VERSION"
     export KUBERNETES_VERSION=$resolveVersion

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -43,9 +43,9 @@ capi:buildDockerImages () {
 # k8s::prepareKindestImages checks all the e2e test variables representing a Kubernetes version,
 # and makes sure a corresponding kindest/node image is available locally.
 k8s::prepareKindestImages() {
-  if [ -n "${MANAGEMENT_KUBERNETES_VERSION:-}" ]; then
-    k8s::resolveVersion "MANAGEMENT_KUBERNETES_VERSION" "$MANAGEMENT_KUBERNETES_VERSION"
-    export MANAGEMENT_KUBERNETES_VERSION=$resolveVersion
+  if [ -n "${KUBERNETES_VERSION_MANAGEMENT:-}" ]; then
+    k8s::resolveVersion "KUBERNETES_VERSION_MANAGEMENT" "$KUBERNETES_VERSION_MANAGEMENT"
+    export KUBERNETES_VERSION_MANAGEMENT=$resolveVersion
 
     kind::prepareKindestImage "$resolveVersion"
   fi

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -33,7 +33,7 @@ import (
 
 // Test suite constants for e2e config variables.
 const (
-	ManagementClusterImage       = "MANAGEMENT_CLUSTER_IMAGE"
+	ManagementKubernetesVersion  = "MANAGEMENT_KUBERNETES_VERSION"
 	KubernetesVersion            = "KUBERNETES_VERSION"
 	CNIPath                      = "CNI"
 	CNIResources                 = "CNI_RESOURCES"

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -33,6 +33,7 @@ import (
 
 // Test suite constants for e2e config variables.
 const (
+	ManagementClusterImage       = "MANAGEMENT_CLUSTER_IMAGE"
 	KubernetesVersion            = "KUBERNETES_VERSION"
 	CNIPath                      = "CNI"
 	CNIResources                 = "CNI_RESOURCES"

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -33,7 +33,7 @@ import (
 
 // Test suite constants for e2e config variables.
 const (
-	ManagementKubernetesVersion  = "MANAGEMENT_KUBERNETES_VERSION"
+	KubernetesVersionManagement  = "KUBERNETES_VERSION_MANAGEMENT"
 	KubernetesVersion            = "KUBERNETES_VERSION"
 	CNIPath                      = "CNI"
 	CNIResources                 = "CNI_RESOURCES"

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -110,6 +110,7 @@ providers:
 variables:
   # default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
+  MANAGEMENT_CLUSTER_IMAGE: "kindest/node:v1.22.0"
   KUBERNETES_VERSION: "v1.22.0"
   ETCD_VERSION_UPGRADE_TO: "3.5.0-0"
   COREDNS_VERSION_UPGRADE_TO: "1.8.4"

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -108,14 +108,16 @@ providers:
     - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
 
 variables:
-  # default variables for the e2e test; those values could be overridden via env variables, thus
-  # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
-  MANAGEMENT_KUBERNETES_VERSION: "v1.22.0"
+  # Default variables for the e2e test; those values could be overridden via env variables, thus
+  # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
+  # The following Kubernetes versions should be the latest versions with already published kindest/node images.
+  # This avoids building node images in the default case which improves the test duration significantly.
+  KUBERNETES_VERSION_MANAGEMENT: "v1.22.0"
   KUBERNETES_VERSION: "v1.22.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.21.2"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.22.0"
   ETCD_VERSION_UPGRADE_TO: "3.5.0-0"
   COREDNS_VERSION_UPGRADE_TO: "1.8.4"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.22.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.21.2"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "IPv4"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -110,7 +110,7 @@ providers:
 variables:
   # default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
-  MANAGEMENT_CLUSTER_IMAGE: "kindest/node:v1.22.0"
+  MANAGEMENT_KUBERNETES_VERSION: "v1.22.0"
   KUBERNETES_VERSION: "v1.22.0"
   ETCD_VERSION_UPGRADE_TO: "3.5.0-0"
   COREDNS_VERSION_UPGRADE_TO: "1.8.4"

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -191,7 +191,7 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 	if !useExistingCluster {
 		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 			Name:               config.ManagementClusterName,
-			Image:              config.GetVariable(ManagementClusterImage),
+			KubernetesVersion:  config.GetVariable(ManagementKubernetesVersion),
 			RequiresDockerSock: config.HasDockerProvider(),
 			Images:             config.Images,
 			IPFamily:           config.GetVariable(IPFamily),

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -191,7 +191,7 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 	if !useExistingCluster {
 		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 			Name:               config.ManagementClusterName,
-			KubernetesVersion:  config.GetVariable(ManagementKubernetesVersion),
+			KubernetesVersion:  config.GetVariable(KubernetesVersionManagement),
 			RequiresDockerSock: config.HasDockerProvider(),
 			Images:             config.Images,
 			IPFamily:           config.GetVariable(IPFamily),

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -191,6 +191,7 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 	if !useExistingCluster {
 		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(ctx, bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 			Name:               config.ManagementClusterName,
+			Image:              config.GetVariable(ManagementClusterImage),
 			RequiresDockerSock: config.HasDockerProvider(),
 			Images:             config.Images,
 			IPFamily:           config.GetVariable(IPFamily),

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -29,8 +29,11 @@ import (
 )
 
 const (
-	// DefaultNodeImage is the default node image to be used for for testing.
-	DefaultNodeImage = "kindest/node:v1.22.0"
+	// DefaultNodeImageRepository is the default node image repository to be used for testing.
+	DefaultNodeImageRepository = "kindest/node"
+
+	// DefaultNodeImage is the default node image to be used for testing.
+	DefaultNodeImage = DefaultNodeImageRepository + ":v1.22.0"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -18,6 +18,7 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	. "github.com/onsi/gomega"
@@ -32,8 +33,8 @@ const (
 	// DefaultNodeImageRepository is the default node image repository to be used for testing.
 	DefaultNodeImageRepository = "kindest/node"
 
-	// DefaultNodeImage is the default node image to be used for testing.
-	DefaultNodeImage = DefaultNodeImageRepository + ":v1.22.0"
+	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
+	DefaultNodeImageVersion = "v1.22.0"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.
@@ -132,7 +133,7 @@ func (k *KindClusterProvider) createKindCluster() {
 
 	kindCreateOptions = append(kindCreateOptions, kind.CreateWithV1Alpha4Config(cfg))
 
-	nodeImage := DefaultNodeImage
+	nodeImage := fmt.Sprintf("%s:%s", DefaultNodeImageRepository, DefaultNodeImageVersion)
 	if k.nodeImage != "" {
 		nodeImage = k.nodeImage
 	}

--- a/test/framework/bootstrap/kind_util.go
+++ b/test/framework/bootstrap/kind_util.go
@@ -34,13 +34,16 @@ import (
 
 // CreateKindBootstrapClusterAndLoadImagesInput is the input for CreateKindBootstrapClusterAndLoadImages.
 type CreateKindBootstrapClusterAndLoadImagesInput struct {
-	// Name of the cluster
+	// Name of the cluster.
 	Name string
 
-	// RequiresDockerSock defines if the cluster requires the docker sock
+	// Image of the cluster.
+	Image string
+
+	// RequiresDockerSock defines if the cluster requires the docker sock.
 	RequiresDockerSock bool
 
-	// Images to be loaded in the cluster (this is kind specific)
+	// Images to be loaded in the cluster.
 	Images []clusterctl.ContainerImage
 
 	// IPFamily is either ipv4 or ipv6. Default is ipv4.
@@ -55,6 +58,9 @@ func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKi
 	log.Logf("Creating a kind cluster with name %q", input.Name)
 
 	options := []KindClusterOption{}
+	if input.Image != "" {
+		options = append(options, WithNodeImage(input.Image))
+	}
 	if input.RequiresDockerSock {
 		options = append(options, WithDockerSockMount())
 	}

--- a/test/framework/bootstrap/kind_util.go
+++ b/test/framework/bootstrap/kind_util.go
@@ -18,6 +18,7 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -37,8 +38,8 @@ type CreateKindBootstrapClusterAndLoadImagesInput struct {
 	// Name of the cluster.
 	Name string
 
-	// Image of the cluster.
-	Image string
+	// KubernetesVersion of the cluster.
+	KubernetesVersion string
 
 	// RequiresDockerSock defines if the cluster requires the docker sock.
 	RequiresDockerSock bool
@@ -58,8 +59,8 @@ func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKi
 	log.Logf("Creating a kind cluster with name %q", input.Name)
 
 	options := []KindClusterOption{}
-	if input.Image != "" {
-		options = append(options, WithNodeImage(input.Image))
+	if input.KubernetesVersion != "" {
+		options = append(options, WithNodeImage(fmt.Sprintf("%s:%s", DefaultNodeImageRepository, input.KubernetesVersion)))
 	}
 	if input.RequiresDockerSock {
 		options = append(options, WithDockerSockMount())


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially implements #5078
