### PR TITLE
✨ Clusterctl: add support for v1alpha3 to v1beta1 upgrades

### DIFF
--- a/cmd/clusterctl/client/cluster/inventory.go
+++ b/cmd/clusterctl/client/cluster/inventory.go
@@ -51,8 +51,8 @@ type CheckCAPIContractOptions struct {
 	// AllowCAPINotInstalled instructs CheckCAPIContract to tolerate management clusters without Cluster API installed yet.
 	AllowCAPINotInstalled bool
 
-	// AllowCAPIContract instructs CheckCAPIContract to tolerate management clusters with Cluster API with the given contract.
-	AllowCAPIContract string
+	// AllowCAPIContracts instructs CheckCAPIContract to tolerate management clusters with Cluster API with the given contract.
+	AllowCAPIContracts []string
 }
 
 // AllowCAPINotInstalled instructs CheckCAPIContract to tolerate management clusters without Cluster API installed yet.
@@ -72,7 +72,7 @@ type AllowCAPIContract struct {
 
 // Apply applies this configuration to the given CheckCAPIContractOptions.
 func (t AllowCAPIContract) Apply(in *CheckCAPIContractOptions) {
-	in.AllowCAPIContract = t.Contract
+	in.AllowCAPIContracts = append(in.AllowCAPIContracts, t.Contract)
 }
 
 // InventoryClient exposes methods to interface with a cluster's provider inventory.
@@ -397,8 +397,13 @@ func (p *inventoryClient) CheckCAPIContract(options ...CheckCAPIContractOption) 
 
 	for _, version := range crd.Spec.Versions {
 		if version.Storage {
-			if version.Name == clusterv1.GroupVersion.Version || version.Name == opt.AllowCAPIContract {
+			if version.Name == clusterv1.GroupVersion.Version {
 				return nil
+			}
+			for _, allowedContract := range opt.AllowCAPIContracts {
+				if version.Name == allowedContract {
+					return nil
+				}
 			}
 			return errors.Errorf("this version of clusterctl could be used only with %q management clusters, %q detected", clusterv1.GroupVersion.Version, version.Name)
 		}

--- a/cmd/clusterctl/client/cluster/inventory_test.go
+++ b/cmd/clusterctl/client/cluster/inventory_test.go
@@ -24,6 +24,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	clusterv1v1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -277,6 +278,26 @@ func Test_CheckCAPIContract(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Pass when Cluster API with v1alpha3 contract is installed, but this is explicitly tolerated",
+			fields: fields{
+				proxy: test.NewFakeProxy().WithObjs(&apiextensionsv1.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{Name: "clusters.cluster.x-k8s.io"},
+					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+						Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+							{
+								Name:    clusterv1v1alpha3.GroupVersion.Version,
+								Storage: true,
+							},
+						},
+					},
+				}),
+			},
+			args: args{
+				options: []CheckCAPIContractOption{AllowCAPIContract{Contract: clusterv1v1alpha3.GroupVersion.Version}, AllowCAPIContract{Contract: test.PreviousCAPIContractNotSupported}},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Pass when Cluster API with previous contract is installed, but this is explicitly tolerated",
 			fields: fields{
 				proxy: test.NewFakeProxy().WithObjs(&apiextensionsv1.CustomResourceDefinition{
@@ -295,7 +316,7 @@ func Test_CheckCAPIContract(t *testing.T) {
 				}),
 			},
 			args: args{
-				options: []CheckCAPIContractOption{AllowCAPIContract{Contract: test.PreviousCAPIContractNotSupported}},
+				options: []CheckCAPIContractOption{AllowCAPIContract{Contract: clusterv1v1alpha3.GroupVersion.Version}, AllowCAPIContract{Contract: test.PreviousCAPIContractNotSupported}},
 			},
 			wantErr: false,
 		},

--- a/cmd/clusterctl/client/cluster/inventory_test.go
+++ b/cmd/clusterctl/client/cluster/inventory_test.go
@@ -24,7 +24,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	clusterv1v1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -285,7 +285,7 @@ func Test_CheckCAPIContract(t *testing.T) {
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
 							{
-								Name:    clusterv1v1alpha3.GroupVersion.Version,
+								Name:    clusterv1alpha3.GroupVersion.Version,
 								Storage: true,
 							},
 						},
@@ -293,7 +293,7 @@ func Test_CheckCAPIContract(t *testing.T) {
 				}),
 			},
 			args: args{
-				options: []CheckCAPIContractOption{AllowCAPIContract{Contract: clusterv1v1alpha3.GroupVersion.Version}, AllowCAPIContract{Contract: test.PreviousCAPIContractNotSupported}},
+				options: []CheckCAPIContractOption{AllowCAPIContract{Contract: clusterv1alpha3.GroupVersion.Version}, AllowCAPIContract{Contract: test.PreviousCAPIContractNotSupported}},
 			},
 			wantErr: false,
 		},
@@ -316,7 +316,7 @@ func Test_CheckCAPIContract(t *testing.T) {
 				}),
 			},
 			args: args{
-				options: []CheckCAPIContractOption{AllowCAPIContract{Contract: clusterv1v1alpha3.GroupVersion.Version}, AllowCAPIContract{Contract: test.PreviousCAPIContractNotSupported}},
+				options: []CheckCAPIContractOption{AllowCAPIContract{Contract: clusterv1alpha3.GroupVersion.Version}, AllowCAPIContract{Contract: test.PreviousCAPIContractNotSupported}},
 			},
 			wantErr: false,
 		},

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1v1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha4"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
@@ -57,7 +57,7 @@ func (c *clusterctlClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePla
 	// NOTE: given that v1beta1 (current) and v1alpha4 (previous) does not have breaking changes, we support also upgrades from v1alpha3 to v1beta1;
 	// this is an exception and support for skipping releases should be removed in future releases.
 	if err := clusterClient.ProviderInventory().CheckCAPIContract(
-		cluster.AllowCAPIContract{Contract: clusterv1v1alpha3.GroupVersion.Version},
+		cluster.AllowCAPIContract{Contract: clusterv1alpha3.GroupVersion.Version},
 		cluster.AllowCAPIContract{Contract: clusterv1old.GroupVersion.Version},
 	); err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func (c *clusterctlClient) ApplyUpgrade(options ApplyUpgradeOptions) error {
 	// NOTE: given that v1beta1 (current) and v1alpha4 (previous) does not have breaking changes, we support also upgrades from v1alpha3 to v1beta1;
 	// this is an exception and support for skipping releases should be removed in future releases.
 	if err := clusterClient.ProviderInventory().CheckCAPIContract(
-		cluster.AllowCAPIContract{Contract: clusterv1v1alpha3.GroupVersion.Version},
+		cluster.AllowCAPIContract{Contract: clusterv1alpha3.GroupVersion.Version},
 		cluster.AllowCAPIContract{Contract: clusterv1old.GroupVersion.Version},
 	); err != nil {
 		return err

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -21,7 +21,8 @@ import (
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1v1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha4"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
@@ -53,7 +54,12 @@ func (c *clusterctlClient) PlanUpgrade(options PlanUpgradeOptions) ([]UpgradePla
 	}
 
 	// Ensure this command only runs against management clusters with the current Cluster API contract (default) or the previous one.
-	if err := clusterClient.ProviderInventory().CheckCAPIContract(cluster.AllowCAPIContract{Contract: clusterv1old.GroupVersion.Version}); err != nil {
+	// NOTE: given that v1beta1 (current) and v1alpha4 (previous) does not have breaking changes, we support also upgrades from v1alpha3 to v1beta1;
+	// this is an exception and support for skipping releases should be removed in future releases.
+	if err := clusterClient.ProviderInventory().CheckCAPIContract(
+		cluster.AllowCAPIContract{Contract: clusterv1v1alpha3.GroupVersion.Version},
+		cluster.AllowCAPIContract{Contract: clusterv1old.GroupVersion.Version},
+	); err != nil {
 		return nil, err
 	}
 
@@ -114,7 +120,12 @@ func (c *clusterctlClient) ApplyUpgrade(options ApplyUpgradeOptions) error {
 	}
 
 	// Ensure this command only runs against management clusters with the current Cluster API contract (default) or the previous one.
-	if err := clusterClient.ProviderInventory().CheckCAPIContract(cluster.AllowCAPIContract{Contract: clusterv1old.GroupVersion.Version}); err != nil {
+	// NOTE: given that v1beta1 (current) and v1alpha4 (previous) does not have breaking changes, we support also upgrades from v1alpha3 to v1beta1;
+	// this is an exception and support for skipping releases should be removed in future releases.
+	if err := clusterClient.ProviderInventory().CheckCAPIContract(
+		cluster.AllowCAPIContract{Contract: clusterv1v1alpha3.GroupVersion.Version},
+		cluster.AllowCAPIContract{Contract: clusterv1old.GroupVersion.Version},
+	); err != nil {
 		return err
 	}
 

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = Describe("When testing clusterctl upgrades", func() {
+var _ = Describe("When testing clusterctl upgrades [clusterctl-Upgrade]", func() {
 
 	ClusterctlUpgradeSpec(ctx, func() ClusterctlUpgradeSpecInput {
 		return ClusterctlUpgradeSpecInput{

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -32,15 +32,21 @@ providers:
   - name: v0.3.23 # latest published release in the v1alpha3 series; this is used for v1alpha3 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/core-components.yaml"
     type: "url"
+    contract: v1alpha3
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
+    files:
+      - sourcePath: "../data/shared/v1alpha3/metadata.yaml"
   - name: v0.4.3 # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
-      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.3/core-components.yaml"
-      type: "url"
-      replacements:
-        - old: --metrics-addr=127.0.0.1:8080
-          new: --metrics-addr=:8080
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.3/core-components.yaml"
+    type: "url"
+    contract: v1alpha4
+    replacements:
+      - old: --metrics-addr=127.0.0.1:8080
+        new: --metrics-addr=:8080
+    files:
+      - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
   - name: v1.0.99 # next; use manifest from source files
     value: ../../../config/default
     replacements:
@@ -55,15 +61,21 @@ providers:
   - name: v0.3.23 # latest published release in the v1alpha3 series; this is used for v1alpha3 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/bootstrap-components.yaml"
     type: "url"
+    contract: v1alpha3
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
         new: --metrics-addr=:8080
+    files:
+      - sourcePath: "../data/shared/v1alpha3/metadata.yaml"
   - name: v0.4.3 # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.3/bootstrap-components.yaml"
     type: "url"
+    contract: v1alpha4
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
         new: --metrics-addr=:8080
+    files:
+      - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
   - name: v1.0.99 # next; use manifest from source files
     value: ../../../bootstrap/kubeadm/config/default
     replacements:
@@ -78,15 +90,21 @@ providers:
   - name: v0.3.23 # latest published release in the v1alpha3 series; this is used for v1alpha3 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/control-plane-components.yaml"
     type: "url"
+    contract: v1alpha3
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
         new: --metrics-addr=:8080
+    files:
+      - sourcePath: "../data/shared/v1alpha3/metadata.yaml"
   - name: v0.4.3 # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.3/control-plane-components.yaml"
     type: "url"
+    contract: v1alpha4
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
         new: --metrics-addr=:8080
+    files:
+      - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
   - name: v1.0.99 # next; use manifest from source files
     value: ../../../controlplane/kubeadm/config/default
     replacements:
@@ -101,20 +119,22 @@ providers:
   - name: v0.3.23 # latest published release in the v1alpha3 series; this is used for v1alpha3 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/infrastructure-components-development.yaml"
     type: "url"
+    contract: v1alpha3
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
         new: --metrics-addr=:8080
     files:
-      # Add cluster templates
+      - sourcePath: "../data/shared/v1alpha3/metadata.yaml"
       - sourcePath: "../data/infrastructure-docker/v1alpha3/cluster-template.yaml"
   - name: v0.4.3 # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.3/infrastructure-components-development.yaml"
     type: "url"
+    contract: v1alpha4
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
         new: --metrics-addr=:8080
     files:
-      # Add cluster templates
+      - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
       - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template.yaml"
   - name: v1.0.99 # next; use manifest from source files
     value: ../../../test/infrastructure/docker/config/default
@@ -156,9 +176,9 @@ variables:
   NODE_DRAIN_TIMEOUT: "60s"
   # NOTE: INIT_WITH_BINARY and INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
-  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/clusterctl-{OS}-{ARCH}"
-  # CAPI v0.3.x cannot be deployed on Kubernetes >= v1.22.
-  INIT_WITH_KUBERNETES_VERSION: "v1.21.2"
+  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.3/clusterctl-{OS}-{ARCH}"
+  INIT_WITH_PROVIDERS_CONTRACT: "v1alpha4"
+  INIT_WITH_KUBERNETES_VERSION: "v1.22.0"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -29,12 +29,18 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v0.3.23 # latest published release
+  - name: v0.3.23 # latest published release in the v1alpha3 series; this is used for v1alpha3 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/core-components.yaml"
     type: "url"
     replacements:
     - old: --metrics-addr=127.0.0.1:8080
       new: --metrics-addr=:8080
+  - name: v0.4.3 # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
+      value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.3/core-components.yaml"
+      type: "url"
+      replacements:
+        - old: --metrics-addr=127.0.0.1:8080
+          new: --metrics-addr=:8080
   - name: v1.0.99 # next; use manifest from source files
     value: ../../../config/default
     replacements:
@@ -46,8 +52,14 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v0.3.23 # latest published release
+  - name: v0.3.23 # latest published release in the v1alpha3 series; this is used for v1alpha3 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/bootstrap-components.yaml"
+    type: "url"
+    replacements:
+      - old: --metrics-addr=127.0.0.1:8080
+        new: --metrics-addr=:8080
+  - name: v0.4.3 # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.3/bootstrap-components.yaml"
     type: "url"
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
@@ -63,8 +75,14 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v0.3.23 # latest published release
+  - name: v0.3.23 # latest published release in the v1alpha3 series; this is used for v1alpha3 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/control-plane-components.yaml"
+    type: "url"
+    replacements:
+      - old: --metrics-addr=127.0.0.1:8080
+        new: --metrics-addr=:8080
+  - name: v0.4.3 # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.3/control-plane-components.yaml"
     type: "url"
     replacements:
       - old: --metrics-addr=127.0.0.1:8080
@@ -80,7 +98,7 @@ providers:
 - name: docker
   type: InfrastructureProvider
   versions:
-  - name: v0.3.23 # latest published release
+  - name: v0.3.23 # latest published release in the v1alpha3 series; this is used for v1alpha3 --> v1beta1 clusterctl upgrades test only.
     value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.23/infrastructure-components-development.yaml"
     type: "url"
     replacements:
@@ -89,6 +107,15 @@ providers:
     files:
       # Add cluster templates
       - sourcePath: "../data/infrastructure-docker/v1alpha3/cluster-template.yaml"
+  - name: v0.4.3 # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.3/infrastructure-components-development.yaml"
+    type: "url"
+    replacements:
+      - old: --metrics-addr=127.0.0.1:8080
+        new: --metrics-addr=:8080
+    files:
+      # Add cluster templates
+      - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template.yaml"
   - name: v1.0.99 # next; use manifest from source files
     value: ../../../test/infrastructure/docker/config/default
     replacements:

--- a/test/e2e/data/shared/v1alpha3/metadata.yaml
+++ b/test/e2e/data/shared/v1alpha3/metadata.yaml
@@ -1,0 +1,9 @@
+apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
+releaseSeries:
+  - major: 0
+    minor: 3
+    contract: v1alpha3
+  - major: 0
+    minor: 2
+    contract: v1alpha2


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add support for v1alpha3 to v1beta1 upgrades in clusterctl, under the assumption v1alpha4 and v1beta1 contract are the same.

It also add support for testing both v1alpha3 --> v1beta1 and v1alpha4 --> v1beta1 upgrades (this will require a PR in test infra as soon as this PR will be merged)

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5269
