### PR TITLE
🌱 Move Cluster and ClusterClass webhook implementation to top level package

### DIFF
--- a/webhooks/cluster.go
+++ b/webhooks/cluster.go
@@ -19,20 +19,26 @@ package webhooks
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/blang/semver"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/util/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 // SetupWebhookWithManager sets up Cluster webhooks.
-func (c *Cluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *Cluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&clusterv1.Cluster{}).
-		WithDefaulter(c).
-		WithValidator(c).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
 		Complete()
 }
 
@@ -46,39 +52,42 @@ var _ webhook.CustomDefaulter = &Cluster{}
 var _ webhook.CustomValidator = &Cluster{}
 
 // Default satisfies the defaulting webhook interface.
-func (c *Cluster) Default(_ context.Context, obj runtime.Object) error {
+func (webhook *Cluster) Default(_ context.Context, obj runtime.Object) error {
 	cluster, ok := obj.(*clusterv1.Cluster)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
 	}
 
-	// Note: The code in Default is intentionally not duplicated to avoid that we accidentally
-	// implement new checks in the API package and forget to duplicate them to the webhook package.
-	// The idea is to add new defaulting which requires a reader in the webhook package.
-	// When we drop the method in the API package we must inline it here.
-	cluster.Default()
+	if cluster.Spec.InfrastructureRef != nil && len(cluster.Spec.InfrastructureRef.Namespace) == 0 {
+		cluster.Spec.InfrastructureRef.Namespace = cluster.Namespace
+	}
 
+	if cluster.Spec.ControlPlaneRef != nil && len(cluster.Spec.ControlPlaneRef.Namespace) == 0 {
+		cluster.Spec.ControlPlaneRef.Namespace = cluster.Namespace
+	}
+
+	// If the Cluster uses a managed topology
+	if cluster.Spec.Topology != nil {
+		// tolerate version strings without a "v" prefix: prepend it if it's not there
+		if !strings.HasPrefix(cluster.Spec.Topology.Version, "v") {
+			cluster.Spec.Topology.Version = "v" + cluster.Spec.Topology.Version
+		}
+	}
 	return nil
 }
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
-func (c *Cluster) ValidateCreate(_ context.Context, obj runtime.Object) error {
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *Cluster) ValidateCreate(_ context.Context, obj runtime.Object) error {
 	cluster, ok := obj.(*clusterv1.Cluster)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
 	}
-
-	// Note: The code in ValidateCreate is intentionally not duplicated to avoid that we accidentally
-	// implement new checks in the API package and forget to duplicate them to the webhook package.
-	// The idea is to add new validation which requires a reader and Cluster variable/patch validation
-	// in the webhook package.
-	// When we drop the method in the API package we must inline it here.
-	return cluster.ValidateCreate()
+	return webhook.validate(nil, cluster)
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
-func (c *Cluster) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
-	cluster, ok := newObj.(*clusterv1.Cluster)
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *Cluster) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
+	newCluster, ok := newObj.(*clusterv1.Cluster)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", newObj))
 	}
@@ -86,20 +95,154 @@ func (c *Cluster) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Objec
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", oldObj))
 	}
-
-	// Note: The code in ValidateUpdate is intentionally not duplicated to avoid that we accidentally
-	// implement new checks in the API package and forget to duplicate them to the webhook package.
-	// The idea is to add new validation which requires a reader and Cluster variable/patch validation
-	// in the webhook package.
-	// When we drop the method in the API package we must inline it here.
-	return cluster.ValidateUpdate(oldCluster)
+	return webhook.validate(oldCluster, newCluster)
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
-func (c *Cluster) ValidateDelete(ctx context.Context, obj runtime.Object) error {
-	cluster, ok := obj.(*clusterv1.Cluster)
-	if !ok {
-		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *Cluster) ValidateDelete(_ context.Context, obj runtime.Object) error {
+	return nil
+}
+
+func (webhook *Cluster) validate(old, new *clusterv1.Cluster) error {
+	var allErrs field.ErrorList
+	if new.Spec.InfrastructureRef != nil && new.Spec.InfrastructureRef.Namespace != new.Namespace {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				field.NewPath("spec", "infrastructureRef", "namespace"),
+				new.Spec.InfrastructureRef.Namespace,
+				"must match metadata.namespace",
+			),
+		)
 	}
-	return cluster.ValidateDelete()
+
+	if new.Spec.ControlPlaneRef != nil && new.Spec.ControlPlaneRef.Namespace != new.Namespace {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				field.NewPath("spec", "controlPlaneRef", "namespace"),
+				new.Spec.ControlPlaneRef.Namespace,
+				"must match metadata.namespace",
+			),
+		)
+	}
+
+	// Validate the managed topology, if defined.
+	if new.Spec.Topology != nil {
+		if topologyErrs := webhook.validateTopology(old, new); len(topologyErrs) > 0 {
+			allErrs = append(allErrs, topologyErrs...)
+		}
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("Cluster").GroupKind(), new.Name, allErrs)
+}
+
+func (webhook *Cluster) validateTopology(old, new *clusterv1.Cluster) field.ErrorList {
+	// NOTE: ClusterClass and managed topologies are behind ClusterTopology feature gate flag; the web hook
+	// must prevent the usage of Cluster.Topology in case the feature flag is disabled.
+	if !feature.Gates.Enabled(feature.ClusterTopology) {
+		return field.ErrorList{
+			field.Forbidden(
+				field.NewPath("spec", "topology"),
+				"can be set only if the ClusterTopology feature flag is enabled",
+			),
+		}
+	}
+
+	var allErrs field.ErrorList
+
+	// class should be defined.
+	if len(new.Spec.Topology.Class) == 0 {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				field.NewPath("spec", "topology", "class"),
+				new.Spec.Topology.Class,
+				"cannot be empty",
+			),
+		)
+	}
+
+	// version should be valid.
+	if !version.KubeSemver.MatchString(new.Spec.Topology.Version) {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				field.NewPath("spec", "topology", "version"),
+				new.Spec.Topology.Version,
+				"must be a valid semantic version",
+			),
+		)
+	}
+
+	// MachineDeployment names must be unique.
+	if new.Spec.Topology.Workers != nil {
+		names := sets.String{}
+		for _, md := range new.Spec.Topology.Workers.MachineDeployments {
+			if names.Has(md.Name) {
+				allErrs = append(allErrs,
+					field.Invalid(
+						field.NewPath("spec", "topology", "workers", "machineDeployments"),
+						md,
+						fmt.Sprintf("MachineDeployment names should be unique. MachineDeployment with name %q is defined more than once.", md.Name),
+					),
+				)
+			}
+			names.Insert(md.Name)
+		}
+	}
+
+	if old != nil { // On update
+		// Class could not be mutated.
+		if new.Spec.Topology.Class != old.Spec.Topology.Class {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath("spec", "topology", "class"),
+					new.Spec.Topology.Class,
+					"class cannot be changed",
+				),
+			)
+		}
+
+		// Version could only be increased.
+		inVersion, err := semver.ParseTolerant(new.Spec.Topology.Version)
+		if err != nil {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath("spec", "topology", "version"),
+					new.Spec.Topology.Version,
+					"is not a valid version",
+				),
+			)
+		}
+		oldVersion, err := semver.ParseTolerant(old.Spec.Topology.Version)
+		if err != nil {
+			// NOTE: this should never happen. Nevertheless, handling this for extra caution.
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath("spec", "topology", "version"),
+					new.Spec.Topology.Class,
+					"cannot be compared with the old version",
+				),
+			)
+		}
+		if inVersion.NE(semver.Version{}) && oldVersion.NE(semver.Version{}) && version.Compare(inVersion, oldVersion, version.WithBuildTags()) == -1 {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath("spec", "topology", "version"),
+					new.Spec.Topology.Version,
+					"cannot be decreased",
+				),
+			)
+		}
+	}
+
+	return allErrs
 }

--- a/webhooks/cluster_test.go
+++ b/webhooks/cluster_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/component-base/featuregate/testing"
@@ -31,7 +30,7 @@ import (
 func TestClusterDefaultNamespaces(t *testing.T) {
 	g := NewWithT(t)
 
-	in := &clusterv1.Cluster{
+	c := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "fooboo",
 		},
@@ -40,14 +39,12 @@ func TestClusterDefaultNamespaces(t *testing.T) {
 			ControlPlaneRef:   &corev1.ObjectReference{},
 		},
 	}
-
 	webhook := &Cluster{}
-	t.Run("for Cluster", customDefaultValidateTest(ctx, in, webhook))
+	t.Run("for Cluster", customDefaultValidateTest(ctx, c, webhook))
+	g.Expect(webhook.Default(ctx, c)).To(Succeed())
 
-	g.Expect(webhook.Default(ctx, in)).To(Succeed())
-
-	g.Expect(in.Spec.InfrastructureRef.Namespace).To(Equal(in.Namespace))
-	g.Expect(in.Spec.ControlPlaneRef.Namespace).To(Equal(in.Namespace))
+	g.Expect(c.Spec.InfrastructureRef.Namespace).To(Equal(c.Namespace))
+	g.Expect(c.Spec.ControlPlaneRef.Namespace).To(Equal(c.Namespace))
 }
 
 func TestClusterDefaultTopologyVersion(t *testing.T) {
@@ -57,7 +54,7 @@ func TestClusterDefaultTopologyVersion(t *testing.T) {
 
 	g := NewWithT(t)
 
-	in := &clusterv1.Cluster{
+	c := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "fooboo",
 		},
@@ -69,8 +66,380 @@ func TestClusterDefaultTopologyVersion(t *testing.T) {
 		},
 	}
 	webhook := &Cluster{}
-	t.Run("for Cluster", customDefaultValidateTest(ctx, in, webhook))
-	g.Expect(webhook.Default(ctx, in)).To(Succeed())
+	t.Run("for Cluster", customDefaultValidateTest(ctx, c, webhook))
+	g.Expect(webhook.Default(ctx, c)).To(Succeed())
 
-	g.Expect(in.Spec.Topology.Version).To(HavePrefix("v"))
+	g.Expect(c.Spec.Topology.Version).To(HavePrefix("v"))
+}
+
+func TestClusterValidation(t *testing.T) {
+	// NOTE: ClusterTopology feature flag is disabled by default, thus preventing to set Cluster.Topologies.
+
+	tests := []struct {
+		name      string
+		in        *clusterv1.Cluster
+		old       *clusterv1.Cluster
+		expectErr bool
+	}{
+		{
+			name:      "should return error when cluster namespace and infrastructure ref namespace mismatch",
+			expectErr: true,
+			in: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Namespace: "bar",
+					},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Namespace: "foo",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when cluster namespace and controlplane ref namespace mismatch",
+			expectErr: true,
+			in: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Namespace: "foo",
+					},
+					ControlPlaneRef: &corev1.ObjectReference{
+						Namespace: "bar",
+					},
+				},
+			},
+		},
+		{
+			name:      "should succeed when namespaces match",
+			expectErr: false,
+			in: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: clusterv1.ClusterSpec{
+					ControlPlaneRef: &corev1.ObjectReference{
+						Namespace: "foo",
+					},
+					InfrastructureRef: &corev1.ObjectReference{
+						Namespace: "foo",
+					},
+				},
+			},
+		},
+		{
+			name:      "fails if topology is set but feature flag is disabled",
+			expectErr: true,
+			in: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+				Spec: clusterv1.ClusterSpec{
+					ControlPlaneRef: &corev1.ObjectReference{
+						Namespace: "foo",
+					},
+					InfrastructureRef: &corev1.ObjectReference{
+						Namespace: "foo",
+					},
+					Topology: &clusterv1.Topology{},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			webhook := Cluster{}
+			err := webhook.validate(tt.old, tt.in)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestClusterTopologyValidation(t *testing.T) {
+	// NOTE: ClusterTopology feature flag is disabled by default, thus preventing to set Cluster.Topologies.
+	// Enabling the feature flag temporarily for this test.
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
+
+	tests := []struct {
+		name      string
+		in        *clusterv1.Cluster
+		old       *clusterv1.Cluster
+		expectErr bool
+	}{
+		{
+			name:      "should return error when topology does not have class",
+			expectErr: true,
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{},
+				},
+			},
+		},
+		{
+			name:      "should return error when topology does not have valid version",
+			expectErr: true,
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "invalid",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when downgrading topology version - major",
+			expectErr: true,
+			old: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v2.2.3",
+					},
+				},
+			},
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.2.3",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when downgrading topology version - minor",
+			expectErr: true,
+			old: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.2.3",
+					},
+				},
+			},
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.1.3",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when downgrading topology version - patch",
+			expectErr: true,
+			old: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.2.3",
+					},
+				},
+			},
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.2.2",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when downgrading topology version - pre-release",
+			expectErr: true,
+			old: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.2.3-xyz.2",
+					},
+				},
+			},
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.2.3-xyz.1",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when downgrading topology version - build tag",
+			expectErr: true,
+			old: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.2.3+xyz.2",
+					},
+				},
+			},
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.2.3+xyz.1",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error when duplicated MachineDeployments names exists in a Topology",
+			expectErr: true,
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.19.1",
+						Workers: &clusterv1.WorkersTopology{
+							MachineDeployments: []clusterv1.MachineDeploymentTopology{
+								{
+									Name: "aa",
+								},
+								{
+									Name: "aa",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "should pass when MachineDeployments names in a Topology are unique",
+			expectErr: false,
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.19.1",
+						Workers: &clusterv1.WorkersTopology{
+							MachineDeployments: []clusterv1.MachineDeploymentTopology{
+								{
+									Name: "aa",
+								},
+								{
+									Name: "bb",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error on update when Topology class is changed",
+			expectErr: true,
+			old: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{},
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.19.1",
+					},
+				},
+			},
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{},
+					Topology: &clusterv1.Topology{
+						Class:   "bar",
+						Version: "v1.19.1",
+					},
+				},
+			},
+		},
+		{
+			name:      "should return error on update when Topology version is downgraded",
+			expectErr: true,
+			old: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{},
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.19.1",
+					},
+				},
+			},
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{},
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.19.0",
+					},
+				},
+			},
+		},
+		{
+			name:      "should update",
+			expectErr: false,
+			old: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{},
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.19.1",
+						Workers: &clusterv1.WorkersTopology{
+							MachineDeployments: []clusterv1.MachineDeploymentTopology{
+								{
+									Name: "aa",
+								},
+								{
+									Name: "bb",
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.Cluster{
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{},
+					Topology: &clusterv1.Topology{
+						Class:   "foo",
+						Version: "v1.19.2",
+						Workers: &clusterv1.WorkersTopology{
+							MachineDeployments: []clusterv1.MachineDeploymentTopology{
+								{
+									Name: "aa",
+								},
+								{
+									Name: "bb",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			webhook := Cluster{}
+			err := webhook.validate(tt.old, tt.in)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
 }

--- a/webhooks/clusterclass.go
+++ b/webhooks/clusterclass.go
@@ -19,19 +19,25 @@ package webhooks
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-func (c *ClusterClass) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (webhook *ClusterClass) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&clusterv1.ClusterClass{}).
-		WithDefaulter(c).
-		WithValidator(c).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
 		Complete()
 }
 
@@ -45,39 +51,44 @@ var _ webhook.CustomDefaulter = &ClusterClass{}
 var _ webhook.CustomValidator = &ClusterClass{}
 
 // Default implements defaulting for ClusterClass create and update.
-func (c *ClusterClass) Default(_ context.Context, obj runtime.Object) error {
-	clusterClass, ok := obj.(*clusterv1.ClusterClass)
+func (webhook *ClusterClass) Default(_ context.Context, obj runtime.Object) error {
+	in, ok := obj.(*clusterv1.ClusterClass)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterClass but got a %T", obj))
 	}
+	// Default all namespaces in the references to the object namespace.
+	defaultNamespace(in.Spec.Infrastructure.Ref, in.Namespace)
+	defaultNamespace(in.Spec.ControlPlane.Ref, in.Namespace)
 
-	// Note: The code in Default is intentionally not duplicated to avoid that we accidentally
-	// implement new checks in the API package and forget to duplicate them to the webhook package.
-	// The idea is to add new defaulting which requires a reader in the webhook package.
-	// When we drop the method in the API package we must inline it here.
-	clusterClass.Default()
+	if in.Spec.ControlPlane.MachineInfrastructure != nil {
+		defaultNamespace(in.Spec.ControlPlane.MachineInfrastructure.Ref, in.Namespace)
+	}
 
+	for i := range in.Spec.Workers.MachineDeployments {
+		defaultNamespace(in.Spec.Workers.MachineDeployments[i].Template.Bootstrap.Ref, in.Namespace)
+		defaultNamespace(in.Spec.Workers.MachineDeployments[i].Template.Infrastructure.Ref, in.Namespace)
+	}
 	return nil
 }
 
+func defaultNamespace(ref *corev1.ObjectReference, namespace string) {
+	if ref != nil && len(ref.Namespace) == 0 {
+		ref.Namespace = namespace
+	}
+}
+
 // ValidateCreate implements validation for ClusterClass create.
-func (c *ClusterClass) ValidateCreate(_ context.Context, obj runtime.Object) error {
-	clusterClass, ok := obj.(*clusterv1.ClusterClass)
+func (webhook *ClusterClass) ValidateCreate(_ context.Context, obj runtime.Object) error {
+	in, ok := obj.(*clusterv1.ClusterClass)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterClass but got a %T", obj))
 	}
-
-	// Note: The code in ValidateCreate is intentionally not duplicated to avoid that we accidentally
-	// implement new checks in the API package and forget to duplicate them to the webhook package.
-	// The idea is to add new validation which requires a reader and ClusterClass variable/patch validation
-	// in the webhook package.
-	// When we drop the method in the API package we must inline it here.
-	return clusterClass.ValidateCreate()
+	return webhook.validate(nil, in)
 }
 
 // ValidateUpdate implements validation for ClusterClass update.
-func (c *ClusterClass) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
-	clusterClass, ok := newObj.(*clusterv1.ClusterClass)
+func (webhook *ClusterClass) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) error {
+	newClusterClass, ok := newObj.(*clusterv1.ClusterClass)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterClass but got a %T", newObj))
 	}
@@ -85,21 +96,286 @@ func (c *ClusterClass) ValidateUpdate(_ context.Context, oldObj, newObj runtime.
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterClass but got a %T", oldObj))
 	}
-
-	// Note: The code in ValidateUpdate is intentionally not duplicated to avoid that we accidentally
-	// implement new checks in the API package and forget to duplicate them to the webhook package.
-	// The idea is to add new validation which requires a reader and ClusterClass variable/patch validation
-	// in the webhook package.
-	// When we drop the method in the API package we must inline it here.
-	return clusterClass.ValidateUpdate(oldClusterClass)
+	return webhook.validate(oldClusterClass, newClusterClass)
 }
 
 // ValidateDelete implements validation for ClusterClass delete.
-func (c *ClusterClass) ValidateDelete(ctx context.Context, obj runtime.Object) error {
-	clusterClass, ok := obj.(*clusterv1.ClusterClass)
-	if !ok {
-		return apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterClass but got a %T", obj))
+func (webhook *ClusterClass) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return nil
+}
+
+func (webhook *ClusterClass) validate(old, in *clusterv1.ClusterClass) error {
+	// NOTE: ClusterClass and managed topologies are behind ClusterTopology feature gate flag; the web hook
+	// must prevent creating in objects in case the feature flag is disabled.
+	if !feature.Gates.Enabled(feature.ClusterTopology) {
+		return field.Forbidden(
+			field.NewPath("spec"),
+			"can be set only if the ClusterTopology feature flag is enabled",
+		)
 	}
 
-	return clusterClass.ValidateDelete()
+	var allErrs field.ErrorList
+
+	// Ensure all references are valid.
+	allErrs = append(allErrs, webhook.validateAllRefs(in)...)
+
+	// Ensure all MachineDeployment classes are unique.
+	allErrs = append(allErrs, webhook.validateUniqueClasses(in.Spec.Workers, field.NewPath("spec", "workers"))...)
+
+	// Ensure spec changes are compatible.
+	allErrs = append(allErrs, webhook.validateCompatibleSpecChanges(old, in)...)
+
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("ClusterClass").GroupKind(), in.Name, allErrs)
+	}
+	return nil
+}
+
+func (webhook *ClusterClass) validateAllRefs(in *clusterv1.ClusterClass) field.ErrorList {
+	var allErrs field.ErrorList
+
+	allErrs = append(allErrs, webhook.validateTemplate(&in.Spec.Infrastructure, in.Namespace, field.NewPath("spec", "infrastructure"))...)
+	allErrs = append(allErrs, webhook.validateTemplate(&in.Spec.ControlPlane.LocalObjectTemplate, in.Namespace, field.NewPath("spec", "controlPlane"))...)
+	if in.Spec.ControlPlane.MachineInfrastructure != nil {
+		allErrs = append(allErrs, webhook.validateTemplate(in.Spec.ControlPlane.MachineInfrastructure, in.Namespace, field.NewPath("spec", "controlPlane", "machineInfrastructure"))...)
+	}
+
+	for i, class := range in.Spec.Workers.MachineDeployments {
+		allErrs = append(allErrs, webhook.validateTemplate(&class.Template.Bootstrap, in.Namespace, field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("template", "bootstrap"))...)
+		allErrs = append(allErrs, webhook.validateTemplate(&class.Template.Infrastructure, in.Namespace, field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("template", "infrastructure"))...)
+	}
+
+	return allErrs
+}
+
+func (webhook *ClusterClass) validateCompatibleSpecChanges(old, in *clusterv1.ClusterClass) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// in case of create, no changes to verify
+	// return early.
+	if old == nil {
+		return nil
+	}
+
+	// Validate changes to MachineDeployments.
+	allErrs = append(allErrs, webhook.validateMachineDeploymentsCompatibleChanges(old, in)...)
+
+	// Validate InfrastructureClusterTemplate changes in a compatible way.
+	allErrs = append(allErrs, webhook.validateTemplatesAreCompatible(in.Spec.Infrastructure,
+		old.Spec.Infrastructure,
+		field.NewPath("spec", "infrastructure"),
+	)...)
+
+	// Validate control plane changes in a compatible way.
+	allErrs = append(allErrs, webhook.validateTemplatesAreCompatible(in.Spec.ControlPlane.LocalObjectTemplate,
+		old.Spec.ControlPlane.LocalObjectTemplate,
+		field.NewPath("spec", "controlPlane"),
+	)...)
+
+	if in.Spec.ControlPlane.MachineInfrastructure != nil && old.Spec.ControlPlane.MachineInfrastructure != nil {
+		allErrs = append(allErrs, webhook.validateTemplatesAreCompatible(
+			*old.Spec.ControlPlane.MachineInfrastructure,
+			*in.Spec.ControlPlane.MachineInfrastructure,
+			field.NewPath("spec", "controlPlane", "machineInfrastructure"),
+		)...)
+	}
+
+	return allErrs
+}
+
+func (webhook *ClusterClass) validateMachineDeploymentsCompatibleChanges(old, in *clusterv1.ClusterClass) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// Ensure no MachineDeployment class was removed.
+	classes := webhook.classNamesFromWorkerClass(in.Spec.Workers)
+	for _, oldClass := range old.Spec.Workers.MachineDeployments {
+		if !classes.Has(oldClass.Class) {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec", "workers", "machineDeployments"),
+					in.Spec.Workers.MachineDeployments,
+					fmt.Sprintf("The %q MachineDeployment class can't be removed.", oldClass.Class),
+				),
+			)
+		}
+	}
+
+	// Ensure previous MachineDeployment class was modified in a compatible way.
+	for i, class := range in.Spec.Workers.MachineDeployments {
+		for _, oldClass := range old.Spec.Workers.MachineDeployments {
+			if class.Class == oldClass.Class {
+				// NOTE: class.Template.Metadata and class.Template.Bootstrap are allowed to change;
+				// class.Template.Bootstrap are ensured syntactically correct by validateAllRefs.
+
+				// Validates class.Template.Infrastructure template changes in a compatible way
+				allErrs = append(allErrs, webhook.validateTemplatesAreCompatible(
+					class.Template.Infrastructure,
+					oldClass.Template.Infrastructure,
+					field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("template", "infrastructure"),
+				)...)
+			}
+		}
+	}
+
+	return allErrs
+}
+
+func (webhook *ClusterClass) validateTemplate(in *clusterv1.LocalObjectTemplate, namespace string, pathPrefix *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// check if ref is not nil.
+	if in.Ref == nil {
+		return field.ErrorList{field.Invalid(
+			pathPrefix.Child("ref"),
+			in.Ref.Name,
+			"cannot be nil",
+		)}
+	}
+
+	// check if a name is provided
+	if in.Ref.Name == "" {
+		allErrs = append(allErrs,
+			field.Invalid(
+				pathPrefix.Child("ref", "name"),
+				in.Ref.Name,
+				"cannot be empty",
+			),
+		)
+	}
+
+	// validate if namespace matches the provided namespace
+	if namespace != "" && in.Ref.Namespace != namespace {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				pathPrefix.Child("ref", "namespace"),
+				in.Ref.Namespace,
+				fmt.Sprintf("must be '%s'", namespace),
+			),
+		)
+	}
+
+	// check if kind is a template
+	if len(in.Ref.Kind) <= len(clusterv1.TemplateSuffix) || !strings.HasSuffix(in.Ref.Kind, clusterv1.TemplateSuffix) {
+		allErrs = append(allErrs,
+			field.Invalid(
+				pathPrefix.Child("ref", "kind"),
+				in.Ref.Kind,
+				fmt.Sprintf("kind must be of form '<name>%s'", clusterv1.TemplateSuffix),
+			),
+		)
+	}
+
+	// check if apiVersion is valid
+	gv, err := schema.ParseGroupVersion(in.Ref.APIVersion)
+	if err != nil {
+		allErrs = append(allErrs,
+			field.Invalid(
+				pathPrefix.Child("ref", "apiVersion"),
+				in.Ref.APIVersion,
+				fmt.Sprintf("must be a valid apiVersion: %v", err),
+			),
+		)
+	}
+	if err == nil && gv.Empty() {
+		allErrs = append(allErrs,
+			field.Invalid(
+				pathPrefix.Child("ref", "apiVersion"),
+				in.Ref.APIVersion,
+				"value cannot be empty",
+			),
+		)
+	}
+
+	return allErrs
+}
+
+// validateTemplatesAreCompatible checks if a reference is compatible with the old one.
+// NOTE: this func assumes that validateTemplate() is called before, thus both ref are defined and syntactically valid;
+// also namespace are enforced to be the same of the ClusterClass.
+func (webhook *ClusterClass) validateTemplatesAreCompatible(old, in clusterv1.LocalObjectTemplate, pathPrefix *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// Check for nil Ref here to avoid panic.
+	if in.Ref == nil || old.Ref == nil {
+		return allErrs
+	}
+
+	// Ensure that the API Group and Kind does not change, while instead we allow version to change.
+	// TODO: In the future we might want to relax this requirement with some sort of opt-in behavior (e.g. annotation).
+
+	gv, err := schema.ParseGroupVersion(in.Ref.APIVersion)
+	if err != nil {
+		// NOTE this should never happen.
+		allErrs = append(allErrs,
+			field.Invalid(
+				pathPrefix.Child("ref", "apiVersion"),
+				in.Ref.APIVersion,
+				fmt.Sprintf("must be a valid apiVersion: %v", err),
+			),
+		)
+	}
+
+	oldGV, err := schema.ParseGroupVersion(old.Ref.APIVersion)
+	if err != nil {
+		// NOTE this should never happen.
+		allErrs = append(allErrs,
+			field.Invalid(
+				pathPrefix.Child("ref", "apiVersion"),
+				old.Ref.APIVersion,
+				fmt.Sprintf("must be a valid apiVersion: %v", err),
+			),
+		)
+	}
+
+	if gv.Group != oldGV.Group {
+		allErrs = append(allErrs,
+			field.Invalid(
+				pathPrefix.Child("ref", "apiVersion"),
+				in.Ref.APIVersion,
+				"apiGroup cannot be changed",
+			),
+		)
+	}
+
+	if in.Ref.Kind != old.Ref.Kind {
+		allErrs = append(allErrs,
+			field.Invalid(
+				pathPrefix.Child("ref", "kind"),
+				in.Ref.Kind,
+				"value cannot be changed",
+			),
+		)
+	}
+
+	return allErrs
+}
+
+// classNames returns the set of MachineDeployment class names.
+func (webhook *ClusterClass) classNamesFromWorkerClass(w clusterv1.WorkersClass) sets.String {
+	classes := sets.NewString()
+	for _, class := range w.MachineDeployments {
+		classes.Insert(class.Class)
+	}
+	return classes
+}
+
+func (webhook *ClusterClass) validateUniqueClasses(w clusterv1.WorkersClass, pathPrefix *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	classes := sets.NewString()
+	for i, class := range w.MachineDeployments {
+		if classes.Has(class.Class) {
+			allErrs = append(allErrs,
+				field.Invalid(
+					pathPrefix.Child("machineDeployments").Index(i).Child("class"),
+					class.Class,
+					fmt.Sprintf("MachineDeployment class should be unique. MachineDeployment with class %q is defined more than once.", class.Class),
+				),
+			)
+		}
+		classes.Insert(class.Class)
+	}
+
+	return allErrs
 }

--- a/webhooks/clusterclass_test.go
+++ b/webhooks/clusterclass_test.go
@@ -74,7 +74,6 @@ func TestClusterClassDefaultNamespaces(t *testing.T) {
 	}
 
 	webhook := &ClusterClass{}
-
 	t.Run("for ClusterClass", customDefaultValidateTest(ctx, in, webhook))
 
 	g := NewWithT(t)
@@ -87,5 +86,1373 @@ func TestClusterClassDefaultNamespaces(t *testing.T) {
 	for i := range in.Spec.Workers.MachineDeployments {
 		g.Expect(in.Spec.Workers.MachineDeployments[i].Template.Bootstrap.Ref.Namespace).To(Equal(namespace))
 		g.Expect(in.Spec.Workers.MachineDeployments[i].Template.Infrastructure.Ref.Namespace).To(Equal(namespace))
+	}
+}
+
+func TestClusterClassValidationFeatureGated(t *testing.T) {
+	// NOTE: ClusterTopology feature flag is disabled by default, thus preventing to create or update ClusterClasses.
+
+	ref := &corev1.ObjectReference{
+		APIVersion: "foo",
+		Kind:       "barTemplate",
+		Name:       "baz",
+		Namespace:  "default",
+	}
+	tests := []struct {
+		name      string
+		in        *clusterv1.ClusterClass
+		old       *clusterv1.ClusterClass
+		expectErr bool
+	}{
+		{
+			name: "creation should fail if feature flag is disabled, no matter the ClusterClass is valid(or not)",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "update should fail if feature flag is disabled, no matter the ClusterClass is valid(or not)",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			webhook := &ClusterClass{}
+			if tt.expectErr {
+				g.Expect(webhook.validate(tt.old, tt.in)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.validate(tt.old, tt.in)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestClusterClassValidation(t *testing.T) {
+	// NOTE: ClusterTopology feature flag is disabled by default, thus preventing to create or update ClusterClasses.
+	// Enabling the feature flag temporarily for this test.
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
+
+	ref := &corev1.ObjectReference{
+		APIVersion: "group.test.io/foo",
+		Kind:       "barTemplate",
+		Name:       "baz",
+		Namespace:  "default",
+	}
+	refInAnotherNamespace := &corev1.ObjectReference{
+		APIVersion: "group.test.io/foo",
+		Kind:       "barTemplate",
+		Name:       "baz",
+		Namespace:  "another-namespace",
+	}
+	refBadTemplate := &corev1.ObjectReference{
+		APIVersion: "group.test.io/foo",
+		Kind:       "bar",
+		Name:       "baz",
+		Namespace:  "default",
+	}
+	refBadAPIVersion := &corev1.ObjectReference{
+		APIVersion: "group/test.io/v1/foo",
+		Kind:       "barTemplate",
+		Name:       "baz",
+		Namespace:  "default",
+	}
+	refEmptyName := &corev1.ObjectReference{
+		APIVersion: "group.test.io/foo",
+		Namespace:  "default",
+		Kind:       "barTemplate",
+	}
+	incompatibleRef := &corev1.ObjectReference{
+		APIVersion: "group.test.io/foo",
+		Kind:       "another-barTemplate",
+		Name:       "baz",
+		Namespace:  "default",
+	}
+	compatibleRef := &corev1.ObjectReference{
+		APIVersion: "group.test.io/another-foo",
+		Kind:       "barTemplate",
+		Name:       "another-baz",
+		Namespace:  "default",
+	}
+
+	tests := []struct {
+		name      string
+		in        *clusterv1.ClusterClass
+		old       *clusterv1.ClusterClass
+		expectErr bool
+	}{
+
+		/*
+			CREATE Tests
+		*/
+
+		{
+			name: "create pass",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+							{
+								Class: "bb",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+
+		// empty name in ref tests
+		{
+			name: "create fail infrastructure has empty name",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: refEmptyName},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "create fail control plane class has empty name",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: refEmptyName},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "create fail control plane class machineinfrastructure has empty name",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate:   clusterv1.LocalObjectTemplate{Ref: ref},
+						MachineInfrastructure: &clusterv1.LocalObjectTemplate{Ref: refEmptyName},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "create fail machine deployment bootstrap has empty name",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: refEmptyName},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "create fail machine deployment infrastructure has empty name",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: refEmptyName},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+
+		// inconsistent namespace in ref tests
+		{
+			name: "create fail if infrastructure has inconsistent namespace",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: refInAnotherNamespace},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "create fail if control plane has inconsistent namespace",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: refInAnotherNamespace},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "create fail if control plane class machineinfrastructure has inconsistent namespace",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate:   clusterv1.LocalObjectTemplate{Ref: ref},
+						MachineInfrastructure: &clusterv1.LocalObjectTemplate{Ref: refInAnotherNamespace},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "create fail if machine deployment / bootstrap has inconsistent namespace",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: refInAnotherNamespace},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "create fail if machine deployment / infrastructure has inconsistent namespace",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: refInAnotherNamespace},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+
+		// bad template in ref tests
+		{
+			name: "create fail if bad template in control plane",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: refBadTemplate},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			old:       nil,
+			expectErr: true,
+		},
+		{
+			name: "create fail if bad template in control plane class machineinfrastructure",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate:   clusterv1.LocalObjectTemplate{Ref: ref},
+						MachineInfrastructure: &clusterv1.LocalObjectTemplate{Ref: refBadTemplate},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			old:       nil,
+			expectErr: true,
+		},
+		{
+			name: "create fail if bad template in infrastructure",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: refBadTemplate},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			old:       nil,
+			expectErr: true,
+		},
+		{
+			name: "create fail if bad template in machine deployment bootstrap",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: refBadTemplate},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			old:       nil,
+			expectErr: true,
+		},
+		{
+			name: "create fail if bad template in machine deployment infrastructure",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: refBadTemplate},
+								},
+							},
+						},
+					},
+				},
+			},
+			old:       nil,
+			expectErr: true,
+		},
+
+		// bad apiVersion in ref tests
+		{
+			name: "create fail if bad apiVersion in control plane",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: refBadAPIVersion},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			old:       nil,
+			expectErr: true,
+		},
+		{
+			name: "create fail if bad apiVersion in control plane class machineinfrastructure",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate:   clusterv1.LocalObjectTemplate{Ref: ref},
+						MachineInfrastructure: &clusterv1.LocalObjectTemplate{Ref: refBadAPIVersion},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			old:       nil,
+			expectErr: true,
+		},
+		{
+			name: "create fail if bad apiVersion in infrastructure",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: refBadAPIVersion},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			old:       nil,
+			expectErr: true,
+		},
+		{
+			name: "create fail if bad apiVersion in machine deployment bootstrap",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: refBadAPIVersion},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			old:       nil,
+			expectErr: true,
+		},
+		{
+			name: "create fail if bad apiVersion in machine deployment infrastructure",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: refBadAPIVersion},
+								},
+							},
+						},
+					},
+				},
+			},
+			old:       nil,
+			expectErr: true,
+		},
+
+		// create test
+		{
+			name: "create fail if duplicated DeploymentClasses",
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+
+		/*
+			UPDATE Tests
+		*/
+
+		{
+			name: "update pass in case of no changes",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "update pass if infrastructure changes in a compatible way",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: compatibleRef},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "update fails if infrastructure changes in an incompatible way",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: incompatibleRef},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "update pass if controlPlane changes in a compatible way",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate:   clusterv1.LocalObjectTemplate{Ref: ref},
+						MachineInfrastructure: &clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						Metadata: clusterv1.ObjectMeta{
+							Labels:      map[string]string{"foo": "bar"},
+							Annotations: map[string]string{"foo": "bar"},
+						},
+						LocalObjectTemplate:   clusterv1.LocalObjectTemplate{Ref: compatibleRef},
+						MachineInfrastructure: &clusterv1.LocalObjectTemplate{Ref: compatibleRef},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "update fails if controlPlane changes in an incompatible way (control plane template)",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: incompatibleRef},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "update fails if controlPlane changes in an incompatible way (control plane infrastructure machine template)",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate:   clusterv1.LocalObjectTemplate{Ref: ref},
+						MachineInfrastructure: &clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate:   clusterv1.LocalObjectTemplate{Ref: ref},
+						MachineInfrastructure: &clusterv1.LocalObjectTemplate{Ref: incompatibleRef},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "update pass if a machine deployment changes in a compatible way",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata: clusterv1.ObjectMeta{
+										Labels:      map[string]string{"foo": "bar"},
+										Annotations: map[string]string{"foo": "bar"},
+									},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: incompatibleRef}, // NOTE: this should be tolerated
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: compatibleRef},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "update fails a machine deployment changes in an incompatible way",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Metadata:       clusterv1.ObjectMeta{},
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: incompatibleRef},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "update pass if a machine deployment class gets added",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+							{
+								Class: "bb",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "update fails if a duplicated deployment class gets added",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "update fails if a machine deployment class gets removed",
+			old: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+							{
+								Class: "bb",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			in: &clusterv1.ClusterClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterClassSpec{
+					Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{Ref: ref},
+					},
+					Workers: clusterv1.WorkersClass{
+						MachineDeployments: []clusterv1.MachineDeploymentClass{
+							{
+								Class: "aa",
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap:      clusterv1.LocalObjectTemplate{Ref: ref},
+									Infrastructure: clusterv1.LocalObjectTemplate{Ref: ref},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			webhook := &ClusterClass{}
+			if tt.expectErr {
+				g.Expect(webhook.validate(tt.old, tt.in)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.validate(tt.old, tt.in)).To(Succeed())
+			}
+		})
 	}
 }


### PR DESCRIPTION
Move the implementations of validation checks from the internal API package to the webhooks package. The webhooks package was previously calling the public methods in the API package which are deprecated and due to be removed in a future release.

Some details of the internal methods of the validation methods were changed in order to make this move.

Fixes #5594 
