### PR TITLE
🐛 KCP: don't rollout machines when format is defaulted

### DIFF
--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -196,6 +196,15 @@ func cleanupConfigFields(kcpConfig *bootstrapv1.KubeadmConfigSpec, machineConfig
 	kcpConfig.ClusterConfiguration = nil
 	machineConfig.Spec.ClusterConfiguration = nil
 
+	// We have to treat the "empty" and CloudConfig format the same
+	// otherwise defaulting on KCP will trigger a machine rollout.
+	if kcpConfig.Format == "" {
+		kcpConfig.Format = bootstrapv1.CloudConfig
+	}
+	if machineConfig.Spec.Format == "" {
+		machineConfig.Spec.Format = bootstrapv1.CloudConfig
+	}
+
 	// If KCP JoinConfiguration is not present, set machine JoinConfiguration to nil (nothing can trigger rollout here).
 	// NOTE: this is required because CABPK applies an empty joinConfiguration in case no one is provided.
 	if kcpConfig.JoinConfiguration == nil {

--- a/controlplane/kubeadm/internal/filters_test.go
+++ b/controlplane/kubeadm/internal/filters_test.go
@@ -148,6 +148,20 @@ func TestGetAdjustedKcpConfig(t *testing.T) {
 }
 
 func TestCleanupConfigFields(t *testing.T) {
+	t.Run("Format gets set to cloud-config if not set", func(t *testing.T) {
+		g := NewWithT(t)
+		kcpConfig := &bootstrapv1.KubeadmConfigSpec{
+			Format: "",
+		}
+		machineConfig := &bootstrapv1.KubeadmConfig{
+			Spec: bootstrapv1.KubeadmConfigSpec{
+				Format: "",
+			},
+		}
+		cleanupConfigFields(kcpConfig, machineConfig)
+		g.Expect(kcpConfig.Format).To(Equal(bootstrapv1.CloudConfig))
+		g.Expect(machineConfig.Spec.Format).To(Equal(bootstrapv1.CloudConfig))
+	})
 	t.Run("ClusterConfiguration gets removed from KcpConfig and MachineConfig", func(t *testing.T) {
 		g := NewWithT(t)
 		kcpConfig := &bootstrapv1.KubeadmConfigSpec{
@@ -280,6 +294,52 @@ func TestMatchInitOrJoinConfiguration(t *testing.T) {
 		g := NewWithT(t)
 		kcp := &controlplanev1.KubeadmControlPlane{}
 		g.Expect(matchInitOrJoinConfiguration(nil, kcp)).To(BeTrue())
+	})
+	t.Run("returns true if one format is empty and the other one cloud-config", func(t *testing.T) {
+		g := NewWithT(t)
+		kcp := &controlplanev1.KubeadmControlPlane{
+			Spec: controlplanev1.KubeadmControlPlaneSpec{
+				KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+					Format: bootstrapv1.CloudConfig,
+				},
+			},
+		}
+		m := &clusterv1.Machine{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KubeadmConfig",
+				APIVersion: clusterv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test",
+			},
+			Spec: clusterv1.MachineSpec{
+				Bootstrap: clusterv1.Bootstrap{
+					ConfigRef: &corev1.ObjectReference{
+						Kind:       "KubeadmConfig",
+						Namespace:  "default",
+						Name:       "test",
+						APIVersion: bootstrapv1.GroupVersion.String(),
+					},
+				},
+			},
+		}
+		machineConfigs := map[string]*bootstrapv1.KubeadmConfig{
+			m.Name: {
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "KubeadmConfig",
+					APIVersion: bootstrapv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format: "",
+				},
+			},
+		}
+		g.Expect(matchInitOrJoinConfiguration(machineConfigs[m.Name], kcp)).To(BeTrue())
 	})
 	t.Run("returns true if InitConfiguration is equal", func(t *testing.T) {
 		g := NewWithT(t)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
In v1.1.0 after upgrade a KCP rollout is triggered. The problem is that the format is defaulted to `cloud-config` and KCP rolls out the machines because a change is detected.

**Notes**
* This PR is targeted at release-1.1 to fix the issue in the easiest possible way. We will follow-up with another PR against main to move the defaulting into webhooks/ a Default func which can then be used across the codebase (instead of creating the implicit dependency between KubeadmConfig defaulting and KCP rollout behaviour)
* This is not an issue with MachineDeployments as changes like this in KubeadmConfig and KubeadmConfigTemplate do not trigger rollouts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Implements #6093 (for release-1.1)
