### PR TITLE
📖 Update migration doc with latest changes

### DIFF
--- a/docs/book/src/developer/providers/v1.0-to-v1.1.md
+++ b/docs/book/src/developer/providers/v1.0-to-v1.1.md
@@ -13,6 +13,9 @@ maintainer of other providers and consumers of our Go API.
 are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`. 
 
 - sigs.k8s.io/controller-runtime: v0.10.x => v0.11.x
+- k8s.io/*: v0.22.x => v0.23.x (derived from controller-runtime)
+- github.com/go-logr/logr: v0.4.0 => v1.2.0 (derived from controller-runtime)
+- k8s.io/klog/v2: v2.9.0 => v2.30.0 (derived from controller-runtime)
 - sigs.k8s.io/controller-tools: v0.7.x => v0.8.x
 - sigs.k8s.io/kind: v0.11.x => v0.11.x
 
@@ -27,11 +30,11 @@ are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
 
 ### API Change
 
-* Some controllers have been moved to internal to reduce there API surface. We now only
+* Some controllers have been moved to internal to reduce their API surface. We now only
   surface what is necessary, e.g. the reconciler and the `SetupWithManager` func:
-    * [bootstrap/kubeadm](https://github.com/kubernetes-sigs/cluster-api/pull/5493)
-    * [test/infrastructure/docker/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5595)
-    * [exp/addons](https://github.com/kubernetes-sigs/cluster-api/pull/5639)
+    * [bootstrap/kubeadm/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5493) 
+    * [exp/addons/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5639) 
+    * [test/infrastructure/docker/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5595) 
 
 ### Other
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds the latest changes to our migration docs.

Let's wait until the following PRs are merged:
* https://github.com/kubernetes-sigs/cluster-api/pull/5639
* https://github.com/kubernetes-sigs/cluster-api/pull/5595
/hold

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
