### PR TITLE
 🐛 Fix/backup restore error handling.

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -933,8 +933,12 @@ func (o *objectMover) backupTargetObject(nodeToCreate *node, directory string) e
 	objectFile := filepath.Join(directory, filenameObj)
 
 	// If file exists, then remove it to be written again
-	if _, err = os.Stat(objectFile); err == nil {
-		if err = os.Remove(objectFile); err != nil {
+	_, err = os.Stat(objectFile)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err == nil {
+		if err := os.Remove(objectFile); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Co-authored-by: Stefan Büringer buringerst@vmware.com
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Previously errors thrown by os.Stat were not handled if they were not nil. This may may be relate to some failures seen in the Test_objectMover_backupTargetObject test.