### PR TITLE
📖 Update prerequisites for installing Metal3 provider

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -557,6 +557,10 @@ A full configuration reference can be found in [configuration.md](https://github
 {{#/tab }}
 {{#tab Metal3}}
 
+**Note**: If you are running CAPM3 release prior to v0.5.0, make sure to export the following
+environment variables. However, you don't need them to be exported if you use
+CAPM3 release v0.5.0 or higher.
+
 ```bash
 # The URL of the kernel to deploy.
 export DEPLOY_KERNEL_URL="http://172.22.0.1:6180/images/ironic-python-agent.kernel"


### PR DESCRIPTION
**What this PR does / why we need it**:
From release [v0.5.0](https://github.com/metal3-io/cluster-api-provider-metal3/releases/tag/v0.5.0) of Cluster-api-provider-metal3, the following
environment variables don't need to be exported because Baremetal
Operator is now decoupled from CAPM3. Instead, they need to be
exported when installing Baremetal Operator manually (not via
clusterctl).

