### PR TITLE
✨ Introduce version check validation for generate provider command

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -75,6 +75,9 @@ type Client interface {
 	// DescribeCluster returns the object tree representing the status of a Cluster API cluster.
 	DescribeCluster(options DescribeClusterOptions) (*tree.ObjectTree, error)
 
+	// GenerateProvider validates the input provider version is compatible with the version of clusterctl and returns the provider components.
+	GenerateProvider(providerName string, providerType clusterctlv1.ProviderType, options ComponentsOptions) (Components, error)
+
 	// AlphaClient is an Interface for alpha features in clusterctl
 	AlphaClient
 }

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -80,6 +80,10 @@ func (f fakeClient) GetProviderComponents(provider string, providerType clusterc
 	return f.internalClient.GetProviderComponents(provider, providerType, options)
 }
 
+func (f fakeClient) GenerateProvider(provider string, providerType clusterctlv1.ProviderType, options ComponentsOptions) (Components, error) {
+	return f.internalClient.GenerateProvider(provider, providerType, options)
+}
+
 func (f fakeClient) GetClusterTemplate(options GetClusterTemplateOptions) (Template, error) {
 	return f.internalClient.GetClusterTemplate(options)
 }

--- a/cmd/clusterctl/cmd/generate_provider.go
+++ b/cmd/clusterctl/cmd/generate_provider.go
@@ -107,7 +107,7 @@ func runGenerateProviderComponents() error {
 		SkipTemplateProcess: gpo.raw,
 	}
 
-	components, err := c.GetProviderComponents(providerName, providerType, options)
+	components, err := c.GenerateProvider(providerName, providerType, options)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: tharun <rajendrantharun@live.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
This PR introduces validation for incompatible versions while generating providers using the `generate provider` command.
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5864
