### PR TITLE
:book: Redirect on curl k8s stable version and kustomize install

### DIFF
--- a/docs/book/src/developer/providers/implementers-guide/overview.md
+++ b/docs/book/src/developer/providers/implementers-guide/overview.md
@@ -33,18 +33,20 @@ brew install kustomize
 
 ```bash
 # Install kubectl
-KUBECTL_VERSION=$(curl -sf https://dl.k8s.io/release/stable.txt)
+KUBECTL_VERSION=$(curl -sfL https://dl.k8s.io/release/stable.txt)
 curl -fLO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 
 # Install kustomize
 OS_TYPE=linux
+FILE=kustomize_*_${OS_TYPE}_amd64.tar.gz
 curl -sf https://api.github.com/repos/kubernetes-sigs/kustomize/releases/latest |\
   grep browser_download |\
   grep ${OS_TYPE} |\
   cut -d '"' -f 4 |\
   xargs curl -f -O -L
-mv kustomize_*_${OS_TYPE}_amd64 /usr/local/bin/kustomize
-chmod u+x /usr/local/bin/kustomize
+tar zxvf $FILE; rm -f $FILE
+sudo mv kustomize /usr/local/bin/kustomize
+sudo chmod u+x /usr/local/bin/kustomize
 ```
 
 {{#/tab }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix Kustomize bash installation documentation and redirect stable.txt download

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
