### PR TITLE
🐛 topology should not generate empty patch for metadata

### DIFF
--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -1325,3 +1325,28 @@ func duplicateMachineDeploymentsState(s scope.MachineDeploymentsStateMap) scope.
 	}
 	return n
 }
+
+func TestMergeMap(t *testing.T) {
+	t.Run("Merge maps", func(t *testing.T) {
+		g := NewWithT(t)
+
+		m := mergeMap(
+			map[string]string{
+				"a": "a",
+				"b": "b",
+			}, map[string]string{
+				"a": "ax",
+				"c": "c",
+			},
+		)
+		g.Expect(m).To(HaveKeyWithValue("a", "a"))
+		g.Expect(m).To(HaveKeyWithValue("b", "b"))
+		g.Expect(m).To(HaveKeyWithValue("c", "c"))
+	})
+	t.Run("Nils empty maps", func(t *testing.T) {
+		g := NewWithT(t)
+
+		m := mergeMap(map[string]string{}, map[string]string{})
+		g.Expect(m).To(BeNil())
+	})
+}

--- a/controllers/topology/internal/contract/metadata_test.go
+++ b/controllers/topology/internal/contract/metadata_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contract
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestMetadata(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+
+	t.Run("Manages metadata", func(t *testing.T) {
+		g := NewWithT(t)
+
+		metadata := &clusterv1.ObjectMeta{
+			Labels: map[string]string{
+				"label1": "labelValue1",
+			},
+			Annotations: map[string]string{
+				"annotation1": "annotationValue1",
+			},
+		}
+
+		m := Metadata{path: Path{"foo"}}
+		g.Expect(m.Path()).To(Equal(Path{"foo"}))
+
+		err := m.Set(obj, metadata)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := m.Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got).To(Equal(metadata))
+	})
+	t.Run("Manages empty metadata", func(t *testing.T) {
+		g := NewWithT(t)
+
+		metadata := &clusterv1.ObjectMeta{
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		}
+
+		m := Metadata{path: Path{"foo"}}
+		g.Expect(m.Path()).To(Equal(Path{"foo"}))
+
+		err := m.Set(obj, metadata)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := m.Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(got).To(Equal(metadata))
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
While testing ClusterClass handling of metadata I have found that under certain conditions the generated patch has an empty map, something like {"metadata":{"annotations":{}}}. This leads to topology reconcile assuming that the patch is not empty, and thus trying to patch an object indefinitely.

This change ensures that in case there are no labels/annotations, we are not generating empty maps in our objects, thus preventing empty patch for metadata being generated.