### PR TITLE
🐛 Fix incorrect array initalization causing incorrect webhook failures

### DIFF
--- a/internal/webhooks/clusterclass.go
+++ b/internal/webhooks/clusterclass.go
@@ -197,7 +197,7 @@ func validateVariableUpdates(clusters []clusterv1.Cluster, old, new *clusterv1.C
 	varsDiff := getClusterClassVariablesForValidation(oldVars, newVars)
 
 	errorInfo := errorAggregator{}
-	allClusters := make([]string, len(clusters))
+	allClusters := []string{}
 
 	// Validate the variable values on each Cluster ensuring they are still compatible with the new ClusterClass.
 	for _, cluster := range clusters {

--- a/internal/webhooks/clusterclass_test.go
+++ b/internal/webhooks/clusterclass_test.go
@@ -1815,6 +1815,74 @@ func TestClusterClassValidationWithVariableChecks(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name: "Pass if an update is made to a ClusterClass with required variables, but with no changes to variables",
+			clusters: []client.Object{
+				builder.Cluster(metav1.NamespaceDefault, "cluster1").
+					WithLabels(map[string]string{clusterv1.ClusterTopologyOwnedLabel: ""}).
+					WithTopology(
+						builder.ClusterTopology().
+							WithClass("class1").
+							WithVariables(
+								clusterv1.ClusterVariable{
+									Name: "cpu",
+									Value: apiextensionsv1.JSON{
+										Raw: []byte(`4`),
+									},
+								},
+								clusterv1.ClusterVariable{
+									Name: "hdd",
+									Value: apiextensionsv1.JSON{
+										Raw: []byte(`4`),
+									},
+								}).
+							Build()).
+					Build(),
+			},
+			oldClusterClass: clusterClassBuilder.
+				WithVariables(
+					clusterv1.ClusterClassVariable{
+						Name: "cpu",
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "integer",
+							},
+						},
+					},
+					clusterv1.ClusterClassVariable{
+						Name:     "hdd",
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "number",
+							},
+						},
+					},
+				).
+				Build(),
+			newClusterClass: clusterClassBuilder.
+				WithVariables(
+					clusterv1.ClusterClassVariable{
+						Name: "cpu",
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "integer",
+							},
+						},
+					},
+					clusterv1.ClusterClassVariable{
+						Name:     "hdd",
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "number",
+							},
+						},
+					},
+				).
+				Build(),
+			expectErr: false,
+		},
+		{
 			name: "Pass if adding a non-required variable to the ClusterClass",
 			clusters: []client.Object{
 				builder.Cluster(metav1.NamespaceDefault, "cluster1").


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

This fixes an issue where non-variable related updates on ClusterClasses are rejected due to incorrect initialisation of an array for checking variables.

/cc @sbueringer 