### PR TITLE
⚠️ ClusterToObjectsMapper: replace runtime.Object parameter with client.ObjectList

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -483,11 +483,7 @@ func (o MachinesByCreationTimestamp) Less(i, j int) bool {
 // ClusterToObjectsMapper returns a mapper function that gets a cluster and lists all objects for the object passed in
 // and returns a list of requests.
 // NB: The objects are required to have `clusterv1.ClusterLabelName` applied.
-func ClusterToObjectsMapper(c client.Client, ro runtime.Object, scheme *runtime.Scheme) (handler.MapFunc, error) {
-	if _, ok := ro.(metav1.ListInterface); !ok {
-		return nil, errors.Errorf("expected a metav1.ListInterface, got %T instead", ro)
-	}
-
+func ClusterToObjectsMapper(c client.Client, ro client.ObjectList, scheme *runtime.Scheme) (handler.MapFunc, error) {
 	gvk, err := apiutil.GVKForObject(ro, scheme)
 	if err != nil {
 		return nil, err

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -600,7 +600,7 @@ func TestClusterToObjectsMapper(t *testing.T) {
 	table := []struct {
 		name        string
 		objects     []client.Object
-		input       runtime.Object
+		input       client.ObjectList
 		output      []ctrl.Request
 		expectError bool
 	}{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Extracted from: https://github.com/kubernetes-sigs/cluster-api/pull/5383#discussion_r722547894

Let's make this breaking change now (before v1.0.0), so we can avoid it after the release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
