### PR TITLE
🌱 create internal/contract package for ClusterClass

### DIFF
--- a/controllers/topology/current_state.go
+++ b/controllers/topology/current_state.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/scope"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -94,7 +95,7 @@ func (r *ClusterReconciler) getCurrentControlPlaneState(ctx context.Context, clu
 	}
 
 	// Otherwise, get the control plane machine infrastructureMachine template.
-	machineInfrastructureRef, err := getNestedRef(res.Object, "spec", "machineTemplate", "infrastructureRef")
+	machineInfrastructureRef, err := contract.ControlPlane().InfrastructureMachineTemplate().Get(res.Object)
 	if err != nil {
 		return res, errors.Wrapf(err, "failed to get InfrastructureMachineTemplate reference for %s, %s", res.Object.GetKind(), res.Object.GetName())
 	}

--- a/controllers/topology/internal/contract/controlplane.go
+++ b/controllers/topology/internal/contract/controlplane.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ControlPlaneContract encodes information about the Cluster API contract for ControlPlane objects
+// like e.g the KubeadmControlPlane etc.
+type ControlPlaneContract struct{}
+
+var controlPlane *ControlPlaneContract
+var onceControlPlane sync.Once
+
+// ControlPlane provide access to the information about the Cluster API contract for ControlPlane objects.
+func ControlPlane() *ControlPlaneContract {
+	onceControlPlane.Do(func() {
+		controlPlane = &ControlPlaneContract{}
+	})
+	return controlPlane
+}
+
+// InfrastructureMachineTemplate provide access to InfrastructureMachineTemplate reference in a ControlPlane object, if any.
+// NOTE: When working with unstructured there is no way to understand if the ControlPlane provider
+// do support a field in the type definition from the fact that a field is not set in a given instance.
+// This is why in we are deriving if InfrastructureMachineTemplate is required from the ClusterClass in the topology reconciler code.
+func (c *ControlPlaneContract) InfrastructureMachineTemplate() *Ref {
+	return &Ref{
+		path: []string{"spec", "machineTemplate", "infrastructureRef"},
+	}
+}
+
+// Version provide access to version field  in a ControlPlane object, if any.
+// NOTE: When working with unstructured there is no way to understand if the ControlPlane provider
+// do support a field in the type definition from the fact that a field is not set in a given instance.
+// This is why in we are deriving if version is required from the ClusterClass in the topology reconciler code.
+func (c *ControlPlaneContract) Version() *ControlPlaneVersion {
+	return &ControlPlaneVersion{}
+}
+
+// Replicas provide access to replicas field  in a ControlPlane object, if any.
+// NOTE: When working with unstructured there is no way to understand if the ControlPlane provider
+// do support a field in the type definition from the fact that a field is not set in a given instance.
+// This is why in we are deriving if replicas is required from the ClusterClass in the topology reconciler code.
+func (c *ControlPlaneContract) Replicas() *ControlPlaneReplicas {
+	return &ControlPlaneReplicas{}
+}
+
+// ControlPlaneVersion provide a helper struct for working with version in ClusterClass.
+type ControlPlaneVersion struct{}
+
+// Path returns the path of the reference.
+func (v *ControlPlaneVersion) Path() Path {
+	return Path{"spec", "version"}
+}
+
+// Set sets the version value in the ControlPlane object.
+func (v *ControlPlaneVersion) Set(obj *unstructured.Unstructured, value string) error {
+	return unstructured.SetNestedField(obj.UnstructuredContent(), value, v.Path()...)
+}
+
+// ControlPlaneReplicas provide a helper struct for working with version in ClusterClass.
+type ControlPlaneReplicas struct{}
+
+// Path returns the path of the reference.
+func (r *ControlPlaneReplicas) Path() Path {
+	return Path{"spec", "replicas"}
+}
+
+// Set sets the replica value in the ControlPlane object.
+func (r *ControlPlaneReplicas) Set(obj *unstructured.Unstructured, value int64) error {
+	return unstructured.SetNestedField(obj.UnstructuredContent(), value, r.Path()...)
+}

--- a/controllers/topology/internal/contract/controlplane.go
+++ b/controllers/topology/internal/contract/controlplane.go
@@ -17,8 +17,10 @@ limitations under the License.
 package contract
 
 import (
+	"strings"
 	"sync"
 
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -71,6 +73,18 @@ func (v *ControlPlaneVersion) Path() Path {
 	return Path{"spec", "version"}
 }
 
+// Get gets the version value from the ControlPlane object.
+func (v *ControlPlaneVersion) Get(obj *unstructured.Unstructured) (*string, error) {
+	value, ok, err := unstructured.NestedString(obj.UnstructuredContent(), v.Path()...)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errors.Errorf("%s not found", "."+strings.Join(v.Path(), "."))
+	}
+	return &value, nil
+}
+
 // Set sets the version value in the ControlPlane object.
 func (v *ControlPlaneVersion) Set(obj *unstructured.Unstructured, value string) error {
 	return unstructured.SetNestedField(obj.UnstructuredContent(), value, v.Path()...)
@@ -82,6 +96,18 @@ type ControlPlaneReplicas struct{}
 // Path returns the path of the reference.
 func (r *ControlPlaneReplicas) Path() Path {
 	return Path{"spec", "replicas"}
+}
+
+// Get gets the replicas value from the ControlPlane object.
+func (r *ControlPlaneReplicas) Get(obj *unstructured.Unstructured) (*int64, error) {
+	value, ok, err := unstructured.NestedInt64(obj.UnstructuredContent(), r.Path()...)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, errors.Errorf("%s not found", "."+strings.Join(r.Path(), "."))
+	}
+	return &value, nil
 }
 
 // Set sets the replica value in the ControlPlane object.

--- a/controllers/topology/internal/contract/controlplane_template.go
+++ b/controllers/topology/internal/contract/controlplane_template.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import "sync"
+
+// ControlPlaneTemplateContract encodes information about the Cluster API contract for ControlPlaneTemplate objects
+// like e.g. the KubeadmControlPlane etc.
+type ControlPlaneTemplateContract struct{}
+
+var controlPlaneTemplate *ControlPlaneTemplateContract
+var onceControlPlaneTemplate sync.Once
+
+// ControlPlaneTemplate provide access to the information about the Cluster API contract for ControlPlaneTemplate objects.
+func ControlPlaneTemplate() *ControlPlaneTemplateContract {
+	onceControlPlaneTemplate.Do(func() {
+		controlPlaneTemplate = &ControlPlaneTemplateContract{}
+	})
+	return controlPlaneTemplate
+}
+
+// InfrastructureMachineTemplate provide access to InfrastructureMachineTemplate reference, if any.
+// NOTE: When working with unstructured there is no way to understand if the ControlPlane provider
+// do support a field in the type definition from the fact that a field is not set in a given instance.
+// This is why in we are deriving if this field is required from the ClusterClass in the topology reconciler code.
+func (c *ControlPlaneTemplateContract) InfrastructureMachineTemplate() *Ref {
+	return &Ref{
+		path: []string{"spec", "template", "spec", "machineTemplate", "infrastructureRef"},
+	}
+}

--- a/controllers/topology/internal/contract/controlplane_template_test.go
+++ b/controllers/topology/internal/contract/controlplane_template_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestControlPlaneTemplate(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+
+	t.Run("Manages spec.template.spec.machineTemplate.infrastructureRef", func(t *testing.T) {
+		g := NewWithT(t)
+
+		refObj := fooRefBuilder()
+
+		g.Expect(ControlPlaneTemplate().InfrastructureMachineTemplate().Path()).To(Equal(Path{"spec", "template", "spec", "machineTemplate", "infrastructureRef"}))
+
+		err := ControlPlaneTemplate().InfrastructureMachineTemplate().Set(obj, refObj)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlaneTemplate().InfrastructureMachineTemplate().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.APIVersion).To(Equal(refObj.GetAPIVersion()))
+		g.Expect(got.Kind).To(Equal(refObj.GetKind()))
+		g.Expect(got.Name).To(Equal(refObj.GetName()))
+		g.Expect(got.Namespace).To(Equal(refObj.GetNamespace()))
+	})
+}

--- a/controllers/topology/internal/contract/controlplane_test.go
+++ b/controllers/topology/internal/contract/controlplane_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestControlPlane(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+
+	t.Run("Manages spec.version", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(ControlPlane().Version().Path()).To(Equal(Path{"spec", "version"}))
+
+		err := ControlPlane().Version().Set(obj, "vFoo")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlane().Version().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(*got).To(Equal("vFoo"))
+	})
+	t.Run("Manages spec.replicas", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(ControlPlane().Replicas().Path()).To(Equal(Path{"spec", "replicas"}))
+
+		err := ControlPlane().Replicas().Set(obj, int64(3))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlane().Replicas().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(*got).To(Equal(int64(3)))
+	})
+	t.Run("Manages spec.machineTemplate.infrastructureRef", func(t *testing.T) {
+		g := NewWithT(t)
+
+		refObj := fooRefBuilder()
+
+		g.Expect(ControlPlane().InfrastructureMachineTemplate().Path()).To(Equal(Path{"spec", "machineTemplate", "infrastructureRef"}))
+
+		err := ControlPlane().InfrastructureMachineTemplate().Set(obj, refObj)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlane().InfrastructureMachineTemplate().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got.APIVersion).To(Equal(refObj.GetAPIVersion()))
+		g.Expect(got.Kind).To(Equal(refObj.GetKind()))
+		g.Expect(got.Name).To(Equal(refObj.GetName()))
+		g.Expect(got.Namespace).To(Equal(refObj.GetNamespace()))
+	})
+}

--- a/controllers/topology/internal/contract/doc.go
+++ b/controllers/topology/internal/contract/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package contract provides support for the ClusterReconciler to handle with providers objects
+// according to the Cluster API contract.
+package contract

--- a/controllers/topology/internal/contract/infrastructure_cluster.go
+++ b/controllers/topology/internal/contract/infrastructure_cluster.go
@@ -36,6 +36,8 @@ func InfrastructureCluster() *InfrastructureClusterContract {
 // IgnorePaths returns a list of paths to be ignored when reconciling a topology.
 func (c *InfrastructureClusterContract) IgnorePaths() []Path {
 	return []Path{
+		// NOTE: the controlPlaneEndpoint struct currently contains two mandatory fields (host and port); without this
+		// ignore path they are going to be always reconciled to the default value or to the value set into the template.
 		{"spec", "controlPlaneEndpoint"},
 	}
 }

--- a/controllers/topology/internal/contract/infrastructure_cluster.go
+++ b/controllers/topology/internal/contract/infrastructure_cluster.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import "sync"
+
+// InfrastructureClusterContract encodes information about the Cluster API contract for InfrastructureCluster objects
+// like e.g the DockerCluster, AWS Cluster etc.
+type InfrastructureClusterContract struct{}
+
+var infrastructureCluster *InfrastructureClusterContract
+var onceInfrastructureCluster sync.Once
+
+// InfrastructureCluster provide access to the information about the Cluster API contract for InfrastructureCluster objects.
+func InfrastructureCluster() *InfrastructureClusterContract {
+	onceInfrastructureCluster.Do(func() {
+		infrastructureCluster = &InfrastructureClusterContract{}
+	})
+	return infrastructureCluster
+}
+
+// IgnorePaths returns a list of paths to be ignored when reconciling a topology.
+func (c *InfrastructureClusterContract) IgnorePaths() []Path {
+	return []Path{
+		{"spec", "controlPlaneEndpoint"},
+	}
+}

--- a/controllers/topology/internal/contract/infrastructure_cluster_test.go
+++ b/controllers/topology/internal/contract/infrastructure_cluster_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestInfrastructureCluster(t *testing.T) {
+	t.Run("Has ignore paths", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(InfrastructureCluster().IgnorePaths()).To(Equal([]Path{
+			{"spec", "controlPlaneEndpoint"},
+		}))
+	})
+}

--- a/controllers/topology/internal/contract/references.go
+++ b/controllers/topology/internal/contract/references.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Ref provide a helper struct for working with references in Unstructured objects.
+type Ref struct {
+	path Path
+}
+
+// Path returns the path of the reference.
+func (r *Ref) Path() Path {
+	return r.path
+}
+
+// Get gets the reference value from the Unstructured object.
+func (r *Ref) Get(obj *unstructured.Unstructured) (*corev1.ObjectReference, error) {
+	return GetNestedRef(obj, r.path...)
+}
+
+// Set sets the reference value in the Unstructured object.
+func (r *Ref) Set(obj, refObj *unstructured.Unstructured) error {
+	return SetNestedRef(obj, refObj, r.path...)
+}
+
+// GetNestedRef returns the ref value from a nested field in an Unstructured object.
+func GetNestedRef(obj *unstructured.Unstructured, fields ...string) (*corev1.ObjectReference, error) {
+	ref := &corev1.ObjectReference{}
+	if v, ok, err := unstructured.NestedString(obj.UnstructuredContent(), append(fields, "apiVersion")...); ok && err == nil {
+		ref.APIVersion = v
+	} else {
+		return nil, errors.Errorf("failed to get %s.apiVersion from %s", strings.Join(fields, "."), obj.GetKind())
+	}
+	if v, ok, err := unstructured.NestedString(obj.UnstructuredContent(), append(fields, "kind")...); ok && err == nil {
+		ref.Kind = v
+	} else {
+		return nil, errors.Errorf("failed to get %s.kind from %s", strings.Join(fields, "."), obj.GetKind())
+	}
+	if v, ok, err := unstructured.NestedString(obj.UnstructuredContent(), append(fields, "name")...); ok && err == nil {
+		ref.Name = v
+	} else {
+		return nil, errors.Errorf("failed to get %s.name from %s", strings.Join(fields, "."), obj.GetKind())
+	}
+	if v, ok, err := unstructured.NestedString(obj.UnstructuredContent(), append(fields, "namespace")...); ok && err == nil {
+		ref.Namespace = v
+	} else {
+		return nil, errors.Errorf("failed to get %s.namespace from %s", strings.Join(fields, "."), obj.GetKind())
+	}
+	return ref, nil
+}
+
+// SetNestedRef sets the value of a nested field in an Unstructured to a reference to the refObj provided.
+func SetNestedRef(obj, refObj *unstructured.Unstructured, fields ...string) error {
+	ref := map[string]interface{}{
+		"kind":       refObj.GetKind(),
+		"namespace":  refObj.GetNamespace(),
+		"name":       refObj.GetName(),
+		"apiVersion": refObj.GetAPIVersion(),
+	}
+	return unstructured.SetNestedField(obj.UnstructuredContent(), ref, fields...)
+}
+
+// ObjToRef returns a reference to the given object.
+func ObjToRef(obj client.Object) *corev1.ObjectReference {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	return &corev1.ObjectReference{
+		Kind:       gvk.Kind,
+		APIVersion: gvk.GroupVersion().String(),
+		Namespace:  obj.GetNamespace(),
+		Name:       obj.GetName(),
+	}
+}

--- a/controllers/topology/internal/contract/references_test.go
+++ b/controllers/topology/internal/contract/references_test.go
@@ -23,16 +23,20 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+var fooRefBuilder = func() *unstructured.Unstructured {
+	refObj := &unstructured.Unstructured{}
+	refObj.SetAPIVersion("fooApiVersion")
+	refObj.SetKind("fooKind")
+	refObj.SetNamespace("fooNamespace")
+	refObj.SetName("fooName")
+	return refObj
+}
+
 func TestGetNestedRef(t *testing.T) {
 	t.Run("Gets a nested ref if defined", func(t *testing.T) {
 		g := NewWithT(t)
 
-		refObj := &unstructured.Unstructured{}
-		refObj.SetAPIVersion("foo.foo")
-		refObj.SetKind("Bar")
-		refObj.SetNamespace("Baz")
-		refObj.SetName("Bar")
-
+		refObj := fooRefBuilder()
 		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
 
 		err := SetNestedRef(obj, refObj, "spec", "machineTemplate", "infrastructureRef")
@@ -77,12 +81,8 @@ func TestGetNestedRef(t *testing.T) {
 func TestSetNestedRef(t *testing.T) {
 	t.Run("Sets a nested ref", func(t *testing.T) {
 		g := NewWithT(t)
-		refObj := &unstructured.Unstructured{}
-		refObj.SetAPIVersion("foo.foo")
-		refObj.SetKind("Bar")
-		refObj.SetNamespace("Baz")
-		refObj.SetName("Bar")
 
+		refObj := fooRefBuilder()
 		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
 
 		err := SetNestedRef(obj, refObj, "spec", "machineTemplate", "infrastructureRef")
@@ -101,12 +101,8 @@ func TestSetNestedRef(t *testing.T) {
 func TestObjToRef(t *testing.T) {
 	t.Run("Gets a ref from an obj", func(t *testing.T) {
 		g := NewWithT(t)
-		refObj := &unstructured.Unstructured{}
-		refObj.SetAPIVersion("foo.foo")
-		refObj.SetKind("Bar")
-		refObj.SetNamespace("Baz")
-		refObj.SetName("Bar")
 
+		refObj := fooRefBuilder()
 		ref := ObjToRef(refObj)
 
 		g.Expect(ref).ToNot(BeNil())

--- a/controllers/topology/internal/contract/references_test.go
+++ b/controllers/topology/internal/contract/references_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGetNestedRef(t *testing.T) {
+	t.Run("Gets a nested ref if defined", func(t *testing.T) {
+		g := NewWithT(t)
+
+		refObj := &unstructured.Unstructured{}
+		refObj.SetAPIVersion("foo.foo")
+		refObj.SetKind("Bar")
+		refObj.SetNamespace("Baz")
+		refObj.SetName("Bar")
+
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+
+		err := SetNestedRef(obj, refObj, "spec", "machineTemplate", "infrastructureRef")
+		g.Expect(err).To(BeNil())
+
+		ref, err := GetNestedRef(obj, "spec", "machineTemplate", "infrastructureRef")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ref).ToNot(BeNil())
+		g.Expect(ref.APIVersion).To(Equal(refObj.GetAPIVersion()))
+		g.Expect(ref.Kind).To(Equal(refObj.GetKind()))
+		g.Expect(ref.Name).To(Equal(refObj.GetName()))
+		g.Expect(ref.Namespace).To(Equal(refObj.GetNamespace()))
+	})
+	t.Run("getNestedRef fails if the nested ref does not exist", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+
+		ref, err := GetNestedRef(obj, "spec", "machineTemplate", "infrastructureRef")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(ref).To(BeNil())
+	})
+	t.Run("getNestedRef fails if the nested ref exist but it is incomplete", func(t *testing.T) {
+		g := NewWithT(t)
+
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+
+		err := unstructured.SetNestedField(obj.UnstructuredContent(), "foo", "spec", "machineTemplate", "infrastructureRef", "kind")
+		g.Expect(err).ToNot(HaveOccurred())
+		err = unstructured.SetNestedField(obj.UnstructuredContent(), "bar", "spec", "machineTemplate", "infrastructureRef", "namespace")
+		g.Expect(err).ToNot(HaveOccurred())
+		err = unstructured.SetNestedField(obj.UnstructuredContent(), "baz", "spec", "machineTemplate", "infrastructureRef", "apiVersion")
+		g.Expect(err).ToNot(HaveOccurred())
+		// Reference name missing
+
+		ref, err := GetNestedRef(obj, "spec", "machineTemplate", "infrastructureRef")
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(ref).To(BeNil())
+	})
+}
+
+func TestSetNestedRef(t *testing.T) {
+	t.Run("Sets a nested ref", func(t *testing.T) {
+		g := NewWithT(t)
+		refObj := &unstructured.Unstructured{}
+		refObj.SetAPIVersion("foo.foo")
+		refObj.SetKind("Bar")
+		refObj.SetNamespace("Baz")
+		refObj.SetName("Bar")
+
+		obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+
+		err := SetNestedRef(obj, refObj, "spec", "machineTemplate", "infrastructureRef")
+		g.Expect(err).To(BeNil())
+
+		ref, err := GetNestedRef(obj, "spec", "machineTemplate", "infrastructureRef")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(ref).ToNot(BeNil())
+		g.Expect(ref.APIVersion).To(Equal(refObj.GetAPIVersion()))
+		g.Expect(ref.Kind).To(Equal(refObj.GetKind()))
+		g.Expect(ref.Name).To(Equal(refObj.GetName()))
+		g.Expect(ref.Namespace).To(Equal(refObj.GetNamespace()))
+	})
+}
+
+func TestObjToRef(t *testing.T) {
+	t.Run("Gets a ref from an obj", func(t *testing.T) {
+		g := NewWithT(t)
+		refObj := &unstructured.Unstructured{}
+		refObj.SetAPIVersion("foo.foo")
+		refObj.SetKind("Bar")
+		refObj.SetNamespace("Baz")
+		refObj.SetName("Bar")
+
+		ref := ObjToRef(refObj)
+
+		g.Expect(ref).ToNot(BeNil())
+		g.Expect(ref.APIVersion).To(Equal(refObj.GetAPIVersion()))
+		g.Expect(ref.Kind).To(Equal(refObj.GetKind()))
+		g.Expect(ref.Name).To(Equal(refObj.GetName()))
+		g.Expect(ref.Namespace).To(Equal(refObj.GetNamespace()))
+	})
+}

--- a/controllers/topology/internal/contract/types.go
+++ b/controllers/topology/internal/contract/types.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+// Path defines a how to access a field in an Unstructured object.
+type Path []string

--- a/controllers/topology/internal/mergepatch/mergepatch.go
+++ b/controllers/topology/internal/mergepatch/mergepatch.go
@@ -24,10 +24,11 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var allowedPaths = [][]string{
+var allowedPaths = []contract.Path{
 	{"metadata", "labels"},
 	{"metadata", "annotations"},
 	{"spec"},
@@ -92,7 +93,7 @@ func NewHelper(original, modified client.Object, c client.Client, opts ...Helper
 }
 
 // filterPatch removes from the patch diffs not in the allowed paths.
-func filterPatch(patch []byte, allowedPaths, ignorePaths [][]string) ([]byte, error) {
+func filterPatch(patch []byte, allowedPaths, ignorePaths []contract.Path) ([]byte, error) {
 	// converts the patch into a Map
 	patchMap := make(map[string]interface{})
 	err := json.Unmarshal(patch, &patchMap)
@@ -117,7 +118,7 @@ func filterPatch(patch []byte, allowedPaths, ignorePaths [][]string) ([]byte, er
 }
 
 // filterPatch removes from the patchMap diffs not in the allowed paths.
-func filterPatchMap(patchMap map[string]interface{}, allowedPaths [][]string) {
+func filterPatchMap(patchMap map[string]interface{}, allowedPaths []contract.Path) {
 	// Loop through the entries in the map.
 	for k, m := range patchMap {
 		// Check if item is in the allowed paths.
@@ -141,7 +142,7 @@ func filterPatchMap(patchMap map[string]interface{}, allowedPaths [][]string) {
 		if !ok {
 			continue
 		}
-		nestedPaths := make([][]string, 0)
+		nestedPaths := make([]contract.Path, 0)
 		for _, path := range allowedPaths {
 			if k == path[0] && len(path) > 1 {
 				nestedPaths = append(nestedPaths, path[1:])
@@ -160,7 +161,7 @@ func filterPatchMap(patchMap map[string]interface{}, allowedPaths [][]string) {
 }
 
 // removePath removes from the patchMap diffs a given path.
-func removePath(patchMap map[string]interface{}, path []string) {
+func removePath(patchMap map[string]interface{}, path contract.Path) {
 	switch len(path) {
 	case 0:
 		// if path is empty, no-op.

--- a/controllers/topology/internal/mergepatch/mergepatch_test.go
+++ b/controllers/topology/internal/mergepatch/mergepatch_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
 )
 
 func TestNewHelper(t *testing.T) {
@@ -317,7 +318,7 @@ func TestNewHelper(t *testing.T) {
 					},
 				},
 			},
-			options:        []HelperOption{IgnorePath{"spec", "controlPlaneEndpoint"}},
+			options:        []HelperOption{IgnorePaths{contract.Path{"spec", "controlPlaneEndpoint"}}},
 			wantHasChanges: false,
 			wantPatch:      []byte("{}"),
 		},

--- a/controllers/topology/internal/mergepatch/options.go
+++ b/controllers/topology/internal/mergepatch/options.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package mergepatch
 
+import "sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
+
 // HelperOption is some configuration that modifies options for Helper.
 type HelperOption interface {
 	// ApplyToHelper applies this configuration to the given helper options.
@@ -24,7 +26,7 @@ type HelperOption interface {
 
 // HelperOptions contains options for Helper.
 type HelperOptions struct {
-	ignorePaths [][]string
+	ignorePaths []contract.Path
 }
 
 // ApplyOptions applies the given patch options on these options,
@@ -36,10 +38,10 @@ func (o *HelperOptions) ApplyOptions(opts []HelperOption) *HelperOptions {
 	return o
 }
 
-// IgnorePath instruct the Helper to ignore a given path when computing a patch.
-type IgnorePath []string
+// IgnorePaths instruct the Helper to ignore given paths when computing a patch.
+type IgnorePaths []contract.Path
 
 // ApplyToHelper applies this configuration to the given helper options.
-func (i IgnorePath) ApplyToHelper(opts *HelperOptions) {
-	opts.ignorePaths = append(opts.ignorePaths, i)
+func (i IgnorePaths) ApplyToHelper(opts *HelperOptions) {
+	opts.ignorePaths = i
 }

--- a/controllers/topology/object_builders_test.go
+++ b/controllers/topology/object_builders_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
 	"sigs.k8s.io/cluster-api/internal/testtypes"
 )
 
@@ -189,10 +190,10 @@ func (f *fakeCluster) Obj() *clusterv1.Cluster {
 		},
 	}
 	if f.infrastructureCluster != nil {
-		obj.Spec.InfrastructureRef = objToRef(f.infrastructureCluster)
+		obj.Spec.InfrastructureRef = contract.ObjToRef(f.infrastructureCluster)
 	}
 	if f.controlPlane != nil {
-		obj.Spec.ControlPlaneRef = objToRef(f.controlPlane)
+		obj.Spec.ControlPlaneRef = contract.ObjToRef(f.controlPlane)
 	}
 	return obj
 }
@@ -275,7 +276,7 @@ func (f *fakeClusterClass) Obj() *clusterv1.ClusterClass {
 	}
 	if f.infrastructureClusterTemplate != nil {
 		obj.Spec.Infrastructure = clusterv1.LocalObjectTemplate{
-			Ref: objToRef(f.infrastructureClusterTemplate),
+			Ref: contract.ObjToRef(f.infrastructureClusterTemplate),
 		}
 	}
 	if f.controlPlaneMetadata != nil {
@@ -283,12 +284,12 @@ func (f *fakeClusterClass) Obj() *clusterv1.ClusterClass {
 	}
 	if f.controlPlaneTemplate != nil {
 		obj.Spec.ControlPlane.LocalObjectTemplate = clusterv1.LocalObjectTemplate{
-			Ref: objToRef(f.controlPlaneTemplate),
+			Ref: contract.ObjToRef(f.controlPlaneTemplate),
 		}
 	}
 	if f.controlPlaneInfrastructureMachineTemplate != nil {
 		obj.Spec.ControlPlane.MachineInfrastructure = &clusterv1.LocalObjectTemplate{
-			Ref: objToRef(f.controlPlaneInfrastructureMachineTemplate),
+			Ref: contract.ObjToRef(f.controlPlaneInfrastructureMachineTemplate),
 		}
 	}
 	if len(f.workerMachineDeploymentTemplates) > 0 {
@@ -301,10 +302,10 @@ func (f *fakeClusterClass) Obj() *clusterv1.ClusterClass {
 						Annotations: mdt.Annotations,
 					},
 					Bootstrap: clusterv1.LocalObjectTemplate{
-						Ref: objToRef(mdt.bootstrapTemplate),
+						Ref: contract.ObjToRef(mdt.bootstrapTemplate),
 					},
 					Infrastructure: clusterv1.LocalObjectTemplate{
-						Ref: objToRef(mdt.infrastructureMachineTemplate),
+						Ref: contract.ObjToRef(mdt.infrastructureMachineTemplate),
 					},
 				},
 			})
@@ -423,7 +424,7 @@ func (f *fakeControlPlaneTemplate) Obj() *unstructured.Unstructured {
 	}
 
 	if f.infrastructureMachineTemplate != nil {
-		if err := setNestedRef(obj, f.infrastructureMachineTemplate, "spec", "template", "spec", "machineTemplate", "infrastructureRef"); err != nil {
+		if err := contract.ControlPlaneTemplate().InfrastructureMachineTemplate().Set(obj, f.infrastructureMachineTemplate); err != nil {
 			panic(err)
 		}
 	}
@@ -492,7 +493,7 @@ func (f *fakeControlPlane) Obj() *unstructured.Unstructured {
 	}
 
 	if f.infrastructureMachineTemplate != nil {
-		if err := setNestedRef(obj, f.infrastructureMachineTemplate, "spec", "machineTemplate", "infrastructureRef"); err != nil {
+		if err := contract.ControlPlane().InfrastructureMachineTemplate().Set(obj, f.infrastructureMachineTemplate); err != nil {
 			panic(err)
 		}
 	}
@@ -542,10 +543,10 @@ func (f *fakeMachineDeployment) Obj() *clusterv1.MachineDeployment {
 		},
 	}
 	if f.bootstrapTemplate != nil {
-		obj.Spec.Template.Spec.Bootstrap.ConfigRef = objToRef(f.bootstrapTemplate)
+		obj.Spec.Template.Spec.Bootstrap.ConfigRef = contract.ObjToRef(f.bootstrapTemplate)
 	}
 	if f.infrastructureTemplate != nil {
-		obj.Spec.Template.Spec.InfrastructureRef = *objToRef(f.infrastructureTemplate)
+		obj.Spec.Template.Spec.InfrastructureRef = *contract.ObjToRef(f.infrastructureTemplate)
 	}
 	return obj
 }

--- a/controllers/topology/reconcile_state_test.go
+++ b/controllers/topology/reconcile_state_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/scope"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -478,7 +479,7 @@ func TestReconcileControlPlaneInfrastructureMachineTemplate(t *testing.T) {
 			// This check is just for the naming format uses by generated templates - here it's templateName-*
 			// This check is only performed when we had an initial template that has been changed
 			if tt.current.InfrastructureMachineTemplate != nil {
-				item, err := getNestedRef(gotControlPlaneObject, "spec", "machineTemplate", "infrastructureRef")
+				item, err := contract.ControlPlane().InfrastructureMachineTemplate().Get(gotControlPlaneObject)
 				g.Expect(err).ToNot(HaveOccurred())
 				// This pattern should match return value in controlPlaneinfrastructureMachineTemplateNamePrefix
 				pattern := fmt.Sprintf("%s-controlplane-.*", tt.desired.Object.GetClusterName())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR creates and internal/contract package for ClusterClass thus centralising in a single point all the knowledge about how to deal with Unstructured objects according to the Cluster API contract.

**Anything else you would like to add:**
This package is potentially usable in the entire Cluster API codebase, but for this first iteration we are intentionally keeping it scoped to ClusterClass.