### PR TITLE
🌱 Upgrade cert-manager to 1.5.3

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -256,6 +256,6 @@ load_provider_tiltfiles()
 load("ext://cert_manager", "deploy_cert_manager")
 
 if settings.get("deploy_cert_manager"):
-    deploy_cert_manager(version = "v1.5.0")
+    deploy_cert_manager(version = "v1.5.3")
 
 enable_providers()

--- a/cmd/clusterctl/client/config/cert_manager_client.go
+++ b/cmd/clusterctl/client/config/cert_manager_client.go
@@ -27,7 +27,7 @@ const (
 	CertManagerConfigKey = "cert-manager"
 
 	// CertManagerDefaultVersion defines the default cert-manager version to be used by clusterctl.
-	CertManagerDefaultVersion = "v1.5.0"
+	CertManagerDefaultVersion = "v1.5.3"
 
 	// CertManagerDefaultURL defines the default cert-manager repository url to be used by clusterctl.
 	// NOTE: At runtime /latest will be replaced with the CertManagerDefaultVersion or with the

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -178,7 +178,7 @@ If this happens, there are no guarantees about the proper functioning of `cluste
 Cluster API providers require a cert-manager version supporting the `cert-manager.io/v1` API to be installed in the cluster.
 
 While doing init, clusterctl checks if there is a version of cert-manager already installed. If not, clusterctl will 
-install a default version (currently cert-manager v1.5.0). See [clusterctl configuration](../configuration.md) for
+install a default version (currently cert-manager v1.5.3). See [clusterctl configuration](../configuration.md) for
 available options to customize this operation.
 
 <aside class="note warning">

--- a/docs/book/src/clusterctl/commands/upgrade.md
+++ b/docs/book/src/clusterctl/commands/upgrade.md
@@ -16,7 +16,7 @@ Produces an output similar to this:
 
 ```shell
 Checking cert-manager version...
-Cert-Manager will be upgraded from "v0.11.0" to "v1.5.0"
+Cert-Manager will be upgraded from "v0.11.0" to "v1.5.3"
 
 Checking new release availability...
 

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -193,7 +193,7 @@ images:
   all:
     repository: myorg.io/local-repo
   cert-manager:
-    tag: v1.5.0
+    tag: v1.5.3
 ```
 
 In this example we are overriding the image repository for all the components and the image tag for
@@ -206,7 +206,7 @@ images:
   all:
     repository: myorg.io/local-repo
   cert-manager/cert-manager-cainjector:
-    tag: v1.5.0
+    tag: v1.5.3
 ```
 
 ## Debugging/Logging

--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -81,7 +81,7 @@ The generated binary can be found at ./hack/tools/bin/envsubst
 You'll need to deploy [cert-manager] components on your [management cluster][mcluster], using `kubectl`
 
 ```bash
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.0/cert-manager.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
 ```
 
 Ensure the cert-manager webhook service is ready before creating the Cluster API components.

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -330,7 +330,7 @@ The output of `clusterctl init` is similar to this:
 
 ```shell
 Fetching providers
-Installing cert-manager Version="v1.5.0"
+Installing cert-manager Version="v1.5.3"
 Waiting for cert-manager to be available...
 Installing Provider="cluster-api" Version="v0.4.0" TargetNamespace="capi-system"
 Installing Provider="bootstrap-kubeadm" Version="v0.4.0" TargetNamespace="capi-kubeadm-bootstrap-system"

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -205,9 +205,9 @@ EOL
 # the actual test run less sensible to the network speed.
 kind:prepullAdditionalImages () {
   # Pulling cert manager images so we can pre-load in kind nodes
-  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.5.0"
-  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.5.0"
-  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.5.0"
+  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.5.3"
+  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.5.3"
+  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.5.3"
 }
 
 # kind:prepullImage pre-pull a docker image if no already present locally.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -17,11 +17,11 @@ images:
   loadBehavior: tryLoad
 - name: gcr.io/k8s-staging-cluster-api/capd-manager-amd64:dev
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.5.0
+- name: quay.io/jetstack/cert-manager-cainjector:v1.5.3
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.5.0
+- name: quay.io/jetstack/cert-manager-webhook:v1.5.3
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.5.0
+- name: quay.io/jetstack/cert-manager-controller:v1.5.3
   loadBehavior: tryLoad
 
 providers:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR upgrades cert-manager to 1.5.3