### PR TITLE
📖 Add HasPausedAnnotation and HasSkipRemediationAnnotation func deprecation notes to v1.0-v1.1 migration doc

### DIFF
--- a/docs/book/src/developer/providers/v1.0-to-v1.1.md
+++ b/docs/book/src/developer/providers/v1.0-to-v1.1.md
@@ -27,6 +27,8 @@ are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
   in `api/v1beta1` are deprecated: `SetupWebhookWithManager`, `Default`, `ValidateCreate`, `ValidateUpdate` and `ValidateDelete`.
 * The `third_party/kubernetes-drain` package is deprecated, as we're now using `k8s.io/kubectl/pkg/drain` instead ([PR](https://github.com/kubernetes-sigs/cluster-api/pull/5440)). 
 * `util/version.CompareWithBuildIdentifiers` has been deprecated, please use `util/version.Compare(a, b, WithBuildTags())` instead.
+* The functions `annotations.HasPausedAnnotation` and `annotations.HasSkipRemediationAnnotation` have been deprecated, please use
+  `annotations.HasPaused` and `annotations.HasSkipRemediation` respectively instead.
 
 ### Removals
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates v1.0-v1.1 migration doc with deprecation notice of  `HasPausedAnnotation` and `HasSkipRemediationAnnotation` functions that was missed to be added in #5545  


