### PR TITLE
🌱 Group resources in tilt

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -258,6 +258,12 @@ Set to `false` if your provider does not have a ./config folder or you do not wa
 
 **go_main** (String, default="main.go"): The go main file if not located at the root of the folder
 
+**label** (String, default=provider name): The label to be used to group provider components in the tilt UI 
+in tilt version >= v0.22.2 (see https://blog.tilt.dev/2021/08/09/resource-grouping.html); as a convention,
+provider abbreviation should be used (CAPD, KCP etc.).
+
+**manager_name** (String): If provided, it will allow tilt to move the provider controller under the above label.
+
 ## Customizing Tilt
 
 If you need to customize Tilt's behavior, you can create files in cluster-api's `tilt.d` directory. This file is ignored


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR plays on a feature recently added in tilt that allows us to to group resources in the tilt dashboard see https://blog.tilt.dev/2021/08/09/resource-grouping.html.

I'm currently providing two different grouping strategies:
- by controllers and local binaries
- by provider

~~ The tricky part is that in order to get this to work nicely, we should change current default provider names, and this requires a small change to `tilt_settings.json` on the developer side ~~ (fixed)

I also have to investigate if this works with older releases...

@CecileRobertMichon @vincepri @sbueringer opinions?