### PR TITLE
:book:  Update Quick Start doc to include GCP env variables.

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -463,6 +463,19 @@ export SERVICE_DOMAIN="k8s.test"
 {{#/tab }}
 {{#tab GCP}}
 
+
+```bash
+# Name of the GCP datacenter location. Change this value to your desired location
+export GCP_REGION="<GCP_REGION>"
+export GCP_PROJECT="<GCP_PROJECT>"
+# Make sure to use same kubernetes version here as building the GCE image
+export KUBERNETES_VERSION=1.20.9
+export GCP_CONTROL_PLANE_MACHINE_TYPE=n1-standard-2
+export GCP_NODE_MACHINE_TYPE=n1-standard-2
+export GCP_NETWORK_NAME=<GCP_NETWORK_NAME or default>
+export CLUSTER_NAME="<CLUSTER_NAME>"
+```
+
 See the [GCP provider] for more information.
 
 {{#/tab }}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The [Quick Start](https://release-0-3.cluster-api.sigs.k8s.io/user/quick-start.html#required-configuration-for-common-providers) page lists environment variables needed to configure a cluster for all the providers but GCP. To configure a GCP infrastructure, the user has to currently look into the GCP Provider's documentation or run the `--list-variables` command to find out the variables for the configuration. This can be improved with this PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
