### PR TITLE
🌱 Add test coverage for container runtime calls

### DIFF
--- a/docs/book/src/developer/providers/v1.0-to-v1.1.md
+++ b/docs/book/src/developer/providers/v1.0-to-v1.1.md
@@ -41,7 +41,7 @@ are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
     * [test/infrastructure/docker/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5595) 
     * [test/infrastructure/docker/exp/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5690) 
     * [exp/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5651)
-  
+
 * Following packages have been moved to internal
     * [/test/infrastructure/docker/cloudinit](https://github.com/kubernetes-sigs/cluster-api/pull/5795)
     * [/test/infrastructure/docker/docker](https://github.com/kubernetes-sigs/cluster-api/pull/5795)

--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -317,6 +317,7 @@ func (p *clusterProxy) isDockerCluster(ctx context.Context, namespace string, na
 func (p *clusterProxy) fixConfig(ctx context.Context, name string, config *api.Config) {
 	containerRuntime, err := container.NewDockerClient()
 	Expect(err).ToNot(HaveOccurred(), "Failed to get Docker runtime client")
+	ctx = container.RuntimeInto(ctx, containerRuntime)
 
 	lbContainerName := name + "-lb"
 	port, err := containerRuntime.GetHostPort(ctx, lbContainerName, "6443/tcp")

--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -177,6 +177,7 @@ func Run(ctx context.Context, input RunInput) error {
 	if err != nil {
 		return errors.Wrap(err, "Unable to run conformance tests")
 	}
+	ctx = container.RuntimeInto(ctx, containerRuntime)
 
 	err = containerRuntime.RunContainer(ctx, &container.RunContainerInput{
 		Image:           input.ConformanceImage,

--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -45,7 +45,7 @@ const (
 	noProxy    = "NO_PROXY"
 )
 
-type docker struct {
+type dockerRuntime struct {
 	dockerClient *client.Client
 }
 
@@ -55,7 +55,7 @@ func NewDockerClient() (Runtime, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to created docker runtime client")
 	}
-	return &docker{
+	return &dockerRuntime{
 		dockerClient: dockerClient,
 	}, nil
 }
@@ -71,7 +71,7 @@ func getDockerClient() (*client.Client, error) {
 }
 
 // SaveContainerImage saves a Docker image to the file specified by dest.
-func (d *docker) SaveContainerImage(ctx context.Context, image, dest string) error {
+func (d *dockerRuntime) SaveContainerImage(ctx context.Context, image, dest string) error {
 	reader, err := d.dockerClient.ImageSave(ctx, []string{image})
 	if err != nil {
 		return fmt.Errorf("unable to read image data: %v", err)
@@ -95,7 +95,7 @@ func (d *docker) SaveContainerImage(ctx context.Context, image, dest string) err
 // PullContainerImageIfNotExists triggers the Docker engine to pull an image, but only if it doesn't
 // already exist. This is important when we're using locally build images in CI which
 // do not exist remotely.
-func (d *docker) PullContainerImageIfNotExists(ctx context.Context, image string) error {
+func (d *dockerRuntime) PullContainerImageIfNotExists(ctx context.Context, image string) error {
 	filters := dockerfilters.NewArgs()
 	filters.Add("reference", image)
 	images, err := d.dockerClient.ImageList(ctx, types.ImageListOptions{
@@ -125,7 +125,7 @@ func (d *docker) PullContainerImageIfNotExists(ctx context.Context, image string
 }
 
 // GetHostPort looks up the host port bound for the port and protocol (e.g. "6443/tcp").
-func (d *docker) GetHostPort(ctx context.Context, containerName, portAndProtocol string) (string, error) {
+func (d *dockerRuntime) GetHostPort(ctx context.Context, containerName, portAndProtocol string) (string, error) {
 	// Get details about the container
 	containerInfo, err := d.dockerClient.ContainerInspect(ctx, containerName)
 	if err != nil {
@@ -145,7 +145,7 @@ func (d *docker) GetHostPort(ctx context.Context, containerName, portAndProtocol
 }
 
 // ExecContainer executes a command in a running container and writes any output to the provided writer.
-func (d *docker) ExecContainer(ctxd context.Context, containerName string, config *ExecContainerInput, command string, args ...string) error {
+func (d *dockerRuntime) ExecContainer(ctxd context.Context, containerName string, config *ExecContainerInput, command string, args ...string) error {
 	ctx := context.Background() // Let the command finish, even if it takes longer than the default timeout
 	execConfig := types.ExecConfig{
 		// Run with privileges so we can remount etc..
@@ -240,7 +240,7 @@ func (d *docker) ExecContainer(ctxd context.Context, containerName string, confi
 }
 
 // ListContainers returns a list of all containers.
-func (d *docker) ListContainers(ctx context.Context, filters FilterBuilder) ([]Container, error) {
+func (d *dockerRuntime) ListContainers(ctx context.Context, filters FilterBuilder) ([]Container, error) {
 	listOptions := types.ContainerListOptions{
 		All:     true,
 		Limit:   -1,
@@ -275,7 +275,7 @@ func (d *docker) ListContainers(ctx context.Context, filters FilterBuilder) ([]C
 }
 
 // DeleteContainer will remove a container, forcing removal if still running.
-func (d *docker) DeleteContainer(ctx context.Context, containerName string) error {
+func (d *dockerRuntime) DeleteContainer(ctx context.Context, containerName string) error {
 	return d.dockerClient.ContainerRemove(ctx, containerName, types.ContainerRemoveOptions{
 		Force:         true, // force the container to be delete now
 		RemoveVolumes: true, // delete volumes
@@ -283,14 +283,14 @@ func (d *docker) DeleteContainer(ctx context.Context, containerName string) erro
 }
 
 // KillContainer will kill a running container with the specified signal.
-func (d *docker) KillContainer(ctx context.Context, containerName, signal string) error {
+func (d *dockerRuntime) KillContainer(ctx context.Context, containerName, signal string) error {
 	return d.dockerClient.ContainerKill(ctx, containerName, signal)
 }
 
 // GetContainerIPs inspects a container to get its IPv4 and IPv6 IP addresses.
 // Will not error if there is no IP address assigned. Calling code will need to
 // determine whether that is an issue or not.
-func (d *docker) GetContainerIPs(ctx context.Context, containerName string) (string, string, error) {
+func (d *dockerRuntime) GetContainerIPs(ctx context.Context, containerName string) (string, string, error) {
 	containerInfo, err := d.dockerClient.ContainerInspect(ctx, containerName)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to get container details")
@@ -304,7 +304,7 @@ func (d *docker) GetContainerIPs(ctx context.Context, containerName string) (str
 }
 
 // ContainerDebugInfo gets the container metadata and logs from the runtime (docker inspect, docker logs).
-func (d *docker) ContainerDebugInfo(ctx context.Context, containerName string, w io.Writer) error {
+func (d *dockerRuntime) ContainerDebugInfo(ctx context.Context, containerName string, w io.Writer) error {
 	containerInfo, err := d.dockerClient.ContainerInspect(ctx, containerName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to inspect container %q", containerName)
@@ -364,7 +364,7 @@ func (crc *RunContainerInput) environmentVariables() []string {
 }
 
 // RunContainer will run a docker container with the given settings and arguments, returning any errors.
-func (d *docker) RunContainer(ctx context.Context, runConfig *RunContainerInput, output io.Writer) error {
+func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContainerInput, output io.Writer) error {
 	containerConfig := dockercontainer.Config{
 		Tty:          true,           // allocate a tty for entrypoint logs
 		Hostname:     runConfig.Name, // make hostname match container name
@@ -513,7 +513,7 @@ func (d *docker) RunContainer(ctx context.Context, runConfig *RunContainerInput,
 // needsDevMapper checks whether we need to mount /dev/mapper.
 // This is required when the docker storage driver is Btrfs or ZFS.
 // https://github.com/kubernetes-sigs/kind/pull/1464
-func (d *docker) needsDevMapper(ctx context.Context) (bool, error) {
+func (d *dockerRuntime) needsDevMapper(ctx context.Context) (bool, error) {
 	info, err := d.dockerClient.Info(ctx)
 	if err != nil {
 		return false, err
@@ -582,7 +582,7 @@ func configureVolumes(crc *RunContainerInput, config *dockercontainer.Config, ho
 }
 
 // getSubnets returns a slice of subnets for a specified network.
-func (d *docker) getSubnets(ctx context.Context, networkName string) ([]string, error) {
+func (d *dockerRuntime) getSubnets(ctx context.Context, networkName string) ([]string, error) {
 	subnets := []string{}
 	networkInfo, err := d.dockerClient.NetworkInspect(ctx, networkName, types.NetworkInspectOptions{})
 	if err != nil {
@@ -603,7 +603,7 @@ type proxyDetails struct {
 
 // getProxyDetails returns a struct with the host environment proxy settings
 // that should be passed to the nodes.
-func (d *docker) getProxyDetails(ctx context.Context, network string) (*proxyDetails, error) {
+func (d *dockerRuntime) getProxyDetails(ctx context.Context, network string) (*proxyDetails, error) {
 	var val string
 	details := proxyDetails{Envs: make(map[string]string)}
 	proxyEnvs := []string{httpProxy, httpsProxy, noProxy}
@@ -637,7 +637,7 @@ func (d *docker) getProxyDetails(ctx context.Context, network string) (*proxyDet
 }
 
 // usernsRemap checks if userns-remap is enabled in dockerd.
-func (d *docker) usernsRemap(ctx context.Context) bool {
+func (d *dockerRuntime) usernsRemap(ctx context.Context) bool {
 	info, err := d.dockerClient.Info(ctx)
 	if err != nil {
 		return false

--- a/test/infrastructure/container/fake.go
+++ b/test/infrastructure/container/fake.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package container
+
+import (
+	"context"
+	"io"
+)
+
+var runContainerCallLog []RunContainerArgs
+var deleteContainerCallLog []string
+var killContainerCallLog []KillContainerArgs
+var execContainerCallLog []ExecContainerArgs
+
+// RunContainerArgs contains the arguments passed to calls to RunContainer.
+type RunContainerArgs struct {
+	RunConfig *RunContainerInput
+	Output    io.Writer
+}
+
+// KillContainerArgs contains the arguments passed to calls to Kill.
+type KillContainerArgs struct {
+	Container string
+	Signal    string
+}
+
+// ExecContainerArgs contains the arguments passed to calls to ExecContainer.
+type ExecContainerArgs struct {
+	ContainerName string
+	Config        *ExecContainerInput
+	Command       string
+	Args          []string
+}
+
+type FakeRuntime struct {
+}
+
+// NewFakeClient gets a client for testing.
+func NewFakeClient() (Runtime, error) {
+	return &FakeRuntime{}, nil
+}
+
+// SaveContainerImage saves a Docker image to the file specified by dest.
+func (f *FakeRuntime) SaveContainerImage(ctx context.Context, image, dest string) error {
+	return nil
+}
+
+// PullContainerImageIfNotExists triggers the Docker engine to pull an image, but only if it doesn't
+// already exist. This is important when we're using locally built images in CI which
+// do not exist remotely.
+func (f *FakeRuntime) PullContainerImageIfNotExists(ctx context.Context, image string) error {
+	return nil
+}
+
+// GetHostPort looks up the host port bound for the port and protocol (e.g. "6443/tcp").
+func (f *FakeRuntime) GetHostPort(ctx context.Context, containerName, portAndProtocol string) (string, error) {
+	return "", nil
+}
+
+// ExecContainer executes a command in a running container and writes any output to the provided writer.
+func (f *FakeRuntime) ExecContainer(ctx context.Context, containerName string, config *ExecContainerInput, command string, args ...string) error {
+	execContainerCallLog = append(execContainerCallLog, ExecContainerArgs{
+		ContainerName: containerName,
+		Config:        config,
+		Command:       command,
+		Args:          args,
+	})
+	return nil
+}
+
+// ExecContainerCalls returns the set of arguments that have been passed to the ExecContainer method. This can
+// be used by test code to validate the expected input.
+func (f *FakeRuntime) ExecContainerCalls() []ExecContainerArgs {
+	return execContainerCallLog
+}
+
+// ResetExecContainerCallLogs clears all existing records of any calls to the ExecContainer method.
+func (f *FakeRuntime) ResetExecContainerCallLogs() {
+	execContainerCallLog = []ExecContainerArgs{}
+}
+
+// ListContainers returns a list of all containers.
+func (f *FakeRuntime) ListContainers(ctx context.Context, filters FilterBuilder) ([]Container, error) {
+	return []Container{}, nil
+}
+
+// DeleteContainer will remove a container, forcing removal if still running.
+func (f *FakeRuntime) DeleteContainer(ctx context.Context, containerName string) error {
+	deleteContainerCallLog = append(deleteContainerCallLog, containerName)
+	return nil
+}
+
+// DeleteContainerCalls returns the list of containerName arguments passed to calls to DeleteContainer.
+func (f *FakeRuntime) DeleteContainerCalls() []string {
+	return deleteContainerCallLog
+}
+
+// ResetDeleteContainerCallLogs clears all existing records of any calls to the DeleteContainer method.
+func (f *FakeRuntime) ResetDeleteContainerCallLogs() {
+	deleteContainerCallLog = []string{}
+}
+
+// KillContainer will kill a running container with the specified signal.
+func (f *FakeRuntime) KillContainer(ctx context.Context, containerName, signal string) error {
+	killContainerCallLog = append(killContainerCallLog, KillContainerArgs{
+		Container: containerName,
+		Signal:    signal,
+	})
+	return nil
+}
+
+// KillContainerCalls returns the list of arguments passed to calls to the KillContainer method.
+func (f *FakeRuntime) KillContainerCalls() []KillContainerArgs {
+	return killContainerCallLog
+}
+
+// ResetKillContainerCallLogs clears all existing records of any calls to the KillContainer method.
+func (f *FakeRuntime) ResetKillContainerCallLogs() {
+	killContainerCallLog = []KillContainerArgs{}
+}
+
+// GetContainerIPs inspects a container to get its IPv4 and IPv6 IP addresses.
+// Will not error if there is no IP address assigned. Calling code will need to
+// determine whether that is an issue or not.
+func (f *FakeRuntime) GetContainerIPs(ctx context.Context, containerName string) (string, string, error) {
+	return containerName + "IPv4", containerName + "IPv6", nil
+}
+
+// ContainerDebugInfo gets the container metadata and logs from the runtime (docker inspect, docker logs).
+func (f *FakeRuntime) ContainerDebugInfo(ctx context.Context, containerName string, w io.Writer) error {
+	return nil
+}
+
+// RunContainer will run a docker container with the given settings and arguments, returning any errors.
+func (f *FakeRuntime) RunContainer(ctx context.Context, runConfig *RunContainerInput, output io.Writer) error {
+	runContainerCallLog = append(runContainerCallLog, RunContainerArgs{runConfig, output})
+	return nil
+}
+
+// RunContainerCalls returns a list of arguments passed in to all calls to RunContainer.
+func (f *FakeRuntime) RunContainerCalls() []RunContainerArgs {
+	return runContainerCallLog
+}
+
+// ResetRunContainerCallLogs clears all existing records of calls to the RunContainer method.
+func (f *FakeRuntime) ResetRunContainerCallLogs() {
+	runContainerCallLog = []RunContainerArgs{}
+}

--- a/test/infrastructure/container/interface_test.go
+++ b/test/infrastructure/container/interface_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package container
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestFilterBuildKeyValue(t *testing.T) {
+	g := NewWithT(t)
+
+	filters := FilterBuilder{}
+	filters.AddKeyValue("key1", "value1")
+
+	g.Expect(filters).To(Equal(FilterBuilder{"key1": {"value1": []string{""}}}))
+}
+
+func TestFilterBuildKeyNameValue(t *testing.T) {
+	g := NewWithT(t)
+
+	filters := FilterBuilder{}
+	filters.AddKeyNameValue("key1", "name1", "value1")
+
+	g.Expect(filters).To(Equal(FilterBuilder{"key1": {"name1": []string{"value1"}}}))
+}
+
+func TestFakeContext(t *testing.T) {
+	g := NewWithT(t)
+	fake := FakeRuntime{}
+	ctx := RuntimeInto(context.Background(), &fake)
+	rtc, err := RuntimeFrom(ctx)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	_, ok := rtc.(*FakeRuntime)
+	g.Expect(ok).To(BeTrue())
+}
+
+func TestDockerContext(t *testing.T) {
+	g := NewWithT(t)
+	docker := dockerRuntime{}
+	ctx := RuntimeInto(context.Background(), &docker)
+	rtc, err := RuntimeFrom(ctx)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	_, ok := rtc.(*dockerRuntime)
+	g.Expect(ok).To(BeTrue())
+}
+
+func TestInvalidContext(t *testing.T) {
+	g := NewWithT(t)
+	_, err := RuntimeFrom(context.Background())
+	g.Expect(err).Should(HaveOccurred())
+}

--- a/test/infrastructure/docker/controllers/alias.go
+++ b/test/infrastructure/docker/controllers/alias.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
+	"sigs.k8s.io/cluster-api/test/infrastructure/container"
 	dockercontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/controllers"
 )
 
@@ -32,24 +33,28 @@ import (
 
 // DockerMachineReconciler reconciles a DockerMachine object.
 type DockerMachineReconciler struct {
-	Client client.Client
+	Client           client.Client
+	ContainerRuntime container.Runtime
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *DockerMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&dockercontrollers.DockerMachineReconciler{
-		Client: r.Client,
+		Client:           r.Client,
+		ContainerRuntime: r.ContainerRuntime,
 	}).SetupWithManager(ctx, mgr, options)
 }
 
 // DockerClusterReconciler reconciles a DockerMachine object.
 type DockerClusterReconciler struct {
-	Client client.Client
+	Client           client.Client
+	ContainerRuntime container.Runtime
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
 func (r *DockerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&dockercontrollers.DockerClusterReconciler{
-		Client: r.Client,
+		Client:           r.Client,
+		ContainerRuntime: r.ContainerRuntime,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/test/infrastructure/docker/exp/controllers/alias.go
+++ b/test/infrastructure/docker/exp/controllers/alias.go
@@ -25,19 +25,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
+	"sigs.k8s.io/cluster-api/test/infrastructure/container"
 	dockermachinepoolcontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers"
 )
 
 // DockerMachinePoolReconciler reconciles a DockerMachinePool object.
 type DockerMachinePoolReconciler struct {
-	Client client.Client
-	Scheme *runtime.Scheme
+	Client           client.Client
+	Scheme           *runtime.Scheme
+	ContainerRuntime container.Runtime
 }
 
 // SetupWithManager will add watches for this controller.
 func (r *DockerMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&dockermachinepoolcontrollers.DockerMachinePoolReconciler{
-		Client: r.Client,
-		Scheme: r.Scheme,
+		Client:           r.Client,
+		Scheme:           r.Scheme,
+		ContainerRuntime: r.ContainerRuntime,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/infrastructure/container"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/docker"
 	"sigs.k8s.io/cluster-api/util"
@@ -41,6 +42,7 @@ import (
 // DockerClusterReconciler reconciles a DockerCluster object.
 type DockerClusterReconciler struct {
 	client.Client
+	ContainerRuntime container.Runtime
 }
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=dockerclusters,verbs=get;list;watch;create;update;patch;delete
@@ -50,6 +52,7 @@ type DockerClusterReconciler struct {
 // and what is in the DockerCluster.Spec.
 func (r *DockerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	log := ctrl.LoggerFrom(ctx)
+	ctx = container.RuntimeInto(ctx, r.ContainerRuntime)
 
 	// Fetch the DockerCluster instance
 	dockerCluster := &infrav1.DockerCluster{}
@@ -73,7 +76,7 @@ func (r *DockerClusterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	log = log.WithValues("cluster", cluster.Name)
 
 	// Create a helper for managing a docker container hosting the loadbalancer.
-	externalLoadBalancer, err := docker.NewLoadBalancer(cluster, dockerCluster)
+	externalLoadBalancer, err := docker.NewLoadBalancer(ctx, cluster, dockerCluster)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to create helper for managing the externalLoadBalancer")
 	}

--- a/test/infrastructure/docker/internal/docker/kind_manager.go
+++ b/test/infrastructure/docker/internal/docker/kind_manager.go
@@ -171,7 +171,7 @@ func createNode(ctx context.Context, opts *nodeCreateOpts) (*types.Node, error) 
 	}
 	log.V(6).Info("Container run options: %+v", runOptions)
 
-	containerRuntime, err := container.NewDockerClient()
+	containerRuntime, err := container.RuntimeFrom(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to container runtime: %v", err)
 	}

--- a/test/infrastructure/docker/internal/docker/kind_manager_test.go
+++ b/test/infrastructure/docker/internal/docker/kind_manager_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
+	"sigs.k8s.io/kind/pkg/cluster/constants"
+
+	"sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/test/infrastructure/container"
+)
+
+func TestCreateNode(t *testing.T) {
+	g := NewWithT(t)
+	containerRuntime := &container.FakeRuntime{}
+	ctx := container.RuntimeInto(context.Background(), containerRuntime)
+	containerRuntime.ResetRunContainerCallLogs()
+
+	portMappingsWithAPIServer := []v1alpha4.PortMapping{
+		{
+			ListenAddress: "0.0.0.0",
+			HostPort:      32765,
+			ContainerPort: KubeadmContainerPort,
+			Protocol:      v1alpha4.PortMappingProtocolTCP,
+		},
+	}
+	createOpts := &nodeCreateOpts{
+		Name:         "TestName",
+		Image:        "TestImage",
+		ClusterName:  "TestClusterName",
+		Role:         constants.ControlPlaneNodeRoleValue,
+		PortMappings: portMappingsWithAPIServer,
+		Mounts:       []v1alpha4.Mount{},
+		IPFamily:     v1beta1.IPv4IPFamily,
+	}
+	_, err := createNode(ctx, createOpts)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	callLog := containerRuntime.RunContainerCalls()
+	g.Expect(callLog).To(HaveLen(1))
+	g.Expect(callLog[0].Output).To(BeNil())
+
+	runConfig := callLog[0].RunConfig
+	g.Expect(runConfig).ToNot(BeNil())
+	g.Expect(runConfig.Name).To(Equal("TestName"))
+	g.Expect(runConfig.Image).To(Equal("TestImage"))
+	g.Expect(runConfig.Network).To(Equal(DefaultNetwork))
+	g.Expect(runConfig.Labels).To(HaveLen(2))
+	g.Expect(runConfig.Labels["io.x-k8s.kind.cluster"]).To(Equal("TestClusterName"))
+}
+
+func TestCreateControlPlaneNode(t *testing.T) {
+	g := NewWithT(t)
+	containerRuntime := &container.FakeRuntime{}
+	ctx := container.RuntimeInto(context.Background(), containerRuntime)
+	containerRuntime.ResetRunContainerCallLogs()
+
+	containerRuntime.ResetRunContainerCallLogs()
+	m := Manager{}
+	node, err := m.CreateControlPlaneNode(ctx, "TestName", "TestImage", "TestCluster", "100.100.100.100", 80, []v1alpha4.Mount{}, []v1alpha4.PortMapping{}, make(map[string]string), v1beta1.IPv4IPFamily)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(node.Role()).Should(Equal(constants.ControlPlaneNodeRoleValue))
+
+	callLog := containerRuntime.RunContainerCalls()
+	g.Expect(callLog).To(HaveLen(1))
+	g.Expect(callLog[0].Output).To(BeNil())
+
+	runConfig := callLog[0].RunConfig
+	g.Expect(runConfig).ToNot(BeNil())
+	g.Expect(runConfig.Labels).To(HaveLen(2))
+	g.Expect(runConfig.Labels["io.x-k8s.kind.role"]).To(Equal(constants.ControlPlaneNodeRoleValue))
+}
+
+func TestCreateWorkerNode(t *testing.T) {
+	g := NewWithT(t)
+	containerRuntime := &container.FakeRuntime{}
+	ctx := container.RuntimeInto(context.Background(), containerRuntime)
+	containerRuntime.ResetRunContainerCallLogs()
+
+	containerRuntime.ResetRunContainerCallLogs()
+	m := Manager{}
+	node, err := m.CreateWorkerNode(ctx, "TestName", "TestImage", "TestCluster", []v1alpha4.Mount{}, []v1alpha4.PortMapping{}, make(map[string]string), v1beta1.IPv4IPFamily)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(node.Role()).Should(Equal(constants.WorkerNodeRoleValue))
+
+	callLog := containerRuntime.RunContainerCalls()
+	g.Expect(callLog).To(HaveLen(1))
+	g.Expect(callLog[0].Output).To(BeNil())
+
+	runConfig := callLog[0].RunConfig
+	g.Expect(runConfig).ToNot(BeNil())
+	g.Expect(runConfig.Labels).To(HaveLen(2))
+	g.Expect(runConfig.Labels["io.x-k8s.kind.role"]).To(Equal(constants.WorkerNodeRoleValue))
+}
+
+func TestCreateExternalLoadBalancerNode(t *testing.T) {
+	g := NewWithT(t)
+	containerRuntime := &container.FakeRuntime{}
+	ctx := container.RuntimeInto(context.Background(), containerRuntime)
+	containerRuntime.ResetRunContainerCallLogs()
+
+	containerRuntime.ResetRunContainerCallLogs()
+	m := Manager{}
+	node, err := m.CreateExternalLoadBalancerNode(ctx, "TestName", "TestImage", "TestCluster", "100.100.100.100", 0, v1beta1.IPv4IPFamily)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(node.Role()).Should(Equal(constants.ExternalLoadBalancerNodeRoleValue))
+
+	callLog := containerRuntime.RunContainerCalls()
+	g.Expect(callLog).To(HaveLen(1))
+	g.Expect(callLog[0].Output).To(BeNil())
+
+	runConfig := callLog[0].RunConfig
+	g.Expect(runConfig).ToNot(BeNil())
+	g.Expect(runConfig.Labels).To(HaveLen(2))
+	g.Expect(runConfig.Labels["io.x-k8s.kind.role"]).To(Equal(constants.ExternalLoadBalancerNodeRoleValue))
+}

--- a/test/infrastructure/docker/internal/docker/loadbalancer.go
+++ b/test/infrastructure/docker/internal/docker/loadbalancer.go
@@ -46,7 +46,7 @@ type LoadBalancer struct {
 }
 
 // NewLoadBalancer returns a new helper for managing a docker loadbalancer with a given name.
-func NewLoadBalancer(cluster *clusterv1.Cluster, dockerCluster *infrav1.DockerCluster) (*LoadBalancer, error) {
+func NewLoadBalancer(ctx context.Context, cluster *clusterv1.Cluster, dockerCluster *infrav1.DockerCluster) (*LoadBalancer, error) {
 	if cluster.Name == "" {
 		return nil, errors.New("create load balancer: cluster name is empty")
 	}
@@ -58,7 +58,7 @@ func NewLoadBalancer(cluster *clusterv1.Cluster, dockerCluster *infrav1.DockerCl
 	filters.AddKeyNameValue(filterLabel, clusterLabelKey, cluster.Name)
 	filters.AddKeyNameValue(filterLabel, nodeRoleLabelKey, constants.ExternalLoadBalancerNodeRoleValue)
 
-	container, err := getContainer(filters)
+	container, err := getContainer(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (s *LoadBalancer) UpdateConfiguration(ctx context.Context) error {
 	filters.AddKeyNameValue(filterLabel, clusterLabelKey, s.name)
 	filters.AddKeyNameValue(filterLabel, nodeRoleLabelKey, constants.ControlPlaneNodeRoleValue)
 
-	controlPlaneNodes, err := listContainers(filters)
+	controlPlaneNodes, err := listContainers(ctx, filters)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/test/infrastructure/docker/internal/docker/types/node.go
+++ b/test/infrastructure/docker/internal/docker/types/node.go
@@ -70,7 +70,7 @@ func (n *Node) Role() (string, error) {
 // IP gets the docker ipv4 and ipv6 of the node.
 func (n *Node) IP(ctx context.Context) (ipv4 string, ipv6 string, err error) {
 	// retrieve the IP address of the node using docker inspect
-	containerRuntime, err := container.NewDockerClient()
+	containerRuntime, err := container.RuntimeFrom(ctx)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to connect to container runtime")
 	}
@@ -91,7 +91,7 @@ func (n *Node) IsRunning() bool {
 
 // Delete removes the container.
 func (n *Node) Delete(ctx context.Context) error {
-	containerRuntime, err := container.NewDockerClient()
+	containerRuntime, err := container.RuntimeFrom(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to container runtime")
 	}
@@ -119,7 +119,7 @@ func (n *Node) WriteFile(ctx context.Context, dest, content string) error {
 
 // Kill sends the named signal to the container.
 func (n *Node) Kill(ctx context.Context, signal string) error {
-	containerRuntime, err := container.NewDockerClient()
+	containerRuntime, err := container.RuntimeFrom(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to container runtime")
 	}
@@ -182,7 +182,7 @@ func (c *ContainerCmd) RunLoggingOutputOnFail(ctx context.Context) ([]string, er
 
 // Run will run a configured ContainerCmd inside a container instance.
 func (c *ContainerCmd) Run(ctx context.Context) error {
-	containerRuntime, err := container.NewDockerClient()
+	containerRuntime, err := container.RuntimeFrom(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to container runtime")
 	}

--- a/test/infrastructure/docker/internal/docker/types/node_test.go
+++ b/test/infrastructure/docker/internal/docker/types/node_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/cluster-api/test/infrastructure/container"
+)
+
+func TestIP(t *testing.T) {
+	g := NewWithT(t)
+	containerRuntime := &container.FakeRuntime{}
+	ctx := container.RuntimeInto(context.Background(), containerRuntime)
+
+	node := &Node{
+		Name: "TestNode",
+	}
+
+	ipv4, ipv6, err := node.IP(ctx)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(ipv4).To(Equal("TestNodeIPv4"))
+	g.Expect(ipv6).To(Equal("TestNodeIPv6"))
+}
+
+func TestDeleteContainer(t *testing.T) {
+	g := NewWithT(t)
+	containerRuntime := &container.FakeRuntime{}
+	ctx := container.RuntimeInto(context.Background(), containerRuntime)
+
+	node := &Node{
+		Name: "TestNode",
+	}
+
+	containerRuntime.ResetDeleteContainerCallLogs()
+	err := node.Delete(ctx)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	callLog := containerRuntime.DeleteContainerCalls()
+	g.Expect(callLog).To(HaveLen(1))
+	g.Expect(callLog[0]).To(Equal("TestNode"))
+}
+
+func TestKillContainer(t *testing.T) {
+	g := NewWithT(t)
+	containerRuntime := &container.FakeRuntime{}
+	ctx := container.RuntimeInto(context.Background(), containerRuntime)
+
+	node := &Node{
+		Name: "TestNode",
+	}
+
+	containerRuntime.ResetKillContainerCallLogs()
+	err := node.Kill(ctx, "TestSignal")
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	callLog := containerRuntime.KillContainerCalls()
+	g.Expect(callLog).To(HaveLen(1))
+	g.Expect(callLog[0].Container).To(Equal("TestNode"))
+	g.Expect(callLog[0].Signal).To(Equal("TestSignal"))
+}
+
+func TestCommandRun(t *testing.T) {
+	g := NewWithT(t)
+	containerRuntime := &container.FakeRuntime{}
+	ctx := container.RuntimeInto(context.Background(), containerRuntime)
+
+	containerRuntime.ResetExecContainerCallLogs()
+	cmd := GetContainerCmder("TestContainer").Command("test", "one", "two")
+	err := cmd.Run(ctx)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	callLog := containerRuntime.ExecContainerCalls()
+	g.Expect(callLog).To(HaveLen(1))
+	g.Expect(callLog[0].ContainerName).To(Equal("TestContainer"))
+	g.Expect(callLog[0].Command).To(Equal("test"))
+	g.Expect(callLog[0].Args).To(ContainElements([]string{"one", "two"}))
+}
+
+func TestWriteFile(t *testing.T) {
+	g := NewWithT(t)
+	containerRuntime := &container.FakeRuntime{}
+	ctx := container.RuntimeInto(context.Background(), containerRuntime)
+
+	containerRuntime.ResetExecContainerCallLogs()
+
+	node := NewNode("TestContainer", "TestImage", "testing")
+	err := node.WriteFile(ctx, "/tmp/test123", "testcontent")
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	callLog := containerRuntime.ExecContainerCalls()
+	g.Expect(callLog).To(HaveLen(2))
+
+	// First call is to make sure the output directory exists
+	g.Expect(callLog[0].ContainerName).To(Equal("TestContainer"))
+	g.Expect(callLog[0].Command).To(Equal("mkdir"))
+	g.Expect(callLog[0].Args).To(ContainElements([]string{"-p", "/tmp"}))
+
+	// Second call is to write out the contents to the file
+	g.Expect(callLog[1].ContainerName).To(Equal("TestContainer"))
+	g.Expect(callLog[1].Command).To(Equal("cp"))
+	g.Expect(callLog[1].Args).To(ContainElements([]string{"/dev/stdin", "/tmp/test123"}))
+
+	content := make([]byte, 12)
+	count, err := callLog[1].Config.InputBuffer.Read(content)
+	data := string(content[:count])
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(data).To(Equal("testcontent"))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This builds on the CAPD changes to use the docker API instead of calling
out to the CLI. With those changes, it is now possible to insert a
testing fake and perform unit testing for the code that would normally
call out to Docker.

The test coverage introduced by this change is not extensive, but it
does add coverage where we previously had none at all. With this basic
coverage in place, it should now be easier to add new tests if we find
specific scenarios that we want to reproduce and validate for any new
bug reports.

**Which issue(s) this PR fixes**:
Fixes #4380
