### PR TITLE
🌱 Add v1.1 to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,7 +4,11 @@
 #
 # update this file only when a new major or minor version is released
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+kind: Metadata
 releaseSeries:
+  - major: 1
+    minor: 1
+    contract: v1beta1
   - major: 1
     minor: 0
     contract: v1beta1


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds the upcoming v1.1 release series to the `metadata.yaml`

I tried to deploy providers via the local repository (generated via `cmd/clusterctl/hack/create-local-repository.py` which is using the top-level `./metadata.yaml`)
and it failed because the release series was missing:
```bash
./bin/clusterctl init --core cluster-api:v1.1.99 --bootstrap kubeadm:v1.1.99 --control-plane kubeadm:v1.1.99 --infrastructure docker:v1.1.99 --config ~/.cluster-api/dev-repository/config.yaml
Fetching providers
Error: invalid provider metadata: version v1.1.99 for the provider capi-system/cluster-api does not match any release series
```

I think we have to add it before the release anyway.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
