### PR TITLE
🌱  Address in-loop deferred-close in etcd client generator

### DIFF
--- a/controlplane/kubeadm/internal/etcd_client_generator_test.go
+++ b/controlplane/kubeadm/internal/etcd_client_generator_test.go
@@ -203,7 +203,7 @@ func TestForLeader(t *testing.T) {
 			cc: func(ctx context.Context, endpoints []string) (*etcd.Client, error) {
 				return nil, errors.New("node down")
 			},
-			expectedErr: "could not establish a connection to the etcd leader: could not establish a connection to any etcd node: node down",
+			expectedErr: "could not establish a connection to the etcd leader: [could not establish a connection to any etcd node: node down, failed to connect to etcd node]",
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The etcd connection was deferred-close inside a loop which causes ~all but the last loop iteration to leak connections~ the connections to be held longer than necessary (i.e., until the entire loop completes). Address the issue by moving the logic into a dedicated method that is invoked once per each iteration.