### PR TITLE
:seedling: Add conversion-verifier to always verify conversion code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/controller-gen)
 GOTESTSUM := $(abspath $(TOOLS_BIN_DIR)/gotestsum)
 GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/golangci-lint)
 CONVERSION_GEN := $(abspath $(TOOLS_BIN_DIR)/conversion-gen)
+CONVERSION_VERIFIER := $(abspath $(TOOLS_BIN_DIR)/conversion-verifier)
 ENVSUBST := $(abspath $(TOOLS_BIN_DIR)/envsubst)
 
 # clusterctl.
@@ -204,6 +205,9 @@ $(GOTESTSUM): $(TOOLS_DIR)/go.mod # Build gotestsum from tools folder.
 $(CONVERSION_GEN): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/conversion-gen k8s.io/code-generator/cmd/conversion-gen
 
+$(CONVERSION_VERIFIER): $(TOOLS_DIR)/go.mod
+	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/conversion-verifier sigs.k8s.io/cluster-api/hack/tools/conversion-verifier
+
 $(GO_APIDIFF): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR) && go build -tags=tools -o $(GO_APIDIFF_BIN) github.com/joelanford/go-apidiff
 
@@ -223,6 +227,7 @@ kustomize: $(KUSTOMIZE) ## Build a local copy of kustomize.
 setup-envtest: $(SETUP_ENVTEST) ## Build a local copy of setup-envtest.
 controller-gen: $(CONTROLLER_GEN) ## Build a local copy of controller-gen.
 conversion-gen: $(CONVERSION_GEN) ## Build a local copy of conversion-gen.
+conversion-verifier: $(CONVERSION_VERIFIER) ## Build a local copy of conversion-verifier.
 gotestsum: $(GOTESTSUM) ## Build a local copy of gotestsum.
 
 .PHONY: e2e-framework
@@ -655,6 +660,7 @@ verify:
 	./hack/verify-starlark.sh
 	$(MAKE) verify-modules
 	$(MAKE) verify-gen
+	$(MAKE) verify-conversions
 	$(MAKE) verify-docker-provider
 
 .PHONY: verify-modules
@@ -674,6 +680,10 @@ verify-gen: generate
 		git diff; \
 		echo "generated files are out of date, run make generate"; exit 1; \
 	fi
+
+.PHONY: verify-conversions
+verify-conversions: $(CONVERSION_VERIFIER)
+	$(CONVERSION_VERIFIER)
 
 .PHONY: verify-docker-provider
 verify-docker-provider:

--- a/hack/tools/conversion-verifier/doc.go
+++ b/hack/tools/conversion-verifier/doc.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This command line application runs verification steps for conversion types.
+//
+// The following checks are performed:
+// - For each API Kind and Group, only one storage version must exist.
+// - Each storage version type and its List counterpart, if there are multiple API versions,
+//   the type MUST have a Hub() method.
+// - For each type with multiple versions, that has a Hub() and storage version,
+//   the type MUST have ConvertFrom() and ConvertTo() methods.
+package main

--- a/hack/tools/conversion-verifier/main.go
+++ b/hack/tools/conversion-verifier/main.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"go/types"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+	crdmarkers "sigs.k8s.io/controller-tools/pkg/crd/markers"
+	"sigs.k8s.io/controller-tools/pkg/loader"
+	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+var (
+	groupNameMarker        = markers.Must(markers.MakeDefinition("groupName", markers.DescribesPackage, ""))
+	storageVersionMarker   = markers.Must(markers.MakeDefinition("kubebuilder:storageversion", markers.DescribesType, crdmarkers.StorageVersion{}))
+	nolintConversionMarker = markers.Must(markers.MakeDefinition("kubebuilder:conversion:nolint", markers.DescribesType, false))
+
+	apiPackages         = map[string]*apiPackage{}
+	storageVersionTypes = map[string]*storageVersionType{}
+)
+
+type apiPackage struct {
+	*loader.Package
+	Group string
+}
+
+// versionType contains information about
+// a specific type.
+type versionType struct {
+	pkg *loader.Package
+	typ *markers.TypeInfo
+}
+
+// IsConvertible checks if the type has ConvertFrom and ConvertTo methods.
+func (v *versionType) IsConvertible() bool {
+	return hasMethod(v.pkg, v.typ, "ConvertFrom") && hasMethod(v.pkg, v.typ, "ConvertTo")
+}
+
+// storageVersionType is a versionType that has been found to be also a storage version
+// this type should only be created once per type.
+type storageVersionType struct {
+	*versionType
+
+	// otherDecls contains all the other declarations for the same type in other packages.
+	otherDecls map[string]*versionType
+}
+
+// IsHub checks if the type has Hub method.
+func (s *storageVersionType) IsHub() bool {
+	return hasMethod(s.pkg, s.typ, "Hub")
+}
+
+func main() {
+	var result error
+
+	// Define the marker collector.
+	col := &markers.Collector{
+		Registry: &markers.Registry{},
+	}
+	// Register the markers.
+	if err := col.Registry.Register(groupNameMarker); err != nil {
+		klog.Fatal(err)
+	}
+	if err := col.Registry.Register(storageVersionMarker); err != nil {
+		klog.Fatal(err)
+	}
+	if err := col.Registry.Register(nolintConversionMarker); err != nil {
+		klog.Fatal(err)
+	}
+
+	// Load all packages.
+	// TODO: Move the path parameter to a multi-string flag.
+	packages, err := loader.LoadRoots("./...")
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	// First loop through all the packages
+	// and find the ones that have a storage version assigned.
+	for _, pkg := range packages {
+		group := apiGroupForPackage(col, pkg)
+		if len(group) == 0 {
+			// We're only interested in api folders, exclude everything
+			// else that's not an API package.
+			continue
+		}
+
+		// Store the packages.
+		apiPackages[pkg.PkgPath] = &apiPackage{
+			Package: pkg,
+			Group:   group,
+		}
+
+		// Populate type information and loop through every type in from this package root.
+		pkg.NeedTypesInfo()
+		if err := markers.EachType(col, pkg, func(info *markers.TypeInfo) {
+			// Check if the type is registered with storage version.
+			if m := info.Markers.Get(storageVersionMarker.Name); m == nil {
+				return
+			}
+			if _, ok := storageVersionTypes[info.Name]; ok {
+				result = multierror.Append(result,
+					errors.Errorf("type %q has a redeclared storage version in package %q", info.Name, pkg.PkgPath),
+				)
+				return
+			}
+
+			// Store the type and package as selected storage version.
+			storageVersionTypes[path.Join(group, info.Name)] = &storageVersionType{
+				versionType: &versionType{
+					pkg: pkg,
+					typ: info,
+				},
+				otherDecls: make(map[string]*versionType),
+			}
+		}); err != nil {
+			klog.Fatal(err)
+		}
+	}
+
+	// Find and populate all <Kind>List types.
+	for _, pkg := range apiPackages {
+		if err := markers.EachType(col, pkg.Package, func(info *markers.TypeInfo) {
+			if !strings.HasSuffix(info.Name, "List") {
+				// We're only interested in List types in this iteration.
+				return
+			}
+			storage, ok := storageVersionTypes[path.Join(pkg.Group, strings.TrimSuffix(info.Name, "List"))]
+			if !ok || pkg.PkgPath != storage.pkg.PkgPath {
+				// Return early if the type isn't in the same storage package
+				// or if there is no storage version registered for this type.
+				return
+			}
+
+			// If we're here, we've found <Kind>List type that's also a storage version.
+			storageVersionTypes[path.Join(pkg.Group, info.Name)] = &storageVersionType{
+				versionType: &versionType{
+					pkg: pkg.Package,
+					typ: info,
+				},
+				otherDecls: make(map[string]*versionType),
+			}
+		}); err != nil {
+			klog.Fatal(err)
+		}
+	}
+
+	// Now that we have storage version information,
+	// loop through every package again and collect info about all declarations.
+	for _, pkg := range apiPackages {
+		if err := markers.EachType(col, pkg.Package, func(info *markers.TypeInfo) {
+			storage, ok := storageVersionTypes[path.Join(pkg.Group, info.Name)]
+			if !ok {
+				// If this type isn't a storage version, keep looping.
+				return
+			}
+			if pkg.PkgPath == storage.pkg.PkgPath {
+				// If we're in the same package, we've probably found again the
+				// storage version.
+				return
+			}
+			// Check if the type should not be checked against conversion rules.
+			if m := info.Markers.Get(nolintConversionMarker.Name); m != nil && m.(bool) {
+				return
+			}
+			storage.otherDecls[pkg.PkgPath] = &versionType{
+				pkg: pkg.Package,
+				typ: info,
+			}
+		}); err != nil {
+			klog.Fatal(err)
+		}
+	}
+
+	for name, storageType := range storageVersionTypes {
+		if len(storageType.otherDecls) == 0 {
+			continue
+		}
+
+		if !storageType.IsHub() {
+			result = multierror.Append(result,
+				errors.Errorf("type %q in package %q marked as storage version but it's not convertible, missing Hub() method", name, storageType.pkg.PkgPath),
+			)
+		}
+		for _, decl := range storageType.otherDecls {
+			if !decl.IsConvertible() {
+				result = multierror.Append(result,
+					errors.Errorf("type %q in package %q it's not convertible, missing ConvertFrom() and ConvertTo() methods", name, decl.pkg.PkgPath),
+				)
+			}
+		}
+	}
+
+	if result != nil {
+		klog.Exit(result.Error())
+	}
+}
+
+func apiGroupForPackage(col *markers.Collector, pkg *loader.Package) string {
+	pkgMarkers, err := markers.PackageMarkers(col, pkg)
+	if err != nil {
+		klog.Fatal(err)
+	}
+	group := pkgMarkers.Get(groupNameMarker.Name)
+	if group == nil {
+		return ""
+	}
+	return group.(string)
+}
+
+func hasMethod(pkg *loader.Package, typ *markers.TypeInfo, name string) bool {
+	t := pkg.TypesInfo.TypeOf(typ.RawSpec.Name)
+	method, ind, _ := types.LookupFieldOrMethod(t, true, pkg.Types, name)
+	if len(ind) != 1 {
+		// ignore embedded methods
+		return false
+	}
+	if method == nil {
+		return false
+	}
+	return true
+}

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -5,13 +5,16 @@ go 1.16
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/drone/envsubst/v2 v2.0.0-20210615175204-7bf45dbf5372
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/joelanford/go-apidiff v0.1.0
 	github.com/onsi/ginkgo v1.16.4
+	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.2.0 // indirect
 	golang.org/x/exp v0.0.0-20210625193404-fa9d1d177d71 // indirect
 	golang.org/x/tools v0.1.5
 	gotest.tools/gotestsum v1.6.4
 	k8s.io/code-generator v0.22.2
+	k8s.io/klog/v2 v2.9.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20210827150604-1730628f118b
 	sigs.k8s.io/controller-tools v0.7.0
 	sigs.k8s.io/kubebuilder/docs/book/utils v0.0.0-20210702145813-742983631190

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -309,10 +309,12 @@ github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBt
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=


### PR DESCRIPTION
This change adds a sort-of-custom linter to the hack/tools folder which
does basic verification of our types. The linter isn't generic and it's
customized to the Cluster API's codebase needs and structure. It can be
improved and made better in the future and we should be able to further
generalize it with time.

The conversion-verifier is needed given that conversion information has
been missed in the past causing types to remain unconvertible.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5287
