### PR TITLE
🐛 Fix predicate log key/values

### DIFF
--- a/util/predicates/generic_predicates.go
+++ b/util/predicates/generic_predicates.go
@@ -132,16 +132,16 @@ func Any(logger logr.Logger, predicates ...predicate.Funcs) predicate.Funcs {
 func ResourceHasFilterLabel(logger logr.Logger, labelValue string) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return processIfLabelMatch(logger.WithValues("predicate", "updateEvent"), e.ObjectNew, labelValue)
+			return processIfLabelMatch(logger.WithValues("predicate", "ResourceHasFilterLabel", "eventType", "update"), e.ObjectNew, labelValue)
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return processIfLabelMatch(logger.WithValues("predicate", "createEvent"), e.Object, labelValue)
+			return processIfLabelMatch(logger.WithValues("predicate", "ResourceHasFilterLabel", "eventType", "create"), e.Object, labelValue)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return processIfLabelMatch(logger.WithValues("predicate", "deleteEvent"), e.Object, labelValue)
+			return processIfLabelMatch(logger.WithValues("predicate", "ResourceHasFilterLabel", "eventType", "delete"), e.Object, labelValue)
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return processIfLabelMatch(logger.WithValues("predicate", "genericEvent"), e.Object, labelValue)
+			return processIfLabelMatch(logger.WithValues("predicate", "ResourceHasFilterLabel", "eventType", "generic"), e.Object, labelValue)
 		},
 	}
 }
@@ -162,16 +162,16 @@ func ResourceHasFilterLabel(logger logr.Logger, labelValue string) predicate.Fun
 func ResourceNotPaused(logger logr.Logger) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return processIfNotPaused(logger.WithValues("predicate", "updateEvent"), e.ObjectNew)
+			return processIfNotPaused(logger.WithValues("predicate", "ResourceNotPaused", "eventType", "update"), e.ObjectNew)
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return processIfNotPaused(logger.WithValues("predicate", "createEvent"), e.Object)
+			return processIfNotPaused(logger.WithValues("predicate", "ResourceNotPaused", "eventType", "create"), e.Object)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return processIfNotPaused(logger.WithValues("predicate", "deleteEvent"), e.Object)
+			return processIfNotPaused(logger.WithValues("predicate", "ResourceNotPaused", "eventType", "delete"), e.Object)
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return processIfNotPaused(logger.WithValues("predicate", "genericEvent"), e.Object)
+			return processIfNotPaused(logger.WithValues("predicate", "ResourceNotPaused", "eventType", "generic"), e.Object)
 		},
 	}
 }
@@ -216,16 +216,16 @@ func processIfLabelMatch(logger logr.Logger, obj client.Object, labelValue strin
 func ResourceIsNotExternallyManaged(logger logr.Logger) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return processIfNotExternallyManaged(logger.WithValues("predicate", "updateEvent"), e.ObjectNew)
+			return processIfNotExternallyManaged(logger.WithValues("predicate", "ResourceIsNotExternallyManaged", "eventType", "update"), e.ObjectNew)
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return processIfNotExternallyManaged(logger.WithValues("predicate", "createEvent"), e.Object)
+			return processIfNotExternallyManaged(logger.WithValues("predicate", "ResourceIsNotExternallyManaged", "eventType", "create"), e.Object)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return processIfNotExternallyManaged(logger.WithValues("predicate", "deleteEvent"), e.Object)
+			return processIfNotExternallyManaged(logger.WithValues("predicate", "ResourceIsNotExternallyManaged", "eventType", "delete"), e.Object)
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return processIfNotExternallyManaged(logger.WithValues("predicate", "genericEvent"), e.Object)
+			return processIfNotExternallyManaged(logger.WithValues("predicate", "ResourceIsNotExternallyManaged", "eventType", "generic"), e.Object)
 		},
 	}
 }
@@ -246,16 +246,16 @@ func processIfNotExternallyManaged(logger logr.Logger, obj client.Object) bool {
 func ResourceIsTopologyOwned(logger logr.Logger) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return processIfTopologyOwned(logger.WithValues("predicate", "updateEvent"), e.ObjectNew)
+			return processIfTopologyOwned(logger.WithValues("predicate", "ResourceIsTopologyOwned", "eventType", "update"), e.ObjectNew)
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return processIfTopologyOwned(logger.WithValues("predicate", "createEvent"), e.Object)
+			return processIfTopologyOwned(logger.WithValues("predicate", "ResourceIsTopologyOwned", "eventType", "create"), e.Object)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return processIfTopologyOwned(logger.WithValues("predicate", "deleteEvent"), e.Object)
+			return processIfTopologyOwned(logger.WithValues("predicate", "ResourceIsTopologyOwned", "eventType", "delete"), e.Object)
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return processIfTopologyOwned(logger.WithValues("predicate", "genericEvent"), e.Object)
+			return processIfTopologyOwned(logger.WithValues("predicate", "ResourceIsTopologyOwned", "eventType", "generic"), e.Object)
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR fixes the logs in our predicates to log with:
```go
predicate: <predicate-name>, eventType: <eventType>
```
instead of
```go
predicate: <eventType>
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to https://github.com/kubernetes-sigs/cluster-api/pull/5665#discussion_r750018201
