### PR TITLE
:bug: restore - set tenants on the new object graph constructed from files in the backup directory

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -128,6 +128,9 @@ func (o *objectMover) Restore(toCluster Client, directory string) error {
 	// by a naming convention (without any explicit OwnerReference).
 	objectGraph.setSoftOwnership()
 
+	// Completes the graph by setting for each node the list of tenants the node belongs to.
+	objectGraph.setTenants()
+
 	// Check whether nodes are not included in GVK considered for restore.
 	objectGraph.checkVirtualNode()
 

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -901,8 +901,12 @@ func Test_objectMover_restore(t *testing.T) {
 				g.Expect(graph.addRestoredObj(&objs[i])).NotTo(HaveOccurred())
 			}
 
-			// trigger discovery the content of the source cluster
-			g.Expect(graph.Discovery("")).To(Succeed())
+			// restore works on the target cluster which does not yet have objs to discover
+			// instead set the owners and tenants correctly on object graph like how ObjectMover.Restore does
+			// https://github.com/kubernetes-sigs/cluster-api/blob/main/cmd/clusterctl/client/cluster/mover.go#L129-L132
+			graph.setSoftOwnership()
+			graph.setTenants()
+			graph.checkVirtualNode()
 
 			err = mover.restore(graph, toProxy)
 			if tt.wantErr {


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
While restore is pretty much works like move, the difference is the the object graph being constructed in move shows the uidToNode objects with the tenants set correctly (as does the backup command). However, with restore, since a new object graph is created, the tenant is not being set at on the restored object after reading the object from the backup directory. This leads restore to only restore the cluster object. I think the restore function is missing the o.setTenants call

Since the `Test_objectMover_restore` test uses `getObjectGraph` instead of creating a new graph like the actual restore does, I'm not sure if I need to add a test [here](https://github.com/kubernetes-sigs/cluster-api/blob/main/cmd/clusterctl/client/cluster/mover_test.go#L874). 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5587 
