### PR TITLE
:bug: KubeadmControlPlane rolloutstrategy should be defaulted in openapi

### DIFF
--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_types.go
@@ -79,6 +79,7 @@ type KubeadmControlPlaneSpec struct {
 	// The RolloutStrategy to use to replace control plane machines with
 	// new ones.
 	// +optional
+	// +kubebuilder:default={type: "RollingUpdate", rollingUpdate: {maxSurge: 1}}
 	RolloutStrategy *RolloutStrategy `json:"rolloutStrategy,omitempty"`
 }
 

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -2226,6 +2226,10 @@ spec:
                 format: date-time
                 type: string
               rolloutStrategy:
+                default:
+                  rollingUpdate:
+                    maxSurge: 1
+                  type: RollingUpdate
                 description: The RolloutStrategy to use to replace control plane machines
                   with new ones.
                 properties:

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -1125,6 +1125,10 @@ spec:
                         format: date-time
                         type: string
                       rolloutStrategy:
+                        default:
+                          rollingUpdate:
+                            maxSurge: 1
+                          type: RollingUpdate
                         description: The RolloutStrategy to use to replace control
                           plane machines with new ones.
                         properties:


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Admission webhooks only run on create/update, our codebase requires these fields to be set when the upgrade code runs.

Consider the following scenario:
- Management cluster on an older version of Cluster API (< v0.3.15)
- Starts upgrade
- Upgrade management cluster to a newer version (>= v0.3.15)
- KCP fails because there is no rolloutStrategy set

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5136
