### PR TITLE
🐛  KCP: stop reconciling ObjectMeta into the KCP machine template

### DIFF
--- a/controlplane/kubeadm/internal/cluster_labels.go
+++ b/controlplane/kubeadm/internal/cluster_labels.go
@@ -23,9 +23,12 @@ import (
 
 // ControlPlaneMachineLabelsForCluster returns a set of labels to add to a control plane machine for this specific cluster.
 func ControlPlaneMachineLabelsForCluster(kcp *controlplanev1.KubeadmControlPlane, clusterName string) map[string]string {
-	labels := kcp.Spec.MachineTemplate.ObjectMeta.Labels
-	if labels == nil {
-		labels = map[string]string{}
+	labels := map[string]string{}
+
+	// Add the labels from the MachineTemplate.
+	// Note: we intentionally don't use the map directly to ensure we don't modify the map in KCP.
+	for k, v := range kcp.Spec.MachineTemplate.ObjectMeta.Labels {
+		labels[k] = v
 	}
 
 	// Always force these labels over the ones coming from the spec.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The intention of the KCP code is to propagate the ObjectMeta from `kcp.Spec.MachineTemplate.ObjectMeta` to the control plane machines. 

During the machine generation we add a few additional labels/annotations. Unfortunately, we used *same* map from KCP to add the labels/annotations. So while we wanted to calculate labels/annotations for a new machine we also modified the in-memory ObjectMeta of `kcp.Spec.MachineTemplate.ObjectMeta`. Later on KCP was automatically patched a few layers above in the call stack. 

This PR makes sure we copy the labels/annotations into a new map.

Note: 
* this bug only occurred when `kcp.Spec.MachineTemplate.ObjectMeta.{labels,annotations}` was set. It then lead to an additional rollout, i.e. when creating a new KCP a new machine was created and automatically replaced by another new machine.
* tested locally with quickstart (+ using labels/annotations) > no additional reconcile, no `kcp.Spec.MachineTemplate.ObjectMeta` "reconciliation"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
