### PR TITLE
📖 ClusterClass: fix YAMLs in proposal

### DIFF
--- a/docs/proposals/202105256-cluster-class-and-managed-topologies.md
+++ b/docs/proposals/202105256-cluster-class-and-managed-topologies.md
@@ -752,7 +752,7 @@ intentionally use resources without patches and variables to focus on the simple
 ##### Create a new Cluster using ClusterClass object
 1. User creates a ClusterClass object.
    ```yaml
-    apiVersion: cluster.x-k8s.io/v1alpha4
+    apiVersion: cluster.x-k8s.io/v1beta1
     kind: ClusterClass
     metadata:
       name: mixed
@@ -760,9 +760,14 @@ intentionally use resources without patches and variables to focus on the simple
     spec:
       controlPlane:
         ref:
-          apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
           kind: KubeadmControlPlaneTemplate
           name: vsphere-prod-cluster-template-kcp
+        machineInfrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: VSphereMachineTemplate
+            name: linux-vsphere-template
         # This will create a MachineHealthCheck for ControlPlane machines.
         machineHealthCheck:
           nodeStartupTimeout: 3m
@@ -775,17 +780,17 @@ intentionally use resources without patches and variables to focus on the simple
               status: "False"
               timeout: 300s
       workers:
-        deployments:
+        machineDeployments:
         - class: linux-worker
           template:
             bootstrap:
               ref:
-                apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+                apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
                 kind: KubeadmConfigTemplate
                 name: existing-boot-ref
             infrastructure:
               ref:
-                apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+                apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
                 kind: VSphereMachineTemplate
                 name: linux-vsphere-template
           # This will create a health check for each deployment created with the "linux-worker" MachineDeploymentClass
@@ -796,17 +801,17 @@ intentionally use resources without patches and variables to focus on the simple
                 timeout: 300s
               - type: Ready
                 status: "False"
-               timeout: 300s
+                timeout: 300s
         - class: windows-worker
           template:
             bootstrap:
               ref:
-                apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+                apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
                 kind: KubeadmConfigTemplate
                 name: existing-boot-ref-windows
             infrastructure:
               ref:
-                apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+                apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
                 kind: VSphereMachineTemplate
                 name: windows-vsphere-template
           # This will create a health check for each deployment created with the "windows-worker" MachineDeploymentClass
@@ -817,16 +822,16 @@ intentionally use resources without patches and variables to focus on the simple
                 timeout: 300s
               - type: Ready
                 status: "False"
-               timeout: 300s
+                timeout: 300s
       infrastructure:
         ref:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
           kind: VSphereClusterTemplate
           name: vsphere-prod-cluster-template
    ```
 2. User creates a cluster using the class name and defining the topology.
    ```yaml
-    apiVersion: cluster.x-k8s.io/v1alpha4
+    apiVersion: cluster.x-k8s.io/v1beta1
     kind: Cluster
     metadata:
       name: foo
@@ -923,7 +928,7 @@ to avoid creating separate ClusterClasses for every small deviation, e.g. a diff
 
 1. User creates a ClusterClass object with variables and patches (other fields are omitted for brevity).
    ```yaml
-   apiVersion: cluster.x-k8s.io/v1alpha4
+   apiVersion: cluster.x-k8s.io/v1beta1
    kind: ClusterClass
    metadata:
      name: my-cluster-class
@@ -944,7 +949,7 @@ to avoid creating separate ClusterClasses for every small deviation, e.g. a diff
      - name: region
        definitions:
        - selector:
-           apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+           apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
            kind: AWSClusterTemplate
          jsonPatches:
          - op: replace
@@ -954,7 +959,7 @@ to avoid creating separate ClusterClasses for every small deviation, e.g. a diff
      - name: controlPlaneMachineType
        definitions:
        - selector:
-           apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+           apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
            kind: AWSMachineTemplate
            matchResources:
              controlPlane: true
@@ -969,7 +974,7 @@ to avoid creating separate ClusterClasses for every small deviation, e.g. a diff
 
 1. User creates a Cluster referencing the ClusterClass created above and defining variables (other fields are omitted for brevity).
    ```yaml
-   apiVersion: cluster.x-k8s.io/v1alpha4
+   apiVersion: cluster.x-k8s.io/v1beta1
    kind: Cluster
    metadata:
      name: my-cluster


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
I'm aware that we can't keep those YAMLs up-to-date forever, but I almost used the wrong YAML (deployments => machineDeployments) based on the proposal.

I fixed that issue and also upgraded to v1beta1 (machineHealthCheck only exists there) to avoid confusion for readers.
(Intellij at least now doesn't report any issues in those YAMLs anymore)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
