### PR TITLE
🐛 test/e2e/cluster-upgrade: skip worker upgrades if worker count is 0

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -167,19 +167,20 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 				WaitForEtcdUpgrade:          input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 			})
 
-			By("Upgrading the machine deployment")
-			framework.UpgradeMachineDeploymentsAndWait(ctx, framework.UpgradeMachineDeploymentsAndWaitInput{
-				ClusterProxy:                input.BootstrapClusterProxy,
-				Cluster:                     clusterResources.Cluster,
-				UpgradeVersion:              input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
-				MachineDeployments:          clusterResources.MachineDeployments,
-				WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
-			})
+			if workerMachineCount > 0 {
+				By("Upgrading the machine deployment")
+				framework.UpgradeMachineDeploymentsAndWait(ctx, framework.UpgradeMachineDeploymentsAndWaitInput{
+					ClusterProxy:                input.BootstrapClusterProxy,
+					Cluster:                     clusterResources.Cluster,
+					UpgradeVersion:              input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
+					MachineDeployments:          clusterResources.MachineDeployments,
+					WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+				})
+			}
 		}
 
-		// Only attempt to upgrade MachinePools if they were provided in the template,
-		// also adjust the expected workerMachineCount if we have MachinePools
-		if len(clusterResources.MachinePools) > 0 {
+		// Only attempt to upgrade MachinePools if they were provided in the template.
+		if len(clusterResources.MachinePools) > 0 && workerMachineCount > 0 {
 			By("Upgrading the machinepool instances")
 			framework.UpgradeMachinePoolAndWait(ctx, framework.UpgradeMachinePoolAndWaitInput{
 				ClusterProxy:                   input.BootstrapClusterProxy,

--- a/test/framework/cluster_topology_helpers.go
+++ b/test/framework/cluster_topology_helpers.go
@@ -130,14 +130,16 @@ func UpgradeClusterTopologyAndWaitForUpgrade(ctx context.Context, input UpgradeC
 	}, input.WaitForEtcdUpgrade...)
 
 	for _, deployment := range input.MachineDeployments {
-		log.Logf("Waiting for Kubernetes versions of machines in MachineDeployment %s/%s to be upgraded to %s",
-			deployment.Namespace, deployment.Name, input.KubernetesUpgradeVersion)
-		WaitForMachineDeploymentMachinesToBeUpgraded(ctx, WaitForMachineDeploymentMachinesToBeUpgradedInput{
-			Lister:                   mgmtClient,
-			Cluster:                  input.Cluster,
-			MachineCount:             int(*deployment.Spec.Replicas),
-			KubernetesUpgradeVersion: input.KubernetesUpgradeVersion,
-			MachineDeployment:        *deployment,
-		}, input.WaitForMachinesToBeUpgraded...)
+		if *deployment.Spec.Replicas > 0 {
+			log.Logf("Waiting for Kubernetes versions of machines in MachineDeployment %s/%s to be upgraded to %s",
+				deployment.Namespace, deployment.Name, input.KubernetesUpgradeVersion)
+			WaitForMachineDeploymentMachinesToBeUpgraded(ctx, WaitForMachineDeploymentMachinesToBeUpgradedInput{
+				Lister:                   mgmtClient,
+				Cluster:                  input.Cluster,
+				MachineCount:             int(*deployment.Spec.Replicas),
+				KubernetesUpgradeVersion: input.KubernetesUpgradeVersion,
+				MachineDeployment:        *deployment,
+			}, input.WaitForMachinesToBeUpgraded...)
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently, the cluster upgrade test fails when the worker count is 0 (https://github.com/kubernetes-sigs/cluster-api/issues/4896#issuecomment-1010523122). This PR makes sure we skip the upgrade of MachineDeployments and MachinePools in that case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
