### PR TITLE
🐛 ClusterClass: fix remove patches

### DIFF
--- a/controllers/topology/internal/extensions/patches/engine.go
+++ b/controllers/topology/internal/extensions/patches/engine.go
@@ -92,7 +92,7 @@ func (e *engine) Apply(ctx context.Context, blueprint *scope.ClusterBlueprint, d
 		// version of the request (including the patched version of the templates).
 		resp, err := generator.Generate(ctx, req)
 		if err != nil {
-			return errors.Errorf("failed to generate patches for patch %q", clusterClassPatch.Name)
+			return errors.Wrapf(err, "failed to generate patches for patch %q", clusterClassPatch.Name)
 		}
 
 		// Apply patches to the request.

--- a/controllers/topology/internal/extensions/patches/inline/json_patch_generator.go
+++ b/controllers/topology/internal/extensions/patches/inline/json_patch_generator.go
@@ -162,9 +162,9 @@ func patchIsEnabled(enabledIf *string, variables map[string]apiextensionsv1.JSON
 
 // jsonPatchRFC6902 is used to render the generated JSONPatches.
 type jsonPatchRFC6902 struct {
-	Op    string               `json:"op"`
-	Path  string               `json:"path"`
-	Value apiextensionsv1.JSON `json:"value"`
+	Op    string                `json:"op"`
+	Path  string                `json:"path"`
+	Value *apiextensionsv1.JSON `json:"value,omitempty"`
 }
 
 // generateJSONPatches generates JSON patches based on the given JSONPatches and variables.
@@ -172,15 +172,19 @@ func generateJSONPatches(jsonPatches []clusterv1.JSONPatch, variables map[string
 	res := []jsonPatchRFC6902{}
 
 	for _, jsonPatch := range jsonPatches {
-		value, err := calculateValue(jsonPatch, variables)
-		if err != nil {
-			return nil, err
+		var value *apiextensionsv1.JSON
+		if jsonPatch.Op == "add" || jsonPatch.Op == "replace" {
+			var err error
+			value, err = calculateValue(jsonPatch, variables)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		res = append(res, jsonPatchRFC6902{
 			Op:    jsonPatch.Op,
 			Path:  jsonPatch.Path,
-			Value: *value,
+			Value: value,
 		})
 	}
 

--- a/controllers/topology/internal/extensions/patches/inline/json_patch_generator_test.go
+++ b/controllers/topology/internal/extensions/patches/inline/json_patch_generator_test.go
@@ -182,6 +182,10 @@ func TestGenerate(t *testing.T) {
 `),
 								},
 							},
+							{
+								Op:   "remove",
+								Path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs",
+							},
 						},
 					},
 					{
@@ -249,7 +253,8 @@ func TestGenerate(t *testing.T) {
 						},
 						Patch: toJSONCompact(`[
 {"op":"replace","path":"/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/cluster-name","value":"cluster-name"},
-{"op":"replace","path":"/spec/template/spec/kubeadmConfigSpec/files","value":[{"contentFrom":{"secret":{"key":"control-plane-azure.json","name":"cluster-name-control-plane-azure-json"}},"owner":"root:root"}]}
+{"op":"replace","path":"/spec/template/spec/kubeadmConfigSpec/files","value":[{"contentFrom":{"secret":{"key":"control-plane-azure.json","name":"cluster-name-control-plane-azure-json"}},"owner":"root:root"}]},
+{"op":"remove","path":"/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs"}
 ]`),
 						PatchType: api.JSONPatchType,
 					},


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Previously remove patch generation failed because there was no value. Now it doesn't calculate a value for remove patches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
