### PR TITLE
🌱 Move controllers to internal - part1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -237,7 +237,7 @@ issues:
   - linters:
     - ifshort
     text:  "variable 'isDeleteNodeAllowed' is only used in the if-statement.*"
-    path: ^controllers/machine_controller\.go$
+    path: ^internal/controllers/machine/machine_controller\.go$
 
 run:
   timeout: 10m

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ generate-manifests-core: $(CONTROLLER_GEN) $(KUSTOMIZE) ## Generate manifests e.
 	$(CONTROLLER_GEN) \
 		paths=./api/... \
 		paths=./controllers/... \
+		paths=./internal/controllers/... \
 		paths=./internal/webhooks/... \
 		paths=./$(EXP_DIR)/api/... \
 		paths=./$(EXP_DIR)/internal/controllers/... \

--- a/controllers/alias.go
+++ b/controllers/alias.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"golang.org/x/net/context"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	clustercontroller "sigs.k8s.io/cluster-api/internal/controllers/cluster"
+	machinecontroller "sigs.k8s.io/cluster-api/internal/controllers/machine"
+)
+
+// Following types provides access to reconcilers implemented in internal/controllers, thus
+// allowing users to provide a single binary "batteries included" with Cluster API and providers of choice.
+
+// ClusterReconciler reconciles a Cluster object.
+type ClusterReconciler struct {
+	Client    client.Client
+	APIReader client.Reader
+
+	// WatchFilterValue is the label value used to filter events prior to reconciliation.
+	WatchFilterValue string
+}
+
+func (r *ClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	return (&clustercontroller.Reconciler{
+		Client:           r.Client,
+		APIReader:        r.APIReader,
+		WatchFilterValue: r.WatchFilterValue,
+	}).SetupWithManager(ctx, mgr, options)
+}
+
+// MachineReconciler reconciles a Machine object.
+type MachineReconciler struct {
+	Client    client.Client
+	APIReader client.Reader
+	Tracker   *remote.ClusterCacheTracker
+
+	// WatchFilterValue is the label value used to filter events prior to reconciliation.
+	WatchFilterValue string
+}
+
+func (r *MachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	return (&machinecontroller.Reconciler{
+		Client:           r.Client,
+		APIReader:        r.APIReader,
+		Tracker:          r.Tracker,
+		WatchFilterValue: r.WatchFilterValue,
+	}).SetupWithManager(ctx, mgr, options)
+}

--- a/controllers/machinehealthcheck_controller.go
+++ b/controllers/machinehealthcheck_controller.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/cluster-api/internal/controllers/machine"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -494,7 +495,7 @@ func (r *MachineHealthCheckReconciler) machineToMachineHealthCheck(o client.Obje
 	var requests []reconcile.Request
 	for k := range mhcList.Items {
 		mhc := &mhcList.Items[k]
-		if hasMatchingLabels(mhc.Spec.Selector, m.Labels) {
+		if machine.HasMatchingLabels(mhc.Spec.Selector, m.Labels) {
 			key := util.ObjectKey(mhc)
 			requests = append(requests, reconcile.Request{NamespacedName: key})
 		}

--- a/controllers/machineset_controller.go
+++ b/controllers/machineset_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/external"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/cluster-api/internal/controllers/machine"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
@@ -611,7 +612,7 @@ func (r *MachineSetReconciler) getMachineSetsForMachine(ctx context.Context, m *
 	var mss []*clusterv1.MachineSet
 	for idx := range msList.Items {
 		ms := &msList.Items[idx]
-		if hasMatchingLabels(ms.Spec.Selector, m.Labels) {
+		if machine.HasMatchingLabels(ms.Spec.Selector, m.Labels) {
 			mss = append(mss, ms)
 		}
 	}

--- a/docs/book/src/developer/providers/v1.0-to-v1.1.md
+++ b/docs/book/src/developer/providers/v1.0-to-v1.1.md
@@ -36,7 +36,8 @@ are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
 
 * Some controllers have been moved to internal to reduce their API surface. We now only
   surface what is necessary, e.g. the reconciler and the `SetupWithManager` func:
-    * [bootstrap/kubeadm/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5493) 
+    * [bootstrap/kubeadm/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5493)
+    * [controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5899)
     * [exp/addons/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5639) 
     * [test/infrastructure/docker/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5595) 
     * [test/infrastructure/docker/exp/controllers](https://github.com/kubernetes-sigs/cluster-api/pull/5690) 

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+require golang.org/x/net v0.0.0-20210825183410-e898025ed96a
+
 require (
 	cloud.google.com/go v0.93.3 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
@@ -129,7 +131,6 @@ require (
 	go.uber.org/zap v1.19.1 // indirect
 	go4.org v0.0.0-20201209231011-d4a079459e60 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
-	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
 	golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/internal/controllers/cluster/cluster_controller_phases.go
+++ b/internal/controllers/cluster/cluster_controller_phases.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package cluster
 
 import (
 	"context"
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/secret"
 )
 
-func (r *ClusterReconciler) reconcilePhase(_ context.Context, cluster *clusterv1.Cluster) {
+func (r *Reconciler) reconcilePhase(_ context.Context, cluster *clusterv1.Cluster) {
 	if cluster.Status.Phase == "" {
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhasePending)
 	}
@@ -64,7 +64,7 @@ func (r *ClusterReconciler) reconcilePhase(_ context.Context, cluster *clusterv1
 }
 
 // reconcileExternal handles generic unstructured objects referenced by a Cluster.
-func (r *ClusterReconciler) reconcileExternal(ctx context.Context, cluster *clusterv1.Cluster, ref *corev1.ObjectReference) (external.ReconcileOutput, error) {
+func (r *Reconciler) reconcileExternal(ctx context.Context, cluster *clusterv1.Cluster, ref *corev1.ObjectReference) (external.ReconcileOutput, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if err := utilconversion.UpdateReferenceAPIContract(ctx, r.Client, r.APIReader, ref); err != nil {
@@ -135,7 +135,7 @@ func (r *ClusterReconciler) reconcileExternal(ctx context.Context, cluster *clus
 }
 
 // reconcileInfrastructure reconciles the Spec.InfrastructureRef object on a Cluster.
-func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+func (r *Reconciler) reconcileInfrastructure(ctx context.Context, cluster *clusterv1.Cluster) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if cluster.Spec.InfrastructureRef == nil {
@@ -200,7 +200,7 @@ func (r *ClusterReconciler) reconcileInfrastructure(ctx context.Context, cluster
 }
 
 // reconcileControlPlane reconciles the Spec.ControlPlaneRef object on a Cluster.
-func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+func (r *Reconciler) reconcileControlPlane(ctx context.Context, cluster *clusterv1.Cluster) (ctrl.Result, error) {
 	if cluster.Spec.ControlPlaneRef == nil {
 		return ctrl.Result{}, nil
 	}
@@ -255,7 +255,7 @@ func (r *ClusterReconciler) reconcileControlPlane(ctx context.Context, cluster *
 	return ctrl.Result{}, nil
 }
 
-func (r *ClusterReconciler) reconcileKubeconfig(ctx context.Context, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+func (r *Reconciler) reconcileKubeconfig(ctx context.Context, cluster *clusterv1.Cluster) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if !cluster.Spec.ControlPlaneEndpoint.IsValid() {

--- a/internal/controllers/cluster/cluster_controller_phases_test.go
+++ b/internal/controllers/cluster/cluster_controller_phases_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package cluster
 
 import (
 	"testing"
@@ -135,7 +135,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 						WithObjects(builder.GenericInfrastructureMachineCRD.DeepCopy(), tt.cluster).
 						Build()
 				}
-				r := &ClusterReconciler{
+				r := &Reconciler{
 					Client: c,
 				}
 
@@ -214,7 +214,7 @@ func TestClusterReconcilePhases(t *testing.T) {
 						WithObjects(tt.cluster, tt.secret).
 						Build()
 				}
-				r := &ClusterReconciler{
+				r := &Reconciler{
 					Client: c,
 				}
 				res, err := r.reconcileKubeconfig(ctx, tt.cluster)
@@ -363,7 +363,7 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 				WithObjects(tt.cluster).
 				Build()
 
-			r := &ClusterReconciler{
+			r := &Reconciler{
 				Client: c,
 			}
 			r.reconcilePhase(ctx, tt.cluster)
@@ -471,7 +471,7 @@ func TestClusterReconcilePhases_reconcileFailureDomains(t *testing.T) {
 				objs = append(objs, &unstructured.Unstructured{Object: tt.infraRef})
 			}
 
-			r := &ClusterReconciler{
+			r := &Reconciler{
 				Client: fake.NewClientBuilder().WithObjects(objs...).Build(),
 			}
 

--- a/internal/controllers/cluster/cluster_controller_test.go
+++ b/internal/controllers/cluster/cluster_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package cluster
 
 import (
 	"testing"
@@ -473,7 +473,7 @@ func TestClusterReconcilerNodeRef(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				g := NewWithT(t)
 
-				r := &ClusterReconciler{
+				r := &Reconciler{
 					Client: fake.NewClientBuilder().WithObjects(cluster, controlPlaneWithNoderef, controlPlaneWithoutNoderef, nonControlPlaneWithNoderef, nonControlPlaneWithoutNoderef).Build(),
 				}
 				requests := r.controlPlaneMachineToCluster(tt.o)
@@ -748,7 +748,7 @@ func TestReconcileControlPlaneInitializedControlPlaneRef(t *testing.T) {
 		},
 	}
 
-	r := &ClusterReconciler{}
+	r := &Reconciler{}
 	res, err := r.reconcileControlPlaneInitialized(ctx, c)
 	g.Expect(res.IsZero()).To(BeTrue())
 	g.Expect(err).NotTo(HaveOccurred())

--- a/internal/controllers/cluster/doc.go
+++ b/internal/controllers/cluster/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cluster implements cluster controller.
+package cluster

--- a/internal/controllers/machine/doc.go
+++ b/internal/controllers/machine/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package machine implements machine controller.
+package machine

--- a/internal/controllers/machine/machine_controller_node_labels.go
+++ b/internal/controllers/machine/machine_controller_node_labels.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machine
 
 import (
 	"context"
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
-func (r *MachineReconciler) reconcileInterruptibleNodeLabel(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (ctrl.Result, error) {
+func (r *Reconciler) reconcileInterruptibleNodeLabel(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (ctrl.Result, error) {
 	// Check that the Machine hasn't been deleted or in the process
 	// and that the Machine has a NodeRef.
 	if !machine.DeletionTimestamp.IsZero() || machine.Status.NodeRef == nil {
@@ -70,7 +70,7 @@ func (r *MachineReconciler) reconcileInterruptibleNodeLabel(ctx context.Context,
 	return ctrl.Result{}, nil
 }
 
-func (r *MachineReconciler) setInterruptibleNodeLabel(ctx context.Context, remoteClient client.Client, nodeName string) error {
+func (r *Reconciler) setInterruptibleNodeLabel(ctx context.Context, remoteClient client.Client, nodeName string) error {
 	node := &corev1.Node{}
 	if err := remoteClient.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
 		return err

--- a/internal/controllers/machine/machine_controller_node_labels_test.go
+++ b/internal/controllers/machine/machine_controller_node_labels_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machine
 
 import (
 	"context"
@@ -114,7 +114,7 @@ func TestReconcileInterruptibleNodeLabel(t *testing.T) {
 		g.Expect(env.Cleanup(ctx, do...)).To(Succeed())
 	}(cluster, ns, node, infraMachine, machine)
 
-	r := &MachineReconciler{
+	r := &Reconciler{
 		Client:   env.Client,
 		Tracker:  remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), env.Client, scheme.Scheme, client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}),
 		recorder: record.NewFakeRecorder(32),

--- a/internal/controllers/machine/machine_controller_noderef.go
+++ b/internal/controllers/machine/machine_controller_noderef.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machine
 
 import (
 	"context"
@@ -40,7 +40,7 @@ var (
 	ErrNodeNotFound = errors.New("cannot find node with matching ProviderID")
 )
 
-func (r *MachineReconciler) reconcileNode(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (ctrl.Result, error) {
+func (r *Reconciler) reconcileNode(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx, "machine", machine.Name, "namespace", machine.Namespace)
 	log = log.WithValues("cluster", cluster.Name)
 
@@ -172,7 +172,7 @@ func summarizeNodeConditions(node *corev1.Node) (corev1.ConditionStatus, string)
 	return corev1.ConditionUnknown, message
 }
 
-func (r *MachineReconciler) getNode(ctx context.Context, c client.Reader, providerID *noderefutil.ProviderID) (*corev1.Node, error) {
+func (r *Reconciler) getNode(ctx context.Context, c client.Reader, providerID *noderefutil.ProviderID) (*corev1.Node, error) {
 	log := ctrl.LoggerFrom(ctx, "providerID", providerID)
 	nodeList := corev1.NodeList{}
 	if err := c.List(ctx, &nodeList, client.MatchingFields{index.NodeProviderIDField: providerID.IndexKey()}); err != nil {

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machine
 
 import (
 	"testing"
@@ -126,7 +126,7 @@ func TestGetNode(t *testing.T) {
 	)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	r := &MachineReconciler{
+	r := &Reconciler{
 		Tracker: tracker,
 		Client:  env,
 	}

--- a/internal/controllers/machine/machine_controller_phases.go
+++ b/internal/controllers/machine/machine_controller_phases.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machine
 
 import (
 	"context"
@@ -46,7 +46,7 @@ var (
 	externalReadyWait = 30 * time.Second
 )
 
-func (r *MachineReconciler) reconcilePhase(_ context.Context, m *clusterv1.Machine) {
+func (r *Reconciler) reconcilePhase(_ context.Context, m *clusterv1.Machine) {
 	originalPhase := m.Status.Phase //nolint:ifshort // Cannot be inlined because m.Status.Phase might be changed before it is used in the if.
 
 	// Set the phase to "pending" if nil.
@@ -87,7 +87,7 @@ func (r *MachineReconciler) reconcilePhase(_ context.Context, m *clusterv1.Machi
 }
 
 // reconcileExternal handles generic unstructured objects referenced by a Machine.
-func (r *MachineReconciler) reconcileExternal(ctx context.Context, cluster *clusterv1.Cluster, m *clusterv1.Machine, ref *corev1.ObjectReference) (external.ReconcileOutput, error) {
+func (r *Reconciler) reconcileExternal(ctx context.Context, cluster *clusterv1.Cluster, m *clusterv1.Machine, ref *corev1.ObjectReference) (external.ReconcileOutput, error) {
 	log := ctrl.LoggerFrom(ctx, "cluster", cluster.Name)
 
 	if err := utilconversion.UpdateReferenceAPIContract(ctx, r.Client, r.APIReader, ref); err != nil {
@@ -171,7 +171,7 @@ func (r *MachineReconciler) reconcileExternal(ctx context.Context, cluster *clus
 }
 
 // reconcileBootstrap reconciles the Spec.Bootstrap.ConfigRef object on a Machine.
-func (r *MachineReconciler) reconcileBootstrap(ctx context.Context, cluster *clusterv1.Cluster, m *clusterv1.Machine) (ctrl.Result, error) {
+func (r *Reconciler) reconcileBootstrap(ctx context.Context, cluster *clusterv1.Cluster, m *clusterv1.Machine) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx, "cluster", cluster.Name)
 
 	// If the bootstrap data is populated, set ready and return.
@@ -236,7 +236,7 @@ func (r *MachineReconciler) reconcileBootstrap(ctx context.Context, cluster *clu
 }
 
 // reconcileInfrastructure reconciles the Spec.InfrastructureRef object on a Machine.
-func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, cluster *clusterv1.Cluster, m *clusterv1.Machine) (ctrl.Result, error) {
+func (r *Reconciler) reconcileInfrastructure(ctx context.Context, cluster *clusterv1.Cluster, m *clusterv1.Machine) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx, "cluster", cluster.Name)
 
 	// Call generic external reconciler.

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machine
 
 import (
 	"testing"
@@ -116,7 +116,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		bootstrapConfig := defaultBootstrap.DeepCopy()
 		infraConfig := defaultInfra.DeepCopy()
 
-		r := &MachineReconciler{
+		r := &Reconciler{
 			Client: fake.NewClientBuilder().
 				WithScheme(scheme.Scheme).
 				WithObjects(defaultCluster,
@@ -154,7 +154,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		bootstrapConfig := defaultBootstrap.DeepCopy()
 		infraConfig := defaultInfra.DeepCopy()
 
-		r := &MachineReconciler{
+		r := &Reconciler{
 			Client: fake.NewClientBuilder().
 				WithScheme(scheme.Scheme).
 				WithObjects(defaultCluster,
@@ -197,7 +197,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		lastUpdated := metav1.NewTime(time.Now().Add(-10 * time.Second))
 		machine.Status.LastUpdated = &lastUpdated
 
-		r := &MachineReconciler{
+		r := &Reconciler{
 			Client: fake.NewClientBuilder().
 				WithScheme(scheme.Scheme).
 				WithObjects(defaultCluster,
@@ -284,7 +284,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 				infraConfig,
 				defaultKubeconfigSecret,
 			).Build()
-		r := &MachineReconciler{
+		r := &Reconciler{
 			Client:  cl,
 			Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 		}
@@ -350,7 +350,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 				infraConfig,
 				defaultKubeconfigSecret,
 			).Build()
-		r := &MachineReconciler{
+		r := &Reconciler{
 			Client:  cl,
 			Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 		}
@@ -426,7 +426,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 				infraConfig,
 				defaultKubeconfigSecret,
 			).Build()
-		r := &MachineReconciler{
+		r := &Reconciler{
 			Client:  cl,
 			Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 		}
@@ -486,7 +486,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 				infraConfig,
 			).Build()
 
-		r := &MachineReconciler{
+		r := &Reconciler{
 			Client:  cl,
 			Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 		}
@@ -567,7 +567,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 				bootstrapConfig,
 				infraConfig,
 			).Build()
-		r := &MachineReconciler{
+		r := &Reconciler{
 			Client:   cl,
 			Tracker:  remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 			recorder: record.NewFakeRecorder(32),
@@ -866,7 +866,7 @@ func TestReconcileBootstrap(t *testing.T) {
 			}
 
 			bootstrapConfig := &unstructured.Unstructured{Object: tc.bootstrapConfig}
-			r := &MachineReconciler{
+			r := &Reconciler{
 				Client: fake.NewClientBuilder().
 					WithObjects(tc.machine,
 						builder.GenericBootstrapConfigCRD.DeepCopy(),
@@ -1076,7 +1076,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 			}
 
 			infraConfig := &unstructured.Unstructured{Object: tc.infraConfig}
-			r := &MachineReconciler{
+			r := &Reconciler{
 				Client: fake.NewClientBuilder().
 					WithObjects(tc.machine,
 						builder.GenericBootstrapConfigCRD.DeepCopy(),

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machine
 
 import (
 	"testing"
@@ -383,7 +383,7 @@ func TestMachineFinalizer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			mr := &MachineReconciler{
+			mr := &Reconciler{
 				Client: fake.NewClientBuilder().WithObjects(
 					clusterCorrectMeta,
 					machineValidCluster,
@@ -549,7 +549,7 @@ func TestMachineOwnerReference(t *testing.T) {
 				machineValidMachine,
 				machineValidControlled,
 			).Build()
-			mr := &MachineReconciler{
+			mr := &Reconciler{
 				Client:    c,
 				APIReader: c,
 			}
@@ -721,7 +721,7 @@ func TestReconcileRequest(t *testing.T) {
 				&infraConfig,
 			).Build()
 
-			r := &MachineReconciler{
+			r := &Reconciler{
 				Client:  clientFake,
 				Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			}
@@ -966,7 +966,7 @@ func TestMachineConditions(t *testing.T) {
 				node,
 			).Build()
 
-			r := &MachineReconciler{
+			r := &Reconciler{
 				Client:  clientFake,
 				Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			}
@@ -1055,7 +1055,7 @@ func TestReconcileDeleteExternal(t *testing.T) {
 				objs = append(objs, bootstrapConfig)
 			}
 
-			r := &MachineReconciler{
+			r := &Reconciler{
 				Client: fake.NewClientBuilder().WithObjects(objs...).Build(),
 			}
 
@@ -1097,7 +1097,7 @@ func TestRemoveMachineFinalizerAfterDeleteReconcile(t *testing.T) {
 		},
 	}
 	key := client.ObjectKey{Namespace: m.Namespace, Name: m.Name}
-	mr := &MachineReconciler{
+	mr := &Reconciler{
 		Client: fake.NewClientBuilder().WithObjects(testCluster, m).Build(),
 	}
 	_, err := mr.Reconcile(ctx, reconcile.Request{NamespacedName: key})
@@ -1223,7 +1223,7 @@ func TestIsNodeDrainedAllowed(t *testing.T) {
 			var objs []client.Object
 			objs = append(objs, testCluster, tt.machine)
 
-			r := &MachineReconciler{
+			r := &Reconciler{
 				Client: fake.NewClientBuilder().WithObjects(objs...).Build(),
 			}
 
@@ -1572,7 +1572,7 @@ func TestIsDeleteNodeAllowed(t *testing.T) {
 				m2.Labels[clusterv1.MachineControlPlaneLabelName] = ""
 			}
 
-			mr := &MachineReconciler{
+			mr := &Reconciler{
 				Client: fake.NewClientBuilder().WithObjects(
 					tc.cluster,
 					tc.machine,
@@ -1843,7 +1843,7 @@ func TestNodeToMachine(t *testing.T) {
 		},
 	}
 
-	r := &MachineReconciler{
+	r := &Reconciler{
 		Client: env,
 	}
 	for _, node := range fakeNodes {
@@ -1867,6 +1867,7 @@ func addConditionsToExternal(u *unstructured.Unstructured, newConditions cluster
 }
 
 // asserts the conditions set on the Getter object.
+// TODO: replace this with util.condition.MatchConditions (or a new matcher in internal/matchers).
 func assertConditions(t *testing.T, from conditions.Getter, conditions ...*clusterv1.Condition) {
 	t.Helper()
 

--- a/internal/controllers/machine/machine_helpers.go
+++ b/internal/controllers/machine/machine_helpers.go
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machine
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-// hasMatchingLabels verifies that the Label Selector matches the given Labels.
-func hasMatchingLabels(matchSelector metav1.LabelSelector, matchLabels map[string]string) bool {
+// HasMatchingLabels verifies that the Label Selector matches the given Labels.
+func HasMatchingLabels(matchSelector metav1.LabelSelector, matchLabels map[string]string) bool {
 	// This should never fail, validating webhook should catch this first
 	selector, err := metav1.LabelSelectorAsSelector(&matchSelector)
 	if err != nil {

--- a/internal/controllers/machine/machine_helpers_test.go
+++ b/internal/controllers/machine/machine_helpers_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machine
 
 import (
 	"testing"
@@ -84,7 +84,7 @@ func TestHasMatchingLabels(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			got := hasMatchingLabels(tc.selector, tc.labels)
+			got := HasMatchingLabels(tc.selector, tc.labels)
 			g.Expect(got).To(Equal(tc.expected))
 		})
 	}

--- a/internal/controllers/machine/suite_test.go
+++ b/internal/controllers/machine/suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package machine
 
 import (
 	"context"
@@ -38,14 +38,11 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
 	"sigs.k8s.io/cluster-api/controllers/remote"
-	"sigs.k8s.io/cluster-api/internal/controllers/cluster"
-	"sigs.k8s.io/cluster-api/internal/controllers/machine"
 	"sigs.k8s.io/cluster-api/internal/envtest"
 )
 
 const (
-	timeout         = time.Second * 30
-	testClusterName = "test-cluster"
+	timeout = time.Second * 30
 )
 
 var (
@@ -88,40 +85,12 @@ func TestMain(m *testing.M) {
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("Failed to start ClusterCacheReconciler: %v", err))
 		}
-		if err := (&cluster.Reconciler{
-			Client:    mgr.GetClient(),
-			APIReader: mgr.GetClient(),
-		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
-			panic(fmt.Sprintf("Failed to start ClusterReconciler: %v", err))
-		}
-		if err := (&machine.Reconciler{
+		if err := (&Reconciler{
 			Client:    mgr.GetClient(),
 			APIReader: mgr.GetAPIReader(),
 			Tracker:   tracker,
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("Failed to start MachineReconciler: %v", err))
-		}
-		if err := (&MachineSetReconciler{
-			Client:    mgr.GetClient(),
-			APIReader: mgr.GetAPIReader(),
-			Tracker:   tracker,
-			recorder:  mgr.GetEventRecorderFor("machineset-controller"),
-		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
-			panic(fmt.Sprintf("Failed to start MMachineSetReconciler: %v", err))
-		}
-		if err := (&MachineDeploymentReconciler{
-			Client:    mgr.GetClient(),
-			APIReader: mgr.GetAPIReader(),
-			recorder:  mgr.GetEventRecorderFor("machinedeployment-controller"),
-		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
-			panic(fmt.Sprintf("Failed to start MMachineDeploymentReconciler: %v", err))
-		}
-		if err := (&MachineHealthCheckReconciler{
-			Client:   mgr.GetClient(),
-			Tracker:  tracker,
-			recorder: mgr.GetEventRecorderFor("machinehealthcheck-controller"),
-		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
-			panic(fmt.Sprintf("Failed to start MachineHealthCheckReconciler : %v", err))
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves a first group of controllers from /controllers to internal/controllers

**Which issue(s) this PR fixes**:
Rif https://github.com/kubernetes-sigs/cluster-api/issues/5455
