### PR TITLE
🌱 Collect kind logs when e2e bootstrap fails

### DIFF
--- a/docs/book/src/developer/providers/v1.0-to-v1.1.md
+++ b/docs/book/src/developer/providers/v1.0-to-v1.1.md
@@ -58,6 +58,8 @@ are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
     * e2e tests:
         * `QuickStartSpec` is now able to test clusters using ClusterClass. Please see this [PR](https://github.com/kubernetes-sigs/cluster-api/pull/5423) for an example on how to use it.
         * `SelfHostedSpec` is now able to test clusters using ClusterClass. Please see this [PR](https://github.com/kubernetes-sigs/cluster-api/pull/5600) for an example on how to use it.
+* Test framework provides better logging in case of failures when creating the bootstrap kind cluster; in order to
+  fully exploit this feature, it is required to pass the `LogFolder` parameter when calling `CreateKindBootstrapClusterAndLoadImages`. Please see this [PR](https://github.com/kubernetes-sigs/cluster-api/pull/5910) for an example on how to use it. 
 * The `gci` linter has been enabled to enforce consistent imports. As usual, feel free to take a look at our linter config, but of course it's not mandatory to adopt it.
 * The Tilt dev setup has been extended with:
     * [an option to deploy Grafana, Loki and promtail](https://github.com/kubernetes-sigs/cluster-api/pull/5336) 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -218,6 +218,7 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 			RequiresDockerSock: config.HasDockerProvider(),
 			Images:             config.Images,
 			IPFamily:           config.GetVariable(IPFamily),
+			LogFolder:          filepath.Join(artifactFolder, "kind"),
 		})
 		Expect(clusterProvider).ToNot(BeNil(), "Failed to create a bootstrap cluster")
 

--- a/test/framework/bootstrap/kind_util.go
+++ b/test/framework/bootstrap/kind_util.go
@@ -49,6 +49,9 @@ type CreateKindBootstrapClusterAndLoadImagesInput struct {
 
 	// IPFamily is either ipv4 or ipv6. Default is ipv4.
 	IPFamily string
+
+	// LogFolder where to dump logs in case of errors
+	LogFolder string
 }
 
 // CreateKindBootstrapClusterAndLoadImages returns a new Kubernetes cluster with pre-loaded images.
@@ -67,6 +70,9 @@ func CreateKindBootstrapClusterAndLoadImages(ctx context.Context, input CreateKi
 	}
 	if input.IPFamily == "IPv6" {
 		options = append(options, WithIPv6Family())
+	}
+	if input.LogFolder != "" {
+		options = append(options, LogFolder(input.LogFolder))
 	}
 
 	clusterProvider := NewKindClusterProvider(input.Name, options...)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the E2E test framework by collecting kind logs in case creating the bootstrap cluster fails for any reason