### PR TITLE
🌱 test/e2e/framework: log kind output during cluster creation

### DIFF
--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	kindv1 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	kind "sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/cmd"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework/internal/log"
@@ -139,8 +140,8 @@ func (k *KindClusterProvider) createKindCluster() {
 	}
 	kindCreateOptions = append(kindCreateOptions, kind.CreateWithNodeImage(nodeImage))
 
-	err := kind.NewProvider().Create(k.name, kindCreateOptions...)
-	Expect(err).ToNot(HaveOccurred(), "Failed to create the kind cluster %q")
+	err := kind.NewProvider(kind.ProviderWithLogger(cmd.NewLogger())).Create(k.name, kindCreateOptions...)
+	Expect(err).ToNot(HaveOccurred(), "Failed to create the kind cluster")
 }
 
 // setDockerSockConfig returns a kind config for mounting /var/run/docker.sock into the kind node.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
