### PR TITLE
🌱 Set MachineDeployment selector in managed clusters

### DIFF
--- a/controllers/topology/desired_state.go
+++ b/controllers/topology/desired_state.go
@@ -401,6 +401,14 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, desiredControlP
 	labels[clusterv1.ClusterTopologyMachineDeploymentLabelName] = machineDeploymentTopology.Name
 	desiredMachineDeploymentObj.SetLabels(labels)
 
+	// Set the select with the subset of labels identifying controlled machines.
+	// NOTE: this prevents the web hook to add cluster.x-k8s.io/deployment-name label, that is
+	// redundant for managed MachineDeployments given that we already have topology.cluster.x-k8s.io/deployment-name.
+	desiredMachineDeploymentObj.Spec.Selector.MatchLabels = map[string]string{}
+	desiredMachineDeploymentObj.Spec.Selector.MatchLabels[clusterv1.ClusterLabelName] = s.Current.Cluster.Name
+	desiredMachineDeploymentObj.Spec.Selector.MatchLabels[clusterv1.ClusterTopologyOwnedLabel] = ""
+	desiredMachineDeploymentObj.Spec.Selector.MatchLabels[clusterv1.ClusterTopologyMachineDeploymentLabelName] = machineDeploymentTopology.Name
+
 	// Also set the labels in .spec.template.labels so that they are propagated to
 	// MachineSet.labels and MachineSet.spec.template.labels and thus to Machine.labels.
 	// Note: the labels in MachineSet are used to properly cleanup templates when the MachineSet is deleted.

--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -740,6 +740,9 @@ func TestComputeMachineDeployment(t *testing.T) {
 		g.Expect(actualMd.Labels).To(HaveKey(clusterv1.ClusterTopologyOwnedLabel))
 		g.Expect(controllerutil.ContainsFinalizer(actualMd, clusterv1.MachineDeploymentTopologyFinalizer)).To(BeTrue())
 
+		g.Expect(actualMd.Spec.Selector.MatchLabels).To(HaveKey(clusterv1.ClusterTopologyOwnedLabel))
+		g.Expect(actualMd.Spec.Selector.MatchLabels).To(HaveKeyWithValue(clusterv1.ClusterTopologyMachineDeploymentLabelName, "big-pool-of-machines"))
+
 		g.Expect(actualMd.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue("foo", "baz"))
 		g.Expect(actualMd.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue("fizz", "buzz"))
 		g.Expect(actualMd.Spec.Template.ObjectMeta.Labels).To(HaveKey(clusterv1.ClusterTopologyOwnedLabel))


### PR DESCRIPTION
**What this PR does / why we need it**:
As of today when we are creating MachineDeployments in managed cluster we are not setting spec.selector field, and thus it gets initialised by web hooks to something like

```
  selector:
    matchLabels:
      cluster.x-k8s.io/cluster-name: my-cluster1
      cluster.x-k8s.io/deployment-name: my-cluster1-md1-v8hsl
```

However, given that selector labels are enforced in spec.template.metadata where we are already adding topology specific labels, so we end up with 
```
  template:
    metadata:
      labels:
        cluster.x-k8s.io/cluster-name: my-cluster1
        cluster.x-k8s.io/deployment-name: my-cluster1-md1-v8hsl
        topology.cluster.x-k8s.io/deployment-name: md1
        topology.cluster.x-k8s.io/owned: ""
```

And the co-existance of both `cluster.x-k8s.io/deployment-name` and `topology.cluster.x-k8s.io/deployment-name` might be confusing at first sight (both at MD level and also on MS and Machines down the chain).

This PR is proposing a change in how we generate the generated cluster so the resulting machine deployment object will be:

```
 selector:
    matchLabels:
      cluster.x-k8s.io/cluster-name: my-cluster1
      topology.cluster.x-k8s.io/deployment-name: md1
      topology.cluster.x-k8s.io/owned: ""
  template:
    metadata:
      labels:
        cluster.x-k8s.io/cluster-name: my-cluster1
        topology.cluster.x-k8s.io/deployment-name: md1
        topology.cluster.x-k8s.io/owned: ""
```

With a simpler and cleaner label set (both at MD level and also on MS and Machines down the chain).