### PR TITLE
:book: fix docs about generate kubeconfig use CA

### DIFF
--- a/docs/book/src/tasks/certs/generate-kubeconfig.md
+++ b/docs/book/src/tasks/certs/generate-kubeconfig.md
@@ -1,9 +1,9 @@
 ## Generating a Kubeconfig with your own CA
 
-1. Create a new Certificate Signing Request (CSR) for the `system:masters` Kubernetes role, or specify any other role under CN.
+1. Create a new Certificate Signing Request (CSR) for the `admin` user with the `system:masters` Kubernetes role, or specify any other role under O.
 
    ```bash
-   openssl req  -subj "/CN=system:masters" -new -newkey rsa:2048 -nodes -out admin.csr -keyout admin.key  -out admin.csr
+   openssl req  -subj "/CN=admin/O=system:masters" -new -newkey rsa:2048 -nodes -keyout admin.key  -out admin.csr
    ```
 
 2. Sign the CSR using the *[cluster-name]-ca* key:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
As described in https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles, group "system:masters" is the super-user, so we should set subject "/O=system:masters" rather than "/CN=system:masters".

**Which issue(s) this PR fixes**:
Fixes #
