### PR TITLE
[wip] :book: Add CRD reference documentation

### DIFF
--- a/docs/book/Makefile
+++ b/docs/book/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Directories.
-ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT_DIR:=$(realpath $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/../..)
 TOOLS_DIR := $(realpath ../../hack/tools)
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 BIN_DIR := bin
@@ -42,14 +42,22 @@ MDBOOK_LINKCHECK := $(TOOLS_BIN_DIR)/mdbook-linkcheck
 $(MDBOOK_LINKCHECK):
 	$(CRATE_INSTALL) --git Michael-F-Bryan/mdbook-linkcheck --tag v0.7.0 --to $(TOOLS_BIN_DIR) --force
 
+OPENAPIV3_COMPONENT_SCHEMA_GEN := $(TOOLS_BIN_DIR)/openapiv3-component-schema-gen
+$(OPENAPIV3_COMPONENT_SCHEMA_GEN):
+	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/openapiv3-component-schema-gen ./openapiv3-component-schema-gen
+
+.PHONY: src/reference/crds.yaml
+src/reference/crds.yaml: $(OPENAPIV3_COMPONENT_SCHEMA_GEN)
+	$(OPENAPIV3_COMPONENT_SCHEMA_GEN) --input-dirs $(ROOT_DIR)/config/crd/bases,$(ROOT_DIR)/bootstrap/kubeadm/config/crd/bases,$(ROOT_DIR)/controlplane/kubeadm/config/crd/bases > $@
+
 .PHONY: serve
-serve: $(MDBOOK) $(TABULATE) $(EMBED) $(RELEASELINK) $(MDBOOK_LINKCHECK)
+serve: $(MDBOOK) $(TABULATE) $(EMBED) $(RELEASELINK) $(MDBOOK_LINKCHECK) src/reference/crds.yaml
 	$(MDBOOK) serve
 
 .PHONY: build
-build: $(MDBOOK) $(TABULATE) $(EMBED) $(RELEASELINK) $(MDBOOK_LINKCHECK)
+build: $(MDBOOK) $(TABULATE) $(EMBED) $(RELEASELINK) $(MDBOOK_LINKCHECK) src/reference/crds.yaml
 	$(MDBOOK) build
 
 .PHONY: verify
-verify: $(MDBOOK) $(TABULATE) $(EMBED) $(RELEASELINK) $(MDBOOK_LINKCHECK)
+verify: $(MDBOOK) $(TABULATE) $(EMBED) $(RELEASELINK) $(MDBOOK_LINKCHECK) src/reference/crds.yaml
 	$(MDBOOK) build

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -67,6 +67,7 @@
     - [CustomResourceDefinitions relationships](./developer/crd-relationships.md)
 - [Troubleshooting](./user/troubleshooting.md)
 - [Reference](./reference/reference.md)
+    - [CRD Reference](./reference/crds.md)
     - [Glossary](./reference/glossary.md)
     - [Provider List](./reference/providers.md)
     - [Ports](./reference/ports.md)

--- a/docs/book/src/reference/.gitignore
+++ b/docs/book/src/reference/.gitignore
@@ -1,0 +1,1 @@
+crds.yaml

--- a/docs/book/src/reference/crds.md
+++ b/docs/book/src/reference/crds.md
@@ -1,0 +1,48 @@
+# CRD Reference
+
+<style>
+  .content {
+    width: 100%
+  }
+  .content main {
+    max-width: 100%
+  }
+</style>
+<script>
+
+  const SEARCH_HOTKEY_KEYCODE = 83;
+  // hasFocus returns true if the table search is active
+  function hasFocus() {
+    const tableSearchBar = document.querySelector("#content > main > p > rapi-doc");
+    return (tableSearchBar === document.activeElement);
+  }
+
+  // Prevent the mdbook search event listener capturing the 's' key, so users can search for CRD properties.
+  function resetKeyHandler(e) {
+    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey || e.target.type === 'textarea' || e.target.type === 'text') { return; }
+
+    if (e.keyCode === SEARCH_HOTKEY_KEYCODE && hasFocus()) {
+        e.stopPropagation();
+    }
+  }
+
+  // Insert the event listener when the document is ready
+  $(function() {
+    document.addEventListener('keydown', function (e) { resetKeyHandler(e); }, true);
+  });
+
+</script>
+
+<script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+<rapi-doc
+  spec-url = "crds.yaml"
+   allow-server-selection = 'false'
+   schema-style="table"
+   fill-request-fields-with-example='false'
+   render-style = 'focused'
+   allow-authentication = 'false'
+   allow-try = 'false'
+   allow-spec-file-load = 'false'
+   allow-spec-url-load = 'false'
+   show-components = 'true'
+/>

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -11,12 +11,15 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/pkg/errors v0.9.1
 	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/spf13/pflag v1.0.5
 	golang.org/x/exp v0.0.0-20210625193404-fa9d1d177d71 // indirect
 	golang.org/x/tools v0.1.5
 	gotest.tools/gotestsum v1.6.4
+	k8s.io/apiextensions-apiserver v0.22.2
 	k8s.io/code-generator v0.22.2
 	k8s.io/klog/v2 v2.9.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20210827150604-1730628f118b
 	sigs.k8s.io/controller-tools v0.7.0
 	sigs.k8s.io/kubebuilder/docs/book/utils v0.0.0-20210702145813-742983631190
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/hack/tools/openapiv3-component-schema-gen/main.go
+++ b/hack/tools/openapiv3-component-schema-gen/main.go
@@ -1,0 +1,112 @@
+// +build tools
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+
+	"github.com/spf13/pflag"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+)
+
+type document struct {
+	Openapi    string     `json:"openapi"`
+	Info       info       `json:"info"`
+	Servers    []server   `json:"servers"`
+	Components components `json:"components"`
+}
+
+type components struct {
+	Schemas map[string]*apiextensionsv1.JSONSchemaProps `json:"schemas"`
+}
+
+type info struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+}
+
+type server struct {
+	URL string `json:"url"`
+}
+
+func main() {
+	inputDirs := []string{"config/crd/bases"}
+	title := "Kubernetes"
+	pflag.CommandLine.StringSliceVar(&inputDirs, "input-dirs", inputDirs, "input directories to convert CRDs from")
+	pflag.CommandLine.String("title", title, "Title of the API")
+	pflag.Parse()
+
+	document := document{
+		Openapi: "3.0.0",
+		Info: info{
+			Title: title,
+		},
+		Servers: []server{
+			{
+				URL: "kubernetes",
+			},
+		},
+		Components: components{
+			Schemas: map[string]*apiextensionsv1.JSONSchemaProps{},
+		},
+	}
+
+	for _, dir := range inputDirs {
+		files, err := ioutil.ReadDir(dir)
+		if err != nil {
+			panic(err)
+		}
+		document.addFiles(dir, files)
+	}
+
+	newDat, err := yaml.Marshal(document)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(newDat))
+}
+
+func (d *document) addFiles(baseDir string, files []fs.FileInfo) {
+	for _, file := range files {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		dat, err := ioutil.ReadFile(baseDir + "/" + file.Name()) // nolint:gosec
+		if err != nil {
+			panic(err)
+		}
+		err = yaml.Unmarshal(dat, crd)
+		if err != nil {
+			panic(err)
+		}
+		d.addSchema(crd)
+	}
+}
+
+func (d *document) addSchema(crd *apiextensionsv1.CustomResourceDefinition) {
+	singular := crd.Spec.Names.Singular
+	versions := crd.Spec.Versions
+
+	for _, ver := range versions {
+		componentName := ver.Name + "." + singular
+		d.Components.Schemas[componentName] = ver.Schema.OpenAPIV3Schema
+	}
+}


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Fixes #4484 

Uses a tool that's been added in /hack/tool to construct an OpenAPIv3 schema from all input CRD directories, and then use rapidoc to show the schema using client-side JS rendering. It's just good enough, and it's super fast unlike other alternatives, so shouldn't timeout in Netlify.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>


