### PR TITLE
🐛 Release Tooling: Version calculation script should only use annotated tags

### DIFF
--- a/hack/version.sh
+++ b/hack/version.sh
@@ -28,8 +28,8 @@ version::get_version_vars() {
     fi
 
     # stolen from k8s.io/hack/lib/version.sh
-    # Use git describe to find the version based on tags.
-    if GIT_VERSION=$(git describe --tags --abbrev=14 2>/dev/null); then
+    # Use git describe to find the version based on annotated tags.
+    if GIT_VERSION=$(git describe --abbrev=14 --match "v[0-9]*" 2>/dev/null); then
         # This translates the "git describe" to an actual semver.org
         # compatible semantic version that looks something like this:
         #   v1.1.0-alpha.0.6+84c76d1142ea4d


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The version calculation script should limit to using only annotated tags. This help with the release automation not picking up tags like `test/v0.4.3` which causes issues with release scripts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5268
