### PR TITLE
🌱 Make Cluster topology controlPlane optional

### DIFF
--- a/api/v1alpha4/cluster_types.go
+++ b/api/v1alpha4/cluster_types.go
@@ -83,6 +83,7 @@ type Topology struct {
 	RolloutAfter *metav1.Time `json:"rolloutAfter,omitempty"`
 
 	// ControlPlane describes the cluster control plane.
+	// +optional
 	ControlPlane ControlPlaneTopology `json:"controlPlane"`
 
 	// Workers encapsulates the different constructs that form the worker nodes

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -595,7 +595,6 @@ spec:
                     type: object
                 required:
                 - class
-                - controlPlane
                 - version
                 type: object
             type: object


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->



**What this PR does / why we need it**:

Let’s say you want to create a Cluster with the following topology:
```
spec:
  topology:
    class: my-cluster-class
    version: v1.22.0
```

This won’t work with kubectl, because according to the OpenAPI Schema topology.controlPlane is mandatory. When you disable the client-side OpenAPI schema validation with --validate=false it will work. Why?
* kubectl client-side does not block with validate==false
* somehow the server-side validation does not fail. I guess it’s because controlPlane is not a pointer
* The resulting Cluster looks like this:
```
spec:
  topology:
    class: my-cluster-class
    version: v1.22.0
    controlPlane:
      metadata: {}
```

This can be fixed by making the field optional, which kind of makes sense because it doesn't have to be provided by the user.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
