### PR TITLE
🐛 fix ClusterClass control plane infrastructure machine template rotation

### DIFF
--- a/controllers/topology/reconcile_state.go
+++ b/controllers/topology/reconcile_state.go
@@ -84,7 +84,7 @@ func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, s *scope.
 			desired:              s.Desired.ControlPlane.InfrastructureMachineTemplate,
 			compatibilityChecker: check.ReferencedObjectsAreCompatible,
 			templateNamer: func() string {
-				return controlPlaneInfrastructureMachineTemplateNamePrefix(s.Current.ControlPlane.Object.GetClusterName())
+				return controlPlaneInfrastructureMachineTemplateNamePrefix(s.Current.Cluster.Name)
 			},
 		},
 		)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
I tested a template rotation locally and it failed. It failed because the name of the new template was invalid. `getClusterName` returns an empty string, so this results in a name like `-controlplane-s13ds1`.

Note: ClusterName in ObjectMeta is not used by CAPI. Go doc:
```go
	// The name of the cluster which the object belongs to.
	// This is used to distinguish resources with same name and namespace in different clusters.
	// This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
	// +optional
	ClusterName string `json:"clusterName,omitempty" protobuf:"bytes,15,opt,name=clusterName"`
```

I adjusted the code accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
