### PR TITLE
🐛 Fix flaky Test_objectMover

### DIFF
--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -704,7 +704,7 @@ func Test_objectMover_backupTargetObject(t *testing.T) {
 				g.Expect(string(fileContents)).To(Equal(expectedFileContents))
 
 				// Add delay so we ensure the file ModTime of updated files is different from old ones in the original files
-				time.Sleep(time.Millisecond * 5)
+				time.Sleep(time.Millisecond * 50)
 
 				// Running backupTargetObject should override any existing files since it represents a new backup
 				err = mover.backupTargetObject(node, dir)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Based on the Slack discussion (https://kubernetes.slack.com/archives/C8TSNPY4T/p1643414553424199) increasing the timeout has a chance to solve the flake. Let's try it.

Thx @Jont828 !

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5938
