### PR TITLE
🌱 Allow cluster class compatible changes

### DIFF
--- a/docs/proposals/202105256-cluster-class-and-managed-topologies.md
+++ b/docs/proposals/202105256-cluster-class-and-managed-topologies.md
@@ -324,6 +324,7 @@ type LocalObjectTemplate struct {
   - all the reference must be in the same namespace of `metadata.Namespace`
   - `spec.workers.machineDeployments[i].class` field must be unique within a ClusterClass.
   - `spec.workers.machineDeployments` supports adding new deployment classes.
+  - changes should be compliant with the compatibility rules defined in this doc. 
 
 ##### Cluster
 - For object creation:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows compatible changes on ClusterClass, namely metadata, and template rotation.

Please note that those checks now applies to all ClusterClasses, while in a future iteration we can improve UX by not applying compatibility rules if a ClusterClass is actually not used by a Cluster.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5192
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5197
