### PR TITLE
🐛 Ensure we're not trying to reconcile the topology of non-managed clusters

### DIFF
--- a/controllers/external/tracker.go
+++ b/controllers/external/tracker.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/predicates"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -37,7 +38,7 @@ type ObjectTracker struct {
 }
 
 // Watch uses the controller to issue a Watch only if the object hasn't been seen before.
-func (o *ObjectTracker) Watch(log logr.Logger, obj runtime.Object, handler handler.EventHandler) error {
+func (o *ObjectTracker) Watch(log logr.Logger, obj runtime.Object, handler handler.EventHandler, p ...predicate.Predicate) error {
 	// Consider this a no-op if the controller isn't present.
 	if o.Controller == nil {
 		return nil
@@ -56,7 +57,7 @@ func (o *ObjectTracker) Watch(log logr.Logger, obj runtime.Object, handler handl
 	err := o.Controller.Watch(
 		&source.Kind{Type: u},
 		handler,
-		predicates.ResourceNotPaused(log),
+		append(p, predicates.ResourceNotPaused(log))...,
 	)
 	if err != nil {
 		o.m.Delete(key)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently the e2e tests are broken (https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main) this PR fixes it.
The test is broken because the capi-controller panics.

Previously:
* we were watching on:
  * Clusters, MachineDeployments, ClusterClasses
* after a reconcile we were also watching on
  * ControlPlanes, InfrastructureClusters

We had a filter predicate in place and it:
* filtered Clusters correctly
* discarded MachineDeployment and ClusterClass events
* it was not applied on the ControlPlane and InfrastructureCluster watches we create during reconcile
  * => this means we were also reconciling non-managed Clusters triggered by events on their ControlPlanes and InfrastructureClusters

Now:
* We're filtering:
  * Clusters based on if .spec.topology exists
  * ClusterClasses are not filtered (and they don't have to be)
  * MachineDeployments are filtered based on the topology owned label
  * ControlPlanes, InfrastructureCluster are filtered based on the topology owned label
* As a fallback we also check during reconcile if the Cluster has the topology field set, because there could be cases where e.g. MachineDeployments have a topology owned label but belong to a Cluster which is not managed.

Note: This also drastically reduces the Cluster get calls with the live client triggered by changes to unmanaged MDs/ControlPlanes/InfrastructureClusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
