### PR TITLE
✨ Add observability tools to Tiltfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ clusterctl-settings.json
 # test results
 _artifacts
 
-#release artifacts
+# release artifacts
 out
 _releasenotes
+
+# Helm
+.helm

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -79,6 +79,10 @@ for more details.
 **kustomize_substitutions** (Map{String: String}, default={}): An optional map of substitutions for `${}`-style placeholders in the
 provider's yaml.
 
+**deploy_observability** (Bool, default=false): If set to true, it will instrall grafana, loki and promtail in the dev
+cluster. Grafana UI will be accessible via a link in the tilt console.
+Important! This feature requires the `helm` command to be available in the user's path.
+
 **debug** (Map{string: Map} default{}): A map of named configurations for the provider. The key is the name of the provider.
 
 Supported settings:

--- a/hack/observability/grafana/values.yaml
+++ b/hack/observability/grafana/values.yaml
@@ -1,0 +1,24 @@
+# Configuration for grafana chart, see https://github.com/grafana/helm-charts/tree/main/charts/grafana
+
+grafana.ini:
+  # Disable the grafana login form.
+  auth:
+    disable_login_form: true
+  # Enable anonymous user, and set them as part of the default org.
+  auth.anonymous:
+    enabled: true
+    org_name: Main Org.
+    org_role: Admin
+
+# Adds loki as a datasource.
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+    - name: Loki
+      type: loki
+      url: http://loki:3100
+
+# Disable grafana test framework
+testFramework:
+  enabled: false

--- a/hack/observability/kustomization.yaml
+++ b/hack/observability/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - namespace.yaml
+
+helmChartInflationGenerator:
+  - chartName: promtail
+    chartRepoUrl: https://grafana.github.io/helm-charts
+    releaseNamespace: observability
+    releaseName: promtail
+    values: ./hack/observability/promtail/values.yaml
+  - chartName: loki
+    chartRepoUrl: https://grafana.github.io/helm-charts
+    releaseNamespace: observability
+    releaseName: loki
+    values: ./hack/observability/loki/values.yaml
+  - chartName: grafana
+    chartRepoUrl: https://grafana.github.io/helm-charts
+    releaseNamespace: observability
+    releaseName: grafana
+    values: ./hack/observability/grafana/values.yaml

--- a/hack/observability/loki/values.yaml
+++ b/hack/observability/loki/values.yaml
@@ -1,0 +1,1 @@
+# Placeholder for loki chart configuration, see https://github.com/grafana/helm-charts/tree/main/charts/loki

--- a/hack/observability/namespace.yaml
+++ b/hack/observability/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+

--- a/hack/observability/promtail/values.yaml
+++ b/hack/observability/promtail/values.yaml
@@ -1,0 +1,5 @@
+# Configuration for grafana chart, see https://github.com/grafana/helm-charts/tree/main/charts/grafana
+
+config:
+  # publish data to loki
+  lokiAddress: http://loki:3100/loki/api/v1/push


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds to our Tiltfile the capability to install some observability tool to a local test environments (promtail, loki, grafana) when doing `tilt up`.

In order to get those this working, it is required to:
- install helm CLI locally (which is a new, optional requirement for CAPI developers 😅 )
- add `"deploy_observability": true` to your tilt-settings.json

NOTES: 
- this PR mimics what is already present in CAPZ with the difference that we are not forking helm charts, but we are relying on helm charts hosted somewhere else to install tools in our local test environments when required.
- we are relying on Tilt port forwarding for making grafana accessible from outside the local test environment (which is much simpler than installing an egress controller, exposing ports from kind machine etc.)
- we are providing only minimal customisation to the installed components, all via helm standard `values.yaml` used by helm; current customisation are for:
  - disabling grafana basic authentication
  - adding Loki as a pre-configured data source in grafana
  - make prom tail to push data to loki
- ~~we are relying on a tilt extension for the heavy lifting; as per Tilt reccomandations, we are forking the extensions in our repo, at this is more or less the 70% of this PR 😞~~ (not true anymore 😄 ) .