### PR TITLE
:sparkles: Upgrade to Kubernetes 1.23.3 in Quickstart and CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -391,10 +391,10 @@ Examples:
 ```bash
 $ kubectl get kubeadmcontrolplane
 NAMESPACE            NAME                               INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE     VERSION
-quick-start-d5ufye   quick-start-ntysk0-control-plane   true          true                   1          1       1                       2m44s   v1.23.0
+quick-start-d5ufye   quick-start-ntysk0-control-plane   true          true                   1          1       1                       2m44s   v1.23.3
 $ kubectl get machinedeployment
 NAMESPACE            NAME                      CLUSTER              REPLICAS   READY   UPDATED   UNAVAILABLE   PHASE       AGE     VERSION
-quick-start-d5ufye   quick-start-ntysk0-md-0   quick-start-ntysk0   1                  1         1             ScalingUp   3m28s   v1.23.0
+quick-start-d5ufye   quick-start-ntysk0-md-0   quick-start-ntysk0   1                  1         1             ScalingUp   3m28s   v1.23.3
 ```
 
 ## Google Doc Viewing Permissions

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -633,7 +633,7 @@ For the purpose of this tutorial, we'll name our cluster capi-quickstart.
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.23.0 \
+  --kubernetes-version v1.23.3 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -652,7 +652,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.23.0 \
+  --kubernetes-version v1.23.3 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -662,7 +662,7 @@ To create a Cluster with ClusterClass:
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development-topology \
-  --kubernetes-version v1.23.0 \
+  --kubernetes-version v1.23.3 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -722,7 +722,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                            INITIALIZED   API SERVER AVAILABLE   VERSION   REPLICAS   READY   UPDATED   UNAVAILABLE
-capi-quickstart-control-plane   true                                 v1.23.0   3                  3         3
+capi-quickstart-control-plane   true                                 v1.23.3   3                  3         3
 ```
 
 <aside class="note warning">

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -199,10 +199,10 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.23.0"
-  KUBERNETES_VERSION: "v1.23.0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.23.3"
+  KUBERNETES_VERSION: "v1.23.3"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.22.4"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.23.0"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.23.3"
   ETCD_VERSION_UPGRADE_TO: "3.5.1-0"
   COREDNS_VERSION_UPGRADE_TO: "1.8.4"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
@@ -224,7 +224,7 @@ variables:
   # NOTE: We test the latest release with a previous contract.
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.4/clusterctl-{OS}-{ARCH}"
   INIT_WITH_PROVIDERS_CONTRACT: "v1alpha4"
-  INIT_WITH_KUBERNETES_VERSION: "v1.23.0"
+  INIT_WITH_KUBERNETES_VERSION: "v1.23.3"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.23.0"
+	DefaultNodeImageVersion = "v1.23.3"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -25,7 +25,7 @@ ENV GOPROXY=$goproxy
 # Gets additional CAPD dependencies
 WORKDIR /tmp
 
-RUN curl -LO https://dl.k8s.io/release/v1.23.0/bin/linux/${ARCH}/kubectl && \
+RUN curl -LO https://dl.k8s.io/release/v1.23.3/bin/linux/${ARCH}/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl
 

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -29,7 +29,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.23.0
+  version: v1.23.3
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -86,7 +86,7 @@ spec:
         kind: DockerMachinePool
         name: worker-dmp-0
         namespace: default
-      version: v1.23.0
+      version: v1.23.3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePool

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.23.0
+  version: v1.23.3
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -120,7 +120,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.23.0
+      version: v1.23.3
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -38,7 +38,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.23.0
+  version: v1.23.3
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -106,7 +106,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.23.0
+      version: v1.23.3
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.23.0
+  version: v1.23.3
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -105,7 +105,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.23.0
+      version: v1.23.3
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.23.0"
+	defaultImageTag  = "v1.23.3"
 )
 
 type nodeCreator interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade to Kubernetes 1.23.3 in Quickstart and CI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially implements  #5995 
