### PR TITLE
📖 ClusterClass proposal: remove builtin labels & annotations variables, add new

### DIFF
--- a/docs/proposals/202105256-cluster-class-and-managed-topologies.md
+++ b/docs/proposals/202105256-cluster-class-and-managed-topologies.md
@@ -571,11 +571,11 @@ Note: Builtin variables are defined in [Builtin variables](#builtin-variables) b
 #### Builtin variables
 
 It’s also possible to use so-called builtin variables in addition to user-defined variables. The following builtin variables are available:
-- `builtin.cluster.{name,namespace,labels,annotations}`
+- `builtin.cluster.{name,namespace}`
 - `builtin.cluster.topology.{version,class}`
-- `builtin.controlPlane.{labels,annotations,replicas,version}`
+- `builtin.controlPlane.{replicas,version}`
     - **Note**: these variables are only available when patching control plane or control plane machine templates.
-- `builtin.machineDeployment.{labels,annotations,replicas,version,class,name,topologyName}`
+- `builtin.machineDeployment.{replicas,version,class,name,topologyName}`
     - **Note**: these variables are only available when patching MachineDeployment templates and contain the values 
       of the current `MachineDeploymentTopology`.
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
For now we won't implement builtin labels/annotations variables. So let's update the ClusterClass proposal to reflect that to avoid confusing users.

Depending on the outcome of the discussion https://github.com/kubernetes-sigs/cluster-api/issues/5577 we can potentially introduce the labels/annotations variables later and add them to the proposal again.

This PR also syncs the other labels with the latest results from #5534.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
