### PR TITLE
:seedling: Replace disable-grouping with grouping option in clusterctl describe command 

### DIFF
--- a/cmd/clusterctl/client/describe.go
+++ b/cmd/clusterctl/client/describe.go
@@ -45,9 +45,9 @@ type DescribeClusterOptions struct {
 	// or it has the same Status, Severity and Reason of the parent's object ready condition (it is an echo)
 	DisableNoEcho bool
 
-	// DisableGrouping disable grouping machines objects in case the ready condition
-	// has the same Status, Severity and Reason
-	DisableGrouping bool
+	// Grouping groups machines objects in case the ready conditions
+	// have the same Status, Severity and Reason.
+	Grouping bool
 }
 
 // DescribeCluster returns the object tree representing the status of a Cluster API cluster.
@@ -83,6 +83,6 @@ func (c *clusterctlClient) DescribeCluster(options DescribeClusterOptions) (*tre
 		ShowOtherConditions: options.ShowOtherConditions,
 		ShowMachineSets:     options.ShowMachineSets,
 		DisableNoEcho:       options.DisableNoEcho,
-		DisableGrouping:     options.DisableGrouping,
+		Grouping:            options.Grouping,
 	})
 }

--- a/cmd/clusterctl/client/tree/discovery.go
+++ b/cmd/clusterctl/client/tree/discovery.go
@@ -39,9 +39,9 @@ type DiscoverOptions struct {
 	// or it has the same Status, Severity and Reason of the parent's object ready condition (it is an echo)
 	DisableNoEcho bool
 
-	// DisableGrouping disable grouping machines objects in case the ready condition
-	// has the same Status, Severity and Reason
-	DisableGrouping bool
+	// Grouping groups machine objects in case the ready conditions
+	// have the same Status, Severity and Reason.
+	Grouping bool
 }
 
 func (d DiscoverOptions) toObjectTreeOptions() ObjectTreeOptions {

--- a/cmd/clusterctl/client/tree/discovery_test.go
+++ b/cmd/clusterctl/client/tree/discovery_test.go
@@ -42,7 +42,9 @@ func Test_Discovery(t *testing.T) {
 		{
 			name: "Discovery with default discovery settings",
 			args: args{
-				discoverOptions: DiscoverOptions{},
+				discoverOptions: DiscoverOptions{
+					Grouping: true,
+				},
 				objs: test.NewFakeCluster("ns1", "cluster1").
 					WithControlPlane(
 						test.NewFakeControlPlane("cp").
@@ -110,7 +112,7 @@ func Test_Discovery(t *testing.T) {
 			name: "Discovery with grouping disabled",
 			args: args{
 				discoverOptions: DiscoverOptions{
-					DisableGrouping: true,
+					Grouping: false,
 				},
 				objs: test.NewFakeCluster("ns1", "cluster1").
 					WithControlPlane(
@@ -182,8 +184,8 @@ func Test_Discovery(t *testing.T) {
 			name: "Discovery with grouping and no-echo disabled",
 			args: args{
 				discoverOptions: DiscoverOptions{
-					DisableGrouping: true,
-					DisableNoEcho:   true,
+					Grouping:      false,
+					DisableNoEcho: true,
 				},
 				objs: test.NewFakeCluster("ns1", "cluster1").
 					WithControlPlane(

--- a/cmd/clusterctl/client/tree/tree.go
+++ b/cmd/clusterctl/client/tree/tree.go
@@ -43,9 +43,9 @@ type ObjectTreeOptions struct {
 	// same Status, Severity and Reason of the parent's object ready condition (it is an echo)
 	DisableNoEcho bool
 
-	// DisableGrouping disables grouping sibling objects in case the ready condition
-	// has the same Status, Severity and Reason
-	DisableGrouping bool
+	// Grouping groups sibling object in case the ready conditions
+	// have the same Status, Severity and Reason
+	Grouping bool
 }
 
 // ObjectTree defines an object tree representing the status of a Cluster API cluster.
@@ -140,7 +140,7 @@ func (od ObjectTree) Add(parent, obj client.Object, opts ...AddObjectOption) (ad
 	// If it is requested that the child of this node should be grouped in case the ready condition
 	// has the same Status, Severity and Reason, add the GroupingObjectAnnotation to signal
 	// this to the presentation layer.
-	if addOpts.GroupingObject && !od.options.DisableGrouping {
+	if addOpts.GroupingObject && od.options.Grouping {
 		addAnnotation(obj, GroupingObjectAnnotation, "True")
 	}
 

--- a/cmd/clusterctl/client/tree/tree_test.go
+++ b/cmd/clusterctl/client/tree/tree_test.go
@@ -440,9 +440,9 @@ func Test_Add_setsGroupingObjectAnnotation(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "should add the annotation if requested to",
+			name: "should add the annotation if requested to and grouping is enabled",
 			args: args{
-				treeOptions: ObjectTreeOptions{},
+				treeOptions: ObjectTreeOptions{Grouping: true},
 				addOptions:  []AddObjectOption{GroupingObject(true)},
 			},
 			want: true,
@@ -450,7 +450,7 @@ func Test_Add_setsGroupingObjectAnnotation(t *testing.T) {
 		{
 			name: "should not add the annotation if requested to, but grouping is disabled",
 			args: args{
-				treeOptions: ObjectTreeOptions{DisableGrouping: true},
+				treeOptions: ObjectTreeOptions{Grouping: false},
 				addOptions:  []AddObjectOption{GroupingObject(true)},
 			},
 			want: false,

--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -51,13 +51,13 @@ var (
 )
 
 type describeClusterOptions struct {
-	kubeconfig        string
-	kubeconfigContext string
-
+	kubeconfig          string
+	kubeconfigContext   string
 	namespace           string
 	showOtherConditions string
 	showMachineSets     bool
 	disableNoEcho       bool
+	grouping            bool
 	disableGrouping     bool
 }
 
@@ -83,11 +83,11 @@ var describeClusterClusterCmd = &cobra.Command{
 
 		# Describe the cluster named test-1 disabling automatic grouping of objects with the same ready condition
 		# e.g. un-group all the machines with Ready=true instead of showing a single group node.
-		clusterctl describe cluster test-1 --disable-grouping
+		clusterctl describe cluster test-1 --grouping=false
 
 		# Describe the cluster named test-1 disabling automatic echo suppression
         # e.g. show the infrastructure machine objects, no matter if the current state is already reported by the machine's Ready condition.
-		clusterctl describe cluster test-1`),
+		clusterctl describe cluster test-1 --disable-no-echo`),
 
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -110,8 +110,12 @@ func init() {
 
 	describeClusterClusterCmd.Flags().BoolVar(&dc.disableNoEcho, "disable-no-echo", false, ""+
 		"Disable hiding of a MachineInfrastructure and BootstrapConfig when ready condition is true or it has the Status, Severity and Reason of the machine's object.")
+	describeClusterClusterCmd.Flags().BoolVar(&dc.grouping, "grouping", true,
+		"Groups machines when ready condition has the same Status, Severity and Reason.")
 	describeClusterClusterCmd.Flags().BoolVar(&dc.disableGrouping, "disable-grouping", false,
 		"Disable grouping machines when ready condition has the same Status, Severity and Reason.")
+	describeClusterClusterCmd.Flags().MarkDeprecated("disable-grouping",
+		"use --grouping instead.")
 
 	// completions
 	describeClusterClusterCmd.ValidArgsFunction = resourceNameCompletionFunc(
@@ -138,7 +142,7 @@ func runDescribeCluster(name string) error {
 		ShowOtherConditions: dc.showOtherConditions,
 		ShowMachineSets:     dc.showMachineSets,
 		DisableNoEcho:       dc.disableNoEcho,
-		DisableGrouping:     dc.disableGrouping,
+		Grouping:            dc.grouping && !dc.disableGrouping,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

:seedling:

**What this PR does / why we need it**: This deprecates the ``` disable-grouping(false)``` option in the clusterctl describe and uses the ```grouping(true)``` option as per the issue

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5346 (working on)

Comments in the files haven't been updated yet , wanted to know if I am taking the right approach for this


![Selection_047](https://user-images.githubusercontent.com/45638240/139662333-885c1cbc-81fb-4d1d-b683-6eeeaa97db9d.png)

