### PR TITLE
🌱 Use ClusterClass name index in ClusterClass webhook

### DIFF
--- a/internal/controllers/clusterclass/clusterclass_controller_test.go
+++ b/internal/controllers/clusterclass/clusterclass_controller_test.go
@@ -25,17 +25,14 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilfeature "k8s.io/component-base/featuregate/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/feature"
 	tlog "sigs.k8s.io/cluster-api/internal/log"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 )
 
 func TestClusterClassReconciler_reconcile(t *testing.T) {
-	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
 	g := NewWithT(t)
 	timeout := 30 * time.Second
 

--- a/internal/controllers/clusterclass/suite_test.go
+++ b/internal/controllers/clusterclass/suite_test.go
@@ -30,12 +30,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/component-base/featuregate"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
+	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/test/envtest"
 )
 
@@ -51,6 +53,9 @@ func init() {
 	_ = apiextensionsv1.AddToScheme(fakeScheme)
 }
 func TestMain(m *testing.M) {
+	if err := feature.Gates.(featuregate.MutableFeatureGate).Set(fmt.Sprintf("%s=%v", feature.ClusterTopology, true)); err != nil {
+		panic(fmt.Sprintf("unable to set ClusterTopology feature gate: %v", err))
+	}
 	setupIndexes := func(ctx context.Context, mgr ctrl.Manager) {
 		if err := index.AddDefaultIndexes(ctx, mgr); err != nil {
 			panic(fmt.Sprintf("unable to setup index: %v", err))

--- a/internal/controllers/topology/cluster/suite_test.go
+++ b/internal/controllers/topology/cluster/suite_test.go
@@ -53,6 +53,11 @@ func TestMain(m *testing.M) {
 		if err := index.AddDefaultIndexes(ctx, mgr); err != nil {
 			panic(fmt.Sprintf("unable to setup index: %v", err))
 		}
+		// Set up the ClusterClassName index explicitly here. This index is ordinarily created in
+		// index.AddDefaultIndexes. That doesn't happen here because the ClusterClass feature flag is not set.
+		if err := index.ByClusterClassName(ctx, mgr); err != nil {
+			panic(fmt.Sprintf("unable to setup index: %v", err))
+		}
 	}
 	setupReconcilers := func(ctx context.Context, mgr ctrl.Manager) {
 		unstructuredCachingClient, err := client.NewDelegatingClient(

--- a/internal/webhooks/test/clusterclass_test.go
+++ b/internal/webhooks/test/clusterclass_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilfeature "k8s.io/component-base/featuregate/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -258,9 +259,9 @@ func TestClusterWebhook_Fail_Update(t *testing.T) {
 	g.Expect(env.Update(ctx, actualCluster)).NotTo(Succeed())
 }
 
-// TestClusterClassWebhook_Succeed_Delete tests the correct deletion behaviour for a ClusterClass with no references in existing Clusters.
-// In this case deletion of the ClusterClass should succeed.
-func TestClusterClassWebhook_Succeed_Delete(t *testing.T) {
+// TestClusterClassWebhook_Fail_Delete tests the correct deletion behaviour for a ClusterClass with references in existing Clusters.
+// In this case deletion of the ClusterClass should be blocked by the webhook.
+func TestClusterClassWebhook_Delete(t *testing.T) {
 	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
 	g := NewWithT(t)
 
@@ -268,7 +269,7 @@ func TestClusterClassWebhook_Succeed_Delete(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	// Create the objects needed for the integration test:
-	// - two ClusterClasses with all the related templates
+	// - a two ClusterClasses with all the related templates
 	// - a Cluster using one of the ClusterClasses
 	clusterClass1 := builder.ClusterClass(ns.Name, "class1").
 		WithInfrastructureClusterTemplate(
@@ -326,74 +327,9 @@ func TestClusterClassWebhook_Succeed_Delete(t *testing.T) {
 				Build()).
 		Build()
 
-	// Create the two ClusterClasses in the API server.
+	// Create the ClusterClasses in the API server.
 	g.Expect(env.CreateAndWait(ctx, clusterClass1)).To(Succeed())
 	g.Expect(env.CreateAndWait(ctx, clusterClass2)).To(Succeed())
-
-	// Create a cluster.
-	g.Expect(env.CreateAndWait(ctx, cluster)).To(Succeed())
-
-	// Clean up the resources once the test is finished.
-	t.Cleanup(func() {
-		g.Expect(env.CleanupAndWait(ctx, cluster))
-		g.Expect(env.Cleanup(ctx, clusterClass1))
-		g.Expect(env.Cleanup(ctx, ns))
-	})
-
-	// Attempt to delete ClusterClass "class2" which is not in use.
-	// Expect no error here as the webhook should allow the deletion of an existing ClusterClass.
-	g.Expect(env.Delete(ctx, clusterClass2)).To(Succeed())
-}
-
-// TestClusterClassWebhook_Fail_Delete tests the correct deletion behaviour for a ClusterClass with references in existing Clusters.
-// In this case deletion of the ClusterClass should be blocked by the webhook.
-func TestClusterClassWebhook_Fail_Delete(t *testing.T) {
-	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
-	g := NewWithT(t)
-
-	ns, err := env.CreateNamespace(ctx, "test-topology-clusterclass-webhook")
-	g.Expect(err).ToNot(HaveOccurred())
-
-	// Create the objects needed for the integration test:
-	// - a ClusterClass with all the related templates
-	// - a Cluster using one of the ClusterClasses
-	clusterClass1 := builder.ClusterClass(ns.Name, "class1").
-		WithInfrastructureClusterTemplate(
-			builder.InfrastructureClusterTemplate(ns.Name, "inf").Build()).
-		WithControlPlaneTemplate(
-			builder.ControlPlaneTemplate(ns.Name, "cp1").
-				Build()).
-		WithWorkerMachineDeploymentClasses(
-			*builder.MachineDeploymentClass("md1").
-				WithInfrastructureTemplate(
-					builder.InfrastructureMachineTemplate(ns.Name, "OLD_INFRA").Build()).
-				WithBootstrapTemplate(
-					builder.BootstrapTemplate(ns.Name, "bootstrap1").Build()).
-				Build(),
-			*builder.MachineDeploymentClass("md2").
-				WithInfrastructureTemplate(
-					builder.InfrastructureMachineTemplate(ns.Name, "infra1").Build()).
-				WithBootstrapTemplate(
-					builder.BootstrapTemplate(ns.Name, "bootstrap1").Build()).
-				Build()).
-		Build()
-
-	cluster := builder.Cluster(ns.Name, "cluster2").
-		WithLabels(map[string]string{clusterv1.ClusterTopologyOwnedLabel: ""}).
-		WithTopology(
-			builder.ClusterTopology().
-				WithVersion("v1.20.1").
-				WithClass("class1").
-				WithMachineDeployment(
-					builder.MachineDeploymentTopology("workers1").
-						WithClass("md1").
-						Build(),
-				).
-				Build()).
-		Build()
-
-	// Create the ClusterClass in the API server.
-	g.Expect(env.CreateAndWait(ctx, clusterClass1)).To(Succeed())
 
 	// Create a clusters.
 	g.Expect(env.CreateAndWait(ctx, cluster)).To(Succeed())
@@ -406,5 +342,144 @@ func TestClusterClassWebhook_Fail_Delete(t *testing.T) {
 
 	// Attempt to delete ClusterClass "class1" which is in use.
 	// Expect no error here as the webhook should allow the deletion of an existing ClusterClass.
-	g.Expect(env.Delete(ctx, clusterClass1)).NotTo(Succeed())
+	g.Expect(env.Delete(ctx, clusterClass1)).To(Not(Succeed()))
+
+	// Attempt to delete ClusterClass "class2" which is not in use.
+	// Expect no error here as the webhook should allow the deletion of an existing ClusterClass.
+	g.Expect(env.Delete(ctx, clusterClass2)).To(Succeed())
+}
+
+// TestClusterClassWebhook_Succeed_Delete tests the correct deletion behaviour for a ClusterClass with no references in existing Clusters.
+// In this case deletion of the ClusterClass should succeed.
+func TestClusterClassWebhook_Delete_MultipleExistingClusters(t *testing.T) {
+	g := NewWithT(t)
+	ns, err := env.CreateNamespace(ctx, "test-clusterclass-webhook")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// Create the objects needed for the integration test:
+	// - Five ClusterClasses with all the related templates
+	// - Five Clusters using all ClusterClass except "class1"
+	clusterClasses := []client.Object{
+		builder.ClusterClass(ns.Name, "class1").
+			WithInfrastructureClusterTemplate(
+				builder.InfrastructureClusterTemplate(ns.Name, "inf").Build()).
+			WithControlPlaneTemplate(
+				builder.ControlPlaneTemplate(ns.Name, "cp1").
+					Build()).
+			Build(),
+		builder.ClusterClass(ns.Name, "class2").
+			WithInfrastructureClusterTemplate(
+				builder.InfrastructureClusterTemplate(ns.Name, "inf").Build()).
+			WithControlPlaneTemplate(
+				builder.ControlPlaneTemplate(ns.Name, "cp1").
+					Build()).
+			Build(),
+		builder.ClusterClass(ns.Name, "class3").
+			WithInfrastructureClusterTemplate(
+				builder.InfrastructureClusterTemplate(ns.Name, "inf").Build()).
+			WithControlPlaneTemplate(
+				builder.ControlPlaneTemplate(ns.Name, "cp1").
+					Build()).
+			Build(),
+		builder.ClusterClass(ns.Name, "class4").
+			WithInfrastructureClusterTemplate(
+				builder.InfrastructureClusterTemplate(ns.Name, "inf").Build()).
+			WithControlPlaneTemplate(
+				builder.ControlPlaneTemplate(ns.Name, "cp1").
+					Build()).
+			Build(),
+		builder.ClusterClass(ns.Name, "class5").
+			WithInfrastructureClusterTemplate(
+				builder.InfrastructureClusterTemplate(ns.Name, "inf").Build()).
+			WithControlPlaneTemplate(
+				builder.ControlPlaneTemplate(ns.Name, "cp1").
+					Build()).
+			Build(),
+	}
+	clusters := []client.Object{
+		// class1 is not referenced in any of the below Clusters
+		builder.Cluster(ns.Name, "cluster1").
+			WithLabels(map[string]string{clusterv1.ClusterTopologyOwnedLabel: ""}).
+			WithTopology(
+				builder.ClusterTopology().
+					WithVersion("v1.20.1").
+					WithClass("class5").
+					Build()).
+			Build(),
+		builder.Cluster(ns.Name, "cluster2").
+			WithLabels(map[string]string{clusterv1.ClusterTopologyOwnedLabel: ""}).
+			WithTopology(
+				builder.ClusterTopology().
+					WithVersion("v1.20.1").
+					WithClass("class2").
+					Build()).
+			Build(),
+		builder.Cluster(ns.Name, "cluster3").
+			WithLabels(map[string]string{clusterv1.ClusterTopologyOwnedLabel: ""}).
+			WithTopology(
+				builder.ClusterTopology().
+					WithVersion("v1.20.1").
+					WithClass("class3").
+					Build()).
+			Build(),
+		builder.Cluster(ns.Name, "cluster4").
+			WithLabels(map[string]string{clusterv1.ClusterTopologyOwnedLabel: ""}).
+			WithTopology(
+				builder.ClusterTopology().
+					WithVersion("v1.20.1").
+					WithClass("class4").
+					Build()).
+			Build(),
+	}
+	var classForDeletion string
+	// Create the ClusterClasses in the API server.
+	for _, class := range clusterClasses {
+		g.Expect(env.CreateAndWait(ctx, class)).To(Succeed())
+	}
+
+	// Create each of the clusters.
+	for _, c := range clusters {
+		g.Expect(env.CreateAndWait(ctx, c)).To(Succeed())
+	}
+
+	// defer a function to clean up created resources.
+	defer func() {
+		// Delete each of the clusters.
+		for _, c := range clusters {
+			g.Expect(env.Delete(ctx, c)).To(Succeed())
+		}
+
+		// Delete the ClusterClasses in the API server.
+		for _, class := range clusterClasses {
+			// The classForDeletion should not exist at this point.
+			if class.GetName() != classForDeletion {
+				if err := env.Delete(ctx, class); err != nil {
+					if apierrors.IsNotFound(err) {
+						continue
+					}
+					g.Expect(err).To(BeNil())
+				}
+			}
+		}
+	}()
+
+	// This is the unused clusterClass to be deleted.
+	classForDeletion = "class1"
+
+	class := &clusterv1.ClusterClass{}
+	g.Expect(env.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: classForDeletion}, class)).To(Succeed())
+
+	// Attempt to delete ClusterClass "class1" which is not in use.
+	// Expect no error here as the webhook should allow the deletion of an unused ClusterClass.
+	g.Expect(env.Delete(ctx, class)).To(Succeed())
+
+	// This is a clusterClass in use to be deleted.
+	classForDeletion = "class3"
+
+	class = &clusterv1.ClusterClass{}
+	g.Expect(env.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: classForDeletion}, class)).To(Succeed())
+
+	// Attempt to delete ClusterClass "class3" which is in use.
+	// Expect an error here as the webhook should not allow the deletion of an existing ClusterClass.
+	g.Expect(env.Delete(ctx, class)).To(Not(Succeed()))
 }

--- a/internal/webhooks/test/suite_test.go
+++ b/internal/webhooks/test/suite_test.go
@@ -22,9 +22,11 @@ import (
 	"os"
 	"testing"
 
+	"k8s.io/component-base/featuregate"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
+	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/test/envtest"
 )
 
@@ -34,6 +36,9 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	if err := feature.Gates.(featuregate.MutableFeatureGate).Set(fmt.Sprintf("%s=%v", feature.ClusterTopology, true)); err != nil {
+		panic(fmt.Sprintf("unable to set ClusterTopology feature gate: %v", err))
+	}
 	setupIndexes := func(ctx context.Context, mgr ctrl.Manager) {
 		if err := index.AddDefaultIndexes(ctx, mgr); err != nil {
 			panic(fmt.Sprintf("unable to setup index: %v", err))


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add the ClusterClass name index to the client call for getting a ClusterClass in the ClusterClass webhook. 

Certain tests are moved to a new subpackage in order to run them with envtest. This is required as the fakeclient doesn't set up the indexes now in use by the ClusterClass webhook.

Note this PR includes duplicate files from #5803 and should not be merged until that PR is completed.

Fixes #5719 
