### PR TITLE
📖  Rename Packet to Equinix Metal (in title only)

### DIFF
--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -25,7 +25,7 @@ updated info about which API version they are supporting.
 - [MAAS](https://github.com/spectrocloud/cluster-api-provider-maas)
 - [Nested](https://github.com/kubernetes-sigs/cluster-api-provider-nested)
 - [OpenStack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack)
-- [Packet](https://github.com/kubernetes-sigs/cluster-api-provider-packet)
+- [Equinix Metal (formerly Packet)](https://github.com/kubernetes-sigs/cluster-api-provider-packet)
 - [Sidero](https://github.com/talos-systems/sidero)
 - [Tencent Cloud](https://github.com/TencentCloud/cluster-api-provider-tencent)
 - [vSphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere)

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -175,7 +175,7 @@ and `kubeadm` control-plane providers.
 Depending on the infrastructure provider you are planning to use, some additional prerequisites should be satisfied
 before getting started with Cluster API. See below for the expected settings for common providers.
 
-{{#tabs name:"tab-installation-infrastructure" tabs:"AWS,Azure,DigitalOcean,Docker,GCP,vSphere,OpenStack,Metal3,Packet"}}
+{{#tabs name:"tab-installation-infrastructure" tabs:"AWS,Azure,DigitalOcean,Docker,GCP,vSphere,OpenStack,Metal3,Equinix Metal"}}
 {{#tab AWS}}
 
 Download the latest binary of `clusterawsadm` from the [AWS provider releases] and make sure to place it in your path.
@@ -310,12 +310,12 @@ clusterctl init --infrastructure openstack
 Please visit the [Metal3 project][Metal3 provider].
 
 {{#/tab }}
-{{#tab Packet}}
+{{#tab Equinix Metal}}
 
-In order to initialize the Packet Provider you have to expose the environment
+In order to initialize the Equinix Metal Provider (formerly Packet) you have to expose the environment
 variable `PACKET_API_KEY`. This variable is used to authorize the infrastructure
-provider manager against the Packet API. You can retrieve your token directly
-from the [Packet Portal](https://app.packet.net/).
+provider manager against the Equinix Metal API. You can retrieve your token directly
+from the [Equinix Metal Console](https://console.equinix.com/).
 
 ```bash
 export PACKET_API_KEY="34ts3g4s5g45gd45dhdh"
@@ -393,7 +393,7 @@ before configuring a cluster with Cluster API. Instructions are provided for com
 Otherwise, you can look at the `clusterctl generate cluster` [command][clusterctl generate cluster] documentation for details about how to
 discover the list of variables required by a cluster templates.
 
-{{#tabs name:"tab-configuration-infrastructure" tabs:"AWS,Azure,DigitalOcean,Docker,GCP,vSphere,OpenStack,Metal3,Packet"}}
+{{#tabs name:"tab-configuration-infrastructure" tabs:"AWS,Azure,DigitalOcean,Docker,GCP,vSphere,OpenStack,Metal3,Equinix Metal"}}
 {{#tab AWS}}
 
 ```bash
@@ -584,20 +584,20 @@ export IRONIC_INSPECTOR_NO_BASIC_AUTH=true
 Please visit the [Metal3 getting started guide] for more details.
 
 {{#/tab }}
-{{#tab Packet}}
+{{#tab Equinix Metal}}
 
 There are a couple of required environment variables that you have to expose in
 order to get a well tuned and function workload, they are all listed here:
 
 ```bash
 # The project where your cluster will be placed to.
-# You have to get out from Packet Portal if you do not have one already.
+# You have to get one from the Equinix Metal Console if you don't have one already.
 export PROJECT_ID="5yd4thd-5h35-5hwk-1111-125gjej40930"
 # The facility where you want your cluster to be provisioned
 export FACILITY="ewr1"
 # The operatin system used to provision the device
 export NODE_OS="ubuntu_18_04"
-# The ssh key name you loaded in Packet Portal
+# The ssh key name you loaded in the Equinix Metal Console
 export SSH_KEY="my-ssh"
 export POD_CIDR="192.168.0.0/16"
 export SERVICE_CIDR="172.26.0.0/16"
@@ -727,8 +727,8 @@ See [Additional Notes for the Docker Provider](../clusterctl/developers.md#addit
 
 Calico is used here as an example.
 
-{{#tabs name:"tab-deploy-cni" tabs:"AWS|DigitalOcean|Docker|GCP|vSphere|OpenStack|Metal3|Packet,Azure"}}
-{{#tab AWS|DigitalOcean|Docker|GCP|vSphere|OpenStack|Metal3|Packet}}
+{{#tabs name:"tab-deploy-cni" tabs:"AWS|DigitalOcean|Docker|GCP|vSphere|OpenStack|Metal3|Equinix Metal,Azure"}}
+{{#tab AWS|DigitalOcean|Docker|GCP|vSphere|OpenStack|Metal3|Equinix Metal}}
 
 ```bash
 kubectl --kubeconfig=./capi-quickstart.kubeconfig \
@@ -802,7 +802,7 @@ See the [clusterctl] documentation for more detail about clusterctl supported ac
 [management cluster]: ../reference/glossary.md#management-cluster
 [Metal3 getting started guide]: https://github.com/metal3-io/cluster-api-provider-metal3/blob/master/docs/getting-started.md
 [Metal3 provider]: https://github.com/metal3-io/cluster-api-provider-metal3/
-[Packet getting started guide]: https://github.com/kubernetes-sigs/cluster-api-provider-packet#using
+[Equinix Metal getting started guide]: https://github.com/kubernetes-sigs/cluster-api-provider-packet#using
 [provider]:../reference/providers.md
 [provider components]: ../reference/glossary.md#provider-components
 [vSphere getting started guide]: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/master/docs/getting_started.md


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

* Packet was acquired by Equinix in 2020 <https://www.equinix.com/newsroom/press-releases/2020/01/equinix-to-acquire-bare-metal-leader-packet>
* The services offered by Packet are now offered as Equinix Metal, since Oct 2020 <https://www.equinix.com/newsroom/press-releases/2020/10/equinix-unveils-fully-automated-and-interconnected-bare-metal-service>

The Packet API (api.packet.net) continues to be supported and is fully integrated with the Equinix Metal experience, so CAPP continues to be a viable provider for existing Packet users and new Equinix Metal users.

This PR avoids confusion by retitling "Packet" to "Equinix Metal" in the documentation. 

⚠️  **Note** The "Packet" tabs have been renamed to "Equinix Metal".  If the space creates problems we may need to revise the tabs to "Equinix" or "EquinixMetal".

Binaries and variables should continue to use "Packet" names until a replacement to CAPP is made.

CAPP has already adopted some renaming and rearchitecting to adopt Equinix Metal branded tooling and settings.  This work continues in https://github.com/kubernetes-sigs/cluster-api-provider-packet/pull/289 (@detiber).


