### PR TITLE
🌱 Replace ioutil with os/io packages, run gofmt

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -18,7 +18,6 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -142,7 +141,7 @@ func (o *objectMover) filesToObjs(dir string) ([]unstructured.Unstructured, erro
 	log := logf.Log
 	log.Info(fmt.Sprintf("Restoring files from %s", dir))
 
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +150,7 @@ func (o *objectMover) filesToObjs(dir string) ([]unstructured.Unstructured, erro
 	for i := range files {
 		path := filepath.Clean(filepath.Join(dir, files[i].Name()))
 
-		byObj, err := ioutil.ReadFile(path)
+		byObj, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
@@ -823,7 +822,7 @@ func (o *objectMover) backupTargetObject(nodeToCreate *node, directory string) e
 		}
 	}
 
-	err = ioutil.WriteFile(objectFile, byObj, 0600)
+	err = os.WriteFile(objectFile, byObj, 0600)
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -18,7 +18,6 @@ package cluster
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -549,7 +548,7 @@ func Test_objectMover_backupTargetObject(t *testing.T) {
 				fromProxy: graph.proxy,
 			}
 
-			dir, err := ioutil.TempDir("/tmp", "cluster-api")
+			dir, err := os.MkdirTemp("/tmp", "cluster-api")
 			if err != nil {
 				t.Error(err)
 			}
@@ -618,7 +617,7 @@ func Test_objectMover_restoreTargetObject(t *testing.T) {
 			g := NewWithT(t)
 
 			// temporary directory
-			dir, err := ioutil.TempDir("/tmp", "cluster-api")
+			dir, err := os.MkdirTemp("/tmp", "cluster-api")
 			if err != nil {
 				g.Expect(err).NotTo(HaveOccurred())
 			}
@@ -643,7 +642,7 @@ func Test_objectMover_restoreTargetObject(t *testing.T) {
 
 			// Write go string slice to directory
 			for _, file := range tt.files {
-				tempFile, err := ioutil.TempFile(dir, "obj")
+				tempFile, err := os.CreateTemp(dir, "obj")
 				g.Expect(err).NotTo(HaveOccurred())
 
 				_, err = tempFile.Write([]byte(file))
@@ -744,7 +743,7 @@ func Test_objectMover_backup(t *testing.T) {
 				fromProxy: graph.proxy,
 			}
 
-			dir, err := ioutil.TempDir("/tmp", "cluster-api")
+			dir, err := os.MkdirTemp("/tmp", "cluster-api")
 			if err != nil {
 				t.Error(err)
 			}
@@ -778,7 +777,7 @@ func Test_objectMover_backup(t *testing.T) {
 				g.Expect(err).NotTo(HaveOccurred())
 
 				// objects are stored in the temporary directory with the expected filename
-				files, err := ioutil.ReadDir(dir)
+				files, err := os.ReadDir(dir)
 				g.Expect(err).NotTo(HaveOccurred())
 
 				expectedFilename := node.getFilename()
@@ -805,7 +804,7 @@ func Test_objectMover_filesToObjs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			dir, err := ioutil.TempDir("/tmp", "cluster-api")
+			dir, err := os.MkdirTemp("/tmp", "cluster-api")
 			if err != nil {
 				t.Error(err)
 			}
@@ -865,7 +864,7 @@ func Test_objectMover_restore(t *testing.T) {
 			g := NewWithT(t)
 
 			// temporary directory
-			dir, err := ioutil.TempDir("/tmp", "cluster-api")
+			dir, err := os.MkdirTemp("/tmp", "cluster-api")
 			if err != nil {
 				g.Expect(err).NotTo(HaveOccurred())
 			}
@@ -887,7 +886,7 @@ func Test_objectMover_restore(t *testing.T) {
 
 			// Write go string slice to directory
 			for _, file := range tt.files {
-				tempFile, err := ioutil.TempFile(dir, "obj")
+				tempFile, err := os.CreateTemp(dir, "obj")
 				g.Expect(err).NotTo(HaveOccurred())
 
 				_, err = tempFile.Write([]byte(file))

--- a/cmd/clusterctl/client/move_test.go
+++ b/cmd/clusterctl/client/move_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -97,7 +96,7 @@ func Test_clusterctlClient_Move(t *testing.T) {
 }
 
 func Test_clusterctlClient_Backup(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "cluster-api")
+	dir, err := os.MkdirTemp("/tmp", "cluster-api")
 	if err != nil {
 		t.Error(err)
 	}
@@ -160,7 +159,7 @@ func Test_clusterctlClient_Backup(t *testing.T) {
 }
 
 func Test_clusterctlClient_Restore(t *testing.T) {
-	dir, err := ioutil.TempDir("/tmp", "cluster-api")
+	dir, err := os.MkdirTemp("/tmp", "cluster-api")
 	if err != nil {
 		t.Error(err)
 	}

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -22,10 +22,10 @@ package tools
 import (
 	_ "github.com/drone/envsubst/v2/cmd/envsubst"
 	_ "github.com/joelanford/go-apidiff"
+	_ "github.com/mikefarah/yq/v4"
 	_ "github.com/onsi/ginkgo/ginkgo"
 	_ "gotest.tools/gotestsum"
 	_ "k8s.io/code-generator/cmd/conversion-gen"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
-	_ "github.com/mikefarah/yq/v4"
 )

--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -385,7 +384,7 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 }
 
 func downloadToTmpFile(url string) string {
-	tmpFile, err := ioutil.TempFile("", "clusterctl")
+	tmpFile, err := os.CreateTemp("", "clusterctl")
 	Expect(err).ToNot(HaveOccurred(), "failed to get temporary file")
 	defer tmpFile.Close()
 

--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -19,7 +19,6 @@ package clusterctl
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -104,7 +103,7 @@ func InitWithBinary(_ context.Context, binary string, input InitInput) {
 	)
 
 	out, err := cmd.CombinedOutput()
-	_ = ioutil.WriteFile(filepath.Join(input.LogFolder, "clusterctl-init.log"), out, 0644) //nolint:gosec // this is a log file to be shared via prow artifacts
+	_ = os.WriteFile(filepath.Join(input.LogFolder, "clusterctl-init.log"), out, 0644) //nolint:gosec // this is a log file to be shared via prow artifacts
 	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl init:\n%s", string(out))
 }
 
@@ -241,7 +240,7 @@ func ConfigClusterWithBinary(_ context.Context, clusterctlBinaryPath string, inp
 	)
 
 	out, err := cmd.Output()
-	_ = ioutil.WriteFile(filepath.Join(input.LogFolder, fmt.Sprintf("%s-cluster-template.yaml", input.ClusterName)), out, 0644) //nolint:gosec // this is a log file to be shared via prow artifacts
+	_ = os.WriteFile(filepath.Join(input.LogFolder, fmt.Sprintf("%s-cluster-template.yaml", input.ClusterName)), out, 0644) //nolint:gosec // this is a log file to be shared via prow artifacts
 	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl config cluster:\n%s", string(out))
 
 	return out

--- a/test/framework/kubernetesversions/template.go
+++ b/test/framework/kubernetesversions/template.go
@@ -22,7 +22,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -91,7 +90,7 @@ func GenerateCIArtifactsInjectedTemplateForDebian(input GenerateCIArtifactsInjec
 
 	kustomizedTemplate := path.Join(templateDir, "cluster-template-conformance-ci-artifacts.yaml")
 
-	if err := ioutil.WriteFile(path.Join(overlayDir, "kustomization.yaml"), []byte(kustomizationYAMLBytes), 0o600); err != nil {
+	if err := os.WriteFile(path.Join(overlayDir, "kustomization.yaml"), []byte(kustomizationYAMLBytes), 0o600); err != nil {
 		return "", err
 	}
 

--- a/test/infrastructure/docker/exp/api/v1beta1/conversion.go
+++ b/test/infrastructure/docker/exp/api/v1beta1/conversion.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package v1beta1
 
-func (*DockerMachinePool) Hub()             {}
-func (*DockerMachinePoolList) Hub()         {}
+func (*DockerMachinePool) Hub()     {}
+func (*DockerMachinePoolList) Hub() {}


### PR DESCRIPTION
The ioutil package has already been deprecated in golang 1.16, please see [go1.16#ioutil](https://golang.org/doc/go1.16#ioutil). So we need to replace all the ioutil with os and io.

This PR also contains two changes made by gofmt automatically. 