### PR TITLE
🌱 Add nodeDrainTimeout to contract package

### DIFF
--- a/controllers/topology/internal/contract/controlplane.go
+++ b/controllers/topology/internal/contract/controlplane.go
@@ -196,3 +196,10 @@ func (c *ControlPlaneMachineTemplate) Metadata() *Metadata {
 		path: Path{"spec", "machineTemplate", "metadata"},
 	}
 }
+
+// NodeDrainTimeout provides access to the nodeDrainTimeout of a MachineTemplate.
+func (c *ControlPlaneMachineTemplate) NodeDrainTimeout() *Duration {
+	return &Duration{
+		path: Path{"spec", "machineTemplate", "nodeDrainTimeout"},
+	}
+}

--- a/controllers/topology/internal/contract/controlplane_test.go
+++ b/controllers/topology/internal/contract/controlplane_test.go
@@ -18,8 +18,10 @@ package contract
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -144,6 +146,22 @@ func TestControlPlane(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(got).To(Equal(metadata))
+	})
+
+	t.Run("Manages spec.machineTemplate.nodeDrainTimeout", func(t *testing.T) {
+		g := NewWithT(t)
+
+		duration := metav1.Duration{Duration: 2*time.Minute + 5*time.Second}
+
+		g.Expect(ControlPlane().MachineTemplate().NodeDrainTimeout().Path()).To(Equal(Path{"spec", "machineTemplate", "nodeDrainTimeout"}))
+
+		err := ControlPlane().MachineTemplate().NodeDrainTimeout().Set(obj, duration)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlane().MachineTemplate().NodeDrainTimeout().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(*got).To(Equal(duration))
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds new methods to handle `.spec.machineTemplate.nodeDrainTimeout` to the ControlPlane in the contracts package.

Note: This will be required for the ClusterClass patch implementation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
