### PR TITLE
🐛  Add status.version to list of fields to ignore for KubeadmControlPlane update

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -108,6 +108,7 @@ func (in *KubeadmControlPlane) ValidateCreate() error {
 
 const (
 	spec                 = "spec"
+	status               = "status"
 	kubeadmConfigSpec    = "kubeadmConfigSpec"
 	clusterConfiguration = "clusterConfiguration"
 	initConfiguration    = "initConfiguration"
@@ -156,6 +157,7 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, "version"},
 		{spec, "rolloutAfter"},
 		{spec, "rolloutStrategy", "*"},
+		{status, "version"},
 	}
 
 	allErrs := validateKubeadmControlPlaneSpec(in.Spec, in.Namespace, field.NewPath("spec"))


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Fixes an issue with webhook failing when applying v1alpha3 `KubeadmControlPlane` resources with cluster-api controllers that understand the v1beta1 api version. More details in the issue below.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6041
