### PR TITLE
🐛 Fix adding appended list directly causing changing previous value

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -431,7 +431,11 @@ func paths(path []string, diff map[string]interface{}) [][]string {
 	for key, m := range diff {
 		nested, ok := m.(map[string]interface{})
 		if !ok {
-			allPaths = append(allPaths, append(path, key))
+			// We have to use a copy of path, because otherwise the slice we append to
+			// allPaths would be overwritten in another iteration.
+			tmp := make([]string, len(path))
+			copy(tmp, path)
+			allPaths = append(allPaths, append(tmp, key))
 			continue
 		}
 		allPaths = append(allPaths, paths(append(path, key), nested)...)

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -1047,6 +1047,23 @@ func TestPaths(t *testing.T) {
 			diff:     map[string]interface{}{},
 			expected: [][]string{},
 		},
+		{
+			name: "long recursive check with two keys",
+			diff: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"kubeadmConfigSpec": map[string]interface{}{
+						"clusterConfiguration": map[string]interface{}{
+							"version": "v2.0.1",
+							"abc":     "d",
+						},
+					},
+				},
+			},
+			expected: [][]string{
+				{"spec", "kubeadmConfigSpec", "clusterConfiguration", "version"},
+				{"spec", "kubeadmConfigSpec", "clusterConfiguration", "abc"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
* Added new unit test to cover this case, original this test case will fail.

**What this PR does / why we need it**:

Original paths will use appended list directly, this works fine when there is fewer recursion, or there is only one for loop for the diff, but if there are multiple loop, second loop would override the first added array.
Thus I'm creating a new tmp array to do a deepcopy, then add this appended value into allPaths.