### PR TITLE
🐛 Allow KCP to Update when CoreDNS version doesn't change

### DIFF
--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook.go
@@ -471,7 +471,11 @@ func (in *KubeadmControlPlane) validateCoreDNSVersion(prev *KubeadmControlPlane)
 		)
 		return allErrs
 	}
-
+	// If the versions are equal return here without error.
+	// This allows an upgrade where the version of CoreDNS in use is not supported by the migration tool.
+	if toVersion.Equals(fromVersion) {
+		return allErrs
+	}
 	if err := migration.ValidUpMigration(fromVersion.String(), toVersion.String()); err != nil {
 		allErrs = append(
 			allErrs,

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_webhook_test.go
@@ -447,6 +447,13 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			ImageTag:        "v1.6.6_foobar.2",
 		},
 	}
+	validUnsupportedCoreDNSVersion := dns.DeepCopy()
+	validUnsupportedCoreDNSVersion.Spec.KubeadmConfigSpec.ClusterConfiguration.DNS = bootstrapv1.DNS{
+		ImageMeta: bootstrapv1.ImageMeta{
+			ImageRepository: "gcr.io/capi-test",
+			ImageTag:        "v99.99.99",
+		},
+	}
 
 	unsetCoreDNSToVersion := dns.DeepCopy()
 	unsetCoreDNSToVersion.Spec.KubeadmConfigSpec.ClusterConfiguration.DNS = bootstrapv1.DNS{
@@ -689,6 +696,16 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			kcp:       dnsBuildTag,
 		},
 		{
+			name:   "should succeed when using the same CoreDNS version",
+			before: dns,
+			kcp:    dns.DeepCopy(),
+		},
+		{
+			name:   "should succeed when using the same CoreDNS version - not supported",
+			before: validUnsupportedCoreDNSVersion,
+			kcp:    validUnsupportedCoreDNSVersion,
+		},
+		{
 			name:      "should fail when using an invalid DNS build",
 			expectErr: true,
 			before:    before,
@@ -700,6 +717,7 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			before:    dns,
 			kcp:       dnsInvalidCoreDNSToVersion,
 		},
+
 		{
 			name:      "should fail when making a change to the cluster config's certificatesDir",
 			expectErr: true,


### PR DESCRIPTION
Signed-off-by: killianmuldoon kmuldoon@vmware.com

This change allows KCP to perform an upgrade when the version of CoreDNS is not increased. This will allow older branches to stay on the same CoreDNS version when performing upgrade e2e tests for later versions of Kubernetes.

Cherry pick of #5986

Fixes #5952


