### PR TITLE
🌱 Intentionally ignore Deferring unsafe method Close on type *os.File

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,12 +69,10 @@ issues:
   # We are disabling default golangci exclusions because we want to help reviewers to focus on reviewing the most relevant
   # changes in PRs and avoid nitpicking.
   exclude-use-default: false
-  # List of regexps of issue texts to exclude, empty list by default.
-  exclude:
-  # The following are being worked on to remove their exclusion. This list should be reduced or go away all together over time.
-  # If it is decided they will not be addressed they should be moved above this comment.
-  - 'G307: Deferring unsafe method "Close" on type "\*os.File"'
   exclude-rules:
+  - linters:
+    - gosec
+    text: 'G307: Deferring unsafe method "Close" on type "\*os.File"'
   - linters:
     - gosec
     text: "G108: Profiling endpoint is automatically exposed on /debug/pprof"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
As we decided in https://github.com/kubernetes-sigs/cluster-api/issues/4586 we want to ignore this finding, this PR adjusts the golangci-lint config to make clear we ignore this finding intentionally (and we don't want to fix it).

P.S. Feel free to retitle. That's the best title I could come up with :/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4586
