### PR TITLE
📖 doc: update Azure provider links to reference main branch

### DIFF
--- a/docs/book/src/tasks/using-kustomize.md
+++ b/docs/book/src/tasks/using-kustomize.md
@@ -1,14 +1,14 @@
 # Using Kustomize with Workload Cluster Manifests
 
-Although the `clusterctl generate cluster` command exposes a number of different configuration values 
-for customizing workload cluster YAML manifests, some users may need additional flexibility above 
-and beyond what `clusterctl generate cluster` or the example "flavor" templates that some CAPI providers 
-supply (as an example, see [these flavor templates](https://github.com/kubernetes-sigs/cluster-api-provider-azure/tree/master/templates/flavors) 
-for the Cluster API Provider for Azure). In the future, a [templating solution](https://github.com/kubernetes-sigs/cluster-api/issues/3252) 
-may be integrated into `clusterctl` to help address this need, but in the meantime users can use 
+Although the `clusterctl generate cluster` command exposes a number of different configuration values
+for customizing workload cluster YAML manifests, some users may need additional flexibility above
+and beyond what `clusterctl generate cluster` or the example "flavor" templates that some CAPI providers
+supply (as an example, see [these flavor templates](https://github.com/kubernetes-sigs/cluster-api-provider-azure/tree/main/templates/flavors)
+for the Cluster API Provider for Azure). In the future, a [templating solution](https://github.com/kubernetes-sigs/cluster-api/issues/3252)
+may be integrated into `clusterctl` to help address this need, but in the meantime users can use
 `kustomize` as a solution to this need.
 
-This document provides a few examples of using `kustomize` with Cluster API. All of these examples 
+This document provides a few examples of using `kustomize` with Cluster API. All of these examples
 assume that you are using a directory structure that looks something like this:
 
 ```
@@ -25,13 +25,13 @@ assume that you are using a directory structure that looks something like this:
         └── workload-mhc.yaml
 ```
 
-In the overlay directories, the "base" (unmodified) Cluster API configuration (perhaps generated using 
+In the overlay directories, the "base" (unmodified) Cluster API configuration (perhaps generated using
 `clusterctl generate cluster`) would be referenced as a resource in `kustomization.yaml` using `../../base`.
 
 ## Example: Using Kustomize to Specify Custom Images
 
-Users can use `kustomize` to specify custom OS images for Cluster API nodes. Using the Cluster API 
-Provider for AWS (CAPA) as an example, the following `kustomization.yaml` would leverage a JSON 6902 patch 
+Users can use `kustomize` to specify custom OS images for Cluster API nodes. Using the Cluster API
+Provider for AWS (CAPA) as an example, the following `kustomization.yaml` would leverage a JSON 6902 patch
 to modify the AMI for nodes in a workload cluster:
 
 ```yaml
@@ -57,13 +57,13 @@ The referenced JSON 6902 patch in `custom-ami.json` would look something like th
 ]
 ```
 
-This configuration assumes that the workload cluster _only_ uses MachineDeployments. Since 
-MachineDeployments and the KubeadmControlPlane both leverage AWSMachineTemplates, this `kustomize` 
+This configuration assumes that the workload cluster _only_ uses MachineDeployments. Since
+MachineDeployments and the KubeadmControlPlane both leverage AWSMachineTemplates, this `kustomize`
 configuration would catch all nodes in the workload cluster.
 
 ## Example: Adding a MachineHealthCheck for a Workload Cluster
 
-Users could also use `kustomize` to combine additional resources, like a MachineHealthCheck (MHC), with the 
+Users could also use `kustomize` to combine additional resources, like a MachineHealthCheck (MHC), with the
 base Cluster API manifest. In an overlay directory, specify the following in `kustomization.yaml`:
 
 ```yaml
@@ -98,24 +98,24 @@ spec:
     timeout: 300s
 ```
 
-You would want to ensure the `clusterName` field in the MachineHealthCheck manifest appropriately 
-matches the name of the workload cluster, taking into account any transformations you may have specified 
+You would want to ensure the `clusterName` field in the MachineHealthCheck manifest appropriately
+matches the name of the workload cluster, taking into account any transformations you may have specified
 in `kustomization.yaml` (like the use of "namePrefix" or "nameSuffix").
 
-Running `kustomize build .` with this configuration would append the MHC to the base 
+Running `kustomize build .` with this configuration would append the MHC to the base
 Cluster API manifest, thus creating the MHC at the same time as the workload cluster.
 
 ## Modifying Names
 
-The `kustomize` "namePrefix" and "nameSuffix" transformers are not currently "Cluster API aware." 
-Although it is possible to use these transformers with Cluster API manifests, doing so requires separate 
-patches for Clusters versus infrastructure-specific equivalents (like an AzureCluster or a vSphereCluster). 
+The `kustomize` "namePrefix" and "nameSuffix" transformers are not currently "Cluster API aware."
+Although it is possible to use these transformers with Cluster API manifests, doing so requires separate
+patches for Clusters versus infrastructure-specific equivalents (like an AzureCluster or a vSphereCluster).
 This can significantly increase the complexity of using `kustomize` for this use case.
 
-Modifying the transformer configurations for `kustomize` can make it more effective with Cluster API. 
-For example, changes to the `nameReference` transformer in `kustomize` will enable `kustomize` to know 
-about the references between Cluster API objects in a manifest. See 
-[here](https://github.com/kubernetes-sigs/kustomize/tree/master/examples/transformerconfigs) for more 
+Modifying the transformer configurations for `kustomize` can make it more effective with Cluster API.
+For example, changes to the `nameReference` transformer in `kustomize` will enable `kustomize` to know
+about the references between Cluster API objects in a manifest. See
+[here](https://github.com/kubernetes-sigs/kustomize/tree/master/examples/transformerconfigs) for more
 information on transformer configurations.
 
 Add the following content to the `namereference.yaml` transformer configuration:
@@ -175,7 +175,7 @@ Add the following content to the `namereference.yaml` transformer configuration:
     kind: MachineDeployment
 ```
 
-Including this custom configuration in a `kustomization.yaml` would then enable the use of simple 
+Including this custom configuration in a `kustomization.yaml` would then enable the use of simple
 "namePrefix" and/or "nameSuffix" directives, like this:
 
 ```yaml
@@ -190,6 +190,6 @@ namePrefix: "blue-"
 nameSuffix: "-dev"
 ```
 
-Running `kustomize build. ` with this configuration would modify the name of all the Cluster API 
-objects _and_ the associated referenced objects, adding "blue-" at the beginning and appending "-dev" 
+Running `kustomize build. ` with this configuration would modify the name of all the Cluster API
+objects _and_ the associated referenced objects, adding "blue-" at the beginning and appending "-dev"
 at the end.

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -725,7 +725,7 @@ Azure [does not currently support Calico networking](https://docs.projectcalico.
 
 ```bash
 kubectl --kubeconfig=./capi-quickstart.kubeconfig \
-  apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/master/templates/addons/calico.yaml
+  apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico.yaml
 ```
 
 After a short while, our nodes should be running and in `Ready` state,
@@ -743,7 +743,7 @@ kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
 Delete workload cluster.
 ```bash
 kubectl delete cluster capi-quickstart
-```        
+```
 <aside class="note warning">
 
 IMPORTANT: In order to ensure a proper cleanup of your infrastructure you must always delete the cluster object. Deleting the entire cluster template with `kubectl delete -f capi-quickstart.yaml` might lead to pending resources to be cleaned up manually.


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates links to follow the iminent renaming of the cluster-api-provider-azure main branch,,

**Which issue(s) this PR fixes**:

Refs kubernetes-sigs/cluster-api-provider-azure#749

cc: @CecileRobertMichon 