### PR TITLE
🌱 added variable example and description to clusterclass yamls

### DIFF
--- a/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
@@ -39,20 +39,27 @@ spec:
       openAPIV3Schema:
         type: string
         default: "k8s.gcr.io"
+        example: "k8s.gcr.io"
+        description: "imageRepository is the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default."
   - name: etcdImageTag
     required: true
     schema:
       openAPIV3Schema:
         type: string
         default: ""
+        example: "3.5.1-0"
+        description: "etcdImageTag is the tag for the etcd image."
   - name: coreDNSImageTag
     required: true
     schema:
       openAPIV3Schema:
         type: string
         default: ""
+        example: "v1.8.5"
+        description: "coreDNSImageTag is the tag for the coreDNS image."
   patches:
   - name: imageRepository
+    description: "Sets the imageRepository used for the KubeadmControlPlane."
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -65,6 +72,7 @@ spec:
         valueFrom:
           variable: imageRepository
   - name: etcdImageTag
+    description: "Sets tag to use for the etcd image in the KubeadmControlPlane "
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -79,6 +87,7 @@ spec:
             local:
               imageTag: {{ .etcdImageTag }}
   - name: coreDNSImageTag
+    description: "Sets the tag used for the coreDNS Image in the KubeadmControlPlane."
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -92,6 +101,7 @@ spec:
           template: |
             imageTag: {{ .coreDNSImageTag }}
   - name: customImage
+    description: "Sets the container image that is used for running dockerMachines for the controlPlane and default-worker machineDeployments."
     definitions:
     - selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -39,20 +39,27 @@ spec:
       openAPIV3Schema:
         type: string
         default: "k8s.gcr.io"
+        example: "k8s.gcr.io"
+        description: "imageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default."
   - name: etcdImageTag
     required: true
     schema:
       openAPIV3Schema:
         type: string
         default: ""
+        example: "3.5.1-0"
+        description: "etcdImageTag sets the tag for the etcd image."
   - name: coreDNSImageTag
     required: true
     schema:
       openAPIV3Schema:
         type: string
         default: ""
+        example: "v1.8.5"
+        description: "coreDNSImageTag sets the tag for the coreDNS image."
   patches:
   - name: imageRepository
+    description: "Sets the imageRepository used for the KubeadmControlPlane."
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -65,6 +72,7 @@ spec:
         valueFrom:
           variable: imageRepository
   - name: etcdImageTag
+    description: "Sets tag to use for the etcd image in the KubeadmControlPlane."
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -79,6 +87,7 @@ spec:
             local:
               imageTag: {{ .etcdImageTag }}
   - name: coreDNSImageTag
+    description: "Sets tag to use for the etcd image in the KubeadmControlPlane."
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -92,6 +101,7 @@ spec:
           template: |
             imageTag: {{ .coreDNSImageTag }}
   - name: customImage
+    description: "Sets the container image that is used for running dockerMachines for the controlPlane and default-worker machineDeployments."
     definitions:
     - selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add variable examples and description and patch descriptions to the files used in the ClusterClass quickstart end to end tests and the clusterclass-quick-start.yaml docker template.