### PR TITLE
🌱 linter: enable noctx and unused

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
   - misspell
   - nakedret
   - nilerr
+  - noctx
   - nolintlint
   - prealloc
   - predeclared
@@ -37,6 +38,7 @@ linters:
   - typecheck
   - unconvert
   - unparam
+  - unused
   - varcheck
   - whitespace
 
@@ -149,6 +151,8 @@ linters-settings:
     - unnecessaryDefer
     - whyNoLint
     - wrapperFunc
+  unused:
+    go: "1.17"
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/cmd/clusterctl/client/config/reader_viper.go
+++ b/cmd/clusterctl/client/config/reader_viper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -133,6 +134,8 @@ func (v *viperReader) Init(path string) error {
 }
 
 func downloadFile(url string, filepath string) error {
+	ctx := context.TODO()
+
 	// Create the file
 	out, err := os.Create(filepath)
 	if err != nil {
@@ -144,7 +147,12 @@ func downloadFile(url string, filepath string) error {
 		Timeout: 30 * time.Second,
 	}
 	// Get the data
-	resp, err := client.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return errors.Wrapf(err, "failed to download the clusterctl config file from %s: failed to create request", url)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "failed to download the clusterctl config file from %s", url)
 	}

--- a/hack/tools/mdbook/embed/embed.go
+++ b/hack/tools/mdbook/embed/embed.go
@@ -56,7 +56,7 @@ func (l Embed) Process(input *plugin.Input) error {
 			Path:   path.Join("/", repository, branch, filePath),
 		}
 
-		resp, err := http.Get(rawURL.String())
+		resp, err := http.Get(rawURL.String()) //nolint:noctx // NB: as we're just implementing an external interface we won't be able to get a context here.
 		if err != nil {
 			return "", err
 		}

--- a/hack/tools/mdbook/releaselink/releaselink.go
+++ b/hack/tools/mdbook/releaselink/releaselink.go
@@ -68,7 +68,7 @@ func (l ReleaseLink) Process(input *plugin.Input) error {
 			Path:   path.Join(gomodule, "@v", "/list"),
 		}
 
-		resp, err := http.Get(rawURL.String())
+		resp, err := http.Get(rawURL.String()) //nolint:noctx // NB: as we're just implementing an external interface we won't be able to get a context here.
 		if err != nil {
 			return "", err
 		}

--- a/test/framework/clusterctl/repository.go
+++ b/test/framework/clusterctl/repository.go
@@ -143,7 +143,7 @@ func YAMLForComponentSource(ctx context.Context, source ProviderVersionSource) (
 
 	switch source.Type {
 	case URLSource:
-		buf, err := getComponentSourceFromURL(source)
+		buf, err := getComponentSourceFromURL(ctx, source)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get component source YAML from URL")
 		}
@@ -173,7 +173,7 @@ func YAMLForComponentSource(ctx context.Context, source ProviderVersionSource) (
 }
 
 // getComponentSourceFromURL fetches contents of component source YAML file from provided URL source.
-func getComponentSourceFromURL(source ProviderVersionSource) ([]byte, error) {
+func getComponentSourceFromURL(ctx context.Context, source ProviderVersionSource) ([]byte, error) {
 	var buf []byte
 
 	u, err := url.Parse(source.Value)
@@ -189,14 +189,18 @@ func getComponentSourceFromURL(source ProviderVersionSource) ([]byte, error) {
 			return nil, errors.Wrap(err, "failed to read file")
 		}
 	case httpURIScheme, httpsURIScheme:
-		resp, err := http.Get(source.Value)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, source.Value, http.NoBody)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "failed to get %s: failed to create request", source.Value)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get %s", source.Value)
 		}
 		defer resp.Body.Close()
 		buf, err = io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "failed to get %s: failed to read body", source.Value)
 		}
 	default:
 		return nil, errors.Errorf("unknown scheme for component source %q: allowed values are file, http, https", u.Scheme)

--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -341,28 +341,6 @@ func dockerContainerToContainer(container *types.Container) Container {
 	}
 }
 
-// ownerAndGroup gets the user configuration for the container (user:group).
-func (crc *RunContainerInput) ownerAndGroup() string {
-	if crc.User != "" {
-		if crc.Group != "" {
-			return fmt.Sprintf("%s:%s", crc.User, crc.Group)
-		}
-
-		return crc.User
-	}
-
-	return ""
-}
-
-// environmentVariables gets the collection of environment variables for the container.
-func (crc *RunContainerInput) environmentVariables() []string {
-	envVars := []string{}
-	for key, val := range crc.EnvironmentVars {
-		envVars = append(envVars, fmt.Sprintf("%s=%s", key, val))
-	}
-	return envVars
-}
-
 // RunContainer will run a docker container with the given settings and arguments, returning any errors.
 func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContainerInput, output io.Writer) error {
 	containerConfig := dockercontainer.Config{


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR proposes to enable two new linters:
* unused: Checks Go code for unused constants, variables, functions and types
* noctx: finds sending http request without context.Context

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
