### PR TITLE
[WIP] ✨ clusterctl topology dry-run

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/alpha"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
@@ -89,6 +90,8 @@ type AlphaClient interface {
 	RolloutResume(options RolloutOptions) error
 	// RolloutUndo provides rollout rollback of cluster-api resources
 	RolloutUndo(options RolloutOptions) error
+	// DryRunTopology dry runs the topology reconciler
+	DryRunTopology(options DryRunOptions) ([]unstructured.Unstructured, error)
 }
 
 // YamlPrinter exposes methods that prints the processed template and

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -146,6 +147,10 @@ func (f fakeClient) RolloutResume(options RolloutOptions) error {
 
 func (f fakeClient) RolloutUndo(options RolloutOptions) error {
 	return f.internalClient.RolloutUndo(options)
+}
+
+func (f fakeClient) DryRunTopology(options DryRunOptions) ([]unstructured.Unstructured, error) {
+	return nil, nil
 }
 
 // newFakeClient returns a clusterctl client that allows to execute tests on a set of fake config, fake repositories and fake clusters.
@@ -316,6 +321,10 @@ func (f *fakeClusterClient) Template() cluster.TemplateClient {
 
 func (f *fakeClusterClient) WorkloadCluster() cluster.WorkloadCluster {
 	return f.internalclient.WorkloadCluster()
+}
+
+func (f *fakeClusterClient) Topology() cluster.TopologyClient {
+	return nil
 }
 
 func (f *fakeClusterClient) WithObjs(objs ...client.Object) *fakeClusterClient {

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -89,6 +89,8 @@ type Client interface {
 
 	// WorkloadCluster has methods for fetching kubeconfig of workload cluster from management cluster.
 	WorkloadCluster() WorkloadCluster
+
+	Topology() TopologyClient
 }
 
 // PollImmediateWaiter tries a condition func until it returns true, an error, or the timeout is reached.
@@ -148,6 +150,10 @@ func (c *clusterClient) Template() TemplateClient {
 
 func (c *clusterClient) WorkloadCluster() WorkloadCluster {
 	return newWorkloadCluster(c.proxy)
+}
+
+func (c *clusterClient) Topology() TopologyClient {
+	return newTopologyClient()
 }
 
 // Option is a configuration option supplied to New.

--- a/cmd/clusterctl/client/cluster/internal/dryrun/client.go
+++ b/cmd/clusterctl/client/cluster/internal/dryrun/client.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dryrun
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	localScheme = scheme.Scheme
+)
+
+// ClientOperation define a write operation executed by the Client.
+type ClientOperation struct {
+	gvk schema.GroupVersionKind
+	key client.ObjectKey
+	msg string
+}
+
+// Client implements a dry run Client, that is a fake.Client that logs write operations.
+type Client struct {
+	fakeClient client.Client
+	Log        []ClientOperation
+}
+
+// NewClient returns a new dry run Client.
+func NewClient(objs []client.Object) *Client {
+	fakeClient := fake.NewClientBuilder().WithObjects(objs...).WithScheme(localScheme).Build()
+
+	return &Client{
+		fakeClient: fakeClient,
+		Log:        nil,
+	}
+}
+
+// Get retrieves an obj for the given object key from the Kubernetes Cluster.
+func (c *Client) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	return c.fakeClient.Get(ctx, key, obj)
+}
+
+// List retrieves list of objects for a given namespace and list options.
+func (c *Client) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return c.fakeClient.List(ctx, list, opts...)
+}
+
+// Create saves the object obj in the Kubernetes cluster.
+func (c *Client) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	err := c.fakeClient.Create(ctx, obj, opts...)
+	if err == nil {
+		c.Log = append(c.Log, ClientOperation{
+			gvk: obj.GetObjectKind().GroupVersionKind(),
+			key: client.ObjectKeyFromObject(obj),
+			msg: "Create",
+		})
+	}
+	return err
+}
+
+// Delete deletes the given obj from Kubernetes cluster.
+func (c *Client) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	err := c.fakeClient.Delete(ctx, obj, opts...)
+	if err == nil {
+		c.Log = append(c.Log, ClientOperation{
+			gvk: obj.GetObjectKind().GroupVersionKind(),
+			key: client.ObjectKeyFromObject(obj),
+			msg: "Delete",
+		})
+	}
+	return err
+}
+
+// Update updates the given obj in the Kubernetes cluster.
+// NOTE: Topology reconciler does not use update, so we are skipping implementation for now.
+func (c *Client) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	panic("implement me")
+}
+
+// Patch patches the given obj in the Kubernetes cluster.
+func (c *Client) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	err := c.fakeClient.Patch(ctx, obj, patch, opts...)
+	if err == nil {
+		c.Log = append(c.Log, ClientOperation{
+			gvk: obj.GetObjectKind().GroupVersionKind(),
+			key: client.ObjectKeyFromObject(obj),
+			msg: "Patch",
+		})
+	}
+	return err
+}
+
+// DeleteAllOf deletes all objects of the given type matching the given options.
+// NOTE: Topology reconciler does not use DeleteAllOf, so we are skipping implementation for now.
+func (c *Client) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	panic("implement me")
+}
+
+// Status returns a client which can update status subresource for kubernetes objects.
+// NOTE: Topology reconciler does not use Status, so we are skipping implementation for now.
+func (c *Client) Status() client.StatusWriter {
+	panic("implement me")
+}
+
+// Scheme returns the scheme this client is using.
+func (c *Client) Scheme() *runtime.Scheme {
+	return c.fakeClient.Scheme()
+}
+
+// RESTMapper returns the rest this client is using.
+func (c *Client) RESTMapper() meta.RESTMapper {
+	return c.fakeClient.RESTMapper()
+}
+
+// ListModified returns a list of objects modified with this client.
+// NOTE: objects are returned only once, no matter of many operations applied.
+func (c *Client) ListModified(ctx context.Context) ([]unstructured.Unstructured, error) {
+	objs := make([]unstructured.Unstructured, 0, len(c.Log))
+	keys := map[string]bool{}
+	for _, l := range c.Log {
+		key := fmt.Sprintf("%s-%s", l.gvk.String(), l.key.String())
+		if keys[key] {
+			continue
+		}
+		keys[key] = true
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(l.gvk)
+		obj.SetNamespace(l.key.Namespace)
+		obj.SetName(l.key.Name)
+		if err := c.fakeClient.Get(ctx, l.key, obj); err != nil {
+			return nil, errors.Wrapf(err, "failed to read modified object")
+		}
+		objs = append(objs, *obj)
+	}
+	return objs, nil
+}

--- a/cmd/clusterctl/client/cluster/internal/dryrun/doc.go
+++ b/cmd/clusterctl/client/cluster/internal/dryrun/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package dryrun implements clusterctl dryrun functionality.
+package dryrun

--- a/cmd/clusterctl/client/cluster/topology.go
+++ b/cmd/clusterctl/client/cluster/topology.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gobuffalo/flect"
+	"github.com/pkg/errors"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster/internal/dryrun"
+	"sigs.k8s.io/cluster-api/controllers/topology"
+	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TopologyClient has methods to work with ClusterClass and ManagedTopologies.
+type TopologyClient interface {
+	DryRun(in *DryRunInput) (*DryRunOutput, error)
+}
+
+// topologyClient implements TopologyClient.
+type topologyClient struct {
+}
+
+// ensure topologyClient implements TopologyClient.
+var _ TopologyClient = &topologyClient{}
+
+// newTopologyClient returns a TopologyClient.
+func newTopologyClient() TopologyClient {
+	return &topologyClient{}
+}
+
+// DryRunInput defines the input for DryRun.
+type DryRunInput struct {
+	File []byte
+}
+
+// DryRunOutput defines the output for DryRun.
+type DryRunOutput struct {
+	Objs []unstructured.Unstructured
+}
+
+func (t *topologyClient) DryRun(in *DryRunInput) (*DryRunOutput, error) {
+	// Transform the File in a list of unstructured objects.
+	uObjs, err := utilyaml.ToUnstructured(in.File)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse yaml file")
+	}
+
+	request := ctrl.Request{}
+	crds := map[string]bool{}
+	objs := make([]client.Object, 0, len(uObjs))
+	for i := range uObjs {
+		obj := &uObjs[i]
+
+		// If the object does not have a namespace, set it mimicking kubectl behaviour
+		// when you apply objects and your context has namespace set to empty or default.
+		if obj.GetNamespace() == "" {
+			obj.SetNamespace(metav1.NamespaceDefault)
+		}
+
+		// If the object is a ClusterClass, applies defaults.
+		if obj.GetObjectKind().GroupVersionKind() == clusterv1.GroupVersion.WithKind("ClusterClass") {
+			cc := &clusterv1.ClusterClass{}
+			if err := localScheme.Convert(obj, cc, nil); err != nil {
+				return nil, errors.Wrap(err, "failed to convert object to ClusterClass")
+			}
+			cc.Default()
+			if err := localScheme.Convert(cc, obj, nil); err != nil {
+				return nil, errors.Wrap(err, "failed to convert ClusterClass to object")
+			}
+		}
+
+		// Add the object to the list of objects to be created.
+		objs = append(objs, obj)
+
+		// If the object is provider object, create a CRD thus making the fake environment ready
+		// for UpdateReferenceAPIContract to work.
+		// NOTE: CRD should be created only once.
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		if strings.HasSuffix(gvk.Group, ".cluster.x-k8s.io") && !crds[gvk.String()] {
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+					Kind:       "CustomResourceDefinition",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s.%s", flect.Pluralize(strings.ToLower(gvk.Kind)), gvk.Group),
+					Labels: map[string]string{
+						clusterv1.GroupVersion.String(): "v1beta1",
+					},
+				},
+			}
+			objs = append(objs, crd)
+			crds[gvk.String()] = true
+		}
+
+		// If the object is the Cluster, built the reconcile request.
+		if objs[i].GetObjectKind().GroupVersionKind() == clusterv1.GroupVersion.WithKind("Cluster") {
+			request.Namespace = objs[i].GetNamespace()
+			request.Name = objs[i].GetName()
+		}
+	}
+
+	// TODO: implement support for reading objects from the Cluster, thus allow dry running more use cases:
+	//   rebase, change of variables etc. etc.
+
+	// TODO: add validation in case there is no Cluster  no request
+
+	// Create a DryRun client with the object to test.
+	client := dryrun.NewClient(objs)
+
+	// Create the topology reconciler using the DryRun client.
+	// TODO: make it possible to pass an externalTracker (or make the external tracker not mandatory) thus
+	//   allowing to dry run follow up requests.
+	reconciler := topology.ClusterReconciler{
+		Client:                    client,
+		APIReader:                 client,
+		UnstructuredCachingClient: client,
+	}
+
+	// Trigger reconcile
+	if _, err = reconciler.Reconcile(context.TODO(), request); err != nil {
+		return nil, errors.Wrap(err, "failed to dry run the topology controller")
+	}
+
+	// Retrieve the list of modified objects.
+	modified, err := client.ListModified(context.TODO())
+	if err != nil {
+		return nil, err
+	}
+
+	return &DryRunOutput{
+		Objs: modified,
+	}, err
+}

--- a/cmd/clusterctl/client/cluster/topology_test.go
+++ b/cmd/clusterctl/client/cluster/topology_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+var f = []byte(`
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: my-cluster1
+  namespace: default
+  labels:
+    cni: kindnet
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ["10.96.0.0/12"]
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+    serviceDomain: "cluster.local"
+  topology:
+    class: clusterclass1
+    version: v1.21.2
+    controlPlane:
+      replicas: 1
+    workers:
+      machineDeployments:
+        - name: md1
+          class: "md-class-1"
+          replicas: 1
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: clusterclass1
+spec:
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerClusterTemplate
+      name: clusterclass1-infrastructure-cluster-template
+  controlPlane:
+    metadata:
+      labels:
+        class: "clusterclass1-controlplane-label"
+      annotations:
+        class: "clusterclass1-controlplane-annotation"
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: clusterclass1-controlplane-template
+    machineInfrastructure:
+      ref:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: clusterclass1-controlplane-machinetemplate
+  workers:
+    machineDeployments:
+    - class: "md-class-1"
+      template:
+        metadata:
+          labels:
+            class: "clusterclass1-md-class-1-label"
+          annotations:
+            class: "clusterclass1-md-class-1-annotation"
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: clusterclass1-md-class-1-bootstraptemplate
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachineTemplate
+            name: clusterclass1-md-class-1-machinetemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerClusterTemplate
+metadata:
+  name: clusterclass1-infrastructure-cluster-template
+spec:
+  template:
+    spec: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlaneTemplate
+metadata:
+  name: clusterclass1-controlplane-template
+spec:
+  template:
+    spec:
+      version: v1.22.0  # <<< Web hooks or type improvent; this is an instance specific field
+      machineTemplate:  # <<< Web hooks or type improvent; this field is driven by clusterclass.spec.controlplane.machineinfrastructure.ref
+        infrastructureRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          kind: DockerMachineTemplate
+          name: clusterclass1-controlplane-machinetemplate
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            certSANs:
+            - localhost
+            - 127.0.0.1
+            - 0.0.0.0
+          controllerManager:
+            extraArgs:
+              enable-hostpath-provisioner: "true"
+        initConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+              # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+              cgroup-driver: cgroupfs
+              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        joinConfiguration:
+          nodeRegistration:
+            kubeletExtraArgs:
+              # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+              # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+              cgroup-driver: cgroupfs
+              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: clusterclass1-controlplane-machinetemplate
+spec:
+  template:
+    spec: {}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: clusterclass1-md-class-1-bootstraptemplate
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+            cgroup-driver: cgroupfs
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: clusterclass1-md-class-1-machinetemplate
+spec:
+  template:
+    spec: {}
+`)
+
+func Test_topologyClient_DryRun(t *testing.T) {
+	type args struct {
+		in *DryRunInput
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test1",
+			args: args{
+				in: &DryRunInput{File: f},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			tc := &topologyClient{}
+			_, err := tc.DryRun(tt.args.in)
+
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+		})
+	}
+}

--- a/cmd/clusterctl/client/topology.go
+++ b/cmd/clusterctl/client/topology.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"os"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+)
+
+// DryRunOptions define options for DryRunTopology.
+type DryRunOptions struct {
+	File string
+}
+
+func (c *clusterctlClient) DryRunTopology(options DryRunOptions) ([]unstructured.Unstructured, error) {
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.ReadFile(options.File)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := clusterClient.Topology().DryRun(&cluster.DryRunInput{
+		File: file,
+	})
+
+	return out.Objs, err
+}

--- a/cmd/clusterctl/cmd/topology.go
+++ b/cmd/clusterctl/cmd/topology.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
+)
+
+type topologyDryRunOptions struct {
+	file string
+}
+
+var dr = &topologyDryRunOptions{}
+
+var topologyDryRunCmd = &cobra.Command{
+	Use:     "topology-dryrun",
+	Short:   "",
+	Long:    LongDesc(``),
+	Example: Examples(``),
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runTopologyDryRun()
+	},
+}
+
+func init() {
+	topologyDryRunCmd.Flags().StringVarP(&dr.file, "file", "f", "", "")
+
+	alphaCmd.AddCommand(topologyDryRunCmd)
+}
+
+func runTopologyDryRun() error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	objs, err := c.DryRunTopology(client.DryRunOptions{
+		File: dr.file,
+	})
+	if err != nil {
+		return err
+	}
+
+	yaml, err := utilyaml.FromUnstructured(objs)
+	if err != nil {
+		return err
+	}
+	yaml = append(yaml, '\n')
+
+	if _, err := os.Stdout.Write(yaml); err != nil {
+		return errors.Wrap(err, "failed to write yaml to Stdout")
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new command in clusterctl that gets in input a file that takes in input a file with a Cluster, a ClusterClass and related templates and returns the resulting managed topology.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5319
