### PR TITLE
🐛 ClusterClass: use namePrefix func consistently, fix MachineDeployment template rotation

### DIFF
--- a/controllers/topology/reconcile_state.go
+++ b/controllers/topology/reconcile_state.go
@@ -147,7 +147,7 @@ func (r *ClusterReconciler) reconcileMachineDeployments(ctx context.Context, s *
 	for _, mdTopologyName := range diff.toUpdate {
 		currentMD := s.Current.MachineDeployments[mdTopologyName]
 		desiredMD := s.Desired.MachineDeployments[mdTopologyName]
-		if err := r.updateMachineDeployment(ctx, s.Current.Cluster.Name, currentMD, desiredMD); err != nil {
+		if err := r.updateMachineDeployment(ctx, s.Current.Cluster.Name, mdTopologyName, currentMD, desiredMD); err != nil {
 			return err
 		}
 	}
@@ -187,7 +187,7 @@ func (r *ClusterReconciler) createMachineDeployment(ctx context.Context, md *sco
 }
 
 // updateMachineDeployment updates a MachineDeployment. Also rotates the corresponding Templates if necessary.
-func (r *ClusterReconciler) updateMachineDeployment(ctx context.Context, clusterName string, currentMD, desiredMD *scope.MachineDeploymentState) error {
+func (r *ClusterReconciler) updateMachineDeployment(ctx context.Context, clusterName string, mdTopologyName string, currentMD, desiredMD *scope.MachineDeploymentState) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	cleanupOldInfrastructureTemplate, err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
@@ -195,7 +195,7 @@ func (r *ClusterReconciler) updateMachineDeployment(ctx context.Context, cluster
 		current: currentMD.InfrastructureMachineTemplate,
 		desired: desiredMD.InfrastructureMachineTemplate,
 		templateNamer: func() string {
-			return infrastructureMachineTemplateNamePrefix(clusterName, desiredMD.Object.Name)
+			return infrastructureMachineTemplateNamePrefix(clusterName, mdTopologyName)
 		},
 		compatibilityChecker: check.ReferencedObjectsAreCompatible,
 	})
@@ -208,7 +208,7 @@ func (r *ClusterReconciler) updateMachineDeployment(ctx context.Context, cluster
 		current: currentMD.BootstrapTemplate,
 		desired: desiredMD.BootstrapTemplate,
 		templateNamer: func() string {
-			return bootstrapTemplateNamePrefix(clusterName, desiredMD.Object.Name)
+			return bootstrapTemplateNamePrefix(clusterName, mdTopologyName)
 		},
 		compatibilityChecker: check.ObjectsAreInTheSameNamespace,
 	})

--- a/controllers/topology/util.go
+++ b/controllers/topology/util.go
@@ -39,7 +39,7 @@ func infrastructureMachineTemplateNamePrefix(clusterName, machineDeploymentTopol
 
 // infrastructureMachineTemplateNamePrefix calculates the name prefix for a InfrastructureMachineTemplate.
 func controlPlaneInfrastructureMachineTemplateNamePrefix(clusterName string) string {
-	return fmt.Sprintf("%s-controlplane-", clusterName)
+	return fmt.Sprintf("%s-control-plane-", clusterName)
 }
 
 // getReference gets the object referenced in ref.


### PR DESCRIPTION

Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
A few fixes from issues found today during manual testing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
