### PR TITLE
🐛 Fix panic in cluster class reconcile

### DIFF
--- a/controllers/topology/desired_state.go
+++ b/controllers/topology/desired_state.go
@@ -61,7 +61,7 @@ func (r *ClusterReconciler) computeDesiredState(_ context.Context, class *cluste
 	desiredState.cluster = computeCluster(current, desiredState.infrastructureCluster, desiredState.controlPlane.object)
 
 	// Compute the desired state of the MachineDeployment objects for the worker nodes.
-	if len(current.cluster.Spec.Topology.Workers.MachineDeployments) == 0 {
+	if current.cluster.Spec.Topology.Workers == nil || len(current.cluster.Spec.Topology.Workers.MachineDeployments) == 0 {
 		return desiredState, nil
 	}
 

--- a/controllers/topology/desired_state.go
+++ b/controllers/topology/desired_state.go
@@ -328,6 +328,13 @@ func templateToTemplate(in templateToInput) *unstructured.Unstructured {
 	template := &unstructured.Unstructured{}
 	in.template.DeepCopyInto(template)
 
+	// Remove all the info automatically assigned by the API server and not relevant from
+	// the copy of the template.
+	template.SetResourceVersion("")
+	template.SetFinalizers(nil)
+	template.SetUID("")
+	template.SetSelfLink("")
+
 	// Enforce the topology labels into the provided label set.
 	// NOTE: The cluster label is added at creation time so this object could be read by the ClusterTopology
 	// controller immediately after creation, even before other controllers are going to add the label (if missing).


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a panic error in topology/ClusterReconciler if there are no workers in a topology.

It also contain a small change to remove info automatically assigned by the API server when cloning templates
