### PR TITLE
🌱  Promote enxebre to maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,6 +20,7 @@ aliases:
   # non-admin folks who have write-access and can approve any PRs in the repo
   cluster-api-maintainers:
   - CecileRobertMichon
+  - enxebre
   - fabriziopandini
   - vincepri
 
@@ -27,7 +28,6 @@ aliases:
   cluster-api-reviewers:
   - JoelSpeed
   - sbueringer
-  - enxebre
   - stmcginnis
 
   # -----------------------------------------------------------


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This PR moves @enxebre from reviewers to maintainers. @enxebre has been involved with the project and helped it evolve since its early stage. He was involved in discussions about Aggregated API vs CRDs, bootstrapping decoupling, cluster vs machine management, composability, project gradual adoption, etc. that influenced the v1alpha3 redesign. He drove the design and led the team which contributed autoscaling support, Machine health checking, externally managed infrastructure support, and spot instances.

Proposals: https://github.com/kubernetes-sigs/cluster-api/search?q=enxebre
PRs: https://github.com/kubernetes-sigs/cluster-api/pulls?q=is%3Apr+is%3Aclosed+author%3Aenxebre
Reviews: https://github.com/kubernetes-sigs/cluster-api/pulls?page=1&q=is%3Apr+enxebre
Issues: https://github.com/kubernetes-sigs/cluster-api/issues?q=is%3Aissue+author%3Aenxebre+

/cc @fabriziopandini @vincepri 
/hold for approvers and for lazy consensus until Monday 11/1.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
