### PR TITLE
🐛 clusterctl: fix Certificate target namespace

### DIFF
--- a/cmd/clusterctl/client/repository/components_test.go
+++ b/cmd/clusterctl/client/repository/components_test.go
@@ -523,6 +523,58 @@ func Test_fixTargetNamespace(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "fix cert-manager Certificate",
+			objs: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "cert-manager.io/v1",
+						"kind":       "Certificate",
+						"metadata": map[string]interface{}{
+							"name":      "capi-serving-cert",
+							"namespace": "capi-system",
+						},
+						"spec": map[string]interface{}{
+							"dnsNames": []interface{}{
+								"capi-webhook-service.capi-system.svc",
+								"capi-webhook-service.capi-system.svc.cluster.local",
+								"random-other-dns-name",
+							},
+							"issuerRef": map[string]interface{}{
+								"kind": "Issuer",
+								"name": "capi-selfsigned-issuer",
+							},
+							"secretName": "capi-webhook-service-cert",
+						},
+					},
+				},
+			},
+			targetNamespace: "bar",
+			want: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "cert-manager.io/v1",
+						"kind":       "Certificate",
+						"metadata": map[string]interface{}{
+							"name":      "capi-serving-cert",
+							"namespace": "bar",
+						},
+						"spec": map[string]interface{}{
+							"dnsNames": []interface{}{
+								"capi-webhook-service.bar.svc",
+								"capi-webhook-service.bar.svc.cluster.local",
+								"random-other-dns-name",
+							},
+							"issuerRef": map[string]interface{}{
+								"kind": "Issuer",
+								"name": "capi-selfsigned-issuer",
+							},
+							"secretName": "capi-webhook-service-cert",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Stefan Bueringer <buringerst@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

I think it's a bad way to fix the bug, as it depends on a specific dnsName format. Unfortunately, I don't have a better idea. Suggestions for other solutions welcome.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5369
