### PR TITLE
🐛Prevents kubectl.kubernetes.io/last-applied-configuration annotation to be propagated to templates generated by ClusterClass

### DIFF
--- a/controllers/topology/desired_state.go
+++ b/controllers/topology/desired_state.go
@@ -578,13 +578,15 @@ func templateToTemplate(in templateToInput) *unstructured.Unstructured {
 	labels[clusterv1.ClusterTopologyOwnedLabel] = ""
 	template.SetLabels(labels)
 
-	// Enforce cloned from annotations.
+	// Enforce cloned from annotations and removes the kubectl last-applied-configuration annotation
+	// because we don't want to propagate it to the cloned template objects.
 	annotations := template.GetAnnotations()
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
 	annotations[clusterv1.TemplateClonedFromNameAnnotation] = in.templateClonedFromRef.Name
 	annotations[clusterv1.TemplateClonedFromGroupKindAnnotation] = in.templateClonedFromRef.GroupVersionKind().GroupKind().String()
+	delete(annotations, corev1.LastAppliedConfigAnnotation)
 	template.SetAnnotations(annotations)
 
 	// Ensure the generated template gets a meaningful name.

--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -1174,6 +1174,13 @@ func TestTemplateToTemplate(t *testing.T) {
 	template := builder.InfrastructureClusterTemplate(metav1.NamespaceDefault, "infrastructureClusterTemplate").
 		WithSpecFields(map[string]interface{}{"spec.template.spec.fakeSetting": true}).
 		Build()
+	annotations := template.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[corev1.LastAppliedConfigAnnotation] = "foo"
+	template.SetAnnotations(annotations)
+
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cluster1",
@@ -1282,6 +1289,7 @@ func assertTemplateToTemplate(g *WithT, in assertTemplateInput) {
 	}
 	g.Expect(in.obj.GetAnnotations()).To(HaveKeyWithValue(clusterv1.TemplateClonedFromGroupKindAnnotation, in.templateRef.GroupVersionKind().GroupKind().String()))
 	g.Expect(in.obj.GetAnnotations()).To(HaveKeyWithValue(clusterv1.TemplateClonedFromNameAnnotation, in.templateRef.Name))
+	g.Expect(in.obj.GetAnnotations()).ToNot(HaveKey(corev1.LastAppliedConfigAnnotation))
 	for k, v := range in.annotations {
 		g.Expect(in.obj.GetAnnotations()).To(HaveKeyWithValue(k, v))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevents kubectl.kubernetes.io/last-applied-configuration annotation to be propagated to templates generated by ClusterClass

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5411
