### PR TITLE
🐛 Update CAPI version to v1beta1 in kustomization in test-framework

### DIFF
--- a/test/framework/kubernetesversions/data/kustomization.yaml
+++ b/test/framework/kubernetesversions/data/kustomization.yaml
@@ -11,10 +11,10 @@ patchesJson6902:
     group: controlplane.cluster.x-k8s.io
     kind: KubeadmControlPlane
     name: ".*-control-plane"
-    version: v1alpha4
+    version: v1beta1
 - path: kubeadmconfigtemplate-patch.yaml
   target:
     group: bootstrap.cluster.x-k8s.io
     kind: KubeadmConfigTemplate
     name: ".*-md-0"
-    version: v1alpha4
+    version: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the `KubeadmControlPlane` and `KubeadmConfigTemplate` version to v1beta1 in kustomization.yaml in test-framework to fix the conformance tests with k8s main branch in CAPA testgrid

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
