### PR TITLE
🌱 cleanup manager name from Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -100,7 +100,6 @@ RUN wget -qO- https://dl.k8s.io/v1.21.2/kubernetes-client-linux-amd64.tar.gz | t
 COPY --from=tilt-helper /go/kubernetes/client/bin/kubectl /usr/bin/kubectl
 """,
         "label": "CAPD",
-        "manager_name": "capd-controller-manager",
     },
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes a left over usage of the manager_name variable, which is not required anymore