### PR TITLE
🌱 Add a check to the Cluster webhook to ensure ClusterClass exists

### DIFF
--- a/controllers/topology/cluster_controller_test.go
+++ b/controllers/topology/cluster_controller_test.go
@@ -383,7 +383,7 @@ func setupTestEnvForIntegrationTests(ns *corev1.Namespace) (func() error, error)
 	}
 
 	for _, obj := range initObjs {
-		if err := env.Create(ctx, obj); err != nil {
+		if err := env.CreateAndWait(ctx, obj); err != nil {
 			return cleanup, err
 		}
 	}

--- a/internal/envtest/environment.go
+++ b/internal/envtest/environment.go
@@ -216,7 +216,7 @@ func new(uncachedObjs ...client.Object) *Environment {
 	// Set minNodeStartupTimeout for Test, so it does not need to be at least 30s
 	clusterv1.SetMinNodeStartupTimeout(metav1.Duration{Duration: 1 * time.Millisecond})
 
-	if err := (&webhooks.Cluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.Cluster{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("unable to create webhook: %+v", err)
 	}
 	if err := (&webhooks.ClusterClass{}).SetupWebhookWithManager(mgr); err != nil {

--- a/main.go
+++ b/main.go
@@ -409,7 +409,7 @@ func setupWebhooks(mgr ctrl.Manager) {
 
 	// NOTE: ClusterClass and managed topologies are behind ClusterTopology feature gate flag; the webhook
 	// is going to prevent usage of Cluster.Topology in case the feature flag is disabled.
-	if err := (&webhooks.Cluster{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.Cluster{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Cluster")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

This change adds an additional check to the Cluster Webhook to ensure that a ClusterClass referenced by a cluster exists. If the ClusterClass does not exist the Cluster creation or update is rejected. 

This check introduces an expected ordering in the creation and update of the ClusterClass and Cluster objects, and it adds a client to the webhook that is used to fetch the referenced ClusterClass from the API server on Cluster creation and update.

Related to  #5537 
