### PR TITLE
🌱 Topology reconciler collects orphan templates in case of errors - version2

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -266,6 +266,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/topology/cluster_controller.go
+++ b/controllers/topology/cluster_controller.go
@@ -43,6 +43,7 @@ import (
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusterclasses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;create;delete
 
 // ClusterReconciler reconciles a managed topology for a Cluster object.
 type ClusterReconciler struct {

--- a/controllers/topology/internal/scope/scope.go
+++ b/controllers/topology/internal/scope/scope.go
@@ -38,6 +38,9 @@ type Scope struct {
 // New returns a new Scope with only the cluster; while processing a request in the topology/ClusterReconciler controller
 // additional information will be added about the Cluster blueprint, current state and desired state.
 func New(cluster *clusterv1.Cluster) *Scope {
+	// enforce TypeMeta values in the Cluster object so we can assume it is always set during reconciliation.
+	cluster.APIVersion = clusterv1.GroupVersion.String()
+	cluster.Kind = "Cluster"
 	return &Scope{
 		Blueprint: &ClusterBlueprint{},
 		Current: &ClusterState{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR solves the same issue of https://github.com/kubernetes-sigs/cluster-api/pull/5430 but with a different solution that is re-entrant

In case the topology reconciler fails in the middle of a reconciliation there could be a case a objects has been created but it is not yet used by the owning object e.g-

- InfrastructureCluster created, error before upgrading the Cluster to use the InfrastructureCluster
- InfrastructureMachine created, error before creating/upgrading the MachineDeployment to use the InfrastructureMachine

The new solution uses a mix of approaches:

- Templates are created with a ownerReference to the cluster, so they will be garbage collected when the cluster is deleted
- InfrastructureCluster and ControlPlane object can use the same solution, given that an owner reference to the Cluster will trigger provisioning even before the Cluster actually reference those objects- So, in order to avoid this problem, InfrastructureCluster and ControlPlane are created with a ownerReference to a temporary object called cluster-ship, that is responsible of garbage collect those objects if garbage collected.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5307