### PR TITLE
🐛  CAPD: fix panic in DockerMachinePool reconciliation

### DIFF
--- a/test/infrastructure/docker/exp/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/controllers/dockermachinepool_controller.go
@@ -55,7 +55,7 @@ type DockerMachinePoolReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch
 
 func (r *DockerMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res ctrl.Result, rerr error) {
-	log := ctrl.LoggerFrom(ctx, "docker-machine-pool", req.NamespacedName)
+	log := ctrl.LoggerFrom(ctx)
 
 	// Fetch the DockerMachinePool instance.
 	dockerMachinePool := &infrav1exp.DockerMachinePool{}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Since yesterday (https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main) our e2e tests panic. This only occurs when MachinePools are used with CAPD (so it doesn't affect quickstart).

I have no idea why it started to occur only yesterday.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
