### PR TITLE
🐛 ClusterClass: Fix defaulting of nullable variables

### DIFF
--- a/internal/topology/variables/cluster_variable_defaulting_test.go
+++ b/internal/topology/variables/cluster_variable_defaulting_test.go
@@ -287,6 +287,27 @@ func Test_DefaultClusterVariable(t *testing.T) {
 			},
 		},
 		{
+			name: "Default nullable string",
+			clusterClassVariable: &clusterv1.ClusterClassVariable{
+				Name:     "location",
+				Required: true,
+				Schema: clusterv1.VariableSchema{
+					OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+						Type:     "string",
+						Nullable: true,
+						Default:  &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+					},
+				},
+			},
+			clusterVariable: &clusterv1.ClusterVariable{Name: "location"},
+			want: &clusterv1.ClusterVariable{
+				Name: "location",
+				Value: apiextensionsv1.JSON{
+					Raw: []byte(`"us-east"`),
+				},
+			},
+		},
+		{
 			name: "Default number",
 			clusterClassVariable: &clusterv1.ClusterClassVariable{
 				Name:     "location",


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR changes our defaulting code so it's also able to default nullable variables.


Split out of https://github.com/kubernetes-sigs/cluster-api/pull/5764/files

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
