### PR TITLE
🌱  [WIP] enable gocritic importShadow and fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,6 +135,8 @@ linters-settings:
   gocritic:
     enabled-tags:
       - experimental
+    enabled-checks:
+    - importShadow
     disabled-checks:
     - appendAssign
     - dupImport # https://github.com/go-critic/go-critic/issues/845

--- a/api/v1alpha3/machineset_types.go
+++ b/api/v1alpha3/machineset_types.go
@@ -175,8 +175,8 @@ func (m *MachineSet) Validate() field.ErrorList {
 	if err != nil {
 		errors = append(errors, field.Invalid(fldPath.Child("selector"), m.Spec.Selector, "invalid label selector."))
 	} else {
-		labels := labels.Set(m.Spec.Template.Labels)
-		if !selector.Matches(labels) {
+		lbls := labels.Set(m.Spec.Template.Labels)
+		if !selector.Matches(lbls) {
 			errors = append(errors, field.Invalid(fldPath.Child("template", "metadata", "labels"), m.Spec.Template.Labels, "`selector` does not match template `labels`"))
 		}
 	}

--- a/api/v1alpha4/machineset_types.go
+++ b/api/v1alpha4/machineset_types.go
@@ -185,8 +185,8 @@ func (m *MachineSet) Validate() field.ErrorList {
 	if err != nil {
 		errors = append(errors, field.Invalid(fldPath.Child("selector"), m.Spec.Selector, "invalid label selector."))
 	} else {
-		labels := labels.Set(m.Spec.Template.Labels)
-		if !selector.Matches(labels) {
+		lbls := labels.Set(m.Spec.Template.Labels)
+		if !selector.Matches(lbls) {
 			errors = append(errors, field.Invalid(fldPath.Child("template", "metadata", "labels"), m.Spec.Template.Labels, "`selector` does not match template `labels`"))
 		}
 	}

--- a/api/v1beta1/machineset_types.go
+++ b/api/v1beta1/machineset_types.go
@@ -189,8 +189,8 @@ func (m *MachineSet) Validate() field.ErrorList {
 	if err != nil {
 		errors = append(errors, field.Invalid(fldPath.Child("selector"), m.Spec.Selector, "invalid label selector."))
 	} else {
-		labels := labels.Set(m.Spec.Template.Labels)
-		if !selector.Matches(labels) {
+		lbls := labels.Set(m.Spec.Template.Labels)
+		if !selector.Matches(lbls) {
 			errors = append(errors, field.Invalid(fldPath.Child("template", "metadata", "labels"), m.Spec.Template.Labels, "`selector` does not match template `labels`"))
 		}
 	}

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
@@ -739,15 +739,15 @@ func TestBootstrapDataFormat(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 				Name:      *cfg.Status.DataSecretName,
 			}
-			secret := &corev1.Secret{}
-			err = myclient.Get(ctx, key, secret)
+			scrt := &corev1.Secret{}
+			err = myclient.Get(ctx, key, scrt)
 			g.Expect(err).NotTo(HaveOccurred())
 
 			// Verify the format field of the bootstrap data secret is correct.
-			g.Expect(string(secret.Data["format"])).To(Equal(string(tc.format)))
+			g.Expect(string(scrt.Data["format"])).To(Equal(string(tc.format)))
 
 			// Verify the bootstrap data value is in the correct format.
-			data := secret.Data["value"]
+			data := scrt.Data["value"]
 			switch tc.format {
 			case bootstrapv1.CloudConfig, "":
 				// Verify the bootstrap data is valid YAML.
@@ -800,7 +800,7 @@ func TestKubeadmConfigSecretCreatedStatusNotPatched(t *testing.T) {
 		},
 	}
 
-	secret := &corev1.Secret{
+	scrt := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workerJoinConfig.Name,
 			Namespace: workerJoinConfig.Namespace,
@@ -823,7 +823,7 @@ func TestKubeadmConfigSecretCreatedStatusNotPatched(t *testing.T) {
 		Type: clusterv1.ClusterSecretType,
 	}
 
-	err := myclient.Create(ctx, secret)
+	err := myclient.Create(ctx, scrt)
 	g.Expect(err).ToNot(HaveOccurred())
 	result, err := k.Reconcile(ctx, request)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
+++ b/bootstrap/kubeadm/internal/locking/control_plane_init_mutex.go
@@ -41,10 +41,10 @@ type ControlPlaneInitMutex struct {
 }
 
 // NewControlPlaneInitMutex returns a lock that can be held by a control plane node before init.
-func NewControlPlaneInitMutex(log logr.Logger, client client.Client) *ControlPlaneInitMutex {
+func NewControlPlaneInitMutex(log logr.Logger, cl client.Client) *ControlPlaneInitMutex {
 	return &ControlPlaneInitMutex{
 		log:    log,
-		client: client,
+		client: cl,
 	}
 }
 

--- a/cmd/clusterctl/api/v1alpha3/metadata_type.go
+++ b/cmd/clusterctl/api/v1alpha3/metadata_type.go
@@ -58,9 +58,9 @@ func init() {
 }
 
 // GetReleaseSeriesForVersion returns the release series for a given version.
-func (m *Metadata) GetReleaseSeriesForVersion(version *version.Version) *ReleaseSeries {
+func (m *Metadata) GetReleaseSeriesForVersion(vrsn *version.Version) *ReleaseSeries {
 	for _, releaseSeries := range m.ReleaseSeries {
-		if version.Major() == releaseSeries.Major && version.Minor() == releaseSeries.Minor {
+		if vrsn.Major() == releaseSeries.Major && vrsn.Minor() == releaseSeries.Minor {
 			return &releaseSeries
 		}
 	}

--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -134,9 +134,9 @@ var _ Client = &clusterctlClient{}
 type Option func(*clusterctlClient)
 
 // InjectConfig allows to override the default configuration client used by clusterctl.
-func InjectConfig(config config.Client) Option {
+func InjectConfig(cfg config.Client) Option {
 	return func(c *clusterctlClient) {
-		c.configClient = config
+		c.configClient = cfg
 	}
 }
 

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -338,8 +338,8 @@ func (f *fakeClusterClient) WithObjectMover(mover cluster.ObjectMover) *fakeClus
 	return f
 }
 
-func (f *fakeClusterClient) WithCertManagerClient(client cluster.CertManagerClient) *fakeClusterClient {
-	f.certManager = client
+func (f *fakeClusterClient) WithCertManagerClient(cl cluster.CertManagerClient) *fakeClusterClient {
+	f.certManager = cl
 	return f
 }
 
@@ -349,11 +349,11 @@ func (f *fakeClusterClient) WithCertManagerClient(client cluster.CertManagerClie
 func newFakeConfig() *fakeConfigClient {
 	fakeReader := test.NewFakeReader()
 
-	client, _ := config.New("fake-config", config.InjectReader(fakeReader))
+	cl, _ := config.New("fake-config", config.InjectReader(fakeReader))
 
 	return &fakeConfigClient{
 		fakeReader:     fakeReader,
-		internalclient: client,
+		internalclient: cl,
 	}
 }
 

--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -112,12 +112,12 @@ func (cm *certManagerClient) Images() ([]string, error) {
 	}
 
 	// Otherwise, retrieve the images from the cert-manager manifest.
-	config, err := cm.configClient.CertManager().Get()
+	cfg, err := cm.configClient.CertManager().Get()
 	if err != nil {
 		return nil, err
 	}
 
-	objs, err := cm.getManifestObjs(config)
+	objs, err := cm.getManifestObjs(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -166,14 +166,14 @@ func (cm *certManagerClient) EnsureInstalled() error {
 func (cm *certManagerClient) install() error {
 	log := logf.Log
 
-	config, err := cm.configClient.CertManager().Get()
+	cfg, err := cm.configClient.CertManager().Get()
 	if err != nil {
 		return err
 	}
-	log.Info("Installing cert-manager", "Version", config.Version())
+	log.Info("Installing cert-manager", "Version", cfg.Version())
 
 	// Gets the cert-manager components from the repository.
-	objs, err := cm.getManifestObjs(config)
+	objs, err := cm.getManifestObjs(cfg)
 	if err != nil {
 		return err
 	}
@@ -295,7 +295,7 @@ func (cm *certManagerClient) deleteObjs(objs []unstructured.Unstructured) error 
 }
 
 func (cm *certManagerClient) shouldUpgrade(objs []unstructured.Unstructured) (string, string, bool, error) {
-	config, err := cm.configClient.CertManager().Get()
+	cfg, err := cm.configClient.CertManager().Get()
 	if err != nil {
 		return "", "", false, err
 	}
@@ -327,7 +327,7 @@ func (cm *certManagerClient) shouldUpgrade(objs []unstructured.Unstructured) (st
 			return "", "", false, errors.Wrapf(err, "failed to parse version for cert-manager component %s/%s", obj.GetKind(), obj.GetName())
 		}
 
-		c, err := objSemVersion.Compare(config.Version())
+		c, err := objSemVersion.Compare(cfg.Version())
 		if err != nil {
 			return "", "", false, errors.Wrapf(err, "failed to compare target version for cert-manager component %s/%s", obj.GetKind(), obj.GetName())
 		}
@@ -346,7 +346,7 @@ func (cm *certManagerClient) shouldUpgrade(objs []unstructured.Unstructured) (st
 			break
 		}
 	}
-	return currentVersion, config.Version(), needUpgrade, nil
+	return currentVersion, cfg.Version(), needUpgrade, nil
 }
 
 func (cm *certManagerClient) getWaitTimeout() time.Duration {
@@ -416,13 +416,13 @@ func addCerManagerLabel(objs []unstructured.Unstructured) []unstructured.Unstruc
 	return objs
 }
 
-func addCerManagerAnnotations(objs []unstructured.Unstructured, version string) []unstructured.Unstructured {
+func addCerManagerAnnotations(objs []unstructured.Unstructured, vrsn string) []unstructured.Unstructured {
 	for _, o := range objs {
 		annotations := o.GetAnnotations()
 		if annotations == nil {
 			annotations = map[string]string{}
 		}
-		annotations[clusterctlv1.CertManagerVersionAnnotation] = version
+		annotations[clusterctlv1.CertManagerVersionAnnotation] = vrsn
 		o.SetAnnotations(annotations)
 	}
 	return objs

--- a/cmd/clusterctl/client/cluster/cert_manager_test.go
+++ b/cmd/clusterctl/client/cluster/cert_manager_test.go
@@ -661,10 +661,10 @@ func Test_certManagerClient_EnsureLatestVersion(t *testing.T) {
 func newFakeConfig() *fakeConfigClient {
 	fakeReader := test.NewFakeReader()
 
-	client, _ := config.New("fake-config", config.InjectReader(fakeReader))
+	cl, _ := config.New("fake-config", config.InjectReader(fakeReader))
 	return &fakeConfigClient{
 		fakeReader:     fakeReader,
-		internalclient: client,
+		internalclient: cl,
 	}
 }
 

--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -535,7 +535,7 @@ func setClusterPause(proxy Proxy, clusters []*node, value bool, dryRun bool) err
 	}
 
 	log := logf.Log
-	patch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"spec\":{\"paused\":%t}}", value)))
+	ptch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"spec\":{\"paused\":%t}}", value)))
 
 	setClusterPauseBackoff := newWriteBackoff()
 	for i := range clusters {
@@ -544,7 +544,7 @@ func setClusterPause(proxy Proxy, clusters []*node, value bool, dryRun bool) err
 
 		// Nb. The operation is wrapped in a retry loop to make setClusterPause more resilient to unexpected conditions.
 		if err := retryWithExponentialBackoff(setClusterPauseBackoff, func() error {
-			return patchCluster(proxy, cluster, patch)
+			return patchCluster(proxy, cluster, ptch)
 		}); err != nil {
 			return errors.Wrapf(err, "error setting Cluster.Spec.Paused=%t", value)
 		}
@@ -580,7 +580,7 @@ func setClusterClassPause(proxy Proxy, clusterclasses []*node, pause bool, dryRu
 }
 
 // patchCluster applies a patch to a node referring to a Cluster object.
-func patchCluster(proxy Proxy, cluster *node, patch client.Patch) error {
+func patchCluster(proxy Proxy, cluster *node, ptch client.Patch) error {
 	cFrom, err := proxy.NewClient()
 	if err != nil {
 		return err
@@ -597,7 +597,7 @@ func patchCluster(proxy Proxy, cluster *node, patch client.Patch) error {
 			clusterObj.GetNamespace(), clusterObj.GetName())
 	}
 
-	if err := cFrom.Patch(ctx, clusterObj, patch); err != nil {
+	if err := cFrom.Patch(ctx, clusterObj, ptch); err != nil {
 		return errors.Wrapf(err, "error patching Cluster %s/%s",
 			clusterObj.GetNamespace(), clusterObj.GetName())
 	}

--- a/cmd/clusterctl/client/cluster/proxy.go
+++ b/cmd/clusterctl/client/cluster/proxy.go
@@ -120,8 +120,8 @@ func (k *proxy) ValidateKubernetesVersion() error {
 		return err
 	}
 
-	client := discovery.NewDiscoveryClientForConfigOrDie(config)
-	serverVersion, err := client.ServerVersion()
+	cl := discovery.NewDiscoveryClientForConfigOrDie(config)
+	serverVersion, err := cl.ServerVersion()
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve server version")
 	}
@@ -257,10 +257,10 @@ func (k *proxy) ListResources(labels map[string]string, namespaces ...string) ([
 		component, isCoreComponent := labels[clusterctlv1.ClusterctlCoreLabelName]
 		_, isProviderResource := crd.Labels[clusterv1.ProviderLabelName]
 		if (isCoreComponent && component == clusterctlv1.ClusterctlCoreLabelCertManagerValue) || isProviderResource {
-			for _, version := range crd.Spec.Versions {
+			for _, v := range crd.Spec.Versions {
 				crdsToExclude.Insert(metav1.GroupVersionKind{
 					Group:   crd.Spec.Group,
-					Version: version.Name,
+					Version: v.Name,
 					Kind:    crd.Spec.Names.Kind,
 				}.String())
 			}
@@ -332,12 +332,12 @@ func (k *proxy) GetContexts(prefix string) ([]string, error) {
 
 // GetResourceNames returns the list of resource names which begin with prefix.
 func (k *proxy) GetResourceNames(groupVersion, kind string, options []client.ListOption, prefix string) ([]string, error) {
-	client, err := k.NewClient()
+	cl, err := k.NewClient()
 	if err != nil {
 		return nil, err
 	}
 
-	objList, err := listObjByGVK(client, groupVersion, kind, options)
+	objList, err := listObjByGVK(cl, groupVersion, kind, options)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/clusterctl/client/cluster/template.go
+++ b/cmd/clusterctl/client/cluster/template.go
@@ -172,18 +172,18 @@ func (t *templateClient) getGitHubFileContent(rURL *url.URL) ([]byte, error) {
 
 	// Extract all the info from url split.
 	owner := urlSplit[0]
-	repository := urlSplit[1]
+	repo := urlSplit[1]
 	branch := urlSplit[3]
 	path := strings.Join(urlSplit[4:], "/")
 
 	// gets the GitHub client
-	client, err := t.gitHubClientFactory(t.configClient.Variables())
+	cl, err := t.gitHubClientFactory(t.configClient.Variables())
 	if err != nil {
 		return nil, err
 	}
 
 	// gets the file from GiHub
-	fileContent, _, _, err := client.Repositories.GetContents(context.TODO(), owner, repository, path, &github.RepositoryContentGetOptions{Ref: branch})
+	fileContent, _, _, err := cl.Repositories.GetContents(context.TODO(), owner, repo, path, &github.RepositoryContentGetOptions{Ref: branch})
 	if err != nil {
 		return nil, handleGithubErr(err, "failed to get %q", rURL.Path)
 	}

--- a/cmd/clusterctl/client/cluster/upgrader_info.go
+++ b/cmd/clusterctl/client/cluster/upgrader_info.go
@@ -193,10 +193,10 @@ func (i *upgradeInfo) getLatestNextVersion(contract string) *version.Version {
 }
 
 // versionTag converts a version to a RepositoryTag.
-func versionTag(version *version.Version) string {
-	if version == nil {
+func versionTag(vrsn *version.Version) string {
+	if vrsn == nil {
 		return ""
 	}
 
-	return fmt.Sprintf("v%s", version.String())
+	return fmt.Sprintf("v%s", vrsn.String())
 }

--- a/cmd/clusterctl/client/cluster/upgrader_info_test.go
+++ b/cmd/clusterctl/client/cluster/upgrader_info_test.go
@@ -435,7 +435,7 @@ func toSemanticVersions(versions []string) []version.Version {
 	return semanticVersions
 }
 
-func fakeProvider(name string, providerType clusterctlv1.ProviderType, version, targetNamespace string) clusterctlv1.Provider {
+func fakeProvider(name string, providerType clusterctlv1.ProviderType, vrsn, targetNamespace string) clusterctlv1.Provider {
 	return clusterctlv1.Provider{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: clusterctlv1.GroupVersion.String(),
@@ -453,6 +453,6 @@ func fakeProvider(name string, providerType clusterctlv1.ProviderType, version, 
 		},
 		ProviderName: name,
 		Type:         string(providerType),
-		Version:      version,
+		Version:      vrsn,
 	}
 }

--- a/cmd/clusterctl/client/clusterclass.go
+++ b/cmd/clusterctl/client/clusterclass.go
@@ -73,14 +73,14 @@ func clusterClassNamesFromTemplate(template Template) ([]string, error) {
 		if obj.GroupVersionKind().GroupKind() != clusterv1.GroupVersion.WithKind("Cluster").GroupKind() {
 			continue
 		}
-		cluster := &clusterv1.Cluster{}
-		if err := scheme.Scheme.Convert(&obj, cluster, nil); err != nil {
+		clusterFromObject := &clusterv1.Cluster{}
+		if err := scheme.Scheme.Convert(&obj, clusterFromObject, nil); err != nil {
 			return nil, errors.Wrap(err, "failed to convert object to Cluster")
 		}
-		if cluster.Spec.Topology == nil {
+		if clusterFromObject.Spec.Topology == nil {
 			continue
 		}
-		classes = append(classes, cluster.Spec.Topology.Class)
+		classes = append(classes, clusterFromObject.Spec.Topology.Class)
 	}
 	return classes, nil
 }

--- a/cmd/clusterctl/client/clusterclass_test.go
+++ b/cmd/clusterctl/client/clusterclass_test.go
@@ -68,8 +68,8 @@ func TestClusterClassExists(t *testing.T) {
 			g := NewWithT(t)
 
 			config := newFakeConfig()
-			client := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config).WithObjs(tt.objs...)
-			c, _ := client.Proxy().NewClient()
+			cl := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config).WithObjs(tt.objs...)
+			c, _ := cl.Proxy().NewClient()
 
 			actual, err := clusterClassExists(c, tt.clusterClass, metav1.NamespaceDefault)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -157,10 +157,10 @@ func TestAddClusterClassIfMissing(t *testing.T) {
 				WithPaths("root", "").
 				WithDefaultVersion("v1.0.0").
 				WithFile("v1.0.0", "clusterclass-dev.yaml", tt.clusterClassTemplateContent)
-			cluster := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgt-cluster"}, config1).WithObjs(tt.objs...)
+			cluster1 := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgt-cluster"}, config1).WithObjs(tt.objs...)
 
 			if tt.clusterInitialized {
-				cluster.WithObjs(&apiextensionsv1.CustomResourceDefinition{
+				cluster1.WithObjs(&apiextensionsv1.CustomResourceDefinition{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
 						Kind:       "CustomResourceDefinition",
@@ -205,7 +205,7 @@ func TestAddClusterClassIfMissing(t *testing.T) {
 			}
 
 			g := NewWithT(t)
-			template, err := addClusterClassIfMissing(baseTemplate, clusterClassClient, cluster, tt.targetNamespace, tt.listVariablesOnly)
+			template, err := addClusterClassIfMissing(baseTemplate, clusterClassClient, cluster1, tt.targetNamespace, tt.listVariablesOnly)
 			if tt.wantError {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/cmd/clusterctl/client/config/reader_memory.go
+++ b/cmd/clusterctl/client/config/reader_memory.go
@@ -89,11 +89,11 @@ func (f *MemoryReader) AddProvider(name string, ttype clusterctlv1.ProviderType,
 		Type: ttype,
 	})
 
-	yaml, err := yaml.Marshal(f.providers)
+	providerYaml, err := yaml.Marshal(f.providers)
 	if err != nil {
 		return f, err
 	}
-	f.variables["providers"] = string(yaml)
+	f.variables["providers"] = string(providerYaml)
 
 	return f, nil
 }

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -378,11 +378,11 @@ func Test_clusterctlClient_templateOptionsToVariables(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			config := newFakeConfig().
+			cfg := newFakeConfig().
 				WithVar("KUBERNETES_VERSION", "v3.4.5") // with this line we are simulating an env var
 
 			c := &clusterctlClient{
-				configClient: config,
+				configClient: cfg,
 			}
 			err := c.templateOptionsToVariables(tt.args.options)
 			if tt.wantErr {
@@ -392,7 +392,7 @@ func Test_clusterctlClient_templateOptionsToVariables(t *testing.T) {
 			g.Expect(err).NotTo(HaveOccurred())
 
 			for name, wantValue := range tt.wantVars {
-				gotValue, err := config.Variables().Get(name)
+				gotValue, err := cfg.Variables().Get(name)
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(gotValue).To(Equal(wantValue))
 			}

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -187,8 +187,8 @@ func (c *clusterctlClient) InitImages(options InitOptions) ([]string, error) {
 	return images, nil
 }
 
-func (c *clusterctlClient) setupInstaller(cluster cluster.Client, options InitOptions) (cluster.ProviderInstaller, error) {
-	installer := cluster.ProviderInstaller()
+func (c *clusterctlClient) setupInstaller(clusterClient cluster.Client, options InitOptions) (cluster.ProviderInstaller, error) {
+	installer := clusterClient.ProviderInstaller()
 
 	addOptions := addToInstallerOptions{
 		installer:           installer,
@@ -217,12 +217,12 @@ func (c *clusterctlClient) setupInstaller(cluster cluster.Client, options InitOp
 	return installer, nil
 }
 
-func (c *clusterctlClient) addDefaultProviders(cluster cluster.Client, options *InitOptions) bool {
+func (c *clusterctlClient) addDefaultProviders(clusterClient cluster.Client, options *InitOptions) bool {
 	firstRun := false
 	// Check if there is already a core provider installed in the cluster
 	// Nb. we are ignoring the error so this operation can support listing images even if there is no an existing management cluster;
 	// in case there is no an existing management cluster, we assume there are no core providers installed in the cluster.
-	currentCoreProvider, _ := cluster.ProviderInventory().GetDefaultProviderName(clusterctlv1.CoreProviderType)
+	currentCoreProvider, _ := clusterClient.ProviderInventory().GetDefaultProviderName(clusterctlv1.CoreProviderType)
 
 	// If there are no core providers installed in the cluster, consider this a first run and add default providers to the list
 	// of providers to be installed.

--- a/cmd/clusterctl/client/init_test.go
+++ b/cmd/clusterctl/client/init_test.go
@@ -566,8 +566,8 @@ func setupCluster(providers []Provider, certManagerClient cluster.CertManagerCli
 	}
 
 	frepositories := fakeRepositories(cfg, providers)
-	cluster := fakeCluster(cfg, frepositories, certManagerClient)
-	fc := fakeClusterCtlClient(cfg, frepositories, []*fakeClusterClient{cluster})
+	clstr := fakeCluster(cfg, frepositories, certManagerClient)
+	fc := fakeClusterCtlClient(cfg, frepositories, []*fakeClusterClient{clstr})
 	return cfg, fc
 }
 
@@ -591,29 +591,29 @@ func fakeEmptyCluster() *fakeClient {
 }
 
 func fakeConfig(providers []config.Provider, variables map[string]string) *fakeConfigClient {
-	config := newFakeConfig()
+	cfg := newFakeConfig()
 	for _, p := range providers {
-		config = config.WithProvider(p)
+		cfg = cfg.WithProvider(p)
 	}
 	for k, v := range variables {
-		config = config.WithVar(k, v)
+		cfg = cfg.WithVar(k, v)
 	}
-	return config
+	return cfg
 }
 
-func fakeCluster(config *fakeConfigClient, repos []*fakeRepositoryClient, certManagerClient cluster.CertManagerClient) *fakeClusterClient {
-	cluster := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, config)
+func fakeCluster(cfg *fakeConfigClient, repos []*fakeRepositoryClient, certManagerClient cluster.CertManagerClient) *fakeClusterClient {
+	clstr := newFakeCluster(cluster.Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"}, cfg)
 	for _, r := range repos {
-		cluster = cluster.WithRepository(r)
+		clstr = clstr.WithRepository(r)
 	}
-	cluster.WithCertManagerClient(certManagerClient)
-	return cluster
+	clstr.WithCertManagerClient(certManagerClient)
+	return clstr
 }
 
 // fakeRepositories returns a base set of repositories for the different types
 // of providers.
-func fakeRepositories(config *fakeConfigClient, providers []Provider) []*fakeRepositoryClient {
-	repository1 := newFakeRepository(capiProviderConfig, config).
+func fakeRepositories(cfg *fakeConfigClient, providers []Provider) []*fakeRepositoryClient {
+	repository1 := newFakeRepository(capiProviderConfig, cfg).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v1.0.0").
 		WithFile("v0.9.0", "components.yaml", componentsYAML("ns1")).
@@ -636,7 +636,7 @@ func fakeRepositories(config *fakeConfigClient, providers []Provider) []*fakeRep
 				{Major: 1, Minor: 1, Contract: test.CurrentCAPIContract},
 			},
 		})
-	repository2 := newFakeRepository(bootstrapProviderConfig, config).
+	repository2 := newFakeRepository(bootstrapProviderConfig, cfg).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v2.0.0").
 		WithFile("v0.9.0", "components.yaml", componentsYAML("ns1")).
@@ -659,7 +659,7 @@ func fakeRepositories(config *fakeConfigClient, providers []Provider) []*fakeRep
 				{Major: 2, Minor: 1, Contract: test.CurrentCAPIContract},
 			},
 		})
-	repository3 := newFakeRepository(controlPlaneProviderConfig, config).
+	repository3 := newFakeRepository(controlPlaneProviderConfig, cfg).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v2.0.0").
 		WithFile("v0.9.0", "components.yaml", componentsYAML("ns1")).
@@ -682,7 +682,7 @@ func fakeRepositories(config *fakeConfigClient, providers []Provider) []*fakeRep
 				{Major: 2, Minor: 1, Contract: test.CurrentCAPIContract},
 			},
 		})
-	repository4 := newFakeRepository(infraProviderConfig, config).
+	repository4 := newFakeRepository(infraProviderConfig, cfg).
 		WithPaths("root", "components.yaml").
 		WithDefaultVersion("v3.0.0").
 		WithFile("v0.9.0", "components.yaml", componentsYAML("ns1")).
@@ -711,7 +711,7 @@ func fakeRepositories(config *fakeConfigClient, providers []Provider) []*fakeRep
 
 	for _, provider := range providers {
 		providerRepositories = append(providerRepositories,
-			newFakeRepository(provider, config).
+			newFakeRepository(provider, cfg).
 				WithPaths("root", "components.yaml").
 				WithDefaultVersion("v2.0.0").
 				WithFile("v2.0.0", "components.yaml", componentsYAML("ns2")).
@@ -725,8 +725,8 @@ func fakeRepositories(config *fakeConfigClient, providers []Provider) []*fakeRep
 	return providerRepositories
 }
 
-func fakeClusterCtlClient(config *fakeConfigClient, repos []*fakeRepositoryClient, clusters []*fakeClusterClient) *fakeClient {
-	client := newFakeClient(config)
+func fakeClusterCtlClient(cfg *fakeConfigClient, repos []*fakeRepositoryClient, clusters []*fakeClusterClient) *fakeClient {
+	client := newFakeClient(cfg)
 	for _, r := range repos {
 		client = client.WithRepository(r)
 	}

--- a/cmd/clusterctl/client/repository/clusterclass_client_test.go
+++ b/cmd/clusterctl/client/repository/clusterclass_client_test.go
@@ -181,11 +181,11 @@ func Test_ClusterClassClient_Get(t *testing.T) {
 			g.Expect(got.TargetNamespace()).To(Equal(tt.want.targetNamespace))
 
 			// check variable replaced in yaml
-			yaml, err := got.Yaml()
+			gotYAML, err := got.Yaml()
 			g.Expect(err).NotTo(HaveOccurred())
 
 			if !tt.args.listVariablesOnly {
-				g.Expect(yaml).To(ContainSubstring(fmt.Sprintf("variable: %s", variableValue)))
+				g.Expect(gotYAML).To(ContainSubstring(fmt.Sprintf("variable: %s", variableValue)))
 			}
 
 			// check if target namespace is set

--- a/cmd/clusterctl/client/repository/components_client_test.go
+++ b/cmd/clusterctl/client/repository/components_client_test.go
@@ -281,21 +281,21 @@ func Test_componentsClient_Get(t *testing.T) {
 			gs.Expect(got.TargetNamespace()).To(Equal(tt.want.targetNamespace))
 			gs.Expect(got.Variables()).To(Equal(tt.want.variables))
 
-			yaml, err := got.Yaml()
+			gotYAML, err := got.Yaml()
 			if err != nil {
 				t.Errorf("got.Yaml() error = %v", err)
 				return
 			}
 
 			if !tt.args.skipVariables && len(tt.want.variables) > 0 {
-				gs.Expect(yaml).To(ContainSubstring(variableValue))
+				gs.Expect(gotYAML).To(ContainSubstring(variableValue))
 			}
 
 			// Verify that when SkipTemplateProcess is set we have all the variables
 			// in the template without the values processed.
 			if tt.args.skipVariables {
 				for _, v := range tt.want.variables {
-					gs.Expect(yaml).To(ContainSubstring(v))
+					gs.Expect(gotYAML).To(ContainSubstring(v))
 				}
 			}
 

--- a/cmd/clusterctl/client/repository/metadata_client.go
+++ b/cmd/clusterctl/client/repository/metadata_client.go
@@ -48,9 +48,9 @@ type metadataClient struct {
 var _ MetadataClient = &metadataClient{}
 
 // newMetadataClient returns a metadataClient.
-func newMetadataClient(provider config.Provider, version string, repository Repository, config config.VariablesClient) *metadataClient {
+func newMetadataClient(provider config.Provider, version string, repository Repository, cfg config.VariablesClient) *metadataClient {
 	return &metadataClient{
-		configVarClient: config,
+		configVarClient: cfg,
 		provider:        provider,
 		version:         version,
 		repository:      repository,

--- a/cmd/clusterctl/client/repository/repository_github.go
+++ b/cmd/clusterctl/client/repository/repository_github.go
@@ -101,16 +101,16 @@ func (g *gitHubRepository) ComponentsPath() string {
 }
 
 // GetFile returns a file for a given provider version.
-func (g *gitHubRepository) GetFile(version, path string) ([]byte, error) {
-	release, err := g.getReleaseByTag(version)
+func (g *gitHubRepository) GetFile(vrsn, path string) ([]byte, error) {
+	release, err := g.getReleaseByTag(vrsn)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get GitHub release %s", version)
+		return nil, errors.Wrapf(err, "failed to get GitHub release %s", vrsn)
 	}
 
 	// download files from the release
 	files, err := g.downloadFilesFromRelease(release, path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to download files from GitHub release %s", version)
+		return nil, errors.Wrapf(err, "failed to download files from GitHub release %s", vrsn)
 	}
 
 	return files, nil

--- a/cmd/clusterctl/client/repository/repository_local.go
+++ b/cmd/clusterctl/client/repository/repository_local.go
@@ -82,30 +82,30 @@ func (r *localRepository) ComponentsPath() string {
 }
 
 // GetFile returns a file for a given provider version.
-func (r *localRepository) GetFile(version, fileName string) ([]byte, error) {
+func (r *localRepository) GetFile(vrsn, fileName string) ([]byte, error) {
 	var err error
 
-	if version == latestVersionTag {
-		version, err = latestRelease(r)
+	if vrsn == latestVersionTag {
+		vrsn, err = latestRelease(r)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get the latest release")
 		}
-	} else if version == "" {
-		version = r.defaultVersion
+	} else if vrsn == "" {
+		vrsn = r.defaultVersion
 	}
 
-	absolutePath := filepath.Join(r.basepath, r.providerLabel, version, r.RootPath(), fileName)
+	absolutePath := filepath.Join(r.basepath, r.providerLabel, vrsn, r.RootPath(), fileName)
 
 	f, err := os.Stat(absolutePath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read file %q from local release %s", absolutePath, version)
+		return nil, errors.Wrapf(err, "failed to read file %q from local release %s", absolutePath, vrsn)
 	}
 	if f.IsDir() {
 		return nil, errors.Errorf("invalid path: file %q is actually a directory %q", fileName, absolutePath)
 	}
 	content, err := os.ReadFile(absolutePath) //nolint:gosec
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read file %q from local release %s", absolutePath, version)
+		return nil, errors.Wrapf(err, "failed to read file %q from local release %s", absolutePath, vrsn)
 	}
 	return content, nil
 }
@@ -136,13 +136,13 @@ func (r *localRepository) GetVersions() ([]string, error) {
 
 // newLocalRepository returns a new localRepository.
 func newLocalRepository(providerConfig config.Provider, configVariablesClient config.VariablesClient) (*localRepository, error) {
-	url, err := url.Parse(providerConfig.URL())
+	providerURL, err := url.Parse(providerConfig.URL())
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid url")
 	}
 
 	// gets the path part of the url and check it is an absolute path
-	path := url.Path
+	path := providerURL.Path
 	if runtime.GOOS == "windows" {
 		// in case of windows, we should take care of removing the additional / which is required by the URI standard
 		// for windows local paths. see https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/ for more details.

--- a/cmd/clusterctl/client/repository/template_client_test.go
+++ b/cmd/clusterctl/client/repository/template_client_test.go
@@ -204,11 +204,11 @@ func Test_templates_Get(t *testing.T) {
 			g.Expect(got.TargetNamespace()).To(Equal(tt.want.targetNamespace))
 
 			// check variable replaced in yaml
-			yaml, err := got.Yaml()
+			gotYAML, err := got.Yaml()
 			g.Expect(err).NotTo(HaveOccurred())
 
 			if !tt.args.listVariablesOnly {
-				g.Expect(yaml).To(ContainSubstring(fmt.Sprintf("variable: %s", variableValue)))
+				g.Expect(gotYAML).To(ContainSubstring(fmt.Sprintf("variable: %s", variableValue)))
 			}
 
 			// check if target namespace is set

--- a/cmd/clusterctl/client/tree/discovery_test.go
+++ b/cmd/clusterctl/client/tree/discovery_test.go
@@ -276,11 +276,11 @@ func Test_Discovery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			client, err := test.NewFakeProxy().WithObjs(tt.args.objs...).NewClient()
-			g.Expect(client).ToNot(BeNil())
+			cl, err := test.NewFakeProxy().WithObjs(tt.args.objs...).NewClient()
+			g.Expect(cl).ToNot(BeNil())
 			g.Expect(err).ToNot(HaveOccurred())
 
-			tree, err := Discovery(context.TODO(), client, "ns1", "cluster1", tt.args.discoverOptions)
+			tree, err := Discovery(context.TODO(), cl, "ns1", "cluster1", tt.args.discoverOptions)
 			g.Expect(tree).ToNot(BeNil())
 			g.Expect(err).ToNot(HaveOccurred())
 
@@ -298,8 +298,8 @@ func Test_Discovery(t *testing.T) {
 					}
 					g.Expect(found).To(BeTrue(), "got child %q for parent %q, expecting [%s]", gotChild.GetUID(), parent, strings.Join(wantChildren, "] ["))
 
-					if test, ok := tt.wantNodeCheck[string(gotChild.GetUID())]; ok {
-						test(g, gotChild)
+					if nodeCheckTest, ok := tt.wantNodeCheck[string(gotChild.GetUID())]; ok {
+						nodeCheckTest(g, gotChild)
 					}
 				}
 			}

--- a/cmd/clusterctl/client/tree/util.go
+++ b/cmd/clusterctl/client/tree/util.go
@@ -42,17 +42,17 @@ func GetOtherConditions(obj client.Object) []*clusterv1.Condition {
 	if getter == nil {
 		return nil
 	}
-	var conditions []*clusterv1.Condition
-	for _, c := range getter.GetConditions() {
-		c := c
+	var objectConditions []*clusterv1.Condition
+	for _, cond := range getter.GetConditions() {
+		c := cond
 		if c.Type != clusterv1.ReadyCondition {
-			conditions = append(conditions, &c)
+			objectConditions = append(objectConditions, &c)
 		}
 	}
-	sort.Slice(conditions, func(i, j int) bool {
-		return conditions[i].Type < conditions[j].Type
+	sort.Slice(objectConditions, func(i, j int) bool {
+		return objectConditions[i].Type < objectConditions[j].Type
 	})
-	return conditions
+	return objectConditions
 }
 
 func setReadyCondition(obj client.Object, ready *clusterv1.Condition) {

--- a/cmd/clusterctl/client/upgrade.go
+++ b/cmd/clusterctl/client/upgrade.go
@@ -37,12 +37,12 @@ type PlanUpgradeOptions struct {
 
 func (c *clusterctlClient) PlanCertManagerUpgrade(options PlanUpgradeOptions) (CertManagerUpgradePlan, error) {
 	// Get the client for interacting with the management cluster.
-	cluster, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
 	if err != nil {
 		return CertManagerUpgradePlan{}, err
 	}
 
-	certManager := cluster.CertManager()
+	certManager := clusterClient.CertManager()
 	plan, err := certManager.PlanUpgrade()
 	return CertManagerUpgradePlan(plan), err
 }

--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -151,8 +151,8 @@ func contextCompletionFunc(kubeconfigFlag *pflag.Flag) func(cmd *cobra.Command, 
 			return completionError(err)
 		}
 
-		client := cluster.New(cluster.Kubeconfig{Path: kubeconfigFlag.Value.String()}, configClient)
-		comps, err := client.Proxy().GetContexts(toComplete)
+		cl := cluster.New(cluster.Kubeconfig{Path: kubeconfigFlag.Value.String()}, configClient)
+		comps, err := cl.Proxy().GetContexts(toComplete)
 		if err != nil {
 			return completionError(err)
 		}

--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -141,7 +141,7 @@ func runDescribeCluster(name string) error {
 		return err
 	}
 
-	tree, err := c.DescribeCluster(client.DescribeClusterOptions{
+	clusterTree, err := c.DescribeCluster(client.DescribeClusterOptions{
 		Kubeconfig:          client.Kubeconfig{Path: dc.kubeconfig, Context: dc.kubeconfigContext},
 		Namespace:           dc.namespace,
 		ClusterName:         name,
@@ -154,19 +154,19 @@ func runDescribeCluster(name string) error {
 		return err
 	}
 
-	printObjectTree(tree)
+	printObjectTree(clusterTree)
 	return nil
 }
 
 // printObjectTree prints the cluster status to stdout.
-func printObjectTree(tree *tree.ObjectTree) {
+func printObjectTree(objTree *tree.ObjectTree) {
 	// Creates the output table
 	tbl := uitable.New()
 	tbl.Separator = "  "
 	tbl.AddRow("NAME", "READY", "SEVERITY", "REASON", "SINCE", "MESSAGE")
 
 	// Add row for the root object, the cluster, and recursively for all the nodes representing the cluster status.
-	addObjectRow("", tbl, tree, tree.GetRoot())
+	addObjectRow("", tbl, objTree, objTree.GetRoot())
 
 	// Prints the output table
 	fmt.Fprintln(color.Error, tbl)

--- a/cmd/clusterctl/cmd/version_checker.go
+++ b/cmd/clusterctl/cmd/version_checker.go
@@ -176,8 +176,8 @@ func writeStateFile(path string, vs *VersionState) error {
 	return os.WriteFile(path, vsb, 0600)
 }
 
-func readStateFile(filepath string) (*VersionState, error) {
-	b, err := os.ReadFile(filepath) //nolint:gosec
+func readStateFile(path string) (*VersionState, error) {
+	b, err := os.ReadFile(path) //nolint:gosec
 	if err != nil {
 		if os.IsNotExist(err) {
 			// if the file doesn't exist yet, don't error

--- a/cmd/clusterctl/internal/test/fake_github.go
+++ b/cmd/clusterctl/internal/test/fake_github.go
@@ -41,9 +41,9 @@ func NewFakeGitHub() (client *github.Client, mux *http.ServeMux, teardown func()
 
 	// client is the GitHub client being tested and is configured to use test server.
 	client = github.NewClient(nil)
-	url, _ := url.Parse(server.URL + baseURLPath + "/")
-	client.BaseURL = url
-	client.UploadURL = url
+	testURL, _ := url.Parse(server.URL + baseURLPath + "/")
+	client.BaseURL = testURL
+	client.UploadURL = testURL
 
 	return client, mux, server.Close
 }

--- a/cmd/clusterctl/internal/test/fake_reader.go
+++ b/cmd/clusterctl/internal/test/fake_reader.go
@@ -98,8 +98,8 @@ func (f *FakeReader) WithProvider(name string, ttype clusterctlv1.ProviderType, 
 		Type: ttype,
 	})
 
-	yaml, _ := yaml.Marshal(f.providers)
-	f.variables["providers"] = string(yaml)
+	yml, _ := yaml.Marshal(f.providers)
+	f.variables["providers"] = string(yml)
 
 	return f
 }
@@ -111,8 +111,8 @@ func (f *FakeReader) WithCertManager(url, version, timeout string) *FakeReader {
 		Timeout: timeout,
 	}
 
-	yaml, _ := yaml.Marshal(f.certManager)
-	f.variables["cert-manager"] = string(yaml)
+	yml, _ := yaml.Marshal(f.certManager)
+	f.variables["cert-manager"] = string(yml)
 
 	return f
 }
@@ -123,8 +123,8 @@ func (f *FakeReader) WithImageMeta(component, repository, tag string) *FakeReade
 		Tag:        tag,
 	}
 
-	yaml, _ := yaml.Marshal(f.imageMetas)
-	f.variables["images"] = string(yaml)
+	yml, _ := yaml.Marshal(f.imageMetas)
+	f.variables["images"] = string(yml)
 
 	return f
 }

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -75,7 +75,7 @@ type ClusterReconciler struct {
 }
 
 func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	controller, err := ctrl.NewControllerManagedBy(mgr).
+	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.Cluster{}).
 		Watches(
 			&source.Kind{Type: &clusterv1.Machine{}},
@@ -91,7 +91,7 @@ func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 
 	r.recorder = mgr.GetEventRecorderFor("cluster-controller")
 	r.externalTracker = external.ObjectTracker{
-		Controller: controller,
+		Controller: c,
 	}
 	return nil
 }

--- a/controllers/external/tracker.go
+++ b/controllers/external/tracker.go
@@ -39,7 +39,7 @@ type ObjectTracker struct {
 }
 
 // Watch uses the controller to issue a Watch only if the object hasn't been seen before.
-func (o *ObjectTracker) Watch(log logr.Logger, obj runtime.Object, handler handler.EventHandler, p ...predicate.Predicate) error {
+func (o *ObjectTracker) Watch(log logr.Logger, obj runtime.Object, eventHandler handler.EventHandler, p ...predicate.Predicate) error {
 	// Consider this a no-op if the controller isn't present.
 	if o.Controller == nil {
 		return nil
@@ -57,7 +57,7 @@ func (o *ObjectTracker) Watch(log logr.Logger, obj runtime.Object, handler handl
 	log.Info("Adding watcher on external object", "GroupVersionKind", gvk.String())
 	err := o.Controller.Watch(
 		&source.Kind{Type: u},
-		handler,
+		eventHandler,
 		append(p, predicates.ResourceNotPaused(log))...,
 	)
 	if err != nil {

--- a/controllers/machine_controller.go
+++ b/controllers/machine_controller.go
@@ -94,7 +94,7 @@ func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		return err
 	}
 
-	controller, err := ctrl.NewControllerManagedBy(mgr).
+	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.Machine{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
@@ -103,7 +103,7 @@ func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
 
-	err = controller.Watch(
+	err = c.Watch(
 		&source.Kind{Type: &clusterv1.Cluster{}},
 		handler.EnqueueRequestsFromMapFunc(clusterToMachines),
 		// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
@@ -116,11 +116,11 @@ func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		return errors.Wrap(err, "failed to add Watch for Clusters to controller manager")
 	}
 
-	r.controller = controller
+	r.controller = c
 
 	r.recorder = mgr.GetEventRecorderFor("machine-controller")
 	r.externalTracker = external.ObjectTracker{
-		Controller: controller,
+		Controller: c,
 	}
 	return nil
 }

--- a/controllers/machine_controller_test.go
+++ b/controllers/machine_controller_test.go
@@ -600,7 +600,7 @@ func TestReconcileRequest(t *testing.T) {
 		},
 	}
 
-	time := metav1.Now()
+	now := metav1.Now()
 
 	testCluster := clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -690,7 +690,7 @@ func TestReconcileRequest(t *testing.T) {
 						clusterv1.MachineControlPlaneLabelName: "",
 					},
 					Finalizers:        []string{clusterv1.MachineFinalizer},
-					DeletionTimestamp: &time,
+					DeletionTimestamp: &now,
 				},
 				Spec: clusterv1.MachineSpec{
 					ClusterName: "test-cluster",
@@ -1867,10 +1867,10 @@ func addConditionsToExternal(u *unstructured.Unstructured, newConditions cluster
 }
 
 // asserts the conditions set on the Getter object.
-func assertConditions(t *testing.T, from conditions.Getter, conditions ...*clusterv1.Condition) {
+func assertConditions(t *testing.T, from conditions.Getter, testConditions ...*clusterv1.Condition) {
 	t.Helper()
 
-	for _, condition := range conditions {
+	for _, condition := range testConditions {
 		assertCondition(t, from, condition)
 	}
 }

--- a/controllers/machinedeployment_controller.go
+++ b/controllers/machinedeployment_controller.go
@@ -296,10 +296,10 @@ func (r *MachineDeploymentReconciler) getMachineSetsForDeployment(ctx context.Co
 
 // adoptOrphan sets the MachineDeployment as a controller OwnerReference to the MachineSet.
 func (r *MachineDeploymentReconciler) adoptOrphan(ctx context.Context, deployment *clusterv1.MachineDeployment, machineSet *clusterv1.MachineSet) error {
-	patch := client.MergeFrom(machineSet.DeepCopy())
+	ptch := client.MergeFrom(machineSet.DeepCopy())
 	newRef := *metav1.NewControllerRef(deployment, machineDeploymentKind)
 	machineSet.OwnerReferences = append(machineSet.OwnerReferences, newRef)
-	return r.Client.Patch(ctx, machineSet, patch)
+	return r.Client.Patch(ctx, machineSet, ptch)
 }
 
 // getMachineDeploymentsForMachineSet returns a list of MachineDeployments that could potentially match a MachineSet.

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -83,7 +83,7 @@ type MachineHealthCheckReconciler struct {
 }
 
 func (r *MachineHealthCheckReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	controller, err := ctrl.NewControllerManagedBy(mgr).
+	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&clusterv1.MachineHealthCheck{}).
 		Watches(
 			&source.Kind{Type: &clusterv1.Machine{}},
@@ -95,7 +95,7 @@ func (r *MachineHealthCheckReconciler) SetupWithManager(ctx context.Context, mgr
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
-	err = controller.Watch(
+	err = c.Watch(
 		&source.Kind{Type: &clusterv1.Cluster{}},
 		handler.EnqueueRequestsFromMapFunc(r.clusterToMachineHealthCheck),
 		// TODO: should this wait for Cluster.Status.InfrastructureReady similar to Infra Machine resources?
@@ -108,7 +108,7 @@ func (r *MachineHealthCheckReconciler) SetupWithManager(ctx context.Context, mgr
 		return errors.Wrap(err, "failed to add Watch for Clusters to controller manager")
 	}
 
-	r.controller = controller
+	r.controller = c
 	r.recorder = mgr.GetEventRecorderFor("machinehealthcheck-controller")
 	return nil
 }

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -278,13 +278,13 @@ func (r *MachineSetReconciler) reconcile(ctx context.Context, cluster *clusterv1
 		}
 		if conditions.IsFalse(machine, clusterv1.MachineOwnerRemediatedCondition) {
 			log.Info("Deleting unhealthy machine", "machine", machine.GetName())
-			patch := client.MergeFrom(machine.DeepCopy())
+			ptch := client.MergeFrom(machine.DeepCopy())
 			if err := r.Client.Delete(ctx, machine); err != nil {
 				errs = append(errs, errors.Wrap(err, "failed to delete"))
 				continue
 			}
 			conditions.MarkTrue(machine, clusterv1.MachineOwnerRemediatedCondition)
-			if err := r.Client.Status().Patch(ctx, machine, patch); err != nil && !apierrors.IsNotFound(err) {
+			if err := r.Client.Status().Patch(ctx, machine, ptch); err != nil && !apierrors.IsNotFound(err) {
 				errs = append(errs, errors.Wrap(err, "failed to update status"))
 			}
 		}
@@ -493,10 +493,10 @@ func shouldExcludeMachine(machineSet *clusterv1.MachineSet, machine *clusterv1.M
 
 // adoptOrphan sets the MachineSet as a controller OwnerReference to the Machine.
 func (r *MachineSetReconciler) adoptOrphan(ctx context.Context, machineSet *clusterv1.MachineSet, machine *clusterv1.Machine) error {
-	patch := client.MergeFrom(machine.DeepCopy())
+	ptch := client.MergeFrom(machine.DeepCopy())
 	newRef := *metav1.NewControllerRef(machineSet, machineSetKind)
 	machine.OwnerReferences = append(machine.OwnerReferences, newRef)
-	return r.Client.Patch(ctx, machine, patch)
+	return r.Client.Patch(ctx, machine, ptch)
 }
 
 func (r *MachineSetReconciler) waitForMachineCreation(ctx context.Context, machineList []*clusterv1.Machine) error {

--- a/controllers/remote/cluster_test.go
+++ b/controllers/remote/cluster_test.go
@@ -88,13 +88,13 @@ func TestNewClusterClient(t *testing.T) {
 	t.Run("cluster with valid kubeconfig", func(t *testing.T) {
 		gs := NewWithT(t)
 
-		client := fake.NewClientBuilder().WithObjects(validSecret).Build()
-		_, err := NewClusterClient(ctx, "test-source", client, clusterWithValidKubeConfig)
+		cl := fake.NewClientBuilder().WithObjects(validSecret).Build()
+		_, err := NewClusterClient(ctx, "test-source", cl, clusterWithValidKubeConfig)
 		// Since we do not have a remote server to connect to, we should expect to get
 		// an error to that effect for the purpose of this test.
 		gs.Expect(err).To(MatchError(ContainSubstring("no such host")))
 
-		restConfig, err := RESTConfig(ctx, "test-source", client, clusterWithValidKubeConfig)
+		restConfig, err := RESTConfig(ctx, "test-source", cl, clusterWithValidKubeConfig)
 		gs.Expect(err).NotTo(HaveOccurred())
 		gs.Expect(restConfig.Host).To(Equal("https://test-cluster-api.nodomain.example.com:6443"))
 		gs.Expect(restConfig.UserAgent).To(MatchRegexp("remote.test/unknown test-source (.*) cluster.x-k8s.io/unknown"))
@@ -104,16 +104,16 @@ func TestNewClusterClient(t *testing.T) {
 	t.Run("cluster with no kubeconfig", func(t *testing.T) {
 		gs := NewWithT(t)
 
-		client := fake.NewClientBuilder().Build()
-		_, err := NewClusterClient(ctx, "test-source", client, clusterWithNoKubeConfig)
+		cl := fake.NewClientBuilder().Build()
+		_, err := NewClusterClient(ctx, "test-source", cl, clusterWithNoKubeConfig)
 		gs.Expect(err).To(MatchError(ContainSubstring("not found")))
 	})
 
 	t.Run("cluster with invalid kubeconfig", func(t *testing.T) {
 		gs := NewWithT(t)
 
-		client := fake.NewClientBuilder().WithObjects(invalidSecret).Build()
-		_, err := NewClusterClient(ctx, "test-source", client, clusterWithInvalidKubeConfig)
+		cl := fake.NewClientBuilder().WithObjects(invalidSecret).Build()
+		_, err := NewClusterClient(ctx, "test-source", cl, clusterWithInvalidKubeConfig)
 		gs.Expect(err).To(HaveOccurred())
 		gs.Expect(apierrors.IsNotFound(err)).To(BeFalse())
 	})

--- a/controllers/remote/restconfig.go
+++ b/controllers/remote/restconfig.go
@@ -30,9 +30,9 @@ const (
 	unknowString = "unknown"
 )
 
-func buildUserAgent(command, version, sourceName, os, arch, commit string) string {
+func buildUserAgent(command, vrsn, sourceName, userOS, arch, commit string) string {
 	return fmt.Sprintf(
-		"%s/%s %s (%s/%s) cluster.x-k8s.io/%s", command, version, sourceName, os, arch, commit)
+		"%s/%s %s (%s/%s) cluster.x-k8s.io/%s", command, vrsn, sourceName, userOS, arch, commit)
 }
 
 // DefaultClusterAPIUserAgent returns a User-Agent string built from static global vars.

--- a/controllers/topology/desired_state_test.go
+++ b/controllers/topology/desired_state_test.go
@@ -75,15 +75,15 @@ func TestComputeInfrastructureCluster(t *testing.T) {
 		g := NewWithT(t)
 
 		// aggregating current cluster objects into ClusterState (simulating getCurrentState)
-		scope := scope.New(cluster)
-		scope.Blueprint = blueprint
+		testScope := scope.New(cluster)
+		testScope.Blueprint = blueprint
 
-		obj, err := computeInfrastructureCluster(ctx, scope)
+		obj, err := computeInfrastructureCluster(ctx, testScope)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(obj).ToNot(BeNil())
 
 		assertTemplateToObject(g, assertTemplateInput{
-			cluster:     scope.Current.Cluster,
+			cluster:     testScope.Current.Cluster,
 			templateRef: blueprint.ClusterClass.Spec.Infrastructure.Ref,
 			template:    blueprint.InfrastructureClusterTemplate,
 			labels:      nil,
@@ -103,20 +103,20 @@ func TestComputeInfrastructureCluster(t *testing.T) {
 		clusterWithInfrastructureRef.Spec.InfrastructureRef = fakeRef1
 
 		// aggregating current cluster objects into ClusterState (simulating getCurrentState)
-		scope := scope.New(clusterWithInfrastructureRef)
-		scope.Blueprint = blueprint
+		testScope := scope.New(clusterWithInfrastructureRef)
+		testScope.Blueprint = blueprint
 
-		obj, err := computeInfrastructureCluster(ctx, scope)
+		obj, err := computeInfrastructureCluster(ctx, testScope)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(obj).ToNot(BeNil())
 
 		assertTemplateToObject(g, assertTemplateInput{
-			cluster:     scope.Current.Cluster,
+			cluster:     testScope.Current.Cluster,
 			templateRef: blueprint.ClusterClass.Spec.Infrastructure.Ref,
 			template:    blueprint.InfrastructureClusterTemplate,
 			labels:      nil,
 			annotations: nil,
-			currentRef:  scope.Current.Cluster.Spec.InfrastructureRef,
+			currentRef:  testScope.Current.Cluster.Spec.InfrastructureRef,
 			obj:         obj,
 		})
 	})
@@ -164,15 +164,15 @@ func TestComputeControlPlaneInfrastructureMachineTemplate(t *testing.T) {
 		g := NewWithT(t)
 
 		// aggregating current cluster objects into ClusterState (simulating getCurrentState)
-		scope := scope.New(cluster)
-		scope.Blueprint = blueprint
+		testScope := scope.New(cluster)
+		testScope.Blueprint = blueprint
 
-		obj, err := computeControlPlaneInfrastructureMachineTemplate(ctx, scope)
+		obj, err := computeControlPlaneInfrastructureMachineTemplate(ctx, testScope)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(obj).ToNot(BeNil())
 
 		assertTemplateToTemplate(g, assertTemplateInput{
-			cluster:     scope.Current.Cluster,
+			cluster:     testScope.Current.Cluster,
 			templateRef: blueprint.ClusterClass.Spec.ControlPlane.MachineInfrastructure.Ref,
 			template:    blueprint.ControlPlane.InfrastructureMachineTemplate,
 			currentRef:  nil,
@@ -261,15 +261,15 @@ func TestComputeControlPlane(t *testing.T) {
 		}
 
 		// aggregating current cluster objects into ClusterState (simulating getCurrentState)
-		scope := scope.New(cluster)
-		scope.Blueprint = blueprint
+		testScope := scope.New(cluster)
+		testScope.Blueprint = blueprint
 
-		obj, err := computeControlPlane(ctx, scope, nil)
+		obj, err := computeControlPlane(ctx, testScope, nil)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(obj).ToNot(BeNil())
 
 		assertTemplateToObject(g, assertTemplateInput{
-			cluster:     scope.Current.Cluster,
+			cluster:     testScope.Current.Cluster,
 			templateRef: blueprint.ClusterClass.Spec.ControlPlane.Ref,
 			template:    blueprint.ControlPlane.Template,
 			currentRef:  nil,
@@ -299,15 +299,15 @@ func TestComputeControlPlane(t *testing.T) {
 		}
 
 		// aggregating current cluster objects into ClusterState (simulating getCurrentState)
-		scope := scope.New(clusterWithoutReplicas)
-		scope.Blueprint = blueprint
+		testScope := scope.New(clusterWithoutReplicas)
+		testScope.Blueprint = blueprint
 
-		obj, err := computeControlPlane(ctx, scope, nil)
+		obj, err := computeControlPlane(ctx, testScope, nil)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(obj).ToNot(BeNil())
 
 		assertTemplateToObject(g, assertTemplateInput{
-			cluster:     scope.Current.Cluster,
+			cluster:     testScope.Current.Cluster,
 			templateRef: blueprint.ClusterClass.Spec.ControlPlane.Ref,
 			template:    blueprint.ControlPlane.Template,
 			currentRef:  nil,
@@ -339,15 +339,15 @@ func TestComputeControlPlane(t *testing.T) {
 		}
 
 		// aggregating current cluster objects into ClusterState (simulating getCurrentState)
-		scope := scope.New(cluster)
-		scope.Blueprint = blueprint
+		testScope := scope.New(cluster)
+		testScope.Blueprint = blueprint
 
-		obj, err := computeControlPlane(ctx, scope, infrastructureMachineTemplate)
+		obj, err := computeControlPlane(ctx, testScope, infrastructureMachineTemplate)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(obj).ToNot(BeNil())
 
 		assertTemplateToObject(g, assertTemplateInput{
-			cluster:     scope.Current.Cluster,
+			cluster:     testScope.Current.Cluster,
 			templateRef: blueprint.ClusterClass.Spec.ControlPlane.Ref,
 			template:    blueprint.ControlPlane.Template,
 			currentRef:  nil,
@@ -356,12 +356,12 @@ func TestComputeControlPlane(t *testing.T) {
 		gotMetadata, err := contract.ControlPlane().MachineTemplate().Metadata().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 
-		expectedLabels := mergeMap(scope.Current.Cluster.Spec.Topology.ControlPlane.Metadata.Labels, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Labels)
+		expectedLabels := mergeMap(testScope.Current.Cluster.Spec.Topology.ControlPlane.Metadata.Labels, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Labels)
 		expectedLabels[clusterv1.ClusterLabelName] = cluster.Name
 		expectedLabels[clusterv1.ClusterTopologyOwnedLabel] = ""
 		g.Expect(gotMetadata).To(Equal(&clusterv1.ObjectMeta{
 			Labels:      expectedLabels,
-			Annotations: mergeMap(scope.Current.Cluster.Spec.Topology.ControlPlane.Metadata.Annotations, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Annotations),
+			Annotations: mergeMap(testScope.Current.Cluster.Spec.Topology.ControlPlane.Metadata.Annotations, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Annotations),
 		}))
 
 		assertNestedField(g, obj, version, contract.ControlPlane().Version().Path()...)
@@ -389,18 +389,18 @@ func TestComputeControlPlane(t *testing.T) {
 		}
 
 		// aggregating current cluster objects into ClusterState (simulating getCurrentState)
-		scope := scope.New(clusterWithControlPlaneRef)
-		scope.Blueprint = blueprint
+		testScope := scope.New(clusterWithControlPlaneRef)
+		testScope.Blueprint = blueprint
 
-		obj, err := computeControlPlane(ctx, scope, nil)
+		obj, err := computeControlPlane(ctx, testScope, nil)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(obj).ToNot(BeNil())
 
 		assertTemplateToObject(g, assertTemplateInput{
-			cluster:     scope.Current.Cluster,
+			cluster:     testScope.Current.Cluster,
 			templateRef: blueprint.ClusterClass.Spec.ControlPlane.Ref,
 			template:    blueprint.ControlPlane.Template,
-			currentRef:  scope.Current.Cluster.Spec.ControlPlaneRef,
+			currentRef:  testScope.Current.Cluster.Spec.ControlPlaneRef,
 			obj:         obj,
 		})
 	})
@@ -654,9 +654,9 @@ func TestComputeCluster(t *testing.T) {
 	}
 
 	// aggregating current cluster objects into ClusterState (simulating getCurrentState)
-	scope := scope.New(cluster)
+	testScope := scope.New(cluster)
 
-	obj := computeCluster(ctx, scope, infrastructureCluster, controlPlane)
+	obj := computeCluster(ctx, testScope, infrastructureCluster, controlPlane)
 	g.Expect(obj).ToNot(BeNil())
 
 	// TypeMeta
@@ -735,10 +735,10 @@ func TestComputeMachineDeployment(t *testing.T) {
 
 	t.Run("Generates the machine deployment and the referenced templates", func(t *testing.T) {
 		g := NewWithT(t)
-		scope := scope.New(cluster)
-		scope.Blueprint = blueprint
+		testScope := scope.New(cluster)
+		testScope.Blueprint = blueprint
 
-		actual, err := computeMachineDeployment(ctx, scope, nil, mdTopology)
+		actual, err := computeMachineDeployment(ctx, testScope, nil, mdTopology)
 		g.Expect(err).ToNot(HaveOccurred())
 
 		g.Expect(actual.BootstrapTemplate.GetLabels()).To(HaveKeyWithValue(clusterv1.ClusterTopologyMachineDeploymentLabelName, "big-pool-of-machines"))
@@ -829,8 +829,8 @@ func TestComputeMachineDeployment(t *testing.T) {
 
 	t.Run("If a machine deployment references a topology class that does not exist, machine deployment generation fails", func(t *testing.T) {
 		g := NewWithT(t)
-		scope := scope.New(cluster)
-		scope.Blueprint = blueprint
+		testScope := scope.New(cluster)
+		testScope.Blueprint = blueprint
 
 		mdTopology = clusterv1.MachineDeploymentTopology{
 			Metadata: clusterv1.ObjectMeta{
@@ -840,7 +840,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 			Name:  "big-pool-of-machines",
 		}
 
-		_, err := computeMachineDeployment(ctx, scope, nil, mdTopology)
+		_, err := computeMachineDeployment(ctx, testScope, nil, mdTopology)
 		g.Expect(err).To(HaveOccurred())
 	})
 

--- a/controllers/topology/internal/extensions/patches/inline/json_patch_generator.go
+++ b/controllers/topology/internal/extensions/patches/inline/json_patch_generator.go
@@ -55,12 +55,12 @@ func (j *jsonPatchGenerator) Generate(_ context.Context, req *api.GenerateReques
 
 	// Loop over all templates.
 	errs := []error{}
-	for _, template := range req.Items {
+	for _, tmplt := range req.Items {
 		// Calculate the list of patches which match the current template.
 		matchingPatches := []clusterv1.PatchDefinition{}
 		for _, patch := range j.patch.Definitions {
 			// Add the patch to the list, if it matches the template.
-			if templateMatchesSelector(&template.TemplateRef, patch.Selector) {
+			if templateMatchesSelector(&tmplt.TemplateRef, patch.Selector) {
 				matchingPatches = append(matchingPatches, patch)
 			}
 		}
@@ -71,15 +71,15 @@ func (j *jsonPatchGenerator) Generate(_ context.Context, req *api.GenerateReques
 		}
 
 		// Merge template-specific and global variables.
-		variables, err := mergeVariableMaps(req.Variables, template.Variables)
+		variables, err := mergeVariableMaps(req.Variables, tmplt.Variables)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "failed to merge global and template-specific variables for template %s", template.TemplateRef))
+			errs = append(errs, errors.Wrapf(err, "failed to merge global and template-specific variables for template %s", tmplt.TemplateRef))
 			continue
 		}
 
 		enabled, err := patchIsEnabled(j.patch.EnabledIf, variables)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "failed to calculate if patch %s is enabled for template %s", j.patch.Name, template.TemplateRef))
+			errs = append(errs, errors.Wrapf(err, "failed to calculate if patch %s is enabled for template %s", j.patch.Name, tmplt.TemplateRef))
 			continue
 		}
 		if !enabled {
@@ -92,13 +92,13 @@ func (j *jsonPatchGenerator) Generate(_ context.Context, req *api.GenerateReques
 			// Generate JSON patches.
 			jsonPatches, err := generateJSONPatches(patch.JSONPatches, variables)
 			if err != nil {
-				errs = append(errs, errors.Wrapf(err, "failed to generate JSON patches for template %s", template.TemplateRef))
+				errs = append(errs, errors.Wrapf(err, "failed to generate JSON patches for template %s", tmplt.TemplateRef))
 				continue
 			}
 
 			// Add jsonPatches to the response.
 			resp.Items = append(resp.Items, api.GenerateResponsePatch{
-				TemplateRef: template.TemplateRef,
+				TemplateRef: tmplt.TemplateRef,
 				Patch:       *jsonPatches,
 				PatchType:   api.JSONPatchType,
 			})

--- a/controlplane/kubeadm/controllers/controller_test.go
+++ b/controlplane/kubeadm/controllers/controller_test.go
@@ -614,9 +614,9 @@ func TestKubeadmControlPlaneReconciler_adoption(t *testing.T) {
 		secrets := &corev1.SecretList{}
 		g.Expect(fakeClient.List(ctx, secrets, client.InNamespace(cluster.Namespace), client.MatchingLabels{"previous-owner": "kubeadmconfig"})).To(Succeed())
 		g.Expect(secrets.Items).To(HaveLen(3))
-		for _, secret := range secrets.Items {
-			g.Expect(secret.OwnerReferences).To(HaveLen(1))
-			g.Expect(secret.OwnerReferences).To(ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
+		for _, s := range secrets.Items {
+			g.Expect(s.OwnerReferences).To(HaveLen(1))
+			g.Expect(s.OwnerReferences).To(ContainElement(*metav1.NewControllerRef(kcp, controlplanev1.GroupVersion.WithKind("KubeadmControlPlane"))))
 		}
 	})
 

--- a/controlplane/kubeadm/controllers/helpers.go
+++ b/controlplane/kubeadm/controllers/helpers.go
@@ -105,7 +105,7 @@ func (r *KubeadmControlPlaneReconciler) adoptKubeconfigSecret(ctx context.Contex
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Adopting KubeConfig secret created by v1alpha2 controllers", "Name", configSecret.Name)
 
-	patch, err := patch.NewHelper(configSecret, r.Client)
+	ptch, err := patch.NewHelper(configSecret, r.Client)
 	if err != nil {
 		return errors.Wrap(err, "failed to create patch helper for the kubeconfig secret")
 	}
@@ -116,7 +116,7 @@ func (r *KubeadmControlPlaneReconciler) adoptKubeconfigSecret(ctx context.Contex
 		UID:        cluster.UID,
 	})
 	configSecret.OwnerReferences = util.EnsureOwnerRef(configSecret.OwnerReferences, controllerOwnerRef)
-	if err := patch.Patch(ctx, configSecret); err != nil {
+	if err := ptch.Patch(ctx, configSecret); err != nil {
 		return errors.Wrap(err, "failed to patch the kubeconfig secret")
 	}
 	return nil

--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -61,18 +61,18 @@ type ControlPlane struct {
 }
 
 // NewControlPlane returns an instantiated ControlPlane.
-func NewControlPlane(ctx context.Context, client client.Client, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, ownedMachines collections.Machines) (*ControlPlane, error) {
-	infraObjects, err := getInfraResources(ctx, client, ownedMachines)
+func NewControlPlane(ctx context.Context, cl client.Client, cluster *clusterv1.Cluster, kcp *controlplanev1.KubeadmControlPlane, ownedMachines collections.Machines) (*ControlPlane, error) {
+	infraObjects, err := getInfraResources(ctx, cl, ownedMachines)
 	if err != nil {
 		return nil, err
 	}
-	kubeadmConfigs, err := getKubeadmConfigs(ctx, client, ownedMachines)
+	kubeadmConfigs, err := getKubeadmConfigs(ctx, cl, ownedMachines)
 	if err != nil {
 		return nil, err
 	}
 	patchHelpers := map[string]*patch.Helper{}
 	for _, machine := range ownedMachines {
-		patchHelper, err := patch.NewHelper(machine, client)
+		patchHelper, err := patch.NewHelper(machine, cl)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create patch helper for machine %s", machine.Name)
 		}

--- a/controlplane/kubeadm/internal/workload_cluster_coredns.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns.go
@@ -101,7 +101,7 @@ type coreDNSInfo struct {
 
 // UpdateCoreDNS updates the kubeadm configmap, coredns corefile and coredns
 // deployment.
-func (w *Workload) UpdateCoreDNS(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane, version semver.Version) error {
+func (w *Workload) UpdateCoreDNS(ctx context.Context, kcp *controlplanev1.KubeadmControlPlane, vrsn semver.Version) error {
 	// Return early if we've been asked to skip CoreDNS upgrades entirely.
 	if _, ok := kcp.Annotations[controlplanev1.SkipCoreDNSAnnotation]; ok {
 		return nil
@@ -136,13 +136,13 @@ func (w *Workload) UpdateCoreDNS(ctx context.Context, kcp *controlplanev1.Kubead
 	}
 
 	// Perform the upgrade.
-	if err := w.updateCoreDNSImageInfoInKubeadmConfigMap(ctx, &clusterConfig.DNS, version); err != nil {
+	if err := w.updateCoreDNSImageInfoInKubeadmConfigMap(ctx, &clusterConfig.DNS, vrsn); err != nil {
 		return err
 	}
 	if err := w.updateCoreDNSCorefile(ctx, info); err != nil {
 		return err
 	}
-	if err := w.updateCoreDNSClusterRole(ctx, version, info); err != nil {
+	if err := w.updateCoreDNSClusterRole(ctx, vrsn, info); err != nil {
 		return err
 	}
 	if err := w.updateCoreDNSDeployment(ctx, info); err != nil {
@@ -247,11 +247,11 @@ func (w *Workload) updateCoreDNSDeployment(ctx context.Context, info *coreDNSInf
 }
 
 // updateCoreDNSImageInfoInKubeadmConfigMap updates the kubernetes version in the kubeadm config map.
-func (w *Workload) updateCoreDNSImageInfoInKubeadmConfigMap(ctx context.Context, dns *bootstrapv1.DNS, version semver.Version) error {
+func (w *Workload) updateCoreDNSImageInfoInKubeadmConfigMap(ctx context.Context, dns *bootstrapv1.DNS, vrsn semver.Version) error {
 	return w.updateClusterConfiguration(ctx, func(c *bootstrapv1.ClusterConfiguration) {
 		c.DNS.ImageRepository = dns.ImageRepository
 		c.DNS.ImageTag = dns.ImageTag
-	}, version)
+	}, vrsn)
 }
 
 // updateCoreDNSClusterRole updates the CoreDNS ClusterRole when necessary.

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -412,10 +412,10 @@ func (r *ClusterResourceSetReconciler) patchOwnerRefToResource(ctx context.Conte
 
 	if !util.IsOwnedByObject(resource, clusterResourceSet) {
 		refs := resource.GetOwnerReferences()
-		patch := client.MergeFrom(resource.DeepCopy())
+		ownerRefPatch := client.MergeFrom(resource.DeepCopy())
 		refs = append(refs, newRef)
 		resource.SetOwnerReferences(refs)
-		return r.Client.Patch(ctx, resource, patch)
+		return r.Client.Patch(ctx, resource, ownerRefPatch)
 	}
 	return nil
 }
@@ -434,7 +434,7 @@ func (r *ClusterResourceSetReconciler) clusterToClusterResourceSet(o client.Obje
 		return nil
 	}
 
-	labels := labels.Set(cluster.GetLabels())
+	lbls := labels.Set(cluster.GetLabels())
 	for i := range resourceList.Items {
 		rs := &resourceList.Items[i]
 
@@ -448,7 +448,7 @@ func (r *ClusterResourceSetReconciler) clusterToClusterResourceSet(o client.Obje
 			return nil
 		}
 
-		if !selector.Matches(labels) {
+		if !selector.Matches(lbls) {
 			continue
 		}
 

--- a/exp/internal/controllers/machinepool_controller_noderef_test.go
+++ b/exp/internal/controllers/machinepool_controller_noderef_test.go
@@ -68,7 +68,7 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 		},
 	}
 
-	client := fake.NewClientBuilder().WithObjects(nodeList...).Build()
+	cl := fake.NewClientBuilder().WithObjects(nodeList...).Build()
 
 	testCases := []struct {
 		name           string
@@ -134,7 +134,7 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			result, err := r.getNodeReferences(ctx, client, test.providerIDList)
+			result, err := r.getNodeReferences(ctx, cl, test.providerIDList)
 			if test.err == nil {
 				g.Expect(err).To(BeNil())
 			} else {

--- a/internal/webhooks/util_test.go
+++ b/internal/webhooks/util_test.go
@@ -35,7 +35,7 @@ type customDefaulterValidator interface {
 // customDefaultValidateTest returns a new testing function to be used in tests to
 // make sure custom defaulting webhooks also pass validation tests on create,
 // update and delete.
-func customDefaultValidateTest(ctx context.Context, obj runtime.Object, webhook customDefaulterValidator) func(*testing.T) {
+func customDefaultValidateTest(ctx context.Context, obj runtime.Object, wbhook customDefaulterValidator) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Helper()
 
@@ -46,19 +46,19 @@ func customDefaultValidateTest(ctx context.Context, obj runtime.Object, webhook 
 
 		t.Run("validate-on-create", func(t *testing.T) {
 			g := gomega.NewWithT(t)
-			g.Expect(webhook.Default(ctx, createCopy)).To(gomega.Succeed())
-			g.Expect(webhook.ValidateCreate(ctx, createCopy)).To(gomega.Succeed())
+			g.Expect(wbhook.Default(ctx, createCopy)).To(gomega.Succeed())
+			g.Expect(wbhook.ValidateCreate(ctx, createCopy)).To(gomega.Succeed())
 		})
 		t.Run("validate-on-update", func(t *testing.T) {
 			g := gomega.NewWithT(t)
-			g.Expect(webhook.Default(ctx, defaultingUpdateCopy)).To(gomega.Succeed())
-			g.Expect(webhook.Default(ctx, updateCopy)).To(gomega.Succeed())
-			g.Expect(webhook.ValidateUpdate(ctx, createCopy, defaultingUpdateCopy)).To(gomega.Succeed())
+			g.Expect(wbhook.Default(ctx, defaultingUpdateCopy)).To(gomega.Succeed())
+			g.Expect(wbhook.Default(ctx, updateCopy)).To(gomega.Succeed())
+			g.Expect(wbhook.ValidateUpdate(ctx, createCopy, defaultingUpdateCopy)).To(gomega.Succeed())
 		})
 		t.Run("validate-on-delete", func(t *testing.T) {
 			g := gomega.NewWithT(t)
-			g.Expect(webhook.Default(ctx, deleteCopy)).To(gomega.Succeed())
-			g.Expect(webhook.ValidateDelete(ctx, deleteCopy)).To(gomega.Succeed())
+			g.Expect(wbhook.Default(ctx, deleteCopy)).To(gomega.Succeed())
+			g.Expect(wbhook.ValidateDelete(ctx, deleteCopy)).To(gomega.Succeed())
 		})
 	}
 }

--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -77,8 +77,8 @@ func Init(ctx context.Context, input InitInput) {
 		LogUsageInstructions:    true,
 	}
 
-	clusterctlClient, log := getClusterctlClientWithLogger(input.ClusterctlConfigPath, "clusterctl-init.log", input.LogFolder)
-	defer log.Close()
+	clusterctlClient, logFile := getClusterctlClientWithLogger(input.ClusterctlConfigPath, "clusterctl-init.log", input.LogFolder)
+	defer logFile.Close()
 
 	_, err := clusterctlClient.Init(initOpt)
 	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl init")
@@ -135,8 +135,8 @@ func Upgrade(ctx context.Context, input UpgradeInput) {
 		Contract: input.Contract,
 	}
 
-	clusterctlClient, log := getClusterctlClientWithLogger(input.ClusterctlConfigPath, "clusterctl-upgrade.log", input.LogFolder)
-	defer log.Close()
+	clusterctlClient, logFile := getClusterctlClientWithLogger(input.ClusterctlConfigPath, "clusterctl-upgrade.log", input.LogFolder)
+	defer logFile.Close()
 
 	err := clusterctlClient.ApplyUpgrade(upgradeOpt)
 	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl upgrade")
@@ -161,8 +161,8 @@ func Delete(_ context.Context, input DeleteInput) {
 		DeleteAll: true,
 	}
 
-	clusterctlClient, log := getClusterctlClientWithLogger(input.ClusterctlConfigPath, "clusterctl-delete.log", input.LogFolder)
-	defer log.Close()
+	clusterctlClient, logFile := getClusterctlClientWithLogger(input.ClusterctlConfigPath, "clusterctl-delete.log", input.LogFolder)
+	defer logFile.Close()
 
 	err := clusterctlClient.Delete(deleteOpts)
 	Expect(err).ToNot(HaveOccurred(), "failed to run clusterctl upgrade")
@@ -209,8 +209,8 @@ func ConfigCluster(ctx context.Context, input ConfigClusterInput) []byte {
 		TargetNamespace:          input.Namespace,
 	}
 
-	clusterctlClient, log := getClusterctlClientWithLogger(input.ClusterctlConfigPath, fmt.Sprintf("%s-cluster-template.yaml", input.ClusterName), input.LogFolder)
-	defer log.Close()
+	clusterctlClient, logFile := getClusterctlClientWithLogger(input.ClusterctlConfigPath, fmt.Sprintf("%s-cluster-template.yaml", input.ClusterName), input.LogFolder)
+	defer logFile.Close()
 
 	template, err := clusterctlClient.GetClusterTemplate(templateOptions)
 	Expect(err).ToNot(HaveOccurred(), "Failed to run clusterctl config cluster")
@@ -218,7 +218,7 @@ func ConfigCluster(ctx context.Context, input ConfigClusterInput) []byte {
 	yaml, err := template.Yaml()
 	Expect(err).ToNot(HaveOccurred(), "Failed to generate yaml for the workload cluster template")
 
-	_, _ = log.WriteString(string(yaml))
+	_, _ = logFile.WriteString(string(yaml))
 	return yaml
 }
 
@@ -311,8 +311,8 @@ func Move(ctx context.Context, input MoveInput) {
 
 	By("Moving workload clusters")
 
-	clusterctlClient, log := getClusterctlClientWithLogger(input.ClusterctlConfigPath, "clusterctl-move.log", input.LogFolder)
-	defer log.Close()
+	clusterctlClient, logFile := getClusterctlClientWithLogger(input.ClusterctlConfigPath, "clusterctl-move.log", input.LogFolder)
+	defer logFile.Close()
 	options := clusterctlclient.MoveOptions{
 		FromKubeconfig: clusterctlclient.Kubeconfig{Path: input.FromKubeconfigPath, Context: ""},
 		ToKubeconfig:   clusterctlclient.Kubeconfig{Path: input.ToKubeconfigPath, Context: ""},
@@ -323,15 +323,15 @@ func Move(ctx context.Context, input MoveInput) {
 }
 
 func getClusterctlClientWithLogger(configPath, logName, logFolder string) (clusterctlclient.Client, *logger.LogFile) {
-	log := logger.CreateLogFile(logger.CreateLogFileInput{
+	logFile := logger.CreateLogFile(logger.CreateLogFileInput{
 		LogFolder: logFolder,
 		Name:      logName,
 	})
-	clusterctllog.SetLogger(log.Logger())
+	clusterctllog.SetLogger(logFile.Logger())
 
 	c, err := clusterctlclient.New(configPath)
 	Expect(err).ToNot(HaveOccurred(), "Failed to create the clusterctl client library")
-	return c, log
+	return c, logFile
 }
 
 func valueOrDefault(v string) string {

--- a/test/framework/clusterctl/e2e_config.go
+++ b/test/framework/clusterctl/e2e_config.go
@@ -257,12 +257,12 @@ func (c *E2EConfig) Defaults() {
 	for i := range c.Providers {
 		provider := &c.Providers[i]
 		for j := range provider.Versions {
-			version := &provider.Versions[j]
-			if version.Type == "" {
-				version.Type = KustomizeSource
+			vrsn := &provider.Versions[j]
+			if vrsn.Type == "" {
+				vrsn.Type = KustomizeSource
 			}
-			for j := range version.Files {
-				file := &version.Files[j]
+			for j := range vrsn.Files {
+				file := &vrsn.Files[j]
 				if file.SourcePath != "" && file.TargetName == "" {
 					file.TargetName = filepath.Base(file.SourcePath)
 				}
@@ -290,28 +290,28 @@ func (c *E2EConfig) AbsPaths(basePath string) {
 	for i := range c.Providers {
 		provider := &c.Providers[i]
 		for j := range provider.Versions {
-			version := &provider.Versions[j]
-			if version.Type != URLSource && version.Value != "" {
-				if !filepath.IsAbs(version.Value) {
-					version.Value = filepath.Join(basePath, version.Value)
+			vrsn := &provider.Versions[j]
+			if vrsn.Type != URLSource && vrsn.Value != "" {
+				if !filepath.IsAbs(vrsn.Value) {
+					vrsn.Value = filepath.Join(basePath, vrsn.Value)
 				}
-			} else if version.Type == URLSource && version.Value != "" {
+			} else if vrsn.Type == URLSource && vrsn.Value != "" {
 				// Skip error, will be checked later when loading contents from URL
-				u, _ := url.Parse(version.Value)
+				u, _ := url.Parse(vrsn.Value)
 
 				if u != nil {
 					switch u.Scheme {
 					case "", fileURIScheme:
-						fp := strings.TrimPrefix(version.Value, fmt.Sprintf("%s://", fileURIScheme))
+						fp := strings.TrimPrefix(vrsn.Value, fmt.Sprintf("%s://", fileURIScheme))
 						if !filepath.IsAbs(fp) {
-							version.Value = filepath.Join(basePath, fp)
+							vrsn.Value = filepath.Join(basePath, fp)
 						}
 					}
 				}
 			}
 
-			for j := range version.Files {
-				file := &version.Files[j]
+			for j := range vrsn.Files {
+				file := &vrsn.Files[j]
 				if file.SourcePath != "" {
 					if !filepath.IsAbs(file.SourcePath) {
 						file.SourcePath = filepath.Join(basePath, file.SourcePath)

--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -190,13 +190,13 @@ func WatchPodMetrics(ctx context.Context, input WatchPodMetricsInput) {
 }
 
 // dumpPodMetrics captures metrics from all pods. It expects to find port 8080 open on the controller.
-func dumpPodMetrics(ctx context.Context, client *kubernetes.Clientset, metricsPath string, deploymentName string, pods *corev1.PodList) {
+func dumpPodMetrics(ctx context.Context, cl *kubernetes.Clientset, metricsPath string, deploymentName string, pods *corev1.PodList) {
 	for _, pod := range pods.Items {
 		metricsDir := path.Join(metricsPath, deploymentName, pod.Name)
 		metricsFile := path.Join(metricsDir, "metrics.txt")
 		Expect(os.MkdirAll(metricsDir, 0750)).To(Succeed())
 
-		res := client.CoreV1().RESTClient().Get().
+		res := cl.CoreV1().RESTClient().Get().
 			Namespace(pod.Namespace).
 			Resource("pods").
 			Name(fmt.Sprintf("%s:8080", pod.Name)).

--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -144,7 +144,7 @@ func Run(ctx context.Context, input RunInput) error {
 		tmpKubeConfigPath: "/tmp/kubeconfig",
 		reportDir:         "/output",
 	}
-	user, err := user.Current()
+	usr, err := user.Current()
 	if err != nil {
 		return errors.Wrap(err, "unable to determine current user")
 	}
@@ -182,8 +182,8 @@ func Run(ctx context.Context, input RunInput) error {
 	err = containerRuntime.RunContainer(ctx, &container.RunContainerInput{
 		Image:           input.ConformanceImage,
 		Network:         "kind",
-		User:            user.Uid,
-		Group:           user.Gid,
+		User:            usr.Uid,
+		Group:           usr.Gid,
 		Volumes:         volumeMounts,
 		EnvironmentVars: env,
 		CommandArgs:     args,

--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -589,8 +589,8 @@ func (d *dockerRuntime) getSubnets(ctx context.Context, networkName string) ([]s
 		return subnets, errors.Wrapf(err, "failed to inspect network %q", networkName)
 	}
 
-	for _, network := range networkInfo.IPAM.Config {
-		subnets = append(subnets, network.Subnet)
+	for _, netConf := range networkInfo.IPAM.Config {
+		subnets = append(subnets, netConf.Subnet)
 	}
 
 	return subnets, nil
@@ -603,7 +603,7 @@ type proxyDetails struct {
 
 // getProxyDetails returns a struct with the host environment proxy settings
 // that should be passed to the nodes.
-func (d *dockerRuntime) getProxyDetails(ctx context.Context, network string) (*proxyDetails, error) {
+func (d *dockerRuntime) getProxyDetails(ctx context.Context, netConfig string) (*proxyDetails, error) {
 	var val string
 	details := proxyDetails{Envs: make(map[string]string)}
 	proxyEnvs := []string{httpProxy, httpsProxy, noProxy}
@@ -624,7 +624,7 @@ func (d *dockerRuntime) getProxyDetails(ctx context.Context, network string) (*p
 
 	// Specifically add the docker network subnets to NO_PROXY if we are using proxies
 	if proxySupport {
-		subnets, err := d.getSubnets(ctx, network)
+		subnets, err := d.getSubnets(ctx, netConfig)
 		if err != nil {
 			return &details, err
 		}

--- a/test/infrastructure/docker/internal/docker/loadbalancer.go
+++ b/test/infrastructure/docker/internal/docker/loadbalancer.go
@@ -58,7 +58,7 @@ func NewLoadBalancer(ctx context.Context, cluster *clusterv1.Cluster, dockerClus
 	filters.AddKeyNameValue(filterLabel, clusterLabelKey, cluster.Name)
 	filters.AddKeyNameValue(filterLabel, nodeRoleLabelKey, constants.ExternalLoadBalancerNodeRoleValue)
 
-	container, err := getContainer(ctx, filters)
+	ctnr, err := getContainer(ctx, filters)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func NewLoadBalancer(ctx context.Context, cluster *clusterv1.Cluster, dockerClus
 	return &LoadBalancer{
 		name:      cluster.Name,
 		image:     image,
-		container: container,
+		container: ctnr,
 		ipFamily:  ipFamily,
 		lbCreator: &Manager{},
 	}, nil

--- a/util/conversion/conversion.go
+++ b/util/conversion/conversion.go
@@ -146,7 +146,7 @@ func UnmarshalData(from metav1.Object, to interface{}) (bool, error) {
 }
 
 // GetFuzzer returns a new fuzzer to be used for testing.
-func GetFuzzer(scheme *runtime.Scheme, funcs ...fuzzer.FuzzerFuncs) *fuzz.Fuzzer {
+func GetFuzzer(fuzzScheme *runtime.Scheme, funcs ...fuzzer.FuzzerFuncs) *fuzz.Fuzzer {
 	funcs = append([]fuzzer.FuzzerFuncs{
 		metafuzzer.Funcs,
 		func(_ runtimeserializer.CodecFactory) []interface{} {
@@ -170,7 +170,7 @@ func GetFuzzer(scheme *runtime.Scheme, funcs ...fuzzer.FuzzerFuncs) *fuzz.Fuzzer
 	return fuzzer.FuzzerFor(
 		fuzzer.MergeFuzzerFuncs(funcs...),
 		rand.NewSource(rand.Int63()), //nolint:gosec
-		runtimeserializer.NewCodecFactory(scheme),
+		runtimeserializer.NewCodecFactory(fuzzScheme),
 	)
 }
 
@@ -200,12 +200,12 @@ func FuzzTestFunc(input FuzzTestFuncInput) func(*testing.T) {
 		t.Helper()
 		t.Run("spoke-hub-spoke", func(t *testing.T) {
 			g := gomega.NewWithT(t)
-			fuzzer := GetFuzzer(input.Scheme, input.FuzzerFuncs...)
+			fzzr := GetFuzzer(input.Scheme, input.FuzzerFuncs...)
 
 			for i := 0; i < 10000; i++ {
 				// Create the spoke and fuzz it
 				spokeBefore := input.Spoke.DeepCopyObject().(conversion.Convertible)
-				fuzzer.Fuzz(spokeBefore)
+				fzzr.Fuzz(spokeBefore)
 
 				// First convert spoke to hub
 				hubCopy := input.Hub.DeepCopyObject().(conversion.Hub)
@@ -231,12 +231,12 @@ func FuzzTestFunc(input FuzzTestFuncInput) func(*testing.T) {
 		})
 		t.Run("hub-spoke-hub", func(t *testing.T) {
 			g := gomega.NewWithT(t)
-			fuzzer := GetFuzzer(input.Scheme, input.FuzzerFuncs...)
+			fzzr := GetFuzzer(input.Scheme, input.FuzzerFuncs...)
 
 			for i := 0; i < 10000; i++ {
 				// Create the hub and fuzz it
 				hubBefore := input.Hub.DeepCopyObject().(conversion.Hub)
-				fuzzer.Fuzz(hubBefore)
+				fzzr.Fuzz(hubBefore)
 
 				// First convert hub to spoke
 				dstCopy := input.Spoke.DeepCopyObject().(conversion.Convertible)

--- a/util/kubeconfig/kubeconfig_test.go
+++ b/util/kubeconfig/kubeconfig_test.go
@@ -86,9 +86,9 @@ func TestGetKubeConfigSecret(t *testing.T) {
 	}
 	// creating a local copy to ensure validSecret.ObjectMeta.ResourceVersion does not get set by fakeClient
 	validSec := validSecret.DeepCopy()
-	client := fake.NewClientBuilder().WithObjects(validSec).Build()
+	cl := fake.NewClientBuilder().WithObjects(validSec).Build()
 
-	found, err := FromSecret(ctx, client, clusterKey)
+	found, err := FromSecret(ctx, cl, clusterKey)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(found).To(Equal(validSecret.Data[secret.KubeconfigDataName]))
 }

--- a/util/util.go
+++ b/util/util.go
@@ -421,13 +421,13 @@ func HasOwner(refList []metav1.OwnerReference, apiVersion string, kinds []string
 //
 // This function is greatly more efficient than GetCRDWithContract and should be preferred in most cases.
 func GetGVKMetadata(ctx context.Context, c client.Client, gvk schema.GroupVersionKind) (*metav1.PartialObjectMetadata, error) {
-	meta := &metav1.PartialObjectMetadata{}
-	meta.SetName(fmt.Sprintf("%s.%s", flect.Pluralize(strings.ToLower(gvk.Kind)), gvk.Group))
-	meta.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
-	if err := c.Get(ctx, client.ObjectKeyFromObject(meta), meta); err != nil {
-		return meta, errors.Wrap(err, "failed to retrieve metadata from GVK resource")
+	metadata := &metav1.PartialObjectMetadata{}
+	metadata.SetName(fmt.Sprintf("%s.%s", flect.Pluralize(strings.ToLower(gvk.Kind)), gvk.Group))
+	metadata.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	if err := c.Get(ctx, client.ObjectKeyFromObject(metadata), metadata); err != nil {
+		return metadata, errors.Wrap(err, "failed to retrieve metadata from GVK resource")
 	}
-	return meta, nil
+	return metadata, nil
 }
 
 // GetCRDWithContract retrieves a list of CustomResourceDefinitions from using controller-runtime Client,

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -293,7 +293,7 @@ func TestIsOwnedByObject(t *testing.T) {
 	targetKind := "Rainbow"
 	targetName := "fri3ndsh1p"
 
-	meta := fakeMeta{
+	metaData := fakeMeta{
 		metav1.ObjectMeta{
 			Name: targetName,
 		},
@@ -386,7 +386,7 @@ func TestIsOwnedByObject(t *testing.T) {
 				OwnerReferences: test.refs,
 			}
 
-			g.Expect(IsOwnedByObject(pointer, &meta)).To(Equal(test.expected), "Could not find a ref to %+v in %+v", meta, test.refs)
+			g.Expect(IsOwnedByObject(pointer, &metaData)).To(Equal(test.expected), "Could not find a ref to %+v in %+v", metaData, test.refs)
 		})
 	}
 }
@@ -686,8 +686,8 @@ func TestClusterToObjectsMapper(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		restMapper.Add(gvk, meta.RESTScopeNamespace)
 
-		client := fake.NewClientBuilder().WithObjects(tc.objects...).WithRESTMapper(restMapper).Build()
-		f, err := ClusterToObjectsMapper(client, tc.input, scheme)
+		cl := fake.NewClientBuilder().WithObjects(tc.objects...).WithRESTMapper(restMapper).Build()
+		f, err := ClusterToObjectsMapper(cl, tc.input, scheme)
 		g.Expect(err != nil, err).To(Equal(tc.expectError))
 		g.Expect(f(cluster)).To(ConsistOf(tc.output))
 	}


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Enable the gocritic importshadow linter in .golangci-lint and fix the issues it found. These issues are all places where a local variable is declared with the same name as an imported package which could lead to unexpected (and harder to review) behaviour if the type and the package shared the same Function call. 

Many of these changes are standard e.g. 
* container -> ctnt 
* labels -> lbls
* context -> ctx
* version -> vrsn
