### PR TITLE
:bug: log in restore cmd causing crashes

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -140,7 +140,7 @@ func (o *objectMover) Restore(toCluster Client, directory string) error {
 
 func (o *objectMover) filesToObjs(dir string) ([]unstructured.Unstructured, error) {
 	log := logf.Log
-	log.Info("Restoring files from %s", dir)
+	log.Info(fmt.Sprintf("Restoring files from %s", dir))
 
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:
Allows the use of the restore function, as it is right now broken.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
