### PR TITLE
📖  Add note on where to find ClusterClass specific Cluster creation commands

### DIFF
--- a/docs/book/src/tasks/experimental-features/cluster-class/index.md
+++ b/docs/book/src/tasks/experimental-features/cluster-class/index.md
@@ -15,6 +15,7 @@ Additional documentation:
     * Publishing a ClusterClass for clusterctl usage: [clusterctl Provider contract]
 * For Cluster operators:
     * Creating a Cluster: [Quick Start guide]
+        Please note that the experience for creating a Cluster using ClusterClass is very similar to the one for creating a standalone Cluster. Infrastructure providers supporting ClusterClass provide Cluster templates leveraging this feature (e.g the Docker infrastructure provider has a development-topology template).
     * [Operating a managed Cluster](./operate-cluster.md)
     * Planning topology rollouts: [clusterctl alpha topology plan]
 


### PR DESCRIPTION

Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add a note to the quick start guide for those linking to it from the ClusterClass index page, pointing more clearly to the ClusterClass creation commands.
Addresses #5953 
