### PR TITLE
🌱 ClusterClass: validate default and enum JSON, extend schema conversion test

### DIFF
--- a/internal/topology/variables/cluster_variable_validation.go
+++ b/internal/topology/variables/cluster_variable_validation.go
@@ -97,7 +97,7 @@ func validateClusterVariable(clusterVariable *clusterv1.ClusterVariable, cluster
 	// Note: A clusterVariable with a nil value is the result of setting the variable value to "null" via YAML.
 	if clusterVariable.Value.Raw != nil {
 		if err := json.Unmarshal(clusterVariable.Value.Raw, &variableValue); err != nil {
-			return field.ErrorList{field.Invalid(fldPath.Child("value", "raw"), string(clusterVariable.Value.Raw),
+			return field.ErrorList{field.Invalid(fldPath.Child("value"), string(clusterVariable.Value.Raw),
 				fmt.Sprintf("variable %q could not be parsed: %v", clusterVariable.Name, err))}
 		}
 	}

--- a/internal/topology/variables/schema_test.go
+++ b/internal/topology/variables/schema_test.go
@@ -20,7 +20,9 @@ import (
 	"reflect"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -86,8 +88,27 @@ func Test_convertToAPIExtensionsJSONSchemaProps(t *testing.T) {
 			}
 		})
 	}
-}
 
+	t.Run("pass for schema with default and enum", func(t *testing.T) {
+		g := NewWithT(t)
+
+		schema := &clusterv1.JSONSchemaProps{
+			Default: &apiextensionsv1.JSON{
+				Raw: []byte(`"defaultValue"`),
+			},
+			Enum: []apiextensionsv1.JSON{
+				{Raw: []byte(`"enumValue1"`)},
+				{Raw: []byte(`"enumValue2"`)},
+			},
+		}
+
+		got, err := convertToAPIExtensionsJSONSchemaProps(schema)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		g.Expect(*got.Default).To(Equal(apiextensions.JSON(`defaultValue`)))
+		g.Expect(got.Enum).To(Equal([]apiextensions.JSON{`enumValue1`, `enumValue2`}))
+	})
+}
 func convertIntToFloatPointer(i int64) *float64 {
 	f := float64(i)
 	return &f


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR improves the validation of our enum/default JSON fields in the variable schema and adds a unit test which test that the schema conversion also converts enum/default correctly.

Note: Split out of: https://github.com/kubernetes-sigs/cluster-api/pull/5764

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
