### PR TITLE
🐛 Fix panic in clusterctl describe from nil reference

### DIFF
--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -39,6 +39,9 @@ const (
 
 // Get uses the client and reference to get an external, unstructured object.
 func Get(ctx context.Context, c client.Client, ref *corev1.ObjectReference, namespace string) (*unstructured.Unstructured, error) {
+	if ref == nil {
+		return nil, errors.Errorf("cannot get object - object reference not set")
+	}
 	obj := new(unstructured.Unstructured)
 	obj.SetAPIVersion(ref.APIVersion)
 	obj.SetKind(ref.Kind)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR catches an error in clusterctl triggered by a cluster with nil infrastructure or other references. This issue was introduced by the clusterClass flow where these references are initially set to nil. This fix checks if object references are nil before running an external client Get.

Fixes #5226 
