### PR TITLE
🐛 Work around lack of kubebuilder-tools for darwin/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,11 @@ e2e-framework: ## Builds the CAPI e2e framework
 
 ARTIFACTS ?= ${ROOT_DIR}/_artifacts
 
-KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
+ifeq ($(shell go env GOOS),darwin) # Use the darwin/amd64 binary until an arm64 version is available
+	KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path --arch amd64 $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
+else
+	KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
+endif
 
 .PHONY: test
 test: $(SETUP_ENVTEST) ## Run unit and integration tests


### PR DESCRIPTION
**What this PR does / why we need it**:

When I run `make test` on my M1 Mac, I get:

```shell
% make test
unable to fetch checksum for requested version: unable fetch metadata for kubebuilder-tools-1.23.3-darwin-arm64.tar.gz -- got status "404 Not Found" from GCS
KUBEBUILDER_ASSETS="" go test ./...
<numerous test failures of course>
```

Overriding with the equivalent of `GOARCH=amd64` works fine.

**Which issue(s) this PR fixes**:

N/A
