### PR TITLE
🌱 Deprecate controllers/mdutil package, moving to internal

### DIFF
--- a/api/v1alpha4/machinedeployment_types.go
+++ b/api/v1alpha4/machinedeployment_types.go
@@ -53,6 +53,10 @@ const (
 	// is machinedeployment.spec.replicas + maxSurge. Used by the underlying machine sets to estimate their
 	// proportions in case the deployment has surge replicas.
 	MaxReplicasAnnotation = "machinedeployment.clusters.x-k8s.io/max-replicas"
+
+	// MachineDeploymentUniqueLabel is the label applied to Machines
+	// in a MachineDeployment containing the hash of the template.
+	MachineDeploymentUniqueLabel = "machine-template-hash"
 )
 
 // ANCHOR: MachineDeploymentSpec

--- a/cmd/clusterctl/client/alpha/rollout_rollbacker.go
+++ b/cmd/clusterctl/client/alpha/rollout_rollbacker.go
@@ -22,7 +22,6 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
-	"sigs.k8s.io/cluster-api/controllers/mdutil"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
@@ -73,7 +72,7 @@ func rollbackMachineDeployment(proxy cluster.Proxy, d *clusterv1.MachineDeployme
 	}
 	// Copy template into the machinedeployment (excluding the hash)
 	revMSTemplate := *msForRevision.Spec.Template.DeepCopy()
-	delete(revMSTemplate.Labels, mdutil.DefaultMachineDeploymentUniqueLabelKey)
+	delete(revMSTemplate.Labels, clusterv1.MachineDeploymentUniqueLabel)
 
 	d.Spec.Template = revMSTemplate
 	return patchHelper.Patch(ctx, d)

--- a/controllers/internal/mdutil/doc.go
+++ b/controllers/internal/mdutil/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mdutil implements MachineDeployment utilities
+// meant to be consumed internally by the controller.
+package mdutil

--- a/controllers/internal/mdutil/util.go
+++ b/controllers/internal/mdutil/util.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Package mdutil implements MachineDeployment utilities.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 package mdutil
 
 import (
@@ -39,36 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/conversion"
 )
 
-const (
-	// DefaultMachineDeploymentUniqueLabelKey is the label applied to Machines
-	// in a MachineDeployment containing the hash of the template.
-	// Deprecated: This field package is removed, please use the one in the API package instead.
-	DefaultMachineDeploymentUniqueLabelKey = "machine-template-hash"
-
-	// FailedMSCreateReason is added in a machine deployment when it cannot create a new machine set.
-	// Deprecated: This field will be removed in a next release.
-	FailedMSCreateReason = "MachineSetCreateError"
-
-	// FoundNewMSReason is added in a machine deployment when it adopts an existing machine set.
-	// Deprecated: This field will be removed in a next release.
-	FoundNewMSReason = "FoundNewMachineSet"
-
-	// PausedDeployReason is added in a deployment when it is paused. Lack of progress shouldn't be
-	// estimated once a deployment is paused.
-	// Deprecated: This field will be removed in a next release.
-	PausedDeployReason = "DeploymentPaused"
-
-	// MinimumReplicasAvailable is added in a deployment when it has its minimum replicas required available.
-	// Deprecated: This field will be removed in a next release.
-	MinimumReplicasAvailable = "MinimumReplicasAvailable"
-	// MinimumReplicasUnavailable is added in a deployment when it doesn't have the minimum required replicas
-	// available.
-	// Deprecated: This field will be removed in a next release.
-	MinimumReplicasUnavailable = "MinimumReplicasUnavailable"
-)
-
 // MachineSetsByCreationTimestamp sorts a list of MachineSet by creation timestamp, using their names as a tie breaker.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 type MachineSetsByCreationTimestamp []*clusterv1.MachineSet
 
 func (o MachineSetsByCreationTimestamp) Len() int      { return len(o) }
@@ -82,7 +52,6 @@ func (o MachineSetsByCreationTimestamp) Less(i, j int) bool {
 
 // MachineSetsBySizeOlder sorts a list of MachineSet by size in descending order, using their creation timestamp or name as a tie breaker.
 // By using the creation timestamp, this sorts from old to new machine sets.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 type MachineSetsBySizeOlder []*clusterv1.MachineSet
 
 func (o MachineSetsBySizeOlder) Len() int      { return len(o) }
@@ -96,7 +65,6 @@ func (o MachineSetsBySizeOlder) Less(i, j int) bool {
 
 // MachineSetsBySizeNewer sorts a list of MachineSet by size in descending order, using their creation timestamp or name as a tie breaker.
 // By using the creation timestamp, this sorts from new to old machine sets.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 type MachineSetsBySizeNewer []*clusterv1.MachineSet
 
 func (o MachineSetsBySizeNewer) Len() int      { return len(o) }
@@ -109,7 +77,6 @@ func (o MachineSetsBySizeNewer) Less(i, j int) bool {
 }
 
 // SetDeploymentRevision updates the revision for a deployment.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func SetDeploymentRevision(deployment *clusterv1.MachineDeployment, revision string) bool {
 	updated := false
 
@@ -125,7 +92,6 @@ func SetDeploymentRevision(deployment *clusterv1.MachineDeployment, revision str
 }
 
 // MaxRevision finds the highest revision in the machine sets.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func MaxRevision(allMSs []*clusterv1.MachineSet, logger logr.Logger) int64 {
 	max := int64(0)
 	for _, ms := range allMSs {
@@ -141,7 +107,6 @@ func MaxRevision(allMSs []*clusterv1.MachineSet, logger logr.Logger) int64 {
 }
 
 // Revision returns the revision number of the input object.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func Revision(obj runtime.Object) (int64, error) {
 	acc, err := meta.Accessor(obj)
 	if err != nil {
@@ -218,7 +183,6 @@ func getIntFromAnnotation(ms *clusterv1.MachineSet, annotationKey string, logger
 
 // SetNewMachineSetAnnotations sets new machine set's annotations appropriately by updating its revision and
 // copying required deployment annotations to it; it returns true if machine set's annotation is changed.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func SetNewMachineSetAnnotations(deployment *clusterv1.MachineDeployment, newMS *clusterv1.MachineSet, newRevision string, exists bool, logger logr.Logger) bool {
 	logger = logger.WithValues("machineset", newMS.Name)
 
@@ -275,7 +239,6 @@ func SetNewMachineSetAnnotations(deployment *clusterv1.MachineDeployment, newMS 
 // FindOneActiveOrLatest returns the only active or the latest machine set in case there is at most one active
 // machine set. If there are more than one active machine sets, return nil so machine sets can be scaled down
 // to the point where there is only one active machine set.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func FindOneActiveOrLatest(newMS *clusterv1.MachineSet, oldMSs []*clusterv1.MachineSet) *clusterv1.MachineSet {
 	if newMS == nil && len(oldMSs) == 0 {
 		return nil
@@ -299,7 +262,6 @@ func FindOneActiveOrLatest(newMS *clusterv1.MachineSet, oldMSs []*clusterv1.Mach
 }
 
 // SetReplicasAnnotations sets the desiredReplicas and maxReplicas into the annotations.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func SetReplicasAnnotations(ms *clusterv1.MachineSet, desiredReplicas, maxReplicas int32) bool {
 	updated := false
 	if ms.Annotations == nil {
@@ -310,16 +272,14 @@ func SetReplicasAnnotations(ms *clusterv1.MachineSet, desiredReplicas, maxReplic
 		ms.Annotations[clusterv1.DesiredReplicasAnnotation] = desiredString
 		updated = true
 	}
-	maxString := fmt.Sprintf("%d", maxReplicas)
-	if hasString := ms.Annotations[clusterv1.MaxReplicasAnnotation]; hasString != maxString {
-		ms.Annotations[clusterv1.MaxReplicasAnnotation] = maxString
+	if hasString := ms.Annotations[clusterv1.MaxReplicasAnnotation]; hasString != fmt.Sprintf("%d", maxReplicas) {
+		ms.Annotations[clusterv1.MaxReplicasAnnotation] = fmt.Sprintf("%d", maxReplicas)
 		updated = true
 	}
 	return updated
 }
 
 // ReplicasAnnotationsNeedUpdate return true if the replicas annotation needs to be updated.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func ReplicasAnnotationsNeedUpdate(ms *clusterv1.MachineSet, desiredReplicas, maxReplicas int32) bool {
 	if ms.Annotations == nil {
 		return true
@@ -328,15 +288,13 @@ func ReplicasAnnotationsNeedUpdate(ms *clusterv1.MachineSet, desiredReplicas, ma
 	if hasString := ms.Annotations[clusterv1.DesiredReplicasAnnotation]; hasString != desiredString {
 		return true
 	}
-	maxString := fmt.Sprintf("%d", maxReplicas)
-	if hasString := ms.Annotations[clusterv1.MaxReplicasAnnotation]; hasString != maxString {
+	if hasString := ms.Annotations[clusterv1.MaxReplicasAnnotation]; hasString != fmt.Sprintf("%d", maxReplicas) {
 		return true
 	}
 	return false
 }
 
 // MaxUnavailable returns the maximum unavailable machines a rolling deployment can take.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func MaxUnavailable(deployment clusterv1.MachineDeployment) int32 {
 	if !IsRollingUpdate(&deployment) || *(deployment.Spec.Replicas) == 0 {
 		return int32(0)
@@ -350,7 +308,6 @@ func MaxUnavailable(deployment clusterv1.MachineDeployment) int32 {
 }
 
 // MaxSurge returns the maximum surge machines a rolling deployment can take.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func MaxSurge(deployment clusterv1.MachineDeployment) int32 {
 	if !IsRollingUpdate(&deployment) {
 		return int32(0)
@@ -363,7 +320,6 @@ func MaxSurge(deployment clusterv1.MachineDeployment) int32 {
 // GetProportion will estimate the proportion for the provided machine set using 1. the current size
 // of the parent deployment, 2. the replica count that needs be added on the machine sets of the
 // deployment, and 3. the total replicas added in the machine sets of the deployment so far.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func GetProportion(ms *clusterv1.MachineSet, d clusterv1.MachineDeployment, deploymentReplicasToAdd, deploymentReplicasAdded int32, logger logr.Logger) int32 {
 	if ms == nil || *(ms.Spec.Replicas) == 0 || deploymentReplicasToAdd == 0 || deploymentReplicasToAdd == deploymentReplicasAdded {
 		return int32(0)
@@ -386,7 +342,6 @@ func GetProportion(ms *clusterv1.MachineSet, d clusterv1.MachineDeployment, depl
 
 // getMachineSetFraction estimates the fraction of replicas a machine set can have in
 // 1. a scaling event during a rollout or 2. when scaling a paused deployment.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func getMachineSetFraction(ms clusterv1.MachineSet, d clusterv1.MachineDeployment, logger logr.Logger) int32 {
 	// If we are scaling down to zero then the fraction of this machine set is its whole size (negative)
 	if *(d.Spec.Replicas) == int32(0) {
@@ -411,7 +366,6 @@ func getMachineSetFraction(ms clusterv1.MachineSet, d clusterv1.MachineDeploymen
 
 // EqualMachineTemplate returns true if two given machineTemplateSpec are equal,
 // ignoring the diff in value of Labels["machine-template-hash"], and the version from external references.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func EqualMachineTemplate(template1, template2 *clusterv1.MachineTemplateSpec) bool {
 	t1Copy := template1.DeepCopy()
 	t2Copy := template2.DeepCopy()
@@ -420,8 +374,8 @@ func EqualMachineTemplate(template1, template2 *clusterv1.MachineTemplateSpec) b
 	// 1. The hash result would be different upon machineTemplateSpec API changes
 	//    (e.g. the addition of a new field will cause the hash code to change)
 	// 2. The deployment template won't have hash labels
-	delete(t1Copy.Labels, DefaultMachineDeploymentUniqueLabelKey)
-	delete(t2Copy.Labels, DefaultMachineDeploymentUniqueLabelKey)
+	delete(t1Copy.Labels, clusterv1.MachineDeploymentUniqueLabel)
+	delete(t2Copy.Labels, clusterv1.MachineDeploymentUniqueLabel)
 
 	// Remove the version part from the references APIVersion field,
 	// for more details see issue #2183 and #2140.
@@ -438,7 +392,6 @@ func EqualMachineTemplate(template1, template2 *clusterv1.MachineTemplateSpec) b
 }
 
 // FindNewMachineSet returns the new MS this given deployment targets (the one with the same machine template).
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func FindNewMachineSet(deployment *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) *clusterv1.MachineSet {
 	sort.Sort(MachineSetsByCreationTimestamp(msList))
 	for i := range msList {
@@ -458,7 +411,6 @@ func FindNewMachineSet(deployment *clusterv1.MachineDeployment, msList []*cluste
 // Returns two list of machine sets
 //  - the first contains all old machine sets with all non-zero replicas
 //  - the second contains all old machine sets
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func FindOldMachineSets(deployment *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) ([]*clusterv1.MachineSet, []*clusterv1.MachineSet) {
 	var requiredMSs []*clusterv1.MachineSet
 	allMSs := make([]*clusterv1.MachineSet, 0, len(msList))
@@ -477,7 +429,6 @@ func FindOldMachineSets(deployment *clusterv1.MachineDeployment, msList []*clust
 }
 
 // GetReplicaCountForMachineSets returns the sum of Replicas of the given machine sets.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func GetReplicaCountForMachineSets(machineSets []*clusterv1.MachineSet) int32 {
 	totalReplicas := int32(0)
 	for _, ms := range machineSets {
@@ -489,7 +440,6 @@ func GetReplicaCountForMachineSets(machineSets []*clusterv1.MachineSet) int32 {
 }
 
 // GetActualReplicaCountForMachineSets returns the sum of actual replicas of the given machine sets.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func GetActualReplicaCountForMachineSets(machineSets []*clusterv1.MachineSet) int32 {
 	totalActualReplicas := int32(0)
 	for _, ms := range machineSets {
@@ -506,7 +456,6 @@ func GetActualReplicaCountForMachineSets(machineSets []*clusterv1.MachineSet) in
 // Use max(spec.Replicas,status.Replicas) to cover the cases that:
 // 1. Scale up, where spec.Replicas increased but no machine created yet, so spec.Replicas > status.Replicas
 // 2. Scale down, where spec.Replicas decreased but machine not deleted yet, so spec.Replicas < status.Replicas.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func TotalMachineSetsReplicaSum(machineSets []*clusterv1.MachineSet) int32 {
 	totalReplicas := int32(0)
 	for _, ms := range machineSets {
@@ -518,7 +467,6 @@ func TotalMachineSetsReplicaSum(machineSets []*clusterv1.MachineSet) int32 {
 }
 
 // GetReadyReplicaCountForMachineSets returns the number of ready machines corresponding to the given machine sets.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func GetReadyReplicaCountForMachineSets(machineSets []*clusterv1.MachineSet) int32 {
 	totalReadyReplicas := int32(0)
 	for _, ms := range machineSets {
@@ -530,7 +478,6 @@ func GetReadyReplicaCountForMachineSets(machineSets []*clusterv1.MachineSet) int
 }
 
 // GetAvailableReplicaCountForMachineSets returns the number of available machines corresponding to the given machine sets.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func GetAvailableReplicaCountForMachineSets(machineSets []*clusterv1.MachineSet) int32 {
 	totalAvailableReplicas := int32(0)
 	for _, ms := range machineSets {
@@ -542,14 +489,12 @@ func GetAvailableReplicaCountForMachineSets(machineSets []*clusterv1.MachineSet)
 }
 
 // IsRollingUpdate returns true if the strategy type is a rolling update.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func IsRollingUpdate(deployment *clusterv1.MachineDeployment) bool {
 	return deployment.Spec.Strategy.Type == clusterv1.RollingUpdateMachineDeploymentStrategyType
 }
 
 // DeploymentComplete considers a deployment to be complete once all of its desired replicas
 // are updated and available, and no old machines are running.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func DeploymentComplete(deployment *clusterv1.MachineDeployment, newStatus *clusterv1.MachineDeploymentStatus) bool {
 	return newStatus.UpdatedReplicas == *(deployment.Spec.Replicas) &&
 		newStatus.Replicas == *(deployment.Spec.Replicas) &&
@@ -562,7 +507,6 @@ func DeploymentComplete(deployment *clusterv1.MachineDeployment, newStatus *clus
 // 1) The new MS is saturated: newMS's replicas == deployment's replicas
 // 2) For RollingUpdateStrategy: Max number of machines allowed is reached: deployment's replicas + maxSurge == all MSs' replicas.
 // 3) For OnDeleteStrategy: Max number of machines allowed is reached: deployment's replicas == all MSs' replicas.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func NewMSNewReplicas(deployment *clusterv1.MachineDeployment, allMSs []*clusterv1.MachineSet, newMS *clusterv1.MachineSet) (int32, error) {
 	switch deployment.Spec.Strategy.Type {
 	case clusterv1.RollingUpdateMachineDeploymentStrategyType:
@@ -603,7 +547,6 @@ func NewMSNewReplicas(deployment *clusterv1.MachineDeployment, allMSs []*cluster
 // Both the deployment and the machine set have to believe this machine set can own all of the desired
 // replicas in the deployment and the annotation helps in achieving that. All machines of the MachineSet
 // need to be available.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func IsSaturated(deployment *clusterv1.MachineDeployment, ms *clusterv1.MachineSet) bool {
 	if ms == nil {
 		return false
@@ -627,7 +570,6 @@ func IsSaturated(deployment *clusterv1.MachineDeployment, ms *clusterv1.MachineS
 // 1 desired, max unavailable 25%, surge 1% - should scale new(+1), then old(-1)
 // 2 desired, max unavailable 0%, surge 1% - should scale new(+1), then old(-1), then new(+1), then old(-1)
 // 1 desired, max unavailable 0%, surge 1% - should scale new(+1), then old(-1).
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func ResolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired int32) (int32, int32, error) {
 	surge, err := intstrutil.GetScaledValueFromIntOrPercent(maxSurge, int(desired), true)
 	if err != nil {
@@ -650,7 +592,6 @@ func ResolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired
 }
 
 // FilterActiveMachineSets returns machine sets that have (or at least ought to have) machines.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func FilterActiveMachineSets(machineSets []*clusterv1.MachineSet) []*clusterv1.MachineSet {
 	activeFilter := func(ms *clusterv1.MachineSet) bool {
 		return ms != nil && ms.Spec.Replicas != nil && *(ms.Spec.Replicas) > 0
@@ -661,7 +602,6 @@ func FilterActiveMachineSets(machineSets []*clusterv1.MachineSet) []*clusterv1.M
 type filterMS func(ms *clusterv1.MachineSet) bool
 
 // FilterMachineSets returns machine sets that are filtered by filterFn (all returned ones should match filterFn).
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func FilterMachineSets(mSes []*clusterv1.MachineSet, filterFn filterMS) []*clusterv1.MachineSet {
 	var filtered []*clusterv1.MachineSet
 	for i := range mSes {
@@ -674,7 +614,6 @@ func FilterMachineSets(mSes []*clusterv1.MachineSet, filterFn filterMS) []*clust
 
 // CloneAndAddLabel clones the given map and returns a new map with the given key and value added.
 // Returns the given map, if labelKey is empty.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func CloneAndAddLabel(labels map[string]string, labelKey, labelValue string) map[string]string {
 	if labelKey == "" {
 		// Don't need to add a label.
@@ -691,7 +630,6 @@ func CloneAndAddLabel(labels map[string]string, labelKey, labelValue string) map
 
 // CloneSelectorAndAddLabel clones the given selector and returns a new selector with the given key and value added.
 // Returns the given selector, if labelKey is empty.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func CloneSelectorAndAddLabel(selector *metav1.LabelSelector, labelKey, labelValue string) *metav1.LabelSelector {
 	if labelKey == "" {
 		// Don't need to add a label.
@@ -730,27 +668,9 @@ func CloneSelectorAndAddLabel(selector *metav1.LabelSelector, labelKey, labelVal
 	return newSelector
 }
 
-// DeepHashObject writes specified object to hash using the spew library
-// which follows pointers and prints actual values of the nested objects
-// ensuring the hash does not change when a pointer changes.
-// Deprecated: Please use controllers/mdutil SpewHashObject(hasher, objectToWrite).
-func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
-	hasher.Reset()
-	printer := spew.ConfigState{
-		Indent:         " ",
-		SortKeys:       true,
-		DisableMethods: true,
-		SpewKeys:       true,
-	}
-	// We ignore the returned error because there is no way to return the error without
-	// breaking API compatibility. Please use SpewHashObject instead.
-	_, _ = printer.Fprintf(hasher, "%#v", objectToWrite)
-}
-
 // SpewHashObject writes specified object to hash using the spew library
 // which follows pointers and prints actual values of the nested objects
 // ensuring the hash does not change when a pointer changes.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func SpewHashObject(hasher hash.Hash, objectToWrite interface{}) error {
 	hasher.Reset()
 	printer := spew.ConfigState{
@@ -766,19 +686,10 @@ func SpewHashObject(hasher hash.Hash, objectToWrite interface{}) error {
 	return nil
 }
 
-// ComputeHash computes the hash of a MachineTemplateSpec using the spew library.
-// Deprecated: Please use controllers/mdutil ComputeSpewHash(template).
-func ComputeHash(template *clusterv1.MachineTemplateSpec) uint32 {
-	machineTemplateSpecHasher := fnv.New32a()
-	DeepHashObject(machineTemplateSpecHasher, *template)
-	return machineTemplateSpecHasher.Sum32()
-}
-
 // ComputeSpewHash computes the hash of a MachineTemplateSpec using the spew library.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
-func ComputeSpewHash(template *clusterv1.MachineTemplateSpec) (uint32, error) {
+func ComputeSpewHash(objectToWrite interface{}) (uint32, error) {
 	machineTemplateSpecHasher := fnv.New32a()
-	if err := SpewHashObject(machineTemplateSpecHasher, *template); err != nil {
+	if err := SpewHashObject(machineTemplateSpecHasher, objectToWrite); err != nil {
 		return 0, err
 	}
 	return machineTemplateSpecHasher.Sum32(), nil
@@ -786,7 +697,6 @@ func ComputeSpewHash(template *clusterv1.MachineTemplateSpec) (uint32, error) {
 
 // GetDeletingMachineCount gets the number of machines that are in the process of being deleted
 // in a machineList.
-// Deprecated: This package is becoming internal and it will be removed in a next release.
 func GetDeletingMachineCount(machineList *clusterv1.MachineList) int32 {
 	var deletingMachineCount int32
 	for _, machine := range machineList.Items {

--- a/controllers/internal/mdutil/util_test.go
+++ b/controllers/internal/mdutil/util_test.go
@@ -1,0 +1,828 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mdutil
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/klog/v2/klogr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+)
+
+func newDControllerRef(d *clusterv1.MachineDeployment) *metav1.OwnerReference {
+	isController := true
+	return &metav1.OwnerReference{
+		APIVersion: "clusters/v1alpha",
+		Kind:       "MachineDeployment",
+		Name:       d.GetName(),
+		UID:        d.GetUID(),
+		Controller: &isController,
+	}
+}
+
+// generateMS creates a machine set, with the input deployment's template as its template.
+func generateMS(deployment clusterv1.MachineDeployment) clusterv1.MachineSet {
+	template := deployment.Spec.Template.DeepCopy()
+	return clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:             randomUID(),
+			Name:            names.SimpleNameGenerator.GenerateName("machineset"),
+			Labels:          template.Labels,
+			OwnerReferences: []metav1.OwnerReference{*newDControllerRef(&deployment)},
+		},
+		Spec: clusterv1.MachineSetSpec{
+			Replicas: new(int32),
+			Template: *template,
+			Selector: metav1.LabelSelector{MatchLabels: template.Labels},
+		},
+	}
+}
+
+func randomUID() types.UID {
+	return types.UID(strconv.FormatInt(rand.Int63(), 10)) //nolint:gosec
+}
+
+// generateDeployment creates a deployment, with the input image as its template.
+func generateDeployment(image string) clusterv1.MachineDeployment {
+	machineLabels := map[string]string{"name": image}
+	return clusterv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        image,
+			Annotations: make(map[string]string),
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			Replicas: func(i int32) *int32 { return &i }(1),
+			Selector: metav1.LabelSelector{MatchLabels: machineLabels},
+			Template: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: machineLabels,
+				},
+				Spec: clusterv1.MachineSpec{},
+			},
+		},
+	}
+}
+
+func generateMachineTemplateSpec(annotations, labels map[string]string) clusterv1.MachineTemplateSpec {
+	return clusterv1.MachineTemplateSpec{
+		ObjectMeta: clusterv1.ObjectMeta{
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Spec: clusterv1.MachineSpec{},
+	}
+}
+
+func TestEqualMachineTemplate(t *testing.T) {
+	tests := []struct {
+		Name           string
+		Former, Latter clusterv1.MachineTemplateSpec
+		Expected       bool
+	}{
+		{
+			Name:     "Same spec, same labels",
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Expected: true,
+		},
+		{
+			Name:     "Same spec, only machine-template-hash label value is different",
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Expected: true,
+		},
+		{
+			Name:     "Same spec, the former doesn't have machine-template-hash label",
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Expected: true,
+		},
+		{
+			Name:     "Same spec, the former doesn't have machine-template-hash label",
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Expected: true,
+		},
+		{
+			Name:     "Same spec, the label is different, the former doesn't have machine-template-hash label, same number of labels",
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2"}),
+			Expected: false,
+		},
+		{
+			Name:     "Same spec, the label is different, the latter doesn't have machine-template-hash label, same number of labels",
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
+			Expected: false,
+		},
+		{
+			Name:     "Same spec, the label is different, and the machine-template-hash label value is the same",
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Expected: false,
+		},
+		{
+			Name:     "Different spec, same labels",
+			Former:   generateMachineTemplateSpec(map[string]string{"former": "value"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{"latter": "value"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Expected: false,
+		},
+		{
+			Name:     "Different spec, different machine-template-hash label value",
+			Former:   generateMachineTemplateSpec(map[string]string{"x": ""}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-1", "something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{"x": "1"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Expected: false,
+		},
+		{
+			Name:     "Different spec, the former doesn't have machine-template-hash label",
+			Former:   generateMachineTemplateSpec(map[string]string{"x": ""}, map[string]string{"something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{"x": "1"}, map[string]string{clusterv1.MachineDeploymentUniqueLabel: "value-2", "something": "else"}),
+			Expected: false,
+		},
+		{
+			Name:     "Different spec, different labels",
+			Former:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"something": "else"}),
+			Latter:   generateMachineTemplateSpec(map[string]string{}, map[string]string{"nothing": "else"}),
+			Expected: false,
+		},
+		{
+			Name: "Same spec, except for references versions",
+			Former: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
+							Kind:       "MachineBootstrap",
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+						Kind:       "MachineInfrastructure",
+					},
+				},
+			},
+			Latter: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha4",
+							Kind:       "MachineBootstrap",
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+						Kind:       "MachineInfrastructure",
+					},
+				},
+			},
+			Expected: true,
+		},
+		{
+			Name: "Same spec, bootstrap references are different kinds",
+			Former: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha2",
+							Kind:       "MachineBootstrap1",
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha2",
+						Kind:       "MachineInfrastructure",
+					},
+				},
+			},
+			Latter: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+				Spec: clusterv1.MachineSpec{
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha4",
+							Kind:       "MachineBootstrap2",
+						},
+					},
+					InfrastructureRef: corev1.ObjectReference{
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+						Kind:       "MachineInfrastructure",
+					},
+				},
+			},
+			Expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			runTest := func(t1, t2 *clusterv1.MachineTemplateSpec) {
+				// Run
+				equal := EqualMachineTemplate(t1, t2)
+				g.Expect(equal).To(Equal(test.Expected))
+				g.Expect(t1.Labels).NotTo(BeNil())
+				g.Expect(t2.Labels).NotTo(BeNil())
+			}
+
+			runTest(&test.Former, &test.Latter)
+			// Test the same case in reverse order
+			runTest(&test.Latter, &test.Former)
+		})
+	}
+}
+
+func TestFindNewMachineSet(t *testing.T) {
+	now := metav1.Now()
+	later := metav1.Time{Time: now.Add(time.Minute)}
+
+	deployment := generateDeployment("nginx")
+	newMS := generateMS(deployment)
+	newMS.Labels[clusterv1.MachineDeploymentUniqueLabel] = "hash"
+	newMS.CreationTimestamp = later
+
+	newMSDup := generateMS(deployment)
+	newMSDup.Labels[clusterv1.MachineDeploymentUniqueLabel] = "different-hash"
+	newMSDup.CreationTimestamp = now
+
+	oldDeployment := generateDeployment("nginx")
+	oldMS := generateMS(oldDeployment)
+	oldMS.Spec.Template.Annotations = map[string]string{
+		"old": "true",
+	}
+	oldMS.Status.FullyLabeledReplicas = *(oldMS.Spec.Replicas)
+
+	tests := []struct {
+		Name       string
+		deployment clusterv1.MachineDeployment
+		msList     []*clusterv1.MachineSet
+		expected   *clusterv1.MachineSet
+	}{
+		{
+			Name:       "Get new MachineSet with the same template as Deployment spec but different machine-template-hash value",
+			deployment: deployment,
+			msList:     []*clusterv1.MachineSet{&newMS, &oldMS},
+			expected:   &newMS,
+		},
+		{
+			Name:       "Get the oldest new MachineSet when there are more than one MachineSet with the same template",
+			deployment: deployment,
+			msList:     []*clusterv1.MachineSet{&newMS, &oldMS, &newMSDup},
+			expected:   &newMSDup,
+		},
+		{
+			Name:       "Get nil new MachineSet",
+			deployment: deployment,
+			msList:     []*clusterv1.MachineSet{&oldMS},
+			expected:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ms := FindNewMachineSet(&test.deployment, test.msList)
+			g.Expect(ms).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestFindOldMachineSets(t *testing.T) {
+	now := metav1.Now()
+	later := metav1.Time{Time: now.Add(time.Minute)}
+	before := metav1.Time{Time: now.Add(-time.Minute)}
+
+	deployment := generateDeployment("nginx")
+	newMS := generateMS(deployment)
+	*(newMS.Spec.Replicas) = 1
+	newMS.Labels[clusterv1.MachineDeploymentUniqueLabel] = "hash"
+	newMS.CreationTimestamp = later
+
+	newMSDup := generateMS(deployment)
+	newMSDup.Labels[clusterv1.MachineDeploymentUniqueLabel] = "different-hash"
+	newMSDup.CreationTimestamp = now
+
+	oldDeployment := generateDeployment("nginx")
+	oldMS := generateMS(oldDeployment)
+	oldMS.Spec.Template.Annotations = map[string]string{
+		"old": "true",
+	}
+	oldMS.Status.FullyLabeledReplicas = *(oldMS.Spec.Replicas)
+	oldMS.CreationTimestamp = before
+
+	oldDeployment = generateDeployment("nginx")
+	oldDeployment.Spec.Selector.MatchLabels["old-label"] = "old-value"
+	oldDeployment.Spec.Template.Labels["old-label"] = "old-value"
+	oldMSwithOldLabel := generateMS(oldDeployment)
+	oldMSwithOldLabel.Status.FullyLabeledReplicas = *(oldMSwithOldLabel.Spec.Replicas)
+	oldMSwithOldLabel.CreationTimestamp = before
+
+	tests := []struct {
+		Name            string
+		deployment      clusterv1.MachineDeployment
+		msList          []*clusterv1.MachineSet
+		expected        []*clusterv1.MachineSet
+		expectedRequire []*clusterv1.MachineSet
+	}{
+		{
+			Name:            "Get old MachineSets",
+			deployment:      deployment,
+			msList:          []*clusterv1.MachineSet{&newMS, &oldMS},
+			expected:        []*clusterv1.MachineSet{&oldMS},
+			expectedRequire: nil,
+		},
+		{
+			Name:            "Get old MachineSets with no new MachineSet",
+			deployment:      deployment,
+			msList:          []*clusterv1.MachineSet{&oldMS},
+			expected:        []*clusterv1.MachineSet{&oldMS},
+			expectedRequire: nil,
+		},
+		{
+			Name:            "Get old MachineSets with two new MachineSets, only the oldest new MachineSet is seen as new MachineSet",
+			deployment:      deployment,
+			msList:          []*clusterv1.MachineSet{&oldMS, &newMS, &newMSDup},
+			expected:        []*clusterv1.MachineSet{&oldMS, &newMS},
+			expectedRequire: []*clusterv1.MachineSet{&newMS},
+		},
+		{
+			Name:            "Get empty old MachineSets",
+			deployment:      deployment,
+			msList:          []*clusterv1.MachineSet{&newMS},
+			expected:        []*clusterv1.MachineSet{},
+			expectedRequire: nil,
+		},
+		{
+			Name:            "Get old MachineSets after label changed in MachineDeployments",
+			deployment:      deployment,
+			msList:          []*clusterv1.MachineSet{&newMS, &oldMSwithOldLabel},
+			expected:        []*clusterv1.MachineSet{&oldMSwithOldLabel},
+			expectedRequire: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			requireMS, allMS := FindOldMachineSets(&test.deployment, test.msList)
+			g.Expect(allMS).To(ConsistOf(test.expected))
+			// MSs are getting filtered correctly by ms.spec.replicas
+			g.Expect(requireMS).To(ConsistOf(test.expectedRequire))
+		})
+	}
+}
+
+func TestGetReplicaCountForMachineSets(t *testing.T) {
+	ms1 := generateMS(generateDeployment("foo"))
+	*(ms1.Spec.Replicas) = 1
+	ms1.Status.Replicas = 2
+	ms2 := generateMS(generateDeployment("bar"))
+	*(ms2.Spec.Replicas) = 5
+	ms2.Status.Replicas = 3
+
+	tests := []struct {
+		Name           string
+		Sets           []*clusterv1.MachineSet
+		ExpectedCount  int32
+		ExpectedActual int32
+		ExpectedTotal  int32
+	}{
+		{
+			Name:           "1:2 Replicas",
+			Sets:           []*clusterv1.MachineSet{&ms1},
+			ExpectedCount:  1,
+			ExpectedActual: 2,
+			ExpectedTotal:  2,
+		},
+		{
+			Name:           "6:5 Replicas",
+			Sets:           []*clusterv1.MachineSet{&ms1, &ms2},
+			ExpectedCount:  6,
+			ExpectedActual: 5,
+			ExpectedTotal:  7,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(GetReplicaCountForMachineSets(test.Sets)).To(Equal(test.ExpectedCount))
+			g.Expect(GetActualReplicaCountForMachineSets(test.Sets)).To(Equal(test.ExpectedActual))
+			g.Expect(TotalMachineSetsReplicaSum(test.Sets)).To(Equal(test.ExpectedTotal))
+		})
+	}
+}
+
+func TestResolveFenceposts(t *testing.T) {
+	tests := []struct {
+		maxSurge          string
+		maxUnavailable    string
+		desired           int32
+		expectSurge       int32
+		expectUnavailable int32
+		expectError       bool
+	}{
+		{
+			maxSurge:          "0%",
+			maxUnavailable:    "0%",
+			desired:           0,
+			expectSurge:       0,
+			expectUnavailable: 1,
+			expectError:       false,
+		},
+		{
+			maxSurge:          "39%",
+			maxUnavailable:    "39%",
+			desired:           10,
+			expectSurge:       4,
+			expectUnavailable: 3,
+			expectError:       false,
+		},
+		{
+			maxSurge:          "oops",
+			maxUnavailable:    "39%",
+			desired:           10,
+			expectSurge:       0,
+			expectUnavailable: 0,
+			expectError:       true,
+		},
+		{
+			maxSurge:          "55%",
+			maxUnavailable:    "urg",
+			desired:           10,
+			expectSurge:       0,
+			expectUnavailable: 0,
+			expectError:       true,
+		},
+		{
+			maxSurge:          "5",
+			maxUnavailable:    "1",
+			desired:           7,
+			expectSurge:       0,
+			expectUnavailable: 0,
+			expectError:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("maxSurge="+test.maxSurge, func(t *testing.T) {
+			g := NewWithT(t)
+
+			maxSurge := intstr.FromString(test.maxSurge)
+			maxUnavail := intstr.FromString(test.maxUnavailable)
+			surge, unavail, err := ResolveFenceposts(&maxSurge, &maxUnavail, test.desired)
+			if test.expectError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			g.Expect(surge).To(Equal(test.expectSurge))
+			g.Expect(unavail).To(Equal(test.expectUnavailable))
+		})
+	}
+}
+
+func TestNewMSNewReplicas(t *testing.T) {
+	tests := []struct {
+		Name          string
+		strategyType  clusterv1.MachineDeploymentStrategyType
+		depReplicas   int32
+		newMSReplicas int32
+		maxSurge      int
+		expected      int32
+	}{
+		{
+			"can not scale up - to newMSReplicas",
+			clusterv1.RollingUpdateMachineDeploymentStrategyType,
+			1, 5, 1, 5,
+		},
+		{
+			"scale up - to depReplicas",
+			clusterv1.RollingUpdateMachineDeploymentStrategyType,
+			6, 2, 10, 6,
+		},
+	}
+	newDeployment := generateDeployment("nginx")
+	newRC := generateMS(newDeployment)
+	rs5 := generateMS(newDeployment)
+	*(rs5.Spec.Replicas) = 5
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			*(newDeployment.Spec.Replicas) = test.depReplicas
+			newDeployment.Spec.Strategy = &clusterv1.MachineDeploymentStrategy{Type: test.strategyType}
+			newDeployment.Spec.Strategy.RollingUpdate = &clusterv1.MachineRollingUpdateDeployment{
+				MaxUnavailable: func(i int) *intstr.IntOrString {
+					x := intstr.FromInt(i)
+					return &x
+				}(1),
+				MaxSurge: func(i int) *intstr.IntOrString {
+					x := intstr.FromInt(i)
+					return &x
+				}(test.maxSurge),
+			}
+			*(newRC.Spec.Replicas) = test.newMSReplicas
+			ms, err := NewMSNewReplicas(&newDeployment, []*clusterv1.MachineSet{&rs5}, &newRC)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(ms).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestDeploymentComplete(t *testing.T) {
+	deployment := func(desired, current, updated, available, maxUnavailable, maxSurge int32) *clusterv1.MachineDeployment {
+		return &clusterv1.MachineDeployment{
+			Spec: clusterv1.MachineDeploymentSpec{
+				Replicas: &desired,
+				Strategy: &clusterv1.MachineDeploymentStrategy{
+					RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+						MaxUnavailable: func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(maxUnavailable)),
+						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(maxSurge)),
+					},
+					Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+				},
+			},
+			Status: clusterv1.MachineDeploymentStatus{
+				Replicas:          current,
+				UpdatedReplicas:   updated,
+				AvailableReplicas: available,
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+
+		d *clusterv1.MachineDeployment
+
+		expected bool
+	}{
+		{
+			name: "not complete: min but not all machines become available",
+
+			d:        deployment(5, 5, 5, 4, 1, 0),
+			expected: false,
+		},
+		{
+			name: "not complete: min availability is not honored",
+
+			d:        deployment(5, 5, 5, 3, 1, 0),
+			expected: false,
+		},
+		{
+			name: "complete",
+
+			d:        deployment(5, 5, 5, 5, 0, 0),
+			expected: true,
+		},
+		{
+			name: "not complete: all machines are available but not updated",
+
+			d:        deployment(5, 5, 4, 5, 0, 0),
+			expected: false,
+		},
+		{
+			name: "not complete: still running old machines",
+
+			// old machine set: spec.replicas=1, status.replicas=1, status.availableReplicas=1
+			// new machine set: spec.replicas=1, status.replicas=1, status.availableReplicas=0
+			d:        deployment(1, 2, 1, 1, 0, 1),
+			expected: false,
+		},
+		{
+			name: "not complete: one replica deployment never comes up",
+
+			d:        deployment(1, 1, 1, 0, 1, 1),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(DeploymentComplete(test.d, &test.d.Status)).To(Equal(test.expected))
+		})
+	}
+}
+
+func TestMaxUnavailable(t *testing.T) {
+	deployment := func(replicas int32, maxUnavailable intstr.IntOrString) clusterv1.MachineDeployment {
+		return clusterv1.MachineDeployment{
+			Spec: clusterv1.MachineDeploymentSpec{
+				Replicas: func(i int32) *int32 { return &i }(replicas),
+				Strategy: &clusterv1.MachineDeploymentStrategy{
+					RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(1)),
+						MaxUnavailable: &maxUnavailable,
+					},
+					Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+				},
+			},
+		}
+	}
+	tests := []struct {
+		name       string
+		deployment clusterv1.MachineDeployment
+		expected   int32
+	}{
+		{
+			name:       "maxUnavailable less than replicas",
+			deployment: deployment(10, intstr.FromInt(5)),
+			expected:   int32(5),
+		},
+		{
+			name:       "maxUnavailable equal replicas",
+			deployment: deployment(10, intstr.FromInt(10)),
+			expected:   int32(10),
+		},
+		{
+			name:       "maxUnavailable greater than replicas",
+			deployment: deployment(5, intstr.FromInt(10)),
+			expected:   int32(5),
+		},
+		{
+			name:       "maxUnavailable with replicas is 0",
+			deployment: deployment(0, intstr.FromInt(10)),
+			expected:   int32(0),
+		},
+		{
+			name:       "maxUnavailable less than replicas with percents",
+			deployment: deployment(10, intstr.FromString("50%")),
+			expected:   int32(5),
+		},
+		{
+			name:       "maxUnavailable equal replicas with percents",
+			deployment: deployment(10, intstr.FromString("100%")),
+			expected:   int32(10),
+		},
+		{
+			name:       "maxUnavailable greater than replicas with percents",
+			deployment: deployment(5, intstr.FromString("100%")),
+			expected:   int32(5),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(MaxUnavailable(test.deployment)).To(Equal(test.expected))
+		})
+	}
+}
+
+// TestAnnotationUtils is a set of simple tests for annotation related util functions.
+func TestAnnotationUtils(t *testing.T) {
+	// Setup
+	tDeployment := generateDeployment("nginx")
+	tMS := generateMS(tDeployment)
+	tDeployment.Annotations[clusterv1.RevisionAnnotation] = "999"
+	logger := klogr.New()
+
+	// Test Case 1: Check if anotations are copied properly from deployment to MS
+	t.Run("SetNewMachineSetAnnotations", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Try to set the increment revision from 1 through 20
+		for i := 0; i < 20; i++ {
+			nextRevision := fmt.Sprintf("%d", i+1)
+			SetNewMachineSetAnnotations(&tDeployment, &tMS, nextRevision, true, logger)
+			// Now the MachineSets Revision Annotation should be i+1
+			g.Expect(tMS.Annotations).To(HaveKeyWithValue(clusterv1.RevisionAnnotation, nextRevision))
+		}
+	})
+
+	// Test Case 2:  Check if annotations are set properly
+	t.Run("SetReplicasAnnotations", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(SetReplicasAnnotations(&tMS, 10, 11)).To(BeTrue())
+		g.Expect(tMS.Annotations).To(HaveKeyWithValue(clusterv1.DesiredReplicasAnnotation, "10"))
+		g.Expect(tMS.Annotations).To(HaveKeyWithValue(clusterv1.MaxReplicasAnnotation, "11"))
+	})
+
+	// Test Case 3:  Check if annotations reflect deployments state
+	tMS.Annotations[clusterv1.DesiredReplicasAnnotation] = "1"
+	tMS.Status.AvailableReplicas = 1
+	tMS.Spec.Replicas = new(int32)
+	*tMS.Spec.Replicas = 1
+
+	t.Run("IsSaturated", func(t *testing.T) {
+		g := NewWithT(t)
+
+		g.Expect(IsSaturated(&tDeployment, &tMS)).To(BeTrue())
+	})
+}
+
+func TestReplicasAnnotationsNeedUpdate(t *testing.T) {
+	desiredReplicas := fmt.Sprintf("%d", int32(10))
+	maxReplicas := fmt.Sprintf("%d", int32(20))
+
+	tests := []struct {
+		name       string
+		machineSet *clusterv1.MachineSet
+		expected   bool
+	}{
+		{
+			name: "test Annotations nil",
+			machineSet: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: metav1.NamespaceDefault},
+				Spec: clusterv1.MachineSetSpec{
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "test desiredReplicas update",
+			machineSet: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "hello",
+					Namespace:   metav1.NamespaceDefault,
+					Annotations: map[string]string{clusterv1.DesiredReplicasAnnotation: "8", clusterv1.MaxReplicasAnnotation: maxReplicas},
+				},
+				Spec: clusterv1.MachineSetSpec{
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "test maxReplicas update",
+			machineSet: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "hello",
+					Namespace:   metav1.NamespaceDefault,
+					Annotations: map[string]string{clusterv1.DesiredReplicasAnnotation: desiredReplicas, clusterv1.MaxReplicasAnnotation: "16"},
+				},
+				Spec: clusterv1.MachineSetSpec{
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "test needn't update",
+			machineSet: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "hello",
+					Namespace:   metav1.NamespaceDefault,
+					Annotations: map[string]string{clusterv1.DesiredReplicasAnnotation: desiredReplicas, clusterv1.MaxReplicasAnnotation: maxReplicas},
+				},
+				Spec: clusterv1.MachineSetSpec{
+					Selector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(ReplicasAnnotationsNeedUpdate(test.machineSet, 10, 20)).To(Equal(test.expected))
+		})
+	}
+}

--- a/controllers/machinedeployment_rolling.go
+++ b/controllers/machinedeployment_rolling.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/utils/integer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	"sigs.k8s.io/cluster-api/controllers/mdutil"
+	"sigs.k8s.io/cluster-api/controllers/internal/mdutil"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/controllers/machinedeployment_rolling_test.go
+++ b/controllers/machinedeployment_rolling_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	"sigs.k8s.io/cluster-api/controllers/mdutil"
+	"sigs.k8s.io/cluster-api/controllers/internal/mdutil"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/controllers/machinedeployment_rollout_ondelete.go
+++ b/controllers/machinedeployment_rollout_ondelete.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	"sigs.k8s.io/cluster-api/controllers/mdutil"
+	"sigs.k8s.io/cluster-api/controllers/internal/mdutil"
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/controllers/machinedeployment_sync.go
+++ b/controllers/machinedeployment_sync.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	"sigs.k8s.io/cluster-api/controllers/mdutil"
+	"sigs.k8s.io/cluster-api/controllers/internal/mdutil"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -147,11 +147,11 @@ func (r *MachineDeploymentReconciler) getNewMachineSet(ctx context.Context, d *c
 	}
 	machineTemplateSpecHash := fmt.Sprintf("%d", hash)
 	newMSTemplate.Labels = mdutil.CloneAndAddLabel(d.Spec.Template.Labels,
-		mdutil.DefaultMachineDeploymentUniqueLabelKey, machineTemplateSpecHash)
+		clusterv1.MachineDeploymentUniqueLabel, machineTemplateSpecHash)
 
 	// Add machineTemplateHash label to selector.
 	newMSSelector := mdutil.CloneSelectorAndAddLabel(&d.Spec.Selector,
-		mdutil.DefaultMachineDeploymentUniqueLabelKey, machineTemplateSpecHash)
+		clusterv1.MachineDeploymentUniqueLabel, machineTemplateSpecHash)
 
 	minReadySeconds := int32(0)
 	if d.Spec.MinReadySeconds != nil {

--- a/controllers/machinedeployment_sync_test.go
+++ b/controllers/machinedeployment_sync_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	"sigs.k8s.io/cluster-api/controllers/mdutil"
+	"sigs.k8s.io/cluster-api/controllers/internal/mdutil"
 	capierrors "sigs.k8s.io/cluster-api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/controllers/topology/internal/scope/state.go
+++ b/controllers/topology/internal/scope/state.go
@@ -19,7 +19,7 @@ package scope
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	"sigs.k8s.io/cluster-api/controllers/mdutil"
+	"sigs.k8s.io/cluster-api/controllers/internal/mdutil"
 )
 
 // ClusterState holds all the objects representing the state of a managed Cluster topology.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Creates controllers/internal/machinedeployment
Deprecate all exported funcs and consts in controllers/mdutil

Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5244
Ports https://github.com/kubernetes-sigs/cluster-api/pull/5297

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
