### PR TITLE
⚠️ Remove Condition suffix from EtcdClusterHealthyCondition name

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/condition_consts.go
+++ b/controlplane/kubeadm/api/v1beta1/condition_consts.go
@@ -111,7 +111,7 @@ const (
 
 const (
 	// EtcdClusterHealthyCondition documents the overall etcd cluster's health.
-	EtcdClusterHealthyCondition clusterv1.ConditionType = "EtcdClusterHealthyCondition"
+	EtcdClusterHealthyCondition clusterv1.ConditionType = "EtcdClusterHealthy"
 
 	// EtcdClusterInspectionFailedReason documents a failure in inspecting the etcd cluster status.
 	EtcdClusterInspectionFailedReason = "EtcdClusterInspectionFailed"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes Condition suffix from EtcdClusterHealthyCondition name

