### PR TITLE
:seedling: Added C-R validating webhook for KCP scale subresource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,7 @@ generate-manifests-kcp: $(CONTROLLER_GEN)
 	$(CONTROLLER_GEN) \
 		paths=./controlplane/kubeadm/api/... \
 		paths=./controlplane/kubeadm/controllers/... \
+		paths=./controlplane/kubeadm/webhooks/... \
 		crd:crdVersions=v1 \
 		rbac:roleName=manager-role \
 		output:crd:dir=./controlplane/kubeadm/config/crd/bases \

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -236,7 +236,7 @@ func validateKubeadmControlPlaneSpec(s KubeadmControlPlaneSpec, namespace string
 				allErrs,
 				field.Forbidden(
 					pathPrefix.Child("replicas"),
-					"cannot be an even number when using managed etcd",
+					"cannot be an even number when etcd is stacked",
 				),
 			)
 		}

--- a/controlplane/kubeadm/config/webhook/manifests.yaml
+++ b/controlplane/kubeadm/config/webhook/manifests.yaml
@@ -98,3 +98,24 @@ webhooks:
     resources:
     - kubeadmcontrolplanetemplates
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-scale-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation-scale.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanes/scale
+  sideEffects: None

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -44,11 +44,13 @@ import (
 	kcpv1alpha4 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
 	kcpv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	kubeadmcontrolplanecontrollers "sigs.k8s.io/cluster-api/controlplane/kubeadm/controllers"
+	kcpwebhooks "sigs.k8s.io/cluster-api/controlplane/kubeadm/webhooks"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/version"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var (
@@ -244,6 +246,12 @@ func setupWebhooks(mgr ctrl.Manager) {
 	if err := (&kcpv1.KubeadmControlPlaneTemplate{}).SetupWebhookWithManager((mgr)); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "KubeadmControlPlaneTemplate")
 	}
+
+	mgr.GetWebhookServer().Register("/validate-scale-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane", &webhook.Admission{
+		Handler: &kcpwebhooks.ScaleValidator{
+			Client: mgr.GetClient(),
+		},
+	})
 }
 
 func concurrency(c int) controller.Options {

--- a/controlplane/kubeadm/webhooks/doc.go
+++ b/controlplane/kubeadm/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks provides the validating webhook for kubeadmcontrolplane scale subresource.
+package webhooks

--- a/controlplane/kubeadm/webhooks/scale.go
+++ b/controlplane/kubeadm/webhooks/scale.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/pkg/errors"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:verbs=update,path=/validate-scale-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=controlplane.cluster.x-k8s.io,resources=kubeadmcontrolplanes/scale,versions=v1beta1,name=validation-scale.kubeadmcontrolplane.controlplane.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// ScaleValidator validates KCP for replicas.
+type ScaleValidator struct {
+	Client  client.Reader
+	decoder *admission.Decoder
+}
+
+// Handle will validate for number of replicas.
+func (v *ScaleValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	scale := &autoscalingv1.Scale{}
+
+	err := v.decoder.Decode(req, scale)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, errors.Wrapf(err, "failed to decode Scale resource"))
+	}
+
+	kcp := &v1beta1.KubeadmControlPlane{}
+	kcpKey := types.NamespacedName{Namespace: scale.ObjectMeta.Namespace, Name: scale.ObjectMeta.Name}
+	if err = v.Client.Get(ctx, kcpKey, kcp); err != nil {
+		return admission.Errored(http.StatusInternalServerError, errors.Wrapf(err, "failed to get KubeadmControlPlane %s/%s", scale.ObjectMeta.Namespace, scale.ObjectMeta.Name))
+	}
+
+	if scale.Spec.Replicas == 0 {
+		return admission.Denied("replicas cannot be 0")
+	}
+
+	externalEtcd := false
+	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration != nil {
+		if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External != nil {
+			externalEtcd = true
+		}
+	}
+
+	if !externalEtcd {
+		if scale.Spec.Replicas%2 == 0 {
+			return admission.Denied("replicas cannot be an even number when etcd is stacked")
+		}
+	}
+
+	return admission.Allowed("")
+}
+
+// InjectDecoder injects the decoder.
+// ScaleValidator implements admission.DecoderInjector.
+// A decoder will be automatically injected.
+func (v *ScaleValidator) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}

--- a/controlplane/kubeadm/webhooks/scale_test.go
+++ b/controlplane/kubeadm/webhooks/scale_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/pointer"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	kcpv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = kcpv1.AddToScheme(scheme)
+	_ = admissionv1.AddToScheme(scheme)
+}
+
+var (
+	scheme *runtime.Scheme
+)
+
+func TestKubeadmControlPlaneValidateScale(t *testing.T) {
+	kcpManagedEtcd := &kcpv1.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kcp-managed-etcd",
+			Namespace: "foo",
+		},
+		Spec: kcpv1.KubeadmControlPlaneSpec{
+			MachineTemplate: kcpv1.KubeadmControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					APIVersion: "test/v1alpha1",
+					Kind:       "UnknownInfraMachine",
+					Namespace:  "foo",
+					Name:       "infraTemplate",
+				},
+				NodeDrainTimeout: &metav1.Duration{Duration: time.Second},
+			},
+			Replicas: pointer.Int32Ptr(1),
+			RolloutStrategy: &kcpv1.RolloutStrategy{
+				Type: kcpv1.RollingUpdateStrategyType,
+				RollingUpdate: &kcpv1.RollingUpdate{
+					MaxSurge: &intstr.IntOrString{
+						IntVal: 1,
+					},
+				},
+			},
+			KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+				InitConfiguration: &bootstrapv1.InitConfiguration{
+					LocalAPIEndpoint: bootstrapv1.APIEndpoint{
+						AdvertiseAddress: "127.0.0.1",
+						BindPort:         int32(443),
+					},
+					NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+						Name: "kcp-managed-etcd",
+					},
+				},
+				ClusterConfiguration: &bootstrapv1.ClusterConfiguration{
+					ClusterName: "kcp-managed-etcd",
+					DNS: bootstrapv1.DNS{
+						ImageMeta: bootstrapv1.ImageMeta{
+							ImageRepository: "k8s.gcr.io/coredns",
+							ImageTag:        "1.6.5",
+						},
+					},
+				},
+				JoinConfiguration: &bootstrapv1.JoinConfiguration{
+					Discovery: bootstrapv1.Discovery{
+						Timeout: &metav1.Duration{
+							Duration: 10 * time.Minute,
+						},
+					},
+					NodeRegistration: bootstrapv1.NodeRegistrationOptions{
+						Name: "kcp-managed-etcd",
+					},
+				},
+				PreKubeadmCommands: []string{
+					"kcp-managed-etcd", "foo",
+				},
+				PostKubeadmCommands: []string{
+					"kcp-managed-etcd", "foo",
+				},
+				Files: []bootstrapv1.File{
+					{
+						Path: "kcp-managed-etcd",
+					},
+				},
+				Users: []bootstrapv1.User{
+					{
+						Name: "user",
+						SSHAuthorizedKeys: []string{
+							"ssh-rsa foo",
+						},
+					},
+				},
+				NTP: &bootstrapv1.NTP{
+					Servers: []string{"test-server-1", "test-server-2"},
+					Enabled: pointer.BoolPtr(true),
+				},
+			},
+			Version: "v1.16.6",
+		},
+	}
+
+	kcpExternalEtcd := kcpManagedEtcd.DeepCopy()
+	kcpExternalEtcd.ObjectMeta.Name = "kcp-external-etcd"
+	kcpExternalEtcd.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.External = &bootstrapv1.ExternalEtcd{}
+
+	tests := []struct {
+		name              string
+		admissionRequest  admission.Request
+		expectRespAllowed bool
+		expectRespReason  string
+	}{
+		{
+			name:              "should return error when trying to scale to zero",
+			expectRespAllowed: false,
+			expectRespReason:  "replicas cannot be 0",
+			admissionRequest: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       uuid.NewUUID(),
+				Kind:      metav1.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "Scale"},
+				Operation: admissionv1.Update,
+				Object:    runtime.RawExtension{Raw: []byte(`{"metadata":{"name":"kcp-managed-etcd","namespace":"foo"},"spec":{"replicas":0}}`)},
+			}},
+		},
+		{
+			name:              "should return error when trying to scale to even number of replicas with managed etcd",
+			expectRespAllowed: false,
+			expectRespReason:  "replicas cannot be an even number when etcd is stacked",
+			admissionRequest: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       uuid.NewUUID(),
+				Kind:      metav1.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "Scale"},
+				Operation: admissionv1.Update,
+				Object:    runtime.RawExtension{Raw: []byte(`{"metadata":{"name":"kcp-managed-etcd","namespace":"foo"},"spec":{"replicas":2}}`)},
+			}},
+		},
+		{
+			name:              "should allow odd number of replicas with managed etcd",
+			expectRespAllowed: true,
+			expectRespReason:  "",
+			admissionRequest: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       uuid.NewUUID(),
+				Kind:      metav1.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "Scale"},
+				Operation: admissionv1.Update,
+				Object:    runtime.RawExtension{Raw: []byte(`{"metadata":{"name":"kcp-managed-etcd","namespace":"foo"},"spec":{"replicas":3}}`)},
+			}},
+		},
+		{
+			name:              "should allow even number of replicas with external etcd",
+			expectRespAllowed: true,
+			expectRespReason:  "",
+			admissionRequest: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       uuid.NewUUID(),
+				Kind:      metav1.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "Scale"},
+				Operation: admissionv1.Update,
+				Object:    runtime.RawExtension{Raw: []byte(`{"metadata":{"name":"kcp-external-etcd","namespace":"foo"},"spec":{"replicas":4}}`)},
+			}},
+		},
+		{
+			name:              "should allow odd number of replicas with external etcd",
+			expectRespAllowed: true,
+			expectRespReason:  "",
+			admissionRequest: admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+				UID:       uuid.NewUUID(),
+				Kind:      metav1.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "Scale"},
+				Operation: admissionv1.Update,
+				Object:    runtime.RawExtension{Raw: []byte(`{"metadata":{"name":"kcp-external-etcd","namespace":"foo"},"spec":{"replicas":3}}`)},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			decoder, _ := admission.NewDecoder(scheme)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kcpManagedEtcd, kcpExternalEtcd).Build()
+
+			// Create the webhook and add the fakeClient as its client.
+			scaleHandler := ScaleValidator{
+				Client:  fakeClient,
+				decoder: decoder,
+			}
+
+			resp := scaleHandler.Handle(context.Background(), tt.admissionRequest)
+			g.Expect(resp.Allowed).Should(Equal(tt.expectRespAllowed))
+			g.Expect(string(resp.Result.Reason)).Should(Equal(tt.expectRespReason))
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Dharmjit Singh <sdharmjit@vmware.com>

**What this PR does / why we need it**:
This PR introduces a `Controller-Runtime` validating webhook for `kubeadmControlPlane` scale subresource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5466 
