### PR TITLE
✨ Upgrade support for managed topologies

### DIFF
--- a/api/v1alpha4/cluster_webhook.go
+++ b/api/v1alpha4/cluster_webhook.go
@@ -233,7 +233,7 @@ func (c *Cluster) validateTopology(old *Cluster) field.ErrorList {
 				),
 			)
 		}
-		if inVersion.NE(semver.Version{}) && oldVersion.NE(semver.Version{}) && !inVersion.GTE(oldVersion) {
+		if inVersion.NE(semver.Version{}) && oldVersion.NE(semver.Version{}) && version.CompareWithBuildIdentifiers(inVersion, oldVersion) == -1 {
 			allErrs = append(
 				allErrs,
 				field.Invalid(

--- a/api/v1alpha4/cluster_webhook_test.go
+++ b/api/v1alpha4/cluster_webhook_test.go
@@ -199,6 +199,106 @@ func TestClusterTopologyValidation(t *testing.T) {
 			},
 		},
 		{
+			name:      "should return error when downgrading topology version - major",
+			expectErr: true,
+			old: &Cluster{
+				Spec: ClusterSpec{
+					Topology: &Topology{
+						Class:   "foo",
+						Version: "v2.2.3",
+					},
+				},
+			},
+			in: &Cluster{
+				Spec: ClusterSpec{
+					Topology: &Topology{
+						Class:   "foo",
+						Version: "v1.2.3",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when downgrading topology version - minor",
+			expectErr: true,
+			old: &Cluster{
+				Spec: ClusterSpec{
+					Topology: &Topology{
+						Class:   "foo",
+						Version: "v1.2.3",
+					},
+				},
+			},
+			in: &Cluster{
+				Spec: ClusterSpec{
+					Topology: &Topology{
+						Class:   "foo",
+						Version: "v1.1.3",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when downgrading topology version - patch",
+			expectErr: true,
+			old: &Cluster{
+				Spec: ClusterSpec{
+					Topology: &Topology{
+						Class:   "foo",
+						Version: "v1.2.3",
+					},
+				},
+			},
+			in: &Cluster{
+				Spec: ClusterSpec{
+					Topology: &Topology{
+						Class:   "foo",
+						Version: "v1.2.2",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when downgrading topology version - pre-release",
+			expectErr: true,
+			old: &Cluster{
+				Spec: ClusterSpec{
+					Topology: &Topology{
+						Class:   "foo",
+						Version: "v1.2.3-xyz.2",
+					},
+				},
+			},
+			in: &Cluster{
+				Spec: ClusterSpec{
+					Topology: &Topology{
+						Class:   "foo",
+						Version: "v1.2.3-xyz.1",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when downgrading topology version - build tag",
+			expectErr: true,
+			old: &Cluster{
+				Spec: ClusterSpec{
+					Topology: &Topology{
+						Class:   "foo",
+						Version: "v1.2.3+xyz.2",
+					},
+				},
+			},
+			in: &Cluster{
+				Spec: ClusterSpec{
+					Topology: &Topology{
+						Class:   "foo",
+						Version: "v1.2.3+xyz.1",
+					},
+				},
+			},
+		},
+		{
 			name:      "should return error when duplicated MachineDeployments names exists in a Topology",
 			expectErr: true,
 			in: &Cluster{

--- a/controllers/topology/current_state.go
+++ b/controllers/topology/current_state.go
@@ -113,7 +113,7 @@ func (r *ClusterReconciler) getCurrentControlPlaneState(ctx context.Context, clu
 // expected on first reconcile. If MachineDeployments are found for the Cluster their Infrastructure and Bootstrap references
 // are inspected. Where these are not found the function will throw an error.
 func (r *ClusterReconciler) getCurrentMachineDeploymentState(ctx context.Context, cluster *clusterv1.Cluster) (map[string]*scope.MachineDeploymentState, error) {
-	state := make(map[string]*scope.MachineDeploymentState)
+	state := make(scope.MachineDeploymentsStateMap)
 
 	// List all the machine deployments in the current cluster and in a managed topology.
 	md := &clusterv1.MachineDeploymentList{}

--- a/controllers/topology/desired_state.go
+++ b/controllers/topology/desired_state.go
@@ -70,14 +70,13 @@ func (r *ClusterReconciler) computeDesiredState(ctx context.Context, s *scope.Sc
 		return desiredState, nil
 	}
 
-	desiredState.MachineDeployments = map[string]*scope.MachineDeploymentState{}
-	for _, mdTopology := range s.Blueprint.Topology.Workers.MachineDeployments {
-		desiredMachineDeployment, err := computeMachineDeployment(ctx, s, mdTopology)
-		if err != nil {
-			return nil, err
-		}
-		desiredState.MachineDeployments[mdTopology.Name] = desiredMachineDeployment
+	// Compute the desired state of the MachineDeployments from the list of MachineDeploymentTopologies
+	// defined in the cluster.
+	desiredState.MachineDeployments, err = computeMachineDeployments(ctx, s, desiredState.ControlPlane)
+	if err != nil {
+		return nil, err
 	}
+
 	return desiredState, nil
 }
 
@@ -183,12 +182,75 @@ func computeControlPlane(_ context.Context, s *scope.Scope, infrastructureMachin
 	}
 
 	// Sets the desired Kubernetes version for the control plane.
-	// TODO: improve this logic by adding support for version upgrade component by component
-	if err := contract.ControlPlane().Version().Set(controlPlane, s.Blueprint.Topology.Version); err != nil {
+	version, err := computeControlPlaneVersion(s)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compute version of control plane")
+	}
+	if err := contract.ControlPlane().Version().Set(controlPlane, version); err != nil {
 		return nil, errors.Wrap(err, "failed to set spec.version in the ControlPlane object")
 	}
 
 	return controlPlane, nil
+}
+
+// computeControlPlaneVersion calculates the version of the desired control plane.
+// The version is calculated using the state of the current machine deployments, the current control plane
+// and the version defined in the topology.
+func computeControlPlaneVersion(s *scope.Scope) (string, error) {
+	desiredVersion := s.Blueprint.Topology.Version
+	// If we are creating the control plane object (current control plane is nil), use version from topology.
+	if s.Current.ControlPlane == nil || s.Current.ControlPlane.Object == nil {
+		return desiredVersion, nil
+	}
+
+	// Get the current currentVersion of the control plane.
+	currentVersion, err := contract.ControlPlane().Version().Get(s.Current.ControlPlane.Object)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get the version from control plane spec")
+	}
+
+	// Return early if the version is already equal to the desired version
+	// no further checks required.
+	if *currentVersion == desiredVersion {
+		return *currentVersion, nil
+	}
+
+	// Check if the current control plane is upgrading
+	cpUpgrading, err := contract.ControlPlane().IsUpgrading(s.Current.ControlPlane.Object)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to check if control plane is upgrading")
+	}
+	// If the current control plane is upgrading  (still completing a previous upgrade),
+	// then do not pick up the desiredVersion yet.
+	// Return the current version of the control plane. We will pick up the new version
+	// after the control plane is stable.
+	if cpUpgrading {
+		return *currentVersion, nil
+	}
+
+	// If the control plane supports replicas, check if the control plane is in the middle of a scale operation.
+	// If yes, then do not pick up the desiredVersion yet. We will pick up the new version after the control plane is stable.
+	if s.Blueprint.Topology.ControlPlane.Replicas != nil {
+		cpScaling, err := contract.ControlPlane().IsScaling(s.Current.ControlPlane.Object)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to check if the control plane is scaling")
+		}
+		if cpScaling {
+			return *currentVersion, nil
+		}
+	}
+
+	// If the control plane is not upgrading or scaling, we can assume the control plane is stable.
+	// However, we should also check for the MachineDeployments to be stable.
+	// If the MachineDeployments are rolling out (still completing a previous upgrade), then do not pick
+	// up the desiredVersion yet. We will pick up the new version after the MachineDeployments are stable.
+	if s.Current.MachineDeployments.IsAnyRollingOut() {
+		return *currentVersion, nil
+	}
+
+	// Control plane and machine deployments are stable.
+	// Ready to pick up the topology version.
+	return desiredVersion, nil
 }
 
 // computeCluster computes the desired state for the Cluster object.
@@ -215,10 +277,23 @@ func computeCluster(_ context.Context, s *scope.Scope, infrastructureCluster, co
 	return cluster
 }
 
+// computeMachineDeployments computes the desired state of the list of MachineDeployments.
+func computeMachineDeployments(ctx context.Context, s *scope.Scope, desiredControlPlaneState *scope.ControlPlaneState) (scope.MachineDeploymentsStateMap, error) {
+	machineDeploymentsStateMap := make(scope.MachineDeploymentsStateMap)
+	for _, mdTopology := range s.Blueprint.Topology.Workers.MachineDeployments {
+		desiredMachineDeployment, err := computeMachineDeployment(ctx, s, desiredControlPlaneState, mdTopology)
+		if err != nil {
+			return nil, err
+		}
+		machineDeploymentsStateMap[mdTopology.Name] = desiredMachineDeployment
+	}
+	return machineDeploymentsStateMap, nil
+}
+
 // computeMachineDeployment computes the desired state for a MachineDeploymentTopology.
 // The generated machineDeployment object is calculated using the values from the machineDeploymentTopology and
 // the machineDeployment class.
-func computeMachineDeployment(_ context.Context, s *scope.Scope, machineDeploymentTopology clusterv1.MachineDeploymentTopology) (*scope.MachineDeploymentState, error) {
+func computeMachineDeployment(_ context.Context, s *scope.Scope, desiredControlPlaneState *scope.ControlPlaneState, machineDeploymentTopology clusterv1.MachineDeploymentTopology) (*scope.MachineDeploymentState, error) {
 	desiredMachineDeployment := &scope.MachineDeploymentState{}
 
 	// Gets the blueprint for the MachineDeployment class.
@@ -270,6 +345,10 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, machineDeployme
 	// Add ClusterTopologyMachineDeploymentLabel to the generated InfrastructureMachine template
 	infraMachineTemplateLabels[clusterv1.ClusterTopologyMachineDeploymentLabelName] = machineDeploymentTopology.Name
 	desiredMachineDeployment.InfrastructureMachineTemplate.SetLabels(infraMachineTemplateLabels)
+	version, err := computeMachineDeploymentVersion(s, desiredControlPlaneState, currentMachineDeployment)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to compute version for %s", machineDeploymentTopology.Name)
+	}
 
 	// Compute the MachineDeployment object.
 	gv := clusterv1.GroupVersion
@@ -290,10 +369,8 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, machineDeployme
 					Annotations: mergeMap(machineDeploymentTopology.Metadata.Annotations, machineDeploymentBlueprint.Metadata.Annotations),
 				},
 				Spec: clusterv1.MachineSpec{
-					ClusterName: s.Current.Cluster.Name,
-					// Sets the desired Kubernetes version for the MachineDeployment.
-					// TODO: improve this logic by adding support for version upgrade component by component
-					Version:           pointer.String(s.Blueprint.Topology.Version),
+					ClusterName:       s.Current.Cluster.Name,
+					Version:           pointer.String(version),
 					Bootstrap:         clusterv1.Bootstrap{ConfigRef: contract.ObjToRef(desiredMachineDeployment.BootstrapTemplate)},
 					InfrastructureRef: *contract.ObjToRef(desiredMachineDeployment.InfrastructureMachineTemplate),
 				},
@@ -328,6 +405,99 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, machineDeployme
 
 	desiredMachineDeployment.Object = desiredMachineDeploymentObj
 	return desiredMachineDeployment, nil
+}
+
+// computeMachineDeploymentVersion calculates the version of the desired machine deployment.
+// The version is calculated using the state of the current machine deployments,
+// the current control plane and the version defined in the topology.
+// Nb: No MachineDeployment upgrades will be triggered while any MachineDeployment is in the middle
+// of an upgrade. Even if the number of MachineDeployments that are being upgraded is less
+// than the number of allowed concurrent upgrades.
+func computeMachineDeploymentVersion(s *scope.Scope, desiredControlPlaneState *scope.ControlPlaneState, currentMDState *scope.MachineDeploymentState) (string, error) {
+	desiredVersion := s.Blueprint.Topology.Version
+	// If creating a new machine deployment, we can pick up the desired version
+	// Note: We are not blocking the creation of new machine deployments when
+	// the control plane or any of the machine deployments are upgrading/scaling.
+	if currentMDState == nil || currentMDState.Object == nil {
+		return desiredVersion, nil
+	}
+
+	// Get the current version of the machine deployment.
+	currentVersion := *currentMDState.Object.Spec.Template.Spec.Version
+
+	// Return early if we are not allowed to upgrade the machine deployment.
+	if !s.UpgradeTracker.MachineDeployments.AllowUpgrade() {
+		return currentVersion, nil
+	}
+
+	// Return early if the currentVersion is already equal to the desiredVersion
+	// no further checks required.
+	if currentVersion == desiredVersion {
+		return currentVersion, nil
+	}
+
+	// If the control plane is being created (current control plane is nil), do not perform
+	// any machine deployment upgrade in this case.
+	// Return the current version of the machine deployment.
+	// NOTE: this case should never happen (upgrading a MachineDeployment) before creating a CP,
+	// but we are implementing this check for extra safety.
+	if s.Current.ControlPlane == nil || s.Current.ControlPlane.Object == nil {
+		return currentVersion, nil
+	}
+
+	// If the current control plane is upgrading, then do not pick up the desiredVersion yet.
+	// Return the current version of the machine deployment. We will pick up the new version after the control
+	// plane is stable.
+	cpUpgrading, err := contract.ControlPlane().IsUpgrading(s.Current.ControlPlane.Object)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to check if control plane is upgrading")
+	}
+	if cpUpgrading {
+		return currentVersion, nil
+	}
+
+	// If control plane supports replicas, check if the control plane is in the middle of a scale operation.
+	// If the current control plane is scaling, then do not pick up the desiredVersion yet.
+	// Return the current version of the machine deployment. We will pick up the new version after the control
+	// plane is stable.
+	if s.Blueprint.Topology.ControlPlane.Replicas != nil {
+		cpScaling, err := contract.ControlPlane().IsScaling(s.Current.ControlPlane.Object)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to check if the control plane is scaling")
+		}
+		if cpScaling {
+			return currentVersion, nil
+		}
+	}
+
+	// Check if we are about to upgrade the control plane. In that case, do not upgrade the machine deployment yet.
+	// Wait for the new upgrade operation on the control plane to finish before picking up the new version for the
+	// machine deployment.
+	currentCPVersion, err := contract.ControlPlane().Version().Get(s.Current.ControlPlane.Object)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get version of current control plane")
+	}
+	desiredCPVersion, err := contract.ControlPlane().Version().Get(desiredControlPlaneState.Object)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get version of desired control plane")
+	}
+	if *currentCPVersion != *desiredCPVersion {
+		// The versions of the current and desired control planes do no match,
+		// implies we are about to upgrade the control plane.
+		return currentVersion, nil
+	}
+
+	// At this point the control plane is stable (not scaling, not upgrading, not being upgraded).
+	// Checking to see if the machine deployments are also stable.
+	// If any of the MachineDeployments is rolling out, do not upgrade the machine deployment yet.
+	if s.Current.MachineDeployments.IsAnyRollingOut() {
+		return currentVersion, nil
+	}
+
+	// Control plane and machine deployments are stable.
+	// Ready to pick up the topology version.
+	s.UpgradeTracker.MachineDeployments.Insert(currentMDState.Object.Name)
+	return desiredVersion, nil
 }
 
 type templateToInput struct {

--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/scope"
@@ -394,6 +395,235 @@ func TestComputeControlPlane(t *testing.T) {
 			obj:         obj,
 		})
 	})
+	t.Run("Should choose the correct version for control plane", func(t *testing.T) {
+		// Note: in all of the following tests we are setting it up so that there are not machine deployments.
+		// A more extensive list of scenarios is tested in TestComputeControlPlaneVersion.
+		tests := []struct {
+			name                string
+			currentControlPlane *unstructured.Unstructured
+			topologyVersion     string
+			expectedVersion     string
+		}{
+			{
+				name:                "use cluster.spec.topology.version if creating a new control plane",
+				currentControlPlane: nil,
+				topologyVersion:     "v1.2.3",
+				expectedVersion:     "v1.2.3",
+			},
+			{
+				name: "use controlplane.spec.version if the control plane's spec.version is not equal to status.version",
+				currentControlPlane: testtypes.NewControlPlaneBuilder("test1", "cp1").
+					WithSpecFields(map[string]interface{}{
+						"spec.version": "v1.2.2",
+					}).
+					WithStatusFields(map[string]interface{}{
+						"status.version": "v1.2.1",
+					}).
+					Build(),
+				topologyVersion: "v1.2.3",
+				expectedVersion: "v1.2.2",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				g := NewWithT(t)
+
+				// Current cluster objects for the test scenario.
+				clusterWithControlPlaneRef := cluster.DeepCopy()
+				clusterWithControlPlaneRef.Spec.ControlPlaneRef = fakeRef1
+				clusterWithControlPlaneRef.Spec.Topology.Version = tt.topologyVersion
+
+				blueprint := &scope.ClusterBlueprint{
+					Topology:     clusterWithControlPlaneRef.Spec.Topology,
+					ClusterClass: clusterClass,
+					ControlPlane: &scope.ControlPlaneBlueprint{
+						Template: controlPlaneTemplate,
+					},
+				}
+
+				// Aggregating current cluster objects into ClusterState (simulating getCurrentState).
+				s := scope.New(clusterWithControlPlaneRef)
+				s.Blueprint = blueprint
+				s.Current.ControlPlane = &scope.ControlPlaneState{
+					Object: tt.currentControlPlane,
+				}
+
+				obj, err := computeControlPlane(ctx, s, nil)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(obj).NotTo(BeNil())
+				assertNestedField(g, obj, tt.expectedVersion, contract.ControlPlane().Version().Path()...)
+			})
+		}
+	})
+}
+
+func TestComputeControlPlaneVersion(t *testing.T) {
+	// Note: the version used by the machine deployments does
+	// not affect how we determining the control plane version.
+	// We only want to know if the machine deployments are stable.
+	//
+	// A machine deployment is considere stable if all the following are true:
+	// - md.spec.replicas == md.status.replicas
+	// - md.spec.replicas == md.status.updatedReplicas
+	// - md.spec.replicas == md.status.readyReplicas
+	// - md.Generation < md.status.observedGeneration
+	//
+	// A machine deployment is considered upgrading if any of the above conditions
+	// is false.
+	machineDeploymentStable := testtypes.NewMachineDeploymentBuilder("test-namespace", "md1").
+		WithGeneration(int64(1)).
+		WithReplicas(int32(2)).
+		WithStatus(clusterv1.MachineDeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           2,
+			UpdatedReplicas:    2,
+			AvailableReplicas:  2,
+			ReadyReplicas:      2,
+		}).
+		Build()
+	machineDeploymentRollingOut := testtypes.NewMachineDeploymentBuilder("test-namespace", "md2").
+		WithGeneration(int64(1)).
+		WithReplicas(int32(2)).
+		WithStatus(clusterv1.MachineDeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           1,
+			UpdatedReplicas:    1,
+			AvailableReplicas:  1,
+			ReadyReplicas:      1,
+		}).
+		Build()
+
+	tests := []struct {
+		name                    string
+		topologyVersion         string
+		controlPlaneObj         *unstructured.Unstructured
+		machineDeploymentsState scope.MachineDeploymentsStateMap
+		expectedVersion         string
+	}{
+		{
+			name:            "should return cluster.spec.topology.version if creating a new control plane",
+			topologyVersion: "v1.2.3",
+			controlPlaneObj: nil,
+			expectedVersion: "v1.2.3",
+		},
+		{
+			// Control plane is not upgrading implies that controlplane.spec.version is equal to controlplane.status.version.
+			// Control plane is not scaling implies that controlplane.spec.replicas is equal to controlplane.status.replicas,
+			// Controlplane.status.updatedReplicas and controlplane.status.readyReplicas.
+			name:            "should return cluster.spec.topology.version if the control plane is not upgrading and not scaling",
+			topologyVersion: "v1.2.3",
+			controlPlaneObj: testtypes.NewControlPlaneBuilder("test1", "cp1").
+				WithSpecFields(map[string]interface{}{
+					"spec.version":  "v1.2.2",
+					"spec.replicas": int64(2),
+				}).
+				WithStatusFields(map[string]interface{}{
+					"status.version":         "v1.2.2",
+					"status.replicas":        int64(2),
+					"status.updatedReplicas": int64(2),
+					"status.readyReplicas":   int64(2),
+				}).
+				Build(),
+			expectedVersion: "v1.2.3",
+		},
+		{
+			// Control plane is considered upgrading if controlplane.spec.version is not equal to controlplane.status.version.
+			name:            "should return controlplane.spec.version if the control plane is upgrading",
+			topologyVersion: "v1.2.3",
+			controlPlaneObj: testtypes.NewControlPlaneBuilder("test1", "cp1").
+				WithSpecFields(map[string]interface{}{
+					"spec.version": "v1.2.2",
+				}).
+				WithStatusFields(map[string]interface{}{
+					"status.version": "v1.2.1",
+				}).
+				Build(),
+			expectedVersion: "v1.2.2",
+		},
+		{
+			// Control plane is considered scaling if controlplane.spec.replicas is not equal to any of
+			// controlplane.status.replicas, controlplane.status.readyReplicas, controlplane.status.updatedReplicas.
+			name:            "should return controlplane.spec.version if the control plane is scaling",
+			topologyVersion: "v1.2.3",
+			controlPlaneObj: testtypes.NewControlPlaneBuilder("test1", "cp1").
+				WithSpecFields(map[string]interface{}{
+					"spec.version":  "v1.2.2",
+					"spec.replicas": int64(2),
+				}).
+				WithStatusFields(map[string]interface{}{
+					"status.version":         "v1.2.2",
+					"status.replicas":        int64(1),
+					"status.updatedReplicas": int64(1),
+					"status.readyReplicas":   int64(1),
+				}).
+				Build(),
+			expectedVersion: "v1.2.2",
+		},
+		{
+			name:            "should return controlplane.spec.version if control plane is not upgrading and not scaling and one of the machine deployments is rolling out",
+			topologyVersion: "v1.2.3",
+			controlPlaneObj: testtypes.NewControlPlaneBuilder("test1", "cp1").
+				WithSpecFields(map[string]interface{}{
+					"spec.version":  "v1.2.2",
+					"spec.replicas": int64(2),
+				}).
+				WithStatusFields(map[string]interface{}{
+					"status.version":         "v1.2.2",
+					"status.replicas":        int64(2),
+					"status.updatedReplicas": int64(2),
+					"status.readyReplicas":   int64(2),
+				}).
+				Build(),
+			machineDeploymentsState: scope.MachineDeploymentsStateMap{
+				"md1": &scope.MachineDeploymentState{Object: machineDeploymentStable},
+				"md2": &scope.MachineDeploymentState{Object: machineDeploymentRollingOut},
+			},
+			expectedVersion: "v1.2.2",
+		},
+		{
+			name:            "should return cluster.spec.topology.version if control plane is not upgrading and not scaling and none of the machine deployments are rolling out",
+			topologyVersion: "v1.2.3",
+			controlPlaneObj: testtypes.NewControlPlaneBuilder("test1", "cp1").
+				WithSpecFields(map[string]interface{}{
+					"spec.version":  "v1.2.2",
+					"spec.replicas": int64(2),
+				}).
+				WithStatusFields(map[string]interface{}{
+					"status.version":         "v1.2.2",
+					"status.replicas":        int64(2),
+					"status.updatedReplicas": int64(2),
+					"status.readyReplicas":   int64(2),
+				}).
+				Build(),
+			machineDeploymentsState: scope.MachineDeploymentsStateMap{
+				"md1": &scope.MachineDeploymentState{Object: machineDeploymentStable},
+				"md2": &scope.MachineDeploymentState{Object: machineDeploymentStable},
+			},
+			expectedVersion: "v1.2.3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			s := &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{Topology: &clusterv1.Topology{
+					Version: tt.topologyVersion,
+					ControlPlane: clusterv1.ControlPlaneTopology{
+						Replicas: pointer.Int32(2),
+					},
+				}},
+				Current: &scope.ClusterState{
+					ControlPlane:       &scope.ControlPlaneState{Object: tt.controlPlaneObj},
+					MachineDeployments: tt.machineDeploymentsState,
+				},
+			}
+			version, err := computeControlPlaneVersion(s)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(version).To(Equal(tt.expectedVersion))
+		})
+	}
 }
 
 func TestComputeCluster(t *testing.T) {
@@ -498,7 +728,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 		scope := scope.New(cluster)
 		scope.Blueprint = blueprint
 
-		actual, err := computeMachineDeployment(ctx, scope, mdTopology)
+		actual, err := computeMachineDeployment(ctx, scope, nil, mdTopology)
 		g.Expect(err).ToNot(HaveOccurred())
 
 		g.Expect(actual.BootstrapTemplate.GetLabels()).To(HaveKeyWithValue(clusterv1.ClusterTopologyMachineDeploymentLabelName, "big-pool-of-machines"))
@@ -534,6 +764,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 				Replicas: &currentReplicas,
 				Template: clusterv1.MachineTemplateSpec{
 					Spec: clusterv1.MachineSpec{
+						Version: pointer.String("v1.21.2"),
 						Bootstrap: clusterv1.Bootstrap{
 							ConfigRef: contract.ObjToRef(workerBootstrapTemplate),
 						},
@@ -550,7 +781,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 			},
 		}
 
-		actual, err := computeMachineDeployment(ctx, s, mdTopology)
+		actual, err := computeMachineDeployment(ctx, s, nil, mdTopology)
 		g.Expect(err).ToNot(HaveOccurred())
 
 		actualMd := actual.Object
@@ -580,9 +811,306 @@ func TestComputeMachineDeployment(t *testing.T) {
 			Name:  "big-pool-of-machines",
 		}
 
-		_, err := computeMachineDeployment(ctx, scope, mdTopology)
+		_, err := computeMachineDeployment(ctx, scope, nil, mdTopology)
 		g.Expect(err).To(HaveOccurred())
 	})
+
+	t.Run("Should choose the correct version for machine deployment", func(t *testing.T) {
+		controlPlaneStable123 := testtypes.NewControlPlaneBuilder("test1", "cp1").
+			WithSpecFields(map[string]interface{}{
+				"spec.version":  "v1.2.3",
+				"spec.replicas": int64(2),
+			}).
+			WithStatusFields(map[string]interface{}{
+				"status.version":         "v1.2.3",
+				"status.replicas":        int64(2),
+				"status.updatedReplicas": int64(2),
+				"status.readyReplicas":   int64(2),
+			}).
+			Build()
+
+		machineDeploymentStable := testtypes.NewMachineDeploymentBuilder("test-namespace", "md-1").
+			WithGeneration(1).
+			WithReplicas(2).
+			WithStatus(clusterv1.MachineDeploymentStatus{
+				ObservedGeneration: 2,
+				Replicas:           2,
+				UpdatedReplicas:    2,
+				AvailableReplicas:  2,
+			}).
+			Build()
+
+		machineDeploymentRollingOut := testtypes.NewMachineDeploymentBuilder("test-namespace", "md-1").
+			WithGeneration(1).
+			WithReplicas(2).
+			WithStatus(clusterv1.MachineDeploymentStatus{
+				ObservedGeneration: 2,
+				Replicas:           1,
+				UpdatedReplicas:    1,
+				AvailableReplicas:  1,
+			}).
+			Build()
+
+		machineDeploymentsStateRollingOut := scope.MachineDeploymentsStateMap{
+			"class-1": &scope.MachineDeploymentState{Object: machineDeploymentStable},
+			"class-2": &scope.MachineDeploymentState{Object: machineDeploymentRollingOut},
+		}
+
+		// Note: in all the following tests we are setting it up so that the control plane is already
+		// stable at the topology version.
+		// A more extensive list of sceniarios is tested in TestComputeMachineDeploymentVersion.
+		tests := []struct {
+			name                    string
+			machineDeploymentsState scope.MachineDeploymentsStateMap
+			currentMDVersion        *string
+			topologyVersion         string
+			expectedVersion         string
+		}{
+			{
+				name:                    "use cluster.spec.topology.version if creating a new machine deployment",
+				machineDeploymentsState: nil,
+				currentMDVersion:        nil,
+				topologyVersion:         "v1.2.3",
+				expectedVersion:         "v1.2.3",
+			},
+			{
+				name:                    "use machine deployment's spec.template.spec.version if one of the machine deployments is rolling out",
+				machineDeploymentsState: machineDeploymentsStateRollingOut,
+				currentMDVersion:        pointer.String("v1.2.2"),
+				topologyVersion:         "v1.2.3",
+				expectedVersion:         "v1.2.2",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				g := NewWithT(t)
+				s := scope.New(cluster)
+				s.Blueprint = blueprint
+				s.Blueprint.Topology.Version = tt.topologyVersion
+				s.Blueprint.Topology.ControlPlane = clusterv1.ControlPlaneTopology{
+					Replicas: pointer.Int32(2),
+				}
+
+				mdsState := tt.machineDeploymentsState
+				if tt.currentMDVersion != nil {
+					// testing a case with an existing machine deployment
+					// add the stable machine deployment to the current machine deployments state
+					md := testtypes.NewMachineDeploymentBuilder("test-namespace", "big-pool-of-machines").
+						WithGeneration(1).
+						WithReplicas(2).
+						WithVersion(*tt.currentMDVersion).
+						WithStatus(clusterv1.MachineDeploymentStatus{
+							ObservedGeneration: 2,
+							Replicas:           2,
+							UpdatedReplicas:    2,
+							AvailableReplicas:  2,
+						}).
+						Build()
+					mdsState = duplicateMachineDeploymentsState(mdsState)
+					mdsState["big-pool-of-machines"] = &scope.MachineDeploymentState{
+						Object: md,
+					}
+				}
+				s.Current.MachineDeployments = mdsState
+				s.Current.ControlPlane = &scope.ControlPlaneState{
+					Object: controlPlaneStable123,
+				}
+				desiredControlPlaneState := &scope.ControlPlaneState{
+					Object: controlPlaneStable123,
+				}
+
+				mdTopology := clusterv1.MachineDeploymentTopology{
+					Class:    "linux-worker",
+					Name:     "big-pool-of-machines",
+					Replicas: pointer.Int32(2),
+				}
+
+				obj, err := computeMachineDeployment(ctx, s, desiredControlPlaneState, mdTopology)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(*obj.Object.Spec.Template.Spec.Version).To(Equal(tt.expectedVersion))
+			})
+		}
+	})
+}
+
+func TestComputeMachineDeploymentVersion(t *testing.T) {
+	controlPlaneStable122 := testtypes.NewControlPlaneBuilder("test1", "cp1").
+		WithSpecFields(map[string]interface{}{
+			"spec.version":  "v1.2.2",
+			"spec.replicas": int64(2),
+		}).
+		WithStatusFields(map[string]interface{}{
+			"status.version":         "v1.2.2",
+			"status.replicas":        int64(2),
+			"status.updatedReplicas": int64(2),
+			"status.readyReplicas":   int64(2),
+		}).
+		Build()
+	controlPlaneStable123 := testtypes.NewControlPlaneBuilder("test1", "cp1").
+		WithSpecFields(map[string]interface{}{
+			"spec.version":  "v1.2.3",
+			"spec.replicas": int64(2),
+		}).
+		WithStatusFields(map[string]interface{}{
+			"status.version":         "v1.2.3",
+			"status.replicas":        int64(2),
+			"status.updatedReplicas": int64(2),
+			"status.readyReplicas":   int64(2),
+		}).
+		Build()
+	controlPlaneUpgrading := testtypes.NewControlPlaneBuilder("test1", "cp1").
+		WithSpecFields(map[string]interface{}{
+			"spec.version": "v1.2.3",
+		}).
+		WithStatusFields(map[string]interface{}{
+			"status.version": "v1.2.1",
+		}).
+		Build()
+	controlPlaneScaling := testtypes.NewControlPlaneBuilder("test1", "cp1").
+		WithSpecFields(map[string]interface{}{
+			"spec.version":  "v1.2.3",
+			"spec.replicas": int64(2),
+		}).
+		WithStatusFields(map[string]interface{}{
+			"status.version":         "v1.2.3",
+			"status.replicas":        int64(1),
+			"status.updatedReplicas": int64(1),
+			"status.readyReplicas":   int64(1),
+		}).
+		Build()
+	controlPlaneDesired := testtypes.NewControlPlaneBuilder("test1", "cp1").
+		WithSpecFields(map[string]interface{}{
+			"spec.version": "v1.2.3",
+		}).
+		Build()
+
+	// A machine deployment is considere stable if all the following are true:
+	// - md.spec.replicas == md.status.replicas
+	// - md.spec.replicas == md.status.updatedReplicas
+	// - md.spec.replicas == md.status.readyReplicas
+	// - md.Generation < md.status.observedGeneration
+	//
+	// A machine deployment is considered upgrading if any of the above conditions
+	// is false.
+	machineDeploymentStable := testtypes.NewMachineDeploymentBuilder("test-namespace", "md-1").
+		WithGeneration(1).
+		WithReplicas(2).
+		WithStatus(clusterv1.MachineDeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           2,
+			UpdatedReplicas:    2,
+			AvailableReplicas:  2,
+			ReadyReplicas:      2,
+		}).
+		Build()
+	machineDeploymentRollingOut := testtypes.NewMachineDeploymentBuilder("test-namespace", "md-2").
+		WithGeneration(1).
+		WithReplicas(2).
+		WithStatus(clusterv1.MachineDeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           1,
+			UpdatedReplicas:    1,
+			AvailableReplicas:  1,
+			ReadyReplicas:      1,
+		}).
+		Build()
+
+	machineDeploymentsStateStable := scope.MachineDeploymentsStateMap{
+		"md1": &scope.MachineDeploymentState{Object: machineDeploymentStable},
+		"md2": &scope.MachineDeploymentState{Object: machineDeploymentStable},
+	}
+	machineDeploymentsStateRollingOut := scope.MachineDeploymentsStateMap{
+		"md1": &scope.MachineDeploymentState{Object: machineDeploymentStable},
+		"md2": &scope.MachineDeploymentState{Object: machineDeploymentRollingOut},
+	}
+
+	tests := []struct {
+		name                          string
+		currentMachineDeploymentState *scope.MachineDeploymentState
+		machineDeploymentsStateMap    scope.MachineDeploymentsStateMap
+		currentControlPlane           *unstructured.Unstructured
+		desiredControlPlane           *unstructured.Unstructured
+		topologyVersion               string
+		expectedVersion               string
+	}{
+		{
+			name:                          "should return cluster.spec.topology.version if creating a new machine deployment",
+			currentMachineDeploymentState: nil,
+			machineDeploymentsStateMap:    make(scope.MachineDeploymentsStateMap),
+			topologyVersion:               "v1.2.3",
+			expectedVersion:               "v1.2.3",
+		},
+		{
+			name:                          "should return machine deployment's spec.template.spec.version if any one of the machine deployments is rolling out",
+			currentMachineDeploymentState: &scope.MachineDeploymentState{Object: testtypes.NewMachineDeploymentBuilder("test1", "md-current").WithVersion("v1.2.2").Build()},
+			machineDeploymentsStateMap:    machineDeploymentsStateRollingOut,
+			currentControlPlane:           controlPlaneStable123,
+			desiredControlPlane:           controlPlaneDesired,
+			topologyVersion:               "v1.2.3",
+			expectedVersion:               "v1.2.2",
+		},
+		{
+			// Control plane is considered upgrading if the control plane's spec.version and status.version is not equal.
+			name:                          "should return machine deployment's spec.template.spec.version if control plane is upgrading",
+			currentMachineDeploymentState: &scope.MachineDeploymentState{Object: testtypes.NewMachineDeploymentBuilder("test1", "md-current").WithVersion("v1.2.2").Build()},
+			machineDeploymentsStateMap:    machineDeploymentsStateStable,
+			currentControlPlane:           controlPlaneUpgrading,
+			topologyVersion:               "v1.2.3",
+			expectedVersion:               "v1.2.2",
+		},
+		{
+			// Control plane is considered ready to upgrade if spec.version of current and desired control planes are not equal.
+			name:                          "should return machine deployment's spec.template.spec.version if control plane is ready to upgrade",
+			currentMachineDeploymentState: &scope.MachineDeploymentState{Object: testtypes.NewMachineDeploymentBuilder("test1", "md-current").WithVersion("v1.2.2").Build()},
+			machineDeploymentsStateMap:    machineDeploymentsStateStable,
+			currentControlPlane:           controlPlaneStable122,
+			desiredControlPlane:           controlPlaneDesired,
+			topologyVersion:               "v1.2.3",
+			expectedVersion:               "v1.2.2",
+		},
+		{
+			// Control plane is considered scaling if its spec.replicas is not equal to any of status.replicas, status.readyReplicas or status.updatedReplicas.
+			name:                          "should return machine deployment's spec.template.spec.version if control plane is scaling",
+			currentMachineDeploymentState: &scope.MachineDeploymentState{Object: testtypes.NewMachineDeploymentBuilder("test1", "md-current").WithVersion("v1.2.2").Build()},
+			machineDeploymentsStateMap:    machineDeploymentsStateStable,
+			currentControlPlane:           controlPlaneScaling,
+			topologyVersion:               "v1.2.3",
+			expectedVersion:               "v1.2.2",
+		},
+		{
+			name:                          "should return cluster.spec.topology.version if the control plane is not upgrading, not scaling, not ready to upgrade and none of the machine deployments are rolling out",
+			currentMachineDeploymentState: &scope.MachineDeploymentState{Object: testtypes.NewMachineDeploymentBuilder("test1", "md-current").WithVersion("v1.2.2").Build()},
+			machineDeploymentsStateMap:    machineDeploymentsStateStable,
+			currentControlPlane:           controlPlaneStable123,
+			desiredControlPlane:           controlPlaneDesired,
+			topologyVersion:               "v1.2.3",
+			expectedVersion:               "v1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			s := &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{Topology: &clusterv1.Topology{
+					Version: tt.topologyVersion,
+					ControlPlane: clusterv1.ControlPlaneTopology{
+						Replicas: pointer.Int32(2),
+					},
+				}},
+				Current: &scope.ClusterState{
+					ControlPlane:       &scope.ControlPlaneState{Object: tt.currentControlPlane},
+					MachineDeployments: tt.machineDeploymentsStateMap,
+				},
+				UpgradeTracker: scope.NewUpgradeTracker(),
+			}
+			desiredControlPlaneState := &scope.ControlPlaneState{Object: tt.desiredControlPlane}
+			version, err := computeMachineDeploymentVersion(s, desiredControlPlaneState, tt.currentMachineDeploymentState)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(version).To(Equal(tt.expectedVersion))
+		})
+	}
 }
 
 func TestTemplateToObject(t *testing.T) {
@@ -778,4 +1306,12 @@ func assertNestedFieldUnset(g *WithT, obj *unstructured.Unstructured, fields ...
 
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(ok).To(BeFalse())
+}
+
+func duplicateMachineDeploymentsState(s scope.MachineDeploymentsStateMap) scope.MachineDeploymentsStateMap {
+	n := make(scope.MachineDeploymentsStateMap)
+	for k, v := range s {
+		n[k] = v
+	}
+	return n
 }

--- a/controllers/topology/internal/contract/controlplane_test.go
+++ b/controllers/topology/internal/contract/controlplane_test.go
@@ -40,6 +40,19 @@ func TestControlPlane(t *testing.T) {
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(*got).To(Equal("vFoo"))
 	})
+	t.Run("Manages status.version", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(ControlPlane().StatusVersion().Path()).To(Equal(Path{"status", "version"}))
+
+		err := ControlPlane().StatusVersion().Set(obj, "1.2.3")
+		g.Expect(err).NotTo(HaveOccurred())
+
+		got, err := ControlPlane().StatusVersion().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(*got).To(Equal("1.2.3"))
+	})
 	t.Run("Manages spec.replicas", func(t *testing.T) {
 		g := NewWithT(t)
 
@@ -49,6 +62,45 @@ func TestControlPlane(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		got, err := ControlPlane().Replicas().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(*got).To(Equal(int64(3)))
+	})
+	t.Run("Manages status.replicas", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(ControlPlane().StatusReplicas().Path()).To(Equal(Path{"status", "replicas"}))
+
+		err := ControlPlane().StatusReplicas().Set(obj, int64(3))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlane().StatusReplicas().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(*got).To(Equal(int64(3)))
+	})
+	t.Run("Manages status.updatedreplicas", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(ControlPlane().UpdatedReplicas().Path()).To(Equal(Path{"status", "updatedReplicas"}))
+
+		err := ControlPlane().UpdatedReplicas().Set(obj, int64(3))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlane().UpdatedReplicas().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(*got).To(Equal(int64(3)))
+	})
+	t.Run("Manages status.readyReplicas", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(ControlPlane().ReadyReplicas().Path()).To(Equal(Path{"status", "readyReplicas"}))
+
+		err := ControlPlane().ReadyReplicas().Set(obj, int64(3))
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlane().ReadyReplicas().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(*got).To(Equal(int64(3)))
@@ -93,4 +145,169 @@ func TestControlPlane(t *testing.T) {
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(got).To(Equal(metadata))
 	})
+}
+
+func TestControlPlaneIsUpgrading(t *testing.T) {
+	tests := []struct {
+		name          string
+		obj           *unstructured.Unstructured
+		wantUpgrading bool
+	}{
+		{
+			name: "should return false if status is not set on control plane",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"version": "v1.2.3",
+				},
+			}},
+			wantUpgrading: false,
+		},
+		{
+			name: "should return false if status.version is not set on control plane",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"version": "v1.2.3",
+				},
+				"status": map[string]interface{}{},
+			}},
+			wantUpgrading: false,
+		},
+		{
+			name: "should return false if status.version is equal to spec.version",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"version": "v1.2.3",
+				},
+				"status": map[string]interface{}{
+					"version": "v1.2.3",
+				},
+			}},
+			wantUpgrading: false,
+		},
+		{
+			name: "should return true if status.version is less than spec.version",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"version": "v1.2.3",
+				},
+				"status": map[string]interface{}{
+					"version": "v1.2.2",
+				},
+			}},
+			wantUpgrading: true,
+		},
+		{
+			name: "should return false if status.version is greater than spec.version",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"version": "v1.2.2",
+				},
+				"status": map[string]interface{}{
+					"version": "v1.2.3",
+				},
+			}},
+			wantUpgrading: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			actual, _ := ControlPlane().IsUpgrading(tt.obj)
+			g.Expect(actual).To(Equal(tt.wantUpgrading))
+		})
+	}
+}
+
+func TestControlPlaneIsScaling(t *testing.T) {
+	tests := []struct {
+		name        string
+		obj         *unstructured.Unstructured
+		wantScaling bool
+	}{
+		{
+			name: "should return false for stable control plane",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+				"status": map[string]interface{}{
+					"replicas":        int64(2),
+					"updatedReplicas": int64(2),
+					"readyReplicas":   int64(2),
+				},
+			}},
+			wantScaling: false,
+		},
+		{
+			name: "should return true if status is not set on control plane",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+			}},
+			wantScaling: true,
+		},
+		{
+			name: "should return true if status.replicas is not set on control plane",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+				"status": map[string]interface{}{},
+			}},
+			wantScaling: true,
+		},
+		{
+			name: "should return true if spec and status replicas do not match",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+				"status": map[string]interface{}{
+					"replicas":        int64(1),
+					"updatedReplicas": int64(2),
+					"readyReplicas":   int64(2),
+				},
+			}},
+			wantScaling: true,
+		},
+		{
+			name: "should return true if spec and status updatedReplicas do not match",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+				"status": map[string]interface{}{
+					"replicas":        int64(2),
+					"updatedReplicas": int64(1),
+					"readyReplicas":   int64(2),
+				},
+			}},
+			wantScaling: true,
+		},
+		{
+			name: "should return true if spec and status readyReplicas do not match",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+				"status": map[string]interface{}{
+					"replicas":        int64(2),
+					"updatedReplicas": int64(2),
+					"readyReplicas":   int64(1),
+				},
+			}},
+			wantScaling: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			actual, err := ControlPlane().IsScaling(tt.obj)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(actual).To(Equal(tt.wantScaling))
+		})
+	}
 }

--- a/controllers/topology/internal/contract/types.go
+++ b/controllers/topology/internal/contract/types.go
@@ -16,5 +16,74 @@ limitations under the License.
 
 package contract
 
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var errNotFound = errors.New("not found")
+
 // Path defines a how to access a field in an Unstructured object.
 type Path []string
+
+// Int64 represents an accessor to an int64 path value.
+type Int64 struct {
+	path Path
+}
+
+// Path returns the path to the int64 value.
+func (i *Int64) Path() Path {
+	return i.path
+}
+
+// Get gets the int64 value.
+func (i *Int64) Get(obj *unstructured.Unstructured) (*int64, error) {
+	value, ok, err := unstructured.NestedInt64(obj.UnstructuredContent(), i.path...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %s from object", "."+strings.Join(i.path, "."))
+	}
+	if !ok {
+		return nil, errors.Wrapf(errNotFound, "path %s", "."+strings.Join(i.path, "."))
+	}
+	return &value, nil
+}
+
+// Set set the int64 value in the path.
+func (i *Int64) Set(obj *unstructured.Unstructured, value int64) error {
+	if err := unstructured.SetNestedField(obj.UnstructuredContent(), value, i.path...); err != nil {
+		return errors.Wrapf(err, "failed to set path %s of object %v", "."+strings.Join(i.path, "."), obj.GroupVersionKind())
+	}
+	return nil
+}
+
+// String represents an accessor to a string path value.
+type String struct {
+	path Path
+}
+
+// Path returns the path to the string value.
+func (s *String) Path() Path {
+	return s.path
+}
+
+// Get gets the string value.
+func (s *String) Get(obj *unstructured.Unstructured) (*string, error) {
+	value, ok, err := unstructured.NestedString(obj.UnstructuredContent(), s.path...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get %s from object", "."+strings.Join(s.path, "."))
+	}
+	if !ok {
+		return nil, errors.Wrapf(errNotFound, "path %s", "."+strings.Join(s.path, "."))
+	}
+	return &value, nil
+}
+
+// Set set the string value in the path.
+func (s *String) Set(obj *unstructured.Unstructured, value string) error {
+	if err := unstructured.SetNestedField(obj.UnstructuredContent(), value, s.path...); err != nil {
+		return errors.Wrapf(err, "failed to set path %s of object %v", "."+strings.Join(s.path, "."), obj.GroupVersionKind())
+	}
+	return nil
+}

--- a/controllers/topology/internal/scope/scope.go
+++ b/controllers/topology/internal/scope/scope.go
@@ -30,6 +30,9 @@ type Scope struct {
 
 	// Desired holds the desired state of the managed topology.
 	Desired *ClusterState
+
+	// UpgradeTracker holds information about ongoing upgrades in the managed topology.
+	UpgradeTracker *UpgradeTracker
 }
 
 // New returns a new Scope with only the cluster; while processing a request in the topology/ClusterReconciler controller
@@ -40,5 +43,6 @@ func New(cluster *clusterv1.Cluster) *Scope {
 		Current: &ClusterState{
 			Cluster: cluster,
 		},
+		UpgradeTracker: NewUpgradeTracker(),
 	}
 }

--- a/controllers/topology/internal/scope/upgradetracker.go
+++ b/controllers/topology/internal/scope/upgradetracker.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+const maxMachineDeploymentUpgradeConcurrency = 1
+
+// UpgradeTracker is a helper to capture the upgrade status and make upgrade decisions.
+type UpgradeTracker struct {
+	MachineDeployments MachineDeploymentUpgradeTracker
+}
+
+// MachineDeploymentUpgradeTracker holds the current upgrade status and makes upgrade
+// decisions for MachineDeployments.
+type MachineDeploymentUpgradeTracker struct {
+	names sets.String
+}
+
+// NewUpgradeTracker returns an upgrade tracker with empty tracking information.
+func NewUpgradeTracker() *UpgradeTracker {
+	return &UpgradeTracker{
+		MachineDeployments: MachineDeploymentUpgradeTracker{
+			names: sets.NewString(),
+		},
+	}
+}
+
+// Insert adds name to the set of MachineDeployments that will be upgraded.
+func (m *MachineDeploymentUpgradeTracker) Insert(name string) {
+	m.names.Insert(name)
+}
+
+// AllowUpgrade returns true if a MachineDeployment is allowed to upgrade,
+// returns false otherwise.
+func (m *MachineDeploymentUpgradeTracker) AllowUpgrade() bool {
+	return m.names.Len() < maxMachineDeploymentUpgradeConcurrency
+}

--- a/internal/testtypes/builders.go
+++ b/internal/testtypes/builders.go
@@ -422,6 +422,7 @@ type ControlPlaneBuilder struct {
 	name                          string
 	infrastructureMachineTemplate *unstructured.Unstructured
 	specFields                    map[string]interface{}
+	statusFields                  map[string]interface{}
 }
 
 // NewControlPlaneBuilder returns a ControlPlaneBuilder with the given name and Namespace.
@@ -438,6 +439,32 @@ func (f *ControlPlaneBuilder) WithInfrastructureMachineTemplate(t *unstructured.
 	return f
 }
 
+// WithSpecFields sets a map of spec fields on the unstructured object. The keys in the map represent the path and the value corresponds
+// to the value of the spec field.
+//
+// Note: all the paths should start with "spec."
+//
+// Example map: map[string]interface{}{
+//     "spec.version": "v1.2.3",
+// }.
+func (f *ControlPlaneBuilder) WithSpecFields(m map[string]interface{}) *ControlPlaneBuilder {
+	f.specFields = m
+	return f
+}
+
+// WithStatusFields sets a map of status fields on the unstructured object. The keys in the map represent the path and the value corresponds
+// to the value of the status field.
+//
+// Note: all the paths should start with "status."
+//
+// Example map: map[string]interface{}{
+//     "status.version": "v1.2.3",
+// }.
+func (f *ControlPlaneBuilder) WithStatusFields(m map[string]interface{}) *ControlPlaneBuilder {
+	f.statusFields = m
+	return f
+}
+
 // Build generates an Unstructured object from the information passed to the ControlPlaneBuilder.
 func (f *ControlPlaneBuilder) Build() *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
@@ -447,6 +474,7 @@ func (f *ControlPlaneBuilder) Build() *unstructured.Unstructured {
 	obj.SetName(f.name)
 
 	setSpecFields(obj, f.specFields)
+	setStatusFields(obj, f.statusFields)
 
 	if f.infrastructureMachineTemplate != nil {
 		// TODO(killianmuldoon): Update to use the internal/contract package
@@ -463,8 +491,11 @@ type MachineDeploymentBuilder struct {
 	name                   string
 	bootstrapTemplate      *unstructured.Unstructured
 	infrastructureTemplate *unstructured.Unstructured
+	version                *string
 	replicas               *int32
+	generation             *int64
 	labels                 map[string]string
+	status                 *clusterv1.MachineDeploymentStatus
 }
 
 // NewMachineDeploymentBuilder creates a MachineDeploymentBuilder with the given name and namespace.
@@ -493,9 +524,28 @@ func (m *MachineDeploymentBuilder) WithLabels(labels map[string]string) *Machine
 	return m
 }
 
+// WithVersion sets the passed version on the machine deployment spec.
+func (m *MachineDeploymentBuilder) WithVersion(version string) *MachineDeploymentBuilder {
+	m.version = &version
+	return m
+}
+
 // WithReplicas sets the number of replicas for the MachineDeploymentClassBuilder.
-func (m *MachineDeploymentBuilder) WithReplicas(replicas *int32) *MachineDeploymentBuilder {
-	m.replicas = replicas
+func (m *MachineDeploymentBuilder) WithReplicas(replicas int32) *MachineDeploymentBuilder {
+	m.replicas = &replicas
+	return m
+}
+
+// WithGeneration sets the passed value on the machine deployments object metadata.
+func (m *MachineDeploymentBuilder) WithGeneration(generation int64) *MachineDeploymentBuilder {
+	m.generation = &generation
+	return m
+}
+
+// WithStatus sets the passed status object as the status of the machine deployment object.
+// TODO (killianmuldoon): Revise making this method consistent with WithSpec fields in objectbuilders.
+func (m *MachineDeploymentBuilder) WithStatus(status clusterv1.MachineDeploymentStatus) *MachineDeploymentBuilder {
+	m.status = &status
 	return m
 }
 
@@ -512,12 +562,21 @@ func (m *MachineDeploymentBuilder) Build() *clusterv1.MachineDeployment {
 			Labels:    m.labels,
 		},
 	}
+	if m.generation != nil {
+		obj.Generation = *m.generation
+	}
+	if m.version != nil {
+		obj.Spec.Template.Spec.Version = m.version
+	}
 	obj.Spec.Replicas = m.replicas
 	if m.bootstrapTemplate != nil {
 		obj.Spec.Template.Spec.Bootstrap.ConfigRef = objToRef(m.bootstrapTemplate)
 	}
 	if m.infrastructureTemplate != nil {
 		obj.Spec.Template.Spec.InfrastructureRef = *objToRef(m.infrastructureTemplate)
+	}
+	if m.status != nil {
+		obj.Status = *m.status
 	}
 	return obj
 }
@@ -553,6 +612,21 @@ func setSpecFields(obj *unstructured.Unstructured, fields map[string]interface{}
 		}
 		if fieldParts[0] != "spec" {
 			panic(fmt.Errorf("can not set fields outside spec"))
+		}
+		if err := unstructured.SetNestedField(obj.UnstructuredContent(), v, strings.Split(k, ".")...); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func setStatusFields(obj *unstructured.Unstructured, fields map[string]interface{}) {
+	for k, v := range fields {
+		fieldParts := strings.Split(k, ".")
+		if len(fieldParts) == 0 {
+			panic(fmt.Errorf("fieldParts invalid"))
+		}
+		if fieldParts[0] != "status" {
+			panic(fmt.Errorf("can not set fields outside status"))
 		}
 		if err := unstructured.SetNestedField(obj.UnstructuredContent(), v, strings.Split(k, ".")...); err != nil {
 			panic(err)

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -175,10 +175,10 @@ func (v buildIdentifier) compare(o buildIdentifier) int {
 
 // CompareWithBuildIdentifiers compares 2 version a and b.
 // Perfoms a standard version compare between a and b. If the versions
-// are equal build identifiers will be used to compare further.
-// -1 == a is less than b.
-// 0 == a is equal to b.
-// 1 == a is greater than b.
+// are equal, build identifiers will be used to compare further.
+//   -1 == a is less than b.
+//   0 == a is equal to b.
+//   1 == a is greater than b.
 func CompareWithBuildIdentifiers(a semver.Version, b semver.Version) int {
 	if comp := a.Compare(b); comp != 0 {
 		return comp


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds upgrade support to managed topologies.

Upgrading the control plane follows these rules:
* Upgrade only if the control plane and none of the machine deployments are upgrading
* Do not allow downgrades

Upgrading the machine deployment follows these rules:
* Upgrade only one machine deployment at a time
* Upgrade only if none of the machine deployments and the control plane are upgrading.
* Do not upgrade if the control plane is about to upgrade i.e., the control plane is stable for now but its version is about to change.
* Do not allow downgrades

Some of the assumptions made for the initial implementation :
* No additional changes are made to the cluster or the clusterclass when dealing with the version change.

The upgrade flow was manually tested with the following files:
* https://gist.github.com/ykakarap/7c89769ab87ac34cf62550c5102cd125
  * clsuterclass.yaml - Cluster Class definition
  * cluster.yaml - Cluster definition with v1.21.2
  * cluster2.yaml - Cluster definition with upgraded version (v1.22.0)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5016
