### PR TITLE
🌱 ClusterClass: validate MachineDeployment topology name not empty

### DIFF
--- a/internal/topology/check/compatibility.go
+++ b/internal/topology/check/compatibility.go
@@ -263,8 +263,9 @@ func MachineDeploymentClassesAreUnique(clusterClass *clusterv1.ClusterClass) fie
 	return allErrs
 }
 
-// MachineDeploymentTopologiesAreUniqueAndDefinedInClusterClass checks that each MachineDeploymentTopology name is unique, and each class in use is defined in ClusterClass.spec.Workers.MachineDeployments.
-func MachineDeploymentTopologiesAreUniqueAndDefinedInClusterClass(desired *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) field.ErrorList {
+// MachineDeploymentTopologiesAreValidAndDefinedInClusterClass checks that each MachineDeploymentTopology name is not empty
+// and unique, and each class in use is defined in ClusterClass.spec.Workers.MachineDeployments.
+func MachineDeploymentTopologiesAreValidAndDefinedInClusterClass(desired *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) field.ErrorList {
 	var allErrs field.ErrorList
 	if desired.Spec.Topology.Workers == nil {
 		return nil
@@ -286,6 +287,19 @@ func MachineDeploymentTopologiesAreUniqueAndDefinedInClusterClass(desired *clust
 				),
 			)
 		}
+
+		// MachineDeploymentTopology name should not be empty.
+		if md.Name == "" {
+			allErrs = append(
+				allErrs,
+				field.Required(
+					field.NewPath("spec", "topology", "workers", "machineDeployments").Index(i).Child("name"),
+					"name must not be empty",
+				),
+			)
+			continue
+		}
+
 		if names.Has(md.Name) {
 			allErrs = append(allErrs,
 				field.Invalid(

--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -215,7 +215,7 @@ func (webhook *Cluster) validateTopology(ctx context.Context, oldCluster, newClu
 		return allErrs
 	}
 
-	allErrs = append(allErrs, check.MachineDeploymentTopologiesAreUniqueAndDefinedInClusterClass(newCluster, clusterClass)...)
+	allErrs = append(allErrs, check.MachineDeploymentTopologiesAreValidAndDefinedInClusterClass(newCluster, clusterClass)...)
 
 	// Check if the variables defined in the clusterClass are valid.
 	allErrs = append(allErrs, variables.ValidateClusterVariables(newCluster.Spec.Topology.Variables, clusterClass.Spec.Variables, field.NewPath("spec", "topology", "variables"))...)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Setting the MD topology name to an empty string leads to errors during reconcile, so this PR now
validates that it is not empty.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
