### PR TITLE
🐛 Clusterctl enforce provider order during init and upgrade

### DIFF
--- a/cmd/clusterctl/client/cluster/installer.go
+++ b/cmd/clusterctl/client/cluster/installer.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -76,6 +77,11 @@ var _ ProviderInstaller = &providerInstaller{}
 
 func (i *providerInstaller) Add(components repository.Components) {
 	i.installQueue = append(i.installQueue, components)
+
+	// Ensure Providers are installed in the following order: Core, Bootstrap, ControlPlane, Infrastructure.
+	sort.Slice(i.installQueue, func(a, b int) bool {
+		return i.installQueue[a].Type().Order() < i.installQueue[b].Type().Order()
+	})
 }
 
 func (i *providerInstaller) Install(opts InstallOptions) ([]repository.Components, error) {

--- a/cmd/clusterctl/client/cluster/upgrader.go
+++ b/cmd/clusterctl/client/cluster/upgrader.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cluster
 
 import (
+	"sort"
+
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -344,7 +346,13 @@ func (u *providerUpgrader) doUpgrade(upgradePlan *UpgradePlan) error {
 		}
 	}
 
-	for _, upgradeItem := range upgradePlan.Providers {
+	// Ensure Providers are updated in the following order: Core, Bootstrap, ControlPlane, Infrastructure.
+	providers := upgradePlan.Providers
+	sort.Slice(providers, func(a, b int) bool {
+		return providers[a].GetProviderType().Order() < providers[b].GetProviderType().Order()
+	})
+
+	for _, upgradeItem := range providers {
 		// If there is not a specified next version, skip it (we are already up-to-date).
 		if upgradeItem.NextVersion == "" {
 			continue


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enforce clusterctl to install or upgrade providers in a predictable order.
This should prevent flakiness in case providers gets updates before CAPI types of a given version are installed

