### PR TITLE
🐛 ClusterClass variable schema: drop multipleOf, change min/max to *int64

### DIFF
--- a/api/v1alpha4/conversion_test.go
+++ b/api/v1alpha4/conversion_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha4
 
 import (
-	"encoding/json"
 	"testing"
 
 	fuzz "github.com/google/gofuzz"
@@ -113,10 +112,4 @@ func JSONSchemaPropsFuzzer(in *v1beta1.JSONSchemaProps, c fuzz.Continue) {
 		{Raw: []byte("\"c\"")},
 	}
 	in.Default = &apiextensionsv1.JSON{Raw: []byte("true")}
-
-	// Not every random string is a valid JSON number, so we're setting a valid JSON number.
-	number := json.Number("1")
-	in.MultipleOf = &number
-	in.Minimum = &number
-	in.Maximum = &number
 }

--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"encoding/json"
-
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -189,7 +187,7 @@ type JSONSchemaProps struct {
 	// If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum.
 	// If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum.
 	// +optional
-	Maximum *json.Number `json:"maximum,omitempty"`
+	Maximum *int64 `json:"maximum,omitempty"`
 
 	// ExclusiveMaximum specifies if the Maximum is exclusive.
 	// +optional
@@ -199,15 +197,11 @@ type JSONSchemaProps struct {
 	// If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum.
 	// If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum.
 	// +optional
-	Minimum *json.Number `json:"minimum,omitempty"`
+	Minimum *int64 `json:"minimum,omitempty"`
 
 	// ExclusiveMinimum specifies if the Minimum is exclusive.
 	// +optional
 	ExclusiveMinimum bool `json:"exclusiveMinimum,omitempty"`
-
-	// MultipleOf specifies the number of which the variable must be a multiple of.
-	// +optional
-	MultipleOf *json.Number `json:"multipleOf,omitempty"`
 
 	// Enum is the list of valid values of the variable.
 	// +optional

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"encoding/json"
 	"k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -566,17 +565,12 @@ func (in *JSONSchemaProps) DeepCopyInto(out *JSONSchemaProps) {
 	}
 	if in.Maximum != nil {
 		in, out := &in.Maximum, &out.Maximum
-		*out = new(json.Number)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Minimum != nil {
 		in, out := &in.Minimum, &out.Minimum
-		*out = new(json.Number)
-		**out = **in
-	}
-	if in.MultipleOf != nil {
-		in, out := &in.MultipleOf, &out.MultipleOf
-		*out = new(json.Number)
+		*out = new(int64)
 		**out = **in
 	}
 	if in.Enum != nil {

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -756,7 +756,8 @@ spec:
                                 the value of Maximum. If ExclusiveMaximum is true,
                                 the variable is valid if it is strictly lower than
                                 the value of Maximum.
-                              type: string
+                              format: int64
+                              type: integer
                             minLength:
                               description: MinLength is the min length of a string
                                 variable.
@@ -769,11 +770,8 @@ spec:
                                 to, the value of Minimum. If ExclusiveMinimum is true,
                                 the variable is valid if it is strictly greater than
                                 the value of Minimum.
-                              type: string
-                            multipleOf:
-                              description: MultipleOf specifies the number of which
-                                the variable must be a multiple of.
-                              type: string
+                              format: int64
+                              type: integer
                             nullable:
                               description: Nullable specifies if the variable can
                                 be set to null.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR changes min/max fields to `*int64` and drops multipleOf entirely (as it's not that useful).

I though I had tested `json.Number` entirely, but I forgot a use case. When using the structs on client-side and sending a `json.Number` to the server it is marshaled as follows:
* 1.5, "1.5" => 1.5
* 1, "1" => 1
This does not match the OpenAPI schema validation of `string` or even "int or string". So we cannot use `json.Number` as the marshaling behavior is not what we want.

Using `float64` is not recommended:
```
found float, the usage of which is highly discouraged, as support for them varies across languages. Please consider serializing your float as string instead. If you are really sure you want to use them, re-run with crd:allowDangerousTypes=true
Error: not all generators ran successfully
```

So we could use `IntOrString` (floats would have to be serialized as strings), but let's start with `int64` for now as that covers the most use cases. If we want to support floats later on we can tackle that later, although it's not 100% a compatible change to change the field from `int64` to `intorstring` ("Going from int->intorstring is a ~compatible change from API schema perspective, not from code").

xref: lenghty Slack thread discussing the options / prototyping: https://kubernetes.slack.com/archives/C8TSNPY4T/p1635175756089200

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
