### PR TITLE
🌱 add mergehelper IgnorePath option

### DIFF
--- a/controllers/topology/internal/mergepatch/doc.go
+++ b/controllers/topology/internal/mergepatch/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mergepatch implements merge patch support for managed topology.
+package mergepatch

--- a/controllers/topology/internal/mergepatch/options.go
+++ b/controllers/topology/internal/mergepatch/options.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mergepatch
+
+// HelperOption is some configuration that modifies options for Helper.
+type HelperOption interface {
+	// ApplyToHelper applies this configuration to the given helper options.
+	ApplyToHelper(*HelperOptions)
+}
+
+// HelperOptions contains options for Helper.
+type HelperOptions struct {
+	ignorePaths [][]string
+}
+
+// ApplyOptions applies the given patch options on these options,
+// and then returns itself (for convenient chaining).
+func (o *HelperOptions) ApplyOptions(opts []HelperOption) *HelperOptions {
+	for _, opt := range opts {
+		opt.ApplyToHelper(o)
+	}
+	return o
+}
+
+// IgnorePath instruct the Helper to ignore a given path when computing a patch.
+type IgnorePath []string
+
+// ApplyToHelper applies this configuration to the given helper options.
+func (i IgnorePath) ApplyToHelper(opts *HelperOptions) {
+	opts.ignorePaths = append(opts.ignorePaths, i)
+}

--- a/controllers/topology/reconcile_state.go
+++ b/controllers/topology/reconcile_state.go
@@ -57,7 +57,7 @@ func (r *ClusterReconciler) reconcileState(ctx context.Context, s *scope.Scope) 
 
 // reconcileInfrastructureCluster reconciles the desired state of the InfrastructureCluster object.
 func (r *ClusterReconciler) reconcileInfrastructureCluster(ctx context.Context, s *scope.Scope) error {
-	return r.reconcileReferencedObject(ctx, s.Current.InfrastructureCluster, s.Desired.InfrastructureCluster)
+	return r.reconcileReferencedObject(ctx, s.Current.InfrastructureCluster, s.Desired.InfrastructureCluster, mergepatch.IgnorePath{"spec", "controlPlaneEndpoint"})
 }
 
 // reconcileControlPlane works to bring the current state of a managed topology in line with the desired state. This involves
@@ -270,7 +270,7 @@ func calculateMachineDeploymentDiff(current, desired map[string]*scope.MachineDe
 // reconcileReferencedObject reconciles the desired state of the referenced object.
 // NOTE: After a referenced object is created it is assumed that the reference should
 // never change (only the content of the object can eventually change). Thus, we are checking for strict compatibility.
-func (r *ClusterReconciler) reconcileReferencedObject(ctx context.Context, current, desired *unstructured.Unstructured) error {
+func (r *ClusterReconciler) reconcileReferencedObject(ctx context.Context, current, desired *unstructured.Unstructured, opts ...mergepatch.HelperOption) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	// If there is no current object, create it.
@@ -288,7 +288,7 @@ func (r *ClusterReconciler) reconcileReferencedObject(ctx context.Context, curre
 	}
 
 	// Check differences between current and desired state, and eventually patch the current object.
-	patchHelper, err := mergepatch.NewHelper(current, desired, r.Client)
+	patchHelper, err := mergepatch.NewHelper(current, desired, r.Client, opts...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create patch helper for %s/%s", current.GroupVersionKind(), current.GetKind())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

While testing ClusterClass, I discovered that the controller was overriding `spec.controlPlaneEndpoint` in the infrastructure Cluster.

This is because the `spec.controlPlaneEndpoint` fields (host and port) are defined as mandatory and as a consequence defaulted to "" and 0 in the template, and then enforced in the managed object.

This PR adds to the merge helper an option that allows us to specify fields to be ignored when computing diff; this can be used to solve the above issue given that `spec.controlPlaneEndpoint` is a field defined in the contract and we know that this field will be set by the controller.

Similar change should be applied for other spec fields defined in the contract in follow up PRs.