### PR TITLE
🌱 resolved Spelling of webhook in defaulting.go

### DIFF
--- a/util/defaulting/defaulting.go
+++ b/util/defaulting/defaulting.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package defaulting implements defaulting webook functionality.
+// Package defaulting implements defaulting webhook functionality.
 package defaulting
 
 import (


### PR DESCRIPTION
🌱 

Spelling of webhook in defaulting.go file is wrong, it is webook.
Updated it to webhook.

Fixes # Webhook is misspelt in defaulting.go file #5682
