### PR TITLE
🌱 enable predeclared linter and fix problems

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
   - nilerr
   - nolintlint
   - prealloc
+  - predeclared
   - revive
   - rowserrcheck
   - staticcheck


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Enable the predeclared linter and remove instances where go keywords were used as variable names in the codebase.

