### PR TITLE
✨ Add dynamic completion support for context in kubeconfig and namespace

### DIFF
--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -235,6 +235,12 @@ type Proxy interface {
 
 	// ListResources returns all the Kubernetes objects with the given labels existing the listed namespaces.
 	ListResources(labels map[string]string, namespaces ...string) ([]unstructured.Unstructured, error)
+
+	// GetContexts returns the list of contexts in kubeconfig which begin with prefix.
+	GetContexts(prefix string) ([]string, error)
+
+	// GetResourceNames returns the list of resource names which begin with prefix.
+	GetResourceNames(groupVersion, kind string, options []client.ListOption, prefix string) ([]string, error)
 }
 
 // retryWithExponentialBackoff repeats an operation until it passes or the exponential backoff times out.

--- a/cmd/clusterctl/client/cluster/proxy.go
+++ b/cmd/clusterctl/client/cluster/proxy.go
@@ -204,6 +204,47 @@ func (k *proxy) ListResources(labels map[string]string, namespaces ...string) ([
 	return ret, nil
 }
 
+// GetContexts returns the list of contexts in kubeconfig which begin with prefix.
+func (k *proxy) GetContexts(prefix string) ([]string, error) {
+	config, err := k.configLoadingRules.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	var comps []string
+	for name := range config.Contexts {
+		if strings.HasPrefix(name, prefix) {
+			comps = append(comps, name)
+		}
+	}
+
+	return comps, nil
+}
+
+// GetResourceNames returns the list of resource names which begin with prefix.
+func (k *proxy) GetResourceNames(groupVersion, kind string, options []client.ListOption, prefix string) ([]string, error) {
+	client, err := k.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	objList, err := listObjByGVK(client, groupVersion, kind, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var comps []string
+	for _, item := range objList.Items {
+		name := item.GetName()
+
+		if strings.HasPrefix(name, prefix) {
+			comps = append(comps, name)
+		}
+	}
+
+	return comps, nil
+}
+
 func listObjByGVK(c client.Client, groupVersion, kind string, options []client.ListOption) (*unstructured.UnstructuredList, error) {
 	objList := new(unstructured.UnstructuredList)
 	objList.SetAPIVersion(groupVersion)

--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -23,6 +23,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 )
 
 const completionBoilerPlate = `# Copyright 2021 The Kubernetes Authors.
@@ -137,4 +139,43 @@ func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
 	fmt.Fprintln(out, "compdef _clusterctl clusterctl")
 
 	return nil
+}
+
+func contextCompletionFunc(kubeconfig *string) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		configClient, err := config.New(cfgFile)
+		if err != nil {
+			return completionError(err)
+		}
+
+		client := cluster.New(cluster.Kubeconfig{Path: *kubeconfig}, configClient)
+		comps, err := client.Proxy().GetContexts(toComplete)
+		if err != nil {
+			return completionError(err)
+		}
+
+		return comps, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func resourceNameCompletionFunc(kubeconfig *string, groupVersion, kind string) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		configClient, err := config.New(cfgFile)
+		if err != nil {
+			return completionError(err)
+		}
+
+		client := cluster.New(cluster.Kubeconfig{Path: *kubeconfig}, configClient)
+		comps, err := client.Proxy().GetResourceNames(groupVersion, kind, nil, toComplete)
+		if err != nil {
+			return completionError(err)
+		}
+
+		return comps, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func completionError(err error) ([]string, cobra.ShellCompDirective) {
+	cobra.CompError(err.Error())
+	return nil, cobra.ShellCompDirectiveError
 }

--- a/cmd/clusterctl/cmd/util.go
+++ b/cmd/clusterctl/cmd/util.go
@@ -26,6 +26,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 )
 
@@ -165,4 +166,13 @@ func printComponentsAsText(c client.Components) error {
 	fmt.Println()
 
 	return nil
+}
+
+// visitCommands visits the commands.
+func visitCommands(cmd *cobra.Command, fn func(*cobra.Command)) {
+	fn(cmd)
+
+	for _, c := range cmd.Commands() {
+		visitCommands(c, fn)
+	}
 }

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -122,6 +122,14 @@ func (f *FakeProxy) ListResources(labels map[string]string, namespaces ...string
 	return ret, nil
 }
 
+func (f *FakeProxy) GetContexts(prefix string) ([]string, error) {
+	return nil, nil
+}
+
+func (f *FakeProxy) GetResourceNames(groupVersion, kind string, options []client.ListOption, prefix string) ([]string, error) {
+	return nil, nil
+}
+
 func NewFakeProxy() *FakeProxy {
 	return &FakeProxy{
 		namespace: "default",


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds dynamic completion support for context in kubeconfig and namespace.

- `--kubeconfig-context` flag
- `clusterctl move --to-kubeconfig-context` flag
- `--namespace` flag
- `--target-namespace` flag
- `--from-config-map-namespace` flag

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
ref/ #4089
