### PR TITLE
🌱 test/e2e: Implement release informing jobs with CC & IPv6

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -209,6 +209,8 @@ variables:
   IP_FAMILY: "IPv4"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"
   DOCKER_POD_CIDRS: "192.168.0.0/16"
+  DOCKER_SERVICE_IPV6_CIDRS: "fd00:100:64::/108"
+  DOCKER_POD_IPV6_CIDRS: "fd00:100:96::/48"
   CNI: "./data/cni/kindnet/kindnet.yaml"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   NODE_DRAIN_TIMEOUT: "60s"

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-ipv6/cluster-ipv6.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-ipv6/cluster-ipv6.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: '${CLUSTER_NAME}'
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ['${DOCKER_SERVICE_IPV6_CIDRS}']
+    pods:
+      cidrBlocks: ['${DOCKER_POD_IPV6_CIDRS}']

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-ipv6/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-ipv6/kustomization.yaml
@@ -4,5 +4,6 @@ bases:
   - ../bases/crs.yaml
 
 patchesStrategicMerge:
+  - ./cluster-ipv6.yaml
   - ./md-ipv6.yaml
   - ./kcp-ipv6.yaml

--- a/test/e2e/quick_start.go
+++ b/test/e2e/quick_start.go
@@ -77,9 +77,9 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 	It("Should create a workload cluster", func() {
 		By("Creating a workload cluster")
 
-		defaultFlavor := clusterctl.DefaultFlavor
-		if input.E2EConfig.GetVariable(IPFamily) == "IPv6" {
-			defaultFlavor = "ipv6"
+		flavor := clusterctl.DefaultFlavor
+		if input.Flavor != nil {
+			flavor = *input.Flavor
 		}
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
@@ -89,7 +89,7 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 				ClusterctlConfigPath:     input.ClusterctlConfigPath,
 				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
 				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
-				Flavor:                   pointer.StringDeref(input.Flavor, defaultFlavor),
+				Flavor:                   flavor,
 				Namespace:                namespace.Name,
 				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
 				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -36,7 +36,7 @@ var _ = Describe("When following the Cluster API quick-start [PR-Blocking]", fun
 	})
 })
 
-var _ = Describe("When following the Cluster API quick-start with ClusterClass", func() {
+var _ = Describe("When following the Cluster API quick-start with ClusterClass [PR-Informing]", func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:             e2eConfig,
@@ -45,6 +45,20 @@ var _ = Describe("When following the Cluster API quick-start with ClusterClass",
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
 			Flavor:                pointer.String("topology"),
+		}
+	})
+})
+
+// NOTE: This test requires an IPv6 management cluster (can be configured via IP_FAMILY=IPv6).
+var _ = Describe("When following the Cluster API quick-start with IPv6 [IPv6] [PR-Informing]", func() {
+	QuickStartSpec(ctx, func() QuickStartSpecInput {
+		return QuickStartSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+			Flavor:                pointer.String("ipv6"),
 		}
 	})
 })


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Turns out the IPv6 test requires an IPv6 management cluster. And from an IPv6 management cluster we're not able to create IPv4 clusters. => we have to separate IPv4 and IPv6 tests in separate jobs.

The following changes should be made to our test jobs:

* `pull-cluster-api-e2e-full-main` & `periodic-cluster-api-e2e-main` & `periodic-cluster-api-e2e-mink8s-main`: 
    * `GINKGO_SKIP`: add `[IPv6]`
* `pull-cluster-api-e2e-informing-main`: (to be created)
    * `GINKGO_SKIP` `[IPv6]`
    * `GINKGO_FOCUS`: `[PR-Informing]`
* `pull-cluster-api-e2e-informing-ipv6-main`: (previously `pull-cluster-api-e2e-ipv6-main`) (TBD?)
    * Drop `DOCKER_SERVICE_CIDRS` & `DOCKER_POD_CIDRS`
    * `GINKGO_FOCUS`: `[IPv6][PR-Informing]`


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5768
