### PR TITLE
🐛  Implement template deletion for topology-owned MD and MS

### DIFF
--- a/api/v1alpha4/machinedeployment_types.go
+++ b/api/v1alpha4/machinedeployment_types.go
@@ -21,6 +21,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	// MachineDeploymentTopologyFinalizer is the finalizer used by the topology MachineDeployment controller to
+	// clean up referenced template resources if necessary when a MachineDeployment is being deleted.
+	MachineDeploymentTopologyFinalizer = "machinedeployment.topology.cluster.x-k8s.io"
+)
+
 // MachineDeploymentStrategyType defines the type of MachineDeployment rollout strategies.
 type MachineDeploymentStrategyType string
 

--- a/api/v1alpha4/machineset_types.go
+++ b/api/v1alpha4/machineset_types.go
@@ -24,6 +24,12 @@ import (
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 
+const (
+	// MachineSetTopologyFinalizer is the finalizer used by the topology MachineDeployment controller to
+	// clean up referenced template resources if necessary when a MachineSet is being deleted.
+	MachineSetTopologyFinalizer = "machineset.topology.cluster.x-k8s.io"
+)
+
 // ANCHOR: MachineSetSpec
 
 // MachineSetSpec defines the desired state of MachineSet.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,7 +66,14 @@ rules:
   - cluster.x-k8s.io
   resources:
   - clusterclasses
-  - machinedeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
   verbs:
   - get
   - list
@@ -93,6 +100,29 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/finalizers
+  verbs:
   - get
   - list
   - patch
@@ -161,6 +191,25 @@ rules:
   - delete
   - get
   - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  - machinesets/finalizers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - cluster.x-k8s.io

--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -50,6 +50,19 @@ func Get(ctx context.Context, c client.Client, ref *corev1.ObjectReference, name
 	return obj, nil
 }
 
+// Delete uses the client and reference to delete an external, unstructured object.
+func Delete(ctx context.Context, c client.Client, ref *corev1.ObjectReference) error {
+	obj := new(unstructured.Unstructured)
+	obj.SetAPIVersion(ref.APIVersion)
+	obj.SetKind(ref.Kind)
+	obj.SetName(ref.Name)
+	obj.SetNamespace(ref.Namespace)
+	if err := c.Delete(ctx, obj); err != nil {
+		return errors.Wrapf(err, "failed to delete %s external object %q/%q", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+	}
+	return nil
+}
+
 // CloneTemplateInput is the input to CloneTemplate.
 type CloneTemplateInput struct {
 	// Client is the controller runtime client.

--- a/controllers/topology/cluster_controller.go
+++ b/controllers/topology/cluster_controller.go
@@ -39,7 +39,8 @@ import (
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io;controlplane.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusterclasses;machinedeployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusterclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 
 // ClusterReconciler reconciles a managed topology for a Cluster object.
@@ -57,7 +58,7 @@ type ClusterReconciler struct {
 func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.Cluster{}).
-		Named("cluster/topology").
+		Named("topology/cluster").
 		Watches(
 			&source.Kind{Type: &clusterv1.ClusterClass{}},
 			handler.EnqueueRequestsFromMapFunc(r.clusterClassToCluster),

--- a/controllers/topology/desired_state.go
+++ b/controllers/topology/desired_state.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
 	tlog "sigs.k8s.io/cluster-api/controllers/topology/internal/log"
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/scope"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // computeDesiredState computes the desired state of the cluster topology.
@@ -299,6 +300,13 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, machineDeployme
 				},
 			},
 		},
+	}
+
+	// If it's a new MachineDeployment, set the finalizer.
+	// Note: we only add it on creation to avoid race conditions later on when
+	// the MachineDeployment topology controller removes the finalizer.
+	if currentMachineDeployment == nil {
+		controllerutil.AddFinalizer(desiredMachineDeploymentObj, clusterv1.MachineDeploymentTopologyFinalizer)
 	}
 
 	// If an existing MachineDeployment is present, override the MachineDeployment generate name

--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/cluster-api/internal/testtypes"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -512,6 +513,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 
 		g.Expect(actualMd.Labels).To(HaveKeyWithValue(clusterv1.ClusterTopologyMachineDeploymentLabelName, "big-pool-of-machines"))
 		g.Expect(actualMd.Labels).To(HaveKey(clusterv1.ClusterTopologyOwnedLabel))
+		g.Expect(controllerutil.ContainsFinalizer(actualMd, clusterv1.MachineDeploymentTopologyFinalizer)).To(BeTrue())
 
 		g.Expect(actualMd.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue("foo", "baz"))
 		g.Expect(actualMd.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue("fizz", "buzz"))
@@ -559,6 +561,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 
 		g.Expect(actualMd.Labels).To(HaveKeyWithValue(clusterv1.ClusterTopologyMachineDeploymentLabelName, "big-pool-of-machines"))
 		g.Expect(actualMd.Labels).To(HaveKey(clusterv1.ClusterTopologyOwnedLabel))
+		g.Expect(controllerutil.ContainsFinalizer(actualMd, clusterv1.MachineDeploymentTopologyFinalizer)).To(BeFalse())
 
 		g.Expect(actualMd.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue("foo", "baz"))
 		g.Expect(actualMd.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue("fizz", "buzz"))

--- a/controllers/topology/internal/log/log.go
+++ b/controllers/topology/internal/log/log.go
@@ -47,6 +47,10 @@ type Logger interface {
 	// a resources being part of the Cluster by reconciled.
 	WithObject(obj client.Object) Logger
 
+	// WithRef adds to the logger information about the object ref being modified by reconcile, which in most case it is
+	// a resources being part of the Cluster by reconciled.
+	WithRef(ref *corev1.ObjectReference) Logger
+
 	// WithMachineDeployment adds to the logger information about the MachineDeployment object being processed.
 	WithMachineDeployment(md *clusterv1.MachineDeployment) Logger
 
@@ -76,6 +80,17 @@ func (l *topologyReconcileLogger) WithObject(obj client.Object) Logger {
 		"object groupVersion", obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
 		"object kind", obj.GetObjectKind().GroupVersionKind().Kind,
 		"object", obj.GetName(),
+	)
+	return l
+}
+
+// WithRef adds to the logger information about the object ref being modified by reconcile, which in most case it is
+// a resources being part of the Cluster by reconciled.
+func (l *topologyReconcileLogger) WithRef(ref *corev1.ObjectReference) Logger {
+	l.Logger = l.Logger.WithValues(
+		"object groupVersion", ref.APIVersion,
+		"object kind", ref.Kind,
+		"object", ref.Name,
 	)
 	return l
 }

--- a/controllers/topology/machinedeployment_controller.go
+++ b/controllers/topology/machinedeployment_controller.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	tlog "sigs.k8s.io/cluster-api/controllers/topology/internal/log"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io,resources=*,verbs=delete
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments;machinedeployments/finalizers,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets,verbs=get;list;watch
+
+// MachineDeploymentReconciler deletes referenced templates during deletion of topology-owned MachineDeployments.
+// The templates are only deleted, if they are not used in other MachineDeployments or MachineSets which are not in deleting state,
+// i.e. the templates would otherwise be orphaned after the MachineDeployment deletion completes.
+// Note: To achieve this the cluster topology controller sets a finalizer to hook into the MachineDeployment deletions.
+type MachineDeploymentReconciler struct {
+	Client client.Client
+	// APIReader is used to list MachineSets directly via the API server to avoid
+	// race conditions caused by an outdated cache.
+	APIReader        client.Reader
+	WatchFilterValue string
+}
+
+func (r *MachineDeploymentReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.MachineDeployment{}).
+		Named("topology/machinedeployment").
+		WithOptions(options).
+		WithEventFilter(predicates.All(ctrl.LoggerFrom(ctx),
+			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+			predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx)),
+		)).
+		Complete(r)
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+
+	return nil
+}
+
+// Reconcile deletes referenced templates during deletion of topology-owned MachineDeployments.
+// The templates are only deleted, if they are not used in other MachineDeployments or MachineSets which are not in deleting state,
+// i.e. the templates would otherwise be orphaned after the MachineDeployment deletion completes.
+// Additional context:
+// * MachineDeployment deletion:
+//   * MachineDeployments are deleted and garbage collected first (without waiting until all MachineSets are also deleted).
+//   * After that, deletion of MachineSets is automatically triggered by Kubernetes based on owner references.
+// Note: We assume templates are not reused by different MachineDeployments, which is only true for topology-owned
+//       MachineDeployments.
+// We don't have to set the finalizer, as it's already set during MachineDeployment creation
+// in the cluster topology controller.
+func (r *MachineDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Fetch the MachineDeployment instance.
+	md := &clusterv1.MachineDeployment{}
+	if err := r.Client.Get(ctx, req.NamespacedName, md); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Object not found, return.
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, errors.Wrapf(err, "failed to get MachineDeployment/%s", req.NamespacedName.Name)
+	}
+
+	cluster, err := util.GetClusterByName(ctx, r.Client, md.Namespace, md.Spec.ClusterName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Return early if the object or Cluster is paused.
+	if annotations.IsPaused(cluster, md) {
+		log.Info("Reconciliation is paused for this object")
+		return ctrl.Result{}, nil
+	}
+
+	// Handle deletion reconciliation loop.
+	if !md.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, md)
+	}
+
+	// Nothing to do.
+	return ctrl.Result{}, nil
+}
+
+// reconcileDelete deletes templates referenced in a MachineDeployment, if the templates are not used by other
+// MachineDeployments or MachineSets.
+func (r *MachineDeploymentReconciler) reconcileDelete(ctx context.Context, md *clusterv1.MachineDeployment) (ctrl.Result, error) {
+	// Get the corresponding MachineSets.
+	msList, err := getMachineSetsForDeployment(ctx, r.APIReader, client.ObjectKeyFromObject(md))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Calculate which templates are still in use by MachineDeployments or MachineSets which are not in deleting state.
+	templatesInUse, err := calculateTemplatesInUse(md, msList)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Delete unused templates.
+	ref := md.Spec.Template.Spec.Bootstrap.ConfigRef
+	if err := deleteTemplateIfUnused(ctx, r.Client, templatesInUse, ref); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to delete bootstrap template for %s", tlog.KObj{Obj: md})
+	}
+	ref = &md.Spec.Template.Spec.InfrastructureRef
+	if err := deleteTemplateIfUnused(ctx, r.Client, templatesInUse, ref); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to delete infrastructure template for %s", tlog.KObj{Obj: md})
+	}
+
+	// Remove the finalizer so the MachineDeployment can be garbage collected by Kubernetes.
+	patchHelper, err := patch.NewHelper(md, r.Client)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to create patch helper for %s", tlog.KObj{Obj: md})
+	}
+	controllerutil.RemoveFinalizer(md, clusterv1.MachineDeploymentTopologyFinalizer)
+	if err := patchHelper.Patch(ctx, md); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to patch %s", tlog.KObj{Obj: md})
+	}
+
+	return ctrl.Result{}, nil
+}

--- a/controllers/topology/machinedeployment_controller_test.go
+++ b/controllers/topology/machinedeployment_controller_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/internal/testtypes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func TestMachineDeploymentReconciler_ReconcileDelete(t *testing.T) {
+	deletionTimeStamp := metav1.Now()
+
+	mdBT := testtypes.NewBootstrapTemplateBuilder(metav1.NamespaceDefault, "mdBT").Build()
+	mdIMT := testtypes.NewInfrastructureMachineTemplateBuilder(metav1.NamespaceDefault, "mdIMT").Build()
+	md := testtypes.NewMachineDeploymentBuilder(metav1.NamespaceDefault, "md").
+		WithBootstrapTemplate(mdBT).
+		WithInfrastructureTemplate(mdIMT).
+		Build()
+	md.SetDeletionTimestamp(&deletionTimeStamp)
+
+	t.Run("Should delete templates of a MachineDeployment", func(t *testing.T) {
+		g := NewWithT(t)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(fakeScheme).
+			WithObjects(md, mdBT, mdIMT).
+			Build()
+
+		r := &MachineDeploymentReconciler{
+			Client:    fakeClient,
+			APIReader: fakeClient,
+		}
+		_, err := r.reconcileDelete(ctx, md)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		afterMD := &clusterv1.MachineDeployment{}
+		g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(md), afterMD)).To(Succeed())
+
+		g.Expect(controllerutil.ContainsFinalizer(afterMD, clusterv1.MachineDeploymentTopologyFinalizer)).To(BeFalse())
+		g.Expect(templateExists(fakeClient, mdBT)).To(BeFalse())
+		g.Expect(templateExists(fakeClient, mdIMT)).To(BeFalse())
+	})
+
+	t.Run("Should delete infra template of a MachineDeployment without a bootstrap template", func(t *testing.T) {
+		g := NewWithT(t)
+
+		mdWithoutBootstrapTemplateIMT := testtypes.NewInfrastructureMachineTemplateBuilder(metav1.NamespaceDefault, "mdWithoutBootstrapTemplateIMT").Build()
+		mdWithoutBootstrapTemplate := testtypes.NewMachineDeploymentBuilder(metav1.NamespaceDefault, "mdWithoutBootstrapTemplate").
+			WithInfrastructureTemplate(mdWithoutBootstrapTemplateIMT).
+			Build()
+		mdWithoutBootstrapTemplate.SetDeletionTimestamp(&deletionTimeStamp)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(fakeScheme).
+			WithObjects(mdWithoutBootstrapTemplate, mdWithoutBootstrapTemplateIMT).
+			Build()
+
+		r := &MachineDeploymentReconciler{
+			Client:    fakeClient,
+			APIReader: fakeClient,
+		}
+		_, err := r.reconcileDelete(ctx, mdWithoutBootstrapTemplate)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		afterMD := &clusterv1.MachineDeployment{}
+		g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(mdWithoutBootstrapTemplate), afterMD)).To(Succeed())
+
+		g.Expect(controllerutil.ContainsFinalizer(afterMD, clusterv1.MachineDeploymentTopologyFinalizer)).To(BeFalse())
+		g.Expect(templateExists(fakeClient, mdWithoutBootstrapTemplateIMT)).To(BeFalse())
+	})
+
+	t.Run("Should not delete templates of a MachineDeployment when they are still in use in a MachineSet", func(t *testing.T) {
+		g := NewWithT(t)
+
+		ms := testtypes.NewMachineSetBuilder(md.Namespace, "ms").
+			WithBootstrapTemplate(mdBT).
+			WithInfrastructureTemplate(mdIMT).
+			WithLabels(map[string]string{
+				clusterv1.MachineDeploymentLabelName: md.Name,
+			}).
+			Build()
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(fakeScheme).
+			WithObjects(md, ms, mdBT, mdIMT).
+			Build()
+
+		r := &MachineDeploymentReconciler{
+			Client:    fakeClient,
+			APIReader: fakeClient,
+		}
+		_, err := r.reconcileDelete(ctx, md)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		afterMD := &clusterv1.MachineDeployment{}
+		g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(md), afterMD)).To(Succeed())
+
+		g.Expect(controllerutil.ContainsFinalizer(afterMD, clusterv1.MachineDeploymentTopologyFinalizer)).To(BeFalse())
+		g.Expect(templateExists(fakeClient, mdBT)).To(BeTrue())
+		g.Expect(templateExists(fakeClient, mdIMT)).To(BeTrue())
+	})
+}
+
+func templateExists(fakeClient client.Reader, template *unstructured.Unstructured) bool {
+	obj := &unstructured.Unstructured{}
+	obj.SetKind(template.GetKind())
+	obj.SetAPIVersion(template.GetAPIVersion())
+
+	err := fakeClient.Get(ctx, client.ObjectKeyFromObject(template), obj)
+	if err != nil && !apierrors.IsNotFound(err) {
+		panic(errors.Wrapf(err, "failed to get %s/%s", template.GetKind(), template.GetName()))
+	}
+	return err == nil
+}

--- a/controllers/topology/machineset_controller.go
+++ b/controllers/topology/machineset_controller.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	tlog "sigs.k8s.io/cluster-api/controllers/topology/internal/log"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io,resources=*,verbs=delete
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinesets;machinesets/finalizers,verbs=get;list;watch;update;patch
+
+// MachineSetReconciler deletes referenced templates during deletion of topology-owned MachineSets.
+// The templates are only deleted, if they are not used in other MachineDeployments or MachineSets which are not in deleting state,
+// i.e. the templates would otherwise be orphaned after the MachineSet deletion completes.
+// Note: To achieve this the reconciler sets a finalizer to hook into the MachineSet deletions.
+type MachineSetReconciler struct {
+	Client client.Client
+	// APIReader is used to list MachineSets directly via the API server to avoid
+	// race conditions caused by an outdated cache.
+	APIReader        client.Reader
+	WatchFilterValue string
+}
+
+func (r *MachineSetReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.MachineSet{}).
+		Named("topology/machineset").
+		WithOptions(options).
+		WithEventFilter(predicates.All(ctrl.LoggerFrom(ctx),
+			predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue),
+			predicates.ResourceIsTopologyOwned(ctrl.LoggerFrom(ctx)),
+		)).
+		Complete(r)
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+
+	return nil
+}
+
+// Reconcile deletes referenced templates during deletion of topology-owned MachineSets.
+// The templates are only deleted, if they are not used in other MachineDeployments or MachineSets which are not in deleting state,
+// i.e. the templates would otherwise be orphaned after the MachineSet deletion completes.
+// Additional context:
+// * MachineSet deletion:
+//   * MachineSets are deleted and garbage collected first (without waiting until all Machines are also deleted)
+//   * After that, deletion of Machines is automatically triggered by Kubernetes based on owner references.
+// Note: We assume templates are not reused by different MachineDeployments, which is (only) true for topology-owned
+//       MachineDeployments.
+// We don't have to set the finalizer, as it's already set during MachineSet creation
+// in the MachineSet controller.
+func (r *MachineSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Fetch the MachineSet instance.
+	ms := &clusterv1.MachineSet{}
+	if err := r.Client.Get(ctx, req.NamespacedName, ms); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Object not found, return.
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, errors.Wrapf(err, "failed to get MachineSet/%s", req.NamespacedName.Name)
+	}
+
+	cluster, err := util.GetClusterByName(ctx, r.Client, ms.Namespace, ms.Spec.ClusterName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Return early if the object or Cluster is paused.
+	if annotations.IsPaused(cluster, ms) {
+		log.Info("Reconciliation is paused for this object")
+		return ctrl.Result{}, nil
+	}
+
+	// Handle deletion reconciliation loop.
+	if !ms.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, ms)
+	}
+
+	// Nothing to do.
+	return ctrl.Result{}, nil
+}
+
+// reconcileDelete deletes templates referenced in a MachineSet, if the templates are not used by other
+// MachineDeployments or MachineSets.
+func (r *MachineSetReconciler) reconcileDelete(ctx context.Context, ms *clusterv1.MachineSet) (ctrl.Result, error) {
+	// Gets the name of the MachineDeployment that controls this MachineSet.
+	mdName, err := getMachineDeploymentName(ms)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Get all the MachineSets for the MachineDeployment.
+	msList, err := getMachineSetsForDeployment(ctx, r.APIReader, *mdName)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Fetch the MachineDeployment instance, if it still exists.
+	// Note: This can happen because MachineDeployments are deleted before their corresponding MachineSets.
+	md := &clusterv1.MachineDeployment{}
+	if err := r.Client.Get(ctx, *mdName, md); err != nil {
+		if !apierrors.IsNotFound(err) {
+			// Error reading the object - requeue the request.
+			return ctrl.Result{}, errors.Wrapf(err, "failed to get MachineDeployment/%s", mdName.Name)
+		}
+		// If the MachineDeployment doesn't exist anymore, set md to nil, so we can handle that case correctly below.
+		md = nil
+	}
+
+	// Calculate which templates are still in use by MachineDeployments or MachineSets which are not in deleting state.
+	templatesInUse, err := calculateTemplatesInUse(md, msList)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Delete unused templates.
+	ref := ms.Spec.Template.Spec.Bootstrap.ConfigRef
+	if err := deleteTemplateIfUnused(ctx, r.Client, templatesInUse, ref); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to delete bootstrap template for %s", tlog.KObj{Obj: ms})
+	}
+	ref = &ms.Spec.Template.Spec.InfrastructureRef
+	if err := deleteTemplateIfUnused(ctx, r.Client, templatesInUse, ref); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to delete infrastructure template for %s", tlog.KObj{Obj: ms})
+	}
+
+	// Remove the finalizer so the MachineSet can be garbage collected by Kubernetes.
+	patchHelper, err := patch.NewHelper(ms, r.Client)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to create patch helper for %s", tlog.KObj{Obj: ms})
+	}
+	controllerutil.RemoveFinalizer(ms, clusterv1.MachineSetTopologyFinalizer)
+	if err := patchHelper.Patch(ctx, ms); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to patch %s", tlog.KObj{Obj: ms})
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// getMachineDeploymentName calculates the MachineDeployment name based on owner references.
+func getMachineDeploymentName(ms *clusterv1.MachineSet) (*types.NamespacedName, error) {
+	for _, ref := range ms.OwnerReferences {
+		if ref.Kind != "MachineDeployment" {
+			continue
+		}
+		gv, err := schema.ParseGroupVersion(ref.APIVersion)
+		if err != nil {
+			return nil, errors.Errorf("could not calculate MachineDeployment name for %s: invalid apiVersion %q: %v",
+				tlog.KObj{Obj: ms}, ref.APIVersion, err)
+		}
+		if gv.Group == clusterv1.GroupVersion.Group {
+			return &client.ObjectKey{Namespace: ms.Namespace, Name: ref.Name}, nil
+		}
+	}
+
+	// Note: Once we set an owner reference to a MachineDeployment in a MachineSet it stays there
+	// and is not deleted when the MachineDeployment is deleted. So we assume there's something wrong,
+	// if we couldn't find a MachineDeployment owner reference.
+	return nil, errors.Errorf("could not calculate MachineDeployment name for %s", tlog.KObj{Obj: ms})
+}

--- a/controllers/topology/machineset_controller_test.go
+++ b/controllers/topology/machineset_controller_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/internal/testtypes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func TestMachineSetReconciler_ReconcileDelete(t *testing.T) {
+	deletionTimeStamp := metav1.Now()
+
+	mdName := "md"
+
+	msBT := testtypes.NewBootstrapTemplateBuilder(metav1.NamespaceDefault, "msBT").Build()
+	msIMT := testtypes.NewInfrastructureMachineTemplateBuilder(metav1.NamespaceDefault, "msIMT").Build()
+	ms := testtypes.NewMachineSetBuilder(metav1.NamespaceDefault, "ms").
+		WithBootstrapTemplate(msBT).
+		WithInfrastructureTemplate(msIMT).
+		WithLabels(map[string]string{
+			clusterv1.MachineDeploymentLabelName: mdName,
+		}).
+		Build()
+	ms.SetDeletionTimestamp(&deletionTimeStamp)
+	ms.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			Kind:       "MachineDeployment",
+			APIVersion: clusterv1.GroupVersion.String(),
+			Name:       "md",
+		},
+	})
+
+	t.Run("Should delete templates of a MachineSet", func(t *testing.T) {
+		g := NewWithT(t)
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(fakeScheme).
+			WithObjects(ms, msBT, msIMT).
+			Build()
+
+		r := &MachineSetReconciler{
+			Client:    fakeClient,
+			APIReader: fakeClient,
+		}
+		_, err := r.reconcileDelete(ctx, ms)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		afterMS := &clusterv1.MachineSet{}
+		g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(ms), afterMS)).To(Succeed())
+
+		g.Expect(controllerutil.ContainsFinalizer(afterMS, clusterv1.MachineSetTopologyFinalizer)).To(BeFalse())
+		g.Expect(templateExists(fakeClient, msBT)).To(BeFalse())
+		g.Expect(templateExists(fakeClient, msIMT)).To(BeFalse())
+	})
+
+	t.Run("Should delete infra template of a MachineSet without a bootstrap template", func(t *testing.T) {
+		g := NewWithT(t)
+
+		msWithoutBootstrapTemplateIMT := testtypes.NewInfrastructureMachineTemplateBuilder(metav1.NamespaceDefault, "msWithoutBootstrapTemplateIMT").Build()
+		msWithoutBootstrapTemplate := testtypes.NewMachineSetBuilder(metav1.NamespaceDefault, "msWithoutBootstrapTemplate").
+			WithInfrastructureTemplate(msWithoutBootstrapTemplateIMT).
+			WithLabels(map[string]string{
+				clusterv1.MachineDeploymentLabelName: mdName,
+			}).
+			Build()
+		msWithoutBootstrapTemplate.SetDeletionTimestamp(&deletionTimeStamp)
+		msWithoutBootstrapTemplate.SetOwnerReferences([]metav1.OwnerReference{
+			{
+				Kind:       "MachineDeployment",
+				APIVersion: clusterv1.GroupVersion.String(),
+				Name:       "md",
+			},
+		})
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(fakeScheme).
+			WithObjects(msWithoutBootstrapTemplate, msWithoutBootstrapTemplateIMT).
+			Build()
+
+		r := &MachineSetReconciler{
+			Client:    fakeClient,
+			APIReader: fakeClient,
+		}
+		_, err := r.reconcileDelete(ctx, msWithoutBootstrapTemplate)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		afterMS := &clusterv1.MachineSet{}
+		g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(msWithoutBootstrapTemplate), afterMS)).To(Succeed())
+
+		g.Expect(controllerutil.ContainsFinalizer(afterMS, clusterv1.MachineSetTopologyFinalizer)).To(BeFalse())
+		g.Expect(templateExists(fakeClient, msWithoutBootstrapTemplateIMT)).To(BeFalse())
+	})
+
+	t.Run("Should not delete templates of a MachineSet when they are still in use in a MachineDeployment", func(t *testing.T) {
+		g := NewWithT(t)
+
+		md := testtypes.NewMachineDeploymentBuilder(metav1.NamespaceDefault, "md").
+			WithBootstrapTemplate(msBT).
+			WithInfrastructureTemplate(msIMT).
+			Build()
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(fakeScheme).
+			WithObjects(md, ms, msBT, msIMT).
+			Build()
+
+		r := &MachineSetReconciler{
+			Client:    fakeClient,
+			APIReader: fakeClient,
+		}
+		_, err := r.reconcileDelete(ctx, ms)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		afterMS := &clusterv1.MachineSet{}
+		g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(ms), afterMS)).To(Succeed())
+
+		g.Expect(controllerutil.ContainsFinalizer(afterMS, clusterv1.MachineSetTopologyFinalizer)).To(BeFalse())
+		g.Expect(templateExists(fakeClient, msBT)).To(BeTrue())
+		g.Expect(templateExists(fakeClient, msIMT)).To(BeTrue())
+	})
+
+	t.Run("Should not delete templates of a MachineSet when they are still in use in another MachineSet", func(t *testing.T) {
+		g := NewWithT(t)
+
+		md := testtypes.NewMachineDeploymentBuilder(metav1.NamespaceDefault, "md").
+			WithBootstrapTemplate(msBT).
+			WithInfrastructureTemplate(msIMT).
+			Build()
+		md.SetDeletionTimestamp(&deletionTimeStamp)
+
+		// anotherMS is another MachineSet of the same MachineDeployment using the same templates.
+		// Because anotherMS is not in deleting, reconcileDelete should not delete the templates.
+		anotherMS := testtypes.NewMachineSetBuilder(metav1.NamespaceDefault, "anotherMS").
+			WithBootstrapTemplate(msBT).
+			WithInfrastructureTemplate(msIMT).
+			WithLabels(map[string]string{
+				clusterv1.MachineDeploymentLabelName: mdName,
+			}).
+			Build()
+		anotherMS.SetOwnerReferences([]metav1.OwnerReference{
+			{
+				Kind:       "MachineDeployment",
+				APIVersion: clusterv1.GroupVersion.String(),
+				Name:       "md",
+			},
+		})
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(fakeScheme).
+			WithObjects(md, anotherMS, ms, msBT, msIMT).
+			Build()
+
+		r := &MachineSetReconciler{
+			Client:    fakeClient,
+			APIReader: fakeClient,
+		}
+		_, err := r.reconcileDelete(ctx, ms)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		afterMS := &clusterv1.MachineSet{}
+		g.Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(ms), afterMS)).To(Succeed())
+
+		g.Expect(controllerutil.ContainsFinalizer(afterMS, clusterv1.MachineSetTopologyFinalizer)).To(BeFalse())
+		g.Expect(templateExists(fakeClient, msBT)).To(BeTrue())
+		g.Expect(templateExists(fakeClient, msIMT)).To(BeTrue())
+	})
+}

--- a/controllers/topology/reconcile_state.go
+++ b/controllers/topology/reconcile_state.go
@@ -206,26 +206,24 @@ func (r *ClusterReconciler) updateMachineDeployment(ctx context.Context, cluster
 	log := tlog.LoggerFrom(ctx).WithMachineDeployment(desiredMD.Object)
 
 	ctx, _ = log.WithObject(desiredMD.InfrastructureMachineTemplate).Into(ctx)
-	_, err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
+	if _, err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
 		ref:                  &desiredMD.Object.Spec.Template.Spec.InfrastructureRef,
 		current:              currentMD.InfrastructureMachineTemplate,
 		desired:              desiredMD.InfrastructureMachineTemplate,
 		templateNamePrefix:   infrastructureMachineTemplateNamePrefix(clusterName, mdTopologyName),
 		compatibilityChecker: check.ReferencedObjectsAreCompatible,
-	})
-	if err != nil {
+	}); err != nil {
 		return errors.Wrapf(err, "failed to update %s", tlog.KObj{Obj: currentMD.Object})
 	}
 
 	ctx, _ = log.WithObject(desiredMD.BootstrapTemplate).Into(ctx)
-	_, err = r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
+	if _, err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
 		ref:                  desiredMD.Object.Spec.Template.Spec.Bootstrap.ConfigRef,
 		current:              currentMD.BootstrapTemplate,
 		desired:              desiredMD.BootstrapTemplate,
 		templateNamePrefix:   bootstrapTemplateNamePrefix(clusterName, mdTopologyName),
 		compatibilityChecker: check.ObjectsAreInTheSameNamespace,
-	})
-	if err != nil {
+	}); err != nil {
 		return errors.Wrapf(err, "failed to update %s", tlog.KObj{Obj: currentMD.Object})
 	}
 

--- a/controllers/topology/util.go
+++ b/controllers/topology/util.go
@@ -22,9 +22,15 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/controllers/external"
+	tlog "sigs.k8s.io/cluster-api/controllers/topology/internal/log"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // bootstrapTemplateNamePrefix calculates the name prefix for a BootstrapTemplate.
@@ -67,4 +73,109 @@ func refToUnstructured(ref *corev1.ObjectReference) *unstructured.Unstructured {
 	uns.SetNamespace(ref.Namespace)
 	uns.SetName(ref.Name)
 	return uns
+}
+
+// getMachineSetsForDeployment returns a list of MachineSets associated with a MachineDeployment.
+func getMachineSetsForDeployment(ctx context.Context, c client.Reader, md types.NamespacedName) ([]*clusterv1.MachineSet, error) {
+	// List MachineSets based on the MachineDeployment label.
+	msList := &clusterv1.MachineSetList{}
+	if err := c.List(ctx, msList,
+		client.InNamespace(md.Namespace), client.MatchingLabels{clusterv1.MachineDeploymentLabelName: md.Name}); err != nil {
+		return nil, errors.Wrapf(err, "failed to list MachineSets for MachineDeployment/%s", md.Name)
+	}
+
+	// Copy the MachineSets to an array of MachineSet pointers, to avoid MachineSet copying later.
+	res := make([]*clusterv1.MachineSet, 0, len(msList.Items))
+	for i := range msList.Items {
+		res = append(res, &msList.Items[i])
+	}
+	return res, nil
+}
+
+// calculateTemplatesInUse returns all templates referenced in non-deleting MachineDeployment and MachineSets.
+func calculateTemplatesInUse(md *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) (map[string]bool, error) {
+	templatesInUse := map[string]bool{}
+
+	// Templates of the MachineSet are still in use if the MachineSet is not in deleting state.
+	for _, ms := range msList {
+		if !ms.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		bootstrapRef := ms.Spec.Template.Spec.Bootstrap.ConfigRef
+		infrastructureRef := &ms.Spec.Template.Spec.InfrastructureRef
+		if err := addTemplateRef(templatesInUse, bootstrapRef, infrastructureRef); err != nil {
+			return nil, errors.Wrapf(err, "failed to add templates of %s to templatesInUse", tlog.KObj{Obj: ms})
+		}
+	}
+
+	// If MachineDeployment has already been deleted or still exists and is in deleting state, then there
+	// are no templates referenced in the MachineDeployment which are still in use, so let's return here.
+	if md == nil || !md.DeletionTimestamp.IsZero() {
+		return templatesInUse, nil
+	}
+
+	//  Otherwise, the templates of the MachineDeployment are still in use.
+	bootstrapRef := md.Spec.Template.Spec.Bootstrap.ConfigRef
+	infrastructureRef := &md.Spec.Template.Spec.InfrastructureRef
+	if err := addTemplateRef(templatesInUse, bootstrapRef, infrastructureRef); err != nil {
+		return nil, errors.Wrapf(err, "failed to add templates of %s to templatesInUse", tlog.KObj{Obj: md})
+	}
+	return templatesInUse, nil
+}
+
+// deleteTemplateIfUnused deletes the template (ref), if it is not in use (i.e. in templatesInUse).
+func deleteTemplateIfUnused(ctx context.Context, c client.Client, templatesInUse map[string]bool, ref *corev1.ObjectReference) error {
+	// If ref is nil, do nothing (this can happen, because bootstrap templates are optional).
+	if ref == nil {
+		return nil
+	}
+
+	log := tlog.LoggerFrom(ctx).WithRef(ref)
+
+	refID, err := templateRefID(ref)
+	if err != nil {
+		return errors.Wrapf(err, "failed to calculate templateRefID")
+	}
+
+	// If the template is still in use, do nothing.
+	if templatesInUse[refID] {
+		log.V(3).Infof("Not deleting %s, because it's still in use", tlog.KRef{Ref: ref})
+		return nil
+	}
+
+	log.Infof("Deleting %s", tlog.KRef{Ref: ref})
+	if err := external.Delete(ctx, c, ref); err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to delete %s", tlog.KRef{Ref: ref})
+	}
+	return nil
+}
+
+// addTemplateRef adds the refs to the refMap with the templateRefID as key.
+func addTemplateRef(refMap map[string]bool, refs ...*corev1.ObjectReference) error {
+	for _, ref := range refs {
+		if ref != nil {
+			refID, err := templateRefID(ref)
+			if err != nil {
+				return errors.Wrapf(err, "failed to calculate templateRefID")
+			}
+			refMap[refID] = true
+		}
+	}
+	return nil
+}
+
+// templateRefID returns the templateRefID of a ObjectReference in the format: g/k/name.
+// Note: We don't include the version as references with different versions should be treated as equal.
+func templateRefID(ref *corev1.ObjectReference) (string, error) {
+	if ref == nil {
+		return "", nil
+	}
+
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse apiVersion %q", ref.APIVersion)
+	}
+
+	return fmt.Sprintf("%s/%s/%s", gv.Group, ref.Kind, ref.Name), nil
 }

--- a/main.go
+++ b/main.go
@@ -284,6 +284,24 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 			setupLog.Error(err, "unable to create controller", "controller", "ClusterTopology")
 			os.Exit(1)
 		}
+
+		if err := (&topology.MachineDeploymentReconciler{
+			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
+			WatchFilterValue: watchFilterValue,
+		}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "MachineDeploymentTopology")
+			os.Exit(1)
+		}
+
+		if err := (&topology.MachineSetReconciler{
+			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
+			WatchFilterValue: watchFilterValue,
+		}).SetupWithManager(ctx, mgr, controller.Options{}); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "MachineSetTopology")
+			os.Exit(1)
+		}
 	}
 	if err := (&controllers.ClusterReconciler{
 		Client:           mgr.GetClient(),

--- a/util/labels/helpers.go
+++ b/util/labels/helpers.go
@@ -22,6 +22,12 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 )
 
+// IsTopologyOwned returns true if the object has the `topology.cluster.x-k8s.io/owned` label.
+func IsTopologyOwned(o metav1.Object) bool {
+	_, ok := o.GetLabels()[clusterv1.ClusterTopologyOwnedLabel]
+	return ok
+}
+
 // HasWatchLabel returns true if the object has a label with the WatchLabel key matching the given value.
 func HasWatchLabel(o metav1.Object, labelValue string) bool {
 	val, ok := o.GetLabels()[clusterv1.WatchLabel]

--- a/util/util.go
+++ b/util/util.go
@@ -176,7 +176,7 @@ func GetClusterByName(ctx context.Context, c client.Client, namespace, name stri
 	}
 
 	if err := c.Get(ctx, key, cluster); err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to get Cluster/%s", name)
 	}
 
 	return cluster, nil


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Before this PR, our topology code:
* deleted "old" templates after template rotation of MachineDeployments immediately
  * thus reconciliation of the old MachineSets was immediately broken as the MachineSet controller requires the templates
* didn't delete corresponding templates when deleting MachineDeployments

This PR aims to solve this problem. The high-level concept is:
* topology code doesn't delete templates in "successful" reconciles (template rotation without errors / MachineDeployment deletions)
  * Note: we will have to introduce another separate mechanism which cleans up templates when the template rotation fails (e.g. new templates were never referenced in any MachineDeployment or MachineSet)
* we add new MD and MS topology reconcilers which on MD/MS delete: 
  * calculate which templates are still used by MachineDeployments or MachineSets not in deleting
  * deletes unused templates
 
Note: this is only done for topology-owned  MD and MS

tl;dr we cleanup templates which would otherwise be orphaned during deletion of topology-owned MachineDeployments and MachineSets

I tested the following locally: 
* rotate infra/bootstrap templates in MDs and ensure old templates are properly deleted
* delete MDs and ensure old templates are properly deleted

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
