### PR TITLE
🌱 Pass the ClusterTopology feature flag to CAPD and KCP

### DIFF
--- a/controlplane/kubeadm/config/manager/manager.yaml
+++ b/controlplane/kubeadm/config/manager/manager.yaml
@@ -21,6 +21,7 @@ spec:
         args:
         - "--leader-elect"
         - "--metrics-bind-addr=localhost:8080"
+        - "--feature-gates=ClusterTopology=${CLUSTER_TOPOLOGY:=false}"
         image: controller:latest
         name: manager
         ports:

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -40,6 +40,7 @@ import (
 	kubeadmcontrolplanev1old "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	kubeadmcontrolplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
 	kubeadmcontrolplanecontrollers "sigs.k8s.io/cluster-api/controlplane/kubeadm/controllers"
+	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -119,6 +120,8 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
+
+	feature.MutableGates.AddFlag(fs)
 }
 func main() {
 	rand.Seed(time.Now().UnixNano())

--- a/test/infrastructure/docker/config/manager/manager.yaml
+++ b/test/infrastructure/docker/config/manager/manager.yaml
@@ -19,7 +19,7 @@ spec:
       - args:
         - "--leader-elect"
         - "--metrics-bind-addr=localhost:8080"
-        - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}"
+        - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterTopology=${CLUSTER_TOPOLOGY:=false}"
         image: controller:latest
         name: manager
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
Pass the ClusterTopology feature flag to CAPD and KCP, used for allowing creation of new template types
