### PR TITLE
🌱  fix nil pointer in ClusterClass webhook ref validation

### DIFF
--- a/api/v1alpha4/clusterclass_webhook.go
+++ b/api/v1alpha4/clusterclass_webhook.go
@@ -202,6 +202,15 @@ func (in ClusterClass) validateMachineDeploymentsChanges(old *ClusterClass) fiel
 func (r LocalObjectTemplate) validate(namespace string, pathPrefix *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
+	// check if ref is not nil.
+	if r.Ref == nil {
+		return field.ErrorList{field.Invalid(
+			pathPrefix.Child("ref"),
+			r.Ref.Name,
+			"cannot be nil",
+		)}
+	}
+
 	// check if a name is provided
 	if r.Ref.Name == "" {
 		allErrs = append(allErrs,


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently the ObjectReference is a pointer and thus can be nil. In this case we would get a nil pointer dereference.

Note:
* Not sure if it should be pointer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
