### PR TITLE
📖  Add API conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,6 +308,8 @@ All our CRD objects should have the following `additionalPrinterColumns` order (
 * Version
 * Other fields for -o wide (fields with priority `1` are only shown with `-o wide` and not per default)
 
+***NOTE***: The columns can be configured via the `kubebuilder:printcolumn` annotation on root objects. For examples, please see the `./api` package.
+
 Examples:
 ```bash
 $ kubectl get kubeadmcontrolplane

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,7 @@ This project follows the [Kubernetes API conventions](https://github.com/kuberne
 Optional fields have the following properties:
 * An optional field MUST be marked with `+optional` and include an `omitempty` JSON tag.
 * Fields SHOULD be pointers if the nil and the zero values (by Go standards) have semantic differences.
-  * Note: This doesn't apply to map or slice types as they already have a built-in `nil` value.
+  * Note: This doesn't apply to map or slice types as they are assignable to `nil`.
 
 #### Example
  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,7 +255,7 @@ breaking change might be a fix for a behavioral bug that was released in an init
 
 ## API conventions
 
-This project follows the [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#optional-vs-required). Minor modifications or additions to the conventions are listed below.
+This project follows the [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md). Minor modifications or additions to the conventions are listed below.
 
 ### Optional vs. Required
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds API conventions to establish a standard for our APIs going forward. The main focus is optional fields.

Related PRs:
* #5302: Drops `+required` annotations, because they are not handled by controller-tools
* #5303 Drops `omitempty` for `LastTransitionTime ` which makes the field required in OpenAPI Schema as intended
* #5301 Adds `+optional` to all optional fields which currently only have `omitempty`. This doesn't have any consequences as those fields already have been optional in the OpenAPI schema before (because of the `omitempty`)
* #5305 
    * Adds `omitempty` to some of our `+optional` fields
    * Removes `omitempty` from our object lifecycle boolean status fields and our replica counter status fields so they are always visible (e.g. via `kubectl get`)

Notes:
* this PR contains a few cherry-picks from other PRs for now to provide a full picture
* after this PR and the ones I've cherry-picked all optional fields have `omitempty` and `+optional` with the exception of:
    * boolean flags which signal progress in the object lifecycle and replica counters (as mentioned in `CONTRIBUTING.md`)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Implements parts of #5239