### PR TITLE
🌱  Move cluster webhook to top-level package

### DIFF
--- a/api/v1beta1/cluster_webhook.go
+++ b/api/v1beta1/cluster_webhook.go
@@ -31,19 +31,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+// SetupWebhookWithManager sets up Cluster webhooks.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.Cluster.SetupWebhookWithManager instead.
+// Note: We don't have to call this func for the conversion webhook as there is only a single conversion webhook instance
+// for all resources and we already register it through other types.
 func (c *Cluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(c).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1beta1-cluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=clusters,versions=v1beta1,name=validation.cluster.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-cluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=clusters,versions=v1beta1,name=default.cluster.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
 var _ webhook.Defaulter = &Cluster{}
 var _ webhook.Validator = &Cluster{}
 
 // Default satisfies the defaulting webhook interface.
+// Deprecated: This method is going to be removed in a next release.
 func (c *Cluster) Default() {
 	if c.Spec.InfrastructureRef != nil && len(c.Spec.InfrastructureRef.Namespace) == 0 {
 		c.Spec.InfrastructureRef.Namespace = c.Namespace
@@ -63,11 +66,13 @@ func (c *Cluster) Default() {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
 func (c *Cluster) ValidateCreate() error {
 	return c.validate(nil)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
 func (c *Cluster) ValidateUpdate(old runtime.Object) error {
 	oldCluster, ok := old.(*Cluster)
 	if !ok {
@@ -77,6 +82,7 @@ func (c *Cluster) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
 func (c *Cluster) ValidateDelete() error {
 	return nil
 }

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -13,28 +13,6 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-cluster-x-k8s-io-v1beta1-cluster
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: default.cluster.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - cluster.x-k8s.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusters
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
       path: /mutate-cluster-x-k8s-io-v1beta1-machine
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -145,6 +123,28 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-cluster-x-k8s-io-v1beta1-clusterclass
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -190,28 +190,6 @@ metadata:
   creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-cluster-x-k8s-io-v1beta1-cluster
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validation.cluster.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - cluster.x-k8s.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusters
-  sideEffects: None
 - admissionReviewVersions:
   - v1
   - v1beta1
@@ -321,6 +299,28 @@ webhooks:
     - UPDATE
     resources:
     - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/internal/envtest/environment.go
+++ b/internal/envtest/environment.go
@@ -216,7 +216,7 @@ func new(uncachedObjs ...client.Object) *Environment {
 	// Set minNodeStartupTimeout for Test, so it does not need to be at least 30s
 	clusterv1.SetMinNodeStartupTimeout(metav1.Duration{Duration: 1 * time.Millisecond})
 
-	if err := (&clusterv1.Cluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.Cluster{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("unable to create webhook: %+v", err)
 	}
 	if err := (&webhooks.ClusterClass{}).SetupWebhookWithManager(mgr); err != nil {

--- a/main.go
+++ b/main.go
@@ -396,7 +396,7 @@ func setupWebhooks(mgr ctrl.Manager) {
 
 	// NOTE: ClusterClass and managed topologies are behind ClusterTopology feature gate flag; the webhook
 	// is going to prevent usage of Cluster.Topology in case the feature flag is disabled.
-	if err := (&clusterv1.Cluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.Cluster{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Cluster")
 		os.Exit(1)
 	}

--- a/webhooks/cluster.go
+++ b/webhooks/cluster.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// SetupWebhookWithManager sets up Cluster webhooks.
+func (c *Cluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&clusterv1.Cluster{}).
+		WithDefaulter(c).
+		WithValidator(c).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1beta1-cluster,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=clusters,versions=v1beta1,name=validation.cluster.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-cluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=clusters,versions=v1beta1,name=default.cluster.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// Cluster implements a validating and defaulting webhook for Cluster.
+type Cluster struct{}
+
+var _ webhook.CustomDefaulter = &Cluster{}
+var _ webhook.CustomValidator = &Cluster{}
+
+// Default satisfies the defaulting webhook interface.
+func (c *Cluster) Default(_ context.Context, obj runtime.Object) error {
+	cluster, ok := obj.(*clusterv1.Cluster)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
+	}
+
+	// Note: The code in Default is intentionally not duplicated to avoid that we accidentally
+	// implement new checks in the API package and forget to duplicate them to the webhook package.
+	// The idea is to add new defaulting which requires a reader in the webhook package.
+	// When we drop the method in the API package we must inline it here.
+	cluster.Default()
+
+	return nil
+}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (c *Cluster) ValidateCreate(_ context.Context, obj runtime.Object) error {
+	cluster, ok := obj.(*clusterv1.Cluster)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
+	}
+
+	// Note: The code in ValidateCreate is intentionally not duplicated to avoid that we accidentally
+	// implement new checks in the API package and forget to duplicate them to the webhook package.
+	// The idea is to add new validation which requires a reader and Cluster variable/patch validation
+	// in the webhook package.
+	// When we drop the method in the API package we must inline it here.
+	return cluster.ValidateCreate()
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (c *Cluster) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
+	cluster, ok := newObj.(*clusterv1.Cluster)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", newObj))
+	}
+	oldCluster, ok := oldObj.(*clusterv1.Cluster)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", oldObj))
+	}
+
+	// Note: The code in ValidateUpdate is intentionally not duplicated to avoid that we accidentally
+	// implement new checks in the API package and forget to duplicate them to the webhook package.
+	// The idea is to add new validation which requires a reader and Cluster variable/patch validation
+	// in the webhook package.
+	// When we drop the method in the API package we must inline it here.
+	return cluster.ValidateUpdate(oldCluster)
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (c *Cluster) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	cluster, ok := obj.(*clusterv1.Cluster)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
+	}
+	return cluster.ValidateDelete()
+}

--- a/webhooks/cluster_test.go
+++ b/webhooks/cluster_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/component-base/featuregate/testing"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/feature"
+)
+
+func TestClusterDefaultNamespaces(t *testing.T) {
+	g := NewWithT(t)
+
+	in := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "fooboo",
+		},
+		Spec: clusterv1.ClusterSpec{
+			InfrastructureRef: &corev1.ObjectReference{},
+			ControlPlaneRef:   &corev1.ObjectReference{},
+		},
+	}
+
+	webhook := &Cluster{}
+	t.Run("for Cluster", customDefaultValidateTest(ctx, in, webhook))
+
+	g.Expect(webhook.Default(ctx, in)).To(Succeed())
+
+	g.Expect(in.Spec.InfrastructureRef.Namespace).To(Equal(in.Namespace))
+	g.Expect(in.Spec.ControlPlaneRef.Namespace).To(Equal(in.Namespace))
+}
+
+func TestClusterDefaultTopologyVersion(t *testing.T) {
+	// NOTE: ClusterTopology feature flag is disabled by default, thus preventing to set Cluster.Topologies.
+	// Enabling the feature flag temporarily for this test.
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
+
+	g := NewWithT(t)
+
+	in := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "fooboo",
+		},
+		Spec: clusterv1.ClusterSpec{
+			Topology: &clusterv1.Topology{
+				Class:   "foo",
+				Version: "1.19.1",
+			},
+		},
+	}
+	webhook := &Cluster{}
+	t.Run("for Cluster", customDefaultValidateTest(ctx, in, webhook))
+	g.Expect(webhook.Default(ctx, in)).To(Succeed())
+
+	g.Expect(in.Spec.Topology.Version).To(HavePrefix("v"))
+}


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

This PR moves the Cluster webhook to the new top-level webhooks package. It mirrors #5266 which created the top level package and moved the ClusterClass webhook to it.

 This allows adding dependencies to the webhook without adding dependencies to the API package which is widely imported.

Fixes #5512
/area topology