### PR TITLE
✨Set default KubeadmConfig format to cloud-config✨

### DIFF
--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
@@ -79,6 +79,7 @@ type KubeadmConfigSpec struct {
 
 	// Format specifies the output format of the bootstrap data
 	// +optional
+	// +kubebuilder:default=cloud-config
 	Format Format `json:"format,omitempty"`
 
 	// Verbosity is the number for the kubeadm log level verbosity.

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -2464,6 +2464,7 @@ spec:
                   type: object
                 type: array
               format:
+                default: cloud-config
                 description: Format specifies the output format of the bootstrap data
                 enum:
                 - cloud-config

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -2478,6 +2478,7 @@ spec:
                           type: object
                         type: array
                       format:
+                        default: cloud-config
                         description: Format specifies the output format of the bootstrap
                           data
                         enum:

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -59,7 +59,7 @@ func TestKubeadmControlPlaneDefault(t *testing.T) {
 		Name:       "foo",
 		Namespace:  "foo",
 	}
-	t.Run("for KubeadmControlPLane", utildefaulting.DefaultValidateTest(updateDefaultingValidationKCP))
+	t.Run("for KubeadmControlPlane", utildefaulting.DefaultValidateTest(updateDefaultingValidationKCP))
 	kcp.Default()
 
 	g.Expect(kcp.Spec.MachineTemplate.InfrastructureRef.Namespace).To(Equal(kcp.Namespace))

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -2923,6 +2923,7 @@ spec:
                       type: object
                     type: array
                   format:
+                    default: cloud-config
                     description: Format specifies the output format of the bootstrap
                       data
                     enum:

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -1707,6 +1707,7 @@ spec:
                               type: object
                             type: array
                           format:
+                            default: cloud-config
                             description: Format specifies the output format of the
                               bootstrap data
                             enum:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
So we do not produce format key in bootstrap data with empty value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5823

NOTE: I only unit-tested this. Let me know if I should write more automated tests for it somewhere.
