### PR TITLE
🐛 tilt: deploy observability tools in correct namespace

### DIFF
--- a/hack/observability/kustomization.yaml
+++ b/hack/observability/kustomization.yaml
@@ -1,19 +1,19 @@
 resources:
   - namespace.yaml
 
-helmChartInflationGenerator:
-  - chartName: promtail
-    chartRepoUrl: https://grafana.github.io/helm-charts
-    releaseNamespace: observability
+helmCharts:
+  - name: promtail
+    repo: https://grafana.github.io/helm-charts
     releaseName: promtail
-    values: ./promtail/values.yaml
-  - chartName: loki
-    chartRepoUrl: https://grafana.github.io/helm-charts
-    releaseNamespace: observability
+    namespace: observability
+    valuesFile: ./promtail/values.yaml
+  - name: loki
+    repo: https://grafana.github.io/helm-charts
     releaseName: loki
-    values: ./loki/values.yaml
-  - chartName: grafana
-    chartRepoUrl: https://grafana.github.io/helm-charts
-    releaseNamespace: observability
+    namespace: observability
+    valuesFile: ./loki/values.yaml
+  - name: grafana
+    repo: https://grafana.github.io/helm-charts
     releaseName: grafana
-    values: ./grafana/values.yaml
+    namespace: observability
+    valuesFile: ./grafana/values.yaml


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Current kustomize version does not use releaseNamespace (maybe anymore). Because of that our observability tools are deployed into the `default` namespace, instead of `observability`.
I have a PR open in kustomize to fix that: https://github.com/kubernetes-sigs/kustomize/pull/4460.

But there is also a new format to configure helm charts in kustomize, which is `helmCharts` instead of `helmChartInflationGenerator`. `helmCharts` uses release namespace correctly. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
