### PR TITLE
📖 Update quick start doc for CAPZ

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -433,6 +433,9 @@ export AZURE_LOCATION="centralus"
 # Select VM types.
 export AZURE_CONTROL_PLANE_MACHINE_TYPE="Standard_D2s_v3"
 export AZURE_NODE_MACHINE_TYPE="Standard_D2s_v3"
+
+# [Optional] Select resource group. The default value is ${CLUSTER_NAME}.
+export AZURE_RESOURCE_GROUP="<ResourceGroupName>"
 ```
 
 {{#/tab }}


### PR DESCRIPTION
AZURE_RESOURCE_GROUP is an optional variable. However, if it is
not mentioned here, developers may be confused where the cluster
goes.

Signed-off-by: Zhecheng Li <zhechengli@microsoft.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

It improves quick start doc of capz.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
