### PR TITLE
🐛  Fix to improper formatting of UnhealthyRange

### DIFF
--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -273,7 +273,7 @@ func (r *Reconciler) reconcile(ctx context.Context, logger logr.Logger, cluster 
 			Message:  message,
 		})
 
-		r.recorder.Eventf(
+		r.recorder.Event(
 			m,
 			corev1.EventTypeWarning,
 			EventRemediationRestricted,


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

This change adds formatting to a condition and event in the machineHealthCheck controller that handles the percentage sign included in the message.
 Previously this message would print as: 

` Remediation is not allowed, the number of not started or unhealthy machines exceeds maxUnhealthy (total: 1, unhealthy: 0, maxUnhealthy: 45%!)(MISSING)
`
Due to the percentage sign being included in the unhealthyRange string. There's an example here: https://go.dev/play/p/mX6DG6oRzKW