### PR TITLE
:bug: [e2e framework] Avoid NPE when KCP does not specify ClusterConfiguration

### DIFF
--- a/test/framework/controlplane_helpers.go
+++ b/test/framework/controlplane_helpers.go
@@ -300,6 +300,12 @@ func UpgradeControlPlaneAndWaitForUpgrade(ctx context.Context, input UpgradeCont
 	Expect(err).ToNot(HaveOccurred())
 
 	input.ControlPlane.Spec.Version = input.KubernetesUpgradeVersion
+
+	// If the ClusterConfiguration is not specified, create an empty one.
+	if input.ControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
+		input.ControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration = new(bootstrapv1.ClusterConfiguration)
+	}
+
 	input.ControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd = bootstrapv1.Etcd{
 		Local: &bootstrapv1.LocalEtcd{
 			ImageMeta: bootstrapv1.ImageMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

KubeadmControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration is not a required field, avoid assuming it is set in the e2e framework.
