### PR TITLE
🐛 clusterctl: only fix target namespace in template if TargetNamespace is set

### DIFF
--- a/cmd/clusterctl/client/repository/template.go
+++ b/cmd/clusterctl/client/repository/template.go
@@ -124,12 +124,14 @@ func NewTemplate(input TemplateInput) (Template, error) {
 		return nil, errors.Wrap(err, "failed to parse yaml")
 	}
 
-	// Ensures all the template components are deployed in the target namespace (applies only to namespaced objects)
-	// This is required in order to ensure a cluster and all the related objects are in a single namespace, that is a requirement for
-	// the clusterctl move operation (and also for many controller reconciliation loops).
-	objs, err = fixTargetNamespace(objs, input.TargetNamespace)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to set the TargetNamespace in the template")
+	if input.TargetNamespace != "" {
+		// Ensures all the template components are deployed in the target namespace (applies only to namespaced objects)
+		// This is required in order to ensure a cluster and all the related objects are in a single namespace, that is a requirement for
+		// the clusterctl move operation (and also for many controller reconciliation loops).
+		objs, err = fixTargetNamespace(objs, input.TargetNamespace)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to set the TargetNamespace in the template")
+		}
 	}
 
 	return &template{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
In the `generate yaml` command we don't set a target namespace: 
https://github.com/kubernetes-sigs/cluster-api/blob/61f13e19ca49d2c0e168fe3cbd36aab51a96fd1a/cmd/clusterctl/client/config.go#L86

Even though we don't set it, the `NewTemplate` func tries to fix the target namespace, i.e. it sets the namespace to an empty string.





**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5422
