### PR TITLE
⚠️ MachineSet on scale down now takes into account NodeHealthy condition

### DIFF
--- a/api/v1beta1/machineset_types.go
+++ b/api/v1beta1/machineset_types.go
@@ -96,19 +96,22 @@ type MachineSetDeletePolicy string
 const (
 	// RandomMachineSetDeletePolicy prioritizes both Machines that have the annotation
 	// "cluster.x-k8s.io/delete-machine=yes" and Machines that are unhealthy
-	// (Status.FailureReason or Status.FailureMessage are set to a non-empty value).
+	// (Status.FailureReason or Status.FailureMessage are set to a non-empty value
+	// or NodeHealthy type of Status.Conditions is not true).
 	// Finally, it picks Machines at random to delete.
 	RandomMachineSetDeletePolicy MachineSetDeletePolicy = "Random"
 
 	// NewestMachineSetDeletePolicy prioritizes both Machines that have the annotation
 	// "cluster.x-k8s.io/delete-machine=yes" and Machines that are unhealthy
-	// (Status.FailureReason or Status.FailureMessage are set to a non-empty value).
+	// (Status.FailureReason or Status.FailureMessage are set to a non-empty value
+	// or NodeHealthy type of Status.Conditions is not true).
 	// It then prioritizes the newest Machines for deletion based on the Machine's CreationTimestamp.
 	NewestMachineSetDeletePolicy MachineSetDeletePolicy = "Newest"
 
 	// OldestMachineSetDeletePolicy prioritizes both Machines that have the annotation
 	// "cluster.x-k8s.io/delete-machine=yes" and Machines that are unhealthy
-	// (Status.FailureReason or Status.FailureMessage are set to a non-empty value).
+	// (Status.FailureReason or Status.FailureMessage are set to a non-empty value
+	// or NodeHealthy type of Status.Conditions is not true).
 	// It then prioritizes the oldest Machines for deletion based on the Machine's CreationTimestamp.
 	OldestMachineSetDeletePolicy MachineSetDeletePolicy = "Oldest"
 )

--- a/controllers/machineset_delete_policy.go
+++ b/controllers/machineset_delete_policy.go
@@ -21,9 +21,11 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 )
 
 type (
@@ -48,10 +50,7 @@ func oldestDeletePriority(machine *clusterv1.Machine) deletePriority {
 	if _, ok := machine.ObjectMeta.Annotations[clusterv1.DeleteMachineAnnotation]; ok {
 		return mustDelete
 	}
-	if machine.Status.NodeRef == nil {
-		return mustDelete
-	}
-	if machine.Status.FailureReason != nil || machine.Status.FailureMessage != nil {
+	if !isMachineHealthy(machine) {
 		return mustDelete
 	}
 	if machine.ObjectMeta.CreationTimestamp.Time.IsZero() {
@@ -71,10 +70,7 @@ func newestDeletePriority(machine *clusterv1.Machine) deletePriority {
 	if _, ok := machine.ObjectMeta.Annotations[clusterv1.DeleteMachineAnnotation]; ok {
 		return mustDelete
 	}
-	if machine.Status.NodeRef == nil {
-		return mustDelete
-	}
-	if machine.Status.FailureReason != nil || machine.Status.FailureMessage != nil {
+	if !isMachineHealthy(machine) {
 		return mustDelete
 	}
 	return mustDelete - oldestDeletePriority(machine)
@@ -87,10 +83,7 @@ func randomDeletePolicy(machine *clusterv1.Machine) deletePriority {
 	if _, ok := machine.ObjectMeta.Annotations[clusterv1.DeleteMachineAnnotation]; ok {
 		return betterDelete
 	}
-	if machine.Status.NodeRef == nil {
-		return betterDelete
-	}
-	if machine.Status.FailureReason != nil || machine.Status.FailureMessage != nil {
+	if !isMachineHealthy(machine) {
 		return betterDelete
 	}
 	return couldDelete
@@ -137,4 +130,18 @@ func getDeletePriorityFunc(ms *clusterv1.MachineSet) (deletePriorityFunc, error)
 	default:
 		return nil, errors.Errorf("Unsupported delete policy %s. Must be one of 'Random', 'Newest', or 'Oldest'", msdp)
 	}
+}
+
+func isMachineHealthy(machine *clusterv1.Machine) bool {
+	if machine.Status.NodeRef == nil {
+		return false
+	}
+	if machine.Status.FailureReason != nil || machine.Status.FailureMessage != nil {
+		return false
+	}
+	nodeHealthyCondition := conditions.Get(machine, clusterv1.MachineNodeHealthyCondition)
+	if nodeHealthyCondition != nil && nodeHealthyCondition.Status != corev1.ConditionTrue {
+		return false
+	}
+	return true
 }

--- a/controllers/machineset_delete_policy_test.go
+++ b/controllers/machineset_delete_policy_test.go
@@ -44,6 +44,28 @@ func TestMachineToDelete(t *testing.T) {
 		Status:     clusterv1.MachineStatus{NodeRef: nodeRef},
 	}
 	deleteMachineWithoutNodeRef := &clusterv1.Machine{}
+	nodeHealthyConditionFalseMachine := &clusterv1.Machine{
+		Status: clusterv1.MachineStatus{
+			NodeRef: nodeRef,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.MachineNodeHealthyCondition,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+	nodeHealthyConditionUnknownMachine := &clusterv1.Machine{
+		Status: clusterv1.MachineStatus{
+			NodeRef: nodeRef,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.MachineNodeHealthyCondition,
+					Status: corev1.ConditionUnknown,
+				},
+			},
+		},
+	}
 
 	tests := []struct {
 		desc     string
@@ -174,6 +196,30 @@ func TestMachineToDelete(t *testing.T) {
 				deleteMachineWithoutNodeRef,
 			},
 		},
+		{
+			desc: "func=randomDeletePolicy, NodeHealthyConditionFalseMachine, diff=1",
+			diff: 1,
+			machines: []*clusterv1.Machine{
+				healthyMachine,
+				nodeHealthyConditionFalseMachine,
+				healthyMachine,
+			},
+			expect: []*clusterv1.Machine{
+				nodeHealthyConditionFalseMachine,
+			},
+		},
+		{
+			desc: "func=randomDeletePolicy, NodeHealthyConditionUnknownMachine, diff=1",
+			diff: 1,
+			machines: []*clusterv1.Machine{
+				healthyMachine,
+				nodeHealthyConditionUnknownMachine,
+				healthyMachine,
+			},
+			expect: []*clusterv1.Machine{
+				nodeHealthyConditionUnknownMachine,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -220,6 +266,30 @@ func TestMachineNewestDelete(t *testing.T) {
 	}
 	deleteMachineWithoutNodeRef := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -1))},
+	}
+	nodeHealthyConditionFalseMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -10))},
+		Status: clusterv1.MachineStatus{
+			NodeRef: nodeRef,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.MachineNodeHealthyCondition,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+	nodeHealthyConditionUnknownMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -10))},
+		Status: clusterv1.MachineStatus{
+			NodeRef: nodeRef,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.MachineNodeHealthyCondition,
+					Status: corev1.ConditionUnknown,
+				},
+			},
+		},
 	}
 
 	tests := []struct {
@@ -276,6 +346,22 @@ func TestMachineNewestDelete(t *testing.T) {
 			},
 			expect: []*clusterv1.Machine{unhealthyMachine},
 		},
+		{
+			desc: "func=newestDeletePriority, diff=1 (nodeHealthyConditionFalseMachine)",
+			diff: 1,
+			machines: []*clusterv1.Machine{
+				secondNewest, oldest, secondOldest, newest, nodeHealthyConditionFalseMachine,
+			},
+			expect: []*clusterv1.Machine{nodeHealthyConditionFalseMachine},
+		},
+		{
+			desc: "func=newestDeletePriority, diff=1 (nodeHealthyConditionUnknownMachine)",
+			diff: 1,
+			machines: []*clusterv1.Machine{
+				secondNewest, oldest, secondOldest, newest, nodeHealthyConditionUnknownMachine,
+			},
+			expect: []*clusterv1.Machine{nodeHealthyConditionUnknownMachine},
+		},
 	}
 
 	for _, test := range tests {
@@ -321,6 +407,30 @@ func TestMachineOldestDelete(t *testing.T) {
 	}
 	deleteMachineWithoutNodeRef := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -10))},
+	}
+	nodeHealthyConditionFalseMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -10))},
+		Status: clusterv1.MachineStatus{
+			NodeRef: nodeRef,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.MachineNodeHealthyCondition,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+	nodeHealthyConditionUnknownMachine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -10))},
+		Status: clusterv1.MachineStatus{
+			NodeRef: nodeRef,
+			Conditions: clusterv1.Conditions{
+				{
+					Type:   clusterv1.MachineNodeHealthyCondition,
+					Status: corev1.ConditionUnknown,
+				},
+			},
+		},
 	}
 
 	tests := []struct {
@@ -385,6 +495,22 @@ func TestMachineOldestDelete(t *testing.T) {
 			},
 			expect: []*clusterv1.Machine{unhealthyMachine},
 		},
+		{
+			desc: "func=oldestDeletePriority, diff=1 (nodeHealthyConditionFalseMachine)",
+			diff: 1,
+			machines: []*clusterv1.Machine{
+				empty, secondNewest, oldest, secondOldest, newest, nodeHealthyConditionFalseMachine,
+			},
+			expect: []*clusterv1.Machine{nodeHealthyConditionFalseMachine},
+		},
+		{
+			desc: "func=oldestDeletePriority, diff=1 (nodeHealthyConditionUnknownMachine)",
+			diff: 1,
+			machines: []*clusterv1.Machine{
+				empty, secondNewest, oldest, secondOldest, newest, nodeHealthyConditionUnknownMachine,
+			},
+			expect: []*clusterv1.Machine{nodeHealthyConditionUnknownMachine},
+		},
 	}
 
 	for _, test := range tests {
@@ -392,6 +518,84 @@ func TestMachineOldestDelete(t *testing.T) {
 			g := NewWithT(t)
 
 			result := getMachinesToDeletePrioritized(test.machines, test.diff, oldestDeletePriority)
+			g.Expect(result).To(Equal(test.expect))
+		})
+	}
+}
+
+func TestIsMachineHealthy(t *testing.T) {
+	nodeRef := &corev1.ObjectReference{Name: "some-node"}
+	statusError := capierrors.MachineStatusError("I'm unhealthy!")
+	msg := "something wrong with the machine"
+
+	tests := []struct {
+		desc    string
+		machine *clusterv1.Machine
+		expect  bool
+	}{
+		{
+			desc:    "when it has no NodeRef",
+			machine: &clusterv1.Machine{},
+			expect:  false,
+		},
+		{
+			desc: "when it has a FailureReason",
+			machine: &clusterv1.Machine{
+				Status: clusterv1.MachineStatus{FailureReason: &statusError, NodeRef: nodeRef},
+			},
+			expect: false,
+		},
+		{
+			desc: "when it has a FailureMessage",
+			machine: &clusterv1.Machine{
+				Status: clusterv1.MachineStatus{FailureMessage: &msg, NodeRef: nodeRef},
+			},
+			expect: false,
+		},
+		{
+			desc: "when nodeHealthyCondition is false",
+			machine: &clusterv1.Machine{
+				Status: clusterv1.MachineStatus{
+					NodeRef: nodeRef,
+					Conditions: clusterv1.Conditions{
+						{
+							Type:   clusterv1.MachineNodeHealthyCondition,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			desc: "when nodeHealthyCondition is unknown",
+			machine: &clusterv1.Machine{
+				Status: clusterv1.MachineStatus{
+					NodeRef: nodeRef,
+					Conditions: clusterv1.Conditions{
+						{
+							Type:   clusterv1.MachineNodeHealthyCondition,
+							Status: corev1.ConditionUnknown,
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			desc: "when all requirements are met for node to be healthy",
+			machine: &clusterv1.Machine{
+				Status: clusterv1.MachineStatus{NodeRef: nodeRef},
+			},
+			expect: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			g := NewWithT(t)
+
+			result := isMachineHealthy(test.machine)
 			g.Expect(result).To(Equal(test.expect))
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
I would like to add priority condition to the machineset's delete policy.
It makes sense for unhealthy machines to have a higher deletion priority than healthy machines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
