### PR TITLE
✨Add option for in-cluster client in clusterctl

### DIFF
--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -47,6 +47,8 @@ type Kubeconfig struct {
 	// Specify context within the kubeconfig file. If empty, cluster client
 	// will use the current context.
 	Context string
+	// InCluster if true, incluster config will be created
+	InCluster bool
 }
 
 // Client is used to interact with a management cluster.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Add ability to use the in-cluster client in clusterctl. This will be useful for operator when clusterctl code runs in a container inside a cluster.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
