### PR TITLE
🐛 Prevent orphaned InfrastructureMachines

### DIFF
--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -371,6 +371,12 @@ func (r *MachineSetReconciler) syncReplicas(ctx context.Context, ms *clusterv1.M
 					Namespace:   machine.Namespace,
 					ClusterName: machine.Spec.ClusterName,
 					Labels:      machine.Labels,
+					OwnerRef: &metav1.OwnerReference{
+						APIVersion: clusterv1.GroupVersion.String(),
+						Kind:       "MachineSet",
+						Name:       ms.Name,
+						UID:        ms.UID,
+					},
 				})
 				if err != nil {
 					conditions.MarkFalse(ms, clusterv1.MachinesCreatedCondition, clusterv1.BootstrapTemplateCloningFailedReason, clusterv1.ConditionSeverityError, err.Error())
@@ -386,6 +392,12 @@ func (r *MachineSetReconciler) syncReplicas(ctx context.Context, ms *clusterv1.M
 				ClusterName: machine.Spec.ClusterName,
 				Labels:      machine.Labels,
 				Annotations: machine.Annotations,
+				OwnerRef: &metav1.OwnerReference{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "MachineSet",
+					Name:       ms.Name,
+					UID:        ms.UID,
+				},
 			})
 			if err != nil {
 				conditions.MarkFalse(ms, clusterv1.MachinesCreatedCondition, clusterv1.InfrastructureTemplateCloningFailedReason, clusterv1.ConditionSeverityError, err.Error())


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a backport of https://github.com/kubernetes-sigs/cluster-api/pull/5865

The same commit has been already backported to release-1.0 branch via https://github.com/kubernetes-sigs/cluster-api/pull/5875
