### PR TITLE
🌱 Use Kubernetes 1.23 in: quickstart, CAPD, e2e tests + update doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -389,10 +389,10 @@ Examples:
 ```bash
 $ kubectl get kubeadmcontrolplane
 NAMESPACE            NAME                               INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE     VERSION
-quick-start-d5ufye   quick-start-ntysk0-control-plane   true          true                   1          1       1                       2m44s   v1.22.0
+quick-start-d5ufye   quick-start-ntysk0-control-plane   true          true                   1          1       1                       2m44s   v1.23.0
 $ kubectl get machinedeployment
 NAMESPACE            NAME                      CLUSTER              REPLICAS   READY   UPDATED   UNAVAILABLE   PHASE       AGE     VERSION
-quick-start-d5ufye   quick-start-ntysk0-md-0   quick-start-ntysk0   1                  1         1             ScalingUp   3m28s   v1.22.0
+quick-start-d5ufye   quick-start-ntysk0-md-0   quick-start-ntysk0   1                  1         1             ScalingUp   3m28s   v1.23.0
 ```
 
 ## Google Doc Viewing Permissions

--- a/docs/book/src/reference/jobs.md
+++ b/docs/book/src/reference/jobs.md
@@ -25,7 +25,7 @@ Prow Presubmits:
   * GINKGO_FOCUS: `[PR-Blocking]`, IP_FAMILY: `IPv6`
 * ✳️️ ✴️ [pull-cluster-api-e2e-full-main] `./scripts/ci-e2e.sh`
   * GINKGO_SKIP: `[PR-Blocking] [Conformance] [K8s-Upgrade]` (i.e. "no tags")
-* ✳️️ ✴️ [pull-cluster-api-e2e-workload-upgrade-1-22-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.22` TO: `ci/latest-1.23`
+* ✳️️ ✴️ [pull-cluster-api-e2e-workload-upgrade-1-23-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.23` TO: `ci/latest-1.24`
   * GINKGO_FOCUS: `[K8s-Upgrade]`
 
 GitHub Presubmit Workflows:
@@ -58,7 +58,9 @@ Prow Periodics:
   * GINKGO_FOCUS: `[K8s-Upgrade]`
 * [periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-main] `./scripts/ci-e2e.sh` FROM: `stable-1.21` TO: `stable-1.22`
   * GINKGO_FOCUS: `[K8s-Upgrade]`
-* [periodic-cluster-api-e2e-workload-upgrade-1-22-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.22` TO: `ci/latest-1.23`
+* [periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-main] `./scripts/ci-e2e.sh` FROM: `stable-1.22` TO: `stable-1.23`
+  * GINKGO_FOCUS: `[K8s-Upgrade]`
+* [periodic-cluster-api-e2e-workload-upgrade-1-23-latest-main] `./scripts/ci-e2e.sh` FROM: `stable-1.23` TO: `ci/latest-1.24`
   * GINKGO_FOCUS: `[K8s-Upgrade]`
 * [cluster-api-push-images-nightly] Google Cloud Build: `make release-staging-nightly`, `make -C test/infrastructure/docker release-staging-nightly`
 
@@ -77,7 +79,7 @@ GitHub (On Release) Workflows:
 [pull-cluster-api-e2e-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-main
 [pull-cluster-api-e2e-ipv6-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-main-ipv6
 [pull-cluster-api-e2e-full-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-full-main
-[pull-cluster-api-e2e-workload-upgrade-1-22-latest-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-main-1-22-latest
+[pull-cluster-api-e2e-workload-upgrade-1-23-latest-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-pr-e2e-main-1-23-latest
 [periodic-cluster-api-verify-book-links-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-verify-book-links-main
 [periodic-cluster-api-test-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-test-main
 [periodic-cluster-api-e2e-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main
@@ -88,6 +90,7 @@ GitHub (On Release) Workflows:
 [periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-19-1-20
 [periodic-cluster-api-e2e-workload-upgrade-1-20-1-21-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-20-1-21
 [periodic-cluster-api-e2e-workload-upgrade-1-21-1-22-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-21-1-22
-[periodic-cluster-api-e2e-workload-upgrade-1-22-latest-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-22-latest
+[periodic-cluster-api-e2e-workload-upgrade-1-22-1-23-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-22-1-23
+[periodic-cluster-api-e2e-workload-upgrade-1-23-latest-main]: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main-1-23-latest
 [cluster-api-push-images-nightly]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#cluster-api-push-images-nightly
 [post-cluster-api-push-images]: https://testgrid.k8s.io/sig-cluster-lifecycle-image-pushes#post-cluster-api-push-images

--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -52,6 +52,7 @@ These diagrams show the relationships between components in a Cluster API releas
 | Kubernetes v1.20 | ✓                                | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
 | Kubernetes v1.21 | ✓                                | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
 | Kubernetes v1.22 |                                  | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
+| Kubernetes v1.23 |                                  |                               | ✓                                | ✓                             | ✓                                | ✓                             |
 
 The Core Provider also talks to API server of every Workload Cluster. Therefore, the Workload Cluster's Kubernetes version must also be compatible.
 
@@ -65,7 +66,8 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 | Kubernetes v1.19 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
 | Kubernetes v1.20 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
 | Kubernetes v1.21 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4) |                                  | ✓                             | ✓                               | ✓                             | ✓                             | ✓                             |
+| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) |   | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
+| Kubernetes v1.23 + kubeadm/v1beta3 |                                  |                               | ✓                               | ✓                             | ✓                               | ✓                             |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
@@ -80,6 +82,7 @@ The Kubeadm Bootstrap Provider generates kubeadm configuration using the API ver
 | Kubernetes v1.20 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
 | Kubernetes v1.21 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
 | Kubernetes v1.22 + etcd/v3 |                                 | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
+| Kubernetes v1.23 + etcd/v3 |                                 |                               | ✓                               | ✓                             | ✓                               | ✓                             |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -616,7 +616,7 @@ For the purpose of this tutorial, we'll name our cluster capi-quickstart.
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.22.0 \
+  --kubernetes-version v1.23.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -635,7 +635,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.22.0 \
+  --kubernetes-version v1.23.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -695,7 +695,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                            INITIALIZED   API SERVER AVAILABLE   VERSION   REPLICAS   READY   UPDATED   UNAVAILABLE
-capi-quickstart-control-plane   true                                 v1.22.0   3                  3         3
+capi-quickstart-control-plane   true                                 v1.23.0   3                  3         3
 ```
 
 <aside class="note warning">
@@ -731,7 +731,7 @@ Calico is used here as an example.
 
 ```bash
 kubectl --kubeconfig=./capi-quickstart.kubeconfig \
-  apply -f https://docs.projectcalico.org/v3.20/manifests/calico.yaml
+  apply -f https://docs.projectcalico.org/v3.21/manifests/calico.yaml
 ```
 
 After a short while, our nodes should be running and in `Ready` state,

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -198,10 +198,10 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.22.0"
-  KUBERNETES_VERSION: "v1.22.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.21.2"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.22.0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.23.0"
+  KUBERNETES_VERSION: "v1.23.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.22.4"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.23.0"
   ETCD_VERSION_UPGRADE_TO: "3.5.1-0"
   COREDNS_VERSION_UPGRADE_TO: "1.8.4"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
@@ -220,7 +220,7 @@ variables:
   # NOTE: We test the latest release with a previous contract.
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.4/clusterctl-{OS}-{ARCH}"
   INIT_WITH_PROVIDERS_CONTRACT: "v1alpha4"
-  INIT_WITH_KUBERNETES_VERSION: "v1.22.0"
+  INIT_WITH_KUBERNETES_VERSION: "v1.23.0"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -33,7 +33,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.22.0"
+	DefaultNodeImageVersion = "v1.23.0"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -25,7 +25,7 @@ ENV GOPROXY=$goproxy
 # Gets additional CAPD dependencies
 WORKDIR /tmp
 
-RUN curl -LO https://dl.k8s.io/release/v1.22.0/bin/linux/${ARCH}/kubectl && \
+RUN curl -LO https://dl.k8s.io/release/v1.23.0/bin/linux/${ARCH}/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl
 

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -29,7 +29,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.22.0
+  version: v1.23.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -86,7 +86,7 @@ spec:
         kind: DockerMachinePool
         name: worker-dmp-0
         namespace: default
-      version: v1.22.0
+      version: v1.23.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePool

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.22.0
+  version: v1.23.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -120,7 +120,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.22.0
+      version: v1.23.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -38,7 +38,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.22.0
+  version: v1.23.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -106,7 +106,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.22.0
+      version: v1.23.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.22.0
+  version: v1.23.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -105,7 +105,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.22.0
+      version: v1.23.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.22.0"
+	defaultImageTag  = "v1.23.0"
 )
 
 type nodeCreator interface {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially implements #5793

Related: https://github.com/kubernetes/test-infra/pull/24554