### PR TITLE
🌱 Add GitHub Action to automate creating a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: release
+
+jobs:
+  build:
+    name: create draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env
+        run:  echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
+      - name: checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+      - name: generate release artifacts
+        run: |
+          make release
+      - name: generate release notes
+        run: |
+          make release-notes
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: out/*
+          body_path: _releasenotes/${{ env.RELEASE_TAG }}.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 cmd/clusterctl/clusterctl
 bin
 hack/tools/bin
-out
 
 # Test binary, build with `go test -c`
 *.test
@@ -67,3 +66,7 @@ clusterctl-settings.json
 
 # test results
 _artifacts
+
+#release artifacts
+out
+_releasenotes

--- a/Makefile
+++ b/Makefile
@@ -484,13 +484,19 @@ set-manifest-image:
 ## --------------------------------------
 
 ## latest git tag for the commit, e.g., v0.3.10
-RELEASE_TAG := $(shell git describe --abbrev=0 2>/dev/null)
+RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
+# the previous release tag, e.g., v0.3.9, excluding pre-release tags
+PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | sort -V | grep -B1 $(RELEASE_TAG) | head -n 1 2>/dev/null)
 ## set by Prow, ref name of the base branch, e.g., master
 RELEASE_ALIAS_TAG := $(PULL_BASE_REF)
 RELEASE_DIR := out
+RELEASE_NOTES_DIR := _releasenotes
 
 $(RELEASE_DIR):
 	mkdir -p $(RELEASE_DIR)/
+
+$(RELEASE_NOTES_DIR):
+	mkdir -p $(RELEASE_NOTES_DIR)/
 
 .PHONY: release
 release: clean-release ## Builds and push container images using the latest git tag for the commit.
@@ -586,6 +592,10 @@ release-alias-tag: ## Adds the tag to the last build tag.
 	gcloud container images add-tag $(CONTROLLER_IMG):$(TAG) $(CONTROLLER_IMG):$(RELEASE_ALIAS_TAG)
 	gcloud container images add-tag $(KUBEADM_BOOTSTRAP_CONTROLLER_IMG):$(TAG) $(KUBEADM_BOOTSTRAP_CONTROLLER_IMG):$(RELEASE_ALIAS_TAG)
 	gcloud container images add-tag $(KUBEADM_CONTROL_PLANE_CONTROLLER_IMG):$(TAG) $(KUBEADM_CONTROL_PLANE_CONTROLLER_IMG):$(RELEASE_ALIAS_TAG)
+
+.PHONY: release-notes
+release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
+	go run ./hack/tools/release/notes.go --from=$(PREVIOUS_TAG) > $(RELEASE_NOTES_DIR)/$(RELEASE_TAG).md
 
 ## --------------------------------------
 ## Cleanup / Verification

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -60,20 +60,17 @@ For version v0.x.y:
    > NOTE: To use your GPG signature when pushing the tag, use `git tag -s [...]` instead)
    - `git tag -a v0.x.y -m v0.x.y`
    - `git tag test/v0.x.y` (:warning: MUST NOT be an annotated tag)
-1. Push the tag to the GitHub repository
+1. Push the tag to the GitHub repository. This will automatically trigger a [Github Action](https://github.com/kubernetes-sigs/cluster-api/actions) to create a draft release.
    > NOTE: `origin` should be the name of the remote pointing to `github.com/kubernetes-sigs/cluster-api`
    - `git push origin v0.x.y`
    - `git push origin test/v0.x.y`
-1. Run `make release` to build artifacts (the image is automatically built by CI)
 1. Follow the [Image Promotion process](https://git.k8s.io/k8s.io/k8s.gcr.io#image-promoter) to promote the image from the staging repo to `k8s.gcr.io/cluster-api`
-1. Create a release in GitHub based on the tag created above
-1. Release notes can be created by running `go run ./hack/tools/release/notes.go --from=<PREV_VERSION>`, which will generate an output that can be copied to the drafted release in GitHub.
-   Pay close attention to the `## :question: Sort these by hand` section, as it contains items that need to be manually sorted.
+1. Review the draft release on GitHub. Pay close attention to the `## :question: Sort these by hand` section, as it contains items that need to be manually sorted.
+1. Publish the release
 
 ### Permissions
 
 Releasing requires a particular set of permissions.
 
-* Push access to the staging gcr bucket
 * Tag push access to the GitHub repository
 * GitHub Release creation access

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -211,7 +211,7 @@ set-manifest-pull-policy:
 ## Release
 ## --------------------------------------
 
-RELEASE_TAG := $(shell git describe --abbrev=0 2>/dev/null)
+RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
 RELEASE_ALIAS_TAG ?= $(PULL_BASE_REF)
 RELEASE_DIR := out
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This is part 1 of automating our release process. It adds a GH action for creating the draft release with release notes and generated artifacts on GitHub when a tag is pushed.

Tested on my fork: https://github.com/CecileRobertMichon/cluster-api/actions/runs/1192045111
Resulting draft release: https://github.com/CecileRobertMichon/cluster-api/releases/tag/untagged-88e1db0cbb70a7f9fe19

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
