### PR TITLE
🐛 Point broken links to older book version

### DIFF
--- a/docs/book/src/developer/providers/implementers-guide/generate_crds.md
+++ b/docs/book/src/developer/providers/implementers-guide/generate_crds.md
@@ -83,10 +83,10 @@ make manifests
 
 The cluster API CRDs should be further customized:
 
-- [Apply the contract version label to support conversions](https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#apply-the-contract-version-label-clusterx-k8sioversion-version1_version2_version3-to-your-crds)
-- [Upgrade to CRD v1](https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#upgrade-to-crd-v1)
-- [Set “matchPolicy=Equivalent” kubebuilder marker for webhooks](https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#add-matchpolicyequivalent-kubebuilder-marker-in-webhooks)
-- [Refactor the kustomize config folder to support multi-tenancy](https://cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#refactor-kustomize-config-folder-to-support-multi-tenancy-when-using-webhooks)
+- [Apply the contract version label to support conversions](https://release-0-4.cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#apply-the-contract-version-label-clusterx-k8sioversion-version1_version2_version3-to-your-crds)
+- [Upgrade to CRD v1](https://release-0-4.cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#upgrade-to-crd-v1)
+- [Set “matchPolicy=Equivalent” kubebuilder marker for webhooks](https://release-0-4.cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#add-matchpolicyequivalent-kubebuilder-marker-in-webhooks)
+- [Refactor the kustomize config folder to support multi-tenancy](https://release-0-4.cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#refactor-kustomize-config-folder-to-support-multi-tenancy-when-using-webhooks)
 - [Ensure you are compliant with the clusterctl provider contract](https://cluster-api.sigs.k8s.io/clusterctl/provider-contract.html#components-yaml)
 
 ### Commit your changes


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update some links broken in a recent PR.  This change points those links to the older version of the book where the links aren't broken.
This is a quick fix for the CI and we shouldn't close the underlying issue. 

Alternative better fixes could be:
1. Document the contract label and other information somewhere else
2. Rewrite the implementers guide for a more up to date version of Cluster API

References #6027 