### PR TITLE
🌱 Reconcile control plane resources in ClusterClass

### DIFF
--- a/controllers/topology/controller.go
+++ b/controllers/topology/controller.go
@@ -139,7 +139,7 @@ func (r *ClusterReconciler) reconcile(ctx context.Context, cluster *clusterv1.Cl
 	}
 
 	// Reconciles current and desired state of the Cluster
-	if err := r.reconcileState(ctx, currentState, desiredState); err != nil {
+	if err := r.reconcileState(ctx, class.controlPlane, currentState, desiredState); err != nil {
 		return ctrl.Result{}, errors.Wrap(err, "error reconciling the Cluster topology")
 	}
 

--- a/controllers/topology/util.go
+++ b/controllers/topology/util.go
@@ -39,6 +39,11 @@ func infrastructureMachineTemplateNamePrefix(clusterName, machineDeploymentTopol
 	return fmt.Sprintf("%s-%s-infra-", clusterName, machineDeploymentTopologyName)
 }
 
+// infrastructureMachineTemplateNamePrefix calculates the name prefix for a InfrastructureMachineTemplate.
+func controlPlaneInfrastructureMachineTemplateNamePrefix(clusterName string) string {
+	return fmt.Sprintf("%s-controlplane-", clusterName)
+}
+
 // getReference gets the object referenced in ref.
 // If necessary, it updates the ref to the latest apiVersion of the current contract.
 func (r *ClusterReconciler) getReference(ctx context.Context, ref *corev1.ObjectReference) (*unstructured.Unstructured, error) {
@@ -102,4 +107,20 @@ func objToRef(obj client.Object) *corev1.ObjectReference {
 		Namespace:  obj.GetNamespace(),
 		Name:       obj.GetName(),
 	}
+}
+
+// refToUnstructured returns an unstructured object with details from an ObjectReference.
+func refToUnstructured(ref *corev1.ObjectReference) *unstructured.Unstructured {
+	uns := &unstructured.Unstructured{}
+	uns.SetAPIVersion(ref.APIVersion)
+	uns.SetKind(ref.Kind)
+	uns.SetNamespace(ref.Namespace)
+	uns.SetName(ref.Name)
+	return uns
+}
+
+// HasInfrastructureMachine checks whether the clusterClass mandates the controlPlane has infrastructureMachines
+// This function is in the wrong place for now - waiting on agreement for implmentation.
+func (c *controlPlaneTopologyClass) HasInfrastructureMachine() bool {
+	return c.infrastructureMachineTemplate != nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement the Control Plane reconcilition logic for the ClusterClass controller. This is built on top of #5072 right now, so only the final commit is relevant to the PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5049 
