### PR TITLE
🐛 Improve nolint linter config, fix ifshort flake

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,10 @@ linters-settings:
       # Controller Runtime
       - pkg: sigs.k8s.io/controller-runtime
         alias: ctrl
+  nolintlint:
+    allow-unused: false
+    allow-leading-space: false
+    require-specific: true
   staticcheck:
     go: "1.17"
   stylecheck:
@@ -165,6 +169,12 @@ issues:
     - typecheck
     text: import (".+") is a program, not an importable package
     path: ^tools\.go$
+  # Ignore ifshort false positive
+  # TODO(sbueringer) false positive: https://github.com/esimonov/ifshort/issues/23
+  - linters:
+    - ifshort
+    text:  "variable 'isDeleteNodeAllowed' is only used in the if-statement.*"
+    path: ^controllers/machine_controller\.go$
 
 run:
   timeout: 10m

--- a/cmd/clusterctl/client/config/reader_memory.go
+++ b/cmd/clusterctl/client/config/reader_memory.go
@@ -75,7 +75,7 @@ func (f *MemoryReader) Set(key, value string) {
 func (f *MemoryReader) UnmarshalKey(key string, rawval interface{}) error {
 	data, err := f.Get(key)
 	if err != nil {
-		return nil // nolint:nilerr // We expect to not error if the key is not present
+		return nil //nolint:nilerr // We expect to not error if the key is not present
 	}
 	return yaml.Unmarshal([]byte(data), rawval)
 }

--- a/cmd/clusterctl/client/repository/repository_versions.go
+++ b/cmd/clusterctl/client/repository/repository_versions.go
@@ -42,12 +42,12 @@ func latestContractRelease(repo Repository, contract string) (string, error) {
 	file, err := repo.GetFile(latest, metadataFile)
 	if err != nil {
 		// if we can't get the metadata file from the release, we return latest.
-		return latest, nil // nolint:nilerr
+		return latest, nil //nolint:nilerr
 	}
 	latestMetadata := &clusterctlv1.Metadata{}
 	codecFactory := serializer.NewCodecFactory(scheme.Scheme)
 	if err := runtime.DecodeInto(codecFactory.UniversalDecoder(), file, latestMetadata); err != nil {
-		return latest, nil // nolint:nilerr
+		return latest, nil //nolint:nilerr
 	}
 
 	releaseSeries := latestMetadata.GetReleaseSeriesForContract(contract)
@@ -57,7 +57,7 @@ func latestContractRelease(repo Repository, contract string) (string, error) {
 
 	sv, err := version.ParseSemantic(latest)
 	if err != nil {
-		return latest, nil // nolint:nilerr
+		return latest, nil //nolint:nilerr
 	}
 
 	// If the Major or Minor version of the latest release doesn't match the release series for the current contract,

--- a/cmd/clusterctl/cmd/version_checker.go
+++ b/cmd/clusterctl/cmd/version_checker.go
@@ -145,7 +145,7 @@ func (v *versionChecker) getLatestRelease() (*ReleaseInfo, error) {
 			log.V(1).Info("⚠️ Unable to get latest github release for clusterctl")
 			// failing silently here so we don't error out in air-gapped
 			// environments.
-			return nil, nil // nolint:nilerr
+			return nil, nil //nolint:nilerr
 		}
 
 		vs = &VersionState{

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -94,7 +94,7 @@ func (f *FakeProxy) CheckClusterAvailable() error {
 
 // ListResources returns all the resources known by the FakeProxy.
 func (f *FakeProxy) ListResources(labels map[string]string, namespaces ...string) ([]unstructured.Unstructured, error) {
-	var ret []unstructured.Unstructured //nolint
+	var ret []unstructured.Unstructured //nolint:prealloc
 	for _, o := range f.objs {
 		u := unstructured.Unstructured{}
 		err := FakeScheme.Convert(o, &u, nil)

--- a/cmd/clusterctl/internal/test/fake_reader.go
+++ b/cmd/clusterctl/internal/test/fake_reader.go
@@ -73,7 +73,7 @@ func (f *FakeReader) Set(key, value string) {
 func (f *FakeReader) UnmarshalKey(key string, rawval interface{}) error {
 	data, err := f.Get(key)
 	if err != nil {
-		return nil // nolint:nilerr // We expect to not error if the key is not present
+		return nil //nolint:nilerr // We expect to not error if the key is not present
 	}
 	return yaml.Unmarshal([]byte(data), rawval)
 }

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -430,7 +430,7 @@ func (c clusterDescendants) filterOwnedDescendants(cluster *clusterv1.Cluster) (
 		obj := o.(client.Object)
 		acc, err := meta.Accessor(obj)
 		if err != nil {
-			return nil // nolint:nilerr // We don't want to exit the EachListItem loop, just continue
+			return nil //nolint:nilerr // We don't want to exit the EachListItem loop, just continue
 		}
 
 		if util.IsOwnedByObject(acc, cluster) {

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -277,7 +277,7 @@ func (r *MachineReconciler) reconcileDelete(ctx context.Context, cluster *cluste
 	log := ctrl.LoggerFrom(ctx, "cluster", cluster.Name)
 
 	err := r.isDeleteNodeAllowed(ctx, cluster, m)
-	isDeleteNodeAllowed := err == nil //nolint:ifshort
+	isDeleteNodeAllowed := err == nil
 	if err != nil {
 		switch err {
 		case errNoControlPlaneNodes, errLastControlPlaneNode, errNilNodeRef, errClusterIsBeingDeleted, errControlPlaneIsBeingDeleted:

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -46,7 +46,7 @@ var (
 )
 
 func (r *MachineReconciler) reconcilePhase(_ context.Context, m *clusterv1.Machine) {
-	originalPhase := m.Status.Phase // nolint:ifshort
+	originalPhase := m.Status.Phase //nolint:ifshort // Cannot be inlined because m.Status.Phase might be changed before it is used in the if.
 
 	// Set the phase to "pending" if nil.
 	if m.Status.Phase == "" {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -152,7 +152,7 @@ func (matcher *refGroupKindMatcher) Match(actual interface{}) (success bool, err
 	for _, ref := range ownerRefs {
 		gv, err := schema.ParseGroupVersion(ref.APIVersion)
 		if err != nil {
-			return false, nil // nolint:nilerr // If we can't get the group version we can't match, but it's not a failure
+			return false, nil //nolint:nilerr // If we can't get the group version we can't match, but it's not a failure
 		}
 		if ref.Kind == matcher.kind && gv.Group == clusterv1.GroupVersion.Group {
 			return true, nil

--- a/internal/envtest/environment.go
+++ b/internal/envtest/environment.go
@@ -150,7 +150,7 @@ type Environment struct {
 // usually the environment is initialized in a suite_test.go file within a `BeforeSuite` ginkgo block.
 func new(uncachedObjs ...client.Object) *Environment {
 	// Get the root of the current file to use in CRD paths.
-	_, filename, _, _ := goruntime.Caller(0) //nolint
+	_, filename, _, _ := goruntime.Caller(0) //nolint:dogsled
 	root := path.Join(path.Dir(filename), "..", "..")
 
 	// Create the test environment.

--- a/internal/envtest/webhooks.go
+++ b/internal/envtest/webhooks.go
@@ -43,7 +43,7 @@ func initWebhookInstallOptions() envtest.WebhookInstallOptions {
 	mutatingWebhooks := []*admissionv1.MutatingWebhookConfiguration{}
 
 	// Get the root of the current file to use in CRD paths.
-	_, filename, _, _ := goruntime.Caller(0) //nolint
+	_, filename, _, _ := goruntime.Caller(0) //nolint:dogsled
 	root := path.Join(path.Dir(filename), "..", "..")
 	configyamlFile, err := os.ReadFile(filepath.Join(root, "config", "webhook", "manifests.yaml")) //nolint:gosec
 	if err != nil {

--- a/test/e2e/custom_assertions.go
+++ b/test/e2e/custom_assertions.go
@@ -35,7 +35,7 @@ func (m *controllerMatch) Match(actual interface{}) (success bool, err error) {
 		return false, fmt.Errorf("unable to read meta for %T: %w", actual, err)
 	}
 
-	owner := metav1.GetControllerOf(actualMeta) // nolint:ifshort
+	owner := metav1.GetControllerOf(actualMeta) //nolint:ifshort
 	if owner == nil {
 		return false, fmt.Errorf("no controller found (owner ref with controller = true) for object %#v", actual)
 	}

--- a/test/infrastructure/docker/exp/docker/nodepool.go
+++ b/test/infrastructure/docker/exp/docker/nodepool.go
@@ -282,7 +282,7 @@ func (np *NodePool) reconcileMachine(ctx context.Context, machine *docker.Machin
 		if err != nil {
 			// Requeue if there is an error, as this is likely momentary load balancer
 			// state changes during control plane provisioning.
-			return ctrl.Result{Requeue: true}, nil // nolint:nilerr
+			return ctrl.Result{Requeue: true}, nil //nolint:nilerr
 		}
 
 		machineStatus.Addresses = []clusterv1.MachineAddress{
@@ -308,7 +308,7 @@ func (np *NodePool) reconcileMachine(ctx context.Context, machine *docker.Machin
 		// state changes during control plane provisioning.
 		if err := externalMachine.SetNodeProviderID(ctx); err != nil {
 			log.V(4).Info("transient error setting the provider id")
-			return ctrl.Result{Requeue: true}, nil // nolint:nilerr
+			return ctrl.Result{Requeue: true}, nil //nolint:nilerr
 		}
 		// Set ProviderID so the Cluster API Machine Controller can pull it
 		providerID := externalMachine.ProviderID()

--- a/util/yaml/yaml.go
+++ b/util/yaml/yaml.go
@@ -239,7 +239,7 @@ func JoinYaml(yamls ...[]byte) []byte {
 	var yamlSeparator = []byte("---")
 
 	var cr = []byte("\n")
-	var b [][]byte //nolint
+	var b [][]byte //nolint:prealloc
 	for _, y := range yamls {
 		if !bytes.HasPrefix(y, cr) {
 			y = append(cr, y...)
@@ -259,7 +259,7 @@ func JoinYaml(yamls ...[]byte) []byte {
 
 // FromUnstructured takes a list of Unstructured objects and converts it into a YAML.
 func FromUnstructured(objs []unstructured.Unstructured) ([]byte, error) {
-	var ret [][]byte //nolint
+	var ret [][]byte //nolint:prealloc
 	for _, o := range objs {
 		content, err := yaml.Marshal(o.UnstructuredContent())
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR:
* enforce `//nolint` vs `// nolint`
* `//nolint` must now contain the linter name
* ignores the ifshort flake for `isDeleteNodeAllowed` in a way that it's not a problem if the ifshort linter does not report that finding

I've opened an issue in the ifshort repo: https://github.com/esimonov/ifshort/issues/23

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5652
