### PR TITLE
🌱 Use internal/builders in tests for webhook package

### DIFF
--- a/cmd/clusterctl/internal/test/fake_objects.go
+++ b/cmd/clusterctl/internal/test/fake_objects.go
@@ -1448,7 +1448,7 @@ func (f *FakeClusterClass) Objs() []client.Object {
 			objMap[fakeMDClass.bootstrapTemplate] = true
 			objMap[fakeMDClass.infrastructureTemplate] = true
 		}
-		clusterClassBuilder.WithWorkerMachineDeploymentClasses(mdClasses)
+		clusterClassBuilder.WithWorkerMachineDeploymentClasses(mdClasses...)
 	}
 
 	clusterClass := clusterClassBuilder.Build()

--- a/controllers/topology/blueprint_test.go
+++ b/controllers/topology/blueprint_test.go
@@ -182,7 +182,7 @@ func TestGetBlueprint(t *testing.T) {
 			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
 				WithInfrastructureClusterTemplate(infraClusterTemplate).
 				WithControlPlaneTemplate(controlPlaneTemplate).
-				WithWorkerMachineDeploymentClasses(mds).
+				WithWorkerMachineDeploymentClasses(mds...).
 				Build(),
 			objects: []client.Object{
 				infraClusterTemplate,
@@ -194,7 +194,7 @@ func TestGetBlueprint(t *testing.T) {
 				ClusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
 					WithInfrastructureClusterTemplate(infraClusterTemplate).
 					WithControlPlaneTemplate(controlPlaneTemplate).
-					WithWorkerMachineDeploymentClasses(mds).
+					WithWorkerMachineDeploymentClasses(mds...).
 					Build(),
 				InfrastructureClusterTemplate: infraClusterTemplate,
 				ControlPlane: &scope.ControlPlaneBlueprint{
@@ -217,7 +217,7 @@ func TestGetBlueprint(t *testing.T) {
 			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
 				WithInfrastructureClusterTemplate(infraClusterTemplate).
 				WithControlPlaneTemplate(controlPlaneTemplate).
-				WithWorkerMachineDeploymentClasses(mds).
+				WithWorkerMachineDeploymentClasses(mds...).
 				Build(),
 			objects: []client.Object{
 				infraClusterTemplate,
@@ -232,7 +232,7 @@ func TestGetBlueprint(t *testing.T) {
 			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
 				WithInfrastructureClusterTemplate(infraClusterTemplate).
 				WithControlPlaneTemplate(controlPlaneTemplate).
-				WithWorkerMachineDeploymentClasses(mds).
+				WithWorkerMachineDeploymentClasses(mds...).
 				Build(),
 			objects: []client.Object{
 				infraClusterTemplate,

--- a/controllers/topology/cluster_controller_test.go
+++ b/controllers/topology/cluster_controller_test.go
@@ -325,7 +325,7 @@ func setupTestEnvForIntegrationTests(ns *corev1.Namespace) (func() error, error)
 		WithInfrastructureClusterTemplate(infrastructureClusterTemplate).
 		WithControlPlaneTemplate(controlPlaneTemplate).
 		WithControlPlaneInfrastructureMachineTemplate(infrastructureMachineTemplate).
-		WithWorkerMachineDeploymentClasses([]clusterv1.MachineDeploymentClass{*machineDeploymentClass1, *machineDeploymentClass2}).
+		WithWorkerMachineDeploymentClasses(*machineDeploymentClass1, *machineDeploymentClass2).
 		Build()
 
 	// 3) Two Clusters including a Cluster Topology objects and the MachineDeploymentTopology objects used in the

--- a/controllers/topology/clusterclass_controller_test.go
+++ b/controllers/topology/clusterclass_controller_test.go
@@ -76,7 +76,7 @@ func TestClusterClassReconciler_reconcile(t *testing.T) {
 		WithInfrastructureClusterTemplate(infraClusterTemplate).
 		WithControlPlaneTemplate(controlPlaneTemplate).
 		WithControlPlaneInfrastructureMachineTemplate(infraMachineTemplateControlPlane).
-		WithWorkerMachineDeploymentClasses([]clusterv1.MachineDeploymentClass{*machineDeploymentClass1, *machineDeploymentClass2}).
+		WithWorkerMachineDeploymentClasses(*machineDeploymentClass1, *machineDeploymentClass2).
 		Build()
 
 	// Create the set of initObjects from the objects above to add to the API server when the test environment starts.

--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -677,7 +677,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 		Build()
 	mcds := []clusterv1.MachineDeploymentClass{*md1}
 	fakeClass := builder.ClusterClass(metav1.NamespaceDefault, "class1").
-		WithWorkerMachineDeploymentClasses(mcds).
+		WithWorkerMachineDeploymentClasses(mcds...).
 		Build()
 
 	version := "v1.21.2"

--- a/controllers/topology/internal/extensions/patches/engine_test.go
+++ b/controllers/topology/internal/extensions/patches/engine_test.go
@@ -466,7 +466,7 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 		WithInfrastructureClusterTemplate(infrastructureClusterTemplate).
 		WithControlPlaneTemplate(controlPlaneTemplate).
 		WithControlPlaneInfrastructureMachineTemplate(controlPlaneInfrastructureMachineTemplate).
-		WithWorkerMachineDeploymentClasses([]clusterv1.MachineDeploymentClass{*mdClass1}).
+		WithWorkerMachineDeploymentClasses(*mdClass1).
 		Build()
 
 	cluster := &clusterv1.Cluster{

--- a/internal/builder/builders.go
+++ b/internal/builder/builders.go
@@ -219,7 +219,7 @@ func (c *ClusterClassBuilder) WithControlPlaneInfrastructureMachineTemplate(t *u
 }
 
 // WithWorkerMachineDeploymentClasses adds the variables and objects needed to create MachineDeploymentTemplates for a ClusterClassBuilder.
-func (c *ClusterClassBuilder) WithWorkerMachineDeploymentClasses(mdcs []clusterv1.MachineDeploymentClass) *ClusterClassBuilder {
+func (c *ClusterClassBuilder) WithWorkerMachineDeploymentClasses(mdcs ...clusterv1.MachineDeploymentClass) *ClusterClassBuilder {
 	if c.machineDeploymentClasses == nil {
 		c.machineDeploymentClasses = make([]clusterv1.MachineDeploymentClass, 0)
 	}

--- a/webhooks/cluster.go
+++ b/webhooks/cluster.go
@@ -252,7 +252,7 @@ func (webhook *Cluster) validateTopology(ctx context.Context, old, new *clusterv
 		allErrs = append(
 			allErrs, field.Invalid(
 				field.NewPath("spec", "topology", "class"),
-				new.Name,
+				new.Spec.Topology.Class,
 				"ClusterClass could not be found"))
 	}
 	return allErrs

--- a/webhooks/cluster_test.go
+++ b/webhooks/cluster_test.go
@@ -57,17 +57,12 @@ func TestClusterDefaultTopologyVersion(t *testing.T) {
 
 	g := NewWithT(t)
 
-	c := &clusterv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "fooboo",
-		},
-		Spec: clusterv1.ClusterSpec{
-			Topology: &clusterv1.Topology{
-				Class:   "foo",
-				Version: "1.19.1",
-			},
-		},
-	}
+	c := builder.Cluster("fooboo", "cluster1").
+		WithTopology(builder.ClusterTopology().
+			WithClass("foo").
+			WithVersion("1.19.1").
+			Build()).
+		Build()
 
 	// Sets up the fakeClient for the test case. This is required because the test uses a Managed Topology.
 	fakeClient := fake.NewClientBuilder().
@@ -87,83 +82,56 @@ func TestClusterDefaultTopologyVersion(t *testing.T) {
 func TestClusterValidation(t *testing.T) {
 	// NOTE: ClusterTopology feature flag is disabled by default, thus preventing to set Cluster.Topologies.
 
-	tests := []struct {
-		name      string
-		in        *clusterv1.Cluster
-		old       *clusterv1.Cluster
-		expectErr bool
-	}{
-		{
-			name:      "should return error when cluster namespace and infrastructure ref namespace mismatch",
-			expectErr: true,
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					InfrastructureRef: &corev1.ObjectReference{
-						Namespace: "bar",
-					},
-					ControlPlaneRef: &corev1.ObjectReference{
-						Namespace: "foo",
-					},
-				},
+	var (
+		tests = []struct {
+			name      string
+			in        *clusterv1.Cluster
+			old       *clusterv1.Cluster
+			expectErr bool
+		}{
+			{
+				name:      "should return error when cluster namespace and infrastructure ref namespace mismatch",
+				expectErr: true,
+				in: builder.Cluster("fooNamespace", "cluster1").
+					WithInfrastructureCluster(
+						builder.InfrastructureClusterTemplate("barNamespace", "infra1").Build()).
+					WithControlPlane(
+						builder.ControlPlane("fooNamespace", "cp1").Build()).
+					Build(),
 			},
-		},
-		{
-			name:      "should return error when cluster namespace and controlplane ref namespace mismatch",
-			expectErr: true,
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					InfrastructureRef: &corev1.ObjectReference{
-						Namespace: "foo",
-					},
-					ControlPlaneRef: &corev1.ObjectReference{
-						Namespace: "bar",
-					},
-				},
+			{
+				name:      "should return error when cluster namespace and controlPlane ref namespace mismatch",
+				expectErr: true,
+				in: builder.Cluster("fooNamespace", "cluster1").
+					WithInfrastructureCluster(
+						builder.InfrastructureClusterTemplate("fooNamespace", "infra1").Build()).
+					WithControlPlane(
+						builder.ControlPlane("barNamespace", "cp1").Build()).
+					Build(),
 			},
-		},
-		{
-			name:      "should succeed when namespaces match",
-			expectErr: false,
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					ControlPlaneRef: &corev1.ObjectReference{
-						Namespace: "foo",
-					},
-					InfrastructureRef: &corev1.ObjectReference{
-						Namespace: "foo",
-					},
-				},
+			{
+				name:      "should succeed when namespaces match",
+				expectErr: false,
+				in: builder.Cluster("fooNamespace", "cluster1").
+					WithInfrastructureCluster(
+						builder.InfrastructureClusterTemplate("fooNamespace", "infra1").Build()).
+					WithControlPlane(
+						builder.ControlPlane("fooNamespace", "cp1").Build()).
+					Build(),
 			},
-		},
-		{
-			name:      "fails if topology is set but feature flag is disabled",
-			expectErr: true,
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "foo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					ControlPlaneRef: &corev1.ObjectReference{
-						Namespace: "foo",
-					},
-					InfrastructureRef: &corev1.ObjectReference{
-						Namespace: "foo",
-					},
-					Topology: &clusterv1.Topology{},
-				},
+			{
+				name:      "fails if topology is set but feature flag is disabled",
+				expectErr: true,
+				in: builder.Cluster("fooNamespace", "cluster1").
+					WithInfrastructureCluster(
+						builder.InfrastructureClusterTemplate("fooNamespace", "infra1").Build()).
+					WithControlPlane(
+						builder.ControlPlane("fooNamespace", "cp1").Build()).
+					WithTopology(&clusterv1.Topology{}).
+					Build(),
 			},
-		},
-	}
-
+		}
+	)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
@@ -195,317 +163,166 @@ func TestClusterTopologyValidation(t *testing.T) {
 		{
 			name:      "should return error when topology does not have class",
 			expectErr: true,
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{},
-				},
-			},
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(&clusterv1.Topology{}).
+				Build(),
 		},
 		{
 			name:      "should return error when topology does not have valid version",
 			expectErr: true,
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "invalid",
-					},
-				},
-			},
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("invalid").Build()).
+				Build(),
 		},
 		{
 			name:      "should return error when downgrading topology version - major",
 			expectErr: true,
-			old: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v2.2.3",
-					},
-				},
-			},
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.2.3",
-					},
-				},
-			},
+			old: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v2.2.3").
+					Build()).
+				Build(),
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.2.3").
+					Build()).
+				Build(),
 		},
 		{
 			name:      "should return error when downgrading topology version - minor",
 			expectErr: true,
-			old: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.2.3",
-					},
-				},
-			},
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.1.3",
-					},
-				},
-			},
+			old: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.2.3").
+					Build()).
+				Build(),
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.1.3").
+					Build()).
+				Build(),
 		},
 		{
 			name:      "should return error when downgrading topology version - patch",
 			expectErr: true,
-			old: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.2.3",
-					},
-				},
-			},
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.2.2",
-					},
-				},
-			},
+			old: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.2.3").
+					Build()).
+				Build(),
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.2.2").
+					Build()).
+				Build(),
 		},
 		{
 			name:      "should return error when downgrading topology version - pre-release",
 			expectErr: true,
-			old: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.2.3-xyz.2",
-					},
-				},
-			},
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.2.3-xyz.1",
-					},
-				},
-			},
+			old: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.2.3-xyz.2").
+					Build()).
+				Build(),
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.2.3-xyz.1").
+					Build()).
+				Build(),
 		},
 		{
 			name:      "should return error when downgrading topology version - build tag",
 			expectErr: true,
-			old: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.2.3+xyz.2",
-					},
-				},
-			},
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.2.3+xyz.1",
-					},
-				},
-			},
+			old: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.2.3+xyz.2").
+					Build()).
+				Build(),
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.2.3+xyz.1").
+					Build()).
+				Build(),
 		},
 		{
 			name:      "should return error when duplicated MachineDeployments names exists in a Topology",
 			expectErr: true,
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.19.1",
-						Workers: &clusterv1.WorkersTopology{
-							MachineDeployments: []clusterv1.MachineDeploymentTopology{
-								{
-									Name: "aa",
-								},
-								{
-									Name: "aa",
-								},
-							},
-						},
-					},
-				},
-			},
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.19.1").
+					WithMachineDeployment(
+						builder.MachineDeploymentTopology("aa").Build()).
+					WithMachineDeployment(
+						builder.MachineDeploymentTopology("aa").Build()).
+					Build()).
+				Build(),
 		},
 		{
 			name:      "should pass when MachineDeployments names in a Topology are unique",
 			expectErr: false,
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.19.1",
-						Workers: &clusterv1.WorkersTopology{
-							MachineDeployments: []clusterv1.MachineDeploymentTopology{
-								{
-									Name: "aa",
-								},
-								{
-									Name: "bb",
-								},
-							},
-						},
-					},
-				},
-			},
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.19.1").
+					WithMachineDeployment(
+						builder.MachineDeploymentTopology("aa").Build()).
+					WithMachineDeployment(
+						builder.MachineDeploymentTopology("bb").Build()).
+					Build()).
+				Build(),
 		},
 		{
 			name:      "should return error on update when Topology class is changed",
 			expectErr: true,
-			old: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					InfrastructureRef: &corev1.ObjectReference{},
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.19.1",
-					},
-				},
-			},
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					InfrastructureRef: &corev1.ObjectReference{},
-					Topology: &clusterv1.Topology{
-						Class:   "bar",
-						Version: "v1.19.1",
-					},
-				},
-			},
-		},
-		{
-			name:      "should return error on update when Topology version is downgraded",
-			expectErr: true,
-			old: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					InfrastructureRef: &corev1.ObjectReference{},
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.19.1",
-					},
-				},
-			},
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					InfrastructureRef: &corev1.ObjectReference{},
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.19.0",
-					},
-				},
-			},
+			old: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.19.1").
+					Build()).
+				Build(),
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("bar").
+					WithVersion("v1.19.1").
+					Build()).
+				Build(),
 		},
 		{
 			name:      "should update",
 			expectErr: false,
-			old: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					InfrastructureRef: &corev1.ObjectReference{
-						Namespace: "fooboo",
-					},
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.19.1",
-						Workers: &clusterv1.WorkersTopology{
-							MachineDeployments: []clusterv1.MachineDeploymentTopology{
-								{
-									Name: "aa",
-								},
-								{
-									Name: "bb",
-								},
-							},
-						},
-					},
-				},
-			},
-			in: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "fooboo",
-				},
-				Spec: clusterv1.ClusterSpec{
-					InfrastructureRef: &corev1.ObjectReference{
-						Namespace: "fooboo",
-					},
-					Topology: &clusterv1.Topology{
-						Class:   "foo",
-						Version: "v1.19.2",
-						Workers: &clusterv1.WorkersTopology{
-							MachineDeployments: []clusterv1.MachineDeploymentTopology{
-								{
-									Name: "aa",
-								},
-								{
-									Name: "bb",
-								},
-							},
-						},
-					},
-				},
-			},
+			old: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.19.1").
+					WithMachineDeployment(
+						builder.MachineDeploymentTopology("aa").Build()).
+					WithMachineDeployment(
+						builder.MachineDeploymentTopology("bb").Build()).
+					Build()).
+				Build(),
+			in: builder.Cluster("fooboo", "cluster1").
+				WithTopology(builder.ClusterTopology().
+					WithClass("foo").
+					WithVersion("v1.19.2").
+					WithMachineDeployment(
+						builder.MachineDeploymentTopology("aa").Build()).
+					WithMachineDeployment(
+						builder.MachineDeploymentTopology("bb").Build()).
+					Build()).
+				Build(),
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

This updates the unit tests in the webhooks folder to use our test builders instead of raw structs. This will make it easier to create new tests for compatibility and variables in the webhooks package.

Fixes #5621 
