### PR TITLE
✨ CABPK: Add support for kubeadm skipPhases field

### DIFF
--- a/bootstrap/kubeadm/api/v1alpha3/conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha3/conversion.go
@@ -58,12 +58,14 @@ func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.InitConfiguration = &bootstrapv1.InitConfiguration{}
 		}
 		dst.Spec.InitConfiguration.Patches = restored.Spec.InitConfiguration.Patches
+		dst.Spec.InitConfiguration.SkipPhases = restored.Spec.InitConfiguration.SkipPhases
 	}
 	if restored.Spec.JoinConfiguration != nil {
 		if dst.Spec.JoinConfiguration == nil {
 			dst.Spec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
 		}
 		dst.Spec.JoinConfiguration.Patches = restored.Spec.JoinConfiguration.Patches
+		dst.Spec.JoinConfiguration.SkipPhases = restored.Spec.JoinConfiguration.SkipPhases
 	}
 
 	return nil
@@ -129,12 +131,14 @@ func (src *KubeadmConfigTemplate) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.Template.Spec.InitConfiguration = &bootstrapv1.InitConfiguration{}
 		}
 		dst.Spec.Template.Spec.InitConfiguration.Patches = restored.Spec.Template.Spec.InitConfiguration.Patches
+		dst.Spec.Template.Spec.InitConfiguration.SkipPhases = restored.Spec.Template.Spec.InitConfiguration.SkipPhases
 	}
 	if restored.Spec.Template.Spec.JoinConfiguration != nil {
 		if dst.Spec.Template.Spec.JoinConfiguration == nil {
 			dst.Spec.Template.Spec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
 		}
 		dst.Spec.Template.Spec.JoinConfiguration.Patches = restored.Spec.Template.Spec.JoinConfiguration.Patches
+		dst.Spec.Template.Spec.JoinConfiguration.SkipPhases = restored.Spec.Template.Spec.JoinConfiguration.SkipPhases
 	}
 
 	return nil

--- a/bootstrap/kubeadm/api/v1alpha4/conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha4/conversion.go
@@ -43,12 +43,14 @@ func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.InitConfiguration = &bootstrapv1.InitConfiguration{}
 		}
 		dst.Spec.InitConfiguration.Patches = restored.Spec.InitConfiguration.Patches
+		dst.Spec.InitConfiguration.SkipPhases = restored.Spec.InitConfiguration.SkipPhases
 	}
 	if restored.Spec.JoinConfiguration != nil {
 		if dst.Spec.JoinConfiguration == nil {
 			dst.Spec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
 		}
 		dst.Spec.JoinConfiguration.Patches = restored.Spec.JoinConfiguration.Patches
+		dst.Spec.JoinConfiguration.SkipPhases = restored.Spec.JoinConfiguration.SkipPhases
 	}
 
 	return nil
@@ -95,12 +97,14 @@ func (src *KubeadmConfigTemplate) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.Template.Spec.InitConfiguration = &bootstrapv1.InitConfiguration{}
 		}
 		dst.Spec.Template.Spec.InitConfiguration.Patches = restored.Spec.Template.Spec.InitConfiguration.Patches
+		dst.Spec.Template.Spec.InitConfiguration.SkipPhases = restored.Spec.Template.Spec.InitConfiguration.SkipPhases
 	}
 	if restored.Spec.Template.Spec.JoinConfiguration != nil {
 		if dst.Spec.Template.Spec.JoinConfiguration == nil {
 			dst.Spec.Template.Spec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
 		}
 		dst.Spec.Template.Spec.JoinConfiguration.Patches = restored.Spec.Template.Spec.JoinConfiguration.Patches
+		dst.Spec.Template.Spec.JoinConfiguration.SkipPhases = restored.Spec.Template.Spec.JoinConfiguration.SkipPhases
 	}
 
 	return nil

--- a/bootstrap/kubeadm/api/v1alpha4/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha4/zz_generated.conversion.go
@@ -949,6 +949,7 @@ func autoConvert_v1beta1_InitConfiguration_To_v1alpha4_InitConfiguration(in *v1b
 	if err := Convert_v1beta1_APIEndpoint_To_v1alpha4_APIEndpoint(&in.LocalAPIEndpoint, &out.LocalAPIEndpoint, s); err != nil {
 		return err
 	}
+	// WARNING: in.SkipPhases requires manual conversion: does not exist in peer-type
 	// WARNING: in.Patches requires manual conversion: does not exist in peer-type
 	return nil
 }
@@ -979,6 +980,7 @@ func autoConvert_v1beta1_JoinConfiguration_To_v1alpha4_JoinConfiguration(in *v1b
 		return err
 	}
 	out.ControlPlane = (*JoinControlPlane)(unsafe.Pointer(in.ControlPlane))
+	// WARNING: in.SkipPhases requires manual conversion: does not exist in peer-type
 	// WARNING: in.Patches requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
@@ -54,6 +54,12 @@ type InitConfiguration struct {
 	// +optional
 	LocalAPIEndpoint APIEndpoint `json:"localAPIEndpoint,omitempty"`
 
+	// SkipPhases is a list of phases to skip during command execution.
+	// The list of phases can be obtained with the "kubeadm init --help" command.
+	// This option takes effect only on Kubernetes >=1.22.0.
+	// +optional
+	SkipPhases []string `json:"skipPhases,omitempty"`
+
 	// Patches contains options related to applying patches to components deployed by kubeadm during
 	// "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
 	// +optional
@@ -365,6 +371,12 @@ type JoinConfiguration struct {
 	// If nil, no additional control plane instance will be deployed.
 	// +optional
 	ControlPlane *JoinControlPlane `json:"controlPlane,omitempty"`
+
+	// SkipPhases is a list of phases to skip during command execution.
+	// The list of phases can be obtained with the "kubeadm init --help" command.
+	// This option takes effect only on Kubernetes >=1.22.0.
+	// +optional
+	SkipPhases []string `json:"skipPhases,omitempty"`
 
 	// Patches contains options related to applying patches to components deployed by kubeadm during
 	// "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22

--- a/bootstrap/kubeadm/api/v1beta1/zz_generated.deepcopy.go
+++ b/bootstrap/kubeadm/api/v1beta1/zz_generated.deepcopy.go
@@ -522,6 +522,11 @@ func (in *InitConfiguration) DeepCopyInto(out *InitConfiguration) {
 	}
 	in.NodeRegistration.DeepCopyInto(&out.NodeRegistration)
 	out.LocalAPIEndpoint = in.LocalAPIEndpoint
+	if in.SkipPhases != nil {
+		in, out := &in.SkipPhases, &out.SkipPhases
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Patches != nil {
 		in, out := &in.Patches, &out.Patches
 		*out = new(Patches)
@@ -557,6 +562,11 @@ func (in *JoinConfiguration) DeepCopyInto(out *JoinConfiguration) {
 		in, out := &in.ControlPlane, &out.ControlPlane
 		*out = new(JoinControlPlane)
 		**out = **in
+	}
+	if in.SkipPhases != nil {
+		in, out := &in.SkipPhases, &out.SkipPhases
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.Patches != nil {
 		in, out := &in.Patches, &out.Patches

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -2665,6 +2665,14 @@ spec:
                           content inline or by referencing a secret.
                         type: string
                     type: object
+                  skipPhases:
+                    description: SkipPhases is a list of phases to skip during command
+                      execution. The list of phases can be obtained with the "kubeadm
+                      init --help" command. This option takes effect only on Kubernetes
+                      >=1.22.0.
+                    items:
+                      type: string
+                    type: array
                 type: object
               joinConfiguration:
                 description: JoinConfiguration is the kubeadm configuration for the
@@ -2868,6 +2876,14 @@ spec:
                           content inline or by referencing a secret.
                         type: string
                     type: object
+                  skipPhases:
+                    description: SkipPhases is a list of phases to skip during command
+                      execution. The list of phases can be obtained with the "kubeadm
+                      init --help" command. This option takes effect only on Kubernetes
+                      >=1.22.0.
+                    items:
+                      type: string
+                    type: array
                 type: object
               mounts:
                 description: Mounts specifies a list of mount points to be setup.

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -2697,6 +2697,14 @@ spec:
                                   content inline or by referencing a secret.
                                 type: string
                             type: object
+                          skipPhases:
+                            description: SkipPhases is a list of phases to skip during
+                              command execution. The list of phases can be obtained
+                              with the "kubeadm init --help" command. This option
+                              takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              type: string
+                            type: array
                         type: object
                       joinConfiguration:
                         description: JoinConfiguration is the kubeadm configuration
@@ -2915,6 +2923,14 @@ spec:
                                   content inline or by referencing a secret.
                                 type: string
                             type: object
+                          skipPhases:
+                            description: SkipPhases is a list of phases to skip during
+                              command execution. The list of phases can be obtained
+                              with the "kubeadm init --help" command. This option
+                              takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              type: string
+                            type: array
                         type: object
                       mounts:
                         description: Mounts specifies a list of mount points to be

--- a/bootstrap/kubeadm/types/upstreamv1beta1/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta1/conversion_test.go
@@ -96,6 +96,10 @@ func kubeadmInitConfigurationFuzzer(obj *bootstrapv1.InitConfiguration, c fuzz.C
 	// InitConfiguration.Patches does not exist in kubeadm v1beta1 API, so setting it to nil in order to avoid
 	// v1beta1 --> upstream v1beta1 -> v1beta1 round trip errors.
 	obj.Patches = nil
+
+	// InitConfiguration.SkipPhases does not exist in kubeadm v1beta1 API, so setting it to nil in order to avoid
+	// v1beta1 --> upstream v1beta1 -> v1beta1 round trip errors.
+	obj.SkipPhases = nil
 }
 
 func kubeadmJoinConfigurationFuzzer(obj *bootstrapv1.JoinConfiguration, c fuzz.Continue) {
@@ -104,4 +108,8 @@ func kubeadmJoinConfigurationFuzzer(obj *bootstrapv1.JoinConfiguration, c fuzz.C
 	// JoinConfiguration.Patches does not exist in kubeadm v1beta1 API, so setting it to nil in order to avoid
 	// v1beta1 --> upstream v1beta1 -> v1beta1 round trip errors.
 	obj.Patches = nil
+
+	// JoinConfiguration.SkipPhases does not exist in kubeadm v1beta1 API, so setting it to nil in order to avoid
+	// v1beta1 --> upstream v1beta1 -> v1beta1 round trip errors.
+	obj.SkipPhases = nil
 }

--- a/bootstrap/kubeadm/types/upstreamv1beta1/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta1/zz_generated.conversion.go
@@ -671,6 +671,7 @@ func autoConvert_v1beta1_InitConfiguration_To_upstreamv1beta1_InitConfiguration(
 	if err := Convert_v1beta1_APIEndpoint_To_upstreamv1beta1_APIEndpoint(&in.LocalAPIEndpoint, &out.LocalAPIEndpoint, s); err != nil {
 		return err
 	}
+	// WARNING: in.SkipPhases requires manual conversion: does not exist in peer-type
 	// WARNING: in.Patches requires manual conversion: does not exist in peer-type
 	return nil
 }
@@ -701,6 +702,7 @@ func autoConvert_v1beta1_JoinConfiguration_To_upstreamv1beta1_JoinConfiguration(
 		return err
 	}
 	out.ControlPlane = (*JoinControlPlane)(unsafe.Pointer(in.ControlPlane))
+	// WARNING: in.SkipPhases requires manual conversion: does not exist in peer-type
 	// WARNING: in.Patches requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/bootstrap/kubeadm/types/upstreamv1beta2/conversion_test.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta2/conversion_test.go
@@ -103,6 +103,10 @@ func kubeadmInitConfigurationFuzzer(obj *bootstrapv1.InitConfiguration, c fuzz.C
 	// InitConfiguration.Patches does not exist in kubeadm v1beta1 API, so setting it to nil in order to avoid
 	// v1beta1 --> upstream v1beta2 -> v1beta1 round trip errors.
 	obj.Patches = nil
+
+	// InitConfiguration.SkipPhases does not exist in kubeadm v1beta1 API, so setting it to nil in order to avoid
+	// v1beta1 --> upstream v1beta2 -> v1beta1 round trip errors.
+	obj.SkipPhases = nil
 }
 
 func kubeadmJoinConfigurationFuzzer(obj *bootstrapv1.JoinConfiguration, c fuzz.Continue) {
@@ -111,4 +115,8 @@ func kubeadmJoinConfigurationFuzzer(obj *bootstrapv1.JoinConfiguration, c fuzz.C
 	// JoinConfiguration.Patches does not exist in kubeadm v1beta1 API, so setting it to nil in order to avoid
 	// v1beta1 --> upstream v1beta2 -> v1beta1 round trip errors.
 	obj.Patches = nil
+
+	// JoinConfiguration.SkipPhases does not exist in kubeadm v1beta1 API, so setting it to nil in order to avoid
+	// v1beta1 --> upstream v1beta2 -> v1beta1 round trip errors.
+	obj.SkipPhases = nil
 }

--- a/bootstrap/kubeadm/types/upstreamv1beta2/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta2/zz_generated.conversion.go
@@ -667,6 +667,7 @@ func autoConvert_v1beta1_InitConfiguration_To_upstreamv1beta2_InitConfiguration(
 	if err := Convert_v1beta1_APIEndpoint_To_upstreamv1beta2_APIEndpoint(&in.LocalAPIEndpoint, &out.LocalAPIEndpoint, s); err != nil {
 		return err
 	}
+	// WARNING: in.SkipPhases requires manual conversion: does not exist in peer-type
 	// WARNING: in.Patches requires manual conversion: does not exist in peer-type
 	return nil
 }
@@ -713,6 +714,7 @@ func autoConvert_v1beta1_JoinConfiguration_To_upstreamv1beta2_JoinConfiguration(
 	} else {
 		out.ControlPlane = nil
 	}
+	// WARNING: in.SkipPhases requires manual conversion: does not exist in peer-type
 	// WARNING: in.Patches requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/bootstrap/kubeadm/types/upstreamv1beta3/zz_generated.conversion.go
+++ b/bootstrap/kubeadm/types/upstreamv1beta3/zz_generated.conversion.go
@@ -644,7 +644,7 @@ func autoConvert_upstreamv1beta3_InitConfiguration_To_v1beta1_InitConfiguration(
 		return err
 	}
 	// WARNING: in.CertificateKey requires manual conversion: does not exist in peer-type
-	// WARNING: in.SkipPhases requires manual conversion: does not exist in peer-type
+	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
 	out.Patches = (*v1beta1.Patches)(unsafe.Pointer(in.Patches))
 	return nil
 }
@@ -657,6 +657,7 @@ func autoConvert_v1beta1_InitConfiguration_To_upstreamv1beta3_InitConfiguration(
 	if err := Convert_v1beta1_APIEndpoint_To_upstreamv1beta3_APIEndpoint(&in.LocalAPIEndpoint, &out.LocalAPIEndpoint, s); err != nil {
 		return err
 	}
+	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
 	out.Patches = (*Patches)(unsafe.Pointer(in.Patches))
 	return nil
 }
@@ -683,7 +684,7 @@ func autoConvert_upstreamv1beta3_JoinConfiguration_To_v1beta1_JoinConfiguration(
 	} else {
 		out.ControlPlane = nil
 	}
-	// WARNING: in.SkipPhases requires manual conversion: does not exist in peer-type
+	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
 	out.Patches = (*v1beta1.Patches)(unsafe.Pointer(in.Patches))
 	return nil
 }
@@ -705,6 +706,7 @@ func autoConvert_v1beta1_JoinConfiguration_To_upstreamv1beta3_JoinConfiguration(
 	} else {
 		out.ControlPlane = nil
 	}
+	out.SkipPhases = *(*[]string)(unsafe.Pointer(&in.SkipPhases))
 	out.Patches = (*Patches)(unsafe.Pointer(in.Patches))
 	return nil
 }

--- a/controlplane/kubeadm/api/v1alpha3/conversion.go
+++ b/controlplane/kubeadm/api/v1alpha3/conversion.go
@@ -61,12 +61,14 @@ func (src *KubeadmControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.KubeadmConfigSpec.InitConfiguration = &bootstrapv1.InitConfiguration{}
 		}
 		dst.Spec.KubeadmConfigSpec.InitConfiguration.Patches = restored.Spec.KubeadmConfigSpec.InitConfiguration.Patches
+		dst.Spec.KubeadmConfigSpec.InitConfiguration.SkipPhases = restored.Spec.KubeadmConfigSpec.InitConfiguration.SkipPhases
 	}
 	if restored.Spec.KubeadmConfigSpec.JoinConfiguration != nil {
 		if dst.Spec.KubeadmConfigSpec.JoinConfiguration == nil {
 			dst.Spec.KubeadmConfigSpec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
 		}
 		dst.Spec.KubeadmConfigSpec.JoinConfiguration.Patches = restored.Spec.KubeadmConfigSpec.JoinConfiguration.Patches
+		dst.Spec.KubeadmConfigSpec.JoinConfiguration.SkipPhases = restored.Spec.KubeadmConfigSpec.JoinConfiguration.SkipPhases
 	}
 
 	return nil

--- a/controlplane/kubeadm/api/v1alpha4/conversion.go
+++ b/controlplane/kubeadm/api/v1alpha4/conversion.go
@@ -45,12 +45,14 @@ func (src *KubeadmControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.KubeadmConfigSpec.InitConfiguration = &bootstrapv1.InitConfiguration{}
 		}
 		dst.Spec.KubeadmConfigSpec.InitConfiguration.Patches = restored.Spec.KubeadmConfigSpec.InitConfiguration.Patches
+		dst.Spec.KubeadmConfigSpec.InitConfiguration.SkipPhases = restored.Spec.KubeadmConfigSpec.InitConfiguration.SkipPhases
 	}
 	if restored.Spec.KubeadmConfigSpec.JoinConfiguration != nil {
 		if dst.Spec.KubeadmConfigSpec.JoinConfiguration == nil {
 			dst.Spec.KubeadmConfigSpec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
 		}
 		dst.Spec.KubeadmConfigSpec.JoinConfiguration.Patches = restored.Spec.KubeadmConfigSpec.JoinConfiguration.Patches
+		dst.Spec.KubeadmConfigSpec.JoinConfiguration.SkipPhases = restored.Spec.KubeadmConfigSpec.JoinConfiguration.SkipPhases
 	}
 
 	return nil
@@ -99,12 +101,14 @@ func (src *KubeadmControlPlaneTemplate) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration = &bootstrapv1.InitConfiguration{}
 		}
 		dst.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.Patches = restored.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.Patches
+		dst.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.SkipPhases = restored.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.SkipPhases
 	}
 	if restored.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration != nil {
 		if dst.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration == nil {
 			dst.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
 		}
 		dst.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.Patches = restored.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.Patches
+		dst.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.SkipPhases = restored.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.SkipPhases
 	}
 
 	return nil

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -3134,6 +3134,14 @@ spec:
                               or by referencing a secret.
                             type: string
                         type: object
+                      skipPhases:
+                        description: SkipPhases is a list of phases to skip during
+                          command execution. The list of phases can be obtained with
+                          the "kubeadm init --help" command. This option takes effect
+                          only on Kubernetes >=1.22.0.
+                        items:
+                          type: string
+                        type: array
                     type: object
                   joinConfiguration:
                     description: JoinConfiguration is the kubeadm configuration for
@@ -3346,6 +3354,14 @@ spec:
                               or by referencing a secret.
                             type: string
                         type: object
+                      skipPhases:
+                        description: SkipPhases is a list of phases to skip during
+                          command execution. The list of phases can be obtained with
+                          the "kubeadm init --help" command. This option takes effect
+                          only on Kubernetes >=1.22.0.
+                        items:
+                          type: string
+                        type: array
                     type: object
                   mounts:
                     description: Mounts specifies a list of mount points to be setup.

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -1935,6 +1935,14 @@ spec:
                                       by referencing a secret.
                                     type: string
                                 type: object
+                              skipPhases:
+                                description: SkipPhases is a list of phases to skip
+                                  during command execution. The list of phases can
+                                  be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  type: string
+                                type: array
                             type: object
                           joinConfiguration:
                             description: JoinConfiguration is the kubeadm configuration
@@ -2163,6 +2171,14 @@ spec:
                                       by referencing a secret.
                                     type: string
                                 type: object
+                              skipPhases:
+                                description: SkipPhases is a list of phases to skip
+                                  during command execution. The list of phases can
+                                  be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  type: string
+                                type: array
                             type: object
                           mounts:
                             description: Mounts specifies a list of mount points to


### PR DESCRIPTION
**What this PR does / why we need it**:
In this PR, we enable users to exclude specific phases of their
choice during init/join command execution. This can be helpful in
cases like provisioning a cluster without kube-proxy deployed.

Note: This option takes effect only only on Kubernetes >=1.22.0.

**Which issue(s) this PR fixes** 
Fixes [#5357](https://github.com/kubernetes-sigs/cluster-api/issues/5357)
