### PR TITLE
🌱 Move Predicates allow logs to V6

### DIFF
--- a/util/predicates/cluster_predicates.go
+++ b/util/predicates/cluster_predicates.go
@@ -40,7 +40,7 @@ func ClusterCreateInfraReady(logger logr.Logger) predicate.Funcs {
 
 			// Only need to trigger a reconcile if the Cluster.Status.InfrastructureReady is true
 			if c.Status.InfrastructureReady {
-				log.V(4).Info("Cluster infrastructure is ready, allowing further processing")
+				log.V(6).Info("Cluster infrastructure is ready, allowing further processing")
 				return true
 			}
 
@@ -69,7 +69,7 @@ func ClusterCreateNotPaused(logger logr.Logger) predicate.Funcs {
 
 			// Only need to trigger a reconcile if the Cluster.Spec.Paused is false
 			if !c.Spec.Paused {
-				log.V(4).Info("Cluster is not paused, allowing further processing")
+				log.V(6).Info("Cluster is not paused, allowing further processing")
 				return true
 			}
 
@@ -99,7 +99,7 @@ func ClusterUpdateInfraReady(logger logr.Logger) predicate.Funcs {
 			newCluster := e.ObjectNew.(*clusterv1.Cluster)
 
 			if !oldCluster.Status.InfrastructureReady && newCluster.Status.InfrastructureReady {
-				log.V(4).Info("Cluster infrastructure became ready, allowing further processing")
+				log.V(6).Info("Cluster infrastructure became ready, allowing further processing")
 				return true
 			}
 
@@ -129,7 +129,7 @@ func ClusterUpdateUnpaused(logger logr.Logger) predicate.Funcs {
 			newCluster := e.ObjectNew.(*clusterv1.Cluster)
 
 			if oldCluster.Spec.Paused && !newCluster.Spec.Paused {
-				log.V(4).Info("Cluster was unpaused, allowing further processing")
+				log.V(6).Info("Cluster was unpaused, allowing further processing")
 				return true
 			}
 

--- a/util/predicates/generic_predicates.go
+++ b/util/predicates/generic_predicates.go
@@ -35,44 +35,44 @@ func All(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 			log := logger.WithValues("predicateAggregation", "All")
 			for _, p := range predicates {
 				if !p.UpdateFunc(e) {
-					log.V(4).Info("One of the provided predicates returned false, blocking further processing")
+					log.V(6).Info("One of the provided predicates returned false, blocking further processing")
 					return false
 				}
 			}
-			log.V(4).Info("All provided predicates returned true, allowing further processing")
+			log.V(6).Info("All provided predicates returned true, allowing further processing")
 			return true
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			log := logger.WithValues("predicateAggregation", "All")
 			for _, p := range predicates {
 				if !p.CreateFunc(e) {
-					log.V(4).Info("One of the provided predicates returned false, blocking further processing")
+					log.V(6).Info("One of the provided predicates returned false, blocking further processing")
 					return false
 				}
 			}
-			log.V(4).Info("All provided predicates returned true, allowing further processing")
+			log.V(6).Info("All provided predicates returned true, allowing further processing")
 			return true
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			log := logger.WithValues("predicateAggregation", "All")
 			for _, p := range predicates {
 				if !p.DeleteFunc(e) {
-					log.V(4).Info("One of the provided predicates returned false, blocking further processing")
+					log.V(6).Info("One of the provided predicates returned false, blocking further processing")
 					return false
 				}
 			}
-			log.V(4).Info("All provided predicates returned true, allowing further processing")
+			log.V(6).Info("All provided predicates returned true, allowing further processing")
 			return true
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			log := logger.WithValues("predicateAggregation", "All")
 			for _, p := range predicates {
 				if !p.GenericFunc(e) {
-					log.V(4).Info("One of the provided predicates returned false, blocking further processing")
+					log.V(6).Info("One of the provided predicates returned false, blocking further processing")
 					return false
 				}
 			}
-			log.V(4).Info("All provided predicates returned true, allowing further processing")
+			log.V(6).Info("All provided predicates returned true, allowing further processing")
 			return true
 		},
 	}
@@ -85,44 +85,44 @@ func Any(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 			log := logger.WithValues("predicateAggregation", "Any")
 			for _, p := range predicates {
 				if p.UpdateFunc(e) {
-					log.V(4).Info("One of the provided predicates returned true, allowing further processing")
+					log.V(6).Info("One of the provided predicates returned true, allowing further processing")
 					return true
 				}
 			}
-			log.V(4).Info("All of the provided predicates returned false, blocking further processing")
+			log.V(6).Info("All of the provided predicates returned false, blocking further processing")
 			return false
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
 			log := logger.WithValues("predicateAggregation", "Any")
 			for _, p := range predicates {
 				if p.CreateFunc(e) {
-					log.V(4).Info("One of the provided predicates returned true, allowing further processing")
+					log.V(6).Info("One of the provided predicates returned true, allowing further processing")
 					return true
 				}
 			}
-			log.V(4).Info("All of the provided predicates returned false, blocking further processing")
+			log.V(6).Info("All of the provided predicates returned false, blocking further processing")
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			log := logger.WithValues("predicateAggregation", "Any")
 			for _, p := range predicates {
 				if p.DeleteFunc(e) {
-					log.V(4).Info("One of the provided predicates returned true, allowing further processing")
+					log.V(6).Info("One of the provided predicates returned true, allowing further processing")
 					return true
 				}
 			}
-			log.V(4).Info("All of the provided predicates returned false, blocking further processing")
+			log.V(6).Info("All of the provided predicates returned false, blocking further processing")
 			return false
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			log := logger.WithValues("predicateAggregation", "Any")
 			for _, p := range predicates {
 				if p.GenericFunc(e) {
-					log.V(4).Info("One of the provided predicates returned true, allowing further processing")
+					log.V(6).Info("One of the provided predicates returned true, allowing further processing")
 					return true
 				}
 			}
-			log.V(4).Info("All of the provided predicates returned false, blocking further processing")
+			log.V(6).Info("All of the provided predicates returned false, blocking further processing")
 			return false
 		},
 	}
@@ -190,7 +190,7 @@ func processIfNotPaused(logger logr.Logger, obj client.Object) bool {
 		log.V(4).Info("Resource is paused, will not attempt to map resource")
 		return false
 	}
-	log.V(4).Info("Resource is not paused, will attempt to map resource")
+	log.V(6).Info("Resource is not paused, will attempt to map resource")
 	return true
 }
 
@@ -203,7 +203,7 @@ func processIfLabelMatch(logger logr.Logger, obj client.Object, labelValue strin
 	kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
 	log := logger.WithValues("namespace", obj.GetNamespace(), kind, obj.GetName())
 	if labels.HasWatchLabel(obj, labelValue) {
-		log.V(4).Info("Resource matches label, will attempt to map resource")
+		log.V(6).Info("Resource matches label, will attempt to map resource")
 		return true
 	}
 	log.V(4).Info("Resource does not match label, will not attempt to map resource")
@@ -238,6 +238,6 @@ func processIfNotExternallyManaged(logger logr.Logger, obj client.Object) bool {
 		log.V(4).Info("Resource is externally managed, will not attempt to map resource")
 		return false
 	}
-	log.V(4).Info("Resource is managed, will attempt to map resource")
+	log.V(6).Info("Resource is managed, will attempt to map resource")
 	return true
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently in Cluster API, when log is >=4, predicates start reporting several logs entries reporting:
1. When an object reconciliation is blocked by predicates
2. When an object reconciliation is allowed by predicates
3. How predicates combines via Any or All

This is really chatty given that we are using predicates in many places, and it makes reading Cluster API log hard/difficult to use log levels  >=4.

This PR implement a solution for this problem by moving logs of category 2 and 3 to v6, while instead "object reconciliation being blocked by predicates" will continue to be logger at v4.
