### PR TITLE
🐛 clusterctl: fix target namespace in v1beta1 CRDs and WebhookConfigurations

### DIFF
--- a/cmd/clusterctl/internal/scheme/scheme.go
+++ b/cmd/clusterctl/internal/scheme/scheme.go
@@ -21,6 +21,7 @@ import (
 	admissionregistration "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
@@ -38,6 +39,7 @@ func init() {
 	_ = clusterctlv1.AddToScheme(Scheme)
 	_ = clusterv1.AddToScheme(Scheme)
 	_ = apiextensionsv1.AddToScheme(Scheme)
+	_ = apiextensionsv1beta1.AddToScheme(Scheme)
 	_ = admissionregistration.AddToScheme(Scheme)
 	_ = admissionregistrationv1beta1.AddToScheme(Scheme)
 	_ = addonsv1.AddToScheme(Scheme)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently, clusterctl only overwrites the target namespace of v1 CRDs and WebhookConfigurations. This PR adjusts clusterctl to also handle the v1beta1 versions.

Note: this has to be supported because v1alpha4 providers are not required to use the v1 versions of those resources.

After this fix clusterctl also returns better errors when used together with v1alpha3 provider versions, i.e.
```
Error: current version of clusterctl is only compatible with v1alpha4 providers, detected v1alpha3 for provider infrastructure-aws
```
instead of:
```
Fetching providers
Error: failed to get provider components for the "aws" provider: failed to set the TargetNamespace on the components: converting (v1beta1.MutatingWebhookConfiguration) to (v1.MutatingWebhookConfiguration): unknown conversion
```


xref: https://kubernetes.slack.com/archives/C8TSNPY4T/p1629101098162100


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
