### PR TITLE
🌱 Add GitHub Action to automate creating a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: release
+
+jobs:
+  build:
+    name: create draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env
+        run:  echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
+      - name: checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+      - name: generate release artifacts
+        run: |
+          make release
+      - name: generate release notes
+        run: |
+          make release-notes
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: out/*
+          body_path: _releasenotes/${{ env.RELEASE_TAG }}.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 cmd/clusterctl/clusterctl
 bin
 hack/tools/bin
-out
 
 # Test binary, build with `go test -c`
 *.test
@@ -66,3 +65,7 @@ clusterctl-settings.json
 
 # test results
 _artifacts
+
+#release artifacts
+out
+_releasenotes

--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,7 @@ release: clean-release ## Builds and push container images using the latest git 
 	@if ! [ -z "$$(git status --porcelain)" ]; then echo "Your local git repository contains uncommitted changes, use git clean before proceeding."; exit 1; fi
 	git checkout "${RELEASE_TAG}"
 	# Build binaries first.
-	$(MAKE) release-binaries
+	GIT_VERSION=$(RELEASE_TAG) $(MAKE) release-binaries
 	# Set the core manifest image to the production bucket.
 	$(MAKE) set-manifest-image \
 		MANIFEST_IMG=$(PROD_REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(RELEASE_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -500,8 +500,7 @@ release-binaries: ## Builds the binaries to publish with a release
 	RELEASE_BINARY=./cmd/clusterctl GOOS=linux GOARCH=amd64 $(MAKE) release-binary
 	RELEASE_BINARY=./cmd/clusterctl GOOS=linux GOARCH=arm64 $(MAKE) release-binary
 	RELEASE_BINARY=./cmd/clusterctl GOOS=darwin GOARCH=amd64 $(MAKE) release-binary
-	RELEASE_BINARY=./cmd/clusterctl GOOS=darwin GOARCH=arm64 $(MAKE) release-binary
-
+	
 release-binary: $(RELEASE_DIR)
 	docker run \
 		--rm \

--- a/docs/developer/releasing.md
+++ b/docs/developer/releasing.md
@@ -56,20 +56,21 @@ export DOCKER_CLI_EXPERIMENTAL=enabled
 
 For version v0.x.y:
 
-1. Create an annotated tag `git tag -a v0.x.y -m v0.x.y`
-    1. To use your GPG signature when pushing the tag, use `git tag -s [...]` instead
-1. Push the tag to the GitHub repository `git push origin v0.x.y`
-    1. NB: `origin` should be the name of the remote pointing to `github.com/kubernetes-sigs/cluster-api`
-1. Run `make release` to build artifacts (the image is automatically built by CI)
-1. Follow the [Image Promotion process](https://git.k8s.io/k8s.io/k8s.gcr.io#image-promoter) to promote the image from the staging repo to `us.gcr.io/k8s-artifacts-prod/cluster-api`
-1. Create a release in GitHub based on the tag created above
-1. Release notes can be created by running `make release-notes`, which will generate an output that can be copied to the drafted release in GitHub.
-   Pay close attention to the `## :question: Sort these by hand` section, as it contains items that need to be manually sorted.
+1. Create an annotated tag
+   > NOTE: To use your GPG signature when pushing the tag, use `git tag -s [...]` instead)
+   - `git tag -a v0.x.y -m v0.x.y`
+   - `git tag test/v0.x.y` (:warning: MUST NOT be an annotated tag)
+1. Push the tag to the GitHub repository. This will automatically trigger a [Github Action](https://github.com/kubernetes-sigs/cluster-api/actions) to create a draft release.
+   > NOTE: `origin` should be the name of the remote pointing to `github.com/kubernetes-sigs/cluster-api`
+   - `git push origin v0.x.y`
+   - `git push origin test/v0.x.y`
+1. Follow the [Image Promotion process](https://git.k8s.io/k8s.io/k8s.gcr.io#image-promoter) to promote the image from the staging repo to `k8s.gcr.io/cluster-api`
+1. Review the draft release on GitHub. Pay close attention to the `## :question: Sort these by hand` section, as it contains items that need to be manually sorted.
+1. Publish the release
 
 ### Permissions
 
 Releasing requires a particular set of permissions.
 
-* Push access to the staging gcr bucket
 * Tag push access to the GitHub repository
 * GitHub Release creation access

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -29,7 +29,7 @@ version::get_version_vars() {
 
     # stolen from k8s.io/hack/lib/version.sh
     # Use git describe to find the version based on tags.
-    if GIT_VERSION=$(git describe --tags --abbrev=14 2>/dev/null); then
+    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --abbrev=14 --match "v[0-9]*" 2>/dev/null); then
         # This translates the "git describe" to an actual semver.org
         # compatible semantic version that looks something like this:
         #   v1.1.0-alpha.0.6+84c76d1142ea4d

--- a/test/infrastructure/docker/Makefile
+++ b/test/infrastructure/docker/Makefile
@@ -194,8 +194,8 @@ set-manifest-pull-policy:
 ## Release
 ## --------------------------------------
 
-GIT_TAG := $(shell git describe --abbrev=0 2>/dev/null)
-RELEASE_TAG := $(lastword $(subst /, ,$(GIT_TAG)))
+RELEASE_TAG ?= $(shell git describe --abbrev=0 2>/dev/null)
+RELEASE_ALIAS_TAG ?= $(PULL_BASE_REF)
 RELEASE_DIR := out
 
 $(RELEASE_DIR):
@@ -205,7 +205,7 @@ $(RELEASE_DIR):
 release: clean-release ## Builds and push container images using the latest git tag for the commit.
 	@if [ -z "${RELEASE_TAG}" ]; then echo "RELEASE_TAG is not set"; exit 1; fi
 	@if ! [ -z "$$(git status --porcelain)" ]; then echo "Your local git repository contains uncommitted changes, use git clean before proceeding."; exit 1; fi
-	git checkout "${GIT_TAG}"
+	git checkout "${RELEASE_TAG}"
 	# Set the manifest image to the staging bucket.
 	MANIFEST_IMG=$(STAGING_REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(RELEASE_TAG) \
 		$(MAKE) set-manifest-image


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This is a manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/5188 and https://github.com/kubernetes-sigs/cluster-api/pull/5473 to allow running the release GitHub action to create draft releases for patch releases of v0.3.

The PR also removes darwin arm64 because the go version in the release-0.3 branch does not support arm64. We had to manually drop that artifact during the latest 0.3.x release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
