### PR TITLE
✨ clusterctl alpha topology-dryrun

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -89,6 +89,8 @@ type AlphaClient interface {
 	RolloutResume(options RolloutOptions) error
 	// RolloutUndo provides rollout rollback of cluster-api resources
 	RolloutUndo(options RolloutOptions) error
+	// DryRunTopology dry runs the topology reconciler
+	DryRunTopology(options DryRunOptions) (*cluster.DryRunOutput, error)
 }
 
 // YamlPrinter exposes methods that prints the processed template and

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -148,6 +148,10 @@ func (f fakeClient) RolloutUndo(options RolloutOptions) error {
 	return f.internalClient.RolloutUndo(options)
 }
 
+func (f fakeClient) DryRunTopology(options DryRunOptions) (*cluster.DryRunOutput, error) {
+	return f.internalClient.DryRunTopology(options)
+}
+
 // newFakeClient returns a clusterctl client that allows to execute tests on a set of fake config, fake repositories and fake clusters.
 // you can use WithCluster and WithRepository to prepare for the test case.
 func newFakeClient(configClient config.Client) *fakeClient {
@@ -316,6 +320,10 @@ func (f *fakeClusterClient) Template() cluster.TemplateClient {
 
 func (f *fakeClusterClient) WorkloadCluster() cluster.WorkloadCluster {
 	return f.internalclient.WorkloadCluster()
+}
+
+func (f *fakeClusterClient) Topology() cluster.TopologyClient {
+	return f.internalclient.Topology()
 }
 
 func (f *fakeClusterClient) WithObjs(objs ...client.Object) *fakeClusterClient {

--- a/cmd/clusterctl/client/cluster/assets/topology-test/existing-clusterclass-and-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/existing-clusterclass-and-cluster.yaml
@@ -1,0 +1,267 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: dockerclusters.infrastructure.cluster.x-k8s.io
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: dockerclustertemplates.infrastructure.cluster.x-k8s.io
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: dockermachinetemplates.infrastructure.cluster.x-k8s.io
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: my-cluster-class
+  namespace: default
+spec:
+  controlPlane:
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: control-plane
+      namespace: default
+    machineInfrastructure:
+      ref:
+        kind: DockerMachineTemplate
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        name: "control-plane"
+        namespace: default
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerClusterTemplate
+      name: my-cluster
+      namespace: default
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerClusterTemplate
+metadata:
+  name: my-cluster
+  namespace: default
+spec:
+  template:
+    spec: {}
+---
+kind: KubeadmControlPlaneTemplate
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "control-plane"
+  namespace: default
+spec:
+  template:
+    spec:
+      replicas: 1
+      machineTemplate:
+        nodeDrainTimeout: 1s
+        infrastructureRef:
+          kind: DockerMachineTemplate
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          name: "control-plane"
+          namespace: default
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          controllerManager:
+            extraArgs: { enable-hostpath-provisioner: 'true' }
+          apiServer:
+            certSANs: [ localhost, 127.0.0.1 ]
+        initConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+              # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+              cgroup-driver: cgroupfs
+              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+        joinConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+              # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+              cgroup-driver: cgroupfs
+              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+      version: v1.21.2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: "control-plane"
+  namespace: default
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: "/var/run/docker.sock"
+        hostPath: "/var/run/docker.sock"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "my-cluster"
+  namespace: default
+  labels:
+    cni: kindnet
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ["10.128.0.0/12"]
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+    serviceDomain: "cluster.local"
+  controlPlaneEndpoint:
+    host: 172.19.0.4
+    port: 6443
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: my-cluster-fwbpf
+    namespace: default
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerCluster
+    name: my-cluster-zrq96
+    namespace: default
+  topology:
+    class: my-cluster-class
+    version: v1.21.2
+    controlPlane:
+      metadata: {}
+      replicas: 1
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerCluster
+metadata:
+  annotations:
+    cluster.x-k8s.io/cloned-from-groupkind: DockerClusterTemplate.infrastructure.cluster.x-k8s.io
+    cluster.x-k8s.io/cloned-from-name: my-cluster
+  finalizers:
+    - dockercluster.infrastructure.cluster.x-k8s.io
+  labels:
+    cluster.x-k8s.io/cluster-name: my-cluster
+    topology.cluster.x-k8s.io/owned: ""
+  name: my-cluster-zrq96
+  namespace: default
+spec:
+  controlPlaneEndpoint:
+    host: 172.19.0.4
+    port: 6443
+  loadBalancer: {}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  annotations:
+    cluster.x-k8s.io/cloned-from-groupkind: KubeadmControlPlaneTemplate.controlplane.cluster.x-k8s.io
+    cluster.x-k8s.io/cloned-from-name: control-plane
+  finalizers:
+    - kubeadm.controlplane.cluster.x-k8s.io
+  labels:
+    cluster.x-k8s.io/cluster-name: my-cluster
+    topology.cluster.x-k8s.io/owned: ""
+  name: my-cluster-fwbpf
+  namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: my-cluster
+      uid: 3ba5ce4f-d279-4edb-8ade-62a2381d11a8
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+          - localhost
+          - 127.0.0.1
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+      dns: {}
+      etcd: {}
+      networking: {}
+      scheduler: {}
+    initConfiguration:
+      localAPIEndpoint: {}
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    joinConfiguration:
+      discovery: {}
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerMachineTemplate
+      name: my-cluster-control-plane-44cd4
+      namespace: default
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: my-cluster
+        topology.cluster.x-k8s.io/owned: ""
+    nodeDrainTimeout: 1s
+  replicas: 1
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 1
+    type: RollingUpdate
+  version: v1.21.2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  annotations:
+    cluster.x-k8s.io/cloned-from-groupkind: DockerMachineTemplate.infrastructure.cluster.x-k8s.io
+    cluster.x-k8s.io/cloned-from-name: control-plane
+  labels:
+    cluster.x-k8s.io/cluster-name: my-cluster
+    topology.cluster.x-k8s.io/owned: ""
+  name: my-cluster-control-plane-44cd4
+  namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      kind: Cluster
+      name: my-cluster
+      uid: 3ba5ce4f-d279-4edb-8ade-62a2381d11a8
+spec:
+  template:
+    spec:
+      extraMounts:
+        - containerPath: /var/run/docker.sock
+          hostPath: /var/run/docker.sock

--- a/cmd/clusterctl/client/cluster/assets/topology-test/modified-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/modified-cluster.yaml
@@ -1,0 +1,20 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "my-cluster"
+  namespace: default
+  labels:
+    cni: kindnet
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ["10.128.0.0/12"]
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+    serviceDomain: "cluster.local"
+  topology:
+    class: my-cluster-class
+    version: v1.21.2
+    controlPlane:
+      metadata: {}
+      replicas: 3

--- a/cmd/clusterctl/client/cluster/assets/topology-test/new-clusterclass-and-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/new-clusterclass-and-cluster.yaml
@@ -1,0 +1,170 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: my-cluster-class
+  namespace: default
+spec:
+  controlPlane:
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: control-plane
+      namespace: default
+    machineInfrastructure:
+      ref:
+        kind: DockerMachineTemplate
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        name: "control-plane"
+        namespace: default
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerClusterTemplate
+      name: my-cluster
+      namespace: default
+  workers:
+    machineDeployments:
+    - class: "default-worker"
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: docker-worker-bootstraptemplate
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachineTemplate
+            name: docker-worker-machinetemplate
+    - class: "default-worker-2"
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: docker-worker-bootstraptemplate
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachineTemplate
+            name: docker-worker-machinetemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerClusterTemplate
+metadata:
+  name: my-cluster
+  namespace: default
+spec:
+  template:
+    spec: {}
+---
+kind: KubeadmControlPlaneTemplate
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "control-plane"
+  namespace: default
+spec:
+  template:
+    spec:
+      replicas: 1
+      machineTemplate:
+        nodeDrainTimeout: 1s
+        infrastructureRef:
+          kind: DockerMachineTemplate
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+          name: "control-plane"
+          namespace: default
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          controllerManager:
+            extraArgs: { enable-hostpath-provisioner: 'true' }
+          apiServer:
+            certSANs: [ localhost, 127.0.0.1 ]
+        initConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+              # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+              cgroup-driver: cgroupfs
+              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+        joinConfiguration:
+          nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+              # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+              cgroup-driver: cgroupfs
+              eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+      version: v1.21.2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: "control-plane"
+  namespace: default
+spec:
+  template:
+    spec:
+      preLoadImages: 
+      - gcr.io/kakaraparthy-devel/kindest/kindnetd:0.5.4
+      extraMounts:
+      - containerPath: "/var/run/docker.sock"
+        hostPath: "/var/run/docker.sock"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata:
+  name: "docker-worker-machinetemplate"
+  namespace: default
+spec:
+  template:
+    spec:
+      preLoadImages: 
+      - gcr.io/kakaraparthy-devel/kindest/kindnetd:0.5.4
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "docker-worker-bootstraptemplate"
+  namespace: default
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+            cgroup-driver: cgroupfs
+            eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "my-cluster"
+  namespace: default
+  labels:
+    cni: kindnet
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ["10.128.0.0/12"]
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+    serviceDomain: "cluster.local"
+  topology:
+    class: my-cluster-class
+    version: v1.21.2
+    controlPlane:
+      metadata: {}
+      replicas: 1
+    workers:
+      machineDeployments:
+      - class: "default-worker"
+        name: "md-0"
+        replicas: 1
+      - class: "default-worker"
+        name: "md-1"
+        replicas: 1

--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -87,6 +87,9 @@ type Client interface {
 
 	// WorkloadCluster has methods for fetching kubeconfig of workload cluster from management cluster.
 	WorkloadCluster() WorkloadCluster
+
+	// Topology returns a TopologyClient that can be used for performing dry run executions of the topology reconciler.
+	Topology() TopologyClient
 }
 
 // PollImmediateWaiter tries a condition func until it returns true, an error, or the timeout is reached.
@@ -146,6 +149,10 @@ func (c *clusterClient) Template() TemplateClient {
 
 func (c *clusterClient) WorkloadCluster() WorkloadCluster {
 	return newWorkloadCluster(c.proxy)
+}
+
+func (c *clusterClient) Topology() TopologyClient {
+	return newTopologyClient(c.proxy, c.ProviderInventory())
 }
 
 // Option is a configuration option supplied to New.

--- a/cmd/clusterctl/client/cluster/internal/dryrun/client.go
+++ b/cmd/clusterctl/client/cluster/internal/dryrun/client.go
@@ -1,0 +1,400 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dryrun
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/scheme"
+)
+
+var (
+	localScheme = scheme.Scheme
+)
+
+// changeTrackerID represents a unique identifier of an object.
+type changeTrackerID struct {
+	gvk schema.GroupVersionKind
+	key client.ObjectKey
+}
+
+type operationType string
+
+const (
+	// Represents that a new object is created.
+	opCreate operationType = "create"
+
+	// Represents that the object is modified.
+	// This could be a result of performing Patch or Update or delete and re-create operations on the object.
+	opModify operationType = "modify"
+
+	// Represents that the object is deleted.
+	opDelete operationType = "delete"
+)
+
+// operation represents the final effective operation and the original object (initial state) associated
+// with the operation.
+type operation struct {
+	originalValue client.Object
+	operation     operationType
+}
+
+// changeTracker is used to track the operations performed on the objects.
+// changeTracker flattens all operations performed on the same object and
+// only tracks the final effective operation on the object when compared to
+// the initial state. Example: If an object is created and later modified
+// it is only tracked as created (effective final operation).
+//
+// While changeTracker tracks the operations on objects using unique object identifiers
+// ChangeSummary reports all the operations and the final state of objects. ChangeSummary
+// is calculated using changeTracker and fake client.
+type changeTracker struct {
+	changes map[changeTrackerID]*operation
+}
+
+// Client implements a dry run Client, that is a fake.Client that logs write operations.
+type Client struct {
+	fakeClient client.Client
+	apiReader  client.Reader
+
+	changeTracker *changeTracker
+}
+
+// PatchSummary defines the patch observed on an object.
+type PatchSummary struct {
+	// Initial state of the object.
+	Before *unstructured.Unstructured
+	// Final state of the object.
+	After *unstructured.Unstructured
+}
+
+// ChangeSummary defines all the changes detected by the Dryrun execution.
+// Nb. Only a single operation is reported for each object, flattening operations
+// to show difference between the initial and final states.
+type ChangeSummary struct {
+	// Created is the list of objects that are created during the dry run execution.
+	Created []*unstructured.Unstructured
+
+	// Modified is the list of summary of objects that are modified (Updated, Patched and/or deleted and re-created) during the dry run execution.
+	Modified []*PatchSummary
+
+	// Deleted is the list of objects that are deleted during the dry run execution.
+	Deleted []*unstructured.Unstructured
+}
+
+// NewClient returns a new dry run Client.
+// A dry run client mocks interactions with an api server using a fake internal object tracker.
+// The objects passed will be used to initialize the fake internal object tracker when creating a new dry run client.
+// If an apiReader client is passed the dry run client will use it as a fall back client for read operations (Get, List)
+// when the objects are not found in the internal object tracker. Typically the apiReader passed would be a reader client
+// to a real Kubernetes Cluster.
+func NewClient(apiReader client.Reader, objs []client.Object) *Client {
+	fakeClient := fake.NewClientBuilder().WithObjects(objs...).WithScheme(localScheme).Build()
+	return &Client{
+		fakeClient: fakeClient,
+		apiReader:  apiReader,
+		changeTracker: &changeTracker{
+			changes: map[changeTrackerID]*operation{},
+		},
+	}
+}
+
+// Get retrieves an object for the given object key from the internal object tracker.
+// If the object does not exist in the internal object tracker it tries to fetch the object
+// from the Kubernetes Cluster using the apiReader client (if apiReader is not nil).
+func (c *Client) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	if err := c.fakeClient.Get(ctx, key, obj); err != nil {
+		// If the object is not found by the fake client, get the object
+		// using the apiReader.
+		if apierrors.IsNotFound(err) && c.apiReader != nil {
+			return c.apiReader.Get(ctx, key, obj)
+		}
+		return err
+	}
+	return nil
+}
+
+// List retrieves list of objects for a given namespace and list options.
+// List function returns the union of the lists from the internal object tracker and the Kubernetes Cluster.
+// Nb. For objects that exist both in the internal object tracker and the Kubernetes Cluster, internal object tracker
+// takes precedence.
+func (c *Client) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	var gvk schema.GroupVersionKind
+	if uList, ok := list.(*unstructured.UnstructuredList); ok {
+		gvk = uList.GroupVersionKind()
+	} else {
+		var err error
+		gvk, err = apiutil.GVKForObject(list, c.fakeClient.Scheme())
+		if err != nil {
+			return errors.Wrap(err, "failed to get GVK of target object")
+		}
+	}
+
+	// Fetch lists from both fake client and the apiReader and merge the two lists.
+	unstructuredFakeList := &unstructured.UnstructuredList{}
+	unstructuredFakeList.SetGroupVersionKind(gvk)
+	if err := c.fakeClient.List(ctx, unstructuredFakeList, opts...); err != nil {
+		return err
+	}
+	if c.apiReader != nil {
+		unstructuredReaderList := &unstructured.UnstructuredList{}
+		unstructuredReaderList.SetGroupVersionKind(gvk)
+		if err := c.apiReader.List(ctx, unstructuredReaderList, opts...); err != nil {
+			return err
+		}
+		mergeLists(unstructuredFakeList, unstructuredReaderList)
+	}
+
+	if err := c.Scheme().Convert(unstructuredFakeList, list, nil); err != nil {
+		return errors.Wrapf(err, "failed to convert unstructured list to %T", list)
+	}
+	return nil
+}
+
+// Create saves the object in the internal object tracker.
+func (c *Client) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	err := c.fakeClient.Create(ctx, obj, opts...)
+	if err == nil {
+		id := trackerIDFor(obj)
+		// If the object was previously deleted, it is now being re-created. Effectively it is a modify operation
+		// on the object.
+		if op, ok := c.changeTracker.changes[id]; ok {
+			if op.operation == opDelete {
+				op.operation = opModify
+			}
+		} else {
+			// This is the first operation on this object. Track the create operation.
+			c.changeTracker.changes[id] = &operation{
+				operation: opCreate,
+			}
+		}
+	}
+	return err
+}
+
+// Delete deletes the given obj from internal object tracker.
+// Delete will not affect objects in the Kubernetes Cluster.
+func (c *Client) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	err := c.fakeClient.Delete(ctx, obj, opts...)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		if c.apiReader == nil {
+			return err
+		}
+		// It is possible that we are trying to delete an object that exists in the Kubernetes Cluster but
+		// not in the internal object tracker.
+		// In such cases, check if the underlying object exists and if the object does
+		// not exist return the original error.
+		tmpObj := obj.DeepCopyObject().(client.Object)
+		if getErr := c.apiReader.Get(ctx, client.ObjectKeyFromObject(obj), tmpObj); getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				// Delete was called on an object that does no exists in the internal object tracker and in the
+				// Kubernetes Cluster. Return error.
+				// Note: return the original delete error. Not the get error.
+				return err
+			}
+			return errors.Wrap(err, "failed to check if object exists in underlying cluster")
+		}
+	}
+	// If the object is already tracked under a different operation we need to adjust the effective
+	// operation using the following rules:
+	// - If the object is tracked as created, drop the tracking. Effective operation is object never existed.
+	// - If the object is tracked in modified, change to deleted. Effective operation is object is deleted.
+	id := trackerIDFor(obj)
+	if op, ok := c.changeTracker.changes[id]; ok {
+		if op.operation == opCreate {
+			delete(c.changeTracker.changes, id)
+		}
+		if op.operation == opModify {
+			op.operation = opDelete
+		}
+	} else {
+		// The object is observed for the first time.
+		// Track the delete operation on the object.
+		c.changeTracker.changes[id] = &operation{
+			originalValue: obj,
+			operation:     opDelete,
+		}
+	}
+	return nil
+}
+
+// Update updates the given obj in the internal object tracker.
+// NOTE: Topology reconciler does not use update, so we are skipping implementation for now.
+func (c *Client) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	panic("Update method is not supported by the dryrun client")
+}
+
+// Patch patches the given obj in the internal object tracker.
+// The patch operation will be tracked if the object does not exist in the internal object tracker but exists in the Kubernetes Cluster.
+func (c *Client) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	originalObj := obj.DeepCopyObject().(client.Object)
+	// The fake client Patch operation internally makes a Get call. Therefore,
+	// create the object if it does not exist in the fake object tracker using the fake client.
+	// Note: Because of this operation we will nullify any real errors caused by calling Patch on an object that does no exist.
+	// Such cases can only occur because of bugs in reconciler. The dry run operation is not meant to capture bugs in the reconciler
+	// hence we choose to ignore such edge cases.
+	if err := c.ensureObjInFakeClient(ctx, obj); err != nil {
+		return errors.Wrap(err, "failed to ensure object is available in fake object tracker")
+	}
+	err := c.fakeClient.Patch(ctx, obj, patch, opts...)
+	if err == nil {
+		id := trackerIDFor(obj)
+		// If the object is not already tracked, track the modify operation.
+		// If the object is already tracked we don't need to perform any further action because of the following:
+		// - Tracked as created - created takes precedence over modified.
+		// - Tracked as modified - the object is already tracked with the correct operation.
+		// - Tracked as deleted - case not possible. Object cannot be patched after it is deleted.
+		if _, ok := c.changeTracker.changes[id]; !ok {
+			c.changeTracker.changes[id] = &operation{
+				originalValue: originalObj,
+				operation:     opModify,
+			}
+		}
+	}
+	return err
+}
+
+// DeleteAllOf deletes all objects of the given type matching the given options.
+// NOTE: Topology reconciler does not use DeleteAllOf, so we are skipping implementation for now.
+func (c *Client) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	panic("DeleteAllOf method is not supported by the dryrun client")
+}
+
+// Status returns a client which can update the status subresource for Kubernetes objects.
+func (c *Client) Status() client.StatusWriter {
+	return c.fakeClient.Status()
+}
+
+// Scheme returns the scheme this client is using.
+func (c *Client) Scheme() *runtime.Scheme {
+	return c.fakeClient.Scheme()
+}
+
+// RESTMapper returns the rest this client is using.
+func (c *Client) RESTMapper() meta.RESTMapper {
+	return c.fakeClient.RESTMapper()
+}
+
+// Changes generates a summary of all the changes observed from the creation of the dry run client
+// to when this function is called.
+func (c *Client) Changes(ctx context.Context) (*ChangeSummary, error) {
+	changes := &ChangeSummary{
+		Created:  []*unstructured.Unstructured{},
+		Modified: []*PatchSummary{},
+		Deleted:  []*unstructured.Unstructured{},
+	}
+
+	for id, op := range c.changeTracker.changes {
+		switch op.operation {
+		case opCreate:
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(id.gvk)
+			obj.SetNamespace(id.key.Namespace)
+			obj.SetName(id.key.Name)
+			if err := c.fakeClient.Get(ctx, id.key, obj); err != nil {
+				return nil, errors.Wrapf(err, "failed to read created object %s", id.key.String())
+			}
+			changes.Created = append(changes.Created, obj)
+		case opModify:
+			// Get the final object.
+			after := &unstructured.Unstructured{}
+			after.SetGroupVersionKind(id.gvk)
+			after.SetNamespace(id.key.Namespace)
+			after.SetName(id.key.Name)
+			if err := c.fakeClient.Get(ctx, id.key, after); err != nil {
+				return nil, errors.Wrapf(err, "failed to read modified object %s", id.key.String())
+			}
+			// Get the initial object.
+			before := &unstructured.Unstructured{}
+			if err := c.Scheme().Convert(op.originalValue, before, nil); err != nil {
+				return nil, errors.Wrapf(err, "failed to convert %s to unstructured", client.ObjectKeyFromObject(op.originalValue).String())
+			}
+			changes.Modified = append(changes.Modified, &PatchSummary{
+				Before: before,
+				After:  after,
+			})
+		case opDelete:
+			obj := &unstructured.Unstructured{}
+			if err := c.Scheme().Convert(op.originalValue, obj, nil); err != nil {
+				return nil, errors.Wrapf(err, "failed to convert %s to unstructured", client.ObjectKeyFromObject(op.originalValue).String())
+			}
+			changes.Deleted = append(changes.Deleted, obj)
+		default:
+			return nil, fmt.Errorf("untracked operation detected")
+		}
+	}
+
+	return changes, nil
+}
+
+// ensureObjInFakeClient makes sure that the object is available in the fake client.
+// If the object is not already available it will add it to the fake client by running a "Create"
+// operation.
+func (c *Client) ensureObjInFakeClient(ctx context.Context, obj client.Object) error {
+	o := obj.DeepCopyObject().(client.Object)
+	// During create object should not have resourceVersion.
+	o.SetResourceVersion("")
+	if err := c.fakeClient.Create(ctx, o); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// If the object already exists it is okay for create to fail.
+			return nil
+		}
+		return errors.Wrap(err, "failed to add object to fake object tracker")
+	}
+	return nil
+}
+
+// mergeLists merges the 2 lists a and b by adding every item in b
+// that is not in a to list a.
+// List a will be merged list.
+func mergeLists(a, b *unstructured.UnstructuredList) {
+	keyGen := func(u *unstructured.Unstructured) string {
+		return fmt.Sprintf("%s-%s", u.GroupVersionKind().String(), client.ObjectKeyFromObject(u).String())
+	}
+	keys := map[string]bool{}
+	// Generate all unique keys for the items in list a.
+	for i := range a.Items {
+		keys[keyGen(&a.Items[i])] = true
+	}
+	// For every item in b that is not in a add it to a.
+	for i := range b.Items {
+		if _, ok := keys[keyGen(&b.Items[i])]; !ok {
+			a.Items = append(a.Items, b.Items[i])
+		}
+	}
+}
+
+func trackerIDFor(o client.Object) changeTrackerID {
+	return changeTrackerID{
+		gvk: o.GetObjectKind().GroupVersionKind(),
+		key: client.ObjectKeyFromObject(o),
+	}
+}

--- a/cmd/clusterctl/client/cluster/internal/dryrun/doc.go
+++ b/cmd/clusterctl/client/cluster/internal/dryrun/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,22 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package cmd
-
-import (
-	"github.com/spf13/cobra"
-)
-
-var alphaCmd = &cobra.Command{
-	Use:   "alpha",
-	Short: "Commands for features in alpha.",
-	Long:  `These commands correspond to alpha features in clusterctl.`,
-}
-
-func init() {
-	// Alpha commands should be added here.
-	alphaCmd.AddCommand(rolloutCmd)
-	alphaCmd.AddCommand(topologyDryRunCmd)
-
-	RootCmd.AddCommand(alphaCmd)
-}
+// Package dryrun implements clusterctl dryrun functionality.
+package dryrun

--- a/cmd/clusterctl/client/cluster/proxy.go
+++ b/cmd/clusterctl/client/cluster/proxy.go
@@ -111,7 +111,7 @@ func (k *proxy) CurrentNamespace() (string, error) {
 		return v.Namespace, nil
 	}
 
-	return "default", nil
+	return metav1.NamespaceDefault, nil
 }
 
 func (k *proxy) ValidateKubernetesVersion() error {

--- a/cmd/clusterctl/client/cluster/topology.go
+++ b/cmd/clusterctl/client/cluster/topology.go
@@ -1,0 +1,669 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/gobuffalo/flect"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/featuregate"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster/internal/dryrun"
+	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
+	"sigs.k8s.io/cluster-api/feature"
+	clustertopologycontroller "sigs.k8s.io/cluster-api/internal/controllers/topology/cluster"
+	"sigs.k8s.io/cluster-api/internal/webhooks"
+)
+
+const (
+	maxClusterPerInput        = 1
+	maxClusterClassesPerInput = 1
+)
+
+// TopologyClient has methods to work with ClusterClass and ManagedTopologies.
+type TopologyClient interface {
+	DryRun(in *DryRunInput) (*DryRunOutput, error)
+}
+
+// topologyClient implements TopologyClient.
+type topologyClient struct {
+	proxy           Proxy
+	inventoryClient InventoryClient
+}
+
+// ensure topologyClient implements TopologyClient.
+var _ TopologyClient = &topologyClient{}
+
+// newTopologyClient returns a TopologyClient.
+func newTopologyClient(proxy Proxy, inventoryClient InventoryClient) TopologyClient {
+	return &topologyClient{
+		proxy:           proxy,
+		inventoryClient: inventoryClient,
+	}
+}
+
+// DryRunInput defines the input for DryRun function.
+type DryRunInput struct {
+	Objs              []*unstructured.Unstructured
+	TargetClusterName string
+}
+
+// PatchSummary defined the patch observed on an object.
+type PatchSummary = dryrun.PatchSummary
+
+// ChangeSummary defines all the changes detected by the Dryrun execution.
+type ChangeSummary = dryrun.ChangeSummary
+
+// DryRunOutput defines the output of the DryRun function.
+type DryRunOutput struct {
+	// Clusters is the list clusters affected by the input.
+	Clusters []client.ObjectKey
+	// ClusterClasses is the list of clusters affected by the input.
+	ClusterClasses []client.ObjectKey
+	// ReconciledCluster is the cluster on which the topology reconciler loop is executed.
+	// If there is only one affected cluster then it becomes the ReconciledCluster. If not,
+	// the ReconciledCluster is chosen using addition information in the DryRunInput.
+	// ReconciledCluster can be empty if no single target cluster is provided.
+	ReconciledCluster client.ObjectKey
+	// ChangeSummary is the full list of changes (objects created, modified and deleted) observed
+	// on the ReconciledCluster. ChangeSummary is empty if ReconciledCluster is empty.
+	*ChangeSummary
+}
+
+// DryRun performs a dry run execution of the topology reconciler using the given inputs.
+// It returns a summary of the changes observed during the execution.
+func (t *topologyClient) DryRun(in *DryRunInput) (*DryRunOutput, error) {
+	ctx := context.TODO()
+	log := logf.Log
+
+	// Make sure the inputs are valid.
+	if err := t.validateInput(in); err != nil {
+		return nil, errors.Wrap(err, "input failed validation")
+	}
+
+	// If there is a reachable apiserver with CAPI installed fetch a client for the server.
+	// This client will be used as a fall back client when looking for objects that are not
+	// in the input.
+	// Example: This client will be used to fetch the underlying ClusterClass when the input
+	// only has a Cluster object.
+	var c client.Client
+	if err := t.proxy.CheckClusterAvailable(); err == nil {
+		if initialized, err := t.inventoryClient.CheckCAPIInstalled(); err == nil && initialized {
+			c, err = t.proxy.NewClient()
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to create a client to the cluster")
+			}
+			log.Info("Detected a cluster with Cluster API installed. Will use it to fetch missing objects.")
+		}
+	}
+
+	// Prepare the inputs for a dry run operation. This includes steps like setting missing namespaces on objects
+	// and adjusting cluster objects to reflect updated state.
+	if err := t.prepareInput(ctx, in, c); err != nil {
+		return nil, errors.Wrap(err, "failed preparing input")
+	}
+	// Run defaulting and validation on core CAPI objects - Cluster and ClusterClasses.
+	// This mimics the defaulting and validation webhooks that will run on the objects during a real execution.
+	// Running defaulting and validation on these objects helps to improve the UX of using the dry run operation.
+	// This is especially important when working with Clusters and ClusterClasses that use variable and patches.
+	if err := t.defaultAndValidate(ctx, in, c); err != nil {
+		return nil, errors.Wrap(err, "failed defaulting and validation on input objects")
+	}
+
+	objs := []client.Object{}
+	// Add all the objects from the input to the list used when initializing the dry run client.
+	for _, o := range in.Objs {
+		objs = append(objs, o)
+	}
+	// Add mock CRDs of all the provider objects in the input to the list used when initializing the dry run client.
+	// Adding these CRDs makes sure that UpdateReferenceAPIContract calls in the reconciler can work.
+	for _, o := range t.generateCRDs(in) {
+		objs = append(objs, o)
+	}
+
+	dryRunClient := dryrun.NewClient(c, objs)
+	// Calculate affected ClusterClasses.
+	affectedClusterClasses, err := t.affectedClusterClasses(ctx, in, dryRunClient)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed calculating affected ClusterClasses")
+	}
+	// Calculate affected Clusters.
+	affectedClusters, err := t.affectedClusters(ctx, in, dryRunClient)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed calculating affected Clusters")
+	}
+
+	res := &DryRunOutput{
+		Clusters:       affectedClusters,
+		ClusterClasses: affectedClusterClasses,
+		ChangeSummary:  &dryrun.ChangeSummary{},
+	}
+
+	// Calculate the target cluster object.
+	// Full changeset is only generated for the target cluster.
+	var targetCluster *client.ObjectKey
+	if in.TargetClusterName != "" {
+		// Check if the target cluster is among the list of affected clusters and use that
+		// as the target cluster.
+		if res := matchCluster(affectedClusters, in.TargetClusterName); res != nil {
+			targetCluster = res
+		} else {
+			return nil, fmt.Errorf("target cluster %q is not among the list of affected clusters", in.TargetClusterName)
+		}
+	} else if len(affectedClusters) == 1 {
+		// If no target cluster is specified and if there is only one affected cluster, use that as the target cluster.
+		targetCluster = &affectedClusters[0]
+	}
+
+	if targetCluster == nil {
+		// If there is no target cluster then return here. We will
+		// not generate a full change summary.
+		return res, nil
+	}
+
+	res.ReconciledCluster = *targetCluster
+	reconciler := &clustertopologycontroller.Reconciler{
+		Client:                    dryRunClient,
+		APIReader:                 dryRunClient,
+		UnstructuredCachingClient: dryRunClient,
+	}
+	reconciler.SetupForDryRun(&noOpRecorder{})
+	request := reconcile.Request{NamespacedName: *targetCluster}
+	// Run the topology reconciler.
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		return nil, errors.Wrap(err, "failed to dry run the topology controller")
+	}
+
+	changes, err := dryRunClient.Changes(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get changes made by the topology controller")
+	}
+	res.ChangeSummary = changes
+
+	return res, nil
+}
+
+// validateInput checks that the dryrun input does not violate any of the below expectations:
+// - no more than 1 cluster in the input.
+// - no more than 1 clusterclass in the input.
+func (t *topologyClient) validateInput(in *DryRunInput) error {
+	if len(uniqueNamespaces(in.Objs)) != 1 {
+		return fmt.Errorf("all the objects in the input should belong to the same namespace")
+	}
+	clusterCount, clusterClassCount := len(getClusters(in.Objs)), len(getClusterClasses(in.Objs))
+	if clusterCount > maxClusterPerInput || clusterClassCount > maxClusterClassesPerInput {
+		return fmt.Errorf(
+			"input should have at most %d Cluster(s) and at most %d ClusterClass(es). Found %d Cluster(s) and %d ClusterClass(es)",
+			maxClusterPerInput,
+			maxClusterClassesPerInput,
+			clusterCount,
+			clusterClassCount,
+		)
+	}
+	return nil
+}
+
+// prepareInput does the following on the input objects:
+// - Set the target namespace on the objects if not set (this operation is generally done by kubectl)
+// - Prepare cluster objects so that the state of the cluster, if modified, correctly represents
+//   the expected changes.
+func (t *topologyClient) prepareInput(ctx context.Context, in *DryRunInput, apiReader client.Reader) error {
+	if err := t.setMissingNamespaces(in); err != nil {
+		return errors.Wrap(err, "failed to set missing namespaces")
+	}
+
+	if err := t.prepareClusters(ctx, getClusters(in.Objs), apiReader); err != nil {
+		return errors.Wrap(err, "failed to prepare clusters")
+	}
+	return nil
+}
+
+// setMissingNamespaces sets the object to the current namespace on objects
+// that are missing the namespace field.
+func (t *topologyClient) setMissingNamespaces(in *DryRunInput) error {
+	currentNamespace := metav1.NamespaceDefault
+	// If a cluster is available use the current namespace as defined in its kubeconfig.
+	if err := t.proxy.CheckClusterAvailable(); err == nil {
+		currentNamespace, err = t.proxy.CurrentNamespace()
+		if err != nil {
+			return errors.Wrap(err, "failed to get current namespace")
+		}
+	}
+	for i := range in.Objs {
+		if in.Objs[i].GetNamespace() == "" {
+			in.Objs[i].SetNamespace(currentNamespace)
+		}
+	}
+	return nil
+}
+
+// prepareClusters does the following operations on each Cluster in the input.
+// - Check if the Cluster exists in the real apiserver.
+// - If the Cluster exists in the real apiserver we merge the object from the
+//   server with the object from the input. This final object correctly represents the
+//   modified cluster object.
+//   Note: We are using a simple 2-way merge to calculate the final object in this function
+//   to keep the function simple. In reality kubectl does a lot more. This function does not behave exactly
+//   the same way as kubectl does.
+// *Important note*: We do this above operation because the topology reconciler in a
+//   real run takes as input a cluster object from the apiserver that has merged spec of
+//   the changes in the input and the one stored in the server. For example: the cluster
+//   object in the input will not have cluster.spec.infrastructureRef and cluster.spec.controlPlaneRef
+//   but the merged object will have these fields set.
+func (t *topologyClient) prepareClusters(ctx context.Context, clusters []*unstructured.Unstructured, apiReader client.Reader) error {
+	if apiReader == nil {
+		// If there is no backing server there is nothing more to do here.
+		// Return early.
+		return nil
+	}
+
+	// For a Cluster check if it already exists in the server. If it does, get the object from the server
+	// and merge it with the Cluster from the file to get effective 'modified' Cluster.
+	for _, cluster := range clusters {
+		storedCluster := &clusterv1.Cluster{}
+		if err := apiReader.Get(
+			ctx,
+			client.ObjectKey{Namespace: cluster.GetNamespace(), Name: cluster.GetName()},
+			storedCluster,
+		); err != nil {
+			if apierrors.IsNotFound(err) {
+				// The Cluster does not exist in the server. Nothing more to do here.
+				continue
+			}
+			return errors.Wrapf(err, "failed to get Cluster %s/%s", cluster.GetNamespace(), cluster.GetName())
+		}
+		originalJSON, err := json.Marshal(storedCluster)
+		if err != nil {
+			return errors.Wrapf(err, "failed to convert Cluster %s/%s to json", storedCluster.Namespace, storedCluster.Name)
+		}
+		modifiedJSON, err := json.Marshal(cluster)
+		if err != nil {
+			return errors.Wrapf(err, "failed to convert Cluster %s/%s", cluster.GetNamespace(), cluster.GetName())
+		}
+		// Apply the modified object to the original one, merging the values of both;
+		// in case of conflicts, values from the modified object are preserved.
+		originalWithModifiedJSON, err := jsonpatch.MergePatch(originalJSON, modifiedJSON)
+		if err != nil {
+			return errors.Wrap(err, "failed to apply modified json to original json")
+		}
+		if err := json.Unmarshal(originalWithModifiedJSON, &cluster.Object); err != nil {
+			return errors.Wrap(err, "failed to convert modified json to object")
+		}
+	}
+	return nil
+}
+
+// defaultAndValidate runs the defaulting and validation webhooks on the
+// ClusterClass and Cluster objects in the input thus replicating the real kube-apiserver flow
+// when applied.
+// Nb. Perform ValidateUpdate only if the object is already in the cluster. In all other cases,
+// ValidateCreate is performed.
+// *Important Note*: We cannot perform defaulting and validation on provider objects as we do not have access to
+// that code.
+func (t *topologyClient) defaultAndValidate(ctx context.Context, in *DryRunInput, apiReader client.Reader) error {
+	// Enable the ClusterTopology feature gate so that the defaulter and validators do not complain.
+	// Note: We don't need to disable it later because the CLI is short lived.
+	if err := feature.Gates.(featuregate.MutableFeatureGate).Set(fmt.Sprintf("%s=%v", feature.ClusterTopology, true)); err != nil {
+		return errors.Wrapf(err, "failed to enable %s feature gate", feature.ClusterTopology)
+	}
+
+	// From the inputs gather all the objects that are not Clusters or ClusterClasses.
+	// These objects will be used when initializing a dryrun client to use in the webhooks.
+	filteredObjs := filterObjects(
+		in.Objs,
+		clusterv1.GroupVersion.WithKind("ClusterClass"),
+		clusterv1.GroupVersion.WithKind("Cluster"),
+	)
+	objs := []client.Object{}
+	for _, o := range filteredObjs {
+		objs = append(objs, o)
+	}
+	// Creating a dryrun client will a fall back to the apiReader client (client to the underlying Kubernetes cluster)
+	// allows the defaulting and validation webhooks to complete actions to could potentially depend on other objects in the cluster.
+	// Example: Validation of cluster objects will use the client to read ClusterClasses.
+	webhookClient := dryrun.NewClient(apiReader, objs)
+
+	// Run defaulting and validation on ClusterClasses.
+	ccWebhook := &webhooks.ClusterClass{Client: webhookClient}
+	if err := t.defaultAndValidateObjs(
+		ctx,
+		getClusterClasses(in.Objs),
+		&clusterv1.ClusterClass{},
+		ccWebhook,
+		ccWebhook,
+		apiReader,
+	); err != nil {
+		return errors.Wrap(err, "failed to run defaulting and validation on ClusterClasses")
+	}
+
+	// From the inputs gather all the objects that are not Clusters.
+	// These objects will be used when initializing a dryrun client to use in the webhooks.
+	// We want to keep ClusterClasses in the webhook client. This is because validation of
+	// Cluster objects might need access to ClusterClass objects that are in the input.
+	filteredObjs = filterObjects(
+		in.Objs,
+		clusterv1.GroupVersion.WithKind("Cluster"),
+	)
+	objs = []client.Object{}
+	for _, o := range filteredObjs {
+		objs = append(objs, o)
+	}
+	webhookClient = dryrun.NewClient(apiReader, objs)
+
+	// Run defaulting and validation on Clusters.
+	clusterWebhook := &webhooks.Cluster{Client: webhookClient}
+	if err := t.defaultAndValidateObjs(
+		ctx,
+		getClusters(in.Objs),
+		&clusterv1.Cluster{},
+		clusterWebhook,
+		clusterWebhook,
+		apiReader,
+	); err != nil {
+		return errors.Wrap(err, "failed to run defaulting and validation on Clusters")
+	}
+
+	return nil
+}
+
+func (t *topologyClient) defaultAndValidateObjs(ctx context.Context, objs []*unstructured.Unstructured, o client.Object, defaulter crwebhook.CustomDefaulter, validator crwebhook.CustomValidator, apiReader client.Reader) error {
+	for _, obj := range objs {
+		// The defaulter and validator need a typed object. Convert the unstructured obj to a typed object.
+		object := o.DeepCopyObject().(client.Object) // object here is a typed object.
+		if err := localScheme.Convert(obj, object, nil); err != nil {
+			return errors.Wrapf(err, "failed to convert object to %s", obj.GetKind())
+		}
+
+		// Perform Defaulting
+		if err := defaulter.Default(ctx, object); err != nil {
+			return errors.Wrapf(err, "failed defaulting of %s %s/%s", obj.GroupVersionKind().String(), obj.GetNamespace(), obj.GetName())
+		}
+
+		var oldObject client.Object
+		if apiReader != nil {
+			tmpObj := o.DeepCopyObject().(client.Object)
+			if err := apiReader.Get(ctx, client.ObjectKeyFromObject(obj), tmpObj); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return errors.Wrapf(err, "failed to get object %s %s/%s", obj.GroupVersionKind().String(), obj.GetNamespace(), obj.GetName())
+				}
+			} else {
+				oldObject = tmpObj
+			}
+		}
+		if oldObject != nil {
+			if err := validator.ValidateUpdate(ctx, oldObject, object); err != nil {
+				return errors.Wrapf(err, "failed validation of %s %s/%s", obj.GroupVersionKind().String(), obj.GetNamespace(), obj.GetName())
+			}
+		} else {
+			if err := validator.ValidateCreate(ctx, object); err != nil {
+				return errors.Wrapf(err, "failed validation of %s %s/%s", obj.GroupVersionKind().String(), obj.GetNamespace(), obj.GetName())
+			}
+		}
+
+		// Converted the defaulted and validated object back into unstructured.
+		// Note: This step also makes sure that modified object is updated into the
+		// original unstructured object.
+		if err := localScheme.Convert(object, obj, nil); err != nil {
+			return errors.Wrapf(err, "failed to convert %s to object", obj.GetKind())
+		}
+	}
+
+	return nil
+}
+
+func getClusterClasses(objs []*unstructured.Unstructured) []*unstructured.Unstructured {
+	res := make([]*unstructured.Unstructured, 0)
+	for _, obj := range objs {
+		if obj.GroupVersionKind() == clusterv1.GroupVersion.WithKind("ClusterClass") {
+			res = append(res, obj)
+		}
+	}
+	return res
+}
+
+func getClusters(objs []*unstructured.Unstructured) []*unstructured.Unstructured {
+	res := make([]*unstructured.Unstructured, 0)
+	for _, obj := range objs {
+		if obj.GroupVersionKind() == clusterv1.GroupVersion.WithKind("Cluster") {
+			res = append(res, obj)
+		}
+	}
+	return res
+}
+
+func getTemplates(objs []*unstructured.Unstructured) []*unstructured.Unstructured {
+	res := make([]*unstructured.Unstructured, 0)
+	for _, obj := range objs {
+		if strings.HasSuffix(obj.GetKind(), clusterv1.TemplateSuffix) {
+			res = append(res, obj)
+		}
+	}
+	return res
+}
+
+// generateCRDs creates mock CRD objects for all the provider specific objects in the input.
+// These CRD objects will be added to the dry run client for UpdateReferenceAPIContract
+// to work as expected.
+func (t *topologyClient) generateCRDs(in *DryRunInput) []*apiextensionsv1.CustomResourceDefinition {
+	crds := []*apiextensionsv1.CustomResourceDefinition{}
+	crdMap := map[string]bool{}
+	var gvk schema.GroupVersionKind
+	for _, obj := range in.Objs {
+		gvk = obj.GroupVersionKind()
+		if strings.HasSuffix(gvk.Group, ".cluster.x-k8s.io") && !crdMap[gvk.String()] {
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+					Kind:       "CustomResourceDefinition",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s.%s", flect.Pluralize(strings.ToLower(gvk.Kind)), gvk.Group),
+					Labels: map[string]string{
+						clusterv1.GroupVersion.String(): clusterv1.GroupVersion.Version,
+					},
+				},
+			}
+			crds = append(crds, crd)
+			crdMap[gvk.String()] = true
+		}
+	}
+	return crds
+}
+
+func (t *topologyClient) affectedClusterClasses(ctx context.Context, in *DryRunInput, c client.Reader) ([]client.ObjectKey, error) {
+	affectedClusterClasses := map[client.ObjectKey]bool{}
+	// Each of the ClusterClass that uses any of the Templates in the input is an affected ClusterClass.
+	for _, template := range getTemplates(in.Objs) {
+		ccList := &clusterv1.ClusterClassList{}
+		if err := c.List(
+			ctx,
+			ccList,
+			client.InNamespace(template.GetNamespace()),
+		); err != nil {
+			return nil, errors.Wrapf(err, "failed to list ClusterClasses using Template Kind=%s %s/%s", template.GetKind(), template.GetNamespace(), template.GetName())
+		}
+		for i := range ccList.Items {
+			if clusterClassUsesTemplate(&ccList.Items[i], objToRef(template)) {
+				affectedClusterClasses[client.ObjectKeyFromObject(&ccList.Items[i])] = true
+			}
+		}
+	}
+
+	// All the ClusterClasses in the input are considered affected ClusterClasses.
+	for _, cc := range getClusterClasses(in.Objs) {
+		affectedClusterClasses[client.ObjectKeyFromObject(cc)] = true
+	}
+
+	affectedClusterClassesList := []client.ObjectKey{}
+	for k := range affectedClusterClasses {
+		affectedClusterClassesList = append(affectedClusterClassesList, k)
+	}
+	return affectedClusterClassesList, nil
+}
+
+func (t *topologyClient) affectedClusters(ctx context.Context, in *DryRunInput, c client.Reader) ([]client.ObjectKey, error) {
+	affectedClusters := map[client.ObjectKey]bool{}
+
+	affectedClusterClasses, err := t.affectedClusterClasses(ctx, in, c)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get list of affected ClusterClasses")
+	}
+	// Each of the Cluster that uses the ClusterClass in the input is an affected cluster.
+	for _, cc := range affectedClusterClasses {
+		clusterList := &clusterv1.ClusterList{}
+		if err := c.List(
+			ctx,
+			clusterList,
+			client.InNamespace(cc.Namespace),
+		); err != nil {
+			return nil, errors.Wrapf(err, "failed to list Clusters using ClusterClass %s/%s", cc.Namespace, cc.Name)
+		}
+		for i := range clusterList.Items {
+			if clusterList.Items[i].Spec.Topology != nil && clusterList.Items[i].Spec.Topology.Class == cc.Name {
+				affectedClusters[client.ObjectKeyFromObject(&clusterList.Items[i])] = true
+			}
+		}
+	}
+
+	// All the Clusters in the input are considered affected Clusters.
+	for _, cluster := range getClusters(in.Objs) {
+		affectedClusters[client.ObjectKeyFromObject(cluster)] = true
+	}
+
+	affectedClustersList := []client.ObjectKey{}
+	for k := range affectedClusters {
+		affectedClustersList = append(affectedClustersList, k)
+	}
+	return affectedClustersList, nil
+}
+
+func matchCluster(list []client.ObjectKey, name string) *client.ObjectKey {
+	for _, i := range list {
+		if i.Name == name {
+			return &i
+		}
+	}
+	return nil
+}
+
+// filterObjects returns a new list of objects after dropping all the objects that match any of the given GVKs.
+func filterObjects(objs []*unstructured.Unstructured, gvks ...schema.GroupVersionKind) []*unstructured.Unstructured {
+	res := []*unstructured.Unstructured{}
+	for _, o := range objs {
+		skip := false
+		for _, gvk := range gvks {
+			if o.GroupVersionKind() == gvk {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			res = append(res, o)
+		}
+	}
+	return res
+}
+
+type noOpRecorder struct{}
+
+func (nr *noOpRecorder) Event(_ runtime.Object, _, _, _ string)                       {}
+func (nr *noOpRecorder) Eventf(_ runtime.Object, _, _, _ string, args ...interface{}) {}
+func (nr *noOpRecorder) AnnotatedEventf(_ runtime.Object, _ map[string]string, _, _, _ string, args ...interface{}) {
+}
+
+func objToRef(o *unstructured.Unstructured) *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind:       o.GetKind(),
+		Namespace:  o.GetNamespace(),
+		Name:       o.GetName(),
+		APIVersion: o.GetAPIVersion(),
+	}
+}
+
+func equalRef(a, b *corev1.ObjectReference) bool {
+	if a.APIVersion != b.APIVersion {
+		return false
+	}
+	if a.Namespace != b.Namespace {
+		return false
+	}
+	if a.Name != b.Name {
+		return false
+	}
+	if a.Kind != b.Kind {
+		return false
+	}
+	return true
+}
+
+func clusterClassUsesTemplate(cc *clusterv1.ClusterClass, templateRef *corev1.ObjectReference) bool {
+	// Check infrastructure ref.
+	if equalRef(cc.Spec.Infrastructure.Ref, templateRef) {
+		return true
+	}
+	// Check control plane ref.
+	if equalRef(cc.Spec.ControlPlane.Ref, templateRef) {
+		return true
+	}
+	// If control plane uses machine, check it.
+	if cc.Spec.ControlPlane.MachineInfrastructure != nil && cc.Spec.ControlPlane.MachineInfrastructure.Ref != nil {
+		if equalRef(cc.Spec.ControlPlane.MachineInfrastructure.Ref, templateRef) {
+			return true
+		}
+	}
+
+	for _, mdClass := range cc.Spec.Workers.MachineDeployments {
+		// Check bootstrap template ref.
+		if equalRef(mdClass.Template.Bootstrap.Ref, templateRef) {
+			return true
+		}
+		// Check the infrastructure ref.
+		if equalRef(mdClass.Template.Infrastructure.Ref, templateRef) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func uniqueNamespaces(objs []*unstructured.Unstructured) []string {
+	ns := sets.NewString()
+	for _, obj := range objs {
+		// Note: treat empty namespace (namespace not set) as a unique namespace.
+		// If some have a namespace set and some do not. It is safer to consider them as
+		// objects from different namespaces.
+		ns.Insert(obj.GetNamespace())
+	}
+	return ns.List()
+}

--- a/cmd/clusterctl/client/cluster/topology_test.go
+++ b/cmd/clusterctl/client/cluster/topology_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
+	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
+)
+
+var (
+	//go:embed assets/topology-test/new-clusterclass-and-cluster.yaml
+	newClusterClassAndClusterYAML []byte
+
+	//go:embed assets/topology-test/existing-clusterclass-and-cluster.yaml
+	existingClusterClassAndClusterYAML []byte
+
+	// modifiedClusterYAML changes the control plane replicas from 1 to 3.
+	//go:embed assets/topology-test/modified-cluster.yaml
+	modifiedClusterYAML []byte
+)
+
+func Test_topologyClient_DryRun(t *testing.T) {
+	type args struct {
+		in *DryRunInput
+	}
+	type item struct {
+		kind       string
+		namespace  string
+		namePrefix string
+	}
+	type out struct {
+		affectedClusters       []client.ObjectKey
+		affectedClusterClasses []client.ObjectKey
+		created                []item
+		modified               []item
+		deleted                []item
+	}
+	tests := []struct {
+		name            string
+		existingObjects []*unstructured.Unstructured
+		args            args
+		want            out
+		wantErr         bool
+	}{
+		{
+			name: "Input with new ClusterClass and new Cluster",
+			args: args{
+				in: func() *DryRunInput {
+					objs, err := utilyaml.ToUnstructured(newClusterClassAndClusterYAML)
+					if err != nil {
+						panic(err)
+					}
+					return &DryRunInput{
+						Objs: convertToPtrSlice(objs),
+					}
+				}(),
+			},
+			want: out{
+				created: []item{
+					{kind: "DockerCluster", namespace: "default", namePrefix: "my-cluster-"},
+					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-md-0-"},
+					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-md-1-"},
+					{kind: "DockerMachineTemplate", namespace: "default", namePrefix: "my-cluster-control-plane-"},
+					{kind: "KubeadmConfigTemplate", namespace: "default", namePrefix: "my-cluster-md-0-bootstrap-"},
+					{kind: "KubeadmConfigTemplate", namespace: "default", namePrefix: "my-cluster-md-1-bootstrap-"},
+					{kind: "KubeadmControlPlane", namespace: "default", namePrefix: "my-cluster-"},
+					{kind: "MachineDeployment", namespace: "default", namePrefix: "my-cluster-md-0-"},
+					{kind: "MachineDeployment", namespace: "default", namePrefix: "my-cluster-md-1-"},
+				},
+				modified: []item{
+					{kind: "Cluster", namespace: "default", namePrefix: "my-cluster"},
+				},
+				affectedClusters: func() []client.ObjectKey {
+					cluster := client.ObjectKey{}
+					cluster.Namespace = "default"
+					cluster.Name = "my-cluster"
+					return []client.ObjectKey{cluster}
+				}(),
+				affectedClusterClasses: func() []client.ObjectKey {
+					cc := client.ObjectKey{}
+					cc.Namespace = "default"
+					cc.Name = "my-cluster-class"
+					return []client.ObjectKey{cc}
+				}(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Modifying an existing Cluster",
+			existingObjects: func() []*unstructured.Unstructured {
+				objs, err := utilyaml.ToUnstructured(existingClusterClassAndClusterYAML)
+				if err != nil {
+					panic(err)
+				}
+				return convertToPtrSlice(objs)
+			}(),
+			args: args{
+				in: func() *DryRunInput {
+					objs, err := utilyaml.ToUnstructured(modifiedClusterYAML)
+					if err != nil {
+						panic(err)
+					}
+					return &DryRunInput{
+						Objs: convertToPtrSlice(objs),
+					}
+				}(),
+			},
+			want: out{
+				modified: []item{
+					{kind: "KubeadmControlPlane", namespace: "default", namePrefix: "my-cluster-"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			existingObjects := []client.Object{}
+			for _, o := range tt.existingObjects {
+				existingObjects = append(existingObjects, o)
+			}
+			proxy := test.NewFakeProxy().WithClusterAvailable(true).WithFakeCAPISetup().WithObjs(existingObjects...)
+			inventoryClient := newInventoryClient(proxy, nil)
+			tc := newTopologyClient(
+				proxy,
+				inventoryClient,
+			)
+
+			res, err := tc.DryRun(tt.args.in)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			for _, cc := range tt.want.affectedClusterClasses {
+				g.Expect(res.ClusterClasses).To(ContainElement(cc))
+			}
+			for _, cluster := range tt.want.affectedClusters {
+				g.Expect(res.Clusters).To(ContainElement(cluster))
+			}
+			for _, created := range tt.want.created {
+				g.Expect(res.Created).To(ContainElement(MatchDryRunOutputItem(created.kind, created.namespace, created.namePrefix)))
+			}
+			actualModifiedObjs := []*unstructured.Unstructured{}
+			for _, m := range res.Modified {
+				actualModifiedObjs = append(actualModifiedObjs, m.After)
+			}
+			for _, modified := range tt.want.modified {
+				g.Expect(actualModifiedObjs).To(ContainElement(MatchDryRunOutputItem(modified.kind, modified.namespace, modified.namePrefix)))
+			}
+			for _, deleted := range tt.want.deleted {
+				g.Expect(res.Deleted).To(ContainElement(MatchDryRunOutputItem(deleted.kind, deleted.namespace, deleted.namePrefix)))
+			}
+		})
+	}
+}
+
+func MatchDryRunOutputItem(kind, namespace, namePrefix string) types.GomegaMatcher {
+	return &dryRunOutputItemMatcher{kind, namespace, namePrefix}
+}
+
+type dryRunOutputItemMatcher struct {
+	kind       string
+	namespace  string
+	namePrefix string
+}
+
+func (m *dryRunOutputItemMatcher) Match(actual interface{}) (bool, error) {
+	obj := actual.(*unstructured.Unstructured)
+	if obj.GetKind() != m.kind {
+		return false, nil
+	}
+	if obj.GetNamespace() != m.namespace {
+		return false, nil
+	}
+	if !strings.HasPrefix(obj.GetName(), m.namePrefix) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *dryRunOutputItemMatcher) FailureMessage(actual interface{}) string {
+	return fmt.Sprintf("Expected item Kind=%s, Namespace=%s, Name(prefix)=%s to be present", m.kind, m.namespace, m.namePrefix)
+}
+
+func (m *dryRunOutputItemMatcher) NegatedFailureMessage(actual interface{}) string {
+	return fmt.Sprintf("Expected item Kind=%s, Namespace=%s, Name(prefix)=%s not to be present", m.kind, m.namespace, m.namePrefix)
+}
+
+func convertToPtrSlice(objs []unstructured.Unstructured) []*unstructured.Unstructured {
+	res := []*unstructured.Unstructured{}
+	for i := range objs {
+		res = append(res, &objs[i])
+	}
+	return res
+}

--- a/cmd/clusterctl/client/topology.go
+++ b/cmd/clusterctl/client/topology.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+)
+
+// DryRunOptions define options for DryRunTopology.
+type DryRunOptions struct {
+	// Kubeconfig defines the kubeconfig to use for accessing the management cluster. If empty,
+	// default rules for kubeconfig discovery will be used.
+	Kubeconfig Kubeconfig
+
+	// Objs is the list of objects that are input to the dryrun operation.
+	// The objects can be among new/modified clusters, new/modifed ClusterClasses and new/modified templates.
+	Objs []*unstructured.Unstructured
+
+	// Cluster is the name of the cluster to dryrun reconcile if multiple clusters are affected by the input.
+	Cluster string
+}
+
+// DryRunOutput defines the output of the dry run execution.
+type DryRunOutput = cluster.DryRunOutput
+
+// DryRunTopology performs a dry run execution of the topology reconciler using the given inputs.
+// It returns a summary of the changes observed during the execution.
+func (c *clusterctlClient) DryRunTopology(options DryRunOptions) (*DryRunOutput, error) {
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{Kubeconfig: options.Kubeconfig})
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := clusterClient.Topology().DryRun(&cluster.DryRunInput{
+		Objs:              options.Objs,
+		TargetClusterName: options.Cluster,
+	})
+
+	return out, err
+}

--- a/cmd/clusterctl/cmd/topology.go
+++ b/cmd/clusterctl/cmd/topology.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"sort"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+	utilyaml "sigs.k8s.io/cluster-api/util/yaml"
+)
+
+type topologyDryRunOptions struct {
+	kubeconfig        string
+	kubeconfigContext string
+	file              string
+	cluster           string
+	outDir            string
+}
+
+var dr = &topologyDryRunOptions{}
+
+var topologyDryRunCmd = &cobra.Command{
+	Use:   "topology-dryrun",
+	Short: "Dry run changes to clusters that use managed topologies.",
+	Long: LongDesc(`
+		Provide the list of objects that would be created, modified and deleted when an input file is applied.
+		The input can be a file with a new/modified cluster, new/modified ClusterClass, new/modified templates.
+		Details about the objects that will be created and modified will be stored in a path passed using --output-directory.
+
+		This command can also be run without a real cluster. In such cases, the input should contain all the objects needed
+		to perform a dry run.
+
+		Note: Among all the objects in the input defaulting and validation will be performed only for Cluster
+		and ClusterClasses. All other objects in the input are expected to be valid and have default values.
+	`),
+	Example: Examples(`
+		# List all the objects that will be created and modified when creating a new cluster.
+		clusterctl alpha topology-dryrun -f new-cluster.yaml -o output/
+	    
+		# List the changes when modifying a cluster.
+		clusterctl alpha topology-dryrun -f modified-cluster.yaml -o output/
+
+		# List all the objects that will be created and modified when creating a new cluster along with a new ClusterClass.
+		clusterctl alpha topology-dryrun -f new-cluster-and-cluster-class.yaml -o output/
+
+		# List the clusters impacted by a ClusterClass change.
+		clusterctl alpha topology-dryrun -f modified-cluster-class.yaml -o output/
+	
+		# List the changes to "cluster1" when a ClusterClass is changed.
+		clusterctl alpha topology-dryrun -f modified-cluster-class.yaml --cluster "cluster1" -o output/
+
+		# List the clusters and ClusterClasses impacted by a template change.
+		clusterctl alpha topology-dryrun -f modified-template.yaml -o output/
+	`),
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runTopologyDryRun()
+	},
+}
+
+func init() {
+	topologyDryRunCmd.Flags().StringVar(&initOpts.kubeconfig, "kubeconfig", "",
+		"Path to the kubeconfig for the management cluster. If unspecified, default discovery rules apply.")
+	topologyDryRunCmd.Flags().StringVar(&initOpts.kubeconfigContext, "kubeconfig-context", "",
+		"Context to be used within the kubeconfig file. If empty, current context will be used.")
+
+	topologyDryRunCmd.Flags().StringVarP(&dr.file, "file", "f", "", "path to the file with new or modified resources to be applied; the file should not contain more than one Cluster or more than one ClusterClass")
+	topologyDryRunCmd.Flags().StringVarP(&dr.cluster, "cluster", "c", "", "name of the target cluster; this parameter is required when more than one cluster is affected")
+	topologyDryRunCmd.Flags().StringVarP(&dr.outDir, "output-directory", "o", "", "output directory to write details about created/modified objects")
+
+	if err := topologyDryRunCmd.MarkFlagRequired("file"); err != nil {
+		panic(err)
+	}
+	if err := topologyDryRunCmd.MarkFlagRequired("output-directory"); err != nil {
+		panic(err)
+	}
+}
+
+func runTopologyDryRun() error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	raw, err := os.ReadFile(dr.file)
+	if err != nil {
+		return errors.Wrap(err, "failed to read input file")
+	}
+
+	objs, err := utilyaml.ToUnstructured(raw)
+	if err != nil {
+		return errors.Wrap(err, "failed to convert file to list of objects")
+	}
+
+	out, err := c.DryRunTopology(client.DryRunOptions{
+		Kubeconfig: client.Kubeconfig{Path: dr.kubeconfig, Context: dr.kubeconfigContext},
+		Objs:       convertToPtrSlice(objs),
+		Cluster:    dr.cluster,
+	})
+	if err != nil {
+		return err
+	}
+	return printDryRunOutput(out, dr.outDir)
+}
+
+func printDryRunOutput(out *cluster.DryRunOutput, outdir string) error {
+	printAffectedClusterClasses(out)
+	printAffectedClusters(out)
+	if len(out.Clusters) == 0 {
+		// No affected clusters. Return early.
+		return nil
+	}
+	if out.ReconciledCluster.Name == "" {
+		fmt.Printf("No target cluster identified. Use --cluster to specify a target cluster to get detailed changes.")
+	} else {
+		printChangeSummary(out)
+		if err := writeOutputFiles(out, outdir); err != nil {
+			return errors.Wrap(err, "failed to write output files of target cluster changes")
+		}
+	}
+	fmt.Printf("\n")
+	return nil
+}
+
+func printAffectedClusterClasses(out *cluster.DryRunOutput) {
+	if len(out.ClusterClasses) == 0 {
+		// If there are no affected ClusterClasses return early. Nothing more to do here.
+		fmt.Printf("No ClusterClasses will be affected by the changes.\n")
+		return
+	}
+	fmt.Printf("The following ClusterClasses will be affected by the changes:\n")
+	for _, cc := range out.ClusterClasses {
+		fmt.Printf(" ＊ %s/%s\n", cc.Namespace, cc.Name)
+	}
+	fmt.Printf("\n")
+}
+
+func printAffectedClusters(out *cluster.DryRunOutput) {
+	if len(out.Clusters) == 0 {
+		// if there are not affected Clusters return early. Nothing more to do here.
+		fmt.Printf("No Clusters will be affected by the changes.\n")
+		return
+	}
+	fmt.Printf("The following Clusters will be affected by the changes:\n")
+	for _, cluster := range out.Clusters {
+		fmt.Printf(" ＊ %s/%s\n", cluster.Namespace, cluster.Name)
+	}
+	fmt.Printf("\n")
+}
+
+func printChangeSummary(out *cluster.DryRunOutput) {
+	if len(out.Created) == 0 && len(out.Modified) == 0 && len(out.Deleted) == 0 {
+		fmt.Printf("No changes detected for Cluster %q.\n", fmt.Sprintf("%s/%s", out.ReconciledCluster.Namespace, out.ReconciledCluster.Name))
+		return
+	}
+
+	fmt.Printf("Changes for Cluster %q: \n", fmt.Sprintf("%s/%s", out.ReconciledCluster.Namespace, out.ReconciledCluster.Name))
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Namespace", "Kind", "Name", "Action"})
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+
+	// Add the created rows.
+	sort.Slice(out.Created, func(i, j int) bool { return lessByKindAndName(out.Created[i], out.Created[j]) })
+	for _, c := range out.Created {
+		addRow(table, c, "created", tablewriter.FgGreenColor)
+	}
+
+	// Add the modified rows.
+	sort.Slice(out.Modified, func(i, j int) bool { return lessByKindAndName(out.Modified[i].After, out.Modified[j].After) })
+	for _, m := range out.Modified {
+		addRow(table, m.After, "modified", tablewriter.FgYellowColor)
+	}
+
+	// Add the deleted rows.
+	sort.Slice(out.Deleted, func(i, j int) bool { return lessByKindAndName(out.Deleted[i], out.Deleted[j]) })
+	for _, d := range out.Deleted {
+		addRow(table, d, "deleted", tablewriter.FgRedColor)
+	}
+	fmt.Printf("\n")
+	table.Render()
+	fmt.Printf("\n")
+}
+
+func writeOutputFiles(out *cluster.DryRunOutput, outDir string) error {
+	if _, err := os.Stat(outDir); os.IsNotExist(err) {
+		return fmt.Errorf("output directory %q does not exist", outDir)
+	}
+
+	// Write created files
+	createdDir := path.Join(outDir, "created")
+	if err := os.MkdirAll(createdDir, 0750); err != nil {
+		return errors.Wrapf(err, "failed to create %q directory", createdDir)
+	}
+	for _, c := range out.Created {
+		yaml, err := utilyaml.FromUnstructured([]unstructured.Unstructured{*c})
+		if err != nil {
+			return errors.Wrap(err, "failed to convert object to yaml")
+		}
+		fileName := fmt.Sprintf("%s_%s_%s.yaml", c.GetKind(), c.GetNamespace(), c.GetName())
+		filePath := path.Join(createdDir, fileName)
+		if err := os.WriteFile(filePath, yaml, 0600); err != nil {
+			return errors.Wrapf(err, "failed to write yaml to file %q", filePath)
+		}
+	}
+	if len(out.Created) != 0 {
+		fmt.Printf("Created objects are written to directory %q\n", createdDir)
+	}
+
+	// Write modified files
+	modifiedDir := path.Join(outDir, "modified")
+	if err := os.MkdirAll(modifiedDir, 0750); err != nil {
+		return errors.Wrapf(err, "failed to create %q directory", modifiedDir)
+	}
+	for _, m := range out.Modified {
+		// Write the modified object to file.
+		fileNameModified := fmt.Sprintf("%s_%s_%s.modified.yaml", m.After.GetKind(), m.After.GetNamespace(), m.After.GetName())
+		filePathModified := path.Join(modifiedDir, fileNameModified)
+		if err := writeObjectToFile(filePathModified, m.After); err != nil {
+			return errors.Wrap(err, "failed to write modified object to file")
+		}
+
+		// Write the original object to file.
+		fileNameOriginal := fmt.Sprintf("%s_%s_%s.original.yaml", m.Before.GetKind(), m.Before.GetNamespace(), m.Before.GetName())
+		filePathOriginal := path.Join(modifiedDir, fileNameOriginal)
+		if err := writeObjectToFile(filePathOriginal, m.Before); err != nil {
+			return errors.Wrap(err, "failed to write original object to file")
+		}
+
+		// Calculate the diff and write to a file.
+		patch := crclient.MergeFrom(m.Before)
+		diff, err := patch.Data(m.After)
+		if err != nil {
+			return errors.Wrapf(err, "failed to calculate diff of modified object %s/%s", m.After.GetNamespace(), m.After.GetName())
+		}
+		patchFileName := fmt.Sprintf("%s_%s_%s.patch", m.After.GetKind(), m.After.GetNamespace(), m.After.GetName())
+		patchFilePath := path.Join(modifiedDir, patchFileName)
+		if err := os.WriteFile(patchFilePath, diff, 0600); err != nil {
+			return errors.Wrapf(err, "failed to write diff to file %q", patchFilePath)
+		}
+	}
+	if len(out.Modified) != 0 {
+		fmt.Printf("Modified objects are written to directory %q\n", modifiedDir)
+	}
+
+	return nil
+}
+
+func writeObjectToFile(filePath string, obj *unstructured.Unstructured) error {
+	yaml, err := utilyaml.FromUnstructured([]unstructured.Unstructured{*obj})
+	if err != nil {
+		return errors.Wrap(err, "failed to convert object to yaml")
+	}
+	if err := os.WriteFile(filePath, yaml, 0600); err != nil {
+		return errors.Wrapf(err, "failed to write yaml to file %q", filePath)
+	}
+	return nil
+}
+
+func convertToPtrSlice(objs []unstructured.Unstructured) []*unstructured.Unstructured {
+	res := []*unstructured.Unstructured{}
+	for i := range objs {
+		res = append(res, &objs[i])
+	}
+	return res
+}
+
+func lessByKindAndName(a, b *unstructured.Unstructured) bool {
+	if a.GetKind() == b.GetKind() {
+		return a.GetName() < b.GetName()
+	}
+	return a.GetKind() < b.GetKind()
+}
+
+func addRow(table *tablewriter.Table, o *unstructured.Unstructured, action string, actionColor int) {
+	table.Rich(
+		[]string{
+			o.GetNamespace(),
+			o.GetKind(),
+			o.GetName(),
+			action,
+		},
+		[]tablewriter.Colors{
+			{}, {}, {}, {actionColor},
+		},
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
@@ -106,6 +106,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -447,6 +447,7 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -493,6 +494,8 @@ github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -41,7 +41,11 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e // indirect
+	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
@@ -62,6 +66,7 @@ require (
 	github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
@@ -69,11 +74,15 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/gobuffalo/flect v0.2.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/cel-go v0.9.0 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-containerregistry v0.7.1-0.20211118220127-abdc633f8305 // indirect
 	github.com/google/go-github/v33 v33.0.0 // indirect
@@ -90,10 +99,12 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
@@ -118,7 +129,9 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.9.0 // indirect
 	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/valyala/fastjson v1.6.3 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
@@ -150,6 +163,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/apiextensions-apiserver v0.23.0 // indirect
+	k8s.io/apiserver v0.23.0 // indirect
 	k8s.io/cluster-bootstrap v0.23.0 // indirect
 	k8s.io/component-base v0.23.0 // indirect
 	k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -807,6 +807,7 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -880,6 +881,7 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -1131,6 +1133,7 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlIME=
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -105,6 +105,12 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	return nil
 }
 
+// SetupForDryRun prepares the Reconciler for a dry run execution.
+func (r *Reconciler) SetupForDryRun(recorder record.EventRecorder) {
+	r.patchEngine = patches.NewEngine()
+	r.recorder = recorder
+}
+
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := ctrl.LoggerFrom(ctx)
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -34,7 +34,11 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.5.0 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
+	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e // indirect
+	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/coredns/caddy v1.1.0 // indirect
@@ -48,10 +52,14 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gobuffalo/flect v0.2.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/cel-go v0.9.0 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-github/v33 v33.0.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
@@ -61,8 +69,10 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
@@ -83,7 +93,9 @@ require (
 	github.com/spf13/cobra v1.2.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.9.0 // indirect
+	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/valyala/fastjson v1.6.3 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -636,6 +636,7 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -692,6 +693,7 @@ github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -885,6 +887,7 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
 github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/vincent-petithory/dataurl v1.0.0 h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=
 github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR implements a alpha new command: `clusterctl alpha topology-dryrun`.
This command can be used to dry run ClusterClass and/or Cluster changes.

The command expects as input a file that includes the new or modified objects. Example: the file can contain a modified Cluster or a modified ClusterClass. The output lists all the Clusters and ClusterClasses that will be affected. 

The following example shows the output when dry-running to create a Cluster that uses a pre-installed ClusterClass.
<img width="838" alt="Screen Shot 2021-12-29 at 10 13 50 PM" src="https://user-images.githubusercontent.com/22120431/147726524-03b8325a-8392-4733-b293-0f6fe4369b14.png">


Special thanks to @fabriziopandini for providing guidance for this feature. 🙂

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5319 
