### PR TITLE
🌱 Fix clusterctl upgrade e2e test

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -43,7 +43,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const initWithBinaryVariableName = "INIT_WITH_BINARY"
+const (
+	initWithBinaryVariableName = "INIT_WITH_BINARY"
+	initWithKubernetesVersion  = "INIT_WITH_KUBERNETES_VERSION"
+)
 
 // ClusterctlUpgradeSpecInput is the input for ClusterctlUpgradeSpec.
 type ClusterctlUpgradeSpecInput struct {
@@ -82,6 +85,7 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
 		Expect(input.E2EConfig.Variables).To(HaveKey(initWithBinaryVariableName), "Invalid argument. %s variable must be defined when calling %s spec", initWithBinaryVariableName, specName)
 		Expect(input.E2EConfig.Variables[initWithBinaryVariableName]).ToNot(BeEmpty(), "Invalid argument. %s variable can't be empty when calling %s spec", initWithBinaryVariableName, specName)
+		Expect(input.E2EConfig.Variables).To(HaveKey(initWithKubernetesVersion))
 		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
 		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
 
@@ -105,7 +109,7 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 				Flavor:                   clusterctl.DefaultFlavor,
 				Namespace:                managementClusterNamespace.Name,
 				ClusterName:              managementClusterName,
-				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
+				KubernetesVersion:        input.E2EConfig.GetVariable(initWithKubernetesVersion),
 				ControlPlaneMachineCount: pointer.Int64Ptr(1),
 				WorkerMachineCount:       pointer.Int64Ptr(1),
 			},
@@ -137,7 +141,7 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 		clusterctlBinaryURL = strings.ReplaceAll(clusterctlBinaryURL, "{OS}", runtime.GOOS)
 		clusterctlBinaryURL = strings.ReplaceAll(clusterctlBinaryURL, "{ARCH}", runtime.GOARCH)
 
-		log.Logf("downloading clusterctl binary from %s", clusterctlBinaryURL)
+		log.Logf("Downloading clusterctl binary from %s", clusterctlBinaryURL)
 		clusterctlBinaryPath := downloadToTmpFile(clusterctlBinaryURL)
 		defer os.Remove(clusterctlBinaryPath) // clean up
 

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -29,8 +29,8 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v0.3.16 # latest published release
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/core-components.yaml"
+  - name: v0.3.22 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.22/core-components.yaml"
     type: "url"
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
@@ -46,8 +46,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v0.3.16 # latest published release
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/bootstrap-components.yaml"
+  - name: v0.3.22 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.22/bootstrap-components.yaml"
     type: "url"
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
@@ -63,8 +63,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v0.3.16 # latest published release
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/control-plane-components.yaml"
+  - name: v0.3.22 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.22/control-plane-components.yaml"
     type: "url"
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
@@ -80,8 +80,8 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
-  - name: v0.3.16 # latest published release
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.16/infrastructure-components-development.yaml"
+  - name: v0.3.22 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.22/infrastructure-components-development.yaml"
     type: "url"
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
@@ -124,8 +124,11 @@ variables:
   EXP_MACHINE_POOL: "true"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   NODE_DRAIN_TIMEOUT: "60s"
-  # NOTE: INIT_WITH_BINARY is used only by the clusterctl upgrade test to initialize the management cluster to be upgraded
+  # NOTE: INIT_WITH_BINARY and INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
+  # the management cluster to be upgraded.
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.22/clusterctl-{OS}-{ARCH}"
+  # CAPI v0.3.x cannot be deployed on Kubernetes >= v1.22.
+  INIT_WITH_KUBERNETES_VERSION: "v1.21.2"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Since changing the "default" `KUBERNETES_VERSION` to v1.22 our clusterctl upgrade test was broken. This PR adds a new environment variable to be able to specify a separate Kubernetes version for the clusterctl upgrade test.

This PR also bumps the v0.3 provider versions to "0.3-latest".


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5099
