### PR TITLE
🌱 clusterctl describe show MachineSets

### DIFF
--- a/cmd/clusterctl/client/describe.go
+++ b/cmd/clusterctl/client/describe.go
@@ -38,6 +38,9 @@ type DescribeClusterOptions struct {
 	// to signal to the presentation layer to show all the conditions for the objects.
 	ShowOtherConditions string
 
+	// ShowMachineSets instructs the discovery process to include machine sets in the ObjectTree.
+	ShowMachineSets bool
+
 	// DisableNoEcho disable hiding MachineInfrastructure or BootstrapConfig objects if the object's ready condition is true
 	// or it has the same Status, Severity and Reason of the parent's object ready condition (it is an echo)
 	DisableNoEcho bool
@@ -78,6 +81,7 @@ func (c *clusterctlClient) DescribeCluster(options DescribeClusterOptions) (*tre
 	// Gets the object tree representing the status of a Cluster API cluster.
 	return tree.Discovery(context.TODO(), client, options.Namespace, options.ClusterName, tree.DiscoverOptions{
 		ShowOtherConditions: options.ShowOtherConditions,
+		ShowMachineSets:     options.ShowMachineSets,
 		DisableNoEcho:       options.DisableNoEcho,
 		DisableGrouping:     options.DisableGrouping,
 	})

--- a/cmd/clusterctl/client/tree/tree.go
+++ b/cmd/clusterctl/client/tree/tree.go
@@ -36,6 +36,9 @@ type ObjectTreeOptions struct {
 	// to signal to the presentation layer to show all the conditions for the objects.
 	ShowOtherConditions string
 
+	// ShowMachineSets instructs the discovery process to include machine sets in the ObjectTree.
+	ShowMachineSets bool
+
 	// DisableNoEcho disables hiding objects if the object's ready condition has the
 	// same Status, Severity and Reason of the parent's object ready condition (it is an echo)
 	DisableNoEcho bool

--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -56,6 +56,7 @@ type describeClusterOptions struct {
 
 	namespace           string
 	showOtherConditions string
+	showMachineSets     bool
 	disableNoEcho       bool
 	disableGrouping     bool
 }
@@ -103,7 +104,10 @@ func init() {
 		"The namespace where the workload cluster is located. If unspecified, the current namespace will be used.")
 
 	describeClusterClusterCmd.Flags().StringVar(&dc.showOtherConditions, "show-conditions", "",
-		" list of comma separated kind or kind/name for which the command should show all the object's conditions (use 'all' to show conditions for everything).")
+		"list of comma separated kind or kind/name for which the command should show all the object's conditions (use 'all' to show conditions for everything).")
+	describeClusterClusterCmd.Flags().BoolVar(&dc.showMachineSets, "show-machinesets", false,
+		"Show MachineSet objects.")
+
 	describeClusterClusterCmd.Flags().BoolVar(&dc.disableNoEcho, "disable-no-echo", false, ""+
 		"Disable hiding of a MachineInfrastructure and BootstrapConfig when ready condition is true or it has the Status, Severity and Reason of the machine's object.")
 	describeClusterClusterCmd.Flags().BoolVar(&dc.disableGrouping, "disable-grouping", false,
@@ -132,6 +136,7 @@ func runDescribeCluster(name string) error {
 		Namespace:           dc.namespace,
 		ClusterName:         name,
 		ShowOtherConditions: dc.showOtherConditions,
+		ShowMachineSets:     dc.showMachineSets,
 		DisableNoEcho:       dc.disableNoEcho,
 		DisableGrouping:     dc.disableGrouping,
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes `clusterctl describe` to show MachineSets in the object tree when `--show-machinesets` flag is provided

**Which issue(s) this PR fixes*:
Rif https://github.com/kubernetes-sigs/cluster-api/issues/5346
