### PR TITLE
🌱 Update errors pkg doc to reflect intended usage

### DIFF
--- a/errors/doc.go
+++ b/errors/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package errors implements error functionality.
+// Package errors makes a set of error message handlers available for use by Cluster API Providers.
 package errors


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Small update to the errors package doc to reflect the actual usage of the package and explain why it contains many unused functions and constants.