### PR TITLE
🐛 explicitly ignore error in flag deprecation

### DIFF
--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -114,7 +114,7 @@ func init() {
 		"Groups machines when ready condition has the same Status, Severity and Reason.")
 	describeClusterClusterCmd.Flags().BoolVar(&dc.disableGrouping, "disable-grouping", false,
 		"Disable grouping machines when ready condition has the same Status, Severity and Reason.")
-	describeClusterClusterCmd.Flags().MarkDeprecated("disable-grouping",
+	_ = describeClusterClusterCmd.Flags().MarkDeprecated("disable-grouping",
 		"use --grouping instead.")
 
 	// completions


### PR DESCRIPTION
Errcheck linter was flagging this for me locally. I'm not sure if we want to explicitly ignore this error or instead fail during init if this error happens. This method fails with an Error if :

```
if flag == nil {
		return fmt.Errorf("flag %q does not exist", name)
	}
	if usageMessage == "" {
		return fmt.Errorf("deprecated message for flag %q must be set", name)
	}
```

We know these aren't true unless someone actually changes the method call.
