### PR TITLE
🌱 e2e: self-hosted (clusterctl move) with clusterclass

### DIFF
--- a/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
@@ -103,7 +103,10 @@ metadata:
   name: quick-start-docker-worker-machinetemplate
 spec:
   template:
-    spec: {}
+    spec:
+      extraMounts:
+      - containerPath: "/var/run/docker.sock"
+        hostPath: "/var/run/docker.sock"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -114,6 +117,7 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
             # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726

--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -99,11 +100,28 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 
 		By("Turning the workload cluster into a management cluster")
 
-		// In case of the cluster id a DockerCluster, we should load controller images into the nodes.
+		// In case the cluster is a DockerCluster, we should load controller images into the nodes.
 		// Nb. this can be achieved also by changing the DockerMachine spec, but for the time being we are using
 		// this approach because this allows to have a single source of truth for images, the e2e config
+		// Nb. If the cluster is a managed topology cluster.Spec.InfrastructureRef will be nil till
+		// the cluster object is reconciled. Therefore, we always try to fetch the reconciled cluster object from
+		// the server to check if it is a DockerCluster.
 		cluster := clusterResources.Cluster
-		if cluster.Spec.InfrastructureRef.Kind == "DockerCluster" {
+		isDockerCluster := false
+		Eventually(func() error {
+			c := input.BootstrapClusterProxy.GetClient()
+			tmpCluster := &clusterv1.Cluster{}
+			if err := c.Get(ctx, client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}, tmpCluster); err != nil {
+				return err
+			}
+			if tmpCluster.Spec.InfrastructureRef != nil {
+				isDockerCluster = tmpCluster.Spec.InfrastructureRef.Kind == "DockerCluster"
+				return nil
+			}
+			return errors.New("cluster object not yet reconciled")
+		}, "1m", "5s").Should(Succeed())
+
+		if isDockerCluster {
 			Expect(bootstrap.LoadImagesToKindCluster(ctx, bootstrap.LoadImagesToKindClusterInput{
 				Name:   cluster.Name,
 				Images: input.E2EConfig.Images,

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -31,6 +32,21 @@ var _ = Describe("When testing Cluster API working on self-hosted clusters", fun
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
+		}
+	})
+
+})
+
+var _ = Describe("When testing Cluster API working on self-hosted clusters using ClusterClass", func() {
+
+	SelfHostedSpec(ctx, func() SelfHostedSpecInput {
+		return SelfHostedSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+			Flavor:                "topology",
 		}
 	})
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR add another self-hosted E2E test (tests `clusterctl move`) to also work with ClusterClass based clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
