### PR TITLE
🌱  remove redundant parantheses across codebase

### DIFF
--- a/cmd/clusterctl/client/repository/clusterclass_client_test.go
+++ b/cmd/clusterctl/client/repository/clusterclass_client_test.go
@@ -184,7 +184,7 @@ func Test_ClusterClassClient_Get(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			if !tt.args.listVariablesOnly {
-				g.Expect(yaml).To(ContainSubstring((fmt.Sprintf("variable: %s", variableValue))))
+				g.Expect(yaml).To(ContainSubstring(fmt.Sprintf("variable: %s", variableValue)))
 			}
 
 			// check if target namespace is set

--- a/cmd/clusterctl/client/repository/template_client_test.go
+++ b/cmd/clusterctl/client/repository/template_client_test.go
@@ -207,7 +207,7 @@ func Test_templates_Get(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			if !tt.args.listVariablesOnly {
-				g.Expect(yaml).To(ContainSubstring((fmt.Sprintf("variable: %s", variableValue))))
+				g.Expect(yaml).To(ContainSubstring(fmt.Sprintf("variable: %s", variableValue)))
 			}
 
 			// check if target namespace is set

--- a/controllers/external/util_test.go
+++ b/controllers/external/util_test.go
@@ -251,7 +251,7 @@ func TestCloneTemplateResourceFoundNoOwner(t *testing.T) {
 
 	expectedKind := "Yellow"
 	expectedAPIVersion := templateAPIVersion
-	expectedLabels := (map[string]string{clusterv1.ClusterLabelName: testClusterName})
+	expectedLabels := map[string]string{clusterv1.ClusterLabelName: testClusterName}
 
 	expectedSpec, ok, err := unstructured.NestedMap(template.UnstructuredContent(), "spec", "template", "spec")
 	g.Expect(err).NotTo(HaveOccurred())

--- a/controlplane/kubeadm/controllers/scale_test.go
+++ b/controlplane/kubeadm/controllers/scale_test.go
@@ -565,7 +565,7 @@ func withFailureDomain(fd string) machineOpt {
 
 func withAnnotation(annotation string) machineOpt {
 	return func(m *clusterv1.Machine) {
-		m.ObjectMeta.Annotations = (map[string]string{annotation: ""})
+		m.ObjectMeta.Annotations = map[string]string{annotation: ""}
 	}
 }
 

--- a/controlplane/kubeadm/internal/control_plane_test.go
+++ b/controlplane/kubeadm/internal/control_plane_test.go
@@ -58,7 +58,7 @@ func TestControlPlane(t *testing.T) {
 			g.Expect(*controlPlane.FailureDomainWithMostMachines(controlPlane.Machines)).To(Equal("two"))
 		})
 
-		t.Run(("With some machines in non defined failure domains"), func(t *testing.T) {
+		t.Run("With some machines in non defined failure domains", func(t *testing.T) {
 			controlPlane.Machines.Insert(machine("machine-5", withFailureDomain("unknown")))
 			g.Expect(*controlPlane.FailureDomainWithMostMachines(controlPlane.Machines)).To(Equal("unknown"))
 		})

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -241,7 +241,7 @@ func setupWebhooks(mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 
-	if err := (&kcpv1.KubeadmControlPlaneTemplate{}).SetupWebhookWithManager((mgr)); err != nil {
+	if err := (&kcpv1.KubeadmControlPlaneTemplate{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "KubeadmControlPlaneTemplate")
 	}
 }

--- a/test/e2e/custom_assertions.go
+++ b/test/e2e/custom_assertions.go
@@ -35,13 +35,13 @@ func (m *controllerMatch) Match(actual interface{}) (success bool, err error) {
 		return false, fmt.Errorf("unable to read meta for %T: %w", actual, err)
 	}
 
-	owner := metav1.GetControllerOf(actualMeta) //nolint:ifshort
+	owner := metav1.GetControllerOf(actualMeta)
 	if owner == nil {
 		return false, fmt.Errorf("no controller found (owner ref with controller = true) for object %#v", actual)
 	}
 
-	match := (owner.Kind == m.kind &&
-		owner.Name == m.owner.GetName() && owner.UID == m.owner.GetUID())
+	match := owner.Kind == m.kind &&
+		owner.Name == m.owner.GetName() && owner.UID == m.owner.GetUID()
 
 	return match, nil
 }


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fixes a number of unnecessary redundant parentheses (and one nolint directive) across the CAPI codebase.