### PR TITLE
🌱 kcp: add log message when cluster infra not ready

### DIFF
--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -144,6 +144,7 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	// Wait for the cluster infrastructure to be ready before creating machines
 	if !cluster.Status.InfrastructureReady {
+		log.Info("Cluster infrastructure is not ready yet")
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a log message when KCP reconciliation is aborted because the cluster's infrastructure is not ready yet.

It took me quite a while to figure out this was the reason the KCP wasn't reconciling, and it required looking at the source code. This should make it easier.