### PR TITLE
🌱 Cleanup topology reconcile logs

### DIFF
--- a/controllers/remote/cluster_cache.go
+++ b/controllers/remote/cluster_cache.go
@@ -284,7 +284,7 @@ func (t *ClusterCacheTracker) Watch(ctx context.Context, input WatchInput) error
 	}
 
 	if a.watches.Has(input.Name) {
-		t.log.V(4).Info("Watch already exists", "namespace", input.Cluster.Namespace, "cluster", input.Cluster.Name, "name", input.Name)
+		t.log.V(6).Info("Watch already exists", "namespace", input.Cluster.Namespace, "cluster", input.Cluster.Name, "name", input.Name)
 		return nil
 	}
 

--- a/controllers/topology/internal/mergepatch/mergepatch.go
+++ b/controllers/topology/internal/mergepatch/mergepatch.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -194,5 +195,9 @@ func (h *Helper) Patch(ctx context.Context) error {
 	if !h.HasChanges() {
 		return nil
 	}
+
+	log := ctrl.LoggerFrom(ctx)
+	log.V(5).Info("Patching object", "Patch", string(h.patch))
+
 	return h.client.Patch(ctx, h.original, client.RawPatch(types.MergePatchType, h.patch))
 }

--- a/controllers/topology/util.go
+++ b/controllers/topology/util.go
@@ -20,12 +20,111 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// loggerFrom returns a logger with predefined values from a context.Context.
+// The logger, when used with controllers, can be expected to contain basic information about the object
+// that's being reconciled like:
+// - `reconciler group` and `reconciler kind` coming from the For(...) object passed in when building a controller.
+// - `name` and `namespace` injected from the reconciliation request.
+//
+// This is meant to be used with the context supplied in a struct that satisfies the Reconciler interface.
+func loggerFrom(ctx context.Context) logger {
+	log := ctrl.LoggerFrom(ctx)
+	return &topologyReconcileLogger{
+		Logger: log,
+	}
+}
+
+// logger provides a wrapper to log.Logger to be used for topology reconciler.
+type logger interface {
+	// WithObject adds to the logger information about the object being modified by reconcile, which in most case it is
+	// a resources being part of the Cluster by reconciled.
+	WithObject(obj client.Object) logger
+
+	// WithMachineDeployment adds to the logger information about the MachineDeployment object being processed.
+	WithMachineDeployment(md *clusterv1.MachineDeployment) logger
+
+	// V returns a logger value for a specific verbosity level, relative to
+	// this logger.
+	V(level int) logger
+
+	// Infof logs to the INFO log.
+	// Arguments are handled in the manner of fmt.Printf.
+	Infof(msg string, a ...interface{})
+
+	// Into takes a context and sets the logger as one of its keys.
+	//
+	// This is meant to be used in reconcilers to enrich the logger within a context with additional values.
+	Into(ctx context.Context) (context.Context, logger)
+}
+
+// topologyReconcileLogger implements Logger.
+type topologyReconcileLogger struct {
+	logr.Logger
+}
+
+// WithObject adds to the logger information about the object being modified by reconcile, which in most case it is
+// a resources being part of the Cluster by reconciled.
+func (l *topologyReconcileLogger) WithObject(obj client.Object) logger {
+	l.Logger = l.Logger.WithValues(
+		"object groupVersion", obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		"object kind", obj.GetObjectKind().GroupVersionKind().Kind,
+		"object", obj.GetName(),
+	)
+	return l
+}
+
+// WithMachineDeployment adds to the logger information about the MachineDeployment object being processed.
+func (l *topologyReconcileLogger) WithMachineDeployment(md *clusterv1.MachineDeployment) logger {
+	topologyName := md.Labels[clusterv1.ClusterTopologyMachineDeploymentLabelName]
+	l.Logger = l.Logger.WithValues(
+		"machineDeployment name", md.GetName(),
+		"machineDeployment topologyName", topologyName,
+	)
+	return l
+}
+
+// V returns a logger value for a specific verbosity level, relative to
+// this logger.
+func (l *topologyReconcileLogger) V(level int) logger {
+	l.Logger = l.Logger.V(level)
+	return l
+}
+
+// Infof logs to the INFO log.
+// Arguments are handled in the manner of fmt.Printf.
+func (l *topologyReconcileLogger) Infof(msg string, a ...interface{}) {
+	l.Logger.Info(fmt.Sprintf(msg, a...))
+}
+
+// Into takes a context and sets the logger as one of its keys.
+//
+// This is meant to be used in reconcilers to enrich the logger within a context with additional values.
+func (l *topologyReconcileLogger) Into(ctx context.Context) (context.Context, logger) {
+	return ctrl.LoggerInto(ctx, l.Logger), l
+}
+
+// KRef return a reference to a Kubernetes object in the same format used by kubectl commands (kind/name).
+type KRef struct {
+	Obj client.Object
+}
+
+func (ref KRef) String() string {
+	if ref.Obj == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s", ref.Obj.GetObjectKind().GroupVersionKind().Kind, ref.Obj.GetName())
+}
 
 // bootstrapTemplateNamePrefix calculates the name prefix for a BootstrapTemplate.
 func bootstrapTemplateNamePrefix(clusterName, machineDeploymentTopologyName string) string {

--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -129,11 +129,13 @@ func ClusterUpdateUnpaused(logger logr.Logger) predicate.Funcs {
 			newCluster := e.ObjectNew.(*clusterv1.Cluster)
 
 			if oldCluster.Spec.Paused && !newCluster.Spec.Paused {
-				log.V(6).Info("Cluster was unpaused, allowing further processing")
+				log.V(4).Info("Cluster was unpaused, allowing further processing")
 				return true
 			}
 
-			log.V(4).Info("Cluster was not unpaused, blocking further processing")
+			// This predicate always work in "or" with Paused predicates
+			// so the logs are adjusted to not provide false negatives/verbosity al V<=5.
+			log.V(6).Info("Cluster was not unpaused, blocking further processing")
 			return false
 		},
 		CreateFunc:  func(e event.CreateEvent) bool { return false },


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR Cleanup logs for topology/ClusterReconciler following [sig-instrumentation guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md).

More specifically

At log level 0. (always visible) we are logging:
- A log entry signalling the reconciler is processing
```
I0820 18:26:01.101336      35 reconcile_state.go:41] controller-runtime/manager/controller/cluster "msg"="Reconciling state for topology owned objects" ...
```
- A log entry for each object actually modified by the reconciler, e.g.
```
I0820 18:26:01.101400      35 reconcile_state.go:303] controller-runtime/manager/controller/cluster "msg"="Creating infrastructure.cluster.x-k8s.io/v1alpha4, Kind=DockerCluster/my-cluster1-rl4sf"...
I0820 18:26:01.143041      35 reconcile_state.go:139] controller-runtime/manager/controller/cluster "msg"="Patching Cluster cluster.x-k8s.io/v1alpha4, Kind=Cluster/my-cluster1" ...
```
 
At log level 3. we are adding "Extended information about changes":
- A log entry signalling the reconciler decided to not upgrade objects (but processed them), e.g.
```
I0820 18:28:48.961252      66 reconcile_state.go:321] controller-runtime/manager/controller/cluster "msg"="No changes for infrastructure.cluster.x-k8s.io/v1alpha4, Kind=DockerCluster/my-cluster1-rl4sf" ... 
```

At log level 4. we are adding "Debug level verbosity":
- A log entry signalling the reconciler entering on a sub-step of the reconcile logic, e.g.
```
I0820 18:28:48.961310      66 reconcile_state.go:81] controller-runtime/manager/controller/cluster "msg"="Reconciling the InfrastructureMachineTemplate for the ControlPlane object" ...
```
- A log reporting details about the mergePatch diff and the generated patch, e.g.
```
I0820 18:26:01.143103      35 mergepatch.go:205] controller-runtime/manager/controller/cluster "msg"="Patch" "Diff"="  ..." "Patch"="..." ...
```

**Anything else you would like to add:**

- All the logs now consistently report the object being documented in the log message, because having it as a key value pair wasn't clear due to how key value pairs are ordered
- While the guidelines uses level 5 for tracing this is not pratically possible for CAPI because at this level log for predicates kicks in, making the log flow really hard to read.
- The log mergePatch diff and the generated patch still has room for improvements in order to make the output more readable, but this can come on a follow up iteration