### PR TITLE
:bug: Backport clusterctl discovery fix to branch release-1.0

### DIFF
--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -233,7 +233,12 @@ type Proxy interface {
 	// NewClient returns a new controller runtime Client object for working on the management cluster
 	NewClient() (client.Client, error)
 
-	// ListResources returns all the Kubernetes objects with the given labels existing the listed namespaces.
+	// ListResources lists namespaced and cluster-wide resources for a component matching the labels.
+	// Namespaced resources are only listed in the given namespaces.
+	// Please note that we are not returning resources for the component's CRD (e.g. we are not returning
+	// Certificates for cert-manager, Clusters for CAPI, AWSCluster for CAPA and so on).
+	// This is done to avoid errors when listing resources of providers which have already been
+	// deleted/scaled down to 0 replicas/with malfunctioning webhooks.
 	ListResources(labels map[string]string, namespaces ...string) ([]unstructured.Unstructured, error)
 
 	// GetContexts returns the list of contexts in kubeconfig which begin with prefix.


### PR DESCRIPTION
This patch was originally introduced in PR #5684.
Original name: "clusterctl discovery should ignore provider's resources"
Original commit id: db5b183

Original description:

While managing components (for cert-manager or providers) clusterctl
implements a discovery function to seek for all the objects
part of the component.

This commit makes this code to ignore resources for a provider
(e.g Cluster for CAPI, AWSCluster for CAPA, Certificates for cert-manager)
given that those resources are not part of the component itself.

This will make operations like upgrade plan or apply and delete resilient to actual
state of cert-manager web hooks; in fact, those operations can now work when
web-hooks are not functioning (due to provider's deployment already deleted,
to provider scaled down to 0, to other errors)

This commit also introduces some logic originally implemented in commit
f5a9d76759 that implements the ability to skip excluded CRD during
resource listing.

Reason for backporting:

The issues that were solved by commit db5b183 and f5a9d76759  on the main
branch are also effecting older releases of CAPI currently in use thus backporting
the "discovery fix" and some related code from f5a9d76759 would solve a lot of issues
faced by users e.g related to upgrade process as mentioned in the original db5b183 commit.
