### PR TITLE
🌱 clusterctl config cluster: render ClusterClass before Cluster

### DIFF
--- a/cmd/clusterctl/client/clusterclass.go
+++ b/cmd/clusterctl/client/clusterclass.go
@@ -48,7 +48,9 @@ func addClusterClassIfMissing(template Template, clusterClassClient repository.C
 		return nil, err
 	}
 
-	mergedTemplate, err := repository.MergeTemplates(template, clusterClassesTemplate)
+	// We intentionally render the ClusterClass before the Cluster resource, as the Cluster
+	// is depending on the ClusterClass.
+	mergedTemplate, err := repository.MergeTemplates(clusterClassesTemplate, template)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/repository/template.go
+++ b/cmd/clusterctl/client/repository/template.go
@@ -146,7 +146,7 @@ func NewTemplate(input TemplateInput) (Template, error) {
 // Notes on the merge operation:
 // - The merge operation returns an error if all the templates do not have the same TargetNamespace.
 // - The Variables of the resulting template is a union of all Variables in the templates.
-// - The default value is picked from the first temmplate that defines it.
+// - The default value is picked from the first template that defines it.
 //    The defaults of the same variable in the subsequent templates will be ignored.
 //    (e.g when merging a cluster template and its ClusterClass, the default value from the template takes precedence)
 // - The Objs of the final template will be a union of all the Objs in the templates.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
`clusterctl config cluster` renders a Cluster and a ClusterClass with all its referenced templates. This PR changes the order so that the ClusterClass is rendered before the Cluster. I think it makes sense to first deploy the ClusterClass and then the Cluster, as the Cluster is referencing the ClusterClass.

xref: https://kubernetes.slack.com/archives/C8TSNPY4T/p1635342262173200

The plan is to introduce variable validation for Cluster variables later on. If we make it mandatory that a ClusterClass must exist when a Cluster with variables is created (so that we can validate the variables), this change is necessary. 

But overall I think it's just a good idea to render them in this order to avoid initially failed reconciles when a Cluster references a ClusterClass which does not exist yet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
