### PR TITLE
🐛 Fix a bug that completion suggestions for --namespace are not updated

### DIFF
--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 )
@@ -141,14 +142,14 @@ func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
 	return nil
 }
 
-func contextCompletionFunc(kubeconfig *string) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func contextCompletionFunc(kubeconfigFlag *pflag.Flag) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		configClient, err := config.New(cfgFile)
 		if err != nil {
 			return completionError(err)
 		}
 
-		client := cluster.New(cluster.Kubeconfig{Path: *kubeconfig}, configClient)
+		client := cluster.New(cluster.Kubeconfig{Path: kubeconfigFlag.Value.String()}, configClient)
 		comps, err := client.Proxy().GetContexts(toComplete)
 		if err != nil {
 			return completionError(err)
@@ -158,14 +159,14 @@ func contextCompletionFunc(kubeconfig *string) func(cmd *cobra.Command, args []s
 	}
 }
 
-func resourceNameCompletionFunc(kubeconfig *string, groupVersion, kind string) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func resourceNameCompletionFunc(kubeconfigFlag, contextFlag *pflag.Flag, groupVersion, kind string) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		configClient, err := config.New(cfgFile)
 		if err != nil {
 			return completionError(err)
 		}
 
-		client := cluster.New(cluster.Kubeconfig{Path: *kubeconfig}, configClient)
+		client := cluster.New(cluster.Kubeconfig{Path: kubeconfigFlag.Value.String(), Context: contextFlag.Value.String()}, configClient)
 		comps, err := client.Proxy().GetResourceNames(groupVersion, kind, nil, toComplete)
 		if err != nil {
 			return completionError(err)

--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -137,17 +137,17 @@ func initConfig() {
 
 func registerCompletionFuncForCommonFlags() {
 	visitCommands(RootCmd, func(cmd *cobra.Command) {
-		if f := cmd.Flags().Lookup("kubeconfig"); f != nil {
-			kubeconfig := f.Value.String()
-
+		if kubeconfigFlag := cmd.Flags().Lookup("kubeconfig"); kubeconfigFlag != nil {
 			// context in kubeconfig
 			for _, flagName := range []string{"kubeconfig-context", "to-kubeconfig-context"} {
-				_ = cmd.RegisterFlagCompletionFunc(flagName, contextCompletionFunc(&kubeconfig))
+				_ = cmd.RegisterFlagCompletionFunc(flagName, contextCompletionFunc(kubeconfigFlag))
 			}
 
-			// namespace
-			for _, flagName := range []string{"namespace", "target-namespace", "from-config-map-namespace"} {
-				_ = cmd.RegisterFlagCompletionFunc(flagName, resourceNameCompletionFunc(&kubeconfig, "v1", "namespace"))
+			if contextFlag := cmd.Flags().Lookup("kubeconfig-context"); contextFlag != nil {
+				// namespace
+				for _, flagName := range []string{"namespace", "target-namespace", "from-config-map-namespace"} {
+					_ = cmd.RegisterFlagCompletionFunc(flagName, resourceNameCompletionFunc(kubeconfigFlag, contextFlag, "v1", "namespace"))
+				}
 			}
 		}
 	})


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

If `--kubeconfig-context` is specified, completion suggestions for`--namespace` needs to provide namespaces of the cluster specified with`--kubeconfig-context`.

However, it currently uses the current context even if`--kubeconfig-context` is specified.

**Before**

```shell
$ kind create cluster --name test
$ kubectl create ns kind-test --context kind-test
namespace/kind-test created
$ kind create cluster

# complete namespaces of the cluster of current context
$ clusterctl get kubeconfig --namespace <tab>
default             kube-node-lease     kube-public         kube-system         local-path-storage

# complete namespaces of the cluster of current context even if --kubeconfig-context is specified
$ clusterctl get kubeconfig --kubeconfig-context kind-test --namespace <tab>
default             kube-node-lease     kube-public         kube-system         local-path-storage
```

**After**

```shell
# complete namespaces of the cluster of current context
$ clusterctl get kubeconfig --namespace <tab>
default             kube-node-lease     kube-public         kube-system         local-path-storage

# complete namespaces of the cluster of context specified with --kubeconfig-context
$ clusterctl get kubeconfig --kubeconfig-context kind-test --namespace <tab>
default             kind-test           kube-node-lease     kube-public         kube-system         local-path-storage
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

ref/ https://github.com/kubernetes-sigs/cluster-api/pull/5094
