### PR TITLE
🐛 clusterctl init should report the correct namespace when detecting a provider is already intalled

### DIFF
--- a/cmd/clusterctl/client/cluster/installer.go
+++ b/cmd/clusterctl/client/cluster/installer.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -260,7 +261,14 @@ func simulateInstall(providerList *clusterctlv1.ProviderList, components reposit
 
 	existingInstances := providerList.FilterByProviderNameAndType(provider.ProviderName, provider.GetProviderType())
 	if len(existingInstances) > 0 {
-		return providerList, errors.Errorf("there is already an instance of the %q provider installed in the %q namespace", provider.ManifestLabel(), provider.Namespace)
+		namespaces := func() string {
+			var namespaces []string
+			for _, provider := range existingInstances {
+				namespaces = append(namespaces, provider.Namespace)
+			}
+			return strings.Join(namespaces, ", ")
+		}()
+		return providerList, errors.Errorf("there is already an instance of the %q provider installed in the %q namespace", provider.ManifestLabel(), namespaces)
 	}
 
 	providerList.Items = append(providerList.Items, provider)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5738 
