### PR TITLE
🌱 Check for build metadata in cert-manager version 

### DIFF
--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -145,7 +145,9 @@ func (c *ControlPlaneContract) IsUpgrading(obj *unstructured.Unstructured) (bool
 		return false, errors.Wrap(err, "failed to parse control plane status version")
 	}
 
-	return version.Compare(specV, statusV, version.WithBuildTags()) == 1, nil
+	// NOTE: we are considering the control plane upgrading when the version is greater
+	// or when the version has a different build metadata.
+	return version.Compare(specV, statusV, version.WithBuildTags()) >= 1, nil
 }
 
 // IsScaling returns true if the control plane is in the middle of a scale operation, false otherwise.

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -144,6 +144,7 @@ func newBuildIdentifier(s string) buildIdentifier {
 // -1 == v is less than o.
 // 0 == v is equal to o.
 // 1 == v is greater than o.
+// 2 == v is different than o (it is not possible to identify if lower or greater).
 // Note: number is considered lower than string.
 func (v buildIdentifier) compare(o buildIdentifier) int {
 	if v.IsNum && !o.IsNum {
@@ -162,14 +163,13 @@ func (v buildIdentifier) compare(o buildIdentifier) int {
 			return 1
 		}
 	} else { // both are strings
-		switch {
-		case v.IdentifierStr < o.IdentifierStr:
-			return -1
-		case v.IdentifierStr == o.IdentifierStr:
+		if v.IdentifierStr == o.IdentifierStr {
 			return 0
-		default:
-			return 1
 		}
+		// In order to support random build identifiers, like commit hashes,
+		// we return 2 when the strings are different to signal the
+		// build identifiers are different but we can't determine the precedence
+		return 2
 	}
 }
 
@@ -199,10 +199,18 @@ type CompareOption func(*comparer)
 // WithBuildTags modifies the version comparison to also consider build tags
 // when comparing versions.
 // Performs a standard version compare between a and b. If the versions
-// are equal, build identifiers will be used to compare further.
+// are equal, build identifiers will be used to compare further; precedence for two build
+// identifiers is determined by comparing each dot-separated identifier from left to right
+// until a difference is found as follows:
+// - Identifiers consisting of only digits are compared numerically.
+// - Numeric identifiers always have lower precedence than non-numeric identifiers.
+// - Identifiers with letters or hyphens are compared only for equality, otherwise, 2 is returned given
+// that it is not possible to identify if lower or greater (non-numeric identifiers could be random build
+// identifiers).
 //   -1 == a is less than b.
 //   0 == a is equal to b.
 //   1 == a is greater than b.
+//   2 == v is different than o (it is not possible to identify if lower or greater).
 func WithBuildTags() CompareOption {
 	return func(c *comparer) {
 		c.buildTags = true

--- a/util/version/version_test.go
+++ b/util/version/version_test.go
@@ -156,7 +156,7 @@ func TestCompareWithBuildIdentifiers(t *testing.T) {
 			expected: -1,
 		},
 		{
-			name: "compare with pre release versions and  build identifiers",
+			name: "compare with pre release versions and build identifiers",
 			a: func() semver.Version {
 				v, _ := semver.ParseTolerant("v1.20.1-alpha.1+xyz.1")
 				return v
@@ -240,7 +240,7 @@ func TestCompareWithBuildIdentifiers(t *testing.T) {
 			expected: 1,
 		},
 		{
-			name: "compare with build identifiers - smaller non numeric",
+			name: "compare with build identifiers - different non numeric",
 			a: func() semver.Version {
 				v, _ := semver.ParseTolerant("v1.20.1+xyz.a")
 				return v
@@ -249,7 +249,19 @@ func TestCompareWithBuildIdentifiers(t *testing.T) {
 				v, _ := semver.ParseTolerant("v1.20.1+xyz.b")
 				return v
 			}(),
-			expected: -1,
+			expected: 2,
+		},
+		{
+			name: "compare with build identifiers - equal non numeric",
+			a: func() semver.Version {
+				v, _ := semver.ParseTolerant("v1.20.1+xyz.a")
+				return v
+			}(),
+			b: func() semver.Version {
+				v, _ := semver.ParseTolerant("v1.20.1+xyz.a")
+				return v
+			}(),
+			expected: 0,
 		},
 		{
 			name: "compare with build identifiers - smaller - a is numeric b is not",


### PR DESCRIPTION
**What this PR does / why we need it**:
As an operator, I would like to upgrade `cert-manager` using `clusterctl` even when the version hasn't changed. For example, if I created a new build due to a change in a downstream dependency (imagine security updates in a base image) but I'm still using the same upstream code.

In order to work around this, I could artificially bump the version, but that, aside from being confusing, could be problematic if in the future I need to upgrade to the real version.

The pre-release section could also be used for to work around this, but I find it confusing as well since these are not necessarily pre-release builds, they are production ready.

I propose to use the build metadata in the semver (which fits very well this usecase) to detect such changes. This PR just adds an extra check when the semvers have the same precedence, and if the build metadata is different, trigger an upgrade.