### PR TITLE
🌱 e2e-test: improve error logging for clusterctl init/upgrade with binary

### DIFF
--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -105,7 +105,7 @@ func InitWithBinary(_ context.Context, binary string, input InitInput) {
 
 	out, err := cmd.CombinedOutput()
 	_ = ioutil.WriteFile(filepath.Join(input.LogFolder, "clusterctl-init.log"), out, 0644) //nolint:gosec // this is a log file to be shared via prow artifacts
-	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl init")
+	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl init:\n%s", string(out))
 }
 
 // UpgradeInput is the input for Upgrade.
@@ -216,7 +216,7 @@ func ConfigClusterWithBinary(_ context.Context, clusterctlBinaryPath string, inp
 
 	out, err := cmd.Output()
 	_ = ioutil.WriteFile(filepath.Join(input.LogFolder, fmt.Sprintf("%s-cluster-template.yaml", input.ClusterName)), out, 0644) //nolint:gosec // this is a log file to be shared via prow artifacts
-	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl config cluster")
+	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl config cluster:\n%s", string(out))
 
 	return out
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Makes it easier to debug the clusterctl upgrade e2e test because the output of clusterctl init/upgrade will be visible in the log (only if the call fails)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
