### PR TITLE
🌱 replace hardcoded kind cluster name to pickup env values

### DIFF
--- a/hack/kind-install-for-capd.sh
+++ b/hack/kind-install-for-capd.sh
@@ -26,19 +26,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-NAME="capi-test"
-
-while [[ $# -gt 0 ]]; do
-  key="$1"
-  case $key in
-    -n|--name)
-      NAME="$2"
-      shift
-      shift
-      ;;
-  esac
-done
-
+NAME=${CAPI_KIND_CLUSTER_NAME:-"capi-test"}
 
 # create registry container unless it already exists
 reg_name='kind-registry'

--- a/hack/tools/tilt-prepare/main.go
+++ b/hack/tools/tilt-prepare/main.go
@@ -304,11 +304,20 @@ func preLoadImageTask(image string) taskFunction {
 			return
 		}
 
-		cmd := exec.CommandContext(ctx,
+		// get cluster name from env
+		name, exists := os.LookupEnv("CAPI_KIND_CLUSTER_NAME")
+		if !exists {
+			name = "capi-test"
+		}
+
+		// set command to use capi cluster name
+		namecmd := fmt.Sprintf("--name=%s", name)
+
+		cmd := exec.CommandContext(ctx, //nolint:gosec
 			"kind",
 			"load",
 			"docker-image",
-			"--name=capi-test", // TODO: make this configurable
+			namecmd,
 			image,
 		)
 


### PR DESCRIPTION
🌱 

**What this PR does / why we need it**:
Replaces code to pickup kind cluster alternate from env variables instead of hardcoding it to capi-test. If env variable is not present the default value of capi-test cluster name is taken.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5820 
