### PR TITLE
reduce operations on healthy machine

### DIFF
--- a/controllers/machinehealthcheck_targets.go
+++ b/controllers/machinehealthcheck_targets.go
@@ -302,7 +302,6 @@ func (r *MachineHealthCheckReconciler) healthCheckTargets(targets []healthCheckT
 		}
 
 		if t.Machine.DeletionTimestamp.IsZero() && t.Node != nil {
-			conditions.MarkTrue(t.Machine, clusterv1.MachineHealthCheckSuccededCondition)
 			healthy = append(healthy, t)
 		}
 	}


### PR DESCRIPTION
✨ (:sparkles:, feature additions)  reduce operations on healthy machine

**What this PR does / why we need it**:
The controller will do the following two things to healthy machines, when any node updated
1. Find out whether the ExternalRemediation Object exists, and delete it if it exists
2. Try patch the health check succeed condition on the machine
At this time, when the number of machines is very large, it is a waste of time.
According to logic, if Machine is always healthy, there is no need to do the above events, and it will also reduce the pressure on the API server.

