### PR TITLE
🌱 Add missing constants to v1alpha3 package from release-0.3

### DIFF
--- a/api/v1alpha3/common_types.go
+++ b/api/v1alpha3/common_types.go
@@ -31,12 +31,31 @@ const (
 	// tool uses this label for implementing provider's lifecycle operations.
 	ProviderLabelName = "cluster.x-k8s.io/provider"
 
+	// ClusterNameAnnotation is the annotation set on nodes identifying the name of the cluster the node belongs to.
+	ClusterNameAnnotation = "cluster.x-k8s.io/cluster-name"
+
+	// ClusterNamespaceAnnotation is the annotation set on nodes identifying the namespace of the cluster the node belongs to.
+	ClusterNamespaceAnnotation = "cluster.x-k8s.io/cluster-namespace"
+
+	// MachineAnnotation is the annotation set on nodes identifying the machine the node belongs to.
+	MachineAnnotation = "cluster.x-k8s.io/machine"
+
+	// OwnerKindAnnotation is the annotation set on nodes identifying the owner kind.
+	OwnerKindAnnotation = "cluster.x-k8s.io/owner-kind"
+
+	// OwnerNameAnnotation is the annotation set on nodes identifying the owner name.
+	OwnerNameAnnotation = "cluster.x-k8s.io/owner-name"
+
 	// PausedAnnotation is an annotation that can be applied to any Cluster API
 	// object to prevent a controller from processing a resource.
 	//
 	// Controllers working with Cluster API objects must check the existence of this annotation
 	// on the reconciled object.
 	PausedAnnotation = "cluster.x-k8s.io/paused"
+
+	// DeleteMachineAnnotation marks control plane and worker nodes that will be given priority for deletion
+	// when KCP or a machineset scales down. This annotation is given top priority on all delete policies.
+	DeleteMachineAnnotation = "cluster.x-k8s.io/delete-machine"
 
 	// TemplateClonedFromNameAnnotation is the infrastructure machine annotation that stores the name of the infrastructure template resource
 	// that was cloned for the machine. This annotation is set only during cloning a template. Older/adopted machines will not have this annotation.
@@ -45,6 +64,9 @@ const (
 	// TemplateClonedFromGroupKindAnnotation is the infrastructure machine annotation that stores the group-kind of the infrastructure template resource
 	// that was cloned for the machine. This annotation is set only during cloning a template. Older/adopted machines will not have this annotation.
 	TemplateClonedFromGroupKindAnnotation = "cluster.x-k8s.io/cloned-from-groupkind"
+
+	// MachineSkipRemediationAnnotation is the annotation used to mark the machines that should not be considered for remediation by MachineHealthCheck reconciler.
+	MachineSkipRemediationAnnotation = "cluster.x-k8s.io/skip-remediation"
 
 	// ClusterSecretType defines the type of secret created by core components.
 	ClusterSecretType corev1.SecretType = "cluster.x-k8s.io/secret" //nolint:gosec

--- a/api/v1alpha3/condition_consts.go
+++ b/api/v1alpha3/condition_consts.go
@@ -65,6 +65,13 @@ const (
 	// to be available.
 	// NOTE: This reason is used only as a fallback when the control plane object is not reporting its own ready condition.
 	WaitingForControlPlaneFallbackReason = "WaitingForControlPlane"
+
+	// WaitingForControlPlaneAvailableReason (Severity=Info) documents a Cluster API object
+	// waiting for the control plane machine to be available.
+	//
+	// NOTE: Having the control plane machine available is a pre-condition for joining additional control planes
+	// or workers nodes.
+	WaitingForControlPlaneAvailableReason = "WaitingForControlPlaneAvailable"
 )
 
 // Conditions and condition Reasons for the Machine object


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Implements https://github.com/kubernetes-sigs/cluster-api/issues/5236#issuecomment-919825042

Looks like we missed a few constants we have on our release-0.3 branch. This breaks API consumers when trying to migrate from v1alpha3 to v1alpha4. (of course only when they are used in API consumer code)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
