### PR TITLE
:bug:  Allow move cmd idempotent by making it tolerant to a known kubernetes issue

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -735,6 +735,12 @@ func (o *objectMover) createTargetObject(nodeToCreate *node, toProxy Proxy) erro
 	// Rebuild the owne reference chain
 	o.buildOwnerChain(obj, nodeToCreate)
 
+	// FIXME Workaround for https://github.com/kubernetes/kubernetes/issues/32220. Remove when the issue is fixed.
+	// If the resource already exists, the API server ordinarily returns an AlreadyExists error. Due to the above issue, if the resource has a non-empty metadata.generateName field, the API server returns a ServerTimeoutError. To ensure that the API server returns an AlreadyExists error, we set the metadata.generateName field to an empty string.
+	if len(obj.GetName()) > 0 && len(obj.GetGenerateName()) > 0 {
+		obj.SetGenerateName("")
+	}
+
 	// Creates the targetObj into the target management cluster.
 	cTo, err := toProxy.NewClient()
 	if err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:
More details found in slack: https://kubernetes.slack.com/archives/C8TSNPY4T/p1630421115076500

The move function is not idempotent because currently the Kubernetes apiserver returns a ServerTimoutError for those objects whose metadata has the generateName flag. This can be verified by creating a resource with this flag, and then trying to `create -f` the file again with the same name in place. 

This is a known Kubernetes issue https://github.com/kubernetes/kubernetes/issues/32220

Until a fix is in place, we propose this solution which would allow the move function to be idempotent and handle these kind of objects without tossing an unexpected error.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
