### PR TITLE
🌱 Add script to install Kind for testing with CAPD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,10 @@ docker-build-e2e: ## Rebuild all Cluster API provider images to be used in the e
 test-e2e: ## Run the e2e tests
 	$(MAKE) -C $(TEST_DIR)/e2e run
 
+.PHONY: kind-cluster
+kind-cluster: ## Create a new kind cluster designed for testing with Tilt
+	hack/kind-install-for-capd.sh
+
 ## --------------------------------------
 ## Binaries
 ## --------------------------------------

--- a/hack/kind-install-for-capd.sh
+++ b/hack/kind-install-for-capd.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script installs a local KIND cluster with a local container registry and the correct files mounted for using CAPD
+# to test Cluster API.
+# This script is a customized version of the kind_with_local_registry script supplied by the KIND maintainers at
+# https://kind.sigs.k8s.io/docs/user/local-registry/
+# The modifications mount the docker socket inside the KIND cluster so that CAPD can be used to
+# created docker containers.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAME="capi-test"
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    -n|--name)
+      NAME="$2"
+      shift
+      shift
+      ;;
+  esac
+done
+
+
+# create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --name="$NAME"  --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+    - hostPath: /var/run/docker.sock
+      containerPath: /var/run/docker.sock
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:${reg_port}"]
+EOF
+
+# connect the registry to the cluster network
+# (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
+
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds a script that creates a Kind cluster with a local container registry and the correct mounts for using CAPD. This script is mainly a copy of the kind_with_local_registry.sh script made available by the Kind team at https://kind.sigs.k8s.io/docs/user/local-registry/.

This PR is in response to a comment on our current Tilt workflow at #5204 

Signed-off-by: killianmuldoon <kmuldoon@vmware.com>
