### PR TITLE
🐛  IsScaling error handling in control plane contract

### DIFF
--- a/controllers/topology/internal/contract/controlplane.go
+++ b/controllers/topology/internal/contract/controlplane.go
@@ -152,11 +152,23 @@ func (c *ControlPlaneContract) IsScaling(obj *unstructured.Unstructured) (bool, 
 
 	updatedReplicas, err := c.UpdatedReplicas().Get(obj)
 	if err != nil {
+		if errors.Is(err, errNotFound) {
+			// If updatedReplicas is not set on the control plane
+			// we should consider the control plane to be scaling so that
+			// we block any operation that expect the control plane to be stable.
+			return true, nil
+		}
 		return false, errors.Wrap(err, "failed to get control plane status updatedReplicas")
 	}
 
 	readyReplicas, err := c.ReadyReplicas().Get(obj)
 	if err != nil {
+		if errors.Is(err, errNotFound) {
+			// If readyReplicas is not set on the control plane
+			// we should consider the control plane to be scaling so that
+			// we block any operation that expect the control plane to be stable.
+			return true, nil
+		}
 		return false, errors.Wrap(err, "failed to get control plane status readyReplicas")
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds proper error handling to `IsScaling` function. Control planes might not have `readyReplicas` when they are in the middle of scaling/upgrading. This is to make sure this case is error is properly handled. 

This PR should only be merged after https://github.com/kubernetes-sigs/cluster-api/pull/5221 or else the upgrade flow will behave as expected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
