### PR TITLE
✨ clusterctl: Add completion support for cluster resource

### DIFF
--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -109,6 +109,15 @@ func init() {
 	describeClusterClusterCmd.Flags().BoolVar(&dc.disableGrouping, "disable-grouping", false,
 		"Disable grouping machines when ready condition has the same Status, Severity and Reason.")
 
+	// completions
+	describeClusterClusterCmd.ValidArgsFunction = resourceNameCompletionFunc(
+		describeClusterClusterCmd.Flags().Lookup("kubeconfig"),
+		describeClusterClusterCmd.Flags().Lookup("kubeconfig-context"),
+		describeClusterClusterCmd.Flags().Lookup("namespace"),
+		clusterv1.GroupVersion.String(),
+		"cluster",
+	)
+
 	describeCmd.AddCommand(describeClusterClusterCmd)
 }
 

--- a/cmd/clusterctl/cmd/get_kubeconfig.go
+++ b/cmd/clusterctl/cmd/get_kubeconfig.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 )
 
@@ -57,6 +58,16 @@ func init() {
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
 	getKubeconfigCmd.Flags().StringVar(&gk.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
+
+	// completions
+	getKubeconfigCmd.ValidArgsFunction = resourceNameCompletionFunc(
+		getKubeconfigCmd.Flags().Lookup("kubeconfig"),
+		getKubeconfigCmd.Flags().Lookup("kubeconfig-context"),
+		getKubeconfigCmd.Flags().Lookup("namespace"),
+		clusterv1.GroupVersion.String(),
+		"cluster",
+	)
+
 	getCmd.AddCommand(getKubeconfigCmd)
 }
 

--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -146,7 +146,7 @@ func registerCompletionFuncForCommonFlags() {
 			if contextFlag := cmd.Flags().Lookup("kubeconfig-context"); contextFlag != nil {
 				// namespace
 				for _, flagName := range []string{"namespace", "target-namespace", "from-config-map-namespace"} {
-					_ = cmd.RegisterFlagCompletionFunc(flagName, resourceNameCompletionFunc(kubeconfigFlag, contextFlag, "v1", "namespace"))
+					_ = cmd.RegisterFlagCompletionFunc(flagName, resourceNameCompletionFunc(kubeconfigFlag, contextFlag, nil, "v1", "namespace"))
 				}
 			}
 		}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds completion support for cluster resource:

- `clusterctl get kubeconfig <cluster>`
- `clusterctl describe cluster <cluster>`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

ref/ https://github.com/kubernetes-sigs/cluster-api/issues/4089
