### PR TITLE
🐛 Bootstrap machine only if it conforms to the version skew policy

### DIFF
--- a/util/version/version.go
+++ b/util/version/version.go
@@ -190,7 +190,8 @@ func CompareWithBuildIdentifiers(a semver.Version, b semver.Version) int {
 }
 
 type comparer struct {
-	buildTags bool
+	buildTags          bool
+	ignorePatchVersion bool
 }
 
 // CompareOption is a configuration option for Compare.
@@ -217,6 +218,13 @@ func WithBuildTags() CompareOption {
 	}
 }
 
+// IgnorePatchVersion modifies the version comparison to ignore the patch versions.
+func IgnorePatchVersion() CompareOption {
+	return func(c *comparer) {
+		c.ignorePatchVersion = true
+	}
+}
+
 // Compare 2 semver versions.
 // Defaults to doing the standard semver comparison when no options are specified.
 // The comparison logic can be modified by passing additional compare options.
@@ -226,6 +234,11 @@ func Compare(a, b semver.Version, options ...CompareOption) int {
 	c := &comparer{}
 	for _, o := range options {
 		o(c)
+	}
+
+	if c.ignorePatchVersion {
+		a.Patch = 0
+		b.Patch = 0
 	}
 
 	if c.buildTags {


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the Machine controller enforce the Kubernetes version skew policy before reconciling the bootstrap configuration, effectively  bootstrapping the Machine.

**TODO**
- [ ] Handle absence of `Status.Version` field in ControlPlaneRef.
- [ ]  Additional tests in `machine_controller_test.go`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6040