### PR TITLE
:seedling: KubeadmControlPlane internal/proxy should use pointer structs

### DIFF
--- a/controlplane/kubeadm/internal/proxy/addr.go
+++ b/controlplane/kubeadm/internal/proxy/addr.go
@@ -51,7 +51,7 @@ func (a Addr) String() string {
 }
 
 // NewAddrFromConn creates an Addr from the given connection.
-func NewAddrFromConn(c Conn) Addr {
+func NewAddrFromConn(c *Conn) Addr {
 	return Addr{
 		port:       c.stream.Headers().Get(corev1.PortHeader),
 		identifier: c.stream.Identifier(),

--- a/controlplane/kubeadm/internal/proxy/conn.go
+++ b/controlplane/kubeadm/internal/proxy/conn.go
@@ -33,32 +33,32 @@ type Conn struct {
 }
 
 // Read from the connection.
-func (c Conn) Read(b []byte) (n int, err error) {
+func (c *Conn) Read(b []byte) (n int, err error) {
 	return c.stream.Read(b)
 }
 
 // Close the underlying proxied connection.
-func (c Conn) Close() error {
+func (c *Conn) Close() error {
 	return kerrors.NewAggregate([]error{c.stream.Close(), c.connection.Close()})
 }
 
 // Write to the connection.
-func (c Conn) Write(b []byte) (n int, err error) {
+func (c *Conn) Write(b []byte) (n int, err error) {
 	return c.stream.Write(b)
 }
 
 // LocalAddr returns a fake address representing the proxied connection.
-func (c Conn) LocalAddr() net.Addr {
+func (c *Conn) LocalAddr() net.Addr {
 	return NewAddrFromConn(c)
 }
 
 // RemoteAddr returns a fake address representing the proxied connection.
-func (c Conn) RemoteAddr() net.Addr {
+func (c *Conn) RemoteAddr() net.Addr {
 	return NewAddrFromConn(c)
 }
 
 // SetDeadline sets the read and write deadlines to the specified interval.
-func (c Conn) SetDeadline(t time.Time) error {
+func (c *Conn) SetDeadline(t time.Time) error {
 	// TODO: Handle deadlines
 	c.readDeadline = t
 	c.writeDeadline = t
@@ -66,7 +66,7 @@ func (c Conn) SetDeadline(t time.Time) error {
 }
 
 // SetWriteDeadline sets the read and write deadlines to the specified interval.
-func (c Conn) SetWriteDeadline(t time.Time) error {
+func (c *Conn) SetWriteDeadline(t time.Time) error {
 	c.writeDeadline = t
 	return nil
 }
@@ -79,8 +79,8 @@ func (c Conn) SetReadDeadline(t time.Time) error {
 
 // NewConn creates a new net/conn interface based on an underlying Kubernetes
 // API server proxy connection.
-func NewConn(connection httpstream.Connection, stream httpstream.Stream) Conn {
-	return Conn{
+func NewConn(connection httpstream.Connection, stream httpstream.Stream) *Conn {
+	return &Conn{
 		connection: connection,
 		stream:     stream,
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The net.Conn interface doesn't need a plain struct, it can work well
with pointers as well. To avoid copying structs around every time we
initiate a connection or call a method, convert the underlying Conn
struct in the proxy package to using pointer receiving methods.

This change also fixes an issue with read/writeDeadline, which was being
set in the local copy of the Conn struct before instead of the current
object, which created an ineffective assignment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/assign @sbueringer @randomvariable @fabriziopandini 