### PR TITLE
🌱 Remove +required marker

### DIFF
--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -56,11 +56,9 @@ type Condition struct {
 	// Type of condition in CamelCase or in foo.example.com/CamelCase.
 	// Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
 	// can be useful (see .node.status.conditions), the ability to deconflict is important.
-	// +required
 	Type ConditionType `json:"type"`
 
 	// Status of the condition, one of True, False, Unknown.
-	// +required
 	Status corev1.ConditionStatus `json:"status"`
 
 	// Severity provides an explicit classification of Reason code, so the users or machines can immediately
@@ -72,7 +70,6 @@ type Condition struct {
 	// Last time the condition transitioned from one status to another.
 	// This should be when the underlying condition changed. If that is not known, then using the time when
 	// the API field changed is acceptable.
-	// +required
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
 	// The reason for the condition's last transition in CamelCase.

--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -68,19 +68,15 @@ func Delete(ctx context.Context, c client.Client, ref *corev1.ObjectReference) e
 // CloneTemplateInput is the input to CloneTemplate.
 type CloneTemplateInput struct {
 	// Client is the controller runtime client.
-	// +required
 	Client client.Client
 
 	// TemplateRef is a reference to the template that needs to be cloned.
-	// +required
 	TemplateRef *corev1.ObjectReference
 
 	// Namespace is the Kubernetes namespace the cloned object should be created into.
-	// +required
 	Namespace string
 
 	// ClusterName is the cluster this object is linked to.
-	// +required
 	ClusterName string
 
 	// OwnerRef is an optional OwnerReference to attach to the cloned object.
@@ -127,19 +123,15 @@ func CloneTemplate(ctx context.Context, in *CloneTemplateInput) (*corev1.ObjectR
 // GenerateTemplateInput is the input needed to generate a new template.
 type GenerateTemplateInput struct {
 	// Template is the TemplateRef turned into an unstructured.
-	// +required
 	Template *unstructured.Unstructured
 
 	// TemplateRef is a reference to the template that needs to be cloned.
-	// +required
 	TemplateRef *corev1.ObjectReference
 
 	// Namespace is the Kubernetes namespace the cloned object should be created into.
-	// +required
 	Namespace string
 
 	// ClusterName is the cluster this object is linked to.
-	// +required
 	ClusterName string
 
 	// OwnerRef is an optional OwnerReference to attach to the cloned object.

--- a/docs/proposals/20200506-conditions.md
+++ b/docs/proposals/20200506-conditions.md
@@ -179,11 +179,9 @@ const (
 // Condition defines an extension to status (i.e. an observation) of a Cluster API resource.
 type Condition struct {
    // Type of condition.
-   // +required
    Type ConditionType `json:"type" description:"type of status condition"`
 
    // Status of the condition, one of True, False, Unknown.
-   // +required
    Status corev1.ConditionStatus `json:"status"`
 
    // Severity with which to treat failures of this type of condition.
@@ -192,7 +190,6 @@ type Condition struct {
    Severity ConditionSeverity `json:"severity,omitempty"`
 
    // LastTransitionTime is the last time the condition transitioned from one status to another.
-   // +required
    LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
    // The reason for the condition's last transition.


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing +required marked from our codebase, because it is not relevant for controller-gen and it also used in some cases outsides of the APIs.