### PR TITLE
🐛 Fix tilt prepare to work with kustomize version 4.4.1

### DIFF
--- a/hack/tools/tilt-prepare/main.go
+++ b/hack/tools/tilt-prepare/main.go
@@ -353,8 +353,6 @@ func kustomizeTask(path, out string) taskFunction {
 			kustomizePath,
 			"build",
 			path,
-			// enable helm to enable helmChartInflationGenerator.
-			"--enable-helm",
 		)
 
 		var stdout, stderr bytes.Buffer


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix tilt-prepare to work with kustomize version 4.4.1

**Which issue(s) this PR fixes**:
Fixes #
