### PR TITLE
✨ allow provider specific infra machine template for upgrade tests

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -154,6 +154,10 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 		} else {
 			// Cluster is not using ClusterClass, upgrade via individual resources.
 			By("Upgrading the Kubernetes control-plane")
+			var upgradeMachineTemplateTo *string
+			if input.E2EConfig.HasVariable(MachineTemplateUpgradeTo) {
+				upgradeMachineTemplateTo = pointer.StringPtr(input.E2EConfig.GetVariable(MachineTemplateUpgradeTo))
+			}
 			framework.UpgradeControlPlaneAndWaitForUpgrade(ctx, framework.UpgradeControlPlaneAndWaitForUpgradeInput{
 				ClusterProxy:                input.BootstrapClusterProxy,
 				Cluster:                     clusterResources.Cluster,
@@ -161,6 +165,7 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 				EtcdImageTag:                input.E2EConfig.GetVariable(EtcdVersionUpgradeTo),
 				DNSImageTag:                 input.E2EConfig.GetVariable(CoreDNSVersionUpgradeTo),
 				KubernetesUpgradeVersion:    input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
+				UpgradeMachineTemplate:      upgradeMachineTemplateTo,
 				WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				WaitForKubeProxyUpgrade:     input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				WaitForDNSUpgrade:           input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
@@ -173,6 +178,7 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 					ClusterProxy:                input.BootstrapClusterProxy,
 					Cluster:                     clusterResources.Cluster,
 					UpgradeVersion:              input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
+					UpgradeMachineTemplate:      upgradeMachineTemplateTo,
 					MachineDeployments:          clusterResources.MachineDeployments,
 					WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 				})

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -39,6 +39,7 @@ const (
 	CNIResources                 = "CNI_RESOURCES"
 	KubernetesVersionUpgradeFrom = "KUBERNETES_VERSION_UPGRADE_FROM"
 	KubernetesVersionUpgradeTo   = "KUBERNETES_VERSION_UPGRADE_TO"
+	MachineTemplateUpgradeTo     = "MACHINE_TEMPLATE_UPGRADE_TO"
 	EtcdVersionUpgradeTo         = "ETCD_VERSION_UPGRADE_TO"
 	CoreDNSVersionUpgradeTo      = "COREDNS_VERSION_UPGRADE_TO"
 	IPFamily                     = "IP_FAMILY"

--- a/test/framework/controlplane_helpers.go
+++ b/test/framework/controlplane_helpers.go
@@ -285,6 +285,7 @@ type UpgradeControlPlaneAndWaitForUpgradeInput struct {
 	Cluster                     *clusterv1.Cluster
 	ControlPlane                *controlplanev1.KubeadmControlPlane
 	KubernetesUpgradeVersion    string
+	UpgradeMachineTemplate      *string
 	EtcdImageTag                string
 	DNSImageTag                 string
 	WaitForMachinesToBeUpgraded []interface{}
@@ -310,7 +311,9 @@ func UpgradeControlPlaneAndWaitForUpgrade(ctx context.Context, input UpgradeCont
 	Expect(err).ToNot(HaveOccurred())
 
 	input.ControlPlane.Spec.Version = input.KubernetesUpgradeVersion
-
+	if input.UpgradeMachineTemplate != nil {
+		input.ControlPlane.Spec.MachineTemplate.InfrastructureRef.Name = *input.UpgradeMachineTemplate
+	}
 	// If the ClusterConfiguration is not specified, create an empty one.
 	if input.ControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
 		input.ControlPlane.Spec.KubeadmConfigSpec.ClusterConfiguration = new(bootstrapv1.ClusterConfiguration)

--- a/test/framework/machinedeployment_helpers.go
+++ b/test/framework/machinedeployment_helpers.go
@@ -153,6 +153,7 @@ type UpgradeMachineDeploymentsAndWaitInput struct {
 	ClusterProxy                ClusterProxy
 	Cluster                     *clusterv1.Cluster
 	UpgradeVersion              string
+	UpgradeMachineTemplate      *string
 	MachineDeployments          []*clusterv1.MachineDeployment
 	WaitForMachinesToBeUpgraded []interface{}
 }
@@ -174,6 +175,9 @@ func UpgradeMachineDeploymentsAndWait(ctx context.Context, input UpgradeMachineD
 
 		oldVersion := deployment.Spec.Template.Spec.Version
 		deployment.Spec.Template.Spec.Version = &input.UpgradeVersion
+		if input.UpgradeMachineTemplate != nil {
+			deployment.Spec.Template.Spec.InfrastructureRef.Name = *input.UpgradeMachineTemplate
+		}
 		Expect(patchHelper.Patch(ctx, deployment)).To(Succeed())
 
 		log.Logf("Waiting for Kubernetes versions of machines in MachineDeployment %s/%s to be upgraded from %s to %s",


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR introduces an option to change the infra template in the test spec during the cluster upgrade tests. 

Please refer to [this](https://kubernetes.slack.com/archives/C8TSNPY4T/p1643061146168200) slack conversation for more context
cc: @sbueringer @srm09 