### PR TITLE
🌱 Promote sbueringer to cluster-api-test maintainer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -66,6 +66,7 @@ aliases:
 
   cluster-api-test-reviewers:
   cluster-api-test-maintainers:
+  - sbueringer
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for test/framework


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

**What this PR does / why we need it**:
This PR adds @sbueringer (myself ;)) to cluster-api-test-maintainers.

I think I've been (helping) maintaining our test framework, e2e tests and CAPD for a while now. Mostly keeping testgrid green, tracking down and fixing broken or flaky tests, maintaining ProwJob configurations and of course also reviewing PRs in those areas, etc. .

I don't think we have the data quality to filter down for those specific areas so I'll just list all CAPI contributions:
PRs: https://github.com/kubernetes-sigs/cluster-api/pulls?q=is%3Apr+is%3Aclosed+author%3Asbueringer
Reviews: https://github.com/kubernetes-sigs/cluster-api/pulls?page=1&q=is%3Apr+sbueringer
Issues: https://github.com/kubernetes-sigs/cluster-api/issues?q=is%3Aissue+author%3Asbueringer+
test-infra (cluster-api) PRs: https://github.com/kubernetes/test-infra/pulls?q=is%3Apr+author%3Asbueringer+is%3Aclosed+cluster-api



/cc @vincepri @fabriziopandini @CecileRobertMichon 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
