### PR TITLE
🌱 add validation for default, enum and example definitions in variables

### DIFF
--- a/internal/topology/variables/cluster_variable_defaulting.go
+++ b/internal/topology/variables/cluster_variable_defaulting.go
@@ -91,10 +91,10 @@ func defaultClusterVariable(clusterVariable *clusterv1.ClusterVariable, clusterC
 	}
 
 	// Convert schema to Kubernetes APIExtensions schema.
-	apiExtensionsSchema, err := convertToAPIExtensionsJSONSchemaProps(&clusterClassVariable.Schema.OpenAPIV3Schema)
-	if err != nil {
+	apiExtensionsSchema, errs := convertToAPIExtensionsJSONSchemaProps(&clusterClassVariable.Schema.OpenAPIV3Schema, field.NewPath("schema"))
+	if len(errs) > 0 {
 		return nil, field.ErrorList{field.Invalid(fldPath, "",
-			fmt.Sprintf("invalid schema in ClusterClass for variable %q: error to convert schema %v", clusterVariable.Name, err))}
+			fmt.Sprintf("invalid schema in ClusterClass for variable %q: error to convert schema %v", clusterClassVariable.Name, errs))}
 	}
 
 	var value interface{}

--- a/internal/topology/variables/cluster_variable_validation.go
+++ b/internal/topology/variables/cluster_variable_validation.go
@@ -104,10 +104,10 @@ func ValidateClusterVariable(clusterVariable *clusterv1.ClusterVariable, cluster
 	}
 
 	// Convert schema to Kubernetes APIExtensions Schema.
-	apiExtensionsSchema, err := convertToAPIExtensionsJSONSchemaProps(&clusterClassVariable.Schema.OpenAPIV3Schema)
-	if err != nil {
+	apiExtensionsSchema, allErrs := convertToAPIExtensionsJSONSchemaProps(&clusterClassVariable.Schema.OpenAPIV3Schema, field.NewPath("schema"))
+	if len(allErrs) > 0 {
 		return field.ErrorList{field.InternalError(fldPath,
-			fmt.Errorf("failed to convert schema definition for variable %q; ClusterClass should be checked: %v", clusterVariable.Name, err))} // TODO: consider if to add ClusterClass name
+			fmt.Errorf("failed to convert schema definition for variable %q; ClusterClass should be checked: %v", clusterClassVariable.Name, allErrs))} // TODO: consider if to add ClusterClass name
 	}
 
 	// Create validator for schema.


### PR DESCRIPTION
This PR adds schema validation for values defined for default, enum and example in a ClusterClass variable. 

e.g. 

If a user defines a schema with an integer and minimum value 1 a default, example or enum member of -100 will be found to be invalid and the ClusterClass will be rejected on creation or update.

It also removes the Kubernetes CRD default validation that was part of the code previously.

Fixes #5831 
