### PR TITLE
🌱 Add resized and machineSetsReady conditions to MachineDeployment and conflate syncStatus and calculateStatus into updateStatus

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -235,6 +235,9 @@ const (
 	// MachinesReadyCondition reports an aggregate of current status of the machines controlled by the MachineSet.
 	MachinesReadyCondition ConditionType = "MachinesReady"
 
+	// MachineSetsReadyCondition reports an aggregate of current status of the MachineSets controlled by the MachineDeployment.
+	MachineSetsReadyCondition ConditionType = "MachineSetsReady"
+
 	// BootstrapTemplateCloningFailedReason (Severity=Error) documents a MachineSet failing to
 	// clone the bootstrap template.
 	BootstrapTemplateCloningFailedReason = "BootstrapTemplateCloningFailed"
@@ -247,7 +250,7 @@ const (
 	// generate a machine object.
 	MachineCreationFailedReason = "MachineCreationFailed"
 
-	// ResizedCondition documents a MachineSet is resizing the set of controlled machines.
+	// ResizedCondition documents a MachineDeployment or a MachineSet is resizing the set of controlled machines.
 	ResizedCondition ConditionType = "Resized"
 
 	// ScalingUpReason (Severity=Info) documents a MachineSet is increasing the number of replicas.

--- a/docs/proposals/20200506-conditions.md
+++ b/docs/proposals/20200506-conditions.md
@@ -295,6 +295,9 @@ the following constraints/design principles MUST be applied:
   of the underlying `Machines.Status.Conditions[Ready]` conditions.
 - A corollary of the above set of constraints is that an object SHOULD NEVER be in status `Ready=True`
   if one of the object's conditions are `false` or if one of the object dependents is in status `Ready=False`.
+- During a successful deletion operation conditions that summarise readiness must be cleaned up before removing the finalizer.
+  Otherwise, upper lever resources which aggregates this resource will see and permanently store ready=false for this resource right before it goes away.
+  This would mistakenly impact in the readiness of the owner resource which should disregard the particular ready condition of a resource legitimately deleted since is not intended to exist anymore. 
 
 ##### Controller changes
 

--- a/internal/controllers/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller.go
@@ -166,6 +166,8 @@ func patchMachineDeployment(ctx context.Context, patchHelper *patch.Helper, d *c
 	conditions.SetSummary(d,
 		conditions.WithConditions(
 			clusterv1.MachineDeploymentAvailableCondition,
+			clusterv1.ResizedCondition,
+			clusterv1.MachineSetsReadyCondition,
 		),
 	)
 
@@ -174,6 +176,8 @@ func patchMachineDeployment(ctx context.Context, patchHelper *patch.Helper, d *c
 		patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
 			clusterv1.ReadyCondition,
 			clusterv1.MachineDeploymentAvailableCondition,
+			clusterv1.ResizedCondition,
+			clusterv1.MachineSetsReadyCondition,
 		}},
 	)
 	return patchHelper.Patch(ctx, d, options...)

--- a/internal/controllers/machinedeployment/machinedeployment_rolling.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rolling.go
@@ -50,7 +50,7 @@ func (r *Reconciler) rolloutRolling(ctx context.Context, d *clusterv1.MachineDep
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := updateMachineDeploymentStatus(allMSs, newMS, d); err != nil {
 		return err
 	}
 
@@ -59,7 +59,7 @@ func (r *Reconciler) rolloutRolling(ctx context.Context, d *clusterv1.MachineDep
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := updateMachineDeploymentStatus(allMSs, newMS, d); err != nil {
 		return err
 	}
 

--- a/internal/controllers/machinedeployment/machinedeployment_rollout_ondelete.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rollout_ondelete.go
@@ -51,7 +51,7 @@ func (r *Reconciler) rolloutOnDelete(ctx context.Context, d *clusterv1.MachineDe
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := updateMachineDeploymentStatus(allMSs, newMS, d); err != nil {
 		return err
 	}
 
@@ -60,7 +60,7 @@ func (r *Reconciler) rolloutOnDelete(ctx context.Context, d *clusterv1.MachineDe
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := updateMachineDeploymentStatus(allMSs, newMS, d); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Simplify code by conflating syncDeploymentStatus and calculateStatus into updateStatus consistently with MachineSet and others.
Preserve unit test coverage and clarify test cases.
Introduce resized condition for MachineDeployments.
Introduce machineSetsReady condition for MachineDeployments analogous to machinesReady conditions in MachineSets. This enables visualise individual MachineSet/Machine state in the owning MachineDeployment ready condition.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3486 partially
