### PR TITLE
🌱 Move dockermachinepool controller to internal

### DIFF
--- a/docs/book/src/developer/providers/v1.0-to-v1.1.md
+++ b/docs/book/src/developer/providers/v1.0-to-v1.1.md
@@ -35,6 +35,7 @@ are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
     * [bootstrap/kubeadm/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5493) 
     * [exp/addons/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5639) 
     * [test/infrastructure/docker/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5595) 
+    * [test/infrastructure/docker/exp/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5690) 
 
 ### Other
 

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -147,7 +147,7 @@ generate-manifests: $(CONTROLLER_GEN) ## Generate manifests e.g. CRD, RBAC etc.
 	$(CONTROLLER_GEN) \
 		paths=./api/... \
 		paths=./$(EXP_DIR)/api/... \
-		paths=./$(EXP_DIR)/controllers/... \
+		paths=./$(EXP_DIR)/internal/controllers/... \
 		paths=./internal/controllers/... \
 		crd:crdVersions=v1 \
 		rbac:roleName=manager-role \

--- a/test/infrastructure/docker/exp/controllers/alias.go
+++ b/test/infrastructure/docker/exp/controllers/alias.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllers implements controller functionality.
+package controllers
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	dockermachinepoolcontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+// DockerMachinePoolReconciler reconciles a DockerMachinePool object.
+type DockerMachinePoolReconciler struct {
+	Client client.Client
+	Scheme *runtime.Scheme
+}
+
+// SetupWithManager will add watches for this controller.
+func (r *DockerMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	return (&dockermachinepoolcontrollers.DockerMachinePoolReconciler{
+		Client: r.Client,
+		Scheme: r.Scheme,
+	}).SetupWithManager(ctx, mgr, options)
+}

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -182,8 +182,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if feature.Gates.Enabled(feature.MachinePool) {
 		if err := (&expcontrollers.DockerMachinePoolReconciler{
 			Client: mgr.GetClient(),
-			Log:    ctrl.Log.WithName("controllers").WithName("DockerMachinePool"),
-		}).SetupWithManager(mgr, controller.Options{
+		}).SetupWithManager(ctx, mgr, controller.Options{
 			MaxConcurrentReconciles: concurrency,
 		}); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "DockerMachinePool")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Move Docker  Machin Pool controller package to internal and create alias.go for exposing Reconcile

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Ref: #5455 