### PR TITLE
📖 book: Add API reference page

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -74,6 +74,7 @@
     - [CustomResourceDefinitions relationships](./developer/crd-relationships.md)
 - [Troubleshooting](./user/troubleshooting.md)
 - [Reference](./reference/reference.md)
+    - [API Reference](./reference/api_reference.md) 
     - [Glossary](./reference/glossary.md)
     - [Provider List](./reference/providers.md)
     - [Ports](./reference/ports.md)

--- a/docs/book/src/reference/api_reference.md
+++ b/docs/book/src/reference/api_reference.md
@@ -1,0 +1,7 @@
+# API Reference
+
+Cluster API currently exposes the following APIs:
+
+* the Cluster API Custom Resource Definitions (CRDs): [documentation](https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api)
+
+* Golang APIs: [godoc](https://pkg.go.dev/sigs.k8s.io/cluster-api)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
I don't have strong opinions on how exactly we link the API references, but I think we should do it.

Just adding links to specialized websites seems to be a low-maintenance way to provide this kind of information to our users (which might not know pages like doc.crds.dev). Also we can profit from improvements in those pages or swap them out easily if we find better ones.

*Notes*:
* It's non-trivial/maybe impossible to add an external link to the mdbook sidebar, but I think it's good to have a separate book page anyway, given that we have multiple APIs and there will be more with RuntimeExtensions.
* An alternative would be to integrate the API references in the currently almost empty `reference.md`. I don't have a strong opinion about that.
* For comparison: Kubernetes references: https://kubernetes.io/docs/reference/ https://kubernetes.io/docs/reference/kubernetes-api/


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4484
