### PR TITLE
🌱 fix lint error

### DIFF
--- a/test/infrastructure/docker/controllers/alias.go
+++ b/test/infrastructure/docker/controllers/alias.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package controllers provides access to reconcilers implemented in internal/controllers.
 package controllers
 
 import (


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fixes the lint error due to package comment not present in test/infrastructure/docker/controllers/alias.go

https://github.com/kubernetes-sigs/cluster-api/runs/4192204922?check_suite_focus=true

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
