### PR TITLE
🐛  ClusterClass YAMLs: Add mandatory .spec.template.spec to DockerClusterTemplates

### DIFF
--- a/docs/book/src/tasks/experimental-features/yamls/clusterclass.yaml
+++ b/docs/book/src/tasks/experimental-features/yamls/clusterclass.yaml
@@ -46,6 +46,9 @@ kind: DockerClusterTemplate
 metadata:
   name: clusterclass-infrastructure
   namespace: default
+spec:
+  template:
+    spec: {}
 ---
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -101,7 +104,7 @@ metadata:
   namespace: default
 spec:
   template:
-    spec: { }
+    spec: {}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
@@ -37,6 +37,9 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate
 metadata:
   name: quick-start-my-cluster
+spec:
+  template:
+    spec: {}
 ---
 kind: KubeadmControlPlaneTemplate
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adjusts our ClusterClass YAMLs so that the DockerClusterTemplates contain the required `.spec.template.spec` fields. This is not an issue with `clusterctl` (deploying it with clusterctl results in: https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-cluster-api-e2e-main/1453289590369554432/artifacts/clusters/bootstrap/resources/quick-start-tnjriw/DockerClusterTemplate/quick-start-my-cluster.yaml), but with `kubectl apply`

xref: https://kubernetes.slack.com/archives/C8TSNPY4T/p1635328722152600

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
