### PR TITLE
🌱 Add missing optional tag to omitempty fields

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -99,6 +99,7 @@ type ControlPlaneTopology struct {
 	//
 	// This field is supported if and only if the control plane provider template
 	// referenced in the ClusterClass is Machine based.
+	// +optional
 	Metadata ObjectMeta `json:"metadata,omitempty"`
 
 	// Replicas is the number of control plane nodes.
@@ -112,6 +113,7 @@ type ControlPlaneTopology struct {
 // WorkersTopology represents the different sets of worker nodes in the cluster.
 type WorkersTopology struct {
 	// MachineDeployments is a list of machine deployments in the cluster.
+	// +optional
 	MachineDeployments []MachineDeploymentTopology `json:"machineDeployments,omitempty"`
 }
 
@@ -120,6 +122,7 @@ type WorkersTopology struct {
 type MachineDeploymentTopology struct {
 	// Metadata is the metadata applied to the machines of the MachineDeployment.
 	// At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+	// +optional
 	Metadata ObjectMeta `json:"metadata,omitempty"`
 
 	// Class is the name of the MachineDeploymentClass used to create the set of worker nodes.
@@ -189,6 +192,7 @@ func (n *NetworkRanges) String() string {
 // ClusterStatus defines the observed state of Cluster.
 type ClusterStatus struct {
 	// FailureDomains is a slice of failure domain objects synced from the infrastructure provider.
+	// +optional
 	FailureDomains FailureDomains `json:"failureDomains,omitempty"`
 
 	// FailureReason indicates that there is a fatal problem reconciling the

--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -41,10 +41,12 @@ type ClusterClassSpec struct {
 	// for the underlying provider.
 	// The underlying provider is responsible for the implementation
 	// of the template to an infrastructure cluster.
+	// +optional
 	Infrastructure LocalObjectTemplate `json:"infrastructure,omitempty"`
 
 	// ControlPlane is a reference to a local struct that holds the details
 	// for provisioning the Control Plane for the Cluster.
+	// +optional
 	ControlPlane ControlPlaneClass `json:"controlPlane,omitempty"`
 
 	// Workers describes the worker nodes for the cluster.
@@ -61,6 +63,7 @@ type ControlPlaneClass struct {
 	//
 	// This field is supported if and only if the control plane provider template
 	// referenced is Machine based.
+	// +optional
 	Metadata ObjectMeta `json:"metadata,omitempty"`
 
 	// LocalObjectTemplate contains the reference to the control plane provider.
@@ -80,6 +83,7 @@ type ControlPlaneClass struct {
 type WorkersClass struct {
 	// MachineDeployments is a list of machine deployment classes that can be used to create
 	// a set of worker nodes.
+	// +optional
 	MachineDeployments []MachineDeploymentClass `json:"machineDeployments,omitempty"`
 }
 
@@ -101,6 +105,7 @@ type MachineDeploymentClass struct {
 type MachineDeploymentClassTemplate struct {
 	// Metadata is the metadata applied to the machines of the MachineDeployment.
 	// At runtime this metadata is merged with the corresponding metadata from the topology.
+	// +optional
 	Metadata ObjectMeta `json:"metadata,omitempty"`
 
 	// Bootstrap contains the bootstrap template reference to be used

--- a/api/v1beta1/machinedeployment_types.go
+++ b/api/v1beta1/machinedeployment_types.go
@@ -104,6 +104,7 @@ type MachineDeploymentSpec struct {
 	// process failed deployments and a condition with a ProgressDeadlineExceeded
 	// reason will be surfaced in the deployment status. Note that progress will
 	// not be estimated during the time a deployment is paused. Defaults to 600s.
+	// +optional
 	ProgressDeadlineSeconds *int32 `json:"progressDeadlineSeconds,omitempty"`
 }
 

--- a/api/v1beta1/machinehealthcheck_types.go
+++ b/api/v1beta1/machinehealthcheck_types.go
@@ -98,15 +98,18 @@ type UnhealthyCondition struct {
 type MachineHealthCheckStatus struct {
 	// total number of machines counted by this machine health check
 	// +kubebuilder:validation:Minimum=0
+	// +optional
 	ExpectedMachines int32 `json:"expectedMachines,omitempty"`
 
 	// total number of healthy machines counted by this machine health check
 	// +kubebuilder:validation:Minimum=0
+	// +optional
 	CurrentHealthy int32 `json:"currentHealthy,omitempty"`
 
 	// RemediationsAllowed is the number of further remediations allowed by this machine health check before
 	// maxUnhealthy short circuiting will be applied
 	// +kubebuilder:validation:Minimum=0
+	// +optional
 	RemediationsAllowed int32 `json:"remediationsAllowed,omitempty"`
 
 	// ObservedGeneration is the latest generation observed by the controller.

--- a/api/v1beta1/machineset_types.go
+++ b/api/v1beta1/machineset_types.go
@@ -53,6 +53,7 @@ type MachineSetSpec struct {
 	// DeletePolicy defines the policy used to identify nodes to delete when downscaling.
 	// Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
 	// +kubebuilder:validation:Enum=Random;Newest;Oldest
+	// +optional
 	DeletePolicy string `json:"deletePolicy,omitempty"`
 
 	// Selector is a label query over machines that should match the replica count.

--- a/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
@@ -218,6 +218,7 @@ type NodeRegistrationOptions struct {
 	// Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
 	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
 	// empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+	// +optional
 	Taints []corev1.Taint `json:"taints,omitempty"`
 
 	// KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
@@ -99,6 +99,7 @@ type KubeadmConfigSpec struct {
 // KubeadmConfigStatus defines the observed state of KubeadmConfig.
 type KubeadmConfigStatus struct {
 	// Ready indicates the BootstrapData field is ready to be consumed
+	// +optional
 	Ready bool `json:"ready,omitempty"`
 
 	// DataSecretName is the name of the secret that stores the bootstrap data script.
@@ -279,8 +280,11 @@ type NTP struct {
 // DiskSetup defines input for generated disk_setup and fs_setup in cloud-init.
 type DiskSetup struct {
 	// Partitions specifies the list of the partitions to setup.
+	// +optional
 	Partitions []Partition `json:"partitions,omitempty"`
+
 	// Filesystems specifies the list of file systems to setup.
+	// +optional
 	Filesystems []Filesystem `json:"filesystems,omitempty"`
 }
 

--- a/exp/addons/api/v1beta1/clusterresourceset_types.go
+++ b/exp/addons/api/v1beta1/clusterresourceset_types.go
@@ -41,6 +41,7 @@ type ClusterResourceSetSpec struct {
 	ClusterSelector metav1.LabelSelector `json:"clusterSelector"`
 
 	// Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.
+	// +optional
 	Resources []ResourceRef `json:"resources,omitempty"`
 
 	// Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.

--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
@@ -31,6 +31,7 @@ type ResourceBinding struct {
 
 	// Hash is the hash of a resource's data. This can be used to decide if a resource is changed.
 	// For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+	// +optional
 	Hash string `json:"hash,omitempty"`
 
 	// LastAppliedTime identifies when this resource was last applied to the cluster.
@@ -49,6 +50,7 @@ type ResourceSetBinding struct {
 	ClusterResourceSetName string `json:"clusterResourceSetName"`
 
 	// Resources is a list of resources that the ClusterResourceSet has.
+	// +optional
 	Resources []ResourceBinding `json:"resources,omitempty"`
 }
 
@@ -118,6 +120,7 @@ type ClusterResourceSetBinding struct {
 // ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.
 type ClusterResourceSetBindingSpec struct {
 	// Bindings is a list of ClusterResourceSets and their resources.
+	// +optional
 	Bindings []*ResourceSetBinding `json:"bindings,omitempty"`
 }
 

--- a/exp/api/v1beta1/machinepool_types.go
+++ b/exp/api/v1beta1/machinepool_types.go
@@ -38,6 +38,7 @@ type MachinePoolSpec struct {
 
 	// Number of desired machines. Defaults to 1.
 	// This is a pointer to distinguish between explicit zero and not specified.
+	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Template describes the machines that will be created.
@@ -56,6 +57,7 @@ type MachinePoolSpec struct {
 	ProviderIDList []string `json:"providerIDList,omitempty"`
 
 	// FailureDomains is the list of failure domains this MachinePool should be attached to.
+	// +optional
 	FailureDomains []string `json:"failureDomains,omitempty"`
 }
 


### PR DESCRIPTION
In an attempt to keep `optional` and `omitempty` tags consistent throughout
the code, adding `+optional` tag to fields that have the `omitempty` tag.

Signed-off-by: Stefan Bueringer <buringerst@vmware.com>
Co-authored-by: Stefan Bueringer <buringerst@vmware.com>

