### PR TITLE
:warning: Make ClusterToInfrastructureMapFunc check if the cluster is externally managed

### DIFF
--- a/docs/book/src/developer/providers/v1.1-to-v1.2.md
+++ b/docs/book/src/developer/providers/v1.1-to-v1.2.md
@@ -10,7 +10,7 @@ maintainers of providers and consumers of our Go API.
 ## Dependencies
 
 **Note**: Only the most relevant dependencies are listed, `k8s.io/` and `ginkgo`/`gomega` dependencies
-in ClusterAPI are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`. 
+in ClusterAPI are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
 
 -
 
@@ -26,7 +26,8 @@ in ClusterAPI are kept in sync with the versions used by `sigs.k8s.io/controller
 
 ### API Changes
 
--
+- `util.ClusterToInfrastructureMapFuncWithExternallyManagedCheck` was removed and the externally managed check was added to `util.ClusterToInfrastructureMapFunc`, which required changing its signature.
+   Users of the former simply need to start using the latter and users of the latter need to add the new arguments to their call.
 
 ### Other
 

--- a/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
@@ -200,7 +200,7 @@ func (r *DockerClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 	}
 	return c.Watch(
 		&source.Kind{Type: &clusterv1.Cluster{}},
-		handler.EnqueueRequestsFromMapFunc(util.ClusterToInfrastructureMapFuncWithExternallyManagedCheck(ctx, infrav1.GroupVersion.WithKind("DockerCluster"), mgr.GetClient(), &infrav1.DockerCluster{})),
+		handler.EnqueueRequestsFromMapFunc(util.ClusterToInfrastructureMapFunc(ctx, infrav1.GroupVersion.WithKind("DockerCluster"), mgr.GetClient(), &infrav1.DockerCluster{})),
 		predicates.ClusterUnpaused(ctrl.LoggerFrom(ctx)),
 	)
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -224,7 +224,7 @@ func TestClusterToInfrastructureMapFunc(t *testing.T) {
 			referenceObject.SetAPIVersion(tc.request.Spec.InfrastructureRef.APIVersion)
 			referenceObject.SetKind(tc.request.Spec.InfrastructureRef.Kind)
 
-			fn := ClusterToInfrastructureMapFuncWithExternallyManagedCheck(context.Background(), tc.input, clientBuilder.Build(), referenceObject)
+			fn := ClusterToInfrastructureMapFunc(context.Background(), tc.input, clientBuilder.Build(), referenceObject)
 			out := fn(tc.request)
 			g.Expect(out).To(Equal(tc.output))
 		})


### PR DESCRIPTION

This makes the ClusterToInfrastructureMapFunc handler check if the
cluster is externally managed by adding what was in
ClusterToInfrastructureMapFuncWithExternallyManagedCheck to it.

Users of ClusterToInfrastructureMapFuncWithExternallyManagedCheck need
to switch to ClusterToInfrastructureMapFunc.

Addresses https://github.com/kubernetes-sigs/cluster-api/pull/6039#issuecomment-1029258405
/assign @CecileRobertMichon 

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
