### PR TITLE
🌱 add check to ensure ClusterClass change doesn't invalidate existing cluster variables

### DIFF
--- a/internal/builder/builders.go
+++ b/internal/builder/builders.go
@@ -135,7 +135,7 @@ func (c *ClusterTopologyBuilder) WithMachineDeployment(mdc clusterv1.MachineDepl
 }
 
 // WithVariables adds the passed variables to the ClusterTopologyBuilder.
-func (c *ClusterTopologyBuilder) WithVariables(vars []clusterv1.ClusterVariable) *ClusterTopologyBuilder {
+func (c *ClusterTopologyBuilder) WithVariables(vars ...clusterv1.ClusterVariable) *ClusterTopologyBuilder {
 	c.variables = vars
 	return c
 }
@@ -236,8 +236,8 @@ func (c *ClusterClassBuilder) WithControlPlaneInfrastructureMachineTemplate(t *u
 	return c
 }
 
-// WithVariables adds the Variables to the ClusterClassBuilder.
-func (c *ClusterClassBuilder) WithVariables(vars []clusterv1.ClusterClassVariable) *ClusterClassBuilder {
+// WithVariables adds the Variables the ClusterClassBuilder.
+func (c *ClusterClassBuilder) WithVariables(vars ...clusterv1.ClusterClassVariable) *ClusterClassBuilder {
 	c.variables = vars
 	return c
 }

--- a/internal/topology/variables/cluster_variable_validation.go
+++ b/internal/topology/variables/cluster_variable_validation.go
@@ -52,7 +52,7 @@ func ValidateClusterVariables(clusterVariables []clusterv1.ClusterVariable, clus
 		// corresponding ClusterClass variable, so we don't have to check it again.
 		clusterClassVariable := clusterClassVariablesMap[clusterVariable.Name]
 
-		allErrs = append(allErrs, validateClusterVariable(&clusterVariable, clusterClassVariable, fldPath.Index(i))...)
+		allErrs = append(allErrs, ValidateClusterVariable(&clusterVariable, clusterClassVariable, fldPath.Index(i))...)
 	}
 	return allErrs
 }
@@ -89,8 +89,8 @@ func validateClusterVariablesDefined(clusterVariables []clusterv1.ClusterVariabl
 	return allErrs
 }
 
-// validateClusterVariable validates a clusterVariable.
-func validateClusterVariable(clusterVariable *clusterv1.ClusterVariable, clusterClassVariable *clusterv1.ClusterClassVariable, fldPath *field.Path) field.ErrorList {
+// ValidateClusterVariable validates a clusterVariable.
+func ValidateClusterVariable(clusterVariable *clusterv1.ClusterVariable, clusterClassVariable *clusterv1.ClusterClassVariable, fldPath *field.Path) field.ErrorList {
 	// Parse JSON value.
 	var variableValue interface{}
 	// Only try to unmarshal the clusterVariable if it is not nil, otherwise the variableValue is nil.

--- a/internal/topology/variables/cluster_variable_validation_test.go
+++ b/internal/topology/variables/cluster_variable_validation_test.go
@@ -390,7 +390,7 @@ func Test_ValidateClusterVariable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			errList := validateClusterVariable(tt.clusterVariable, tt.clusterClassVariable,
+			errList := ValidateClusterVariable(tt.clusterVariable, tt.clusterClassVariable,
 				field.NewPath("spec", "topology", "variables"))
 
 			if tt.wantErr {

--- a/internal/topology/variables/clusterclass_variable_validation_test.go
+++ b/internal/topology/variables/clusterclass_variable_validation_test.go
@@ -36,8 +36,7 @@ func Test_ValidateClusterClassVariables(t *testing.T) {
 			name: "Error if multiple variables share a name",
 			clusterClassVariables: []clusterv1.ClusterClassVariable{
 				{
-					Name:     "cpu",
-					Required: true,
+					Name: "cpu",
 					Schema: clusterv1.VariableSchema{
 						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 							Type:    "integer",
@@ -46,8 +45,7 @@ func Test_ValidateClusterClassVariables(t *testing.T) {
 					},
 				},
 				{
-					Name:     "cpu",
-					Required: true,
+					Name: "cpu",
 					Schema: clusterv1.VariableSchema{
 						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 							Type:    "integer",
@@ -62,8 +60,7 @@ func Test_ValidateClusterClassVariables(t *testing.T) {
 			name: "Pass multiple variable validation",
 			clusterClassVariables: []clusterv1.ClusterClassVariable{
 				{
-					Name:     "cpu",
-					Required: true,
+					Name: "cpu",
 					Schema: clusterv1.VariableSchema{
 						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 							Type:    "integer",
@@ -72,8 +69,7 @@ func Test_ValidateClusterClassVariables(t *testing.T) {
 					},
 				},
 				{
-					Name:     "validNumber",
-					Required: true,
+					Name: "validNumber",
 					Schema: clusterv1.VariableSchema{
 						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 							Type:    "number",
@@ -83,8 +79,7 @@ func Test_ValidateClusterClassVariables(t *testing.T) {
 				},
 
 				{
-					Name:     "validVariable",
-					Required: true,
+					Name: "validVariable",
 					Schema: clusterv1.VariableSchema{
 						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 							Type:      "string",
@@ -93,8 +88,7 @@ func Test_ValidateClusterClassVariables(t *testing.T) {
 					},
 				},
 				{
-					Name:     "location",
-					Required: true,
+					Name: "location",
 					Schema: clusterv1.VariableSchema{
 						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 							Type:      "string",
@@ -131,8 +125,7 @@ func Test_ValidateClusterClassVariable(t *testing.T) {
 		{
 			name: "Valid integer schema",
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "cpu",
-				Required: true,
+				Name: "cpu",
 				Schema: clusterv1.VariableSchema{
 					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 						Type:    "integer",
@@ -144,8 +137,7 @@ func Test_ValidateClusterClassVariable(t *testing.T) {
 		{
 			name: "Valid string schema",
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "location",
-				Required: true,
+				Name: "location",
 				Schema: clusterv1.VariableSchema{
 					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 						Type:      "string",
@@ -157,8 +149,7 @@ func Test_ValidateClusterClassVariable(t *testing.T) {
 		{
 			name: "Valid variable name",
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "validVariable",
-				Required: true,
+				Name: "validVariable",
 				Schema: clusterv1.VariableSchema{
 					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 						Type:      "string",
@@ -170,8 +161,7 @@ func Test_ValidateClusterClassVariable(t *testing.T) {
 		{
 			name: "fail on variable name is builtin",
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "builtin",
-				Required: true,
+				Name: "builtin",
 				Schema: clusterv1.VariableSchema{
 					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 						Type:      "string",
@@ -184,8 +174,7 @@ func Test_ValidateClusterClassVariable(t *testing.T) {
 		{
 			name: "fail on empty variable name",
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "",
-				Required: true,
+				Name: "",
 				Schema: clusterv1.VariableSchema{
 					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 						Type:      "string",
@@ -198,8 +187,7 @@ func Test_ValidateClusterClassVariable(t *testing.T) {
 		{
 			name: "fail on variable name containing dot (.)",
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "path.tovariable",
-				Required: true,
+				Name: "path.tovariable",
 				Schema: clusterv1.VariableSchema{
 					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 						Type:      "string",
@@ -275,8 +263,7 @@ func Test_ValidateClusterClassVariable(t *testing.T) {
 		{
 			name: "fail on variable type is null",
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "var",
-				Required: true,
+				Name: "var",
 				Schema: clusterv1.VariableSchema{
 					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 						Type: "null",
@@ -288,8 +275,7 @@ func Test_ValidateClusterClassVariable(t *testing.T) {
 		{
 			name: "fail on variable type is not valid",
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "var",
-				Required: true,
+				Name: "var",
 				Schema: clusterv1.VariableSchema{
 					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 						Type: "invalidVariableType",
@@ -301,8 +287,7 @@ func Test_ValidateClusterClassVariable(t *testing.T) {
 		{
 			name: "fail on variable type length zero",
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
-				Name:     "var",
-				Required: true,
+				Name: "var",
 				Schema: clusterv1.VariableSchema{
 					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
 						Type: "",
@@ -311,8 +296,20 @@ func Test_ValidateClusterClassVariable(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "pass on variable with required set true with a default defined",
+			clusterClassVariable: &clusterv1.ClusterClassVariable{
+				Name:     "var",
+				Required: true,
+				Schema: clusterv1.VariableSchema{
+					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+						Type:    "string",
+						Default: &apiextensionsv1.JSON{Raw: []byte(`"defaultValue"`)},
+					},
+				},
+			},
+		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -65,18 +65,17 @@ func TestClusterDefaultVariables(t *testing.T) {
 		{
 			name: "default a single variable to its correct values",
 			clusterclass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
-				WithVariables([]clusterv1.ClusterClassVariable{
-					{
-						Name:     "location",
-						Required: true,
-						Schema: clusterv1.VariableSchema{
-							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-								Type:    "string",
-								Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
-							},
+				WithVariables(clusterv1.ClusterClassVariable{
+					Name:     "location",
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "string",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
 						},
 					},
-				}).
+				},
+				).
 				Build(),
 			clusterVariables: []clusterv1.ClusterVariable{},
 			expect: []clusterv1.ClusterVariable{
@@ -91,18 +90,17 @@ func TestClusterDefaultVariables(t *testing.T) {
 		{
 			name: "don't change a variable if it is already set",
 			clusterclass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
-				WithVariables([]clusterv1.ClusterClassVariable{
-					{
-						Name:     "location",
-						Required: true,
-						Schema: clusterv1.VariableSchema{
-							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
-								Type:    "string",
-								Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
-							},
+				WithVariables(clusterv1.ClusterClassVariable{
+					Name:     "location",
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "string",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
 						},
 					},
-				}).
+				},
+				).
 				Build(),
 			clusterVariables: []clusterv1.ClusterVariable{
 				{
@@ -124,8 +122,8 @@ func TestClusterDefaultVariables(t *testing.T) {
 		{
 			name: "default many variables to their correct values",
 			clusterclass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
-				WithVariables([]clusterv1.ClusterClassVariable{
-					{
+				WithVariables(
+					clusterv1.ClusterClassVariable{
 						Name:     "location",
 						Required: true,
 						Schema: clusterv1.VariableSchema{
@@ -135,7 +133,7 @@ func TestClusterDefaultVariables(t *testing.T) {
 							},
 						},
 					},
-					{
+					clusterv1.ClusterClassVariable{
 						Name:     "count",
 						Required: true,
 						Schema: clusterv1.VariableSchema{
@@ -144,8 +142,7 @@ func TestClusterDefaultVariables(t *testing.T) {
 								Default: &apiextensionsv1.JSON{Raw: []byte(`0.1`)},
 							},
 						},
-					},
-				}).
+					}).
 				Build(),
 			clusterVariables: []clusterv1.ClusterVariable{},
 			expect: []clusterv1.ClusterVariable{
@@ -170,7 +167,7 @@ func TestClusterDefaultVariables(t *testing.T) {
 				builder.ClusterTopology().
 					WithClass("class1").
 					WithVersion("v1.22.2").
-					WithVariables(tt.clusterVariables).
+					WithVariables(tt.clusterVariables...).
 					Build()).
 			Build()
 		fakeClient := fake.NewClientBuilder().

--- a/internal/webhooks/patch_validation.go
+++ b/internal/webhooks/patch_validation.go
@@ -179,7 +179,7 @@ var validOps = sets.NewString("add", "replace", "remove")
 
 func validateJSONPatches(jsonPatches []clusterv1.JSONPatch, variables []clusterv1.ClusterClassVariable, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-	variableSet := getClusterClassVariablesMap(variables)
+	variableSet, _ := getClusterClassVariablesMapWithReverseIndex(variables)
 
 	for i, jsonPatch := range jsonPatches {
 		if !validOps.Has(jsonPatch.Op) {
@@ -335,14 +335,6 @@ var builtinVariables = sets.NewString(
 	"builtin.machineDeployment.topologyName",
 	"builtin.machineDeployment.replicas",
 )
-
-func getClusterClassVariablesMap(clusterClassVariables []clusterv1.ClusterClassVariable) map[string]*clusterv1.ClusterClassVariable {
-	variablesMap := map[string]*clusterv1.ClusterClassVariable{}
-	for i := range clusterClassVariables {
-		variablesMap[clusterClassVariables[i].Name] = &clusterClassVariables[i]
-	}
-	return variablesMap
-}
 
 // validateIndexAccess checks to see if the jsonPath is attempting to add an element in the array i.e. access by number
 // If the operation is add an error is thrown if a number greater than 0 is used as an index.


### PR DESCRIPTION
 Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

 This PR adds a check to ensure variables which are currently in use by clusters are not invalidated when a clusterClass is updated.

Fixes: #5461 
