### PR TITLE
🌱  controllers/topology: cleanup error handling and templateNamer

### DIFF
--- a/controllers/topology/desired_state.go
+++ b/controllers/topology/desired_state.go
@@ -29,6 +29,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
+	tlog "sigs.k8s.io/cluster-api/controllers/topology/internal/log"
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/scope"
 )
 
@@ -224,7 +225,7 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, machineDeployme
 	className := machineDeploymentTopology.Class
 	machineDeploymentBlueprint, ok := s.Blueprint.MachineDeployments[className]
 	if !ok {
-		return nil, errors.Errorf("MachineDeployment blueprint %s not found in ClusterClass %s", className, s.Blueprint.ClusterClass.Name)
+		return nil, errors.Errorf("MachineDeployment class %s not found in %s", className, tlog.KObj{Obj: s.Blueprint.ClusterClass})
 	}
 
 	// Compute the boostrap template.

--- a/controllers/topology/internal/log/doc.go
+++ b/controllers/topology/internal/log/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package log provides log utilities for the topology package.
+package log

--- a/controllers/topology/internal/log/log.go
+++ b/controllers/topology/internal/log/log.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// LoggerFrom returns a logger with predefined values from a context.Context.
+// The logger, when used with controllers, can be expected to contain basic information about the object
+// that's being reconciled like:
+// - `reconciler group` and `reconciler kind` coming from the For(...) object passed in when building a controller.
+// - `name` and `namespace` injected from the reconciliation request.
+//
+// This is meant to be used with the context supplied in a struct that satisfies the Reconciler interface.
+func LoggerFrom(ctx context.Context) Logger {
+	log := ctrl.LoggerFrom(ctx)
+	return &topologyReconcileLogger{
+		Logger: log,
+	}
+}
+
+// Logger provides a wrapper to log.Logger to be used for topology reconciler.
+type Logger interface {
+	// WithObject adds to the logger information about the object being modified by reconcile, which in most case it is
+	// a resources being part of the Cluster by reconciled.
+	WithObject(obj client.Object) Logger
+
+	// WithMachineDeployment adds to the logger information about the MachineDeployment object being processed.
+	WithMachineDeployment(md *clusterv1.MachineDeployment) Logger
+
+	// V returns a logger value for a specific verbosity level, relative to
+	// this logger.
+	V(level int) Logger
+
+	// Infof logs to the INFO log.
+	// Arguments are handled in the manner of fmt.Printf.
+	Infof(msg string, a ...interface{})
+
+	// Into takes a context and sets the logger as one of its keys.
+	//
+	// This is meant to be used in reconcilers to enrich the logger within a context with additional values.
+	Into(ctx context.Context) (context.Context, Logger)
+}
+
+// topologyReconcileLogger implements Logger.
+type topologyReconcileLogger struct {
+	logr.Logger
+}
+
+// WithObject adds to the logger information about the object being modified by reconcile, which in most case it is
+// a resources being part of the Cluster by reconciled.
+func (l *topologyReconcileLogger) WithObject(obj client.Object) Logger {
+	l.Logger = l.Logger.WithValues(
+		"object groupVersion", obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		"object kind", obj.GetObjectKind().GroupVersionKind().Kind,
+		"object", obj.GetName(),
+	)
+	return l
+}
+
+// WithMachineDeployment adds to the logger information about the MachineDeployment object being processed.
+func (l *topologyReconcileLogger) WithMachineDeployment(md *clusterv1.MachineDeployment) Logger {
+	topologyName := md.Labels[clusterv1.ClusterTopologyMachineDeploymentLabelName]
+	l.Logger = l.Logger.WithValues(
+		"machineDeployment name", md.GetName(),
+		"machineDeployment topologyName", topologyName,
+	)
+	return l
+}
+
+// V returns a logger value for a specific verbosity level, relative to
+// this logger.
+func (l *topologyReconcileLogger) V(level int) Logger {
+	l.Logger = l.Logger.V(level)
+	return l
+}
+
+// Infof logs to the INFO log.
+// Arguments are handled in the manner of fmt.Printf.
+func (l *topologyReconcileLogger) Infof(msg string, a ...interface{}) {
+	l.Logger.Info(fmt.Sprintf(msg, a...))
+}
+
+// Into takes a context and sets the logger as one of its keys.
+//
+// This is meant to be used in reconcilers to enrich the logger within a context with additional values.
+func (l *topologyReconcileLogger) Into(ctx context.Context) (context.Context, Logger) {
+	return ctrl.LoggerInto(ctx, l.Logger), l
+}
+
+// KObj return a reference to a Kubernetes object in the same format used by kubectl commands (kind/name).
+// Note: We're intentionally not using klog.KObj as we want the kind/name format instead of namespace/name.
+type KObj struct {
+	Obj client.Object
+}
+
+func (ref KObj) String() string {
+	if ref.Obj == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s", ref.Obj.GetObjectKind().GroupVersionKind().Kind, ref.Obj.GetName())
+}
+
+// KRef return a reference to a Kubernetes object in the same format used by kubectl commands (kind/name).
+type KRef struct {
+	Ref *corev1.ObjectReference
+}
+
+func (ref KRef) String() string {
+	if ref.Ref == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s", ref.Ref.Kind, ref.Ref.Name)
+}

--- a/controllers/topology/util.go
+++ b/controllers/topology/util.go
@@ -20,111 +20,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// loggerFrom returns a logger with predefined values from a context.Context.
-// The logger, when used with controllers, can be expected to contain basic information about the object
-// that's being reconciled like:
-// - `reconciler group` and `reconciler kind` coming from the For(...) object passed in when building a controller.
-// - `name` and `namespace` injected from the reconciliation request.
-//
-// This is meant to be used with the context supplied in a struct that satisfies the Reconciler interface.
-func loggerFrom(ctx context.Context) logger {
-	log := ctrl.LoggerFrom(ctx)
-	return &topologyReconcileLogger{
-		Logger: log,
-	}
-}
-
-// logger provides a wrapper to log.Logger to be used for topology reconciler.
-type logger interface {
-	// WithObject adds to the logger information about the object being modified by reconcile, which in most case it is
-	// a resources being part of the Cluster by reconciled.
-	WithObject(obj client.Object) logger
-
-	// WithMachineDeployment adds to the logger information about the MachineDeployment object being processed.
-	WithMachineDeployment(md *clusterv1.MachineDeployment) logger
-
-	// V returns a logger value for a specific verbosity level, relative to
-	// this logger.
-	V(level int) logger
-
-	// Infof logs to the INFO log.
-	// Arguments are handled in the manner of fmt.Printf.
-	Infof(msg string, a ...interface{})
-
-	// Into takes a context and sets the logger as one of its keys.
-	//
-	// This is meant to be used in reconcilers to enrich the logger within a context with additional values.
-	Into(ctx context.Context) (context.Context, logger)
-}
-
-// topologyReconcileLogger implements Logger.
-type topologyReconcileLogger struct {
-	logr.Logger
-}
-
-// WithObject adds to the logger information about the object being modified by reconcile, which in most case it is
-// a resources being part of the Cluster by reconciled.
-func (l *topologyReconcileLogger) WithObject(obj client.Object) logger {
-	l.Logger = l.Logger.WithValues(
-		"object groupVersion", obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
-		"object kind", obj.GetObjectKind().GroupVersionKind().Kind,
-		"object", obj.GetName(),
-	)
-	return l
-}
-
-// WithMachineDeployment adds to the logger information about the MachineDeployment object being processed.
-func (l *topologyReconcileLogger) WithMachineDeployment(md *clusterv1.MachineDeployment) logger {
-	topologyName := md.Labels[clusterv1.ClusterTopologyMachineDeploymentLabelName]
-	l.Logger = l.Logger.WithValues(
-		"machineDeployment name", md.GetName(),
-		"machineDeployment topologyName", topologyName,
-	)
-	return l
-}
-
-// V returns a logger value for a specific verbosity level, relative to
-// this logger.
-func (l *topologyReconcileLogger) V(level int) logger {
-	l.Logger = l.Logger.V(level)
-	return l
-}
-
-// Infof logs to the INFO log.
-// Arguments are handled in the manner of fmt.Printf.
-func (l *topologyReconcileLogger) Infof(msg string, a ...interface{}) {
-	l.Logger.Info(fmt.Sprintf(msg, a...))
-}
-
-// Into takes a context and sets the logger as one of its keys.
-//
-// This is meant to be used in reconcilers to enrich the logger within a context with additional values.
-func (l *topologyReconcileLogger) Into(ctx context.Context) (context.Context, logger) {
-	return ctrl.LoggerInto(ctx, l.Logger), l
-}
-
-// KRef return a reference to a Kubernetes object in the same format used by kubectl commands (kind/name).
-type KRef struct {
-	Obj client.Object
-}
-
-func (ref KRef) String() string {
-	if ref.Obj == nil {
-		return ""
-	}
-	return fmt.Sprintf("%s/%s", ref.Obj.GetObjectKind().GroupVersionKind().Kind, ref.Obj.GetName())
-}
 
 // bootstrapTemplateNamePrefix calculates the name prefix for a BootstrapTemplate.
 func bootstrapTemplateNamePrefix(clusterName, machineDeploymentTopologyName string) string {

--- a/controllers/topology/util_test.go
+++ b/controllers/topology/util_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestGetTemplate(t *testing.T) {
+func TestGetReference(t *testing.T) {
 	fakeControlPlaneTemplateCRDv99 := testtypes.GenericControlPlaneTemplateCRD.DeepCopy()
 	fakeControlPlaneTemplateCRDv99.Labels = map[string]string{
 		"cluster.x-k8s.io/v1alpha4": "v1alpha4_v99",


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
