### PR TITLE
✨ Enable ClusterClass rebase operation

### DIFF
--- a/controllers/topology/blueprint_test.go
+++ b/controllers/topology/blueprint_test.go
@@ -248,15 +248,16 @@ func TestGetBlueprint(t *testing.T) {
 			g := NewWithT(t)
 
 			// Set up a cluster using the ClusterClass, if any.
-			cluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").Build()
-			if tt.clusterClass != nil {
-				cluster.Spec.Topology = &clusterv1.Topology{
-					Class: tt.clusterClass.Name,
-				}
-			} else {
-				cluster.Spec.Topology = &clusterv1.Topology{
-					Class: "foo",
-				}
+			cluster := builder.Cluster(metav1.NamespaceDefault, "cluster1").
+				WithTopology(
+					builder.ClusterTopology().
+						WithClass("class1").
+						Build()).
+				Build()
+
+			// If no clusterClass is defined in the test case fill in a dummy value "foo".
+			if tt.clusterClass == nil {
+				cluster.Spec.Topology.Class = "foo"
 			}
 
 			// Sets up the fakeClient for the test case.

--- a/internal/builder/builders.go
+++ b/internal/builder/builders.go
@@ -304,21 +304,26 @@ func (m *MachineDeploymentClassBuilder) WithAnnotations(annotations map[string]s
 
 // Build creates a full MachineDeploymentClass object with the variables passed to the MachineDeploymentClassBuilder.
 func (m *MachineDeploymentClassBuilder) Build() *clusterv1.MachineDeploymentClass {
-	return &clusterv1.MachineDeploymentClass{
+	obj := &clusterv1.MachineDeploymentClass{
 		Class: m.class,
 		Template: clusterv1.MachineDeploymentClassTemplate{
 			Metadata: clusterv1.ObjectMeta{
 				Labels:      m.labels,
 				Annotations: m.annotations,
 			},
-			Bootstrap: clusterv1.LocalObjectTemplate{
-				Ref: objToRef(m.bootstrapTemplate),
-			},
-			Infrastructure: clusterv1.LocalObjectTemplate{
-				Ref: objToRef(m.infrastructureMachineTemplate),
-			},
 		},
 	}
+	if m.bootstrapTemplate != nil {
+		obj.Template.Bootstrap = clusterv1.LocalObjectTemplate{
+			Ref: objToRef(m.bootstrapTemplate),
+		}
+	}
+	if m.infrastructureMachineTemplate != nil {
+		obj.Template.Infrastructure = clusterv1.LocalObjectTemplate{
+			Ref: objToRef(m.infrastructureMachineTemplate),
+		}
+	}
+	return obj
 }
 
 // InfrastructureMachineTemplateBuilder holds the variables and objects needed to build an InfrastructureMachineTemplate.

--- a/internal/topology/check/compatibility.go
+++ b/internal/topology/check/compatibility.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,7 +35,8 @@ func ObjectsAreStrictlyCompatible(current, desired client.Object) field.ErrorLis
 	if current.GetName() != desired.GetName() {
 		allErrs = append(allErrs, field.Forbidden(
 			field.NewPath("metadata", "name"),
-			fmt.Sprintf("cannot be changed from %v to %v to prevent incompatible changes in %v/%v", current.GetName(), desired.GetName(), current.GetObjectKind().GroupVersionKind().GroupKind().String(), current.GetName()),
+			fmt.Sprintf("cannot be changed from %v to %v to prevent incompatible changes in %v/%v",
+				current.GetName(), desired.GetName(), current.GetObjectKind().GroupVersionKind().GroupKind().String(), current.GetName()),
 		))
 	}
 	allErrs = append(allErrs, ObjectsAreCompatible(current, desired)...)
@@ -51,13 +53,15 @@ func ObjectsAreCompatible(current, desired client.Object) field.ErrorList {
 	if currentGK.Group != desiredGK.Group {
 		allErrs = append(allErrs, field.Forbidden(
 			field.NewPath("metadata", "apiVersion"),
-			fmt.Sprintf("group cannot be changed from %v to %v to prevent incompatible changes in %v/%v", currentGK.Group, desiredGK.Group, currentGK.String(), current.GetName()),
+			fmt.Sprintf("group cannot be changed from %v to %v to prevent incompatible changes in %v/%v",
+				currentGK.Group, desiredGK.Group, currentGK.String(), current.GetName()),
 		))
 	}
 	if currentGK.Kind != desiredGK.Kind {
 		allErrs = append(allErrs, field.Forbidden(
 			field.NewPath("metadata", "kind"),
-			fmt.Sprintf("cannot be changed from %v to %v to prevent incompatible changes in %v/%v", currentGK.Kind, desiredGK.Kind, currentGK.String(), current.GetName()),
+			fmt.Sprintf("cannot be changed from %v to %v to prevent incompatible changes in %v/%v",
+				currentGK.Kind, desiredGK.Kind, currentGK.String(), current.GetName()),
 		))
 	}
 	allErrs = append(allErrs, ObjectsAreInTheSameNamespace(current, desired)...)
@@ -80,7 +84,7 @@ func ObjectsAreInTheSameNamespace(current, desired client.Object) field.ErrorLis
 
 // LocalObjectTemplatesAreCompatible checks if two referenced objects are compatible, meaning that
 // they are of the same GroupKind and in the same namespace.
-func LocalObjectTemplatesAreCompatible(current, desired clusterv1.LocalObjectTemplate) field.ErrorList {
+func LocalObjectTemplatesAreCompatible(current, desired clusterv1.LocalObjectTemplate, pathPrefix *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	currentGK := current.Ref.GetObjectKind().GroupVersionKind().GroupKind()
@@ -88,38 +92,39 @@ func LocalObjectTemplatesAreCompatible(current, desired clusterv1.LocalObjectTem
 
 	if currentGK.Group != desiredGK.Group {
 		allErrs = append(allErrs, field.Forbidden(
-			field.NewPath("metadata", "apiVersion"),
+			pathPrefix.Child("ref", "apiVersion"),
 			fmt.Sprintf("group cannot be changed from %v to %v to prevent incompatible changes in %v/%v", currentGK.Group, desiredGK.Group, currentGK.String(), current.Ref.Name),
 		))
 	}
 	if currentGK.Kind != desiredGK.Kind {
 		allErrs = append(allErrs, field.Forbidden(
-			field.NewPath("metadata", "kind"),
+			pathPrefix.Child("ref", "kind"),
 			fmt.Sprintf("cannot be changed from %v to %v to prevent incompatible changes in %v/%v", currentGK.Kind, desiredGK.Kind, currentGK.String(), current.Ref.Name),
 		))
 	}
-	allErrs = append(allErrs, LocalObjectTemplatesAreInSameNamespace(current, desired)...)
+	allErrs = append(allErrs, LocalObjectTemplatesAreInSameNamespace(current, desired, pathPrefix)...)
 	return allErrs
 }
 
 // LocalObjectTemplatesAreInSameNamespace checks if two referenced objects are in the same namespace.
-func LocalObjectTemplatesAreInSameNamespace(current, desired clusterv1.LocalObjectTemplate) field.ErrorList {
+func LocalObjectTemplatesAreInSameNamespace(current, desired clusterv1.LocalObjectTemplate, pathPrefix *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if current.Ref.Namespace != desired.Ref.Namespace {
 		allErrs = append(allErrs, field.Forbidden(
-			field.NewPath("metadata", "namespace"),
-			fmt.Sprintf("cannot be changed from %v to %v to prevent incompatible changes in %v/%v", current.Ref.Namespace, desired.Ref.Namespace, current.Ref.GetObjectKind().GroupVersionKind().GroupKind().String(), current.Ref.Name),
+			pathPrefix.Child("ref", "namespace"),
+			fmt.Sprintf("cannot be changed from %v to %v to prevent incompatible changes in %v/%v",
+				current.Ref.Namespace, desired.Ref.Namespace, current.Ref.GetObjectKind().GroupVersionKind().GroupKind().String(), current.Ref.Name),
 		))
 	}
 	return allErrs
 }
 
 // LocalObjectTemplateIsValid ensures the template is in the correct namespace, has no nil references, and has a valid Kind and GroupVersion.
-func LocalObjectTemplateIsValid(in *clusterv1.LocalObjectTemplate, namespace string, pathPrefix *field.Path) field.ErrorList {
+func LocalObjectTemplateIsValid(template *clusterv1.LocalObjectTemplate, namespace string, pathPrefix *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	// check if ref is not nil.
-	if in.Ref == nil {
+	if template.Ref == nil {
 		return field.ErrorList{field.Invalid(
 			pathPrefix.Child("ref"),
 			"nil",
@@ -128,46 +133,46 @@ func LocalObjectTemplateIsValid(in *clusterv1.LocalObjectTemplate, namespace str
 	}
 
 	// check if a name is provided
-	if in.Ref.Name == "" {
+	if template.Ref.Name == "" {
 		allErrs = append(allErrs,
 			field.Invalid(
 				pathPrefix.Child("ref", "name"),
-				in.Ref.Name,
+				template.Ref.Name,
 				"cannot be empty",
 			),
 		)
 	}
 
 	// validate if namespace matches the provided namespace
-	if namespace != "" && in.Ref.Namespace != namespace {
+	if namespace != "" && template.Ref.Namespace != namespace {
 		allErrs = append(
 			allErrs,
 			field.Invalid(
 				pathPrefix.Child("ref", "namespace"),
-				in.Ref.Namespace,
+				template.Ref.Namespace,
 				fmt.Sprintf("must be '%s'", namespace),
 			),
 		)
 	}
 
 	// check if kind is a template
-	if len(in.Ref.Kind) <= len(clusterv1.TemplateSuffix) || !strings.HasSuffix(in.Ref.Kind, clusterv1.TemplateSuffix) {
+	if len(template.Ref.Kind) <= len(clusterv1.TemplateSuffix) || !strings.HasSuffix(template.Ref.Kind, clusterv1.TemplateSuffix) {
 		allErrs = append(allErrs,
 			field.Invalid(
 				pathPrefix.Child("ref", "kind"),
-				in.Ref.Kind,
+				template.Ref.Kind,
 				fmt.Sprintf("kind must be of form '<name>%s'", clusterv1.TemplateSuffix),
 			),
 		)
 	}
 
 	// check if apiVersion is valid
-	gv, err := schema.ParseGroupVersion(in.Ref.APIVersion)
+	gv, err := schema.ParseGroupVersion(template.Ref.APIVersion)
 	if err != nil {
 		allErrs = append(allErrs,
 			field.Invalid(
 				pathPrefix.Child("ref", "apiVersion"),
-				in.Ref.APIVersion,
+				template.Ref.APIVersion,
 				fmt.Sprintf("must be a valid apiVersion: %v", err),
 			),
 		)
@@ -176,10 +181,164 @@ func LocalObjectTemplateIsValid(in *clusterv1.LocalObjectTemplate, namespace str
 		allErrs = append(allErrs,
 			field.Invalid(
 				pathPrefix.Child("ref", "apiVersion"),
-				in.Ref.APIVersion,
+				template.Ref.APIVersion,
 				"value cannot be empty",
 			),
 		)
 	}
 	return allErrs
+}
+
+// ClusterClassesAreCompatible checks the compatibility between new and old versions of a Cluster Class.
+// It checks that:
+// 1) InfrastructureCluster Templates are compatible.
+// 2) ControlPlane Templates are compatible.
+// 3) ControlPlane InfrastructureMachineTemplates are compatible.
+// 4) MachineDeploymentClasses have not been deleted and are compatible.
+func ClusterClassesAreCompatible(current, desired *clusterv1.ClusterClass) field.ErrorList {
+	var allErrs field.ErrorList
+	if current == nil {
+		return nil
+	}
+
+	// Validate InfrastructureClusterTemplate changes desired a compatible way.
+	allErrs = append(allErrs, LocalObjectTemplatesAreCompatible(current.Spec.Infrastructure, desired.Spec.Infrastructure,
+		field.NewPath("spec", "infrastructure"))...)
+
+	// Validate control plane changes desired a compatible way.
+	allErrs = append(allErrs, LocalObjectTemplatesAreCompatible(current.Spec.ControlPlane.LocalObjectTemplate, desired.Spec.ControlPlane.LocalObjectTemplate,
+		field.NewPath("spec", "controlPlane"))...)
+	if desired.Spec.ControlPlane.MachineInfrastructure != nil && current.Spec.ControlPlane.MachineInfrastructure != nil {
+		allErrs = append(allErrs, LocalObjectTemplatesAreCompatible(*current.Spec.ControlPlane.MachineInfrastructure, *desired.Spec.ControlPlane.MachineInfrastructure,
+			field.NewPath("spec", "controlPlane", "machineInfrastructure"))...)
+	}
+
+	// Validate changes to MachineDeployments.
+	allErrs = append(allErrs, MachineDeploymentClassesAreCompatible(current, desired)...)
+
+	return allErrs
+}
+
+// MachineDeploymentClassesAreCompatible checks if each MachineDeploymentClass in the new ClusterClass is a compatible change from the previous ClusterClass.
+// It checks if:
+// 1) Any MachineDeploymentClass has been removed.
+// 2) If the MachineDeploymentClass.Template.Infrastructure reference has changed its Group or Kind.
+func MachineDeploymentClassesAreCompatible(current, desired *clusterv1.ClusterClass) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// Ensure no MachineDeployment class was removed.
+	classes := classNamesFromWorkerClass(desired.Spec.Workers)
+	for i, oldClass := range current.Spec.Workers.MachineDeployments {
+		if !classes.Has(oldClass.Class) {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec", "workers", "machineDeployments").Index(i),
+					desired.Spec.Workers.MachineDeployments,
+					fmt.Sprintf("The %q MachineDeployment class can't be removed.", oldClass.Class),
+				),
+			)
+		}
+	}
+
+	// Ensure previous MachineDeployment class was modified in a compatible way.
+	for _, class := range desired.Spec.Workers.MachineDeployments {
+		for i, oldClass := range current.Spec.Workers.MachineDeployments {
+			if class.Class == oldClass.Class {
+				// NOTE: class.Template.Metadata and class.Template.Bootstrap are allowed to change;
+
+				// class.Template.Bootstrap is ensured syntactically correct by LocalObjectTemplateIsValid.
+
+				// Validates class.Template.Infrastructure template changes in a compatible way
+				allErrs = append(allErrs, LocalObjectTemplatesAreCompatible(oldClass.Template.Infrastructure, class.Template.Infrastructure,
+					field.NewPath("spec", "workers", "machineDeployments").Index(i))...)
+			}
+		}
+	}
+	return allErrs
+}
+
+// MachineDeploymentClassesAreUnique checks that no two MachineDeploymentClasses in a ClusterClass share a name.
+func MachineDeploymentClassesAreUnique(clusterClass *clusterv1.ClusterClass) field.ErrorList {
+	var allErrs field.ErrorList
+	classes := sets.NewString()
+	for i, class := range clusterClass.Spec.Workers.MachineDeployments {
+		if classes.Has(class.Class) {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("class"),
+					class.Class,
+					fmt.Sprintf("MachineDeployment class should be unique. MachineDeployment with class %q is defined more than once.", class.Class),
+				),
+			)
+		}
+		classes.Insert(class.Class)
+	}
+	return allErrs
+}
+
+// MachineDeploymentTopologiesAreUniqueAndDefinedInClusterClass checks that each MachineDeploymentTopology name is unique, and each class in use is defined in ClusterClass.spec.Workers.MachineDeployments.
+func MachineDeploymentTopologiesAreUniqueAndDefinedInClusterClass(desired *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) field.ErrorList {
+	var allErrs field.ErrorList
+	if desired.Spec.Topology.Workers == nil {
+		return nil
+	}
+	if len(desired.Spec.Topology.Workers.MachineDeployments) == 0 {
+		return nil
+	}
+	// MachineDeployment clusterClass must be defined in the ClusterClass.
+	machineDeploymentClasses := classNamesFromWorkerClass(clusterClass.Spec.Workers)
+	names := sets.String{}
+	for i, md := range desired.Spec.Topology.Workers.MachineDeployments {
+		if !machineDeploymentClasses.Has(md.Class) {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec", "topology", "workers", "machineDeployments").Index(i),
+					md,
+					fmt.Sprintf("MachineDeployment clusterClass must be defined in the ClusterClass. MachineDeployment with clusterClass %q not found in ClusterClass %v.",
+						md.Name, clusterClass.Name),
+				),
+			)
+		}
+		if names.Has(md.Name) {
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("spec", "topology", "workers", "machineDeployments").Index(i),
+					md,
+					fmt.Sprintf("MachineDeploymentTopology names should be unique. MachineDeploymentTopology with name %q is defined more than once.", md.Name),
+				),
+			)
+		}
+		names.Insert(md.Name)
+	}
+	return allErrs
+}
+
+// ClusterClassReferencesAreValid checks that each template reference in the ClusterClass is valid .
+func ClusterClassReferencesAreValid(clusterClass *clusterv1.ClusterClass) field.ErrorList {
+	var allErrs field.ErrorList
+
+	allErrs = append(allErrs, LocalObjectTemplateIsValid(&clusterClass.Spec.Infrastructure, clusterClass.Namespace,
+		field.NewPath("spec", "infrastructure"))...)
+	allErrs = append(allErrs, LocalObjectTemplateIsValid(&clusterClass.Spec.ControlPlane.LocalObjectTemplate, clusterClass.Namespace,
+		field.NewPath("spec", "controlPlane"))...)
+	if clusterClass.Spec.ControlPlane.MachineInfrastructure != nil {
+		allErrs = append(allErrs, LocalObjectTemplateIsValid(clusterClass.Spec.ControlPlane.MachineInfrastructure, clusterClass.Namespace, field.NewPath("spec", "controlPlane", "machineInfrastructure"))...)
+	}
+
+	for i, mdc := range clusterClass.Spec.Workers.MachineDeployments {
+		allErrs = append(allErrs, LocalObjectTemplateIsValid(&mdc.Template.Bootstrap, clusterClass.Namespace,
+			field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("template", "bootstrap"))...)
+		allErrs = append(allErrs, LocalObjectTemplateIsValid(&mdc.Template.Infrastructure, clusterClass.Namespace,
+			field.NewPath("spec", "workers", "machineDeployments").Index(i).Child("template", "infrastructure"))...)
+	}
+	return allErrs
+}
+
+// classNames returns the set of MachineDeployment class names.
+func classNamesFromWorkerClass(w clusterv1.WorkersClass) sets.String {
+	classes := sets.NewString()
+	for _, class := range w.MachineDeployments {
+		classes.Insert(class.Class)
+	}
+	return classes
 }

--- a/webhooks/clusterclass_test.go
+++ b/webhooks/clusterclass_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/component-base/featuregate/testing"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -772,8 +771,7 @@ func TestClusterClassValidation(t *testing.T) {
 				WithControlPlaneTemplate(
 					refToUnstructured(ref)).
 				WithControlPlaneInfrastructureMachineTemplate(
-					builder.InfrastructureMachineTemplate(metav1.NamespaceDefault, "cpInfra1").
-						Build()).
+					refToUnstructured(ref)).
 				WithWorkerMachineDeploymentClasses(
 					*builder.MachineDeploymentClass("aa").
 						WithInfrastructureTemplate(
@@ -788,8 +786,7 @@ func TestClusterClassValidation(t *testing.T) {
 				WithControlPlaneTemplate(
 					refToUnstructured(incompatibleRef)).
 				WithControlPlaneInfrastructureMachineTemplate(
-					builder.InfrastructureMachineTemplate(metav1.NamespaceDefault, "cpInfra1").
-						Build()).
+					refToUnstructured(compatibleRef)).
 				WithWorkerMachineDeploymentClasses(
 					*builder.MachineDeploymentClass("aa").
 						WithInfrastructureTemplate(
@@ -806,8 +803,7 @@ func TestClusterClassValidation(t *testing.T) {
 				WithInfrastructureClusterTemplate(
 					builder.InfrastructureClusterTemplate(metav1.NamespaceDefault, "infra1").Build()).
 				WithControlPlaneTemplate(
-					builder.ControlPlaneTemplate(metav1.NamespaceDefault, "cp1").
-						Build()).
+					refToUnstructured(ref)).
 				WithControlPlaneInfrastructureMachineTemplate(
 					refToUnstructured(ref)).
 				WithWorkerMachineDeploymentClasses(
@@ -822,8 +818,7 @@ func TestClusterClassValidation(t *testing.T) {
 				WithInfrastructureClusterTemplate(
 					builder.InfrastructureClusterTemplate(metav1.NamespaceDefault, "infra1").Build()).
 				WithControlPlaneTemplate(
-					builder.ControlPlaneTemplate(metav1.NamespaceDefault, "cp1").
-						Build()).
+					refToUnstructured(compatibleRef)).
 				WithControlPlaneInfrastructureMachineTemplate(
 					refToUnstructured(incompatibleRef)).
 				WithWorkerMachineDeploymentClasses(
@@ -1055,14 +1050,4 @@ func TestClusterClassValidation(t *testing.T) {
 			}
 		})
 	}
-}
-
-func refToUnstructured(ref *corev1.ObjectReference) *unstructured.Unstructured {
-	gvk := ref.GetObjectKind().GroupVersionKind()
-	output := &unstructured.Unstructured{}
-	output.SetKind(gvk.Kind)
-	output.SetAPIVersion(gvk.GroupVersion().String())
-	output.SetName(ref.Name)
-	output.SetNamespace(ref.Namespace)
-	return output
 }


### PR DESCRIPTION
This change removes a check in the Cluster Webhook which ensure a cluster can't be moved from one ClusterClass to another. Additional compatibility checks have been added to ensure that the resulting update to the Cluster is protected from some unreconcilable changes as outlined in  the clusterClass proposal  #4985 


Fixes #5318 
