### PR TITLE
🌱  Add conversions for ClusterResourceSet and ClusterResourceSetBinding

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -22,6 +22,8 @@ patchesStrategicMerge:
 - patches/webhook_in_machinesets.yaml
 - patches/webhook_in_machinedeployments.yaml
 - patches/webhook_in_machinehealthchecks.yaml
+- patches/webhook_in_clusterresourcesets.yaml
+- patches/webhook_in_clusterresourcesetbindings.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
@@ -32,6 +34,8 @@ patchesStrategicMerge:
 - patches/cainjection_in_machinesets.yaml
 - patches/cainjection_in_machinedeployments.yaml
 - patches/cainjection_in_machinehealthchecks.yaml
+- patches/cainjection_in_clusterresourcesets.yaml
+- patches/cainjection_in_clusterresourcesetbindings.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/crd/patches/cainjection_in_clusterresourcesetbindings.yaml
+++ b/config/crd/patches/cainjection_in_clusterresourcesetbindings.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: clusterresourcesetbindings.addons.cluster.x-k8s.io

--- a/config/crd/patches/cainjection_in_clusterresourcesets.yaml
+++ b/config/crd/patches/cainjection_in_clusterresourcesets.yaml
@@ -1,0 +1,8 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: clusterresourcesets.addons.cluster.x-k8s.io

--- a/config/crd/patches/webhook_in_clusterresourcesetbindings.yaml
+++ b/config/crd/patches/webhook_in_clusterresourcesetbindings.yaml
@@ -1,0 +1,19 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterresourcesetbindings.addons.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/config/crd/patches/webhook_in_clusterresourcesets.yaml
+++ b/config/crd/patches/webhook_in_clusterresourcesets.yaml
@@ -1,0 +1,19 @@
+# The following patch enables conversion webhook for CRD
+# CRD conversion requires k8s 1.13 or later.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterresourcesets.addons.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
+        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
+        caBundle: Cg==
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert

--- a/exp/addons/api/v1alpha3/conversion.go
+++ b/exp/addons/api/v1alpha3/conversion.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	v1beta1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+func (src *ClusterResourceSet) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.ClusterResourceSet)
+
+	return Convert_v1alpha3_ClusterResourceSet_To_v1beta1_ClusterResourceSet(src, dst, nil)
+}
+
+func (dst *ClusterResourceSet) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.ClusterResourceSet)
+
+	return Convert_v1beta1_ClusterResourceSet_To_v1alpha3_ClusterResourceSet(src, dst, nil)
+}
+
+func (src *ClusterResourceSetList) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.ClusterResourceSetList)
+
+	return Convert_v1alpha3_ClusterResourceSetList_To_v1beta1_ClusterResourceSetList(src, dst, nil)
+}
+
+func (dst *ClusterResourceSetList) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.ClusterResourceSetList)
+
+	return Convert_v1beta1_ClusterResourceSetList_To_v1alpha3_ClusterResourceSetList(src, dst, nil)
+}
+
+func (src *ClusterResourceSetBinding) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.ClusterResourceSetBinding)
+
+	return Convert_v1alpha3_ClusterResourceSetBinding_To_v1beta1_ClusterResourceSetBinding(src, dst, nil)
+}
+
+func (dst *ClusterResourceSetBinding) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.ClusterResourceSetBinding)
+
+	return Convert_v1beta1_ClusterResourceSetBinding_To_v1alpha3_ClusterResourceSetBinding(src, dst, nil)
+}
+
+func (src *ClusterResourceSetBindingList) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.ClusterResourceSetBindingList)
+
+	return Convert_v1alpha3_ClusterResourceSetBindingList_To_v1beta1_ClusterResourceSetBindingList(src, dst, nil)
+}
+
+func (dst *ClusterResourceSetBindingList) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.ClusterResourceSetBindingList)
+
+	return Convert_v1beta1_ClusterResourceSetBindingList_To_v1alpha3_ClusterResourceSetBindingList(src, dst, nil)
+}

--- a/exp/addons/api/v1alpha3/conversion_test.go
+++ b/exp/addons/api/v1alpha3/conversion_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	clusterv1addons "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+)
+
+func TestFuzzyConversion(t *testing.T) {
+	t.Run("for ClusterResourceSet", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &clusterv1addons.ClusterResourceSet{},
+		Spoke: &ClusterResourceSet{},
+	}))
+	t.Run("for ClusterResourceSetBinding", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &clusterv1addons.ClusterResourceSetBinding{},
+		Spoke: &ClusterResourceSetBinding{},
+	}))
+}

--- a/exp/addons/api/v1alpha4/conversion.go
+++ b/exp/addons/api/v1alpha4/conversion.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	v1beta1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+)
+
+func (src *ClusterResourceSet) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.ClusterResourceSet)
+
+	return Convert_v1alpha4_ClusterResourceSet_To_v1beta1_ClusterResourceSet(src, dst, nil)
+}
+
+func (dst *ClusterResourceSet) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.ClusterResourceSet)
+
+	return Convert_v1beta1_ClusterResourceSet_To_v1alpha4_ClusterResourceSet(src, dst, nil)
+}
+
+func (src *ClusterResourceSetList) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.ClusterResourceSetList)
+
+	return Convert_v1alpha4_ClusterResourceSetList_To_v1beta1_ClusterResourceSetList(src, dst, nil)
+}
+
+func (dst *ClusterResourceSetList) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.ClusterResourceSetList)
+
+	return Convert_v1beta1_ClusterResourceSetList_To_v1alpha4_ClusterResourceSetList(src, dst, nil)
+}
+
+func (src *ClusterResourceSetBinding) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.ClusterResourceSetBinding)
+
+	return Convert_v1alpha4_ClusterResourceSetBinding_To_v1beta1_ClusterResourceSetBinding(src, dst, nil)
+}
+
+func (dst *ClusterResourceSetBinding) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.ClusterResourceSetBinding)
+
+	return Convert_v1beta1_ClusterResourceSetBinding_To_v1alpha4_ClusterResourceSetBinding(src, dst, nil)
+}
+
+func (src *ClusterResourceSetBindingList) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.ClusterResourceSetBindingList)
+
+	return Convert_v1alpha4_ClusterResourceSetBindingList_To_v1beta1_ClusterResourceSetBindingList(src, dst, nil)
+}
+
+func (dst *ClusterResourceSetBindingList) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.ClusterResourceSetBindingList)
+
+	return Convert_v1beta1_ClusterResourceSetBindingList_To_v1alpha4_ClusterResourceSetBindingList(src, dst, nil)
+}

--- a/exp/addons/api/v1alpha4/conversion_test.go
+++ b/exp/addons/api/v1alpha4/conversion_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"testing"
+
+	clusterv1addons "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+)
+
+func TestFuzzyConversion(t *testing.T) {
+	t.Run("for ClusterResourceSet", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &clusterv1addons.ClusterResourceSet{},
+		Spoke: &ClusterResourceSet{},
+	}))
+	t.Run("for ClusterResourceSetBinding", utilconversion.FuzzTestFunc(utilconversion.FuzzTestFuncInput{
+		Hub:   &clusterv1addons.ClusterResourceSetBinding{},
+		Spoke: &ClusterResourceSetBinding{},
+	}))
+}

--- a/exp/addons/api/v1beta1/conversion.go
+++ b/exp/addons/api/v1beta1/conversion.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+func (*ClusterResourceSet) Hub()            {}
+func (*ClusterResourceSetList) Hub()        {}
+func (*ClusterResourceSetBinding) Hub()     {}
+func (*ClusterResourceSetBindingList) Hub() {}


### PR DESCRIPTION
This adds the conversion functions and configs to create conversion webhooks for both the ClusterResourceSet and the ClusterResourceSetBinding types.
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fixes #5253 
