### PR TITLE
🌱 Enable more gocritic lint checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,9 +83,22 @@ linters-settings:
     - G307 # Deferring unsafe method "Close" on type "\*os.File"
     - G108 # Profiling endpoint is automatically exposed on /debug/pprof
   gocritic:
+    enabled-tags:
+      - experimental
     disabled-checks:
     - appendAssign
-
+    - dupImport # https://github.com/go-critic/go-critic/issues/845
+    - evalOrder
+    - ifElseChain
+    - octalLiteral
+    - regexpSimplify
+    - sloppyReassign
+    - truncateCmp
+    - typeDefFirst
+    - unnamedResult
+    - unnecessaryDefer
+    - whyNoLint
+    - wrapperFunc
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/api/v1beta1/cluster_webhook.go
+++ b/api/v1beta1/cluster_webhook.go
@@ -53,11 +53,11 @@ var _ webhook.Validator = &Cluster{}
 // Deprecated: This method is going to be removed in a next release.
 // Note: We're not using this method anymore and are using webhooks.Cluster.Default instead.
 func (c *Cluster) Default() {
-	if c.Spec.InfrastructureRef != nil && len(c.Spec.InfrastructureRef.Namespace) == 0 {
+	if c.Spec.InfrastructureRef != nil && c.Spec.InfrastructureRef.Namespace == "" {
 		c.Spec.InfrastructureRef.Namespace = c.Namespace
 	}
 
-	if c.Spec.ControlPlaneRef != nil && len(c.Spec.ControlPlaneRef.Namespace) == 0 {
+	if c.Spec.ControlPlaneRef != nil && c.Spec.ControlPlaneRef.Namespace == "" {
 		c.Spec.ControlPlaneRef.Namespace = c.Namespace
 	}
 
@@ -147,7 +147,7 @@ func (c *Cluster) validateTopology(old *Cluster) field.ErrorList {
 	var allErrs field.ErrorList
 
 	// class should be defined.
-	if len(c.Spec.Topology.Class) == 0 {
+	if c.Spec.Topology.Class == "" {
 		allErrs = append(
 			allErrs,
 			field.Invalid(

--- a/api/v1beta1/clusterclass_webhook.go
+++ b/api/v1beta1/clusterclass_webhook.go
@@ -68,7 +68,7 @@ func (in *ClusterClass) Default() {
 }
 
 func defaultNamespace(ref *corev1.ObjectReference, namespace string) {
-	if ref != nil && len(ref.Namespace) == 0 {
+	if ref != nil && ref.Namespace == "" {
 		ref.Namespace = namespace
 	}
 }

--- a/api/v1beta1/machine_webhook.go
+++ b/api/v1beta1/machine_webhook.go
@@ -48,11 +48,11 @@ func (m *Machine) Default() {
 	}
 	m.Labels[ClusterLabelName] = m.Spec.ClusterName
 
-	if m.Spec.Bootstrap.ConfigRef != nil && len(m.Spec.Bootstrap.ConfigRef.Namespace) == 0 {
+	if m.Spec.Bootstrap.ConfigRef != nil && m.Spec.Bootstrap.ConfigRef.Namespace == "" {
 		m.Spec.Bootstrap.ConfigRef.Namespace = m.Namespace
 	}
 
-	if len(m.Spec.InfrastructureRef.Namespace) == 0 {
+	if m.Spec.InfrastructureRef.Namespace == "" {
 		m.Spec.InfrastructureRef.Namespace = m.Namespace
 	}
 

--- a/api/v1beta1/machinehealthcheck_webhook.go
+++ b/api/v1beta1/machinehealthcheck_webhook.go
@@ -78,7 +78,7 @@ func (m *MachineHealthCheck) Default() {
 		m.Spec.NodeStartupTimeout = &DefaultNodeStartupTimeout
 	}
 
-	if m.Spec.RemediationTemplate != nil && len(m.Spec.RemediationTemplate.Namespace) == 0 {
+	if m.Spec.RemediationTemplate != nil && m.Spec.RemediationTemplate.Namespace == "" {
 		m.Spec.RemediationTemplate.Namespace = m.Namespace
 	}
 }

--- a/bootstrap/kubeadm/api/v1alpha4/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1alpha4/kubeadm_types.go
@@ -456,7 +456,7 @@ type BootstrapTokenString struct {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (bts BootstrapTokenString) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, bts.String())), nil
+	return []byte(fmt.Sprintf("%q", bts.String())), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
@@ -457,7 +457,7 @@ type BootstrapTokenString struct {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (bts BootstrapTokenString) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, bts.String())), nil
+	return []byte(fmt.Sprintf("%q", bts.String())), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/bootstrap/kubeadm/internal/controllers/token.go
+++ b/bootstrap/kubeadm/internal/controllers/token.go
@@ -60,7 +60,7 @@ func createToken(ctx context.Context, c client.Client, ttl time.Duration) (strin
 		},
 	}
 
-	if err = c.Create(ctx, secretToken); err != nil {
+	if err := c.Create(ctx, secretToken); err != nil {
 		return "", err
 	}
 	return token, nil

--- a/bootstrap/kubeadm/types/upstreamv1beta1/bootstraptokenstring.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta1/bootstraptokenstring.go
@@ -38,7 +38,7 @@ type BootstrapTokenString struct {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (bts BootstrapTokenString) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, bts.String())), nil
+	return []byte(fmt.Sprintf("%q", bts.String())), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/bootstrap/kubeadm/types/upstreamv1beta2/bootstraptokenstring.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta2/bootstraptokenstring.go
@@ -38,7 +38,7 @@ type BootstrapTokenString struct {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (bts BootstrapTokenString) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, bts.String())), nil
+	return []byte(fmt.Sprintf("%q", bts.String())), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/bootstrap/kubeadm/types/upstreamv1beta3/bootstraptokenstring.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta3/bootstraptokenstring.go
@@ -36,7 +36,7 @@ type BootstrapTokenString struct {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (bts BootstrapTokenString) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, bts.String())), nil
+	return []byte(fmt.Sprintf("%q", bts.String())), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -762,7 +762,7 @@ func Test_objectMover_restoreTargetObject(t *testing.T) {
 				tempFile, err := os.CreateTemp(dir, "obj")
 				g.Expect(err).NotTo(HaveOccurred())
 
-				_, err = tempFile.Write([]byte(file))
+				_, err = tempFile.WriteString(file)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(tempFile.Close()).To(Succeed())
 			}
@@ -1006,7 +1006,7 @@ func Test_objectMover_restore(t *testing.T) {
 				tempFile, err := os.CreateTemp(dir, "obj")
 				g.Expect(err).NotTo(HaveOccurred())
 
-				_, err = tempFile.Write([]byte(file))
+				_, err = tempFile.WriteString(file)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(tempFile.Close()).To(Succeed())
 			}

--- a/cmd/clusterctl/client/cluster/proxy_test.go
+++ b/cmd/clusterctl/client/cluster/proxy_test.go
@@ -219,7 +219,7 @@ func TestProxyCurrentNamespace(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 			var configFile string
-			if len(tt.kubeconfigPath) != 0 {
+			if tt.kubeconfigPath != "" {
 				configFile = tt.kubeconfigPath
 			} else {
 				dir, err := os.MkdirTemp("", "clusterctl")

--- a/cmd/clusterctl/client/config/providers_client_test.go
+++ b/cmd/clusterctl/client/config/providers_client_test.go
@@ -81,9 +81,9 @@ func Test_providers_List(t *testing.T) {
 				configGetter: test.NewFakeReader().
 					WithVar(
 						ProvidersConfigKey,
-						fmt.Sprintf("- name: \"%s\"\n", defaults[0].Name())+
+						fmt.Sprintf("- name: %q\n", defaults[0].Name())+
 							"  url: \"https://zzz/infrastructure-components.yaml\"\n"+
-							fmt.Sprintf("  type: \"%s\"\n", defaults[0].Type()),
+							fmt.Sprintf("  type: %q\n", defaults[0].Type()),
 					),
 			},
 			want:    defaultsWithOverride,

--- a/cmd/clusterctl/client/repository/overrides.go
+++ b/cmd/clusterctl/client/repository/overrides.go
@@ -67,7 +67,7 @@ func newOverride(o *newOverrideInput) Overrider {
 func (o *overrides) Path() string {
 	basepath := filepath.Join(homedir.HomeDir(), config.ConfigFolder, overrideFolder)
 	f, err := o.configVariablesClient.Get(overrideFolderKey)
-	if err == nil && len(strings.TrimSpace(f)) != 0 {
+	if err == nil && strings.TrimSpace(f) != "" {
 		basepath = f
 	}
 

--- a/cmd/clusterctl/client/repository/repository_github.go
+++ b/cmd/clusterctl/client/repository/repository_github.go
@@ -184,9 +184,7 @@ func NewGitHubRepository(providerConfig config.Provider, configVariablesClient c
 
 // getComponentsPath returns the file name.
 func getComponentsPath(path string, rootPath string) string {
-	// filePath = "/filename"
 	filePath := strings.TrimPrefix(path, rootPath)
-	// componentsPath = "filename"
 	componentsPath := strings.TrimPrefix(filePath, "/")
 	return componentsPath
 }

--- a/cmd/clusterctl/client/tree/tree.go
+++ b/cmd/clusterctl/client/tree/tree.go
@@ -271,7 +271,7 @@ func isObjDebug(obj client.Object, debugFilter string) bool {
 		if filter == "" {
 			continue
 		}
-		if strings.ToLower(filter) == "all" {
+		if strings.EqualFold(filter, "all") {
 			return true
 		}
 		kn := strings.Split(filter, "/")

--- a/cmd/clusterctl/client/yamlprocessor/simple_processor.go
+++ b/cmd/clusterctl/client/yamlprocessor/simple_processor.go
@@ -109,7 +109,7 @@ func (tp *SimpleProcessor) Process(rawArtifact []byte, variablesClient func(stri
 		_, err := variablesClient(name)
 		// add to missingVariables list if the variable does not exist in the
 		// variablesClient AND it does not have a default value
-		if err != nil && len(defaultValue) == 0 {
+		if err != nil && defaultValue == "" {
 			missingVariables = append(missingVariables, name)
 			continue
 		}

--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -71,7 +71,7 @@ var RootCmd = &cobra.Command{
 		if err != nil {
 			return errors.Wrap(err, "unable to verify clusterctl version")
 		}
-		if len(output) != 0 {
+		if output != "" {
 			// Print the output in yellow so it is more visible.
 			fmt.Fprintf(os.Stderr, "\033[33m%s\033[0m", output)
 		}
@@ -158,7 +158,7 @@ const indentation = `  `
 
 // LongDesc normalizes a command's long description to follow the conventions.
 func LongDesc(s string) string {
-	if len(s) == 0 {
+	if s == "" {
 		return s
 	}
 	return normalizer{s}.heredoc().trim().string
@@ -166,7 +166,7 @@ func LongDesc(s string) string {
 
 // Examples normalizes a command's examples to follow the conventions.
 func Examples(s string) string {
-	if len(s) == 0 {
+	if s == "" {
 		return s
 	}
 	return normalizer{s}.trim().indent().string

--- a/cmd/clusterctl/cmd/util.go
+++ b/cmd/clusterctl/cmd/util.go
@@ -60,7 +60,7 @@ func printVariablesOutput(template client.Template, options client.GetClusterTem
 			v := *variableMap[name]
 			// Add quotes around any unquoted strings
 			if len(v) > 0 && !strings.HasPrefix(v, "\"") {
-				v = fmt.Sprintf("\"%s\"", v)
+				v = fmt.Sprintf("%q", v)
 				variableMap[name] = &v
 			}
 		}

--- a/cmd/clusterctl/internal/util/obj_refs.go
+++ b/cmd/clusterctl/internal/util/obj_refs.go
@@ -79,7 +79,7 @@ func convertToObjectRef(namespace, s string) (corev1.ObjectReference, bool, erro
 		return corev1.ObjectReference{}, false, fmt.Errorf("arguments in resource/name form may not have more than one slash")
 	}
 	resource, name := seg[0], seg[1]
-	if len(resource) == 0 || len(name) == 0 {
+	if resource == "" || name == "" {
 		return corev1.ObjectReference{}, false, fmt.Errorf("arguments in resource/name form must have a single resource and name")
 	}
 	return corev1.ObjectReference{

--- a/controllers/internal/mdutil/util.go
+++ b/controllers/internal/mdutil/util.go
@@ -223,7 +223,7 @@ func SetNewMachineSetAnnotations(deployment *clusterv1.MachineDeployment, newMS 
 	if ok && annotationChanged {
 		revisionHistoryAnnotation := newMS.Annotations[clusterv1.RevisionHistoryAnnotation]
 		oldRevisions := strings.Split(revisionHistoryAnnotation, ",")
-		if len(oldRevisions[0]) == 0 {
+		if oldRevisions[0] == "" {
 			newMS.Annotations[clusterv1.RevisionHistoryAnnotation] = oldRevision
 		} else {
 			oldRevisions = append(oldRevisions, oldRevision)

--- a/controllers/machine_controller_noderef.go
+++ b/controllers/machine_controller_noderef.go
@@ -137,7 +137,6 @@ func (r *MachineReconciler) reconcileNode(ctx context.Context, cluster *clusterv
 // if all conditions are unknown,  summarized status = Unknown.
 // (semantically true conditions: NodeMemoryPressure/NodeDiskPressure/NodePIDPressure == false or Ready == true.)
 func summarizeNodeConditions(node *corev1.Node) (corev1.ConditionStatus, string) {
-	// totalNumOfConditionsChecked := 4
 	semanticallyFalseStatus := 0
 	unknownStatus := 0
 

--- a/controllers/remote/restconfig.go
+++ b/controllers/remote/restconfig.go
@@ -48,7 +48,7 @@ func DefaultClusterAPIUserAgent(sourceName string) string {
 
 // adjustSourceName returns the name of the source calling the client.
 func adjustSourceName(c string) string {
-	if len(c) == 0 {
+	if c == "" {
 		return unknowString
 	}
 	return c
@@ -56,7 +56,7 @@ func adjustSourceName(c string) string {
 
 // adjustCommit returns sufficient significant figures of the commit's git hash.
 func adjustCommit(c string) string {
-	if len(c) == 0 {
+	if c == "" {
 		return unknowString
 	}
 	if len(c) > 7 {
@@ -68,7 +68,7 @@ func adjustCommit(c string) string {
 // adjustVersion strips "alpha", "beta", etc. from version in form
 // major.minor.patch-[alpha|beta|etc].
 func adjustVersion(v string) string {
-	if len(v) == 0 {
+	if v == "" {
 		return unknowString
 	}
 	seg := strings.SplitN(v, "-", 2)
@@ -79,7 +79,7 @@ func adjustVersion(v string) string {
 // OS-specific command path for use in User-Agent.
 func adjustCommand(p string) string {
 	// Unlikely, but better than returning "".
-	if len(p) == 0 {
+	if p == "" {
 		return unknowString
 	}
 	return filepath.Base(p)

--- a/controllers/topology/current_state.go
+++ b/controllers/topology/current_state.go
@@ -150,7 +150,7 @@ func (r *ClusterReconciler) getCurrentMachineDeploymentState(ctx context.Context
 		// Retrieve the name which is assigned in Cluster's topology
 		// from a well-defined label.
 		mdTopologyName, ok := m.ObjectMeta.Labels[clusterv1.ClusterTopologyMachineDeploymentLabelName]
-		if !ok || len(mdTopologyName) == 0 {
+		if !ok || mdTopologyName == "" {
 			return nil, fmt.Errorf("failed to find label %s in %s", clusterv1.ClusterTopologyMachineDeploymentLabelName, tlog.KObj{Obj: m})
 		}
 

--- a/controlplane/kubeadm/controllers/controller.go
+++ b/controlplane/kubeadm/controllers/controller.go
@@ -199,7 +199,7 @@ func (r *KubeadmControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.
 		// TODO: remove this as soon as we have a proper remote cluster cache in place.
 		// Make KCP to requeue in case status is not ready, so we can check for node status without waiting for a full resync (by default 10 minutes).
 		// Only requeue if we are not going in exponential backoff due to error, or if we are not already re-queueing, or if the object has a deletion timestamp.
-		if reterr == nil && !res.Requeue && !(res.RequeueAfter > 0) && kcp.ObjectMeta.DeletionTimestamp.IsZero() {
+		if reterr == nil && !res.Requeue && res.RequeueAfter <= 0 && kcp.ObjectMeta.DeletionTimestamp.IsZero() {
 			if !kcp.Status.Ready {
 				res = ctrl.Result{RequeueAfter: 20 * time.Second}
 			}

--- a/controlplane/kubeadm/controllers/helpers.go
+++ b/controlplane/kubeadm/controllers/helpers.go
@@ -215,16 +215,17 @@ func (r *KubeadmControlPlaneReconciler) cleanupFromGeneration(ctx context.Contex
 	var errs []error
 
 	for _, ref := range remoteRefs {
-		if ref != nil {
-			config := &unstructured.Unstructured{}
-			config.SetKind(ref.Kind)
-			config.SetAPIVersion(ref.APIVersion)
-			config.SetNamespace(ref.Namespace)
-			config.SetName(ref.Name)
+		if ref == nil {
+			continue
+		}
+		config := &unstructured.Unstructured{}
+		config.SetKind(ref.Kind)
+		config.SetAPIVersion(ref.APIVersion)
+		config.SetNamespace(ref.Namespace)
+		config.SetName(ref.Name)
 
-			if err := r.Client.Delete(ctx, config); err != nil && !apierrors.IsNotFound(err) {
-				errs = append(errs, errors.Wrap(err, "failed to cleanup generated resources after error"))
-			}
+		if err := r.Client.Delete(ctx, config); err != nil && !apierrors.IsNotFound(err) {
+			errs = append(errs, errors.Wrap(err, "failed to cleanup generated resources after error"))
 		}
 	}
 

--- a/exp/api/v1beta1/machinepool_webhook.go
+++ b/exp/api/v1beta1/machinepool_webhook.go
@@ -56,11 +56,11 @@ func (m *MachinePool) Default() {
 		m.Spec.MinReadySeconds = pointer.Int32Ptr(0)
 	}
 
-	if m.Spec.Template.Spec.Bootstrap.ConfigRef != nil && len(m.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace) == 0 {
+	if m.Spec.Template.Spec.Bootstrap.ConfigRef != nil && m.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace == "" {
 		m.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace = m.Namespace
 	}
 
-	if len(m.Spec.Template.Spec.InfrastructureRef.Namespace) == 0 {
+	if m.Spec.Template.Spec.InfrastructureRef.Namespace == "" {
 		m.Spec.Template.Spec.InfrastructureRef.Namespace = m.Namespace
 	}
 }

--- a/hack/tools/conversion-verifier/main.go
+++ b/hack/tools/conversion-verifier/main.go
@@ -98,7 +98,7 @@ func main() {
 	// and find the ones that have a storage version assigned.
 	for _, pkg := range packages {
 		group := apiGroupForPackage(col, pkg)
-		if len(group) == 0 {
+		if group == "" {
 			// We're only interested in api folders, exclude everything
 			// else that's not an API package.
 			continue

--- a/hack/tools/mdbook/tabulate/tabulate.go
+++ b/hack/tools/mdbook/tabulate/tabulate.go
@@ -52,8 +52,8 @@ func (l Tabulate) Process(input *plugin.Input) error {
 				checked = "checked"
 			}
 
-			bld.WriteString(fmt.Sprintf(`<input type="radio" name="%s" id="%s" aria-controls="%s" %s>`, groupName, groupTabID, groupTabID, checked))
-			bld.WriteString(fmt.Sprintf(`<label for="%s">%s</label>`, groupTabID, tabName))
+			bld.WriteString(fmt.Sprintf(`<input type="radio" name=%q id=%q aria-controls=%q %s>`, groupName, groupTabID, groupTabID, checked))
+			bld.WriteString(fmt.Sprintf(`<label for=%q>%s</label>`, groupTabID, tabName))
 		}
 		bld.WriteString(`<div class="tab-panels">`)
 

--- a/internal/envtest/environment.go
+++ b/internal/envtest/environment.go
@@ -191,7 +191,7 @@ func newEnvironment(uncachedObjs ...client.Object) *Environment {
 
 	// Localhost is used on MacOS to avoid Firewall warning popups.
 	host := "localhost"
-	if strings.ToLower(os.Getenv("USE_EXISTING_CLUSTER")) == "true" {
+	if strings.EqualFold(os.Getenv("USE_EXISTING_CLUSTER"), "true") {
 		// 0.0.0.0 is required on Linux when using kind because otherwise the kube-apiserver running in kind
 		// is unable to reach the webhook, because the webhook would be only listening on 127.0.0.1.
 		// Somehow that's not an issue on MacOS.

--- a/internal/envtest/webhooks.go
+++ b/internal/envtest/webhooks.go
@@ -17,11 +17,11 @@ limitations under the License.
 package envtest
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	goruntime "runtime"
-	"strings"
 	"time"
 
 	admissionv1 "k8s.io/api/admissionregistration/v1"
@@ -98,7 +98,7 @@ func appendWebhookConfiguration(mutatingWebhooks []*admissionv1.MutatingWebhookC
 		if o.GetKind() == mutatingWebhookKind {
 			// update the name in metadata
 			if o.GetName() == mutatingwebhook {
-				o.SetName(strings.Join([]string{mutatingwebhook, "-", tag}, ""))
+				o.SetName(fmt.Sprintf("%s-%s", mutatingwebhook, tag))
 
 				webhook := &admissionv1.MutatingWebhookConfiguration{}
 				if err := scheme.Scheme.Convert(&o, webhook, nil); err != nil {
@@ -111,7 +111,7 @@ func appendWebhookConfiguration(mutatingWebhooks []*admissionv1.MutatingWebhookC
 		if o.GetKind() == validatingWebhookKind {
 			// update the name in metadata
 			if o.GetName() == validatingwebhook {
-				o.SetName(strings.Join([]string{validatingwebhook, "-", tag}, ""))
+				o.SetName(fmt.Sprintf("%s-%s", validatingwebhook, tag))
 
 				webhook := &admissionv1.ValidatingWebhookConfiguration{}
 				if err := scheme.Scheme.Convert(&o, webhook, nil); err != nil {

--- a/internal/topology/variables/clusterclass_variable_validation.go
+++ b/internal/topology/variables/clusterclass_variable_validation.go
@@ -140,7 +140,7 @@ func validateSchema(schema *clusterv1.JSONSchemaProps, fldPath *field.Path) fiel
 
 	// Validate that type is one of the validVariableTypes.
 	switch {
-	case len(apiExtensionsSchema.Type) == 0:
+	case apiExtensionsSchema.Type == "":
 		return field.ErrorList{field.Required(fldPath.Child("type"), "openAPIV3Schema.type cannot be empty")}
 	case !validVariableTypes.Has(apiExtensionsSchema.Type):
 		return field.ErrorList{field.NotSupported(fldPath.Child("type"), apiExtensionsSchema.Type, validVariableTypes.List())}

--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -64,11 +64,11 @@ func (webhook *Cluster) Default(ctx context.Context, obj runtime.Object) error {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
 	}
 
-	if cluster.Spec.InfrastructureRef != nil && len(cluster.Spec.InfrastructureRef.Namespace) == 0 {
+	if cluster.Spec.InfrastructureRef != nil && cluster.Spec.InfrastructureRef.Namespace == "" {
 		cluster.Spec.InfrastructureRef.Namespace = cluster.Namespace
 	}
 
-	if cluster.Spec.ControlPlaneRef != nil && len(cluster.Spec.ControlPlaneRef.Namespace) == 0 {
+	if cluster.Spec.ControlPlaneRef != nil && cluster.Spec.ControlPlaneRef.Namespace == "" {
 		cluster.Spec.ControlPlaneRef.Namespace = cluster.Namespace
 	}
 
@@ -181,7 +181,7 @@ func (webhook *Cluster) validateTopology(ctx context.Context, old, new *clusterv
 	var allErrs field.ErrorList
 
 	// class should be defined.
-	if len(new.Spec.Topology.Class) == 0 {
+	if new.Spec.Topology.Class == "" {
 		allErrs = append(
 			allErrs,
 			field.Required(
@@ -222,7 +222,7 @@ func (webhook *Cluster) validateTopology(ctx context.Context, old, new *clusterv
 
 	if old != nil { // On update
 		// Topology or Class can not be added on update.
-		if old.Spec.Topology == nil || len(old.Spec.Topology.Class) == 0 {
+		if old.Spec.Topology == nil || old.Spec.Topology.Class == "" {
 			allErrs = append(
 				allErrs,
 				field.Forbidden(

--- a/internal/webhooks/clusterclass.go
+++ b/internal/webhooks/clusterclass.go
@@ -78,7 +78,7 @@ func (webhook *ClusterClass) Default(_ context.Context, obj runtime.Object) erro
 }
 
 func defaultNamespace(ref *corev1.ObjectReference, namespace string) {
-	if ref != nil && len(ref.Namespace) == 0 {
+	if ref != nil && ref.Namespace == "" {
 		ref.Namespace = namespace
 	}
 }

--- a/test/framework/ginkgoextensions/output.go
+++ b/test/framework/ginkgoextensions/output.go
@@ -72,7 +72,7 @@ type fileWriter struct {
 }
 
 func (w *fileWriter) Write(data []byte) (n int, err error) {
-	return w.file.Write([]byte("[" + time.Now().Format(time.RFC3339) + "] " + string(data)))
+	return w.file.WriteString("[" + time.Now().Format(time.RFC3339) + "] " + string(data))
 }
 
 func (w *fileWriter) Close() error {

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -404,7 +404,7 @@ func (m *Machine) SetNodeProviderID(ctx context.Context) error {
 	}
 
 	log.Info("Setting Kubernetes node providerID")
-	patch := fmt.Sprintf(`{"spec": {"providerID": "%s"}}`, m.ProviderID())
+	patch := fmt.Sprintf(`{"spec": {"providerID": %q}}`, m.ProviderID())
 	cmd := kubectlNode.Commander.Command(
 		"kubectl",
 		"--kubeconfig", "/etc/kubernetes/admin.conf",

--- a/test/infrastructure/docker/internal/provisioning/ignition/kindadapter.go
+++ b/test/infrastructure/docker/internal/provisioning/ignition/kindadapter.go
@@ -88,7 +88,7 @@ func getActions(userData []byte) ([]provisioning.Cmd, error) {
 
 	for _, u := range ignition.Systemd.Units {
 		contents := strings.TrimSpace(u.Contents)
-		path := filepath.Join("/etc/systemd/system", u.Name)
+		path := fmt.Sprintf("/etc/systemd/system/%s", u.Name)
 
 		commands = append(commands, []provisioning.Cmd{
 			{Cmd: "/bin/sh", Args: []string{"-c", fmt.Sprintf("cat > %s /dev/stdin", path)}, Stdin: contents},

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -104,6 +104,9 @@ func initFlags(fs *pflag.FlagSet) {
 
 func main() {
 	rand.Seed(time.Now().UnixNano())
+	if _, err := os.ReadDir("/tmp/"); err != nil {
+		os.Exit(1)
+	}
 
 	initFlags(pflag.CommandLine)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)

--- a/util/certs/types.go
+++ b/util/certs/types.go
@@ -55,7 +55,7 @@ func (cfg *Config) NewSignedCert(key *rsa.PrivateKey, caCert *x509.Certificate, 
 		return nil, errors.Wrap(err, "failed to generate random integer for signed cerficate")
 	}
 
-	if len(cfg.CommonName) == 0 {
+	if cfg.CommonName == "" {
 		return nil, errors.New("must specify a CommonName")
 	}
 

--- a/util/yaml/yaml_test.go
+++ b/util/yaml/yaml_test.go
@@ -439,7 +439,7 @@ func TestToUnstructured(t *testing.T) {
 			got, err := ToUnstructured(tt.args.rawyaml)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
-				if len(tt.err) != 0 {
+				if tt.err != "" {
 					g.Expect(err.Error()).To(ContainSubstring(tt.err))
 				}
 				return


### PR DESCRIPTION
**What this PR does / why we need it**:

There are a multiple groups of checks run by gocritic. Some are enabled
by default, but others require explicit enabling. This enables the
experimental group, minus a few exceptions that would either be too
disruptive or are things we aren't concerned about.

One of the main benefits of this extra coverage is the flagging of using
the deprecated ioutil package.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4419
