### PR TITLE
🌱 Use .Index func when building field.Paths

### DIFF
--- a/api/v1alpha4/clusterclass_webhook.go
+++ b/api/v1alpha4/clusterclass_webhook.go
@@ -121,8 +121,8 @@ func (in *ClusterClass) validateAllRefs() field.ErrorList {
 	}
 
 	for i, class := range in.Spec.Workers.MachineDeployments {
-		allErrs = append(allErrs, class.Template.Bootstrap.isValid(in.Namespace, field.NewPath("spec", "workers", fmt.Sprintf("machineDeployments[%v]", i), "template", "bootstrap"))...)
-		allErrs = append(allErrs, class.Template.Infrastructure.isValid(in.Namespace, field.NewPath("spec", "workers", fmt.Sprintf("machineDeployments[%v]", i), "template", "infrastructure"))...)
+		allErrs = append(allErrs, class.Template.Bootstrap.isValid(in.Namespace, field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("template", "bootstrap"))...)
+		allErrs = append(allErrs, class.Template.Infrastructure.isValid(in.Namespace, field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("template", "infrastructure"))...)
 	}
 
 	return allErrs
@@ -346,7 +346,7 @@ func (w *WorkersClass) validateUniqueClasses(pathPrefix *field.Path) field.Error
 		if classes.Has(class.Class) {
 			allErrs = append(allErrs,
 				field.Invalid(
-					pathPrefix.Child(fmt.Sprintf("machineDeployments[%v]", i), "class"),
+					pathPrefix.Child("machineDeployments").Index(i).Child("class"),
 					class.Class,
 					fmt.Sprintf("MachineDeployment class should be unique. MachineDeployment with class %q is defined more than once.", class.Class),
 				),

--- a/bootstrap/kubeadm/api/v1alpha4/kubeadmconfig_webhook.go
+++ b/bootstrap/kubeadm/api/v1alpha4/kubeadmconfig_webhook.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1alpha4
 
 import (
-	"fmt"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -69,7 +67,7 @@ func (c *KubeadmConfigSpec) validate(name string) error {
 			allErrs = append(
 				allErrs,
 				field.Invalid(
-					field.NewPath("spec", "files", fmt.Sprintf("%d", i)),
+					field.NewPath("spec", "files").Index(i),
 					file,
 					conflictingFileSourceMsg,
 				),
@@ -83,7 +81,7 @@ func (c *KubeadmConfigSpec) validate(name string) error {
 				allErrs = append(
 					allErrs,
 					field.Invalid(
-						field.NewPath("spec", "files", fmt.Sprintf("%d", i), "contentFrom", "secret", "name"),
+						field.NewPath("spec", "files").Index(i).Child("contentFrom", "secret", "name"),
 						file,
 						missingSecretNameMsg,
 					),
@@ -93,7 +91,7 @@ func (c *KubeadmConfigSpec) validate(name string) error {
 				allErrs = append(
 					allErrs,
 					field.Invalid(
-						field.NewPath("spec", "files", fmt.Sprintf("%d", i), "contentFrom", "secret", "key"),
+						field.NewPath("spec", "files").Index(i).Child("contentFrom", "secret", "key"),
 						file,
 						missingSecretKeyMsg,
 					),
@@ -105,7 +103,7 @@ func (c *KubeadmConfigSpec) validate(name string) error {
 			allErrs = append(
 				allErrs,
 				field.Invalid(
-					field.NewPath("spec", "files", fmt.Sprintf("%d", i), "path"),
+					field.NewPath("spec", "files").Index(i).Child("path"),
 					file,
 					pathConflictMsg,
 				),


### PR DESCRIPTION
Using `.Index` func instead of `fmt` package to subscript array indexes

Fixes #5216 
