### PR TITLE
🌱 ClusterClass: make ControlPlane.spec.machineTemplate.nodeDrainTimeout patchable

### DIFF
--- a/controllers/topology/internal/extensions/patches/engine.go
+++ b/controllers/topology/internal/extensions/patches/engine.go
@@ -326,7 +326,6 @@ func updateDesiredState(ctx context.Context, req *api.GenerateRequest, blueprint
 	if err := patchObject(ctx, desired.ControlPlane.Object, controlPlaneTemplate, PreserveFields{
 		contract.ControlPlane().MachineTemplate().Metadata().Path(),
 		contract.ControlPlane().MachineTemplate().InfrastructureRef().Path(),
-		contract.ControlPlane().MachineTemplate().NodeDrainTimeout().Path(),
 		contract.ControlPlane().Replicas().Path(),
 		contract.ControlPlane().Version().Path(),
 	}); err != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR makes it possible to patch ControlPlane.spec.machineTemplate.nodeDrainTimeout via ClusterClass patches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
