### PR TITLE
🌱  Update calico version in quickstart guide

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -727,7 +727,7 @@ Calico is used here as an example.
 
 ```bash
 kubectl --kubeconfig=./capi-quickstart.kubeconfig \
-  apply -f https://docs.projectcalico.org/v3.18/manifests/calico.yaml
+  apply -f https://docs.projectcalico.org/v3.20/manifests/calico.yaml
 ```
 
 After a short while, our nodes should be running and in `Ready` state,


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the version of Calico used in the CAPI quickstart guide. 

