### PR TITLE
🐛 fix Tiltfile from clean-bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ controller-gen: $(CONTROLLER_GEN) ## Build a local copy of controller-gen.
 conversion-gen: $(CONVERSION_GEN) ## Build a local copy of conversion-gen.
 conversion-verifier: $(CONVERSION_VERIFIER) ## Build a local copy of conversion-verifier.
 gotestsum: $(GOTESTSUM) ## Build a local copy of gotestsum.
+yq: $(YQ)  ## Build a local copy of yq.
 
 .PHONY: e2e-framework
 e2e-framework: ## Builds the CAPI e2e framework

--- a/Tiltfile
+++ b/Tiltfile
@@ -328,9 +328,13 @@ def ensure_yq():
     if not os.path.exists(yq_cmd):
         local("make {}".format(yq_cmd))
 
+def ensure_envsubst():
+    if not os.path.exists(envsubst_cmd):
+        local("make {}".format(os.path.abspath(envsubst_cmd)))
+
 def ensure_kustomize():
     if not os.path.exists(kustomize_cmd):
-        local("make {}".format(kustomize_cmd))
+        local("make {}".format(os.path.abspath(kustomize_cmd)))
 
 def deploy_observability():
     k8s_yaml(blob(str(local("{} build {}".format(kustomize_cmd, "./hack/observability/"), quiet = True))))
@@ -344,6 +348,7 @@ def deploy_observability():
 ##############################
 
 ensure_yq()
+ensure_envsubst()
 ensure_kustomize()
 
 include_user_tilt_files()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the Tiltfile so it can start after running `make clean-bin`
It also add `make yq` so the users now can build all the required tools with dedicate make targets