### PR TITLE
🐛 Fix 1.22=>latest upgrade e2e test

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -172,9 +172,10 @@ k8s::checkoutBranch() {
       echo "+ checkout $releaseBranch branch"
       git checkout "$releaseBranch" -B "release-$major.$minor"
     else
-      # otherwise, we should build from main, which is the branch for the next release
-      echo "+ checkout main branch"
-      git checkout main
+      # otherwise, we should build from the main branch, which is the branch for the next release
+      # TODO(sbueringer) we can only change this to main after k/k has migrated to main
+      echo "+ checkout master branch"
+      git checkout master
     fi
   fi
 }


### PR DESCRIPTION
Signed-off-by: Stefan Bueringer <buringerst@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
e2e test is currently broken: 

>  echo '+ checkout main branch'
> + checkout main branch
> + git checkout main
> error: pathspec 'main' did not match any file(s) known to git
> https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-e2e-workload-upgrade-1-22-latest-main/1440962048518262784

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
