### PR TITLE
📖 book: Writing a ClusterClass: add ref example

### DIFF
--- a/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
+++ b/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
@@ -484,22 +484,47 @@ metadata:
   name: docker-clusterclass-v0.1.0
 spec:
   ...
-      jsonPatches:
-      - op: add
-        path: /spec/template/spec/httpProxy/url
-        valueFrom:
-          # Use the url field of the httpProxy variable.
-          variable: httpProxy.url
-      - op: add
-        path: /spec/template/spec/dnsServers
-        valueFrom:
-          # Use the entire dnsServers array.
-          variable: dnsServers
-      - op: add
-        path: /spec/template/spec/dnsServer
-        valueFrom:
-          # Use the first item of the dnsServers array.
-          variable: dnsServers[0]
+  jsonPatches:
+  - op: add
+    path: /spec/template/spec/httpProxy/url
+    valueFrom:
+      # Use the url field of the httpProxy variable.
+      variable: httpProxy.url
+  - op: add
+    path: /spec/template/spec/dnsServers
+    valueFrom:
+      # Use the entire dnsServers array.
+      variable: dnsServers
+  - op: add
+    path: /spec/template/spec/dnsServer
+    valueFrom:
+      # Use the first item of the dnsServers array.
+      variable: dnsServers[0]
+```
+
+**Tips & Tricks**
+
+Complex variables can be used to make references in templates configurable, e.g. the `identityRef` used in `AzureCluster`.
+Of course it's also possible to only make the name of the reference configurable, including restricting the valid values 
+to a pre-defined enum.
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata:
+  name: azure-clusterclass-v0.1.0
+spec:
+  ...
+  variables:
+  - name: clusterIdentityRef
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          kind:
+            type: string
+          name:
+            type: string
 ```
 
 ### Using variable values in JSON patches


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adds an example to showcase how to make refs configurable via variables.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
