### PR TITLE
📖  Docs/remove self links

### DIFF
--- a/docs/book/src/developer/e2e.md
+++ b/docs/book/src/developer/e2e.md
@@ -199,7 +199,7 @@ The [test E2E package] provides examples of how this can be achieved by implemen
 test specs for the most common Cluster API use cases.
 
 <!-- links -->
-[Cluster API quick start]: https://cluster-api.sigs.k8s.io/user/quick-start.html
+[Cluster API quick start]:  ../user/quick-start.md
 [Cluster API test framework]: https://pkg.go.dev/sigs.k8s.io/cluster-api/test/framework?tab=doc
 [deprecated E2E config file]: https://pkg.go.dev/sigs.k8s.io/cluster-api/test/framework?tab=doc#Config
 [deprecated InitManagementCluster method]: https://pkg.go.dev/sigs.k8s.io/cluster-api/test/framework?tab=doc#InitManagementCluster

--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -33,7 +33,7 @@ The easiest way to do this is with [kind] v0.9 or newer, as explained in the qui
 Make sure your cluster is set as the default for `kubectl`.
 If it's not, you will need to modify subsequent `kubectl` commands below.
 
-[mcluster]: https://cluster-api.sigs.k8s.io/reference/glossary.html#management-cluster
+[mcluster]: ../reference/glossary.md#management-cluster
 [kind]: https://github.com/kubernetes-sigs/kind
 
 ### A container registry
@@ -220,7 +220,7 @@ information on each suite.
 Now you can [create CAPI objects][qs]!
 To test another iteration, you'll need to follow the steps to build, push, update the manifests, and apply.
 
-[qs]: https://cluster-api.sigs.k8s.io/user/quick-start.html#usage
+[qs]: ../user/quick-start.md#usage
 
 ## Videos explaining CAPI architecture and code walkthroughs
 

--- a/docs/book/src/developer/providers/implementers-guide/generate_crds.md
+++ b/docs/book/src/developer/providers/implementers-guide/generate_crds.md
@@ -87,7 +87,7 @@ The cluster API CRDs should be further customized:
 - [Upgrade to CRD v1](https://release-0-4.cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#upgrade-to-crd-v1)
 - [Set “matchPolicy=Equivalent” kubebuilder marker for webhooks](https://release-0-4.cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#add-matchpolicyequivalent-kubebuilder-marker-in-webhooks)
 - [Refactor the kustomize config folder to support multi-tenancy](https://release-0-4.cluster-api.sigs.k8s.io/developer/providers/v1alpha2-to-v1alpha3.html#refactor-kustomize-config-folder-to-support-multi-tenancy-when-using-webhooks)
-- [Ensure you are compliant with the clusterctl provider contract](https://cluster-api.sigs.k8s.io/clusterctl/provider-contract.html#components-yaml)
+- [Ensure you are compliant with the clusterctl provider contract](../../../clusterctl/provider-contract.md#components-yaml)
 
 ### Commit your changes
 

--- a/docs/book/src/developer/providers/implementers-guide/naming.md
+++ b/docs/book/src/developer/providers/implementers-guide/naming.md
@@ -18,10 +18,10 @@ Cluster API itself becomes [CAPI], pronounced "Cappy."
 cluster-api-provider-aws is [CAPA], pronounced "KappA."
 cluster-api-provider-gcp is [CAPG], pronounced "Cap Gee," [and so on][letterc].
 
-[CAPI]: https://cluster-api.sigs.k8s.io/reference/glossary.html#capi
-[CAPA]: https://cluster-api.sigs.k8s.io/reference/glossary.html#capa
-[CAPG]: https://cluster-api.sigs.k8s.io/reference/glossary.html#capg
-[letterc]: https://cluster-api.sigs.k8s.io/reference/glossary.html#c
+[CAPI]: ../../../reference/glossary.md#capi
+[CAPA]: ../../../reference/glossary.md#capa
+[CAPG]: ../../../reference/glossary.md#capg
+[letterc]: ../../../reference/glossary.md#c
 
 ## Resource Naming
 

--- a/docs/book/src/developer/providers/implementers-guide/overview.md
+++ b/docs/book/src/developer/providers/implementers-guide/overview.md
@@ -8,7 +8,7 @@ Much of the information here was adapted directly from it.
 This is an _infrastructure_ provider - tasked with managing provider-specific resources for clusters and machines.
 There are also [bootstrap providers][bootstrap], which turn machines into Kubernetes nodes.
 
-[bootstrap]: https://cluster-api.sigs.k8s.io/reference/providers.html?highlight=bootstrap#bootstrap
+[bootstrap]: ../../../reference/providers.md#bootstrap
 
 ## Prerequisites
 

--- a/docs/book/src/developer/providers/v1.0-to-v1.1.md
+++ b/docs/book/src/developer/providers/v1.0-to-v1.1.md
@@ -56,7 +56,7 @@ are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
 
 * ClusterClass:
     * `clusterctl` is now able to handle cluster templates with ClusterClasses ([PR](https://github.com/kubernetes-sigs/cluster-api/pull/5351)).
-      Please check out the corresponding documentation in [clusterctl provider contract](https://cluster-api.sigs.k8s.io/clusterctl/provider-contract.html#clusterclass-definitions).
+      Please check out the corresponding documentation in [clusterctl provider contract](../../clusterctl/provider-contract.md#clusterclass-definitions)
       If you have any further questions about writing ClusterClasses, please let us know.
     * e2e tests:
         * `QuickStartSpec` is now able to test clusters using ClusterClass. Please see this [PR](https://github.com/kubernetes-sigs/cluster-api/pull/5423) for an example on how to use it.

--- a/docs/book/src/developer/testing.md
+++ b/docs/book/src/developer/testing.md
@@ -417,7 +417,7 @@ In Cluster API all the test MUST use [Gomega] assertions.
 
 In Cluster API Unit and integration test MUST use [go test].
 
-[Cluster API quick start]: https://cluster-api.sigs.k8s.io/user/quick-start.html
+[Cluster API quick start]: ../user/quick-start.md
 [Cluster API test framework]: https://pkg.go.dev/sigs.k8s.io/cluster-api/test/framework?tab=doc
 [e2e development]: ./e2e.md
 [Ginkgo]: http://onsi.github.io/ginkgo/

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -276,7 +276,7 @@ some of the clusterctl commands like clusterctl config won't work.
 
 This limitation is an acceptable trade-off while executing fast dev-test iterations on controllers logic. If instead
 you are interested in testing clusterctl workflows, you should refer to the
-[clusterctl developer instructions](https://cluster-api.sigs.k8s.io/clusterctl/developers.html).
+[clusterctl developer instructions](../clusterctl/developers.md).
 
 </aside>
 


### PR DESCRIPTION
Remove the remaining links to the web version of the book from the book text. This ensure that older versions of the book should continue to work by linking to their own versions of pages even when those pages are removed from the book in later versions.

Relates to  #6028 
