### PR TITLE
✨ [WIP] Add defaulting and remove required for MachineHealthCheck UnhealthyConditions

### DIFF
--- a/api/v1beta1/machinehealthcheck_types.go
+++ b/api/v1beta1/machinehealthcheck_types.go
@@ -38,6 +38,7 @@ type MachineHealthCheckSpec struct {
 	// logical OR, i.e. if any of the conditions is met, the node is unhealthy.
 	//
 	// +kubebuilder:validation:MinItems=1
+	// +optional
 	UnhealthyConditions []UnhealthyCondition `json:"unhealthyConditions"`
 
 	// Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by

--- a/api/v1beta1/machinehealthcheck_webhook.go
+++ b/api/v1beta1/machinehealthcheck_webhook.go
@@ -18,7 +18,10 @@ package v1beta1
 
 import (
 	"fmt"
+	"log"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +42,23 @@ var (
 	minNodeStartupTimeout = metav1.Duration{Duration: 30 * time.Second}
 	// We allow users to disable the nodeStartupTimeout by setting the duration to 0.
 	disabledNodeStartupTimeout = ZeroDuration
+
+	defaultUnhealthyConditions = []UnhealthyCondition{
+		{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionUnknown,
+			Timeout: metav1.Duration{
+				Duration: 300 * time.Second,
+			},
+		},
+		{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionFalse,
+			Timeout: metav1.Duration{
+				Duration: 300 * time.Second,
+			},
+		},
+	}
 )
 
 // SetMinNodeStartupTimeout allows users to optionally set a custom timeout
@@ -80,6 +100,11 @@ func (m *MachineHealthCheck) Default() {
 
 	if m.Spec.RemediationTemplate != nil && m.Spec.RemediationTemplate.Namespace == "" {
 		m.Spec.RemediationTemplate.Namespace = m.Namespace
+	}
+
+	log.Print("HERES WHAT IT LOOKS LIKE", m.Spec)
+	if m.Spec.UnhealthyConditions == nil || len(m.Spec.UnhealthyConditions) == 0 {
+		m.Spec.UnhealthyConditions = defaultUnhealthyConditions
 	}
 }
 

--- a/cmd/clusterctl/config/manifest/clusterctl-api.yaml
+++ b/cmd/clusterctl/config/manifest/clusterctl-api.yaml
@@ -36,10 +36,14 @@ spec:
         description: Provider defines an entry in the provider inventory.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -47,13 +51,18 @@ spec:
             description: ProviderName indicates the name of the provider.
             type: string
           type:
-            description: Type indicates the type of the provider. See ProviderType for a list of supported values
+            description: Type indicates the type of the provider. See ProviderType
+              for a list of supported values
             type: string
           version:
             description: Version indicates the component version.
             type: string
           watchedNamespace:
-            description: 'WatchedNamespace indicates the namespace where the provider controller is is watching. if empty the provider controller is watching for objects in all namespaces. Deprecated: in clusterctl v1alpha4 all the providers watch all the namespaces; this field will be removed in a future version of this API'
+            description: 'WatchedNamespace indicates the namespace where the provider
+              controller is is watching. if empty the provider controller is watching
+              for objects in all namespaces. Deprecated: in clusterctl v1alpha4 all
+              the providers watch all the namespaces; this field will be removed in
+              a future version of this API'
             type: string
         type: object
     served: true

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -723,7 +723,6 @@ spec:
             required:
             - clusterName
             - selector
-            - unhealthyConditions
             type: object
           status:
             description: Most recently observed status of MachineHealthCheck resource


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add defaulting for UnhealthConditions when creating a MachineHealthCheck and remove the required validation for it in webhook.  After this change MachineHealthChecks that don't have any HealthConditions defined will be created with:  
```

  unhealthyConditions:
  - type: Ready
    status: Unknown
    timeout: 300s
  - type: Ready
    status: False
    timeout: 300s

```