### PR TITLE
🌱 Improve managed field annotation encoding

### DIFF
--- a/internal/controllers/topology/cluster/mergepatch/mergepatch.go
+++ b/internal/controllers/topology/cluster/mergepatch/mergepatch.go
@@ -60,7 +60,11 @@ func NewHelper(original, modified client.Object, c client.Client, opts ...Helper
 
 	// Infer the list of paths managed by the topology controller in the previous patch operation;
 	// changes to those paths are going to be considered authoritative.
-	helperOptions.managedPaths = getManagedPaths(original)
+	managedPaths, err := getManagedPaths(original)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal original object to json")
+	}
+	helperOptions.managedPaths = managedPaths
 
 	// Convert the input objects to json.
 	originalJSON, err := json.Marshal(original)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the managed field annotation recently introduced for Topology managed objects by reducing the annotation length by about 60% in the case of real KCP objects.

Note: the value is not human readable, but it can be easily converted by `pbcopy | base64 -d | gunzip` (pbcopy can be replaced by echo or other means to get the annotation content)

**Which issue(s) this PR fixes**:
Fixes #
