### PR TITLE
🌱 ClusterClass: Add reconcile repeatedly test

### DIFF
--- a/internal/controllers/topology/cluster/mergepatch/managed_paths_test.go
+++ b/internal/controllers/topology/cluster/mergepatch/managed_paths_test.go
@@ -191,6 +191,43 @@ func Test_ManagedFieldAnnotation(t *testing.T) {
 				{"spec", "kubeadmConfigSpec", "joinConfiguration"},
 			},
 		},
+		{
+			name: "Managed fields annotation ignore empty maps",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"kubeadmConfigSpec": map[string]interface{}{
+							"clusterConfiguration": map[string]interface{}{
+								"version": "v2.0.1",
+							},
+							"initConfiguration": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			wantPaths: []contract.Path{
+				{"spec", "kubeadmConfigSpec", "clusterConfiguration", "version"},
+			},
+		},
+		{
+			name: "Managed fields annotation ignore empty maps - excluding ignore paths",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"kubeadmConfigSpec": map[string]interface{}{
+							"clusterConfiguration": map[string]interface{}{
+								"version": "v2.0.1",
+							},
+							"initConfiguration": map[string]interface{}{},
+						},
+					},
+				},
+			},
+			ignorePaths: []contract.Path{
+				{"spec", "kubeadmConfigSpec", "clusterConfiguration", "version"},
+			},
+			wantPaths: []contract.Path{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/controllers/topology/cluster/mergepatch/mergepatch.go
+++ b/internal/controllers/topology/cluster/mergepatch/mergepatch.go
@@ -62,7 +62,7 @@ func NewHelper(original, modified client.Object, c client.Client, opts ...Helper
 	// changes to those paths are going to be considered authoritative.
 	managedPaths, err := getManagedPaths(original)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal original object to json")
+		return nil, errors.Wrap(err, "failed to get managed paths")
 	}
 	helperOptions.managedPaths = managedPaths
 

--- a/internal/controllers/topology/cluster/mergepatch/mergepatch_test.go
+++ b/internal/controllers/topology/cluster/mergepatch/mergepatch_test.go
@@ -801,15 +801,7 @@ func TestNewHelper(t *testing.T) {
 			wantPatch: []byte(fmt.Sprintf(
 				"{\"metadata\":{\"annotations\":{%q:%q}},\"spec\":{\"kubeadmConfigSpec\":{\"clusterConfiguration\":{\"controllerManager\":{\"extraArgs\":{\"enable-hostpath-provisioner\":null}}}}}}",
 				clusterv1.ClusterTopologyManagedFieldsAnnotation,
-				mustManagedFieldAnnotation(map[string]interface{}{
-					"kubeadmConfigSpec": map[string]interface{}{
-						"clusterConfiguration": map[string]interface{}{
-							"controllerManager": map[string]interface{}{
-								"extraArgs": map[string]interface{}{},
-							},
-						},
-					},
-				}),
+				mustManagedFieldAnnotation(map[string]interface{}{}),
 			)),
 		},
 		{
@@ -923,13 +915,7 @@ func TestNewHelper(t *testing.T) {
 			wantPatch: []byte(fmt.Sprintf(
 				"{\"metadata\":{\"annotations\":{%q:%q}},\"spec\":{\"kubeadmConfigSpec\":{\"clusterConfiguration\":{\"controllerManager\":{\"extraArgs\":{\"enable-hostpath-provisioner\":null}}}}}}",
 				clusterv1.ClusterTopologyManagedFieldsAnnotation,
-				mustManagedFieldAnnotation(map[string]interface{}{
-					"kubeadmConfigSpec": map[string]interface{}{
-						"clusterConfiguration": map[string]interface{}{
-							"controllerManager": map[string]interface{}{},
-						},
-					},
-				}),
+				mustManagedFieldAnnotation(map[string]interface{}{}),
 			)),
 		},
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds a test which runs multiple reconciles and thus validates if a sequence of reconciles behave as expected. The most important behavior we're verifying that way is the handling of `managed-field-paths`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
