### PR TITLE
🐛 Use release tag as git version for building clusterctl binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,7 +528,7 @@ release: clean-release ## Builds and push container images using the latest git 
 	@if ! [ -z "$$(git status --porcelain)" ]; then echo "Your local git repository contains uncommitted changes, use git clean before proceeding."; exit 1; fi
 	git checkout "${RELEASE_TAG}"
 	# Build binaries first.
-	$(MAKE) release-binaries
+	GIT_VERSION=$(RELEASE_TAG) $(MAKE) release-binaries
 	# Set the manifest image to the production bucket.
 	$(MAKE) manifest-modification REGISTRY=$(PROD_REGISTRY)
 	## Build the manifests

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -29,7 +29,7 @@ version::get_version_vars() {
 
     # stolen from k8s.io/hack/lib/version.sh
     # Use git describe to find the version based on annotated tags.
-    if GIT_VERSION=$(git describe --abbrev=14 --match "v[0-9]*" 2>/dev/null); then
+    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --abbrev=14 --match "v[0-9]*" 2>/dev/null); then
         # This translates the "git describe" to an actual semver.org
         # compatible semantic version that looks something like this:
         #   v1.1.0-alpha.0.6+84c76d1142ea4d


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This fixes the issue in encountered during the last release when building artifacts via GH action where the clusterctl binary version was wrong. I confirmed that `git describe --abbrev=14 --match "v[0-9]*" 2>/dev/null` does not work inside the Github action. Since we already know the tag as part of the release, simply setting it and reusing it fixes the issue. 

Tested in https://github.com/CecileRobertMichon/cluster-api/runs/3971209967:

<img width="1176" alt="Screen Shot 2021-10-21 at 7 29 36 PM" src="https://user-images.githubusercontent.com/8650424/138383611-34fae344-39d4-434e-9a5e-dcc896112a1f.png">

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5404 
