### PR TITLE
:seedling: Cleanup controllers/topology code, add more comments

### DIFF
--- a/controllers/topology/cluster_class_test.go
+++ b/controllers/topology/cluster_class_test.go
@@ -102,10 +102,10 @@ func TestGetClass(t *testing.T) {
 					WithControlPlaneTemplate(controlPlaneTemplate).
 					Obj(),
 				infrastructureClusterTemplate: infraClusterTemplate,
-				controlPlane: controlPlaneTopologyClass{
+				controlPlane: &controlPlaneTopologyClass{
 					template: controlPlaneTemplate,
 				},
-				machineDeployments: map[string]machineDeploymentTopologyClass{},
+				machineDeployments: map[string]*machineDeploymentTopologyClass{},
 			},
 		},
 		{
@@ -127,11 +127,11 @@ func TestGetClass(t *testing.T) {
 					WithControlPlaneInfrastructureMachineTemplate(controlPlaneInfrastructureMachineTemplate).
 					Obj(),
 				infrastructureClusterTemplate: infraClusterTemplate,
-				controlPlane: controlPlaneTopologyClass{
+				controlPlane: &controlPlaneTopologyClass{
 					template:                      controlPlaneTemplateWithInfrastructureMachine,
 					infrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate,
 				},
-				machineDeployments: map[string]machineDeploymentTopologyClass{},
+				machineDeployments: map[string]*machineDeploymentTopologyClass{},
 			},
 		},
 		{
@@ -167,10 +167,10 @@ func TestGetClass(t *testing.T) {
 					WithWorkerMachineDeploymentClass("workerclass1", map[string]string{"foo": "bar"}, map[string]string{"a": "b"}, workerInfrastructureMachineTemplate, workerBootstrapTemplate).
 					Obj(),
 				infrastructureClusterTemplate: infraClusterTemplate,
-				controlPlane: controlPlaneTopologyClass{
+				controlPlane: &controlPlaneTopologyClass{
 					template: controlPlaneTemplate,
 				},
-				machineDeployments: map[string]machineDeploymentTopologyClass{
+				machineDeployments: map[string]*machineDeploymentTopologyClass{
 					"workerclass1": {
 						metadata: clusterv1.ObjectMeta{
 							Labels:      map[string]string{"foo": "bar"},

--- a/controllers/topology/controller.go
+++ b/controllers/topology/controller.go
@@ -101,6 +101,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 	}
 
 	// Return early if the Cluster is paused.
+	// TODO: What should we do if the cluster class is paused?
 	if annotations.IsPaused(cluster, cluster) {
 		log.Info("Reconciliation is paused for this object")
 		return ctrl.Result{}, nil
@@ -111,6 +112,8 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 	// In case the object is deleted, the managed topology stops to reconcile;
 	// (the other controllers will take care of deletion).
 	if !cluster.ObjectMeta.DeletionTimestamp.IsZero() {
+		// TODO: When external patching is supported, we should handle the deletion
+		// of those external CRDs we created.
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/topology/current_state.go
+++ b/controllers/topology/current_state.go
@@ -76,41 +76,43 @@ func (r *ClusterReconciler) getCurrentInfrastructureClusterState(ctx context.Con
 // getCurrentControlPlaneState returns information on the ControlPlane being used by the Cluster. If a reference is not found,
 // an error is thrown. If the ControlPlane requires MachineInfrastructure according to its ClusterClass an error will be
 // thrown if the ControlPlane has no MachineTemplates.
-func (r *ClusterReconciler) getCurrentControlPlaneState(ctx context.Context, cluster *clusterv1.Cluster, class *clusterv1.ClusterClass) (controlPlaneTopologyState, error) {
-	cp, err := r.getReference(ctx, cluster.Spec.ControlPlaneRef)
+func (r *ClusterReconciler) getCurrentControlPlaneState(ctx context.Context, cluster *clusterv1.Cluster, class *clusterv1.ClusterClass) (*controlPlaneTopologyState, error) {
+	var err error
+	res := &controlPlaneTopologyState{}
+
+	// Get the control plane object.
+	res.object, err = r.getReference(ctx, cluster.Spec.ControlPlaneRef)
 	if err != nil {
-		return controlPlaneTopologyState{}, errors.Wrapf(err, "failed to read %s %s", cluster.Spec.ControlPlaneRef.Kind, cluster.Spec.ControlPlaneRef.Name)
+		return nil, errors.Wrapf(err, "failed to read %s %s", cluster.Spec.ControlPlaneRef.Kind, cluster.Spec.ControlPlaneRef.Name)
 	}
+
 	// Some ControlPlane providers may not require MachineInfrastructure to run. This check returns early if the field
 	// indicating MachineInfrastructure is required is not found in the ClusterClass of the given Cluster.
 	if class.Spec.ControlPlane.MachineInfrastructure == nil {
-		return controlPlaneTopologyState{
-			cp,
-			nil,
-		}, nil
+		return res, nil
 	}
 
-	cpInfraRef, err := getNestedRef(cp, "spec", "machineTemplate", "infrastructureRef")
+	// Get this control plane machine infrastructure reference.
+	machineInfrastructureRef, err := getNestedRef(res.object, "spec", "machineTemplate", "infrastructureRef")
 	if err != nil {
-		return controlPlaneTopologyState{cp, nil}, errors.Wrapf(err, "failed to get InfrastructureMachineTemplate reference for %s, %s", cp.GetKind(), cp.GetName())
+		return res, errors.Wrapf(err, "failed to get InfrastructureMachineTemplate reference for %s, %s", res.object.GetKind(), res.object.GetName())
 	}
-	infra, err := r.getReference(ctx, cpInfraRef)
+	res.infrastructureMachineTemplate, err = r.getReference(ctx, machineInfrastructureRef)
 	if err != nil {
-		return controlPlaneTopologyState{cp, nil}, errors.Wrapf(err, "failed to get InfrastructureMachineTemplate reference for %s, %s", cp.GetKind(), cp.GetName())
+		return nil, errors.Wrapf(err, "failed to get InfrastructureMachineTemplate for %s, %s", res.object.GetKind(), res.object.GetName())
 	}
-	return controlPlaneTopologyState{
-		cp,
-		infra,
-	}, nil
+
+	return res, nil
 }
 
 // getCurrentMachineDeploymentState queries for all MachineDeployments and filters them for their linked Cluster and
 // whether they are managed by a ClusterClass using labels. A Cluster may have zero or more MachineDeployments. Zero is
 // expected on first reconcile. If MachineDeployments are found for the Cluster their Infrastructure and Bootstrap references
 // are inspected. Where these are not found the function will throw an error.
-func (r *ClusterReconciler) getCurrentMachineDeploymentState(ctx context.Context, cluster *clusterv1.Cluster) (map[string]machineDeploymentTopologyState, error) {
-	mDeploymentState := make(map[string]machineDeploymentTopologyState)
+func (r *ClusterReconciler) getCurrentMachineDeploymentState(ctx context.Context, cluster *clusterv1.Cluster) (map[string]*machineDeploymentTopologyState, error) {
+	state := make(map[string]*machineDeploymentTopologyState)
 
+	// List all the machine deployments in the current cluster and in a managed topology.
 	md := &clusterv1.MachineDeploymentList{}
 	err := r.Client.List(ctx, md, client.MatchingLabels{
 		clusterv1.ClusterLabelName:         cluster.Name,
@@ -119,41 +121,48 @@ func (r *ClusterReconciler) getCurrentMachineDeploymentState(ctx context.Context
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read MachineDeployments for managed topology")
 	}
-	for _, m := range md.Items {
-		machineDeployment := m
+
+	// Loop over each machine deployment and create the current
+	// state by retrieving all required references.
+	for i := range md.Items {
+		m := &md.Items[i]
+
+		// Retrieve the name which is usually assigned in Cluster's topology
+		// from a well-defined label.
 		mdTopologyName, ok := m.ObjectMeta.Labels[clusterv1.ClusterTopologyMachineDeploymentLabelName]
-		if !ok {
-			return nil, fmt.Errorf("failed to find label %s in %s", clusterv1.ClusterTopologyMachineDeploymentLabelName, machineDeployment.Name)
+		if !ok || len(mdTopologyName) == 0 {
+			return nil, fmt.Errorf("failed to find label %s in %s", clusterv1.ClusterTopologyMachineDeploymentLabelName, m.Name)
 		}
-		if mdTopologyName == "" {
-			return nil, fmt.Errorf("no value for MachineDeploymentTopoplogyName for %s", machineDeployment.Name)
-		}
-		if _, ok := mDeploymentState[mdTopologyName]; ok {
-			return nil, fmt.Errorf("duplicate machine deployment %s found for label %s: %s", machineDeployment.Name, clusterv1.ClusterTopologyMachineDeploymentLabelName, mdTopologyName)
+
+		// Make sure that the name of the MachineDeployment stays unique.
+		// If we've already have seen a MachineDeployment with the same name
+		// this is an error, probably caused from manual modifications or a race condition.
+		if _, ok := state[mdTopologyName]; ok {
+			return nil, fmt.Errorf("duplicate machine deployment %s found for label %s: %s", m.Name, clusterv1.ClusterTopologyMachineDeploymentLabelName, mdTopologyName)
 		}
 		infraRef := &m.Spec.Template.Spec.InfrastructureRef
 		if infraRef == nil {
-			return nil, fmt.Errorf("MachineDeployment %s does not have a reference to a InfrastructureMachineTemplate", machineDeployment.Name)
+			return nil, fmt.Errorf("MachineDeployment %s does not have a reference to a InfrastructureMachineTemplate", m.Name)
 		}
 
 		bootstrapRef := m.Spec.Template.Spec.Bootstrap.ConfigRef
 		if bootstrapRef == nil {
-			return nil, fmt.Errorf("MachineDeployment %s does not have a reference to a Bootstrap Config", machineDeployment.Name)
+			return nil, fmt.Errorf("MachineDeployment %s does not have a reference to a Bootstrap Config", m.Name)
 		}
 
 		i, err := r.getReference(ctx, infraRef)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("MachineDeployment %s Infrastructure reference could not be retrieved", machineDeployment.Name))
+			return nil, errors.Wrap(err, fmt.Sprintf("MachineDeployment %s Infrastructure reference could not be retrieved", m.Name))
 		}
 		b, err := r.getReference(ctx, bootstrapRef)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("MachineDeployment %s Bootstrap reference could not be retrieved", machineDeployment.Name))
+			return nil, errors.Wrap(err, fmt.Sprintf("MachineDeployment %s Bootstrap reference could not be retrieved", m.Name))
 		}
-		mDeploymentState[mdTopologyName] = machineDeploymentTopologyState{
-			object:                        &machineDeployment,
+		state[mdTopologyName] = &machineDeploymentTopologyState{
+			object:                        m,
 			bootstrapTemplate:             b,
 			infrastructureMachineTemplate: i,
 		}
 	}
-	return mDeploymentState, nil
+	return state, nil
 }

--- a/controllers/topology/current_state_test.go
+++ b/controllers/topology/current_state_test.go
@@ -74,7 +74,7 @@ func TestGetCurrentState(t *testing.T) {
 	machineDeploymentOutsideCluster := newFakeMachineDeployment(metav1.NamespaceDefault, "wrong-cluster-label").WithLabels(labelsNotInClass).WithBootstrapTemplate(machineDeploymentBootstrap).WithInfrastructureTemplate(machineDeploymentInfrastructure).Obj()
 	machineDeploymentUnmanaged := newFakeMachineDeployment(metav1.NamespaceDefault, "no-managed-label").WithLabels(labelsUnmanaged).WithBootstrapTemplate(machineDeploymentBootstrap).WithInfrastructureTemplate(machineDeploymentInfrastructure).Obj()
 	machineDeploymentWithoutDeploymentName := newFakeMachineDeployment(metav1.NamespaceDefault, "missing-topology-md-labelName").WithLabels(labelsManagedWithoutDeploymentName).WithBootstrapTemplate(machineDeploymentBootstrap).WithInfrastructureTemplate(machineDeploymentInfrastructure).Obj()
-	emptyMachineDeployments := make(map[string]machineDeploymentTopologyState)
+	emptyMachineDeployments := make(map[string]*machineDeploymentTopologyState)
 
 	tests := []struct {
 		name    string
@@ -90,7 +90,7 @@ func TestGetCurrentState(t *testing.T) {
 			// Expecting valid return with no ControlPlane or Infrastructure state defined and empty MachineDeployment state list
 			want: &clusterTopologyState{
 				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
-				controlPlane:          controlPlaneTopologyState{},
+				controlPlane:          nil,
 				infrastructureCluster: nil,
 				machineDeployments:    emptyMachineDeployments,
 			},
@@ -112,7 +112,7 @@ func TestGetCurrentState(t *testing.T) {
 			// Expecting valid return with no ControlPlane or MachineDeployment state defined but with a valid Infrastructure state.
 			want: &clusterTopologyState{
 				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").WithInfrastructureCluster(infraCluster).Obj(),
-				controlPlane:          controlPlaneTopologyState{},
+				controlPlane:          nil,
 				infrastructureCluster: infraCluster,
 				machineDeployments:    emptyMachineDeployments,
 			},
@@ -129,7 +129,7 @@ func TestGetCurrentState(t *testing.T) {
 			// Expecting valid return with ControlPlane, no ControlPlane Infrastructure state, InfrastructureCluster state and no defined MachineDeployment state.
 			want: &clusterTopologyState{
 				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").WithControlPlane(controlPlane).WithInfrastructureCluster(infraCluster).Obj(),
-				controlPlane:          controlPlaneTopologyState{object: controlPlane, infrastructureMachineTemplate: nil},
+				controlPlane:          &controlPlaneTopologyState{object: controlPlane, infrastructureMachineTemplate: nil},
 				infrastructureCluster: infraCluster,
 				machineDeployments:    emptyMachineDeployments,
 			},
@@ -157,7 +157,7 @@ func TestGetCurrentState(t *testing.T) {
 			// Expecting valid return with valid ControlPlane state, but no ControlPlane Infrastructure, InfrastructureCluster or MachineDeployment state defined.
 			want: &clusterTopologyState{
 				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").WithControlPlane(controlPlaneWithInfra).Obj(),
-				controlPlane:          controlPlaneTopologyState{object: controlPlaneWithInfra, infrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate},
+				controlPlane:          &controlPlaneTopologyState{object: controlPlaneWithInfra, infrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate},
 				infrastructureCluster: nil,
 				machineDeployments:    emptyMachineDeployments,
 			},
@@ -175,7 +175,7 @@ func TestGetCurrentState(t *testing.T) {
 			// Expecting valid return with valid ControlPlane state, ControlPlane Infrastructure state and InfrastructureCluster state, but no defined MachineDeployment state.
 			want: &clusterTopologyState{
 				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").WithInfrastructureCluster(infraCluster).WithControlPlane(controlPlaneWithInfra).Obj(),
-				controlPlane:          controlPlaneTopologyState{object: controlPlaneWithInfra, infrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate},
+				controlPlane:          &controlPlaneTopologyState{object: controlPlaneWithInfra, infrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate},
 				infrastructureCluster: infraCluster,
 				machineDeployments:    emptyMachineDeployments,
 			},
@@ -196,9 +196,9 @@ func TestGetCurrentState(t *testing.T) {
 			// Expecting valid return with valid ControlPlane, ControlPlane Infrastructure and InfrastructureCluster state, but no defined MachineDeployment state.
 			want: &clusterTopologyState{
 				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
-				controlPlane:          controlPlaneTopologyState{},
+				controlPlane:          nil,
 				infrastructureCluster: nil,
-				machineDeployments: map[string]machineDeploymentTopologyState{
+				machineDeployments: map[string]*machineDeploymentTopologyState{
 					"md1": {object: machineDeploymentInCluster, bootstrapTemplate: machineDeploymentBootstrap, infrastructureMachineTemplate: machineDeploymentInfrastructure}},
 			},
 		},
@@ -225,7 +225,7 @@ func TestGetCurrentState(t *testing.T) {
 			// Expect valid return with empty MachineDeployments properly filtered by label.
 			want: &clusterTopologyState{
 				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").Obj(),
-				controlPlane:          controlPlaneTopologyState{},
+				controlPlane:          nil,
 				infrastructureCluster: nil,
 				machineDeployments:    emptyMachineDeployments,
 			},
@@ -273,9 +273,9 @@ func TestGetCurrentState(t *testing.T) {
 			// Expect valid return of full clusterTopologyState with MachineDeployments properly filtered by label.
 			want: &clusterTopologyState{
 				cluster:               newFakeCluster(metav1.NamespaceDefault, "cluster1").WithInfrastructureCluster(infraCluster).WithControlPlane(controlPlaneWithInfra).Obj(),
-				controlPlane:          controlPlaneTopologyState{object: controlPlaneWithInfra, infrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate},
+				controlPlane:          &controlPlaneTopologyState{object: controlPlaneWithInfra, infrastructureMachineTemplate: controlPlaneInfrastructureMachineTemplate},
 				infrastructureCluster: infraCluster,
-				machineDeployments: map[string]machineDeploymentTopologyState{
+				machineDeployments: map[string]*machineDeploymentTopologyState{
 					"md1": {object: machineDeploymentInCluster, bootstrapTemplate: machineDeploymentBootstrap, infrastructureMachineTemplate: machineDeploymentInfrastructure}},
 			},
 		},

--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -128,7 +128,7 @@ func TestComputeControlPlaneInfrastructureMachineTemplate(t *testing.T) {
 	// aggregating templates and cluster class into topologyClass (simulating getClass)
 	topologyClass := &clusterTopologyClass{
 		clusterClass: clusterClass,
-		controlPlane: controlPlaneTopologyClass{
+		controlPlane: &controlPlaneTopologyClass{
 			infrastructureMachineTemplate: infrastructureMachineTemplate,
 		},
 	}
@@ -186,7 +186,7 @@ func TestComputeControlPlaneInfrastructureMachineTemplate(t *testing.T) {
 		// aggregating current cluster objects into clusterTopologyState (simulating getCurrentState)
 		current := &clusterTopologyState{
 			cluster: cluster,
-			controlPlane: controlPlaneTopologyState{
+			controlPlane: &controlPlaneTopologyState{
 				object:                        controlPlane,
 				infrastructureMachineTemplate: currentInfrastructureMachineTemplate,
 			},
@@ -222,7 +222,7 @@ func TestComputeControlPlane(t *testing.T) {
 	// aggregating templates and cluster class into topologyClass (simulating getClass)
 	topologyClass := &clusterTopologyClass{
 		clusterClass: clusterClass,
-		controlPlane: controlPlaneTopologyClass{
+		controlPlane: &controlPlaneTopologyClass{
 			template: controlPlaneTemplate,
 		},
 	}
@@ -319,7 +319,7 @@ func TestComputeControlPlane(t *testing.T) {
 		// aggregating templates and cluster class into topologyClass (simulating getClass)
 		topologyClass := &clusterTopologyClass{
 			clusterClass: clusterClass,
-			controlPlane: controlPlaneTopologyClass{
+			controlPlane: &controlPlaneTopologyClass{
 				template:                      controlPlaneTemplate,
 				infrastructureMachineTemplate: infrastructureMachineTemplate,
 			},
@@ -431,7 +431,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 		Obj()
 	class := &clusterTopologyClass{
 		clusterClass: fakeClass,
-		machineDeployments: map[string]machineDeploymentTopologyClass{
+		machineDeployments: map[string]*machineDeploymentTopologyClass{
 			"linux-worker": {
 				metadata: clusterv1.ObjectMeta{
 					Labels:      labels,
@@ -497,7 +497,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 				},
 			},
 		}
-		current.machineDeployments = map[string]machineDeploymentTopologyState{
+		current.machineDeployments = map[string]*machineDeploymentTopologyState{
 			"big-pool-of-machines": {
 				object:                        currentMd,
 				bootstrapTemplate:             workerBootstrapTemplate,

--- a/controllers/topology/reconcile_state.go
+++ b/controllers/topology/reconcile_state.go
@@ -33,7 +33,7 @@ import (
 // NOTE: We are assuming all the required objects are provided as input; also, in case of any error,
 // the entire reconcile operation will fail. This might be improved in the future if support for reconciling
 // subset of a topology will be implemented.
-func (r *ClusterReconciler) reconcileState(ctx context.Context, cpClass controlPlaneTopologyClass, current, desired *clusterTopologyState) error {
+func (r *ClusterReconciler) reconcileState(ctx context.Context, cpClass *controlPlaneTopologyClass, current, desired *clusterTopologyState) error {
 	// Reconcile desired state of the InfrastructureCluster object.
 	if err := r.reconcileInfrastructureCluster(ctx, current, desired); err != nil {
 		return err
@@ -60,7 +60,7 @@ func (r *ClusterReconciler) reconcileInfrastructureCluster(ctx context.Context, 
 
 // reconcileControlPlane works to bring the current state of a managed topology in line with the desired state. This involves
 // updating the cluster where needed.
-func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, class controlPlaneTopologyClass, current, desired *clusterTopologyState) error {
+func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, class *controlPlaneTopologyClass, current, desired *clusterTopologyState) error {
 	log := ctrl.LoggerFrom(ctx)
 	// Set a default nil return function for the cleanup operation.
 	cleanup := func() error { return nil }
@@ -163,7 +163,7 @@ func (r *ClusterReconciler) reconcileMachineDeployments(ctx context.Context, cur
 }
 
 // createMachineDeployment creates a MachineDeployment and the corresponding Templates.
-func (r *ClusterReconciler) createMachineDeployment(ctx context.Context, md machineDeploymentTopologyState) error {
+func (r *ClusterReconciler) createMachineDeployment(ctx context.Context, md *machineDeploymentTopologyState) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	if _, err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
@@ -186,7 +186,7 @@ func (r *ClusterReconciler) createMachineDeployment(ctx context.Context, md mach
 }
 
 // updateMachineDeployment updates a MachineDeployment. Also rotates the corresponding Templates if necessary.
-func (r *ClusterReconciler) updateMachineDeployment(ctx context.Context, clusterName string, currentMD, desiredMD machineDeploymentTopologyState) error {
+func (r *ClusterReconciler) updateMachineDeployment(ctx context.Context, clusterName string, currentMD, desiredMD *machineDeploymentTopologyState) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	cleanupOldInfrastructureTemplate, err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
@@ -232,7 +232,7 @@ func (r *ClusterReconciler) updateMachineDeployment(ctx context.Context, cluster
 }
 
 // deleteMachineDeployment deletes a MachineDeployment.
-func (r *ClusterReconciler) deleteMachineDeployment(ctx context.Context, md machineDeploymentTopologyState) error {
+func (r *ClusterReconciler) deleteMachineDeployment(ctx context.Context, md *machineDeploymentTopologyState) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	log.Info("deleting", md.object.GroupVersionKind().String(), md.object.GetName())
@@ -248,7 +248,7 @@ type machineDeploymentDiff struct {
 
 // calculateMachineDeploymentDiff compares two maps of machineDeploymentTopologyState and calculates which
 // MachineDeployments should be created, updated or deleted.
-func calculateMachineDeploymentDiff(current, desired map[string]machineDeploymentTopologyState) machineDeploymentDiff {
+func calculateMachineDeploymentDiff(current, desired map[string]*machineDeploymentTopologyState) machineDeploymentDiff {
 	var diff machineDeploymentDiff
 
 	for md := range desired {

--- a/controllers/topology/types.go
+++ b/controllers/topology/types.go
@@ -25,8 +25,8 @@ import (
 type clusterTopologyClass struct {
 	clusterClass                  *clusterv1.ClusterClass
 	infrastructureClusterTemplate *unstructured.Unstructured
-	controlPlane                  controlPlaneTopologyClass
-	machineDeployments            map[string]machineDeploymentTopologyClass
+	controlPlane                  *controlPlaneTopologyClass
+	machineDeployments            map[string]*machineDeploymentTopologyClass
 }
 
 // controlPlaneTopologyClass holds the templates required for computing the desired state of a managed control plane.
@@ -48,8 +48,8 @@ type machineDeploymentTopologyClass struct {
 type clusterTopologyState struct {
 	cluster               *clusterv1.Cluster
 	infrastructureCluster *unstructured.Unstructured
-	controlPlane          controlPlaneTopologyState
-	machineDeployments    map[string]machineDeploymentTopologyState
+	controlPlane          *controlPlaneTopologyState
+	machineDeployments    map[string]*machineDeploymentTopologyState
 }
 
 // controlPlaneTopologyState all the objects representing the state of a managed control plane.


### PR DESCRIPTION
This changeset cleans up the current codebase under controller/topology
which is related with the ClusterClass proposal and work that's been
ongoing. It adds more comments throughout the codebase, and uses
pointers which avoids copying structs around.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
