### PR TITLE
🐛  fix flaky TestPatchHelper test

### DIFF
--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -206,13 +206,13 @@ func TestPatchHelper(t *testing.T) {
 				g.Expect(patcher.Patch(ctx, obj)).To(Succeed())
 
 				t.Log("Validating the object has been updated")
-				g.Eventually(func() bool {
+				g.Eventually(func() clusterv1.Conditions {
 					objAfter := obj.DeepCopy()
 					if err := env.Get(ctx, key, objAfter); err != nil {
-						return false
+						return clusterv1.Conditions{}
 					}
-					return cmp.Equal(obj.Status.Conditions, objAfter.Status.Conditions)
-				}, timeout).Should(BeTrue())
+					return objAfter.Status.Conditions
+				}, timeout).Should(conditions.MatchConditions(obj.Status.Conditions))
 			})
 
 			t.Run("should recover if there is a resolvable conflict", func(t *testing.T) {
@@ -261,11 +261,19 @@ func TestPatchHelper(t *testing.T) {
 
 					testConditionCopy := conditions.Get(objCopy, "TestCondition")
 					testConditionAfter := conditions.Get(objAfter, "TestCondition")
+					ok, err := conditions.MatchCondition(*testConditionCopy).Match(*testConditionAfter)
+					if err != nil || !ok {
+						return false
+					}
 
 					readyBefore := conditions.Get(obj, clusterv1.ReadyCondition)
 					readyAfter := conditions.Get(objAfter, clusterv1.ReadyCondition)
+					ok, err = conditions.MatchCondition(*readyBefore).Match(*readyAfter)
+					if err != nil || !ok {
+						return false
+					}
 
-					return cmp.Equal(testConditionCopy, testConditionAfter) && cmp.Equal(readyBefore, readyAfter)
+					return true
 				}, timeout).Should(BeTrue())
 			})
 
@@ -319,12 +327,19 @@ func TestPatchHelper(t *testing.T) {
 
 					testConditionCopy := conditions.Get(objCopy, "TestCondition")
 					testConditionAfter := conditions.Get(objAfter, "TestCondition")
+					ok, err := conditions.MatchCondition(*testConditionCopy).Match(*testConditionAfter)
+					if err != nil || !ok {
+						return false
+					}
 
 					readyBefore := conditions.Get(obj, clusterv1.ReadyCondition)
 					readyAfter := conditions.Get(objAfter, clusterv1.ReadyCondition)
+					ok, err = conditions.MatchCondition(*readyBefore).Match(*readyAfter)
+					if err != nil || !ok {
+						return false
+					}
 
-					return cmp.Equal(testConditionCopy, testConditionAfter) && cmp.Equal(readyBefore, readyAfter) &&
-						obj.Spec.Paused == objAfter.Spec.Paused &&
+					return obj.Spec.Paused == objAfter.Spec.Paused &&
 						obj.Spec.ControlPlaneEndpoint == objAfter.Spec.ControlPlaneEndpoint &&
 						obj.Status.Phase == objAfter.Status.Phase
 				}, timeout).Should(BeTrue(), cmp.Diff(obj, objAfter))
@@ -373,8 +388,15 @@ func TestPatchHelper(t *testing.T) {
 					if err := env.Get(ctx, key, objAfter); err != nil {
 						return false
 					}
-					ok, _ := ContainElement(objCopy.Status.Conditions[0]).Match(objAfter.Status.Conditions)
-					return ok
+
+					for _, afterCondition := range objAfter.Status.Conditions {
+						ok, err := conditions.MatchCondition(objCopy.Status.Conditions[0]).Match(afterCondition)
+						if err == nil && ok {
+							return true
+						}
+					}
+
+					return false
 				}, timeout).Should(BeTrue())
 			})
 
@@ -416,17 +438,15 @@ func TestPatchHelper(t *testing.T) {
 				g.Expect(patcher.Patch(ctx, obj, WithOwnedConditions{Conditions: []clusterv1.ConditionType{clusterv1.ReadyCondition}})).To(Succeed())
 
 				t.Log("Validating the object has been updated")
-				g.Eventually(func() bool {
+				readyBefore := conditions.Get(obj, clusterv1.ReadyCondition)
+				g.Eventually(func() clusterv1.Condition {
 					objAfter := obj.DeepCopy()
 					if err := env.Get(ctx, key, objAfter); err != nil {
-						return false
+						return clusterv1.Condition{}
 					}
 
-					readyBefore := conditions.Get(obj, clusterv1.ReadyCondition)
-					readyAfter := conditions.Get(objAfter, clusterv1.ReadyCondition)
-
-					return cmp.Equal(readyBefore, readyAfter)
-				}, timeout).Should(BeTrue())
+					return *conditions.Get(objAfter, clusterv1.ReadyCondition)
+				}, timeout).Should(conditions.MatchCondition(*readyBefore))
 			})
 
 			t.Run("should not return an error if there is an unresolvable conflict when force overwrite is enabled", func(t *testing.T) {
@@ -467,17 +487,15 @@ func TestPatchHelper(t *testing.T) {
 				g.Expect(patcher.Patch(ctx, obj, WithForceOverwriteConditions{})).To(Succeed())
 
 				t.Log("Validating the object has been updated")
-				g.Eventually(func() bool {
+				readyBefore := conditions.Get(obj, clusterv1.ReadyCondition)
+				g.Eventually(func() clusterv1.Condition {
 					objAfter := obj.DeepCopy()
 					if err := env.Get(ctx, key, objAfter); err != nil {
-						return false
+						return clusterv1.Condition{}
 					}
 
-					readyBefore := conditions.Get(obj, clusterv1.ReadyCondition)
-					readyAfter := conditions.Get(objAfter, clusterv1.ReadyCondition)
-
-					return cmp.Equal(readyBefore, readyAfter)
-				}, timeout).Should(BeTrue())
+					return *conditions.Get(objAfter, clusterv1.ReadyCondition)
+				}, timeout).Should(conditions.MatchCondition(*readyBefore))
 			})
 		})
 	})


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR fixes the two flaky test cases in `TestPatchHelper` (which are two of the most frequent ones we have right now). 

The test assumes that the condition we have in the local object is exactly the same compared to the condition after the patch on the server-side. This is not true, because the patch helper re-calculates the `LastTransitionTime` during the patch func. In theory there are a few more test cases which should be affected. According to testgrid only those two are flaky.

Q:
* Should I also adjust other test cases in the same test accordingly? (I could introduce a func which compares conditions while ignoring `LastTransitionTime`)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
