### PR TITLE
🐛 Making machinedeployment.spec.replicas compatible with a GitOps workflow + Cluster Autoscaler

### DIFF
--- a/api/v1beta1/machinedeployment_types.go
+++ b/api/v1beta1/machinedeployment_types.go
@@ -70,7 +70,6 @@ type MachineDeploymentSpec struct {
 	// Number of desired machines. Defaults to 1.
 	// This is a pointer to distinguish between explicit zero and not specified.
 	// +optional
-	// +kubebuilder:default=1
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Label selector for machines. Existing MachineSets whose machines are

--- a/api/v1beta1/machinedeployment_webhook.go
+++ b/api/v1beta1/machinedeployment_webhook.go
@@ -148,6 +148,10 @@ func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
 	}
 	d.Labels[ClusterLabelName] = d.Spec.ClusterName
 
+	if d.Spec.Replicas == nil {
+		d.Spec.Replicas = pointer.Int32Ptr(1)
+	}
+
 	if d.Spec.MinReadySeconds == nil {
 		d.Spec.MinReadySeconds = pointer.Int32Ptr(0)
 	}

--- a/api/v1beta1/machinedeployment_webhook_test.go
+++ b/api/v1beta1/machinedeployment_webhook_test.go
@@ -46,8 +46,9 @@ func TestMachineDeploymentDefault(t *testing.T) {
 
 	g.Expect(md.Labels[ClusterLabelName]).To(Equal(md.Spec.ClusterName))
 	g.Expect(md.Spec.MinReadySeconds).To(Equal(pointer.Int32Ptr(0)))
-	g.Expect(md.Spec.RevisionHistoryLimit).To(Equal(pointer.Int32Ptr(1)))
 	g.Expect(md.Spec.ProgressDeadlineSeconds).To(Equal(pointer.Int32Ptr(600)))
+	g.Expect(md.Spec.Replicas).To(Equal(pointer.Int32Ptr(1)))
+	g.Expect(md.Spec.RevisionHistoryLimit).To(Equal(pointer.Int32Ptr(1)))
 	g.Expect(md.Spec.Strategy).ToNot(BeNil())
 	g.Expect(md.Spec.Selector.MatchLabels).To(HaveKeyWithValue(MachineDeploymentLabelName, "test-md"))
 	g.Expect(md.Spec.Template.Labels).To(HaveKeyWithValue(MachineDeploymentLabelName, "test-md"))

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -1039,7 +1039,6 @@ spec:
                 format: int32
                 type: integer
               replicas:
-                default: 1
                 description: Number of desired machines. Defaults to 1. This is a
                   pointer to distinguish between explicit zero and not specified.
                 format: int32


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the default value of `machinedeployment.spec.replicas` as it breaks e.g. a gitops engine patcheing a MachineDeployment the cluster-autoscaler already reconfigured, resulting in a cluster scaling way down and then back-up again.
The gitops (in our case flux2) reconciliation returns to the default value of 1 when the field is not set in the manifest, cluster-autoscaler fixes this in its next run -> almost all cluster nodes get replaced.