### PR TITLE
🌱 tilt: disable leader election when debugging is enabled

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -366,10 +366,10 @@ def enable_providers():
         enable_provider(name, settings.get("debug").get(name, {}))
 
 def kustomize_with_envsubst(path, enable_debug = False):
-    # we need to ditch the readiness and liveness probes when debugging, otherwise K8s will restart the pod whenever execution
+    # We need to ditch leader election, the readiness and liveness probes when debugging, otherwise K8s will restart the pod whenever execution
     # has paused.
     if enable_debug:
-        yq_cmd_line = "| {} eval 'del(.. | select(has\"livenessProbe\")).livenessProbe | del(.. | select(has\"readinessProbe\")).readinessProbe' -".format(yq_cmd)
+        yq_cmd_line = "| {} eval 'del(.. | select(. == \"--leader-elect\")) | del(.. | select(has\"livenessProbe\")).livenessProbe | del(.. | select(has\"readinessProbe\")).readinessProbe' -".format(yq_cmd)
     else:
         yq_cmd_line = ""
     return str(local("{} build {} | {} {}".format(kustomize_cmd, path, envsubst_cmd, yq_cmd_line), quiet = True))


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Makes it easier to debug controllers with tilt as we don't have to deal with controller shutdowns because the leader election times out after a few seconds/minutes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
