### PR TITLE
🐛 fix topologyReconcileLogger

### DIFF
--- a/controllers/topology/internal/log/log.go
+++ b/controllers/topology/internal/log/log.go
@@ -76,40 +76,44 @@ type topologyReconcileLogger struct {
 // WithObject adds to the logger information about the object being modified by reconcile, which in most case it is
 // a resources being part of the Cluster by reconciled.
 func (l *topologyReconcileLogger) WithObject(obj client.Object) Logger {
-	l.Logger = l.Logger.WithValues(
-		"object groupVersion", obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
-		"object kind", obj.GetObjectKind().GroupVersionKind().Kind,
-		"object", obj.GetName(),
-	)
-	return l
+	return &topologyReconcileLogger{
+		Logger: l.Logger.WithValues(
+			"object groupVersion", obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+			"object kind", obj.GetObjectKind().GroupVersionKind().Kind,
+			"object", obj.GetName(),
+		),
+	}
 }
 
 // WithRef adds to the logger information about the object ref being modified by reconcile, which in most case it is
 // a resources being part of the Cluster by reconciled.
 func (l *topologyReconcileLogger) WithRef(ref *corev1.ObjectReference) Logger {
-	l.Logger = l.Logger.WithValues(
-		"object groupVersion", ref.APIVersion,
-		"object kind", ref.Kind,
-		"object", ref.Name,
-	)
-	return l
+	return &topologyReconcileLogger{
+		Logger: l.Logger.WithValues(
+			"object groupVersion", ref.APIVersion,
+			"object kind", ref.Kind,
+			"object", ref.Name,
+		),
+	}
 }
 
 // WithMachineDeployment adds to the logger information about the MachineDeployment object being processed.
 func (l *topologyReconcileLogger) WithMachineDeployment(md *clusterv1.MachineDeployment) Logger {
 	topologyName := md.Labels[clusterv1.ClusterTopologyMachineDeploymentLabelName]
-	l.Logger = l.Logger.WithValues(
-		"machineDeployment name", md.GetName(),
-		"machineDeployment topologyName", topologyName,
-	)
-	return l
+	return &topologyReconcileLogger{
+		Logger: l.Logger.WithValues(
+			"machineDeployment name", md.GetName(),
+			"machineDeployment topologyName", topologyName,
+		),
+	}
 }
 
 // V returns a logger value for a specific verbosity level, relative to
 // this logger.
 func (l *topologyReconcileLogger) V(level int) Logger {
-	l.Logger = l.Logger.V(level)
-	return l
+	return &topologyReconcileLogger{
+		Logger: l.Logger.V(level),
+	}
 }
 
 // Infof logs to the INFO log.


### PR DESCRIPTION
**What this PR does / why we need it**:
Current implementation of topology reconcile logger always mutate the current logger when calling WithObject/WithRef/WithMachineDeployment in addition to returning a new one.

This could lead to values leaking in while we are doing multiple calls to those methods with different objects, e.g. in 

https://github.com/kubernetes-sigs/cluster-api/blob/87be2ec7eb52d459ddd34e4dacd1ea654128ea63/controllers/topology/reconcile_state.go#L175

This PR removes the side effect, thus making the logger behaviour consistent to the original logr.Logger.