### PR TITLE
🌱 use k8s-staging-test-infra/gcb-docker-gcloud

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +13,7 @@ steps:
     - DOCKER_BUILDKIT=1
     args:
     - release-staging-nightly
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
     dir: 'test/infrastructure/docker'
     entrypoint: make
     env:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +13,7 @@ steps:
     - DOCKER_BUILDKIT=1
     args:
     - release-staging
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
     dir: 'test/infrastructure/docker'
     entrypoint: make
     env:

--- a/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
+++ b/docs/book/src/developer/providers/v1alpha3-to-v1alpha4.md
@@ -3,7 +3,7 @@
 ## Minimum Go version
 
 - The Go version used by Cluster API is now Go 1.16+
-  - In case cloudbuild is used to push images, please upgrade to `gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583`
+  - In case cloudbuild is used to push images, please upgrade to `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b`
     in the cloudbuild YAML files.
 
 ## Controller Runtime version


### PR DESCRIPTION
Related:
  - Part of: https://github.com/kubernetes/k8s.io/issues/1523
  - Followup to: https://github.com/kubernetes/test-infra/pull/23656

Use a version of gcb-docker-cloud that is hosted in a
community-owned repo instead of a google.com-owned repo

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

