### PR TITLE
🐛 fixed a number of broken markdown links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@
       - [CRD additionalPrinterColumns](#crd-additionalprintercolumns)
     - [Google Doc Viewing Permissions](#google-doc-viewing-permissions)
     - [Issue and Pull Request Management](#issue-and-pull-request-management)
-    - [Subareas of interest](#subareas-of-interest)
+    - [Contributors ladder](#contributors-ladder)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -75,7 +75,7 @@ These guarantees extend to all code exposed in our Go Module, including
 Types and functions not in public APIs are not considered part of the guarantee.
 The test module, clusterctl, and experiments do not provide any backward compatible guarantees.
 
-#### Backporting
+#### Backporting a patch
 
 We only accept backports of critical bugs, security issues, or bugs without easy workarounds, any
 backport MUST not be breaking for either API or behavioral changes.

--- a/docs/book/src/reference/glossary.md
+++ b/docs/book/src/reference/glossary.md
@@ -181,7 +181,7 @@ The pivot process is also used for deleting a management cluster and could also 
 
 ### Provider
 
-See [Infrastructure Provider](#user-content-infrastructure-provider)
+See [Infrastructure Provider](#infrastructure-provider)
 
 ### Provider components
 
@@ -206,7 +206,7 @@ is running as a static pod.
 
 ### Server
 
-The infrastructure that backs a [Machine Resource](#user-content-machine), typically either a cloud instance, virtual machine, or physical host.
+The infrastructure that backs a [Machine Resource](#machine), typically either a cloud instance, virtual machine, or physical host.
 
 # W
 ---

--- a/docs/book/src/tasks/kubeadm-control-plane.md
+++ b/docs/book/src/tasks/kubeadm-control-plane.md
@@ -38,5 +38,4 @@ Cluster API Machines:
   for additional details.
 
 <!-- links -->
-[adoption]: upgrading-cluster-api-versions.md#adopting-existing-machines-into-kubeadmcontrolplane-management
 [upgrades]: upgrading-clusters.md#how-to-upgrade-the-kubernetes-control-plane-version

--- a/docs/staging-use-cases.md
+++ b/docs/staging-use-cases.md
@@ -146,15 +146,12 @@ This is a living document that serves as a reference and a staging area for use 
 - 🔭 As an operator, given I have a management cluster and a workload cluster, I want to monitor the cleanup of created by my workload cluster.
 
 - 🔭 As an operator, given I have a management cluster and a workload cluster, I want to ensure the etcd database in my workload cluster is backed up.
-Multitenancy Management
-- 🔭 As an operator, given I have a management cluster and a workload cluster, I want to setup roles, role bindings, users, and usage quotas on my workload cluster.
 
 ### Adoption
 - 🔭 As an operator, given I have created a Kubernetes-conformant cluster without ClusterAPI, I want to use ClusterAPI to manage it. In order to do so, I need to know the requirements for adopting/importing this cluster in terms of required CRD’s and operators (e.g Machine and Cluster objects).
 
 ### Multitenancy Management
 - 🔭 As an operator, given I have a management cluster and a workload cluster, I want to setup roles, role bindings, users, and usage quotas on my workload cluster.
-
 
 ### Disaster Recovery
 - 🔭As an operator, I want to be able to recover from the complete loss of all the control plane replicas of a workload cluster. This excludes etcd.


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fixes for a number of links in our MD docs which were either outdated or not working properly for some other reason.