### PR TITLE
added CleanupAndWait function to reduce flakiness in test

### DIFF
--- a/controlplane/kubeadm/controllers/remediation_test.go
+++ b/controlplane/kubeadm/controllers/remediation_test.go
@@ -827,7 +827,7 @@ func createMachine(ctx context.Context, g *WithT, namespace, name string, option
 			},
 		},
 	}
-	g.Expect(env.Create(ctx, m)).To(Succeed())
+	g.Expect(env.CreateAndWait(ctx, m)).To(Succeed())
 
 	patchHelper, err := patch.NewHelper(m, env.GetClient())
 	g.Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add a createAndWait function to the remediation test to ensure the object exists before proceeding with the test.

Intended to [fix flakes like this one](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-cluster-api-test-main/1468933028284731392) 
