### PR TITLE
🐛 ClusterClass : fix propagate metadata to machines, KCP fix propagate annotations

### DIFF
--- a/api/v1alpha4/cluster_types.go
+++ b/api/v1alpha4/cluster_types.go
@@ -93,6 +93,11 @@ type Topology struct {
 
 // ControlPlaneTopology specifies the parameters for the control plane nodes in the cluster.
 type ControlPlaneTopology struct {
+	// Metadata is the metadata applied to the machines of the ControlPlane.
+	// At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+	//
+	// This field is supported if and only if the control plane provider template
+	// referenced in the ClusterClass is Machine based.
 	Metadata ObjectMeta `json:"metadata,omitempty"`
 
 	// Replicas is the number of control plane nodes.
@@ -112,6 +117,8 @@ type WorkersTopology struct {
 // MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology.
 // This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
 type MachineDeploymentTopology struct {
+	// Metadata is the metadata applied to the machines of the MachineDeployment.
+	// At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
 	Metadata ObjectMeta `json:"metadata,omitempty"`
 
 	// Class is the name of the MachineDeploymentClass used to create the set of worker nodes.

--- a/api/v1alpha4/clusterclass_types.go
+++ b/api/v1alpha4/clusterclass_types.go
@@ -55,6 +55,11 @@ type ClusterClassSpec struct {
 
 // ControlPlaneClass defines the class for the control plane.
 type ControlPlaneClass struct {
+	// Metadata is the metadata applied to the machines of the ControlPlane.
+	// At runtime this metadata is merged with the corresponding metadata from the topology.
+	//
+	// This field is supported if and only if the control plane provider template
+	// referenced is Machine based.
 	Metadata ObjectMeta `json:"metadata,omitempty"`
 
 	// LocalObjectTemplate contains the reference to the control plane provider.
@@ -93,6 +98,8 @@ type MachineDeploymentClass struct {
 // MachineDeploymentClassTemplate defines how a MachineDeployment generated from a MachineDeploymentClass
 // should look like.
 type MachineDeploymentClassTemplate struct {
+	// Metadata is the metadata applied to the machines of the MachineDeployment.
+	// At runtime this metadata is merged with the corresponding metadata from the topology.
 	Metadata ObjectMeta `json:"metadata,omitempty"`
 
 	// Bootstrap contains the bootstrap template reference to be used

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -93,28 +93,11 @@ spec:
                     - ref
                     type: object
                   metadata:
-                    description: "ObjectMeta is metadata that all persisted resources
-                      must have, which includes all objects users must create. This
-                      is a copy of customizable fields from metav1.ObjectMeta. \n
-                      ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template`
-                      and `MachineSet.Template`, which are not top-level Kubernetes
-                      objects. Given that metav1.ObjectMeta has lots of special cases
-                      and read-only fields which end up in the generated CRD validation,
-                      having it as a subset simplifies the API and some issues that
-                      can impact user experience. \n During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
-                      for v1alpha2, we noticed a failure would occur running Cluster
-                      API test suite against the new CRDs, specifically `spec.metadata.creationTimestamp
-                      in body must be of type string: \"null\"`. The investigation
-                      showed that `controller-tools@v2` behaves differently than its
-                      previous version when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1)
-                      package. \n In more details, we found that embedded (non-top
-                      level) types that embedded `metav1.ObjectMeta` had validation
-                      properties, including for `creationTimestamp` (metav1.Time).
-                      The `metav1.Time` type specifies a custom json marshaller that,
-                      when IsZero() is true, returns `null` which breaks validation
-                      because the field isn't marked as nullable. \n In future versions,
-                      controller-tools@v2 might allow overriding the type and validation
-                      for embedded types. When that happens, this hack should be revisited."
+                    description: "Metadata is the metadata applied to the machines
+                      of the ControlPlane. At runtime this metadata is merged with
+                      the corresponding metadata from the topology. \n This field
+                      is supported if and only if the control plane provider template
+                      referenced is Machine based."
                     properties:
                       annotations:
                         additionalProperties:
@@ -353,33 +336,10 @@ spec:
                               - ref
                               type: object
                             metadata:
-                              description: "ObjectMeta is metadata that all persisted
-                                resources must have, which includes all objects users
-                                must create. This is a copy of customizable fields
-                                from metav1.ObjectMeta. \n ObjectMeta is embedded
-                                in `Machine.Spec`, `MachineDeployment.Template` and
-                                `MachineSet.Template`, which are not top-level Kubernetes
-                                objects. Given that metav1.ObjectMeta has lots of
-                                special cases and read-only fields which end up in
-                                the generated CRD validation, having it as a subset
-                                simplifies the API and some issues that can impact
-                                user experience. \n During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
-                                for v1alpha2, we noticed a failure would occur running
-                                Cluster API test suite against the new CRDs, specifically
-                                `spec.metadata.creationTimestamp in body must be of
-                                type string: \"null\"`. The investigation showed that
-                                `controller-tools@v2` behaves differently than its
-                                previous version when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1)
-                                package. \n In more details, we found that embedded
-                                (non-top level) types that embedded `metav1.ObjectMeta`
-                                had validation properties, including for `creationTimestamp`
-                                (metav1.Time). The `metav1.Time` type specifies a
-                                custom json marshaller that, when IsZero() is true,
-                                returns `null` which breaks validation because the
-                                field isn't marked as nullable. \n In future versions,
-                                controller-tools@v2 might allow overriding the type
-                                and validation for embedded types. When that happens,
-                                this hack should be revisited."
+                              description: Metadata is the metadata applied to the
+                                machines of the MachineDeployment. At runtime this
+                                metadata is merged with the corresponding metadata
+                                from the topology.
                               properties:
                                 annotations:
                                   additionalProperties:

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -441,30 +441,12 @@ spec:
                     description: ControlPlane describes the cluster control plane.
                     properties:
                       metadata:
-                        description: "ObjectMeta is metadata that all persisted resources
-                          must have, which includes all objects users must create.
-                          This is a copy of customizable fields from metav1.ObjectMeta.
-                          \n ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template`
-                          and `MachineSet.Template`, which are not top-level Kubernetes
-                          objects. Given that metav1.ObjectMeta has lots of special
-                          cases and read-only fields which end up in the generated
-                          CRD validation, having it as a subset simplifies the API
-                          and some issues that can impact user experience. \n During
-                          the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
-                          for v1alpha2, we noticed a failure would occur running Cluster
-                          API test suite against the new CRDs, specifically `spec.metadata.creationTimestamp
-                          in body must be of type string: \"null\"`. The investigation
-                          showed that `controller-tools@v2` behaves differently than
-                          its previous version when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1)
-                          package. \n In more details, we found that embedded (non-top
-                          level) types that embedded `metav1.ObjectMeta` had validation
-                          properties, including for `creationTimestamp` (metav1.Time).
-                          The `metav1.Time` type specifies a custom json marshaller
-                          that, when IsZero() is true, returns `null` which breaks
-                          validation because the field isn't marked as nullable. \n
-                          In future versions, controller-tools@v2 might allow overriding
-                          the type and validation for embedded types. When that happens,
-                          this hack should be revisited."
+                        description: "Metadata is the metadata applied to the machines
+                          of the ControlPlane. At runtime this metadata is merged
+                          with the corresponding metadata from the ClusterClass. \n
+                          This field is supported if and only if the control plane
+                          provider template referenced in the ClusterClass is Machine
+                          based."
                         properties:
                           annotations:
                             additionalProperties:
@@ -524,33 +506,10 @@ spec:
                                 field.
                               type: string
                             metadata:
-                              description: "ObjectMeta is metadata that all persisted
-                                resources must have, which includes all objects users
-                                must create. This is a copy of customizable fields
-                                from metav1.ObjectMeta. \n ObjectMeta is embedded
-                                in `Machine.Spec`, `MachineDeployment.Template` and
-                                `MachineSet.Template`, which are not top-level Kubernetes
-                                objects. Given that metav1.ObjectMeta has lots of
-                                special cases and read-only fields which end up in
-                                the generated CRD validation, having it as a subset
-                                simplifies the API and some issues that can impact
-                                user experience. \n During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
-                                for v1alpha2, we noticed a failure would occur running
-                                Cluster API test suite against the new CRDs, specifically
-                                `spec.metadata.creationTimestamp in body must be of
-                                type string: \"null\"`. The investigation showed that
-                                `controller-tools@v2` behaves differently than its
-                                previous version when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1)
-                                package. \n In more details, we found that embedded
-                                (non-top level) types that embedded `metav1.ObjectMeta`
-                                had validation properties, including for `creationTimestamp`
-                                (metav1.Time). The `metav1.Time` type specifies a
-                                custom json marshaller that, when IsZero() is true,
-                                returns `null` which breaks validation because the
-                                field isn't marked as nullable. \n In future versions,
-                                controller-tools@v2 might allow overriding the type
-                                and validation for embedded types. When that happens,
-                                this hack should be revisited."
+                              description: Metadata is the metadata applied to the
+                                machines of the MachineDeployment. At runtime this
+                                metadata is merged with the corresponding metadata
+                                from the ClusterClass.
                               properties:
                                 annotations:
                                   additionalProperties:

--- a/controllers/topology/current_state.go
+++ b/controllers/topology/current_state.go
@@ -95,7 +95,7 @@ func (r *ClusterReconciler) getCurrentControlPlaneState(ctx context.Context, clu
 	}
 
 	// Otherwise, get the control plane machine infrastructureMachine template.
-	machineInfrastructureRef, err := contract.ControlPlane().InfrastructureMachineTemplate().Get(res.Object)
+	machineInfrastructureRef, err := contract.ControlPlane().MachineTemplate().InfrastructureRef().Get(res.Object)
 	if err != nil {
 		return res, errors.Wrapf(err, "failed to get InfrastructureMachineTemplate reference for %s, %s", res.Object.GetKind(), res.Object.GetName())
 	}

--- a/controllers/topology/internal/contract/controlplane.go
+++ b/controllers/topology/internal/contract/controlplane.go
@@ -39,14 +39,12 @@ func ControlPlane() *ControlPlaneContract {
 	return controlPlane
 }
 
-// InfrastructureMachineTemplate provide access to InfrastructureMachineTemplate reference in a ControlPlane object, if any.
+// MachineTemplate provides access to MachineTemplate in a ControlPlane object, if any.
 // NOTE: When working with unstructured there is no way to understand if the ControlPlane provider
 // do support a field in the type definition from the fact that a field is not set in a given instance.
-// This is why in we are deriving if InfrastructureMachineTemplate is required from the ClusterClass in the topology reconciler code.
-func (c *ControlPlaneContract) InfrastructureMachineTemplate() *Ref {
-	return &Ref{
-		path: []string{"spec", "machineTemplate", "infrastructureRef"},
-	}
+// This is why in we are deriving if MachineTemplate is required from the ClusterClass in the topology reconciler code.
+func (c *ControlPlaneContract) MachineTemplate() *ControlPlaneMachineTemplate {
+	return &ControlPlaneMachineTemplate{}
 }
 
 // Version provide access to version field  in a ControlPlane object, if any.
@@ -63,6 +61,23 @@ func (c *ControlPlaneContract) Version() *ControlPlaneVersion {
 // This is why in we are deriving if replicas is required from the ClusterClass in the topology reconciler code.
 func (c *ControlPlaneContract) Replicas() *ControlPlaneReplicas {
 	return &ControlPlaneReplicas{}
+}
+
+// ControlPlaneMachineTemplate provides a helper struct for working with MachineTemplate in ClusterClass.
+type ControlPlaneMachineTemplate struct{}
+
+// InfrastructureRef provides access to the infrastructureRef of a MachineTemplate.
+func (c *ControlPlaneMachineTemplate) InfrastructureRef() *Ref {
+	return &Ref{
+		path: Path{"spec", "machineTemplate", "infrastructureRef"},
+	}
+}
+
+// Metadata provides access to the metadata of a MachineTemplate.
+func (c *ControlPlaneMachineTemplate) Metadata() *Metadata {
+	return &Metadata{
+		path: Path{"spec", "machineTemplate", "metadata"},
+	}
 }
 
 // ControlPlaneVersion provide a helper struct for working with version in ClusterClass.

--- a/controllers/topology/internal/contract/controlplane_template.go
+++ b/controllers/topology/internal/contract/controlplane_template.go
@@ -39,6 +39,6 @@ func ControlPlaneTemplate() *ControlPlaneTemplateContract {
 // This is why in we are deriving if this field is required from the ClusterClass in the topology reconciler code.
 func (c *ControlPlaneTemplateContract) InfrastructureMachineTemplate() *Ref {
 	return &Ref{
-		path: []string{"spec", "template", "spec", "machineTemplate", "infrastructureRef"},
+		path: Path{"spec", "template", "spec", "machineTemplate", "infrastructureRef"},
 	}
 }

--- a/controllers/topology/internal/contract/controlplane_test.go
+++ b/controllers/topology/internal/contract/controlplane_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
 func TestControlPlane(t *testing.T) {
@@ -57,17 +58,39 @@ func TestControlPlane(t *testing.T) {
 
 		refObj := fooRefBuilder()
 
-		g.Expect(ControlPlane().InfrastructureMachineTemplate().Path()).To(Equal(Path{"spec", "machineTemplate", "infrastructureRef"}))
+		g.Expect(ControlPlane().MachineTemplate().InfrastructureRef().Path()).To(Equal(Path{"spec", "machineTemplate", "infrastructureRef"}))
 
-		err := ControlPlane().InfrastructureMachineTemplate().Set(obj, refObj)
+		err := ControlPlane().MachineTemplate().InfrastructureRef().Set(obj, refObj)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		got, err := ControlPlane().InfrastructureMachineTemplate().Get(obj)
+		got, err := ControlPlane().MachineTemplate().InfrastructureRef().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(got.APIVersion).To(Equal(refObj.GetAPIVersion()))
 		g.Expect(got.Kind).To(Equal(refObj.GetKind()))
 		g.Expect(got.Name).To(Equal(refObj.GetName()))
 		g.Expect(got.Namespace).To(Equal(refObj.GetNamespace()))
+	})
+	t.Run("Manages spec.machineTemplate.metadata", func(t *testing.T) {
+		g := NewWithT(t)
+
+		metadata := &clusterv1.ObjectMeta{
+			Labels: map[string]string{
+				"label1": "labelValue1",
+			},
+			Annotations: map[string]string{
+				"annotation1": "annotationValue1",
+			},
+		}
+
+		g.Expect(ControlPlane().MachineTemplate().Metadata().Path()).To(Equal(Path{"spec", "machineTemplate", "metadata"}))
+
+		err := ControlPlane().MachineTemplate().Metadata().Set(obj, metadata)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlane().MachineTemplate().Metadata().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got).To(Equal(metadata))
 	})
 }

--- a/controllers/topology/internal/contract/metadata.go
+++ b/controllers/topology/internal/contract/metadata.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+)
+
+// Metadata provides a helper struct for working with Metadata.
+type Metadata struct {
+	path Path
+}
+
+// Path returns the path of the metadata.
+func (m *Metadata) Path() Path {
+	return m.path
+}
+
+// Get gets the metadata object.
+func (m *Metadata) Get(obj *unstructured.Unstructured) (*clusterv1.ObjectMeta, error) {
+	labelsPath := append(m.path, "labels")
+	labelsValue, ok, err := unstructured.NestedStringMap(obj.UnstructuredContent(), labelsPath...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to retrieve control plane metadata.labels")
+	}
+	if !ok {
+		return nil, errors.Errorf("%s not found", "."+strings.Join(labelsPath, "."))
+	}
+
+	annotationsPath := append(m.path, "annotations")
+	annotationsValue, ok, err := unstructured.NestedStringMap(obj.UnstructuredContent(), annotationsPath...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to retrieve control plane metadata.annotations")
+	}
+	if !ok {
+		return nil, errors.Errorf("%s not found", "."+strings.Join(annotationsPath, "."))
+	}
+
+	return &clusterv1.ObjectMeta{
+		Labels:      labelsValue,
+		Annotations: annotationsValue,
+	}, nil
+}
+
+// Set sets the metadata value.
+func (m *Metadata) Set(obj *unstructured.Unstructured, metadata *clusterv1.ObjectMeta) error {
+	labelsPath := append(m.path, "labels")
+	if err := unstructured.SetNestedStringMap(obj.UnstructuredContent(), metadata.Labels, labelsPath...); err != nil {
+		return errors.Wrap(err, "failed to set control plane metadata.labels")
+	}
+
+	annotationsPath := append(m.path, "annotations")
+	if err := unstructured.SetNestedStringMap(obj.UnstructuredContent(), metadata.Annotations, annotationsPath...); err != nil {
+		return errors.Wrap(err, "failed to set control plane metadata.annotations")
+	}
+	return nil
+}

--- a/controllers/topology/object_builders_test.go
+++ b/controllers/topology/object_builders_test.go
@@ -493,7 +493,7 @@ func (f *fakeControlPlane) Obj() *unstructured.Unstructured {
 	}
 
 	if f.infrastructureMachineTemplate != nil {
-		if err := contract.ControlPlane().InfrastructureMachineTemplate().Set(obj, f.infrastructureMachineTemplate); err != nil {
+		if err := contract.ControlPlane().MachineTemplate().InfrastructureRef().Set(obj, f.infrastructureMachineTemplate); err != nil {
 			panic(err)
 		}
 	}

--- a/controllers/topology/reconcile_state.go
+++ b/controllers/topology/reconcile_state.go
@@ -71,7 +71,7 @@ func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, s *scope.
 
 	// If the clusterClass mandates the controlPlane has infrastructureMachines, reconcile it.
 	if s.Blueprint.HasControlPlaneInfrastructureMachine() {
-		cpInfraRef, err := contract.ControlPlane().InfrastructureMachineTemplate().Get(s.Desired.ControlPlane.Object)
+		cpInfraRef, err := contract.ControlPlane().MachineTemplate().InfrastructureRef().Get(s.Desired.ControlPlane.Object)
 		if err != nil {
 			return errors.Wrapf(err, "failed to update the %s object,", s.Desired.ControlPlane.InfrastructureMachineTemplate.GetKind())
 		}
@@ -93,7 +93,7 @@ func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, s *scope.
 		}
 
 		// The controlPlaneObject.Spec.machineTemplate.infrastructureRef has to be updated in the desired object
-		err = contract.ControlPlane().InfrastructureMachineTemplate().Set(s.Desired.ControlPlane.Object, refToUnstructured(cpInfraRef))
+		err = contract.ControlPlane().MachineTemplate().InfrastructureRef().Set(s.Desired.ControlPlane.Object, refToUnstructured(cpInfraRef))
 		if err != nil {
 			return kerrors.NewAggregate([]error{errors.Wrapf(err, "failed to update the %s object", s.Desired.ControlPlane.Object.GetKind()), cleanup()})
 		}

--- a/controllers/topology/reconcile_state_test.go
+++ b/controllers/topology/reconcile_state_test.go
@@ -471,7 +471,7 @@ func TestReconcileControlPlaneInfrastructureMachineTemplate(t *testing.T) {
 			// This check is just for the naming format uses by generated templates - here it's templateName-*
 			// This check is only performed when we had an initial template that has been changed
 			if tt.current.InfrastructureMachineTemplate != nil {
-				item, err := contract.ControlPlane().InfrastructureMachineTemplate().Get(gotControlPlaneObject)
+				item, err := contract.ControlPlane().MachineTemplate().InfrastructureRef().Get(gotControlPlaneObject)
 				g.Expect(err).ToNot(HaveOccurred())
 				pattern := fmt.Sprintf("%s.*", controlPlaneInfrastructureMachineTemplateNamePrefix(s.Current.Cluster.Name))
 				fmt.Println(pattern, item.Name)

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
@@ -137,7 +137,7 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, "verbosity"},
 		{spec, kubeadmConfigSpec, users},
 		{spec, kubeadmConfigSpec, ntp, "*"},
-		{spec, "machineTemplate", "metadata"},
+		{spec, "machineTemplate", "metadata", "*"},
 		{spec, "machineTemplate", "infrastructureRef", "apiVersion"},
 		{spec, "machineTemplate", "infrastructureRef", "name"},
 		{spec, "replicas"},

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
@@ -321,6 +321,12 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			},
 		},
 	}
+	validUpdate.Spec.MachineTemplate.ObjectMeta.Labels = map[string]string{
+		"label": "labelValue",
+	}
+	validUpdate.Spec.MachineTemplate.ObjectMeta.Annotations = map[string]string{
+		"annotation": "labelAnnotation",
+	}
 	validUpdate.Spec.MachineTemplate.InfrastructureRef.APIVersion = "test/v1alpha2"
 	validUpdate.Spec.MachineTemplate.InfrastructureRef.Name = "orange"
 	validUpdate.Spec.Replicas = pointer.Int32Ptr(5)

--- a/controlplane/kubeadm/controllers/helpers.go
+++ b/controlplane/kubeadm/controllers/helpers.go
@@ -294,7 +294,10 @@ func (r *KubeadmControlPlaneReconciler) generateMachine(ctx context.Context, kcp
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal cluster configuration")
 	}
-	machine.SetAnnotations(map[string]string{controlplanev1.KubeadmClusterConfigurationAnnotation: string(clusterConfig)})
+	if machine.Annotations == nil {
+		machine.Annotations = map[string]string{}
+	}
+	machine.Annotations[controlplanev1.KubeadmClusterConfigurationAnnotation] = string(clusterConfig)
 
 	if err := r.Client.Create(ctx, machine); err != nil {
 		return errors.Wrap(err, "failed to create machine")


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com
Co-authored-by: fabriziopandini <fpandini@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
WIth this PR metadata is propagated to control plane and MachineDeployment machines.

There were also two bugs in KCP:
* the webhook didn't allow changes to metadata
* KCP didn't propagate annotations

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5168
