### PR TITLE
🌱 CAPD: improve image build caching

### DIFF
--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -22,6 +22,13 @@ FROM ${builder_image} as builder
 ARG goproxy=https://proxy.golang.org
 ENV GOPROXY=$goproxy
 
+# Gets additional CAPD dependencies
+WORKDIR /tmp
+
+RUN curl -LO https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/bin/kubectl
+
 WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -49,13 +56,6 @@ WORKDIR /workspace/test/infrastructure/docker
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o /workspace/manager main.go
-
-# Gets additional CAPD dependencies
-WORKDIR /tmp
-
-RUN curl -LO https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl && \
-    chmod +x ./kubectl && \
-    mv ./kubectl /usr/bin/kubectl
 
 # NOTE: CAPD can't use non-root because docker requires access to the docker socket
 FROM gcr.io/distroless/static:latest


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
With this PR the kubectl download is cached even when CAPD has to be recompiled

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
