### PR TITLE
🐛  fix capitalization of error string

### DIFF
--- a/controllers/topology/clusterclass_controller_test.go
+++ b/controllers/topology/clusterclass_controller_test.go
@@ -244,7 +244,7 @@ func assertHasOwnerReference(obj client.Object, ownerRef metav1.OwnerReference) 
 		}
 	}
 	if !found {
-		return fmt.Errorf("Object %s does not have OwnerReference %s", tlog.KObj{Obj: obj}, &ownerRef)
+		return fmt.Errorf("object %s does not have OwnerReference %s", tlog.KObj{Obj: obj}, &ownerRef)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fix an error string starting with a capital letter.