### PR TITLE
🐛  Fix flaky TestGetWorkloadCluster test

### DIFF
--- a/controlplane/kubeadm/internal/cluster_test.go
+++ b/controlplane/kubeadm/internal/cluster_test.go
@@ -192,8 +192,10 @@ func TestGetWorkloadCluster(t *testing.T) {
 				}(o)
 			}
 
+			// Note: The API reader is intentionally used instead of the regular (cached) client
+			// to avoid test failures when the local cache isn't able to catch up in time.
 			m := Management{
-				Client:  env,
+				Client:  env.GetAPIReader(),
 				Tracker: tracker,
 			}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Test frequently fails in CI: [testgrid](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-test-main&exclude-non-failed-tests=50&sort-by-failures=)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
