### PR TITLE
📖 Add CAPG to provider contract book page

### DIFF
--- a/docs/book/src/clusterctl/provider-contract.md
+++ b/docs/book/src/clusterctl/provider-contract.md
@@ -199,6 +199,7 @@ providers.
 |CAPZ          | cluster.x-k8s.io/provider=infrastructure-azure         |
 |CAPO          | cluster.x-k8s.io/provider=infrastructure-openstack     |
 |CAPDO         | cluster.x-k8s.io/provider=infrastructure-digitalocean  |
+|CAPG          | cluster.x-k8s.io/provider=infrastructure-gcp           |
 
 ### Workload cluster templates
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: 
This changes add the `CAPG:  cluster.x-k8s.io/provider=infrastructure-gcp` in the `docs/book/src/clusterctl/provider-contract.md` of line number 202

**Which issue(s) this PR fixes** :
Fixes #5852
