### PR TITLE
🌱 Add ClusterTopologyMachineDeploymentLabelName to MachineDeployment templates

### DIFF
--- a/controllers/topology/desired_state.go
+++ b/controllers/topology/desired_state.go
@@ -236,6 +236,14 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, machineDeployme
 		currentObjectRef:      currentBootstrapTemplateRef,
 	})
 
+	bootstrapTemplateLabels := desiredMachineDeployment.BootstrapTemplate.GetLabels()
+	if bootstrapTemplateLabels == nil {
+		bootstrapTemplateLabels = map[string]string{}
+	}
+	// Add ClusterTopologyMachineDeploymentLabel to the generated Bootstrap template
+	bootstrapTemplateLabels[clusterv1.ClusterTopologyMachineDeploymentLabelName] = machineDeploymentTopology.Name
+	desiredMachineDeployment.BootstrapTemplate.SetLabels(bootstrapTemplateLabels)
+
 	// Compute the Infrastructure template.
 	var currentInfraMachineTemplateRef *corev1.ObjectReference
 	if currentMachineDeployment != nil && currentMachineDeployment.InfrastructureMachineTemplate != nil {
@@ -248,6 +256,14 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, machineDeployme
 		namePrefix:            infrastructureMachineTemplateNamePrefix(s.Current.Cluster.Name, machineDeploymentTopology.Name),
 		currentObjectRef:      currentInfraMachineTemplateRef,
 	})
+
+	infraMachineTemplateLabels := desiredMachineDeployment.InfrastructureMachineTemplate.GetLabels()
+	if infraMachineTemplateLabels == nil {
+		infraMachineTemplateLabels = map[string]string{}
+	}
+	// Add ClusterTopologyMachineDeploymentLabel to the generated InfrastructureMachine template
+	infraMachineTemplateLabels[clusterv1.ClusterTopologyMachineDeploymentLabelName] = machineDeploymentTopology.Name
+	desiredMachineDeployment.InfrastructureMachineTemplate.SetLabels(infraMachineTemplateLabels)
 
 	// Compute the MachineDeployment object.
 	gv := clusterv1.GroupVersion

--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -497,6 +497,9 @@ func TestComputeMachineDeployment(t *testing.T) {
 		actual, err := computeMachineDeployment(ctx, scope, mdTopology)
 		g.Expect(err).ToNot(HaveOccurred())
 
+		g.Expect(actual.BootstrapTemplate.GetLabels()).To(HaveKeyWithValue(clusterv1.ClusterTopologyMachineDeploymentLabelName, "big-pool-of-machines"))
+		g.Expect(actual.InfrastructureMachineTemplate.GetLabels()).To(HaveKeyWithValue(clusterv1.ClusterTopologyMachineDeploymentLabelName, "big-pool-of-machines"))
+
 		actualMd := actual.Object
 		g.Expect(*actualMd.Spec.Replicas).To(Equal(replicas))
 		g.Expect(actualMd.Spec.ClusterName).To(Equal("cluster1"))


### PR DESCRIPTION
Adding `ClusterTopologyMachineDeploymentLabelName` to the generated
`Bootstrap` and `Infrastructure Machine` templates

**What this PR does / why we need it**:
`ClusterTopologyMachineDeploymentLabelName` has to be added on the generated MachineDeployment objects to track the name of the MD topology it represents. Bootstrap and InfrastructureMachine templates are also generated as part of `computeMachineDeployment`. Hence, adding the label on these templates as well.

Fixes #5193 
