### PR TITLE
🌱 Topology reconciler collects orphan templates in case of errors

### DIFF
--- a/controllers/topology/desired_state.go
+++ b/controllers/topology/desired_state.go
@@ -567,6 +567,10 @@ func templateToTemplate(in templateToInput) *unstructured.Unstructured {
 	template.SetUID("")
 	template.SetSelfLink("")
 
+	// Drop OwnerRef from the original template, given that we
+	// don't  want to propagate them to the newly created object.
+	template.SetOwnerReferences(nil)
+
 	// Enforce the topology labels into the provided label set.
 	// NOTE: The cluster label is added at creation time so this object could be read by the ClusterTopology
 	// controller immediately after creation, even before other controllers are going to add the label (if missing).

--- a/controllers/topology/internal/scope/liens.go
+++ b/controllers/topology/internal/scope/liens.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scope
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	tlog "sigs.k8s.io/cluster-api/controllers/topology/internal/log"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Liens tracks the intent of objects to reference other objects at
+// a later stage of the reconcile process.
+type Liens map[string][]client.Object
+
+// Add a liens for an object that will be referenced by an owner at
+// a later stage of the reconcile process.
+func (l Liens) Add(owner, object client.Object) {
+	ownerKey := LiensKey(owner)
+	l[ownerKey] = append(l[ownerKey], object)
+}
+
+// Forget all the liens for an owner, recognizing that
+// the owner object now is actually referencing all the object it was
+// committed to use.
+func (l Liens) Forget(owner client.Object) {
+	ownerKey := LiensKey(owner)
+	delete(l, ownerKey)
+}
+
+// Collect all the pending liens. This method should be called
+// whenever the owner objects fails to reference all the object they were
+// committed to use (usually due to an error).
+// Objects involved in liens not satisfied are deleted from the
+// cluster, thus avoiding orphan objects.
+func (l Liens) Collect(ctx context.Context, c client.Client) error {
+	log := tlog.LoggerFrom(ctx)
+
+	errList := []error{}
+	for ownerKey, objects := range l {
+		for _, object := range objects {
+			log.Infof("Cleaning up %s given that reference from %s was not set", tlog.KObj{Obj: object}, ownerKey)
+			if err := c.Delete(ctx, object); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errList = append(errList, errors.Wrapf(err, "failed to cleanup %s", tlog.KObj{Obj: object}))
+				}
+			}
+		}
+		delete(l, ownerKey)
+	}
+	return kerrors.NewAggregate(errList)
+}
+
+// LiensKey return the key for an object in the Liens map.
+func LiensKey(obj client.Object) string {
+	return fmt.Sprintf("%s/%s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
+}

--- a/controllers/topology/internal/scope/scope.go
+++ b/controllers/topology/internal/scope/scope.go
@@ -33,6 +33,10 @@ type Scope struct {
 
 	// UpgradeTracker holds information about ongoing upgrades in the managed topology.
 	UpgradeTracker *UpgradeTracker
+
+	// Liens tracks the intent of objects to reference other objects at
+	// a later stage of the reconcile process.
+	Liens Liens
 }
 
 // New returns a new Scope with only the cluster; while processing a request in the topology/ClusterReconciler controller
@@ -44,5 +48,6 @@ func New(cluster *clusterv1.Cluster) *Scope {
 			Cluster: cluster,
 		},
 		UpgradeTracker: NewUpgradeTracker(),
+		Liens:          Liens{},
 	}
 }

--- a/controllers/topology/reconcile_state.go
+++ b/controllers/topology/reconcile_state.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/storage/names"
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/check"
 	"sigs.k8s.io/cluster-api/controllers/topology/internal/contract"
@@ -70,9 +69,6 @@ func (r *ClusterReconciler) reconcileInfrastructureCluster(ctx context.Context, 
 // reconcileControlPlane works to bring the current state of a managed topology in line with the desired state. This involves
 // updating the cluster where needed.
 func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, s *scope.Scope) error {
-	// Set a default nil return function for the cleanup operation.
-	cleanup := func() error { return nil }
-
 	// If the clusterClass mandates the controlPlane has infrastructureMachines, reconcile it.
 	if s.Blueprint.HasControlPlaneInfrastructureMachine() {
 		ctx, _ := tlog.LoggerFrom(ctx).WithObject(s.Desired.ControlPlane.InfrastructureMachineTemplate).Into(ctx)
@@ -83,7 +79,7 @@ func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, s *scope.
 		}
 
 		// Create or update the MachineInfrastructureTemplate of the control plane.
-		cleanup, err = r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
+		err = r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
 			ref:                  cpInfraRef,
 			current:              s.Current.ControlPlane.InfrastructureMachineTemplate,
 			desired:              s.Desired.ControlPlane.InfrastructureMachineTemplate,
@@ -98,25 +94,17 @@ func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, s *scope.
 		// The controlPlaneObject.Spec.machineTemplate.infrastructureRef has to be updated in the desired object
 		err = contract.ControlPlane().MachineTemplate().InfrastructureRef().Set(s.Desired.ControlPlane.Object, refToUnstructured(cpInfraRef))
 		if err != nil {
-			return kerrors.NewAggregate([]error{
-				errors.Wrapf(err, "failed to update %s", tlog.KObj{Obj: s.Desired.ControlPlane.Object}),
-				cleanup(),
-			})
+			return errors.Wrapf(err, "failed to update %s", tlog.KObj{Obj: s.Desired.ControlPlane.Object})
 		}
 	}
 
 	// Create or update the ControlPlaneObject for the ControlPlaneState.
 	ctx, _ = tlog.LoggerFrom(ctx).WithObject(s.Desired.ControlPlane.Object).Into(ctx)
 	if err := r.reconcileReferencedObject(ctx, s.Current.ControlPlane.Object, s.Desired.ControlPlane.Object); err != nil {
-		return kerrors.NewAggregate([]error{
-			errors.Wrapf(err, "failed to update %s", tlog.KObj{Obj: s.Desired.ControlPlane.Object}),
-			cleanup(),
-		})
+		return errors.Wrapf(err, "failed to update %s", tlog.KObj{Obj: s.Desired.ControlPlane.Object})
 	}
 
-	// At this point we've updated the ControlPlane object and, where required, the ControlPlane InfrastructureMachineTemplate
-	// without error. Run the cleanup in order to delete the old InfrastructureMachineTemplate if template rotation was done during update.
-	return cleanup()
+	return nil
 }
 
 // reconcileCluster reconciles the desired state of the Cluster object.
@@ -180,14 +168,14 @@ func (r *ClusterReconciler) createMachineDeployment(ctx context.Context, md *sco
 	log := tlog.LoggerFrom(ctx).WithMachineDeployment(md.Object)
 
 	ctx, _ = log.WithObject(md.InfrastructureMachineTemplate).Into(ctx)
-	if _, err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
+	if err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
 		desired: md.InfrastructureMachineTemplate,
 	}); err != nil {
 		return errors.Wrapf(err, "failed to create %s", tlog.KObj{Obj: md.Object})
 	}
 
 	ctx, _ = log.WithObject(md.BootstrapTemplate).Into(ctx)
-	if _, err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
+	if err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
 		desired: md.BootstrapTemplate,
 	}); err != nil {
 		return errors.Wrapf(err, "failed to create %s", tlog.KObj{Obj: md.Object})
@@ -206,7 +194,7 @@ func (r *ClusterReconciler) updateMachineDeployment(ctx context.Context, cluster
 	log := tlog.LoggerFrom(ctx).WithMachineDeployment(desiredMD.Object)
 
 	ctx, _ = log.WithObject(desiredMD.InfrastructureMachineTemplate).Into(ctx)
-	if _, err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
+	if err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
 		ref:                  &desiredMD.Object.Spec.Template.Spec.InfrastructureRef,
 		current:              currentMD.InfrastructureMachineTemplate,
 		desired:              desiredMD.InfrastructureMachineTemplate,
@@ -217,7 +205,7 @@ func (r *ClusterReconciler) updateMachineDeployment(ctx context.Context, cluster
 	}
 
 	ctx, _ = log.WithObject(desiredMD.BootstrapTemplate).Into(ctx)
-	if _, err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
+	if err := r.reconcileReferencedTemplate(ctx, reconcileReferencedTemplateInput{
 		ref:                  desiredMD.Object.Spec.Template.Spec.Bootstrap.ConfigRef,
 		current:              currentMD.BootstrapTemplate,
 		desired:              desiredMD.BootstrapTemplate,
@@ -337,39 +325,37 @@ type reconcileReferencedTemplateInput struct {
 // This function specifically takes care of the first step and updates the reference locally. So the remaining steps
 // can be executed afterwards.
 // NOTE: This func has a side effect in case of template rotation, changing both the desired object and the object reference.
-func (r *ClusterReconciler) reconcileReferencedTemplate(ctx context.Context, in reconcileReferencedTemplateInput) (func() error, error) {
+func (r *ClusterReconciler) reconcileReferencedTemplate(ctx context.Context, in reconcileReferencedTemplateInput) error {
 	log := tlog.LoggerFrom(ctx)
-
-	cleanupFunc := func() error { return nil }
 
 	// If there is no current object, create the desired object.
 	if in.current == nil {
 		log.Infof("Creating %s", tlog.KObj{Obj: in.desired})
 		if err := r.Client.Create(ctx, in.desired.DeepCopy()); err != nil {
-			return nil, errors.Wrapf(err, "failed to create %s", tlog.KObj{Obj: in.desired})
+			return errors.Wrapf(err, "failed to create %s", tlog.KObj{Obj: in.desired})
 		}
-		return cleanupFunc, nil
+		return nil
 	}
 
 	if in.ref == nil {
-		return nil, errors.Errorf("failed to rotate %s: ref should not be nil", in.desired.GroupVersionKind())
+		return errors.Errorf("failed to rotate %s: ref should not be nil", in.desired.GroupVersionKind())
 	}
 
 	// Check if the current and desired referenced object are compatible.
 	if err := in.compatibilityChecker(in.current, in.desired); err != nil {
-		return nil, err
+		return err
 	}
 
 	// Check differences between current and desired objects, and if there are changes eventually start the template rotation.
 	patchHelper, err := mergepatch.NewHelper(in.current, in.desired, r.Client)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create patch helper for %s", tlog.KObj{Obj: in.current})
+		return errors.Wrapf(err, "failed to create patch helper for %s", tlog.KObj{Obj: in.current})
 	}
 
 	// Return if no changes are detected.
 	if !patchHelper.HasChanges() {
 		log.V(3).Infof("No changes for %s", tlog.KObj{Obj: in.desired})
-		return cleanupFunc, nil
+		return nil
 	}
 
 	// If there are no changes in the spec, and thus only changes in metadata, instead of doing a full template
@@ -377,9 +363,9 @@ func (r *ClusterReconciler) reconcileReferencedTemplate(ctx context.Context, in 
 	if !patchHelper.HasSpecChanges() {
 		log.Infof("Patching %s", tlog.KObj{Obj: in.desired})
 		if err := patchHelper.Patch(ctx); err != nil {
-			return nil, errors.Wrapf(err, "failed to patch %s", tlog.KObj{Obj: in.desired})
+			return errors.Wrapf(err, "failed to patch %s", tlog.KObj{Obj: in.desired})
 		}
-		return cleanupFunc, nil
+		return nil
 	}
 
 	// Create the new template.
@@ -392,7 +378,7 @@ func (r *ClusterReconciler) reconcileReferencedTemplate(ctx context.Context, in 
 	log.Infof("Rotating %s, new name %s", tlog.KObj{Obj: in.current}, newName)
 	log.Infof("Creating %s", tlog.KObj{Obj: in.desired})
 	if err := r.Client.Create(ctx, in.desired.DeepCopy()); err != nil {
-		return nil, errors.Wrapf(err, "failed to create %s", tlog.KObj{Obj: in.desired})
+		return errors.Wrapf(err, "failed to create %s", tlog.KObj{Obj: in.desired})
 	}
 
 	// Update the reference with the new name.
@@ -400,13 +386,5 @@ func (r *ClusterReconciler) reconcileReferencedTemplate(ctx context.Context, in 
 	// TODO: find a way to make side effect more explicit
 	in.ref.Name = newName
 
-	// Set up a cleanup func for removing the old template.
-	// NOTE: This function must be called after updating the object containing the reference to the Template.
-	return func() error {
-		log.Infof("Deleting %s", tlog.KObj{Obj: in.current})
-		if err := r.Client.Delete(ctx, in.current); err != nil {
-			return errors.Wrapf(err, "failed to delete %s", tlog.KObj{Obj: in.desired})
-		}
-		return nil
-	}, nil
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In case the topology reconciler fails in the middle of a reconciliation there could be a case a objects has been created but it is not yet used by the owning object e.g-

- InfrastructureCluster created, error before upgrading the Cluster to use the InfrastructureCluster
- InfrastructureMachine created, error before creating/upgrading the MachineDeployment to use the InfrastructureMachine

This PR implements a mechanism to cleanup orphan objects before returning for an error.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5307
