### PR TITLE
🌱 CAPD: add conversion tests for v1alpha3 and v1alpha4

### DIFF
--- a/test/infrastructure/docker/api/v1alpha3/conversion_test.go
+++ b/test/infrastructure/docker/api/v1alpha3/conversion_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+)
+
+func TestFuzzyConversion(t *testing.T) {
+	t.Run("for DockerCluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &v1beta1.DockerCluster{},
+		Spoke: &DockerCluster{},
+	}))
+
+	t.Run("for DockerMachine", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &v1beta1.DockerMachine{},
+		Spoke: &DockerMachine{},
+	}))
+
+	t.Run("for DockerMachineTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &v1beta1.DockerMachineTemplate{},
+		Spoke: &DockerMachineTemplate{},
+	}))
+}

--- a/test/infrastructure/docker/api/v1alpha4/conversion_test.go
+++ b/test/infrastructure/docker/api/v1alpha4/conversion_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"testing"
+
+	"sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+)
+
+func TestFuzzyConversion(t *testing.T) {
+	t.Run("for DockerCluster", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &v1beta1.DockerCluster{},
+		Spoke: &DockerCluster{},
+	}))
+
+	t.Run("for DockerClusterTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &v1beta1.DockerClusterTemplate{},
+		Spoke: &DockerClusterTemplate{},
+	}))
+
+	t.Run("for DockerMachine", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &v1beta1.DockerMachine{},
+		Spoke: &DockerMachine{},
+	}))
+
+	t.Run("for DockerMachineTemplate", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &v1beta1.DockerMachineTemplate{},
+		Spoke: &DockerMachineTemplate{},
+	}))
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds the missing conversion tests to CAPD v1alpha3 and v1alpha4 types.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5256
