### PR TITLE
🌱  add patch validation to clusterclass webhook

### DIFF
--- a/docs/proposals/202105256-cluster-class-and-managed-topologies.md
+++ b/docs/proposals/202105256-cluster-class-and-managed-topologies.md
@@ -620,7 +620,7 @@ Builtin variables are available under the `builtin.` prefix. Some examples:
     - jsonPatches:
       - `op`: one of: `add`, `replace` or `remove`
       - `path`:
-        - must be a valid JSON pointer (RFC 6901) and start with `/spec/`
+        - must be a valid JSON pointer starting with `/spec/`
         - only the indexes `0` (prepend) and `-` (append) in combination with the `add` operation are allowed (append and prepend 
           are the only allowed array modifications).
         - the JSON pointer is not verified against the target CRD as that would require parsing the template CRD, which is impractical in a webhook.

--- a/internal/builder/builders.go
+++ b/internal/builder/builders.go
@@ -198,6 +198,7 @@ type ClusterClassBuilder struct {
 	controlPlaneInfrastructureMachineTemplate *unstructured.Unstructured
 	machineDeploymentClasses                  []clusterv1.MachineDeploymentClass
 	variables                                 []clusterv1.ClusterClassVariable
+	patches                                   []clusterv1.ClusterClassPatch
 }
 
 // ClusterClass returns a ClusterClassBuilder with the given name and namespace.
@@ -235,9 +236,15 @@ func (c *ClusterClassBuilder) WithControlPlaneInfrastructureMachineTemplate(t *u
 	return c
 }
 
-// WithVariables adds the Variables the ClusterClassBuilder.
+// WithVariables adds the Variables to the ClusterClassBuilder.
 func (c *ClusterClassBuilder) WithVariables(vars []clusterv1.ClusterClassVariable) *ClusterClassBuilder {
 	c.variables = vars
+	return c
+}
+
+// WithPatches adds the patches to the ClusterClassBuilder.
+func (c *ClusterClassBuilder) WithPatches(patches []clusterv1.ClusterClassPatch) *ClusterClassBuilder {
+	c.patches = patches
 	return c
 }
 
@@ -263,6 +270,7 @@ func (c *ClusterClassBuilder) Build() *clusterv1.ClusterClass {
 		},
 		Spec: clusterv1.ClusterClassSpec{
 			Variables: c.variables,
+			Patches:   c.patches,
 		},
 	}
 	if c.infrastructureClusterTemplate != nil {

--- a/internal/webhooks/clusterclass.go
+++ b/internal/webhooks/clusterclass.go
@@ -159,6 +159,9 @@ func (webhook *ClusterClass) validate(ctx context.Context, old, new *clusterv1.C
 	// Validate variables.
 	allErrs = append(allErrs, variables.ValidateClusterClassVariables(new.Spec.Variables, field.NewPath("spec", "variables"))...)
 
+	// Validate patches.
+	allErrs = append(allErrs, validatePatches(new)...)
+
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("ClusterClass").GroupKind(), new.Name, allErrs)
 	}

--- a/internal/webhooks/patch_validation.go
+++ b/internal/webhooks/patch_validation.go
@@ -1,0 +1,365 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// validatePatches returns errors if the Patches in the ClusterClass violate any validation rules.
+func validatePatches(clusterClass *clusterv1.ClusterClass) field.ErrorList {
+	var allErrs field.ErrorList
+	names := sets.String{}
+	for i, patch := range clusterClass.Spec.Patches {
+		allErrs = append(
+			allErrs,
+			validatePatch(patch, names, clusterClass, field.NewPath("spec", "patches").Index(i))...,
+		)
+		names.Insert(patch.Name)
+	}
+	return allErrs
+}
+
+func validatePatch(patch clusterv1.ClusterClassPatch, names sets.String, clusterClass *clusterv1.ClusterClass, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs,
+		validatePatchName(patch, names, path)...,
+	)
+	allErrs = append(allErrs,
+		validatePatchDefinitions(patch, clusterClass, path)...,
+	)
+	return allErrs
+}
+
+func validatePatchName(patch clusterv1.ClusterClassPatch, names sets.String, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if patch.Name == "" {
+		allErrs = append(allErrs,
+			field.Required(
+				path.Child("name"),
+				"patch name must be defined",
+			),
+		)
+	}
+
+	if names.Has(patch.Name) {
+		allErrs = append(allErrs,
+			field.Invalid(
+				path.Child("name"),
+				patch.Name,
+				fmt.Sprintf("patch names must be unique. Patch with name %q is defined more than once", patch.Name),
+			),
+		)
+	}
+	return allErrs
+}
+
+func validatePatchDefinitions(patch clusterv1.ClusterClassPatch, clusterClass *clusterv1.ClusterClass, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	for i, definition := range patch.Definitions {
+		allErrs = append(allErrs,
+			validateJSONPatches(definition.JSONPatches, clusterClass.Spec.Variables, path.Child("definitions").Index(i).Child("jsonPatches"))...)
+		allErrs = append(allErrs,
+			validateSelectors(definition.Selector, clusterClass, path.Child("definitions").Index(i).Child("selector"))...)
+	}
+	return allErrs
+}
+
+// validateSelectors tests to see if the selector matches any template in the ClusterClass.
+// It returns nil as soon as it finds any matching template and an error if there is no match.
+func validateSelectors(selector clusterv1.PatchSelector, class *clusterv1.ClusterClass, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// Return an error if none of the possible selectors are enabled.
+	if !(selector.MatchResources.InfrastructureCluster || selector.MatchResources.ControlPlane ||
+		len(selector.MatchResources.MachineDeploymentClass.Names) > 0) {
+		return append(allErrs,
+			field.Invalid(
+				path,
+				prettyPrint(selector),
+				"no selector enabled",
+			))
+	}
+	if selector.MatchResources.InfrastructureCluster {
+		if selectorMatchTemplate(selector, class.Spec.Infrastructure.Ref) {
+			return nil
+		}
+	}
+	if selector.MatchResources.ControlPlane {
+		if selectorMatchTemplate(selector, class.Spec.ControlPlane.Ref) {
+			return nil
+		}
+	}
+
+	if selector.MatchResources.ControlPlane && class.Spec.ControlPlane.MachineInfrastructure != nil {
+		if selectorMatchTemplate(selector, class.Spec.ControlPlane.MachineInfrastructure.Ref) {
+			return nil
+		}
+	}
+
+	if len(selector.MatchResources.MachineDeploymentClass.Names) > 0 {
+		for _, name := range selector.MatchResources.MachineDeploymentClass.Names {
+			for _, md := range class.Spec.Workers.MachineDeployments {
+				if md.Class == name {
+					if selectorMatchTemplate(selector, md.Template.Infrastructure.Ref) {
+						return nil
+					}
+					if selectorMatchTemplate(selector, md.Template.Bootstrap.Ref) {
+						return nil
+					}
+				}
+			}
+		}
+	}
+	// if the code has not returned at this point there is no matching template in the ClusterClass. Return an error.
+	return append(allErrs,
+		field.Invalid(
+			path,
+			prettyPrint(selector),
+			"selector did not match any template in the ClusterClass",
+		))
+}
+
+// selectorMatchTemplate returns true if APIVersion and Kind for the given selector match the reference.
+func selectorMatchTemplate(selector clusterv1.PatchSelector, reference *corev1.ObjectReference) bool {
+	if reference == nil {
+		return false
+	}
+	return selector.Kind == reference.Kind && selector.APIVersion == reference.APIVersion
+}
+
+var validOps = sets.NewString("add", "replace", "remove")
+
+func validateJSONPatches(jsonPatches []clusterv1.JSONPatch, variables []clusterv1.ClusterClassVariable, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	variableSet := getClusterClassVariablesMap(variables)
+
+	for i, jsonPatch := range jsonPatches {
+		if !validOps.Has(jsonPatch.Op) {
+			allErrs = append(allErrs,
+				field.NotSupported(
+					path.Index(i).Child("op"),
+					prettyPrint(jsonPatch),
+					validOps.List(),
+				))
+		}
+
+		if !strings.HasPrefix(jsonPatch.Path, "/spec/") {
+			allErrs = append(allErrs,
+				field.Invalid(
+					path.Index(i).Child("path"),
+					prettyPrint(jsonPatch),
+					"jsonPatch path must start with \"/spec/\"",
+				))
+		}
+
+		// Validate that array access is only prepend or append for add and not allowed for replace or remove.
+		allErrs = append(allErrs,
+			validateIndexAccess(jsonPatch, path.Index(i).Child("path"))...,
+		)
+
+		// Validate the value and valueFrom fields for the patch.
+		allErrs = append(allErrs,
+			validateJSONPatchValues(jsonPatch, variableSet, path.Index(i))...,
+		)
+	}
+	return allErrs
+}
+
+func validateJSONPatchValues(jsonPatch clusterv1.JSONPatch, variableSet map[string]*clusterv1.ClusterClassVariable, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	// move to the next variable if the jsonPatch does not have "replace" or "add" op. Additional validation is not needed.
+	if jsonPatch.Op != "add" && jsonPatch.Op != "replace" {
+		return allErrs
+	}
+
+	if jsonPatch.Value == nil && jsonPatch.ValueFrom == nil {
+		allErrs = append(allErrs,
+			field.Invalid(
+				path,
+				prettyPrint(jsonPatch),
+				"jsonPatch must define one of value or valueFrom",
+			))
+	}
+
+	if jsonPatch.Value != nil && jsonPatch.ValueFrom != nil {
+		allErrs = append(allErrs,
+			field.Invalid(
+				path,
+				prettyPrint(jsonPatch),
+				"jsonPatch can not define both value and valueFrom",
+			))
+	}
+
+	// Attempt to marshal the JSON to discover if it  is valid. If jsonPatch.Value.Raw is set to nil skip this check
+	// and accept the nil value.
+	if jsonPatch.Value != nil && jsonPatch.Value.Raw != nil {
+		if err := json.Unmarshal(jsonPatch.Value.Raw, &struct{}{}); err != nil {
+			allErrs = append(allErrs,
+				field.Invalid(
+					path.Child("value"),
+					string(jsonPatch.Value.Raw),
+					"jsonPatch Value is invalid JSON",
+				))
+		}
+	}
+	if jsonPatch.ValueFrom != nil && jsonPatch.ValueFrom.Template == nil && jsonPatch.ValueFrom.Variable == nil {
+		allErrs = append(allErrs,
+			field.Invalid(
+				path.Child("valueFrom"),
+				prettyPrint(jsonPatch.ValueFrom),
+				"valueFrom must set either template or variable",
+			))
+	}
+	if jsonPatch.ValueFrom != nil && jsonPatch.ValueFrom.Template != nil && jsonPatch.ValueFrom.Variable != nil {
+		allErrs = append(allErrs,
+			field.Invalid(
+				path.Child("valueFrom"),
+				prettyPrint(jsonPatch.ValueFrom),
+				"valueFrom can not set both template and variable",
+			))
+	}
+
+	if jsonPatch.ValueFrom != nil && jsonPatch.ValueFrom.Template != nil {
+		// Error if template can not be parsed.
+		_, err := template.New("valueFrom.template").Parse(*jsonPatch.ValueFrom.Template)
+		if err != nil {
+			allErrs = append(allErrs,
+				field.Invalid(
+					path.Child("valueFrom", "template"),
+					*jsonPatch.ValueFrom.Template,
+					fmt.Sprintf("template can not be parsed: %v", err),
+				))
+		}
+	}
+
+	// If set validate that the variable is valid.
+	if jsonPatch.ValueFrom != nil && jsonPatch.ValueFrom.Variable != nil {
+		// If the variable is one of the list of builtin variables it's valid.
+		if strings.HasPrefix(*jsonPatch.ValueFrom.Variable, "builtin.") {
+			if _, ok := builtinVariables[*jsonPatch.ValueFrom.Variable]; !ok {
+				allErrs = append(allErrs,
+					field.Invalid(
+						path.Child("valueFrom", "variable"),
+						*jsonPatch.ValueFrom.Variable,
+						"not a defined builtin variable",
+					))
+			}
+		} else {
+			if _, ok := variableSet[*jsonPatch.ValueFrom.Variable]; !ok {
+				allErrs = append(allErrs,
+					field.Invalid(
+						path.Child("valueFrom", "variable"),
+						*jsonPatch.ValueFrom.Variable,
+						fmt.Sprintf("variable with name %s cannot be found", *jsonPatch.ValueFrom.Variable),
+					))
+			}
+		}
+	}
+	return allErrs
+}
+
+// This contains a list of all of the valid builtin variables.
+// TODO(killianmuldoon): Match this list to controllers/topology/internal/extensions/patches/variables as those structs become available across the code base i.e. public or top-level internal.
+var builtinVariables = sets.NewString(
+	"builtin",
+
+	// Cluster builtins.
+	"builtin.cluster",
+	"builtin.cluster.name",
+	"builtin.cluster.namespace",
+
+	// ClusterTopology builtins.
+	"builtin.cluster.topology",
+	"builtin.cluster.topology.version",
+	"builtin.cluster.topology.class",
+
+	// ControlPlane builtins.
+	"builtin.controlPlane",
+	"builtin.controlPlane.version",
+	"builtin.controlPlane.replicas",
+
+	// MachineDeployment builtins.
+	"builtin.machineDeployment",
+	"builtin.machineDeployment.version",
+	"builtin.machineDeployment.class",
+	"builtin.machineDeployment.name",
+	"builtin.machineDeployment.topologyName",
+	"builtin.machineDeployment.replicas",
+)
+
+func getClusterClassVariablesMap(clusterClassVariables []clusterv1.ClusterClassVariable) map[string]*clusterv1.ClusterClassVariable {
+	variablesMap := map[string]*clusterv1.ClusterClassVariable{}
+	for i := range clusterClassVariables {
+		variablesMap[clusterClassVariables[i].Name] = &clusterClassVariables[i]
+	}
+	return variablesMap
+}
+
+// validateIndexAccess checks to see if the jsonPath is attempting to add an element in the array i.e. access by number
+// If the operation is add an error is thrown if a number greater than 0 is used as an index.
+// If the operation is replace an error is thrown if an index is used.
+func validateIndexAccess(jsonPatch clusterv1.JSONPatch, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	pathParts := strings.Split(jsonPatch.Path, "/")
+	for _, part := range pathParts {
+		// Check if the path segment is a valid number. If an error is thrown continue to the next segment.
+		index, err := strconv.Atoi(part)
+		if err != nil {
+			continue
+		}
+
+		// If the operation is add an error is thrown if a number greater than 0 is used as an index.
+		if jsonPatch.Op == "add" && index != 0 {
+			allErrs = append(allErrs,
+				field.Invalid(path,
+					jsonPatch.Path,
+					"arrays can only be accessed using \"0\" (prepend) or \"-\" (append)",
+				))
+		}
+
+		// If the jsonPatch operation is replace or remove disallow any number as an element in the path.
+		if jsonPatch.Op == "replace" || jsonPatch.Op == "remove" {
+			allErrs = append(allErrs,
+				field.Invalid(path,
+					jsonPatch.Path,
+					fmt.Sprintf("elements in arrays can not be accessed in a %s operation", jsonPatch.Op),
+				))
+		}
+	}
+	return allErrs
+}
+
+func prettyPrint(v interface{}) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal field value").Error()
+	}
+	return string(b)
+}

--- a/internal/webhooks/patch_validation_test.go
+++ b/internal/webhooks/patch_validation_test.go
@@ -1,0 +1,1544 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/builder"
+)
+
+func TestValidatePatches(t *testing.T) {
+	tests := []struct {
+		name         string
+		clusterClass clusterv1.ClusterClass
+		wantErr      bool
+	}{
+		{
+			name: "pass multiple patches that are correctly formatted",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/variableSetting/variableValue1",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName1"),
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "patch2",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/variableSetting/variableValue2",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName2"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName1",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+						{
+							Name:     "variableName2",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+
+		// Patch name validation
+		{
+			name: "error if patch name is empty",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/cluster-name",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error if patches name is not unique",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/cluster-name",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName1"),
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/variableSetting/variableValue",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName2"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName1",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+						{
+							Name:     "variableName2",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+
+		// Patch "op" (operation) validation
+		{
+			name: "error if patch op is not \"add\" \"remove\" or \"replace\"",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											// OP is set to an unrecognized value here.
+											Op:   "drop",
+											Path: "/spec/template/spec/variableSetting/variableValue2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+
+		// Patch path validation
+		{
+			name: "error if jsonPath does not begin with \"/spec/\"",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op: "remove",
+											// Path is set to status.
+											Path: "/status/template/spec/variableSetting/variableValue2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "pass if jsonPatch path uses a valid index for add i.e. 0",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/0/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "error if jsonPatch path uses an invalid index for add i.e. a number greater than 0.",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/1/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error if jsonPatch path uses an invalid index for add i.e. 01",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/01/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error if jsonPatch path uses any index for remove i.e. 0 or -.",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "remove",
+											Path: "/spec/template/0/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error if jsonPatch path uses any index for replace i.e. 0",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "replace",
+											Path: "/spec/template/0/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+
+		// Patch Value/ValueFrom validation
+		{
+			name: "error if jsonPatch has neither Value nor ValueFrom",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											// Value and ValueFrom not defined.
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error if jsonPatch has both Value and ValueFrom",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName"),
+											},
+											Value: &apiextensionsv1.JSON{Raw: []byte("1")},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+
+		// Patch value validation
+		{
+			name: "pass if jsonPatch value is valid json",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											Value: &apiextensionsv1.JSON{Raw: []byte(
+												"{\"id\": \"file\"" +
+													"," +
+													"\"value\": \"File\"}")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "pass if jsonPatch value is nil",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											Value: &apiextensionsv1.JSON{
+												Raw: nil,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error if jsonPatch value is invalid json",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											Value: &apiextensionsv1.JSON{Raw: []byte(
+												"{\"id\": \"file\"" +
+													// missing comma here +
+													"\"value\": \"File\"}")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+
+		// Patch valueFrom validation
+		{
+			name: "error if jsonPatch defines neither ValueFrom.Template nor ValueFrom.Variable",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+					Patches: []clusterv1.ClusterClassPatch{
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:        "add",
+											Path:      "/spec/template/spec/",
+											ValueFrom: &clusterv1.JSONPatchValue{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error if jsonPatch has both ValueFrom.Template and ValueFrom.Variable",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+					Patches: []clusterv1.ClusterClassPatch{
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("variableName"),
+												Template: pointer.String(`template {{ .variableB }}`),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+
+		// Patch valueFrom.Template validation
+		{
+			name: "pass if jsonPatch defines a valid ValueFrom.Template",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+					Patches: []clusterv1.ClusterClassPatch{
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Template: pointer.String(`template {{ .variableB }}`),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error if jsonPatch defines an invalid ValueFrom.Template",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+					Patches: []clusterv1.ClusterClassPatch{
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												// Template is invalid - too many leading curly braces.
+												Template: pointer.String(`template {{{{{{{{ .variableB }}`),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+
+		// Patch valueFrom.Variable validation
+		{
+			name: "error if jsonPatch valueFrom uses a variable which is not defined",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+					Patches: []clusterv1.ClusterClassPatch{
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("undefinedVariable"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterClassVariable{
+						{
+							Name:     "variableName",
+							Required: true,
+							Schema: clusterv1.VariableSchema{
+								OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+									Type: "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error if jsonPatch uses a builtin variable which is not defined",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+					Patches: []clusterv1.ClusterClassPatch{
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("builtin.notDefined"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "pass if jsonPatch uses a builtin variable which is defined",
+			clusterClass: clusterv1.ClusterClass{
+				Spec: clusterv1.ClusterClassSpec{
+					ControlPlane: clusterv1.ControlPlaneClass{
+						LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+							Ref: &corev1.ObjectReference{
+								APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+								Kind:       "ControlPlaneTemplate",
+							},
+						},
+					},
+
+					Patches: []clusterv1.ClusterClassPatch{
+
+						{
+							Name: "patch1",
+							Definitions: []clusterv1.PatchDefinition{
+								{
+									Selector: clusterv1.PatchSelector{
+										APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+										Kind:       "ControlPlaneTemplate",
+										MatchResources: clusterv1.PatchSelectorMatch{
+											ControlPlane: true,
+										},
+									},
+									JSONPatches: []clusterv1.JSONPatch{
+										{
+											Op:   "add",
+											Path: "/spec/template/spec/",
+											ValueFrom: &clusterv1.JSONPatchValue{
+												Variable: pointer.String("builtin.machineDeployment.version"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			errList := validatePatches(&tt.clusterClass)
+			if tt.wantErr {
+				g.Expect(errList).NotTo(BeEmpty())
+				return
+			}
+			g.Expect(errList).To(BeEmpty())
+		})
+	}
+}
+
+func Test_validateSelectors(t *testing.T) {
+	tests := []struct {
+		name         string
+		selector     clusterv1.PatchSelector
+		clusterClass *clusterv1.ClusterClass
+		wantErr      bool
+	}{
+		{
+			name: "error if no selectors are all set to false or empty",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureClusterTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					ControlPlane:           false,
+					InfrastructureCluster:  false,
+					MachineDeploymentClass: clusterv1.PatchSelectorMatchMachineDeploymentClass{},
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithControlPlaneTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "InfrastructureClusterTemplate",
+						}),
+				).
+				Build(),
+			wantErr: true,
+		},
+		{
+			name: "pass if selector targets an existing infrastructureCluster reference",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureClusterTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					InfrastructureCluster: true,
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithInfrastructureClusterTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "InfrastructureClusterTemplate",
+						}),
+				).
+				Build(),
+		},
+		{
+			name: "error if selector targets a non-existing infrastructureCluster APIVersion reference",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureClusterTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					InfrastructureCluster: true,
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithInfrastructureClusterTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "nonmatchinginfrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "InfrastructureClusterTemplate",
+						}),
+				).
+				Build(),
+			wantErr: true,
+		},
+		{
+			name: "pass if selector targets an existing controlPlane reference",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:       "ControlPlaneTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					ControlPlane: true,
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithControlPlaneTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+							Kind:       "ControlPlaneTemplate",
+						}),
+				).
+				Build(),
+		},
+		{
+			name: "error if selector targets a non-existing controlPlane Kind reference",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+				Kind:       "ControlPlaneTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					ControlPlane: true,
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithControlPlaneTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+							Kind:       "NonMatchingControlPlaneTemplate",
+						}),
+				).
+				Build(),
+			wantErr: true,
+		},
+		{
+			name: "pass if selector targets an existing controlPlane machineInfrastructure reference",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					ControlPlane: true,
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithControlPlaneTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+							Kind:       "NonMatchingControlPlaneTemplate",
+						}),
+				).
+				WithControlPlaneInfrastructureMachineTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "InfrastructureMachineTemplate",
+						}),
+				).
+				Build(),
+		},
+		{
+			name: "error if selector targets a non-existing controlPlane machineInfrastructure reference",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					ControlPlane: true,
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithControlPlaneTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "controlplane.cluster.x-k8s.io/v1beta1",
+							Kind:       "NonMatchingControlPlaneTemplate",
+						}),
+				).
+				WithControlPlaneInfrastructureMachineTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "NonMatchingInfrastructureMachineTemplate",
+						}),
+				).
+				Build(),
+			wantErr: true,
+		},
+		{
+			name: "pass if selector targets an existing MachineDeploymentClass BootstrapTemplate",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:       "BootstrapTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"aa"},
+					},
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithWorkerMachineDeploymentClasses(
+					*builder.MachineDeploymentClass("aa").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "InfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+				).
+				Build(),
+		},
+		{
+			name: "pass if selector targets an existing MachineDeploymentClass InfrastructureTemplate",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"aa"},
+					},
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithWorkerMachineDeploymentClasses(
+					*builder.MachineDeploymentClass("aa").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "InfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+				).
+				Build(),
+		},
+		{
+			name: "error if selector targets a non-existing MachineDeploymentClass InfrastructureTemplate",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"bb"},
+					},
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithWorkerMachineDeploymentClasses(
+					*builder.MachineDeploymentClass("aa").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "InfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+					*builder.MachineDeploymentClass("bb").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "NonMatchingInfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+				).
+				Build(),
+			wantErr: true,
+		},
+		{
+			name: "pass if selector targets BOTH an existing ControlPlane MachineInfrastructureTemplate and an existing MachineDeploymentClass InfrastructureTemplate",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"bb"},
+					},
+					ControlPlane: true,
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithControlPlaneInfrastructureMachineTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "InfrastructureMachineTemplate",
+						}),
+				).
+				WithWorkerMachineDeploymentClasses(
+					*builder.MachineDeploymentClass("aa").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "InfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+					*builder.MachineDeploymentClass("bb").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "InfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+				).
+				Build(),
+			wantErr: false,
+		},
+		{
+			name: "fail if selector targets ControlPlane Machine Infrastructure but does not have MatchResources.ControlPlane enabled",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"bb"},
+					},
+					ControlPlane: false,
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithControlPlaneInfrastructureMachineTemplate(
+					refToUnstructured(
+						&corev1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "InfrastructureMachineTemplate",
+						}),
+				).
+				Build(),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			err := validateSelectors(tt.selector, tt.clusterClass, field.NewPath(""))
+
+			if tt.wantErr {
+				g.Expect(err).NotTo(BeNil())
+				return
+			}
+			g.Expect(err).To(BeNil())
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

This adds validation rules for patches defined in the clusterClass to the webhook. 

This is ready to review in principle, though a couple of needed validations are missing and marked with a TODO.

Fixes #5613
