### PR TITLE
✨ add ClusterClassReconciler

### DIFF
--- a/controllers/topology/clusterclass_controller.go
+++ b/controllers/topology/clusterclass_controller.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/external"
+	tlog "sigs.k8s.io/cluster-api/controllers/topology/internal/log"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io;bootstrap.cluster.x-k8s.io;controlplane.cluster.x-k8s.io,resources=*,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusterclasses,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+
+// ClusterClassReconciler reconciles the ClusterClass object.
+type ClusterClassReconciler struct {
+	Client client.Client
+
+	// WatchFilterValue is the label value used to filter events prior to reconciliation.
+	WatchFilterValue string
+
+	// UnstructuredCachingClient provides a client that forces caching of unstructured objects,
+	// thus allowing to optimize reads for templates or provider specific objects.
+	UnstructuredCachingClient client.Client
+}
+
+func (r *ClusterClassReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&clusterv1.ClusterClass{}).
+		Named("topology/clusterclass").
+		WithOptions(options).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		Complete(r)
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+	return nil
+}
+
+func (r *ClusterClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	clusterClass := &clusterv1.ClusterClass{}
+	if err := r.Client.Get(ctx, req.NamespacedName, clusterClass); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object  - requeue the request.
+		return ctrl.Result{}, err
+	}
+
+	// Return early if the ClusterClass is paused.
+	if annotations.HasPausedAnnotation(clusterClass) {
+		log.Info("Reconciliation is paused for this object")
+		return ctrl.Result{}, nil
+	}
+
+	if !clusterClass.ObjectMeta.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	// We use the patchHelper to patch potential changes to the ObjectReferences in ClusterClass.
+	patchHelper, err := patch.NewHelper(clusterClass, r.Client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	defer func() {
+		if err := patchHelper.Patch(ctx, clusterClass); err != nil {
+			reterr = kerrors.NewAggregate([]error{
+				reterr,
+				errors.Wrapf(err, "failed to patch %s", tlog.KObj{Obj: clusterClass})},
+			)
+		}
+	}()
+
+	return r.reconcile(ctx, clusterClass)
+}
+
+func (r *ClusterClassReconciler) reconcile(ctx context.Context, clusterClass *clusterv1.ClusterClass) (ctrl.Result, error) {
+	// Collect all the reference from the ClusterClass to templates.
+	refs := []*corev1.ObjectReference{}
+
+	if clusterClass.Spec.Infrastructure.Ref != nil {
+		refs = append(refs, clusterClass.Spec.Infrastructure.Ref)
+	}
+
+	if clusterClass.Spec.ControlPlane.Ref != nil {
+		refs = append(refs, clusterClass.Spec.ControlPlane.Ref)
+	}
+	if clusterClass.Spec.ControlPlane.MachineInfrastructure != nil && clusterClass.Spec.ControlPlane.MachineInfrastructure.Ref != nil {
+		refs = append(refs, clusterClass.Spec.ControlPlane.MachineInfrastructure.Ref)
+	}
+
+	for _, mdClass := range clusterClass.Spec.Workers.MachineDeployments {
+		if mdClass.Template.Bootstrap.Ref != nil {
+			refs = append(refs, mdClass.Template.Bootstrap.Ref)
+		}
+		if mdClass.Template.Infrastructure.Ref != nil {
+			refs = append(refs, mdClass.Template.Infrastructure.Ref)
+		}
+	}
+
+	// Ensure all the referenced objects are owned by the ClusterClass and that references are
+	// upgraded to the latest contract.
+	// Nb. Some external objects can be referenced multiple times in the ClusterClass. We
+	// update the API contracts of all the references but we set the owner reference on the unique
+	// external object only once.
+	errs := []error{}
+	patchedRefs := sets.NewString()
+	for i := range refs {
+		ref := refs[i]
+		uniqueKey := uniqueObjectRefKey(ref)
+		if err := r.reconcileExternal(ctx, clusterClass, ref, !patchedRefs.Has(uniqueKey)); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		patchedRefs.Insert(uniqueKey)
+	}
+
+	return ctrl.Result{}, kerrors.NewAggregate(errs)
+}
+
+func (r *ClusterClassReconciler) reconcileExternal(ctx context.Context, clusterClass *clusterv1.ClusterClass, ref *corev1.ObjectReference, setOwnerRef bool) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	if err := utilconversion.UpdateReferenceAPIContract(ctx, r.Client, ref); err != nil {
+		return errors.Wrapf(err, "failed to update reference API contract of %s", tlog.KRef{Ref: ref})
+	}
+
+	// If we dont need to set the ownerReference then return early.
+	if !setOwnerRef {
+		return nil
+	}
+
+	obj, err := external.Get(ctx, r.UnstructuredCachingClient, ref, clusterClass.Namespace)
+	if err != nil {
+		if apierrors.IsNotFound(errors.Cause(err)) {
+			return errors.Wrapf(err, "Could not find external object for the cluster class. refGroupVersionKind: %s, refName: %s", ref.GroupVersionKind(), ref.Name)
+		}
+		return errors.Wrapf(err, "failed to get the external object for the cluster class. refGroupVersionKind: %s, refName: %s", ref.GroupVersionKind(), ref.Name)
+	}
+
+	// If external ref is paused, return early.
+	if annotations.HasPausedAnnotation(obj) {
+		log.V(3).Info("External object referenced is paused", "refGroupVersionKind", ref.GroupVersionKind(), "refName", ref.Name)
+		return nil
+	}
+
+	// Initialize the patch helper.
+	patchHelper, err := patch.NewHelper(obj, r.Client)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create patch helper for %s", tlog.KObj{Obj: obj})
+	}
+
+	// Set external object ControllerReference to the ClusterClass.
+	if err := controllerutil.SetOwnerReference(clusterClass, obj, r.Client.Scheme()); err != nil {
+		return errors.Wrapf(err, "failed to set cluster class owner reference for %s", tlog.KObj{Obj: obj})
+	}
+
+	// Patch the external object.
+	if err := patchHelper.Patch(ctx, obj); err != nil {
+		return errors.Wrapf(err, "failed to patch object %s", tlog.KObj{Obj: obj})
+	}
+
+	return nil
+}
+
+func uniqueObjectRefKey(ref *corev1.ObjectReference) string {
+	return fmt.Sprintf("Name:%s, Namespace:%s, Kind:%s, APIVersion:%s", ref.Name, ref.Namespace, ref.Kind, ref.APIVersion)
+}

--- a/controllers/topology/clusterclass_controller_test.go
+++ b/controllers/topology/clusterclass_controller_test.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topology
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/component-base/featuregate/testing"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	tlog "sigs.k8s.io/cluster-api/controllers/topology/internal/log"
+	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/internal/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestClusterClassReconciler_reconcile(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
+	g := NewWithT(t)
+	timeout := 30 * time.Second
+
+	ns, err := env.CreateNamespace(ctx, "test-topology-clusterclass-reconciler")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	clusterClassName := "class1"
+	workerClassName1 := "linux-worker-1"
+	workerClassName2 := "linux-worker-2"
+
+	// The below objects are created in order to feed the reconcile loop all the information it needs to create a
+	// full tree of ClusterClass objects (the objects should have owner referecen to the ClusterClass).
+
+	// Bootstrap templates for the workers.
+	bootstrapTemplate := builder.BootstrapTemplate(ns.Name, "bootstraptemplate").Build()
+
+	// InfraMachineTemplates for the workers and the control plane.
+	infraMachineTemplateControlPlane := builder.InfrastructureMachineTemplate(ns.Name, "inframachinetemplate-control-plane").Build()
+	infraMachineTemplateWorker := builder.InfrastructureMachineTemplate(ns.Name, "inframachinetemplate-worker").Build()
+
+	// Control plane template.
+	controlPlaneTemplate := builder.ControlPlaneTemplate(ns.Name, "controlplanetemplate").Build()
+
+	// InfraClusterTemplate.
+	infraClusterTemplate := builder.InfrastructureClusterTemplate(ns.Name, "infraclustertemplate").Build()
+
+	// MachineDeploymentClasses that will be part of the ClusterClass.
+	machineDeploymentClass1 := builder.MachineDeploymentClass(ns.Name, workerClassName1).
+		WithClass(workerClassName1).
+		WithBootstrapTemplate(bootstrapTemplate).
+		WithInfrastructureTemplate(infraMachineTemplateWorker).
+		Build()
+	machineDeploymentClass2 := builder.MachineDeploymentClass(ns.Name, workerClassName2).
+		WithClass(workerClassName2).
+		WithBootstrapTemplate(bootstrapTemplate).
+		WithInfrastructureTemplate(infraMachineTemplateWorker).
+		Build()
+
+	// ClusterClass.
+	clusterClass := builder.ClusterClass(ns.Name, clusterClassName).
+		WithInfrastructureClusterTemplate(infraClusterTemplate).
+		WithControlPlaneTemplate(controlPlaneTemplate).
+		WithControlPlaneInfrastructureMachineTemplate(infraMachineTemplateControlPlane).
+		WithWorkerMachineDeploymentClasses([]clusterv1.MachineDeploymentClass{*machineDeploymentClass1, *machineDeploymentClass2}).
+		Build()
+
+	// Create the set of initObjects from the objects above to add to the API server when the test environment starts.
+	initObjs := []client.Object{
+		bootstrapTemplate,
+		infraMachineTemplateWorker,
+		infraMachineTemplateControlPlane,
+		controlPlaneTemplate,
+		infraClusterTemplate,
+		clusterClass,
+	}
+
+	for _, obj := range initObjs {
+		g.Expect(env.Create(ctx, obj)).To(Succeed())
+	}
+	defer func() {
+		for _, obj := range initObjs {
+			g.Expect(env.Delete(ctx, obj)).To(Succeed())
+		}
+	}()
+
+	g.Eventually(func(g Gomega) error {
+		actualClusterClass := &clusterv1.ClusterClass{}
+		g.Expect(env.Get(ctx, client.ObjectKey{Name: clusterClassName, Namespace: ns.Name}, actualClusterClass)).To(Succeed())
+
+		g.Expect(assertInfrastructureClusterTemplate(ctx, actualClusterClass, ns)).Should(Succeed())
+
+		g.Expect(assertControlPlaneTemplate(ctx, actualClusterClass, ns)).Should(Succeed())
+
+		g.Expect(assertMachineDeploymentClasses(ctx, actualClusterClass, ns)).Should(Succeed())
+
+		return nil
+	}, timeout).Should(Succeed())
+}
+
+func assertInfrastructureClusterTemplate(ctx context.Context, actualClusterClass *clusterv1.ClusterClass, ns *corev1.Namespace) error {
+	// Assert the infrastructure cluster template has the correct owner reference.
+	actualInfraClusterTemplate := builder.InfrastructureClusterTemplate("", "").Build()
+	actualInfraClusterTemplateKey := client.ObjectKey{
+		Namespace: ns.Name,
+		Name:      actualClusterClass.Spec.Infrastructure.Ref.Name,
+	}
+	if err := env.Get(ctx, actualInfraClusterTemplateKey, actualInfraClusterTemplate); err != nil {
+		return err
+	}
+	if err := assertHasOwnerReference(actualInfraClusterTemplate, ownerRefereceTo(actualClusterClass)); err != nil {
+		return err
+	}
+
+	// Assert the ClusterClass has the expected APIVersion and Kind of to the infrastructure cluster template
+	if err := referenceExistsWithCorrectKindAndAPIVersion(actualClusterClass.Spec.Infrastructure.Ref,
+		builder.GenericInfrastructureClusterTemplateKind,
+		builder.InfrastructureGroupVersion); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func assertControlPlaneTemplate(ctx context.Context, actualClusterClass *clusterv1.ClusterClass, ns *corev1.Namespace) error {
+	// Assert the control plane template has the correct owner reference.
+	actualControlPlaneTemplate := builder.ControlPlaneTemplate("", "").Build()
+	actualControlPlaneTemplateKey := client.ObjectKey{
+		Namespace: ns.Name,
+		Name:      actualClusterClass.Spec.ControlPlane.Ref.Name,
+	}
+	if err := env.Get(ctx, actualControlPlaneTemplateKey, actualControlPlaneTemplate); err != nil {
+		return err
+	}
+	if err := assertHasOwnerReference(actualControlPlaneTemplate, ownerRefereceTo(actualClusterClass)); err != nil {
+		return err
+	}
+
+	// Assert the ClusterClass has the expected APIVersion and Kind to the control plane template
+	if err := referenceExistsWithCorrectKindAndAPIVersion(actualClusterClass.Spec.ControlPlane.Ref,
+		builder.GenericControlPlaneTemplateKind,
+		builder.ControlPlaneGroupVersion); err != nil {
+		return err
+	}
+
+	// If the control plane has machine infra assert that the infra machine template has the correct owner reference.
+	if actualClusterClass.Spec.ControlPlane.MachineInfrastructure != nil && actualClusterClass.Spec.ControlPlane.MachineInfrastructure.Ref != nil {
+		actualInfrastructureMachineTemplate := builder.InfrastructureMachineTemplate("", "").Build()
+		actualInfrastructureMachineTemplateKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      actualClusterClass.Spec.ControlPlane.MachineInfrastructure.Ref.Name,
+		}
+		if err := env.Get(ctx, actualInfrastructureMachineTemplateKey, actualInfrastructureMachineTemplate); err != nil {
+			return err
+		}
+		if err := assertHasOwnerReference(actualInfrastructureMachineTemplate, ownerRefereceTo(actualClusterClass)); err != nil {
+			return err
+		}
+
+		// Assert the ClusterClass has the expected APIVersion and Kind to the infrastructure machine template
+		if err := referenceExistsWithCorrectKindAndAPIVersion(actualClusterClass.Spec.ControlPlane.MachineInfrastructure.Ref,
+			builder.GenericInfrastructureMachineTemplateKind,
+			builder.InfrastructureGroupVersion); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func assertMachineDeploymentClasses(ctx context.Context, actualClusterClass *clusterv1.ClusterClass, ns *corev1.Namespace) error {
+	for _, mdClass := range actualClusterClass.Spec.Workers.MachineDeployments {
+		if err := assertMachineDeploymentClass(ctx, actualClusterClass, mdClass, ns); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func assertMachineDeploymentClass(ctx context.Context, actualClusterClass *clusterv1.ClusterClass, mdClass clusterv1.MachineDeploymentClass, ns *corev1.Namespace) error {
+	// Assert the infrastructure machine template in the MachineDeploymentClass has an owner reference to the ClusterClass.
+	actualInfrastructureMachineTemplate := builder.InfrastructureMachineTemplate("", "").Build()
+	actualInfrastructureMachineTemplateKey := client.ObjectKey{
+		Namespace: ns.Name,
+		Name:      mdClass.Template.Infrastructure.Ref.Name,
+	}
+	if err := env.Get(ctx, actualInfrastructureMachineTemplateKey, actualInfrastructureMachineTemplate); err != nil {
+		return err
+	}
+	if err := assertHasOwnerReference(actualInfrastructureMachineTemplate, ownerRefereceTo(actualClusterClass)); err != nil {
+		return err
+	}
+
+	// Assert the MachineDeploymentClass has the expected APIVersion and Kind to the infrastructure machine template
+	if err := referenceExistsWithCorrectKindAndAPIVersion(mdClass.Template.Infrastructure.Ref,
+		builder.GenericInfrastructureMachineTemplateKind,
+		builder.InfrastructureGroupVersion); err != nil {
+		return err
+	}
+
+	// Assert the bootstrap template in the MachineDeploymentClass has an owner reference to the ClusterClass.
+	actualBootstrapTemplate := builder.BootstrapTemplate("", "").Build()
+	actualBootstrapTemplateKey := client.ObjectKey{
+		Namespace: ns.Name,
+		Name:      mdClass.Template.Bootstrap.Ref.Name,
+	}
+	if err := env.Get(ctx, actualBootstrapTemplateKey, actualBootstrapTemplate); err != nil {
+		return err
+	}
+	if err := assertHasOwnerReference(actualBootstrapTemplate, ownerRefereceTo(actualClusterClass)); err != nil {
+		return err
+	}
+
+	// Assert the MachineDeploymentClass has the expected APIVersion and Kind to the bootstrap template
+	if err := referenceExistsWithCorrectKindAndAPIVersion(mdClass.Template.Bootstrap.Ref,
+		builder.GenericBootstrapConfigTemplateKind,
+		builder.BootstrapGroupVersion); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func assertHasOwnerReference(obj client.Object, ownerRef metav1.OwnerReference) error {
+	found := false
+	for _, ref := range obj.GetOwnerReferences() {
+		if isOwnerReferenceEqual(ref, ownerRef) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("Object %s does not have OwnerReference %s", tlog.KObj{Obj: obj}, &ownerRef)
+	}
+	return nil
+}
+
+func isOwnerReferenceEqual(a, b metav1.OwnerReference) bool {
+	if a.APIVersion != b.APIVersion {
+		return false
+	}
+	if a.Kind != b.Kind {
+		return false
+	}
+	if a.Name != b.Name {
+		return false
+	}
+	if a.UID != b.UID {
+		return false
+	}
+	return true
+}
+
+func ownerRefereceTo(obj client.Object) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		Kind:       obj.GetObjectKind().GroupVersionKind().Kind,
+		Name:       obj.GetName(),
+		UID:        obj.GetUID(),
+	}
+}

--- a/controllers/topology/suite_test.go
+++ b/controllers/topology/suite_test.go
@@ -73,6 +73,12 @@ func TestMain(m *testing.M) {
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 5}); err != nil {
 			panic(fmt.Sprintf("unable to create topology cluster reconciler: %v", err))
 		}
+		if err := (&ClusterClassReconciler{
+			Client:                    mgr.GetClient(),
+			UnstructuredCachingClient: unstructuredCachingClient,
+		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 5}); err != nil {
+			panic(fmt.Sprintf("unable to create clusterclass reconciler: %v", err))
+		}
 	}
 	SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
 	SetDefaultEventuallyTimeout(30 * time.Second)

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ var (
 	watchFilterValue              string
 	profilerAddress               string
 	clusterTopologyConcurrency    int
+	clusterClassConcurrency       int
 	clusterConcurrency            int
 	machineConcurrency            int
 	machineSetConcurrency         int
@@ -134,6 +135,9 @@ func InitFlags(fs *pflag.FlagSet) {
 
 	fs.IntVar(&clusterTopologyConcurrency, "clustertopology-concurrency", 10,
 		"Number of clusters to process simultaneously")
+
+	fs.IntVar(&clusterClassConcurrency, "clusterclass-concurrency", 10,
+		"Number of cluster classes to process simultaneously")
 
 	fs.IntVar(&clusterConcurrency, "cluster-concurrency", 10,
 		"Number of clusters to process simultaneously")
@@ -296,6 +300,15 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 			WatchFilterValue:          watchFilterValue,
 		}).SetupWithManager(ctx, mgr, concurrency(clusterTopologyConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ClusterTopology")
+			os.Exit(1)
+		}
+
+		if err := (&topology.ClusterClassReconciler{
+			Client:                    mgr.GetClient(),
+			UnstructuredCachingClient: unstructuredCachingClient,
+			WatchFilterValue:          watchFilterValue,
+		}).SetupWithManager(ctx, mgr, concurrency(clusterClassConcurrency)); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ClusterClass")
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds a new ClusterClassReconciler. This reconciler adds the ClusterClass as an owner reference to all the templates referenced in the given ClusterClass.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5446
