### PR TITLE
🐛 ClusterClass: make PatchSelector machineDeploymentClass.names optional

### DIFF
--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -273,7 +273,8 @@ type PatchSelectorMatch struct {
 // in specific MachineDeploymentClasses in .spec.workers.machineDeployments.
 type PatchSelectorMatchMachineDeploymentClass struct {
 	// Names selects templates by class names.
-	Names []string `json:"names"`
+	// +optional
+	Names []string `json:"names,omitempty"`
 }
 
 // JSONPatch defines a JSON patch.

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -674,8 +674,6 @@ spec:
                                         items:
                                           type: string
                                         type: array
-                                    required:
-                                    - names
                                     type: object
                                 type: object
                             required:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR makes `name` in the PatchSelector optional. Otherwise it's mandatory to always specify `.machineDeploymentClass.names` even though the selector is meant to select e.g. `controlPlane`.

This was caused by the change to make the fields non-pointer yesterday.

Detailed ClusterClass creation flow:
* user is creating a ClusterClass with kubectl where `selector.machineDeploymentClass` is not set
* our defaulting webhook is called
   * in the input `selector.machineDeploymentClass` is also not set
   * after our defaulting code is run `selector.machineDeploymentClass` is set to `null` (because `Name` doesn't have `omitempty`)
   * the webhook returns patches to set `selector.machineDeploymentClass` to null
* [Slightly guessing] API server applies the patches returned from the defaulting webhook to the ClusterClass
* API Server decides based on the OpenAPI schema that null is not a valid value for a mandatory field
  > The ClusterClass "quick-start" is invalid: spec.patches.definitions.selector.matchResources.machineDeploymentClass.names: Invalid value: "null": spec.patches.definitions.selector.matchResources.machineDeploymentClass.names in body must be of type array: "null"

By making the field `omitempty` (and also adding `// +optional` for consistency and because `omitempty` itself would already make the field optional in the schema) the defaulting webhook will now add `machineDeploymentClass: {}` (which is also visible via `kubectl get clusterclass`). But I think that's the best we can do. We have a similar UX in other cases, e.g. in Cluster topology `.metadata` is automatically set to `{}` too.

An alternative would be to make the fields pointer again, but I'm not sure it's the right approach to fixing this issue. It feels more straightforward to me to address the issue on a per-field basis vs making fields pointers to avoid follow-up issues in deeper nested fields.

Note: I think this is another case where webhook integration tests could have helped (as the creation of a ClusterClass with patches and without machineDeploymentClass would have simply failed). In this case I broke CI because I didn't think about running the full e2e tests or because we are not running the ClusterClass quickstart on every PR :/.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
