### PR TITLE
:seedling: [release-1.1] ClusterToInfrastructureMapFuncWithExternallyManagedCheck: Remove debugging leftovers

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -237,13 +237,11 @@ func ClusterToInfrastructureMapFuncWithExternallyManagedCheck(ctx context.Contex
 
 			if err := c.Get(ctx, key, providerCluster); err != nil {
 				log.V(4).Error(err, fmt.Sprintf("Failed to get %T", providerCluster))
-				fmt.Printf("failed to get %s: %v\n", key, err)
 				continue
 			}
 
 			if annotations.IsExternallyManaged(providerCluster) {
 				log.V(4).Info(fmt.Sprintf("%T is externally managed, skipping mapping", providerCluster))
-				fmt.Printf("%T is externally managed\n", providerCluster)
 				continue
 			}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Removes some debugging output I accidentally left before.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/cc @sbueringer 
