### PR TITLE
🌱 clusterctl upgrade: enforce that --contract or provider flags have to be set

### DIFF
--- a/cmd/clusterctl/cmd/upgrade_apply.go
+++ b/cmd/clusterctl/cmd/upgrade_apply.go
@@ -86,6 +86,9 @@ func runUpgradeApply() error {
 		(len(ua.controlPlaneProviders) > 0) ||
 		(len(ua.infrastructureProviders) > 0)
 
+	if ua.contract == "" && !hasProviderNames {
+		return errors.New("Either the --contract flag or at least one of the following flags has to be set: --core, --bootstrap, --control-plane, --infrastructure")
+	}
 	if ua.contract != "" && hasProviderNames {
 		return errors.New("The --contract flag can't be used in combination with --core, --bootstrap, --control-plane, --infrastructure")
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently clusterctl upgrade fails to late in case none of the --contract or provider flags is set:
```bash
 clusterctl-e25f0e3 upgrade apply --config ~/.cluster-api/dev-repository/config.yaml
Checking cert-manager version...
Deleting cert-manager Version="v1.1.0"
Installing cert-manager Version="v1.5.3"
Waiting for cert-manager to be available...
Error: current version of clusterctl could only upgrade to v1beta1 contract, requested
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
