### PR TITLE
Errors moved from util to errors package  :seedling:

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -176,8 +176,8 @@ func (r *KubeadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Lookup the cluster the config owner is associated with
 	cluster, err := util.GetClusterByName(ctx, r.Client, configOwner.GetNamespace(), configOwner.ClusterName())
 	if err != nil {
-		cluster_not_found := capierrors.ClusterNotFound("no %q label present", clusterv1.ClusterLabelName)
-		if errors.Cause(err) == cluster_not_found {
+		clusternotfound := capierrors.ClusterNotFound("no %q label present", clusterv1.ClusterLabelName)
+		if errors.Cause(err) == clusternotfound {
 			log.Info(fmt.Sprintf("%s does not belong to a cluster yet, waiting until it's part of a cluster", configOwner.GetKind()))
 			return ctrl.Result{}, nil
 		}

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -39,6 +39,7 @@ import (
 	kubeadmtypes "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types"
 	bsutil "sigs.k8s.io/cluster-api/bootstrap/util"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	capierrors "sigs.k8s.io/cluster-api/errors"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util"
@@ -175,7 +176,8 @@ func (r *KubeadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Lookup the cluster the config owner is associated with
 	cluster, err := util.GetClusterByName(ctx, r.Client, configOwner.GetNamespace(), configOwner.ClusterName())
 	if err != nil {
-		if errors.Cause(err) == util.ErrNoCluster {
+		cluster_not_found := capierrors.ClusterNotFound("no %q label present", clusterv1.ClusterLabelName)
+		if errors.Cause(err) == cluster_not_found {
 			log.Info(fmt.Sprintf("%s does not belong to a cluster yet, waiting until it's part of a cluster", configOwner.GetKind()))
 			return ctrl.Result{}, nil
 		}

--- a/controllers/cluster_controller_phases.go
+++ b/controllers/cluster_controller_phases.go
@@ -188,7 +188,7 @@ func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster
 	}
 
 	// Get and parse Status.FailureDomains from the infrastructure provider.
-	if err := util.UnstructuredUnmarshalField(infraConfig, &cluster.Status.FailureDomains, "status", "failureDomains"); err != nil && err != util.ErrUnstructuredFieldNotFound {
+	if err := util.UnstructuredUnmarshalField(infraConfig, &cluster.Status.FailureDomains, "status", "failureDomains"); err != nil && err != capierrors.ClusterFieldNotFound("field not found") {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to retrieve Status.FailureDomains from infrastructure provider for Cluster %q in namespace %q",
 			cluster.Name, cluster.Namespace)
 	}

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -293,7 +293,7 @@ func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, cluster
 
 	// Get and set Status.Addresses from the infrastructure provider.
 	err = util.UnstructuredUnmarshalField(infraConfig, &m.Status.Addresses, "status", "addresses")
-	if err != nil && err != util.ErrUnstructuredFieldNotFound {
+	if err != nil && err != capierrors.ClusterFieldNotFound("field not found") {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to retrieve addresses from infrastructure provider for Machine %q in namespace %q", m.Name, m.Namespace)
 	}
 
@@ -301,7 +301,7 @@ func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, cluster
 	var failureDomain string
 	err = util.UnstructuredUnmarshalField(infraConfig, &failureDomain, "spec", "failureDomain")
 	switch {
-	case err == util.ErrUnstructuredFieldNotFound: // no-op
+	case err == capierrors.ClusterFieldNotFound("field not found"): // no-op
 	case err != nil:
 		return ctrl.Result{}, errors.Wrapf(err, "failed to failure domain from infrastructure provider for Machine %q in namespace %q", m.Name, m.Namespace)
 	default:

--- a/errors/clusters.go
+++ b/errors/clusters.go
@@ -68,11 +68,3 @@ func ClusterNotFound(format string, args ...interface{}) *ClusterError {
 		Message: fmt.Sprintf(format, args...),
 	}
 }
-
-// ClusterFieldNotFound creates a new error when cluster is not found
-func ClusterFieldNotFound(format string, args ...interface{}) *ClusterError {
-	return &ClusterError{
-		Reason:  ErrUnstructuredFieldNotFound,
-		Message: fmt.Sprintf(format, args...),
-	}
-}

--- a/errors/clusters.go
+++ b/errors/clusters.go
@@ -60,3 +60,19 @@ func DeleteCluster(format string, args ...interface{}) *ClusterError {
 		Message: fmt.Sprintf(format, args...),
 	}
 }
+
+// ClusterNotFound creates a new error when cluster is not found
+func ClusterNotFound(format string, args ...interface{}) *ClusterError {
+	return &ClusterError{
+		Reason:  ErrNoCluster,
+		Message: fmt.Sprintf(format, args...),
+	}
+}
+
+// ClusterFieldNotFound creates a new error when cluster is not found
+func ClusterFieldNotFound(format string, args ...interface{}) *ClusterError {
+	return &ClusterError{
+		Reason:  ErrUnstructuredFieldNotFound,
+		Message: fmt.Sprintf(format, args...),
+	}
+}

--- a/errors/consts.go
+++ b/errors/consts.go
@@ -107,10 +107,6 @@ const (
 	// ErrNoCluster is returned when the cluster
 	// label could not be found on the object passed in.
 	ErrNoCluster ClusterStatusError = "ErrNoCluster"
-
-	// ErrUnstructuredFieldNotFound determines that a field
-	// in an unstructured object could not be found.
-	ErrUnstructuredFieldNotFound ClusterStatusError = "ErrUnstructuredFieldNotFound"
 )
 
 // MachineSetStatusError defines errors states for MachineSet objects.
@@ -163,4 +159,13 @@ const (
 	// DeleteKubeadmControlPlaneError indicates that an error was encountered
 	// when trying to delete the kubeadm control plane.
 	DeleteKubeadmControlPlaneError KubeadmControlPlaneStatusError = "DeleteError"
+)
+
+// UnstructuredFieldError defines errors states for UnStructured Fields errors
+type UnstructuredFieldError string
+
+const (
+	// ErrUnstructuredFieldNotFound determines that a field
+	// in an unstructured object could not be found.
+	ErrUnstructuredFieldNotFound UnstructuredFieldError = "ErrUnstructuredFieldNotFound"
 )

--- a/errors/consts.go
+++ b/errors/consts.go
@@ -103,6 +103,14 @@ const (
 	// DeleteClusterError indicates that an error was encountered
 	// when trying to delete the cluster.
 	DeleteClusterError ClusterStatusError = "DeleteError"
+
+	// ErrNoCluster is returned when the cluster
+	// label could not be found on the object passed in.
+	ErrNoCluster ClusterStatusError = "ErrNoCluster"
+
+	// ErrUnstructuredFieldNotFound determines that a field
+	// in an unstructured object could not be found.
+	ErrUnstructuredFieldNotFound ClusterStatusError = "ErrUnstructuredFieldNotFound"
 )
 
 // MachineSetStatusError defines errors states for MachineSet objects.

--- a/errors/unstructured.go
+++ b/errors/unstructured.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+)
+
+type UnStructuredClusterError struct {
+	Reason  UnstructuredFieldError
+	Message string
+}
+
+// ClusterFieldNotFound creates a new error when cluster is not found
+func ClusterFieldNotFound(format string, args ...interface{}) *UnStructuredClusterError {
+	return &UnStructuredClusterError{
+		Reason:  ErrUnstructuredFieldNotFound,
+		Message: fmt.Sprintf(format, args...),
+	}
+}

--- a/errors/unstructured.go
+++ b/errors/unstructured.go
@@ -20,14 +20,18 @@ import (
 	"fmt"
 )
 
-type UnStructuredClusterError struct {
+type UnStructuredError struct {
 	Reason  UnstructuredFieldError
 	Message string
 }
 
+func (e *UnStructuredError) Error() string {
+	return e.Message
+}
+
 // ClusterFieldNotFound creates a new error when cluster is not found
-func ClusterFieldNotFound(format string, args ...interface{}) *UnStructuredClusterError {
-	return &UnStructuredClusterError{
+func ClusterFieldNotFound(format string, args ...interface{}) *UnStructuredError {
+	return &UnStructuredError{
 		Reason:  ErrUnstructuredFieldNotFound,
 		Message: fmt.Sprintf(format, args...),
 	}

--- a/exp/controllers/machinepool_controller_phases.go
+++ b/exp/controllers/machinepool_controller_phases.go
@@ -284,7 +284,7 @@ func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, clu
 	// Get and set Status.Replicas from the infrastructure provider.
 	err = util.UnstructuredUnmarshalField(infraConfig, &mp.Status.Replicas, "status", "replicas")
 	if err != nil {
-		if err != util.ErrUnstructuredFieldNotFound {
+		if err != capierrors.ClusterFieldNotFound("field not found") {
 			return ctrl.Result{}, errors.Wrapf(err, "failed to retrieve replicas from infrastructure provider for MachinePool %q in namespace %q", mp.Name, mp.Namespace)
 		}
 	} else if mp.Status.Replicas == 0 {

--- a/util/util.go
+++ b/util/util.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sversion "k8s.io/apimachinery/pkg/version"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	capierrors "sigs.k8s.io/cluster-api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -147,7 +148,7 @@ func IsNodeReady(node *corev1.Node) bool {
 // GetClusterFromMetadata returns the Cluster object (if present) using the object metadata.
 func GetClusterFromMetadata(ctx context.Context, c client.Client, obj metav1.ObjectMeta) (*clusterv1.Cluster, error) {
 	if obj.Labels[clusterv1.ClusterLabelName] == "" {
-		return nil, errors.WithStack(ErrNoCluster)
+		return nil, errors.WithStack(capierrors.ClusterNotFound("no %q label present", clusterv1.ClusterLabelName))
 	}
 	return GetClusterByName(ctx, c, obj.Namespace, obj.Labels[clusterv1.ClusterLabelName])
 }
@@ -380,7 +381,7 @@ func UnstructuredUnmarshalField(obj *unstructured.Unstructured, v interface{}, f
 		return errors.Wrapf(err, "failed to retrieve field %q from %q", strings.Join(fields, "."), obj.GroupVersionKind())
 	}
 	if !found || value == nil {
-		return ErrUnstructuredFieldNotFound
+		return capierrors.ClusterFieldNotFound("field not found")
 	}
 	valueBytes, err := json.Marshal(value)
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -54,10 +54,12 @@ const (
 var (
 	rnd = rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
 
+	// Deprecated: This field has no function and is going to be removed in a next release.
 	// ErrNoCluster is returned when the cluster
 	// label could not be found on the object passed in.
 	ErrNoCluster = fmt.Errorf("no %q label present", clusterv1.ClusterLabelName)
 
+	// Deprecated: This field has no function and is going to be removed in a next release.
 	// ErrUnstructuredFieldNotFound determines that a field
 	// in an unstructured object could not be found.
 	ErrUnstructuredFieldNotFound = fmt.Errorf("field not found")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
 🌱

**What this PR does / why we need it**:
It moves the implementation of the  errors from util package to the error package 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5356 
(Working on it)
