### PR TITLE
🌱 MachineDeploymentClassBuilder: Drop unused name and namespace

### DIFF
--- a/controllers/topology/blueprint_test.go
+++ b/controllers/topology/blueprint_test.go
@@ -55,7 +55,7 @@ func TestGetBlueprint(t *testing.T) {
 		Build()
 	workerBootstrapTemplate := builder.BootstrapTemplate(metav1.NamespaceDefault, "workerbootstraptemplate1").
 		Build()
-	machineDeployment := builder.MachineDeploymentClass(metav1.NamespaceDefault, "machinedeployment1").
+	machineDeployment := builder.MachineDeploymentClass().
 		WithClass("workerclass1").
 		WithLabels(map[string]string{"foo": "bar"}).
 		WithAnnotations(map[string]string{"a": "b"}).

--- a/controllers/topology/cluster_controller_test.go
+++ b/controllers/topology/cluster_controller_test.go
@@ -311,14 +311,14 @@ func setupTestEnvForIntegrationTests(ns *corev1.Namespace) (func() error, error)
 	bootstrapTemplate := builder.BootstrapTemplate(ns.Name, "bootstraptemplate").Build()
 
 	// 2) ClusterClass definitions including definitions of MachineDeploymentClasses used inside the ClusterClass.
-	machineDeploymentClass1 := builder.MachineDeploymentClass(ns.Name, "md1").
+	machineDeploymentClass1 := builder.MachineDeploymentClass().
 		WithClass(workerClassName1).
 		WithInfrastructureTemplate(infrastructureMachineTemplate).
 		WithBootstrapTemplate(bootstrapTemplate).
 		WithLabels(map[string]string{"foo": "bar"}).
 		WithAnnotations(map[string]string{"foo": "bar"}).
 		Build()
-	machineDeploymentClass2 := builder.MachineDeploymentClass(ns.Name, "md2").
+	machineDeploymentClass2 := builder.MachineDeploymentClass().
 		WithClass(workerClassName2).
 		WithInfrastructureTemplate(infrastructureMachineTemplate).
 		WithBootstrapTemplate(bootstrapTemplate).

--- a/controllers/topology/clusterclass_controller_test.go
+++ b/controllers/topology/clusterclass_controller_test.go
@@ -62,12 +62,12 @@ func TestClusterClassReconciler_reconcile(t *testing.T) {
 	infraClusterTemplate := builder.InfrastructureClusterTemplate(ns.Name, "infraclustertemplate").Build()
 
 	// MachineDeploymentClasses that will be part of the ClusterClass.
-	machineDeploymentClass1 := builder.MachineDeploymentClass(ns.Name, workerClassName1).
+	machineDeploymentClass1 := builder.MachineDeploymentClass().
 		WithClass(workerClassName1).
 		WithBootstrapTemplate(bootstrapTemplate).
 		WithInfrastructureTemplate(infraMachineTemplateWorker).
 		Build()
-	machineDeploymentClass2 := builder.MachineDeploymentClass(ns.Name, workerClassName2).
+	machineDeploymentClass2 := builder.MachineDeploymentClass().
 		WithClass(workerClassName2).
 		WithBootstrapTemplate(bootstrapTemplate).
 		WithInfrastructureTemplate(infraMachineTemplateWorker).

--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -669,7 +669,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 	labels := map[string]string{"fizz": "buzz", "foo": "bar"}
 	annotations := map[string]string{"annotation-1": "annotation-1-val"}
 
-	md1 := builder.MachineDeploymentClass(metav1.NamespaceDefault, "class1").
+	md1 := builder.MachineDeploymentClass().
 		WithClass("linux-worker").
 		WithLabels(labels).
 		WithAnnotations(annotations).

--- a/internal/builder/builders.go
+++ b/internal/builder/builders.go
@@ -264,8 +264,6 @@ func (c *ClusterClassBuilder) Build() *clusterv1.ClusterClass {
 
 // MachineDeploymentClassBuilder holds the variables and objects required to build a clusterv1.MachineDeploymentClass.
 type MachineDeploymentClassBuilder struct {
-	namespace                     string
-	name                          string
 	class                         string
 	infrastructureMachineTemplate *unstructured.Unstructured
 	bootstrapTemplate             *unstructured.Unstructured
@@ -274,11 +272,8 @@ type MachineDeploymentClassBuilder struct {
 }
 
 // MachineDeploymentClass returns a MachineDeploymentClassBuilder with the given name and namespace.
-func MachineDeploymentClass(namespace, name string) *MachineDeploymentClassBuilder {
-	return &MachineDeploymentClassBuilder{
-		name:      name,
-		namespace: namespace,
-	}
+func MachineDeploymentClass() *MachineDeploymentClassBuilder {
+	return &MachineDeploymentClassBuilder{}
 }
 
 // WithInfrastructureTemplate registers the passed Unstructured object as the InfrastructureMachineTemplate for the MachineDeploymentClassBuilder.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
name/namespace have been stored in the struct but never used (because a MachineDeploymentClass has no name/namespace).

The class name is set with `WithClass`. An alternative is to keep the name parameter and use it as class name (@killianmuldoon WDYT?)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
