### PR TITLE
📖 doc: mention clusterctl download for darwin-arm64

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -123,6 +123,12 @@ Download the latest release; on macOS, type:
 ```
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-amd64" version:"0.4.x"}} -o clusterctl
 ```
+
+Or if your Mac has an M1 CPU ("Apple Silicon"):
+```
+curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-arm64" version:"0.4.x"}} -o clusterctl
+```
+
 Make the clusterctl binary executable.
 ```
 chmod +x ./clusterctl


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a link to the `darwin-arm64` (not `-amd64`) download for `clusterctl`, which is preferable on M1-based Macs.

See #4861.

**Which issue(s) this PR fixes**:

N/A