### PR TITLE
📖  Add instructions to enable ClusterTopology feature for Tilt and e2e tests

### DIFF
--- a/docs/book/src/tasks/experimental-features/experimental-features.md
+++ b/docs/book/src/tasks/experimental-features/experimental-features.md
@@ -27,11 +27,12 @@ As an example, Cluster API Provider Azure (CAPZ) has support for MachinePool thr
 
 ## Enabling Experimental Features for e2e Tests
 
-One way is to set experimental variables on the clusterctl config file. For CAPI, these configs are under ./test/e2e/config/... such as `docker-ci.yaml`:
+One way is to set experimental variables on the clusterctl config file. For CAPI, these configs are under ./test/e2e/config/... such as `docker.yaml`:
 ```yaml
 variables:
   EXP_CLUSTER_RESOURCE_SET: "true"
   EXP_MACHINE_POOL: "true"
+  CLUSTER_TOPOLOGY: "true"
 ```
 Another way is to set them as environmental variables before running e2e tests.
 
@@ -47,7 +48,8 @@ On development environments started with `Tilt`, features can be enabled by sett
   "provider_repos": [],
   "kustomize_substitutions": {
     "EXP_CLUSTER_RESOURCE_SET": "true",
-    "EXP_MACHINE_POOL": "true"
+    "EXP_MACHINE_POOL": "true",
+    "CLUSTER_TOPOLOGY": "true"
   }
 }
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
While developing with Tilt, found that ClusterTopology feature gate needs to be enabled to create a Cluster with ClusterClass.

This PR adds instructions how to enable ClusterTopology feature for Tilt and e2e tests to the doc.
