### PR TITLE
🐛 book: fix make serve on MacOS

### DIFF
--- a/docs/book/util-embed.sh
+++ b/docs/book/util-embed.sh
@@ -18,6 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-EMBED=$(realpath ../../hack/tools/bin/mdbook-embed)
+REPO_ROOT=$(git rev-parse --show-toplevel)
+EMBED=${REPO_ROOT}/hack/tools/bin/mdbook-embed
 make "${EMBED}" GOPROXY="${GOPROXY:-"https://proxy.golang.org"}" &>/dev/null
 ${EMBED} "$@"

--- a/docs/book/util-releaselink.sh
+++ b/docs/book/util-releaselink.sh
@@ -18,6 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-RELEASELINK=$(realpath ../../hack/tools/bin/mdbook-releaselink)
+REPO_ROOT=$(git rev-parse --show-toplevel)
+RELEASELINK=${REPO_ROOT}/hack/tools/bin/mdbook-releaselink
 make "${RELEASELINK}" GOPROXY="${GOPROXY:-"https://proxy.golang.org"}" &>/dev/null
 ${RELEASELINK} "$@"

--- a/docs/book/util-tabulate.sh
+++ b/docs/book/util-tabulate.sh
@@ -18,6 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-TABULATE=$(realpath ../../hack/tools/bin/mdbook-tabulate)
+REPO_ROOT=$(git rev-parse --show-toplevel)
+TABULATE=${REPO_ROOT}/hack/tools/bin/mdbook-tabulate
 make "${TABULATE}" GOPROXY="${GOPROXY:-"https://proxy.golang.org"}" &>/dev/null
 ${TABULATE} "$@"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
`realpath` doesn't exist on MacOS (at least on a clean system). So I got the following errors before this fix:
```bash
$ mdbook serve
2021-10-06 17:33:41 [INFO] (mdbook::book): Book building has started
./util-embed.sh: line 21: realpath: command not found
./util-releaselink.sh: line 21: realpath: command not found
./util-tabulate.sh: line 21: realpath: command not found
```
This lead to rendering issues in e.g. the quickstart page. 

This PR replaces realpath with something which should work on MacOS and on Linux (we're also already using something similar in our ci scripts)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
