### PR TITLE
🐛 ClusterCacheTracker test should wait and close its reconciler

### DIFF
--- a/controllers/remote/cluster_cache_tracker_test.go
+++ b/controllers/remote/cluster_cache_tracker_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,7 +82,7 @@ func TestClusterCacheTracker(t *testing.T) {
 			go func() {
 				g.Expect(mgr.Start(mgrContext)).To(Succeed())
 			}()
-			<-env.Manager.Elected()
+			<-mgr.Elected()
 
 			k8sClient = mgr.GetClient()
 
@@ -115,11 +116,14 @@ func TestClusterCacheTracker(t *testing.T) {
 
 		teardown := func(t *testing.T, g *WithT, ns *corev1.Namespace) {
 			t.Helper()
+			defer close(c.ch)
 
 			t.Log("Deleting any Secrets")
 			g.Expect(cleanupTestSecrets(ctx, k8sClient)).To(Succeed())
 			t.Log("Deleting any Clusters")
 			g.Expect(cleanupTestClusters(ctx, k8sClient)).To(Succeed())
+			g.Expect(<-c.ch).To(Equal("mapped-" + clusterA.Name))
+			g.Consistently(c.ch).ShouldNot(Receive())
 			t.Log("Deleting Namespace")
 			g.Expect(env.Delete(ctx, ns)).To(Succeed())
 			t.Log("Stopping the manager")
@@ -144,9 +148,7 @@ func TestClusterCacheTracker(t *testing.T) {
 			g.Expect(<-c.ch).To(Equal("mapped-" + clusterA.Name))
 
 			t.Log("Ensuring no additional watch notifications arrive")
-			g.Consistently(func() int {
-				return len(c.ch)
-			}).Should(Equal(0))
+			g.Consistently(c.ch).ShouldNot(Receive())
 
 			t.Log("Updating the cluster")
 			clusterA.Annotations = map[string]string{
@@ -158,9 +160,7 @@ func TestClusterCacheTracker(t *testing.T) {
 			g.Expect(<-c.ch).To(Equal("mapped-" + clusterA.Name))
 
 			t.Log("Ensuring no additional watch notifications arrive")
-			g.Consistently(func() int {
-				return len(c.ch)
-			}).Should(Equal(0))
+			g.Consistently(c.ch).ShouldNot(Receive())
 
 			t.Log("Creating the same watch a second time")
 			g.Expect(cct.Watch(ctx, WatchInput{
@@ -172,9 +172,7 @@ func TestClusterCacheTracker(t *testing.T) {
 			})).To(Succeed())
 
 			t.Log("Ensuring no additional watch notifications arrive")
-			g.Consistently(func() int {
-				return len(c.ch)
-			}).Should(Equal(0))
+			g.Consistently(c.ch).ShouldNot(Receive())
 
 			t.Log("Updating the cluster")
 			clusterA.Annotations["update1"] = "2"
@@ -184,9 +182,7 @@ func TestClusterCacheTracker(t *testing.T) {
 			g.Expect(<-c.ch).To(Equal("mapped-" + clusterA.Name))
 
 			t.Log("Ensuring no additional watch notifications arrive")
-			g.Consistently(func() int {
-				return len(c.ch)
-			}).Should(Equal(0))
+			g.Consistently(c.ch).ShouldNot(Receive())
 		})
 	})
 }
@@ -196,7 +192,11 @@ type testController struct {
 }
 
 func (c *testController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	c.ch <- req.Name
+	spew.Dump(req)
+	select {
+	case <-ctx.Done():
+	case c.ch <- req.Name:
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/envtest/environment.go
+++ b/internal/envtest/environment.go
@@ -274,7 +274,7 @@ func (e *Environment) start(ctx context.Context) {
 			panic(fmt.Sprintf("Failed to start the test environment manager: %v", err))
 		}
 	}()
-	e.Manager.Elected()
+	<-e.Manager.Elected()
 	e.WaitForWebhooks()
 }
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
