### PR TITLE
✨ ClusterClass json patches

### DIFF
--- a/controllers/topology/internal/extensions/patches/api/interface.go
+++ b/controllers/topology/internal/extensions/patches/api/interface.go
@@ -23,6 +23,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
@@ -75,6 +76,17 @@ type TemplateRef struct {
 	// MachineDeployment specifies the MachineDeployment in which the template is used.
 	// This field is only set if the template is used in the context of a MachineDeployment.
 	MachineDeploymentRef MachineDeploymentRef
+}
+
+func (t *TemplateRef) String() string {
+	ret := fmt.Sprintf("%s %s/%s", t.TemplateType, t.APIVersion, t.Kind)
+	if t.MachineDeploymentRef.TopologyName != "" {
+		ret = fmt.Sprintf("%s, MachineDeployment topology %s", ret, t.MachineDeploymentRef.TopologyName)
+	}
+	if t.MachineDeploymentRef.Class != "" {
+		ret = fmt.Sprintf("%s, MachineDeployment class %s", ret, t.MachineDeploymentRef.Class)
+	}
+	return ret
 }
 
 // MachineDeploymentRef specifies the MachineDeployment in which the template is used.

--- a/controllers/topology/internal/extensions/patches/inline/json_patch_generator.go
+++ b/controllers/topology/internal/extensions/patches/inline/json_patch_generator.go
@@ -1,0 +1,375 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package inline implements the inline JSON patch generator.
+package inline
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/pkg/errors"
+	"github.com/valyala/fastjson"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/topology/internal/extensions/patches/api"
+	patchvariables "sigs.k8s.io/cluster-api/controllers/topology/internal/extensions/patches/variables"
+	"sigs.k8s.io/yaml"
+)
+
+// jsonPatchGenerator generates JSON patches for a GenerateRequest based on a ClusterClassPatch.
+type jsonPatchGenerator struct {
+	patch *clusterv1.ClusterClassPatch
+}
+
+// New returns a new inline Generator from a given ClusterClassPatch object.
+func New(patch *clusterv1.ClusterClassPatch) api.Generator {
+	return &jsonPatchGenerator{
+		patch: patch,
+	}
+}
+
+// Generate generates JSON patches for the given GenerateRequest based on a ClusterClassPatch.
+func (j *jsonPatchGenerator) Generate(_ context.Context, req *api.GenerateRequest) (*api.GenerateResponse, error) {
+	resp := &api.GenerateResponse{}
+
+	// Loop over all templates.
+	errs := []error{}
+	for _, template := range req.Items {
+		// Calculate the list of patches which match the current template.
+		matchingPatches := []clusterv1.PatchDefinition{}
+		for _, patch := range j.patch.Definitions {
+			// Add the patch to the list, if it matches the template.
+			if templateMatchesSelector(&template.TemplateRef, patch.Selector) {
+				matchingPatches = append(matchingPatches, patch)
+			}
+		}
+
+		// Continue if there are no matching patches.
+		if len(matchingPatches) == 0 {
+			continue
+		}
+
+		// Merge template-specific and global variables.
+		variables, err := mergeVariableMaps(req.Variables, template.Variables)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to merge global and template-specific variables for template %s", template.TemplateRef))
+			continue
+		}
+
+		// Loop over all PatchDefinitions.
+		for _, patch := range matchingPatches {
+			// Generate JSON patches.
+			jsonPatches, err := generateJSONPatches(patch.JSONPatches, variables)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "failed to generate JSON patches for template %s", template.TemplateRef))
+				continue
+			}
+
+			// Add jsonPatches to the response.
+			resp.Items = append(resp.Items, api.GenerateResponsePatch{
+				TemplateRef: template.TemplateRef,
+				Patch:       *jsonPatches,
+				PatchType:   api.JSONPatchType,
+			})
+		}
+	}
+
+	return resp, kerrors.NewAggregate(errs)
+}
+
+// templateMatchesSelector returns true if the template matches the selector.
+func templateMatchesSelector(templateRef *api.TemplateRef, selector clusterv1.PatchSelector) bool {
+	// Check if the apiVersion and kind are matching.
+	if templateRef.APIVersion != selector.APIVersion {
+		return false
+	}
+	if templateRef.Kind != selector.Kind {
+		return false
+	}
+
+	// Check if target matches.
+	switch templateRef.TemplateType {
+	case api.InfrastructureClusterTemplateType:
+		// Check if matchSelector.infrastructureCluster is true.
+		if selector.MatchResources.InfrastructureCluster == nil {
+			return false
+		}
+		return *selector.MatchResources.InfrastructureCluster
+	case api.ControlPlaneTemplateType, api.ControlPlaneInfrastructureMachineTemplateType:
+		// Check if matchSelector.controlPlane is true.
+		if selector.MatchResources.ControlPlane == nil {
+			return false
+		}
+		return *selector.MatchResources.ControlPlane
+	case api.MachineDeploymentBootstrapConfigTemplateType, api.MachineDeploymentInfrastructureMachineTemplateType:
+		// Check if matchSelector.machineDeploymentClass.names contains the
+		// MachineDeployment.Class of the template.
+		if selector.MatchResources.MachineDeploymentClass == nil {
+			return false
+		}
+		for _, name := range selector.MatchResources.MachineDeploymentClass.Names {
+			if name == templateRef.MachineDeploymentRef.Class {
+				return true
+			}
+		}
+		return false
+	default:
+		// Return false if the TargetType is unknown.
+		return false
+	}
+}
+
+// jsonPatchRFC6902 is used to render the generated JSONPatches.
+type jsonPatchRFC6902 struct {
+	Op    string               `json:"op"`
+	Path  string               `json:"path"`
+	Value apiextensionsv1.JSON `json:"value"`
+}
+
+// generateJSONPatches generates JSON patches based on the given JSONPatches and variables.
+func generateJSONPatches(jsonPatches []clusterv1.JSONPatch, variables map[string]apiextensionsv1.JSON) (*apiextensionsv1.JSON, error) {
+	res := []jsonPatchRFC6902{}
+
+	for _, jsonPatch := range jsonPatches {
+		value, err := calculateValue(jsonPatch, variables)
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, jsonPatchRFC6902{
+			Op:    jsonPatch.Op,
+			Path:  jsonPatch.Path,
+			Value: *value,
+		})
+	}
+
+	// Render JSON Patches.
+	resJSON, err := json.Marshal(res)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to marshal JSON Patch %v", jsonPatches)
+	}
+
+	return &apiextensionsv1.JSON{Raw: resJSON}, nil
+}
+
+// calculateValue calculates a value for a JSON patch.
+func calculateValue(patch clusterv1.JSONPatch, variables map[string]apiextensionsv1.JSON) (*apiextensionsv1.JSON, error) {
+	// Return if values are set incorrectly.
+	if patch.Value == nil && patch.ValueFrom == nil {
+		return nil, errors.Errorf("failed to calculate value: neither .value nor .valueFrom are set")
+	}
+	if patch.Value != nil && patch.ValueFrom != nil {
+		return nil, errors.Errorf("failed to calculate value: both .value and .valueFrom are set")
+	}
+	if patch.ValueFrom != nil && patch.ValueFrom.Variable == nil && patch.ValueFrom.Template == nil {
+		return nil, errors.Errorf("failed to calculate value: .valueFrom is set, but neither .valueFrom.variable nor .valueFrom.template are set")
+	}
+	if patch.ValueFrom != nil && patch.ValueFrom.Variable != nil && patch.ValueFrom.Template != nil {
+		return nil, errors.Errorf("failed to calculate value: .valueFrom is set, but both .valueFrom.variable and .valueFrom.template are set")
+	}
+
+	// Return raw value.
+	if patch.Value != nil {
+		return patch.Value, nil
+	}
+
+	// Return variable.
+	if patch.ValueFrom.Variable != nil {
+		value, err := getVariableValue(variables, *patch.ValueFrom.Variable)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to calculate value")
+		}
+		return value, nil
+	}
+
+	// Return rendered value template.
+	value, err := renderValueTemplate(*patch.ValueFrom.Template, variables)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to calculate value")
+	}
+	return value, nil
+}
+
+// getVariableValue returns a variable from the variables map.
+func getVariableValue(variables map[string]apiextensionsv1.JSON, variableName string) (*apiextensionsv1.JSON, error) {
+	// If the variable is a user-defined variable or the top-level "builtin" variable, just do a simple lookup.
+	if !strings.HasPrefix(variableName, fmt.Sprintf("%s.", patchvariables.BuiltinsName)) {
+		value, ok := variables[variableName]
+		if !ok {
+			return nil, errors.Errorf("variable %q does not exist", variableName)
+		}
+		return &value, nil
+	}
+
+	// If the variable is a "builtin.<relativeVariableName>" variable, we inspect the builtin variable object.
+
+	// Get the builtin variable object.
+	builtinsValue, ok := variables[patchvariables.BuiltinsName]
+	if !ok {
+		return nil, errors.Errorf("variable %q does not exist", patchvariables.BuiltinsName)
+	}
+
+	// Parse the builtin variable object.
+	builtins, err := fastjson.ParseBytes(builtinsValue.Raw)
+	if err != nil {
+		return nil, errors.Errorf("cannot parse variable %q", patchvariables.BuiltinsName)
+	}
+
+	// Split the variable name and exclude the first part ("builtins.")
+	relativePath := strings.Split(variableName, ".")[1:]
+
+	// Return if the builtin variable does not exist.
+	if !builtins.Exists(relativePath...) {
+		return nil, errors.Errorf("variable %q does not exist", variableName)
+	}
+
+	// Get the builtin variable from the builtin variable object.
+	variableValue := builtins.Get(relativePath...)
+
+	// Return the marshalled value of the variable.
+	return &apiextensionsv1.JSON{
+		Raw: variableValue.MarshalTo([]byte{}),
+	}, nil
+}
+
+// renderValueTemplate renders a template with the given variables as data.
+func renderValueTemplate(valueTemplate string, variables map[string]apiextensionsv1.JSON) (*apiextensionsv1.JSON, error) {
+	// Parse the template.
+	tpl, err := template.New("tpl").Parse(valueTemplate)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse template: %q", valueTemplate)
+	}
+
+	// Convert the flat variables map in a nested map, so that variables can be
+	// consumed in templates like this: `{{ .builtin.cluster.name }}`
+	// NOTE: Variable values are also converted to their Go types as
+	// they cannot be directly consumed as byte arrays.
+	data, err := calculateTemplateData(variables)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to calculate template data")
+	}
+
+	// Render the template.
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, data); err != nil {
+		return nil, errors.Wrapf(err, "failed to render template: %q", valueTemplate)
+	}
+
+	// Unmarshal the rendered template.
+	// NOTE: The YAML library is used for unmarshalling, to be able to handle YAML and JSON.
+	value := apiextensionsv1.JSON{}
+	if err := yaml.Unmarshal(buf.Bytes(), &value); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal rendered template: %q", buf.String())
+	}
+
+	return &value, nil
+}
+
+// calculateTemplateData calculates data for the template, by converting
+// the variables to their Go types.
+// Example:
+// * Input:
+//   map[string]apiextensionsv1.JSON{
+//     "builtin": {Raw: []byte(`{"cluster":{"name":"cluster-name"}}`},
+//     "integerVariable": {Raw: []byte("4")},
+//     "numberVariable": {Raw: []byte("2.5")},
+//     "booleanVariable": {Raw: []byte("true")},
+//   }
+// * Output:
+//   map[string]interface{}{
+//     "builtin": map[string]interface{}{
+//       "cluster": map[string]interface{}{
+//         "name": <string>"cluster-name"
+//       }
+//     },
+//     "integerVariable": <float64>4,
+//     "numberVariable": <float64>2.5,
+//     "booleanVariable": <bool>true,
+//   }
+func calculateTemplateData(variables map[string]apiextensionsv1.JSON) (map[string]interface{}, error) {
+	res := make(map[string]interface{}, len(variables))
+
+	// Marshal the variables into a byte array.
+	tmp, err := json.Marshal(variables)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to convert variables: failed to marshal variables")
+	}
+
+	// Unmarshal the byte array back.
+	// NOTE: This converts the "leaf nodes" of the nested map
+	// from apiextensionsv1.JSON to their Go types.
+	if err := json.Unmarshal(tmp, &res); err != nil {
+		return nil, errors.Wrapf(err, "failed to convert variables: failed to unmarshal variables")
+	}
+
+	return res, nil
+}
+
+// mergeVariableMaps merges variables.
+// NOTE: In case a variable exists in multiple maps, the variable from the latter map is preserved.
+// NOTE: The builtin variable object is merged instead of simply overwritten.
+func mergeVariableMaps(variableMaps ...map[string]apiextensionsv1.JSON) (map[string]apiextensionsv1.JSON, error) {
+	res := make(map[string]apiextensionsv1.JSON)
+
+	for _, variableMap := range variableMaps {
+		for variableName, variableValue := range variableMap {
+			// If the variable already exits and is the builtin variable, merge it.
+			if _, ok := res[variableName]; ok && variableName == patchvariables.BuiltinsName {
+				mergedV, err := mergeBuiltinVariables(res[variableName], variableValue)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to merge builtin variables")
+				}
+				res[variableName] = *mergedV
+				continue
+			}
+			res[variableName] = variableValue
+		}
+	}
+
+	return res, nil
+}
+
+// mergeBuiltinVariables merges builtin variable objects.
+// NOTE: In case a variable exists in multiple builtin variables, the variable from the latter map is preserved.
+func mergeBuiltinVariables(variableList ...apiextensionsv1.JSON) (*apiextensionsv1.JSON, error) {
+	builtins := &patchvariables.Builtins{}
+
+	// Unmarshal all variables into builtins.
+	// NOTE: This accumulates the fields on the builtins.
+	// Fields will be overwritten by later Unmarshals if fields are
+	// set on multiple variables.
+	for _, variable := range variableList {
+		if err := json.Unmarshal(variable.Raw, builtins); err != nil {
+			return nil, errors.Wrapf(err, "failed to unmarshal builtin variable")
+		}
+	}
+
+	// Marshal builtins to JSON.
+	builtinVariableJSON, err := json.Marshal(builtins)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to marshal builtin variable")
+	}
+
+	return &apiextensionsv1.JSON{
+		Raw: builtinVariableJSON,
+	}, nil
+}

--- a/controllers/topology/internal/extensions/patches/inline/json_patch_generator_test.go
+++ b/controllers/topology/internal/extensions/patches/inline/json_patch_generator_test.go
@@ -1,0 +1,979 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inline
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/topology/internal/extensions/patches/api"
+	patchvariables "sigs.k8s.io/cluster-api/controllers/topology/internal/extensions/patches/variables"
+)
+
+func TestGenerate(t *testing.T) {
+	tests := []struct {
+		name    string
+		patch   *clusterv1.ClusterClassPatch
+		req     *api.GenerateRequest
+		want    *api.GenerateResponse
+		wantErr bool
+	}{
+		{
+			name: "Should generate JSON Patches with correct variable values",
+			patch: &clusterv1.ClusterClassPatch{
+				Name: "clusterName",
+				Definitions: []clusterv1.PatchDefinition{
+					{
+						Selector: clusterv1.PatchSelector{
+							APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+							Kind:       "ControlPlaneTemplate",
+							MatchResources: clusterv1.PatchSelectorMatch{
+								ControlPlane: pointer.Bool(true),
+							},
+						},
+						JSONPatches: []clusterv1.JSONPatch{
+							// .value
+							{
+								Op:    "replace",
+								Path:  "/spec/value",
+								Value: &apiextensionsv1.JSON{Raw: []byte("1")},
+							},
+							// .valueFrom.variable
+							{
+								Op:   "replace",
+								Path: "/spec/valueFrom/variable",
+								ValueFrom: &clusterv1.JSONPatchValue{
+									Variable: pointer.String("variableA"),
+								},
+							},
+							// .valueFrom.template
+							{
+								Op:   "replace",
+								Path: "/spec/valueFrom/template",
+								ValueFrom: &clusterv1.JSONPatchValue{
+									Template: pointer.String(`template {{ .variableB }}`),
+								},
+							},
+							// template-specific variable takes precedent, if the same variable exists
+							// in the global and template-specific variables.
+							{
+								Op:   "replace",
+								Path: "/spec/templatePrecedent",
+								ValueFrom: &clusterv1.JSONPatchValue{
+									Variable: pointer.String("variableC"),
+								},
+							},
+							// global builtin variable should work.
+							// (verify that merging builtin variables works)
+							{
+								Op:   "replace",
+								Path: "/spec/builtinClusterName",
+								ValueFrom: &clusterv1.JSONPatchValue{
+									Variable: pointer.String("builtin.cluster.name"),
+								},
+							},
+							// template-specific builtin variable should work.
+							// (verify that merging builtin variables works)
+							{
+								Op:   "replace",
+								Path: "/spec/builtinControlPlaneReplicas",
+								ValueFrom: &clusterv1.JSONPatchValue{
+									Variable: pointer.String("builtin.controlPlane.replicas"),
+								},
+							},
+						},
+					},
+				},
+			},
+			req: &api.GenerateRequest{
+				Variables: map[string]apiextensionsv1.JSON{
+					"builtin":   {Raw: []byte(`{"cluster":{"name":"cluster-name","namespace":"default","topology":{"class":"clusterClass1","version":"v1.21.1"}}}`)},
+					"variableA": {Raw: []byte(`"A"`)},
+					"variableB": {Raw: []byte(`"B"`)},
+					"variableC": {Raw: []byte(`"C"`)},
+				},
+				Items: []*api.GenerateRequestTemplate{
+					{
+						TemplateRef: api.TemplateRef{
+							APIVersion:   "controlplane.cluster.x-k8s.io/v1beta1",
+							Kind:         "ControlPlaneTemplate",
+							TemplateType: api.ControlPlaneTemplateType,
+						},
+						Variables: map[string]apiextensionsv1.JSON{
+							"builtin":   {Raw: []byte(`{"controlPlane":{"replicas":3}}`)},
+							"variableC": {Raw: []byte(`"C-template"`)},
+						},
+					},
+				},
+			},
+			want: &api.GenerateResponse{
+				Items: []api.GenerateResponsePatch{
+					{
+						TemplateRef: api.TemplateRef{
+							APIVersion:   "controlplane.cluster.x-k8s.io/v1beta1",
+							Kind:         "ControlPlaneTemplate",
+							TemplateType: api.ControlPlaneTemplateType,
+						},
+						Patch: toJSONCompact(`[
+{"op":"replace","path":"/spec/value","value":1},
+{"op":"replace","path":"/spec/valueFrom/variable","value":"A"},
+{"op":"replace","path":"/spec/valueFrom/template","value":"template B"},
+{"op":"replace","path":"/spec/templatePrecedent","value":"C-template"},
+{"op":"replace","path":"/spec/builtinClusterName","value":"cluster-name"},
+{"op":"replace","path":"/spec/builtinControlPlaneReplicas","value":3}
+]`),
+						PatchType: api.JSONPatchType,
+					},
+				},
+			},
+		},
+		{
+			name: "Should generate JSON Patches (multiple PatchDefinitions)",
+			patch: &clusterv1.ClusterClassPatch{
+				Name: "clusterName",
+				Definitions: []clusterv1.PatchDefinition{
+					{
+						Selector: clusterv1.PatchSelector{
+							APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+							Kind:       "ControlPlaneTemplate",
+							MatchResources: clusterv1.PatchSelectorMatch{
+								ControlPlane: pointer.Bool(true),
+							},
+						},
+						JSONPatches: []clusterv1.JSONPatch{
+							{
+								Op:   "replace",
+								Path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/cluster-name",
+								ValueFrom: &clusterv1.JSONPatchValue{
+									Variable: pointer.String("builtin.cluster.name"),
+								},
+							},
+							{
+								Op:   "replace",
+								Path: "/spec/template/spec/kubeadmConfigSpec/files",
+								ValueFrom: &clusterv1.JSONPatchValue{
+									Template: pointer.String(`
+- contentFrom:
+    secret:
+      key: control-plane-azure.json
+      name: "{{ .builtin.cluster.name }}-control-plane-azure-json"
+  owner: root:root
+`),
+								},
+							},
+						},
+					},
+					{
+						Selector: clusterv1.PatchSelector{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+							Kind:       "BootstrapTemplate",
+							MatchResources: clusterv1.PatchSelectorMatch{
+								MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+									Names: []string{"default-worker"},
+								},
+							},
+						},
+						JSONPatches: []clusterv1.JSONPatch{
+							{
+								Op:   "replace",
+								Path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/cluster-name",
+								ValueFrom: &clusterv1.JSONPatchValue{
+									Template: pointer.String(`
+[{
+	"contentFrom":{
+		"secret":{
+			"key":"worker-node-azure.json",
+			"name":"{{ .builtin.cluster.name }}-md-0-azure-json"
+		}
+	},
+	"owner":"root:root"
+}]`),
+								},
+							},
+						},
+					},
+				},
+			},
+			req: &api.GenerateRequest{
+				Variables: map[string]apiextensionsv1.JSON{
+					"builtin": {Raw: []byte(`{"cluster":{"name":"cluster-name","namespace":"default","topology":{"class":"clusterClass1","version":"v1.21.1"}}}`)},
+				},
+				Items: []*api.GenerateRequestTemplate{
+					{
+						TemplateRef: api.TemplateRef{
+							APIVersion:   "controlplane.cluster.x-k8s.io/v1beta1",
+							Kind:         "ControlPlaneTemplate",
+							TemplateType: api.ControlPlaneTemplateType,
+						},
+					},
+					{
+						TemplateRef: api.TemplateRef{
+							APIVersion:   "bootstrap.cluster.x-k8s.io/v1beta1",
+							Kind:         "BootstrapTemplate",
+							TemplateType: api.MachineDeploymentBootstrapConfigTemplateType,
+							MachineDeploymentRef: api.MachineDeploymentRef{
+								Class: "default-worker",
+							},
+						},
+					},
+				},
+			},
+			want: &api.GenerateResponse{
+				Items: []api.GenerateResponsePatch{
+					{
+						TemplateRef: api.TemplateRef{
+							APIVersion:   "controlplane.cluster.x-k8s.io/v1beta1",
+							Kind:         "ControlPlaneTemplate",
+							TemplateType: api.ControlPlaneTemplateType,
+						},
+						Patch: toJSONCompact(`[
+{"op":"replace","path":"/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/cluster-name","value":"cluster-name"},
+{"op":"replace","path":"/spec/template/spec/kubeadmConfigSpec/files","value":[{"contentFrom":{"secret":{"key":"control-plane-azure.json","name":"cluster-name-control-plane-azure-json"}},"owner":"root:root"}]}
+]`),
+						PatchType: api.JSONPatchType,
+					},
+					{
+						TemplateRef: api.TemplateRef{
+							APIVersion:   "bootstrap.cluster.x-k8s.io/v1beta1",
+							Kind:         "BootstrapTemplate",
+							TemplateType: api.MachineDeploymentBootstrapConfigTemplateType,
+							MachineDeploymentRef: api.MachineDeploymentRef{
+								Class: "default-worker",
+							},
+						},
+						Patch: toJSONCompact(`[
+{"op":"replace","path":"/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/cluster-name","value":[{"contentFrom":{"secret":{"key":"worker-node-azure.json","name":"cluster-name-md-0-azure-json"}},"owner":"root:root"}]}
+]`),
+						PatchType: api.JSONPatchType,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got, err := New(tt.patch).Generate(context.Background(), tt.req)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestTemplateMatchesSelector(t *testing.T) {
+	tests := []struct {
+		name        string
+		templateRef *api.TemplateRef
+		selector    clusterv1.PatchSelector
+		match       bool
+	}{
+		{
+			name: "Don't match: apiVersion mismatch",
+			templateRef: &api.TemplateRef{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "AzureMachineTemplate",
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+				Kind:       "AzureMachineTemplate",
+			},
+			match: false,
+		},
+		{
+			name: "Don't match: kind mismatch",
+			templateRef: &api.TemplateRef{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "AzureMachineTemplate",
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "AzureClusterTemplate",
+			},
+			match: false,
+		},
+		{
+			name: "Match InfrastructureClusterTemplate",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:         "AzureClusterTemplate",
+				TemplateType: api.InfrastructureClusterTemplateType,
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "AzureClusterTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					InfrastructureCluster: pointer.Bool(true),
+				},
+			},
+			match: true,
+		},
+		{
+			name: "Don't match InfrastructureClusterTemplate, .matchResources.infrastructureCluster not set",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:         "AzureClusterTemplate",
+				TemplateType: api.InfrastructureClusterTemplateType,
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion:     "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:           "AzureClusterTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{},
+			},
+			match: false,
+		},
+		{
+			name: "Don't match InfrastructureClusterTemplate, .matchResources.infrastructureCluster false",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:         "AzureClusterTemplate",
+				TemplateType: api.InfrastructureClusterTemplateType,
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "AzureClusterTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					InfrastructureCluster: pointer.Bool(false),
+				},
+			},
+			match: false,
+		},
+		{
+			name: "Match ControlPlaneTemplate",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:         "ControlPlaneTemplate",
+				TemplateType: api.ControlPlaneTemplateType,
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:       "ControlPlaneTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					ControlPlane: pointer.Bool(true),
+				},
+			},
+			match: true,
+		},
+		{
+			name: "Don't match ControlPlaneTemplate, .matchResources.controlPlane not set",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:         "ControlPlaneTemplate",
+				TemplateType: api.ControlPlaneTemplateType,
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion:     "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:           "ControlPlaneTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{},
+			},
+			match: false,
+		},
+		{
+			name: "Don't match ControlPlaneTemplate, .matchResources.controlPlane false",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:         "ControlPlaneTemplate",
+				TemplateType: api.ControlPlaneTemplateType,
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:       "ControlPlaneTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					ControlPlane: pointer.Bool(false),
+				},
+			},
+			match: false,
+		},
+		{
+			name: "Match ControlPlane InfrastructureMachineTemplate",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:         "AzureMachineTemplate",
+				TemplateType: api.ControlPlaneInfrastructureMachineTemplateType,
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "AzureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					ControlPlane: pointer.Bool(true),
+				},
+			},
+			match: true,
+		},
+		{
+			name: "Match MD BootstrapTemplate",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:         "BootstrapTemplate",
+				TemplateType: api.MachineDeploymentBootstrapConfigTemplateType,
+				MachineDeploymentRef: api.MachineDeploymentRef{
+					Class: "classA",
+				},
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:       "BootstrapTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"classA"},
+					},
+				},
+			},
+			match: true,
+		},
+		{
+			name: "Don't match BootstrapTemplate, .matchResources.machineDeploymentClass not set",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:         "BootstrapTemplate",
+				TemplateType: api.MachineDeploymentBootstrapConfigTemplateType,
+				MachineDeploymentRef: api.MachineDeploymentRef{
+					Class: "classA",
+				},
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion:     "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:           "BootstrapTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{},
+			},
+			match: false,
+		},
+		{
+			name: "Don't match BootstrapTemplate, .matchResources.machineDeploymentClass does not match",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:         "BootstrapTemplate",
+				TemplateType: api.MachineDeploymentBootstrapConfigTemplateType,
+				MachineDeploymentRef: api.MachineDeploymentRef{
+					Class: "classA",
+				},
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:       "BootstrapTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"classB"},
+					},
+				},
+			},
+			match: false,
+		},
+		{
+			name: "Match MD InfrastructureMachineTemplate",
+			templateRef: &api.TemplateRef{
+				APIVersion:   "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:         "AzureMachineTemplate",
+				TemplateType: api.MachineDeploymentInfrastructureMachineTemplateType,
+				MachineDeploymentRef: api.MachineDeploymentRef{
+					Class: "classA",
+				},
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "AzureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"classA"},
+					},
+				},
+			},
+			match: true,
+		},
+		{
+			name: "Don't match: unknown target type",
+			templateRef: &api.TemplateRef{
+				APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:       "ControlPlaneTemplate",
+				// invalid is an invalid TemplateType.
+				TemplateType: "invalid",
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:       "ControlPlaneTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					ControlPlane: pointer.Bool(true),
+				},
+			},
+			match: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			g.Expect(templateMatchesSelector(tt.templateRef, tt.selector)).To(Equal(tt.match))
+		})
+	}
+}
+
+func TestCalculateValue(t *testing.T) {
+	tests := []struct {
+		name      string
+		patch     clusterv1.JSONPatch
+		variables map[string]apiextensionsv1.JSON
+		want      *apiextensionsv1.JSON
+		wantErr   bool
+	}{
+		{
+			name:    "Fails if neither .value nor .valueFrom are set",
+			patch:   clusterv1.JSONPatch{},
+			wantErr: true,
+		},
+		{
+			name: "Fails if both .value and .valueFrom are set",
+			patch: clusterv1.JSONPatch{
+				Value: &apiextensionsv1.JSON{Raw: []byte(`"value"`)},
+				ValueFrom: &clusterv1.JSONPatchValue{
+					Variable: pointer.String("variableA"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Fails if .valueFrom.variable and .valueFrom.template are set",
+			patch: clusterv1.JSONPatch{
+				ValueFrom: &clusterv1.JSONPatchValue{
+					Variable: pointer.String("variableA"),
+					Template: pointer.String("template"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Fails if .valueFrom is set, but .valueFrom.variable and .valueFrom.template are both not set",
+			patch: clusterv1.JSONPatch{
+				ValueFrom: &clusterv1.JSONPatchValue{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should return .value if set",
+			patch: clusterv1.JSONPatch{
+				Value: &apiextensionsv1.JSON{Raw: []byte(`"value"`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`"value"`)},
+		},
+		{
+			name: "Should return .valueFrom.variable if set",
+			patch: clusterv1.JSONPatch{
+				ValueFrom: &clusterv1.JSONPatchValue{
+					Variable: pointer.String("variableA"),
+				},
+			},
+			variables: map[string]apiextensionsv1.JSON{
+				"variableA": {Raw: []byte(`"value"`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`"value"`)},
+		},
+		{
+			name: "Fails if .valueFrom.variable is set but variable does not exist",
+			patch: clusterv1.JSONPatch{
+				ValueFrom: &clusterv1.JSONPatchValue{
+					Variable: pointer.String("variableA"),
+				},
+			},
+			variables: map[string]apiextensionsv1.JSON{
+				"variableB": {Raw: []byte(`"value"`)},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should return .valueFrom.variable if set: builtinVariable int",
+			patch: clusterv1.JSONPatch{
+				ValueFrom: &clusterv1.JSONPatchValue{
+					Variable: pointer.String("builtin.controlPlane.replicas"),
+				},
+			},
+			variables: map[string]apiextensionsv1.JSON{
+				patchvariables.BuiltinsName: {Raw: []byte(`{"controlPlane":{"replicas":3}}`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`3`)},
+		},
+		{
+			name: "Should return .valueFrom.variable if set: builtinVariable string",
+			patch: clusterv1.JSONPatch{
+				ValueFrom: &clusterv1.JSONPatchValue{
+					Variable: pointer.String("builtin.cluster.topology.version"),
+				},
+			},
+			variables: map[string]apiextensionsv1.JSON{
+				patchvariables.BuiltinsName: {Raw: []byte(`{"cluster":{"name":"cluster-name","namespace":"default","topology":{"class":"clusterClass1","version":"v1.21.1"}}}`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`"v1.21.1"`)},
+		},
+		{
+			name: "Should return .valueFrom.variable if set: variable 'builtin'",
+			patch: clusterv1.JSONPatch{
+				ValueFrom: &clusterv1.JSONPatchValue{
+					Variable: pointer.String("builtin"),
+				},
+			},
+			variables: map[string]apiextensionsv1.JSON{
+				patchvariables.BuiltinsName: {Raw: []byte(`{"cluster":{"name":"cluster-name","namespace":"default","topology":{"class":"clusterClass1","version":"v1.21.1"}}}`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`{"cluster":{"name":"cluster-name","namespace":"default","topology":{"class":"clusterClass1","version":"v1.21.1"}}}`)},
+		},
+		{
+			name: "Should return .valueFrom.variable if set: variable 'builtin.cluster'",
+			patch: clusterv1.JSONPatch{
+				ValueFrom: &clusterv1.JSONPatchValue{
+					Variable: pointer.String("builtin.cluster"),
+				},
+			},
+			variables: map[string]apiextensionsv1.JSON{
+				patchvariables.BuiltinsName: {Raw: []byte(`{"cluster":{"name":"cluster-name","namespace":"default","topology":{"class":"clusterClass1","version":"v1.21.1"}}}`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`{"name":"cluster-name","namespace":"default","topology":{"class":"clusterClass1","version":"v1.21.1"}}`)},
+		},
+		{
+			name: "Should return .valueFrom.variable if set: variable 'builtin.cluster.topology'",
+			patch: clusterv1.JSONPatch{
+				ValueFrom: &clusterv1.JSONPatchValue{
+					Variable: pointer.String("builtin.cluster.topology"),
+				},
+			},
+			variables: map[string]apiextensionsv1.JSON{
+				patchvariables.BuiltinsName: {Raw: []byte(`{"cluster":{"name":"cluster-name","namespace":"default","topology":{"class":"clusterClass1","version":"v1.21.1"}}}`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`{"class":"clusterClass1","version":"v1.21.1"}`)},
+		},
+		{
+			// NOTE: Template rendering is tested more extensively in TestRenderValueTemplate
+			name: "Should return rendered .valueFrom.template if set",
+			patch: clusterv1.JSONPatch{
+				ValueFrom: &clusterv1.JSONPatchValue{
+					Template: pointer.String("{{ .variableA }}"),
+				},
+			},
+			variables: map[string]apiextensionsv1.JSON{
+				"variableA": {Raw: []byte(`"value"`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`"value"`)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got, err := calculateValue(tt.patch, tt.variables)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestRenderValueTemplate(t *testing.T) {
+	tests := []struct {
+		name      string
+		template  string
+		variables map[string]apiextensionsv1.JSON
+		want      *apiextensionsv1.JSON
+		wantErr   bool
+	}{
+		// Basic types
+		{
+			name:     "Should render a string variable",
+			template: `{{ .stringVariable }}`,
+			variables: map[string]apiextensionsv1.JSON{
+				"stringVariable": {Raw: []byte(`"bar"`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`"bar"`)},
+		},
+		{
+			name:     "Should render an integer variable",
+			template: `{{ .integerVariable }}`,
+			variables: map[string]apiextensionsv1.JSON{
+				"integerVariable": {Raw: []byte("3")},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`3`)},
+		},
+		{
+			name:     "Should render a number variable",
+			template: `{{ .numberVariable }}`,
+			variables: map[string]apiextensionsv1.JSON{
+				"numberVariable": {Raw: []byte("2.5")},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`2.5`)},
+		},
+		{
+			name:     "Should render a boolean variable",
+			template: `{{ .booleanVariable }}`,
+			variables: map[string]apiextensionsv1.JSON{
+				"booleanVariable": {Raw: []byte("true")},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`true`)},
+		},
+		// YAML
+		{
+			name: "Should render a YAML array",
+			template: `
+- contentFrom:
+    secret:
+      key: control-plane-azure.json
+      name: "{{ .builtin.cluster.name }}-control-plane-azure-json"
+  owner: root:root
+`,
+			variables: map[string]apiextensionsv1.JSON{
+				patchvariables.BuiltinsName: {Raw: []byte(`{"cluster":{"name":"cluster1"}}`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`
+[{
+	"contentFrom":{
+		"secret":{
+			"key":"control-plane-azure.json",
+			"name":"cluster1-control-plane-azure-json"
+		}
+	},
+	"owner":"root:root"
+}]`),
+			},
+		},
+		{
+			name: "Should render a YAML object",
+			template: `
+contentFrom:
+  secret:
+    key: control-plane-azure.json
+    name: "{{ .builtin.cluster.name }}-control-plane-azure-json"
+owner: root:root
+`,
+			variables: map[string]apiextensionsv1.JSON{
+				patchvariables.BuiltinsName: {Raw: []byte(`{"cluster":{"name":"cluster1"}}`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`
+{
+	"contentFrom":{
+		"secret":{
+			"key":"control-plane-azure.json",
+			"name":"cluster1-control-plane-azure-json"
+		}
+	},
+	"owner":"root:root"
+}`),
+			},
+		},
+		// JSON
+		{
+			name: "Should render a JSON array",
+			template: `
+[{
+	"contentFrom":{
+		"secret":{
+			"key":"control-plane-azure.json",
+			"name":"{{ .builtin.cluster.name }}-control-plane-azure-json"
+		}
+	},
+	"owner":"root:root"
+}]`,
+			variables: map[string]apiextensionsv1.JSON{
+				patchvariables.BuiltinsName: {Raw: []byte(`{"cluster":{"name":"cluster1"}}`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`
+[{
+	"contentFrom":{
+		"secret":{
+			"key":"control-plane-azure.json",
+			"name":"cluster1-control-plane-azure-json"
+		}
+	},
+	"owner":"root:root"
+}]`),
+			},
+		},
+		{
+			name: "Should render a JSON object",
+			template: `
+{
+	"contentFrom":{
+		"secret":{
+			"key":"control-plane-azure.json",
+			"name":"{{ .builtin.cluster.name }}-control-plane-azure-json"
+		}
+	},
+	"owner":"root:root"
+}`,
+			variables: map[string]apiextensionsv1.JSON{
+				patchvariables.BuiltinsName: {Raw: []byte(`{"cluster":{"name":"cluster1"}}`)},
+			},
+			want: &apiextensionsv1.JSON{Raw: []byte(`
+{
+	"contentFrom":{
+		"secret":{
+			"key":"control-plane-azure.json",
+			"name":"cluster1-control-plane-azure-json"
+		}
+	},
+	"owner":"root:root"
+}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got, err := renderValueTemplate(tt.template, tt.variables)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			// Compact tt.want so we can use easily readable multi-line
+			// strings in the test definition.
+			var compactWant bytes.Buffer
+			g.Expect(json.Compact(&compactWant, tt.want.Raw)).To(Succeed())
+
+			g.Expect(string(got.Raw)).To(Equal(compactWant.String()))
+		})
+	}
+}
+
+func TestCalculateTemplateData(t *testing.T) {
+	tests := []struct {
+		name      string
+		variables map[string]apiextensionsv1.JSON
+		want      map[string]interface{}
+		wantErr   bool
+	}{
+		{
+			name: "Fails for invalid JSON value (missing closing quote)",
+			variables: map[string]apiextensionsv1.JSON{
+				"stringVariable": {Raw: []byte(`"cluster-name`)},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Fails for invalid JSON value (string without quotes)",
+			variables: map[string]apiextensionsv1.JSON{
+				"stringVariable": {Raw: []byte(`cluster-name`)},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should convert basic types",
+			variables: map[string]apiextensionsv1.JSON{
+				"stringVariable":  {Raw: []byte(`"cluster-name"`)},
+				"integerVariable": {Raw: []byte("4")},
+				"numberVariable":  {Raw: []byte("2.5")},
+				"booleanVariable": {Raw: []byte("true")},
+			},
+			want: map[string]interface{}{
+				"stringVariable":  "cluster-name",
+				"integerVariable": float64(4),
+				"numberVariable":  float64(2.5),
+				"booleanVariable": true,
+			},
+		},
+		{
+			name: "Should handle nested variables correctly",
+			variables: map[string]apiextensionsv1.JSON{
+				"builtin":      {Raw: []byte(`{"cluster":{"name":"cluster-name","namespace":"default","topology":{"class":"clusterClass1","version":"v1.22.0"}},"controlPlane":{"replicas":3},"machineDeployment":{"version":"v1.21.2"}}`)},
+				"userVariable": {Raw: []byte(`"value"`)},
+			},
+			want: map[string]interface{}{
+				"builtin": map[string]interface{}{
+					"cluster": map[string]interface{}{
+						"name":      "cluster-name",
+						"namespace": "default",
+						"topology": map[string]interface{}{
+							"class":   "clusterClass1",
+							"version": "v1.22.0",
+						},
+					},
+					"controlPlane": map[string]interface{}{
+						"replicas": float64(3),
+					},
+					"machineDeployment": map[string]interface{}{
+						"version": "v1.21.2",
+					},
+				},
+				"userVariable": "value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got, err := calculateTemplateData(tt.variables)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestMergeVariables(t *testing.T) {
+	t.Run("Merge variables", func(t *testing.T) {
+		g := NewWithT(t)
+
+		m, err := mergeVariableMaps(
+			map[string]apiextensionsv1.JSON{
+				patchvariables.BuiltinsName: {Raw: []byte(`{"cluster":{"name":"cluster-name","namespace":"default","topology":{"class":"clusterClass1","version":"v1.21.1"}}}`)},
+				"a":                         {Raw: []byte("a-different")},
+				"c":                         {Raw: []byte("c")},
+			},
+			map[string]apiextensionsv1.JSON{
+				// Verify that builtin variables are merged correctly and
+				// the latter variables take precedent ("cluster-name-overwrite").
+				patchvariables.BuiltinsName: {Raw: []byte(`{"controlPlane":{"replicas":3},"cluster":{"name":"cluster-name-overwrite"}}`)},
+				"a":                         {Raw: []byte("a")},
+				"b":                         {Raw: []byte("b")},
+			},
+		)
+		g.Expect(err).To(BeNil())
+
+		g.Expect(m).To(HaveKeyWithValue(patchvariables.BuiltinsName, apiextensionsv1.JSON{Raw: []byte(`{"cluster":{"name":"cluster-name-overwrite","namespace":"default","topology":{"version":"v1.21.1","class":"clusterClass1"}},"controlPlane":{"replicas":3}}`)}))
+		g.Expect(m).To(HaveKeyWithValue("a", apiextensionsv1.JSON{Raw: []byte("a")}))
+		g.Expect(m).To(HaveKeyWithValue("b", apiextensionsv1.JSON{Raw: []byte("b")}))
+		g.Expect(m).To(HaveKeyWithValue("c", apiextensionsv1.JSON{Raw: []byte("c")}))
+	})
+}
+
+// toJSONCompact is used to be able to write JSON values in a readable manner.
+func toJSONCompact(value string) apiextensionsv1.JSON {
+	var compactValue bytes.Buffer
+	if err := json.Compact(&compactValue, []byte(value)); err != nil {
+		panic(err)
+	}
+	return apiextensionsv1.JSON{Raw: compactValue.Bytes()}
+}

--- a/controllers/topology/internal/extensions/patches/template.go
+++ b/controllers/topology/internal/extensions/patches/template.go
@@ -18,7 +18,6 @@ package patches
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -95,7 +94,7 @@ func getTemplateAsUnstructured(req *api.GenerateRequest, templateRef api.Templat
 
 	// If a patch doesn't apply to any object, this is a misconfiguration.
 	if template == nil {
-		return nil, errors.Errorf("failed to get template %s", templateRefString(templateRef))
+		return nil, errors.Errorf("failed to get template %s", templateRef)
 	}
 
 	return templateToUnstructured(template)
@@ -118,18 +117,6 @@ func templateRefsAreEqual(a, b api.TemplateRef) bool {
 		a.TemplateType == b.TemplateType &&
 		a.MachineDeploymentRef.TopologyName == b.MachineDeploymentRef.TopologyName &&
 		a.MachineDeploymentRef.Class == b.MachineDeploymentRef.Class
-}
-
-// templateRefString returns a string representing the TemplateRef.
-func templateRefString(t api.TemplateRef) string {
-	ret := fmt.Sprintf("%s %s/%s", t.TemplateType, t.APIVersion, t.Kind)
-	if t.MachineDeploymentRef.TopologyName != "" {
-		ret = fmt.Sprintf("%s, MachineDeployment topology %s", ret, t.MachineDeploymentRef.TopologyName)
-	}
-	if t.MachineDeploymentRef.Class != "" {
-		ret = fmt.Sprintf("%s, MachineDeployment class %s", ret, t.MachineDeploymentRef.Class)
-	}
-	return ret
 }
 
 // templateToUnstructured converts a GenerateRequestTemplate into an Unstructured object.

--- a/controllers/topology/internal/extensions/patches/variables/variables_test.go
+++ b/controllers/topology/internal/extensions/patches/variables/variables_test.go
@@ -50,7 +50,7 @@ func TestGlobal(t *testing.T) {
 					{
 						// This is blocked by a webhook, but let's make sure we overwrite
 						// the user-defined variable with the builtin variable anyway.
-						Name:  "builtin.cluster.name",
+						Name:  "builtin",
 						Value: toJSON("8"),
 					},
 				},
@@ -68,12 +68,9 @@ func TestGlobal(t *testing.T) {
 				},
 			},
 			want: VariableMap{
-				"location":                    toJSON("\"us-central\""),
-				"cpu":                         toJSON("8"),
-				BuiltinClusterName:            toJSON("\"cluster1\""),
-				BuiltinClusterNamespace:       toJSON("\"default\""),
-				BuiltinClusterTopologyVersion: toJSON("\"v1.21.1\""),
-				BuiltinClusterTopologyClass:   toJSON("\"clusterClass1\""),
+				"location":   toJSON("\"us-central\""),
+				"cpu":        toJSON("8"),
+				BuiltinsName: toJSON("{\"cluster\":{\"name\":\"cluster1\",\"namespace\":\"default\",\"topology\":{\"version\":\"v1.21.1\",\"class\":\"clusterClass1\"}}}"),
 			},
 		},
 	}
@@ -105,8 +102,7 @@ func TestControlPlane(t *testing.T) {
 				WithVersion("v1.21.1").
 				Build(),
 			want: VariableMap{
-				BuiltinControlPlaneReplicas: toJSON("3"),
-				BuiltinControlPlaneVersion:  toJSON("\"v1.21.1\""),
+				BuiltinsName: toJSON("{\"controlPlane\":{\"version\":\"v1.21.1\",\"replicas\":3}}"),
 			},
 		},
 		{
@@ -116,7 +112,7 @@ func TestControlPlane(t *testing.T) {
 				WithVersion("v1.21.1").
 				Build(),
 			want: VariableMap{
-				BuiltinControlPlaneVersion: toJSON("\"v1.21.1\""),
+				BuiltinsName: toJSON("{\"controlPlane\":{\"version\":\"v1.21.1\"}}"),
 			},
 		},
 	}
@@ -150,11 +146,7 @@ func TestMachineDeployment(t *testing.T) {
 				WithVersion("v1.21.1").
 				Build(),
 			want: VariableMap{
-				BuiltinMachineDeploymentReplicas:     toJSON("3"),
-				BuiltinMachineDeploymentVersion:      toJSON("\"v1.21.1\""),
-				BuiltinMachineDeploymentClass:        toJSON("\"md-class\""),
-				BuiltinMachineDeploymentName:         toJSON("\"md1\""),
-				BuiltinMachineDeploymentTopologyName: toJSON("\"md-topology\""),
+				BuiltinsName: toJSON("{\"machineDeployment\":{\"version\":\"v1.21.1\",\"class\":\"md-class\",\"name\":\"md1\",\"topologyName\":\"md-topology\",\"replicas\":3}}"),
 			},
 		},
 		{
@@ -167,10 +159,7 @@ func TestMachineDeployment(t *testing.T) {
 				WithVersion("v1.21.1").
 				Build(),
 			want: VariableMap{
-				BuiltinMachineDeploymentVersion:      toJSON("\"v1.21.1\""),
-				BuiltinMachineDeploymentClass:        toJSON("\"md-class\""),
-				BuiltinMachineDeploymentName:         toJSON("\"md1\""),
-				BuiltinMachineDeploymentTopologyName: toJSON("\"md-topology\""),
+				BuiltinsName: toJSON("{\"machineDeployment\":{\"version\":\"v1.21.1\",\"class\":\"md-class\",\"name\":\"md1\",\"topologyName\":\"md-topology\"}}"),
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.9.0
+	github.com/valyala/fastjson v1.6.3
 	go.etcd.io/etcd/api/v3 v3.5.0
 	go.etcd.io/etcd/client/v3 v3.5.0
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f

--- a/go.sum
+++ b/go.sum
@@ -584,6 +584,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
+github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca h1:1CFlNzQhALwjS9mBAUkycX616GzgsuYUOCHA5+HSlXI=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/test/e2e/data/infrastructure-docker/v1beta1/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/bases/cluster-with-topology.yaml
@@ -23,3 +23,6 @@ spec:
       - class: "default-worker"
         name: "md-0"
         replicas: ${WORKER_MACHINE_COUNT}
+    variables:
+    - name: imageRepository
+      value: k8s.gcr.io

--- a/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
@@ -20,7 +20,7 @@ spec:
       name: quick-start-my-cluster
   workers:
     machineDeployments:
-    - class: "default-worker"
+    - class: default-worker
       template:
         bootstrap:
           ref:
@@ -32,6 +32,51 @@ spec:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: DockerMachineTemplate
             name: quick-start-docker-worker-machinetemplate
+  variables:
+  - name: imageRepository
+    required: true
+    schema:
+      openAPIV3Schema:
+        type: string
+  patches:
+  - name: imageRepository
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/imageRepository"
+        valueFrom:
+          variable: imageRepository
+  - name: customImage
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - default-worker
+      jsonPatches:
+      - op: add
+        path: "/spec/template/spec/customImage"
+        valueFrom:
+          template: |
+            kindest/node:{{ .builtin.machineDeployment.version }}
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: "/spec/template/spec/customImage"
+        valueFrom:
+          template: |
+            kindest/node:{{ .builtin.controlPlane.version }}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate

--- a/test/go.sum
+++ b/test/go.sum
@@ -833,6 +833,7 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR builds on top of https://github.com/kubernetes-sigs/cluster-api/pull/5534 and adds the inline JSON patch generation. 


**This PR is now ready for review :)**

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
