### PR TITLE
🐛 Fix CAPD v1alpha3=>v1beta1 conversion

### DIFF
--- a/test/infrastructure/docker/api/v1alpha3/conversion.go
+++ b/test/infrastructure/docker/api/v1alpha3/conversion.go
@@ -18,7 +18,6 @@ package v1alpha3
 
 import (
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
-	"sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
@@ -32,7 +31,7 @@ func (src *DockerCluster) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	// Manually restore data.
-	restored := &v1alpha4.DockerCluster{}
+	restored := &v1beta1.DockerCluster{}
 	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Bueringer <buringerst@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
We should use the v1beta1 type to unmarshal the data we wrote with v1beta1. I don't think it led to problems as the v1alpha4/v1beta1 DockerClusters are the same. Nonetheless it's not correct.

Thx @shivi28 for finding this issue

Note: I checked the conversions in other API folders and they are correct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
