### PR TITLE
📖 Use full URL for contrib source paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -434,11 +434,11 @@ Whenever you meet requisites for taking responsibilities in a subarea, the follo
 3. Get positive feedback and +1s in the PR and wait one week lazy consensus after agreement.
 
 As of today there are following OWNERS files/Owner groups defining sub areas:
-- [Clusterctl](cmd/clusterctl)
-- [kubeadm Bootstrap Provider (CABPK)](bootstrap/kubeadm)
-- [kubeadm Control Plane Provider (KCP)](controlplane/kubeadm)
-- [Cluster Managed topologies, ClusterClass](internal/controllers/topology)
-- [Infrastructure Provider Docker (CAPD)](test/infrastructure/docker)
-- [Test](test)
-- [Test Framework](test/framework)
-- [Docs](docs)
+- [Clusterctl](https://github.com/kubernetes-sigs/cluster-api/tree/main/cmd/clusterctl)
+- [kubeadm Bootstrap Provider (CABPK)](https://github.com/kubernetes-sigs/cluster-api/tree/main/bootstrap/kubeadm)
+- [kubeadm Control Plane Provider (KCP)](https://github.com/kubernetes-sigs/cluster-api/tree/main/controlplane/kubeadm)
+- [Cluster Managed topologies, ClusterClass](https://github.com/kubernetes-sigs/cluster-api/tree/main/internal/controllers/topology)
+- [Infrastructure Provider Docker (CAPD)](https://github.com/kubernetes-sigs/cluster-api/tree/main/test/infrastructure/docker)
+- [Test](https://github.com/kubernetes-sigs/cluster-api/tree/main/test)
+- [Test Framework](https://github.com/kubernetes-sigs/cluster-api/tree/main/test/framework)
+- [Docs](https://github.com/kubernetes-sigs/cluster-api/tree/main/docs)


### PR DESCRIPTION
**What this PR does / why we need it**:

In the CONTRIBUTING file, there is a section on the *Contributors
Ladder* that lists the sub areas with the cluster-api project. These
link out to the source for each area.

When viewing the `CONTRIBUTING.md` file via GitHub, these links work great
because they are relative to that file. But this file also gets pulled
in to the published [Cluster-API book](https://cluster-api.sigs.k8s.io/contributing#contributors-ladder). When viewed from this
location, these links will try to go to relative paths within the book,
which do not exist.

To address this, this changes the link targets to the full GitHub URL to
the source code so that it works as expected in both the GitHub and book
rendering of the content.
