### PR TITLE
🌱  Enable envtest with kind

### DIFF
--- a/hack/setup-envtest-with-kind.sh
+++ b/hack/setup-envtest-with-kind.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+os="unknown"
+if [[ "${OSTYPE}" == "linux"* ]]; then
+  os="linux"
+elif [[ "${OSTYPE}" == "darwin"* ]]; then
+  os="darwin"
+fi
+
+if [[ "$os" == "unknown" ]]; then
+  echo "OS '$OSTYPE' not supported. Aborting." >&2
+  exit 1
+fi
+
+echo "Execute the following commands to prepare your environment to run the tests with kind:"
+echo ""
+echo "kind create cluster"
+echo "export USE_EXISTING_CLUSTER=true"
+
+if [[ "${os}" == "linux" ]]; then
+  echo "gateway_ip=\$(docker inspect kind-control-plane | jq '.[0].NetworkSettings.Networks.kind.Gateway' -r)"
+  echo "docker exec kind-control-plane bash -c \"echo \\\"\${gateway_ip} linux.localhost\\\" >> /etc/hosts\""
+  echo "export CAPI_WEBHOOK_HOSTNAME=\"linux.localhost\""
+elif [[ "${os}" == "darwin" ]]; then
+  echo "export CAPI_WEBHOOK_HOSTNAME=\"docker.for.mac.localhost\""
+fi
+
+echo ""
+echo "Now you can run the tests repeatedly, e.g. via:"
+echo ""
+echo "go test ./controllers/..."
+echo ""
+echo "NOTE: You cannot run tests of multiple packages at the same time, because the webhooks would overwrite each other."

--- a/internal/envtest/environment.go
+++ b/internal/envtest/environment.go
@@ -190,7 +190,7 @@ func new(uncachedObjs ...client.Object) *Environment {
 	host := "localhost"
 	if strings.ToLower(os.Getenv("USE_EXISTING_CLUSTER")) == "true" {
 		// 0.0.0.0 is required on Linux when using kind because otherwise the kube-apiserver running in kind
-		// is unable to reach the webhook, because the webhook would be only binded on 127.0.0.1.
+		// is unable to reach the webhook, because the webhook would be only listening on 127.0.0.1.
 		// Somehow that's not an issue on MacOS.
 		if goruntime.GOOS == "linux" {
 			host = "0.0.0.0"

--- a/internal/envtest/webhooks.go
+++ b/internal/envtest/webhooks.go
@@ -74,13 +74,25 @@ func initWebhookInstallOptions() envtest.WebhookInstallOptions {
 	if err != nil {
 		klog.Fatalf("Failed to append controlplane controller webhook config: %v", err)
 	}
+
+	var localServingHostExternalName string
+	if strings.ToLower(os.Getenv("USE_EXISTING_CLUSTER")) == "true" {
+		if goruntime.GOOS == "darwin" {
+			// On MacOS with Docker for Mac localhost is reachable via "docker.for.mac.localhost".
+			localServingHostExternalName = "docker.for.mac.localhost"
+		}
+		if goruntime.GOOS == "linux" {
+			// docker network inspect kind [0].IPA.Config[0].Gateway
+			localServingHostExternalName = "172.18.0.1"
+		}
+	}
+
 	return envtest.WebhookInstallOptions{
 		MaxTime:                      20 * time.Second,
 		PollInterval:                 time.Second,
 		ValidatingWebhooks:           validatingWebhooks,
 		MutatingWebhooks:             mutatingWebhooks,
-		// MacOS: docker.for.mac.localhost
-		LocalServingHostExternalName: os.Getenv("CAPI_WEBHOOK_HOSTNAME"),
+		LocalServingHostExternalName: localServingHostExternalName,
 	}
 }
 

--- a/internal/envtest/webhooks.go
+++ b/internal/envtest/webhooks.go
@@ -74,25 +74,12 @@ func initWebhookInstallOptions() envtest.WebhookInstallOptions {
 	if err != nil {
 		klog.Fatalf("Failed to append controlplane controller webhook config: %v", err)
 	}
-
-	var localServingHostExternalName string
-	if strings.ToLower(os.Getenv("USE_EXISTING_CLUSTER")) == "true" {
-		if goruntime.GOOS == "darwin" {
-			// On MacOS with Docker for Mac localhost is reachable via "docker.for.mac.localhost".
-			localServingHostExternalName = "docker.for.mac.localhost"
-		}
-		if goruntime.GOOS == "linux" {
-			// docker network inspect kind [0].IPA.Config[0].Gateway
-			localServingHostExternalName = "172.18.0.1"
-		}
-	}
-
 	return envtest.WebhookInstallOptions{
 		MaxTime:                      20 * time.Second,
 		PollInterval:                 time.Second,
 		ValidatingWebhooks:           validatingWebhooks,
 		MutatingWebhooks:             mutatingWebhooks,
-		LocalServingHostExternalName: localServingHostExternalName,
+		LocalServingHostExternalName: os.Getenv("CAPI_WEBHOOK_HOSTNAME"),
 	}
 }
 

--- a/internal/envtest/webhooks.go
+++ b/internal/envtest/webhooks.go
@@ -75,10 +75,12 @@ func initWebhookInstallOptions() envtest.WebhookInstallOptions {
 		klog.Fatalf("Failed to append controlplane controller webhook config: %v", err)
 	}
 	return envtest.WebhookInstallOptions{
-		MaxTime:            20 * time.Second,
-		PollInterval:       time.Second,
-		ValidatingWebhooks: validatingWebhooks,
-		MutatingWebhooks:   mutatingWebhooks,
+		MaxTime:                      20 * time.Second,
+		PollInterval:                 time.Second,
+		ValidatingWebhooks:           validatingWebhooks,
+		MutatingWebhooks:             mutatingWebhooks,
+		// MacOS: docker.for.mac.localhost
+		LocalServingHostExternalName: os.Getenv("CAPI_WEBHOOK_HOSTNAME"),
 	}
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR makes it possible to run our unit tests with a local kind cluster (on Mac and on Linux). It also includes a shell script which can be run to get detailed instructions on how to do that.


Note:
* after we have consensus about the implementation I would adjust our testing documentation accordingly (also regarding `CAPI_DISABLE_TEST_ENV`)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5029
