### PR TITLE
WIP: ✨ FailureDomain support in MachineDeployment/MachineSet

### DIFF
--- a/api/v1beta1/machineset_types.go
+++ b/api/v1beta1/machineset_types.go
@@ -110,6 +110,12 @@ const (
 	// (Status.FailureReason or Status.FailureMessage are set to a non-empty value).
 	// It then prioritizes the oldest Machines for deletion based on the Machine's CreationTimestamp.
 	OldestMachineSetDeletePolicy MachineSetDeletePolicy = "Oldest"
+
+	// FailureDomainMachineSetDeletePolicy prioritizes both Machines that have the annotation
+	// "cluster.x-k8s.io/delete-machine=yes" and Machines that are unhealthy
+	// (Status.FailureReason or Status.FailureMessage are set to a non-empty value).
+	// It then prioritizes the Machines for deletion  from failuredomain(s) that have the most machines.
+	FailureDomainMachineSetDeletePolicy MachineSetDeletePolicy = "FailureDomain"
 )
 
 // ANCHOR: MachineSetStatus

--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -279,7 +279,7 @@ func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, cluster
 
 	// If the infrastructure provider is not ready, return early.
 	if !ready {
-		log.Info("Infrastructure provider is not ready, requeuing")
+		log.Info("Infrastructure provider machine is not ready, requeuing")
 		return ctrl.Result{RequeueAfter: externalReadyWait}, nil
 	}
 
@@ -298,6 +298,8 @@ func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, cluster
 	}
 
 	// Get and set the failure domain from the infrastructure provider.
+	// TODO (awander): According to the docs this behavior predates v1alpha3. Should this be removed?
+	// https://cluster-api.sigs.k8s.io/developer/providers/machine-infrastructure.html?highlight=failuredomain#data-types
 	var failureDomain string
 	err = util.UnstructuredUnmarshalField(infraConfig, &failureDomain, "spec", "failureDomain")
 	switch {


### PR DESCRIPTION
**What this PR does / why we need it**:

Brings FailureDomain support to MachineDeployment/MachineSet
 * Scale up: will now balance Machines across FDs.
 * Scale down: a new MachineSet Deletion Policy for FDs is introduced.
   It enables the removal of Machines in a balanced fashion across FDs
   by picking machines from the most populated FD(s).

Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/5666
