### PR TITLE
🌱 CAPD detects missing container

### DIFF
--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -206,7 +206,7 @@ func patchMachine(ctx context.Context, patchHelper *patch.Helper, machine *clust
 			clusterv1.MachineHealthCheckSuccededCondition,
 			clusterv1.MachineOwnerRemediatedCondition,
 		),
-		conditions.WithStepCounterIf(machine.ObjectMeta.DeletionTimestamp.IsZero()),
+		conditions.WithStepCounterIf(machine.ObjectMeta.DeletionTimestamp.IsZero() && machine.Spec.ProviderID == nil),
 		conditions.WithStepCounterIfOnly(
 			clusterv1.BootstrapReadyCondition,
 			clusterv1.InfrastructureReadyCondition,

--- a/test/infrastructure/docker/api/v1beta1/condition_consts.go
+++ b/test/infrastructure/docker/api/v1beta1/condition_consts.go
@@ -42,6 +42,10 @@ const (
 	// an error while provisioning the container that provides the DockerMachine infrastructure; those kind of
 	// errors are usually transient and failed provisioning are automatically re-tried by the controller.
 	ContainerProvisioningFailedReason = "ContainerProvisioningFailed"
+
+	// ContainerDeletedReason (Severity=Error) documents a DockerMachine controller detecting
+	// the underlying container has been deleted unexpectedly.
+	ContainerDeletedReason = "ContainerDeleted"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes CAPD to detect and report when a container backing a Machine goes missing unexpectedly

