### PR TITLE
🌱 bump clusterctl upgrade test to CAPI v0.3.23

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -29,8 +29,8 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v0.3.22 # latest published release
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.22/core-components.yaml"
+  - name: v0.3.23 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/core-components.yaml"
     type: "url"
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
@@ -46,8 +46,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v0.3.22 # latest published release
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.22/bootstrap-components.yaml"
+  - name: v0.3.23 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/bootstrap-components.yaml"
     type: "url"
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
@@ -63,8 +63,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v0.3.22 # latest published release
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.22/control-plane-components.yaml"
+  - name: v0.3.23 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/control-plane-components.yaml"
     type: "url"
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
@@ -80,8 +80,8 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
-  - name: v0.3.22 # latest published release
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.22/infrastructure-components-development.yaml"
+  - name: v0.3.23 # latest published release
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/infrastructure-components-development.yaml"
     type: "url"
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
@@ -129,7 +129,7 @@ variables:
   NODE_DRAIN_TIMEOUT: "60s"
   # NOTE: INIT_WITH_BINARY and INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
-  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.22/clusterctl-{OS}-{ARCH}"
+  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/clusterctl-{OS}-{ARCH}"
   # CAPI v0.3.x cannot be deployed on Kubernetes >= v1.22.
   INIT_WITH_KUBERNETES_VERSION: "v1.21.2"
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Let's use the latest CAPI v0.3 release (released yesterday)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
