### PR TITLE
🌱  Remove noisy log in machine pool upgrade test

### DIFF
--- a/test/framework/machinepool_helpers.go
+++ b/test/framework/machinepool_helpers.go
@@ -258,7 +258,6 @@ func getMachinePoolInstanceVersions(ctx context.Context, input GetMachinesPoolIn
 		} else {
 			versions[i] = node.Status.NodeInfo.KubeletVersion
 		}
-		log.Logf("Node %s version is %s", instance.Name, versions[i])
 	}
 
 	return versions


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:  Removing a log line that was causing a lot of noise in the cluster upgrade test as it prints in a loop a bunch of times until the machine pool is done upgrading.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
