### PR TITLE
🌱 clusterclass: use live client to list MachineDeployments

### DIFF
--- a/controllers/topology/cluster_controller.go
+++ b/controllers/topology/cluster_controller.go
@@ -45,7 +45,10 @@ import (
 
 // ClusterReconciler reconciles a managed topology for a Cluster object.
 type ClusterReconciler struct {
-	Client           client.Client
+	Client client.Client
+	// APIReader is used to list MachineSets directly via the API server to avoid
+	// race conditions caused by an outdated cache.
+	APIReader        client.Reader
 	WatchFilterValue string
 
 	// UnstructuredCachingClient provides a client that forces caching of unstructured objects,
@@ -183,6 +186,7 @@ func (r *ClusterReconciler) clusterClassToCluster(o client.Object) []ctrl.Reques
 		context.TODO(),
 		clusterList,
 		client.MatchingFields{index.ClusterClassNameField: clusterClass.Name},
+		client.InNamespace(clusterClass.Namespace),
 	); err != nil {
 		return nil
 	}

--- a/controllers/topology/current_state.go
+++ b/controllers/topology/current_state.go
@@ -117,10 +117,13 @@ func (r *ClusterReconciler) getCurrentMachineDeploymentState(ctx context.Context
 
 	// List all the machine deployments in the current cluster and in a managed topology.
 	md := &clusterv1.MachineDeploymentList{}
-	err := r.Client.List(ctx, md, client.MatchingLabels{
-		clusterv1.ClusterLabelName:          cluster.Name,
-		clusterv1.ClusterTopologyOwnedLabel: "",
-	})
+	err := r.APIReader.List(ctx, md,
+		client.MatchingLabels{
+			clusterv1.ClusterLabelName:          cluster.Name,
+			clusterv1.ClusterTopologyOwnedLabel: "",
+		},
+		client.InNamespace(cluster.Namespace),
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read MachineDeployments for managed topology")
 	}

--- a/controllers/topology/current_state_test.go
+++ b/controllers/topology/current_state_test.go
@@ -437,6 +437,7 @@ func TestGetCurrentState(t *testing.T) {
 			// Calls getCurrentState.
 			r := &ClusterReconciler{
 				Client:                    fakeClient,
+				APIReader:                 fakeClient,
 				UnstructuredCachingClient: fakeClient,
 			}
 			got, err := r.getCurrentState(ctx, s)

--- a/main.go
+++ b/main.go
@@ -288,6 +288,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 		if err := (&topology.ClusterReconciler{
 			Client:                    mgr.GetClient(),
+			APIReader:                 mgr.GetAPIReader(),
 			UnstructuredCachingClient: unstructuredCachingClient,
 			WatchFilterValue:          watchFilterValue,
 		}).SetupWithManager(ctx, mgr, concurrency(clusterTopologyConcurrency)); err != nil {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR updates the get current state logic in topology controllers to use a live client when listing MachineDeployments. This is to avoid having and race conditions that could be caused due to outdated cache. 

An example issue that was observed a few times is: When creating a topology with 2 MachineDeployments we sometimes observe 3 MachineDeployments being created. This could be happening because the topology controller re-runs before the case is updated with the second MachineDeployment. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
