### PR TITLE
🐛 util/GetGVKMetadata: fix get PartialObjectMetadata

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -422,6 +422,7 @@ func HasOwner(refList []metav1.OwnerReference, apiVersion string, kinds []string
 func GetGVKMetadata(ctx context.Context, c client.Client, gvk schema.GroupVersionKind) (*metav1.PartialObjectMetadata, error) {
 	meta := &metav1.PartialObjectMetadata{}
 	meta.SetName(fmt.Sprintf("%s.%s", flect.Pluralize(strings.ToLower(gvk.Kind)), gvk.Group))
+	meta.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
 	if err := c.Get(ctx, client.ObjectKeyFromObject(meta), meta); err != nil {
 		return meta, errors.Wrap(err, "failed to retrieve metadata from GVK resource")
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Before this change the request always failed with the following log:
```bash
I0827 16:39:27.378997       1 conversion.go:67] controller-runtime/manager/controller/machineset "msg"="Cannot retrieve CRD with metadata only client, falling back to slower listing" "MachineSet"="name" "cluster.x-k8s.io"="reconciler kind" "default"=null "my-cluster-default-worker-topology-mqqb5-947bf9665"="namespace" "err"="failed to retrieve metadata from GVK resource: Object 'Kind' is missing in 'unstructured object has no kind'"
```

I synced the implementation with what I did for release-0.3 here: https://github.com/kubernetes-sigs/cluster-api/pull/5013/files

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
