### PR TITLE
🐛 KCP: don't rollout machines when format is defaulted

### DIFF
--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
@@ -79,7 +79,6 @@ type KubeadmConfigSpec struct {
 
 	// Format specifies the output format of the bootstrap data
 	// +optional
-	// +kubebuilder:default=cloud-config
 	Format Format `json:"format,omitempty"`
 
 	// Verbosity is the number for the kubeadm log level verbosity.

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_webhook.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_webhook.go
@@ -43,6 +43,22 @@ func (c *KubeadmConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig,mutating=true,failurePolicy=fail,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigs,versions=v1beta1,name=default.kubeadmconfig.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+var _ webhook.Defaulter = &KubeadmConfig{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
+func (c *KubeadmConfig) Default() {
+	DefaultKubeadmConfigSpec(&c.Spec)
+}
+
+// DefaultKubeadmConfigSpec defaults a KubeadmConfigSpec.
+func DefaultKubeadmConfigSpec(r *KubeadmConfigSpec) {
+	if r.Format == "" {
+		r.Format = CloudConfig
+	}
+}
+
 // +kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigs,versions=v1beta1,name=validation.kubeadmconfig.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 var _ webhook.Validator = &KubeadmConfig{}

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
@@ -30,6 +30,15 @@ func (r *KubeadmConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error 
 		Complete()
 }
 
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate,mutating=true,failurePolicy=fail,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,versions=v1beta1,name=default.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+var _ webhook.Defaulter = &KubeadmConfigTemplate{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
+func (r *KubeadmConfigTemplate) Default() {
+	DefaultKubeadmConfigSpec(&r.Spec.Template.Spec)
+}
+
 // +kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,versions=v1beta1,name=validation.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
 
 var _ webhook.Validator = &KubeadmConfigTemplate{}

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook_test.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook_test.go
@@ -21,9 +21,28 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
 )
+
+func TestKubeadmConfigTemplateDefault(t *testing.T) {
+	g := NewWithT(t)
+
+	kubeadmConfigTemplate := &bootstrapv1.KubeadmConfigTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+	}
+	updateDefaultingKubeadmConfigTemplate := kubeadmConfigTemplate.DeepCopy()
+	updateDefaultingKubeadmConfigTemplate.Spec.Template.Spec.Verbosity = pointer.Int32Ptr(4)
+	t.Run("for KubeadmConfigTemplate", utildefaulting.DefaultValidateTest(updateDefaultingKubeadmConfigTemplate))
+
+	kubeadmConfigTemplate.Default()
+
+	g.Expect(kubeadmConfigTemplate.Spec.Template.Spec.Format).To(Equal(bootstrapv1.CloudConfig))
+}
 
 func TestKubeadmConfigTemplateValidation(t *testing.T) {
 	cases := map[string]struct {

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -2464,7 +2464,6 @@ spec:
                   type: object
                 type: array
               format:
-                default: cloud-config
                 description: Format specifies the output format of the bootstrap data
                 enum:
                 - cloud-config

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -2478,7 +2478,6 @@ spec:
                           type: object
                         type: array
                       format:
-                        default: cloud-config
                         description: Format specifies the output format of the bootstrap
                           data
                         enum:

--- a/bootstrap/kubeadm/config/default/webhookcainjection_patch.yaml
+++ b/bootstrap/kubeadm/config/default/webhookcainjection_patch.yaml
@@ -1,5 +1,12 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/bootstrap/kubeadm/config/webhook/manifests.yaml
+++ b/bootstrap/kubeadm/config/webhook/manifests.yaml
@@ -1,5 +1,54 @@
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig
+  failurePolicy: Fail
+  name: default.kubeadmconfig.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate
+  failurePolicy: Fail
+  name: default.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmconfigtemplates
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -68,6 +68,8 @@ func defaultKubeadmControlPlaneSpec(s *KubeadmControlPlaneSpec, namespace string
 		s.Version = "v" + s.Version
 	}
 
+	bootstrapv1.DefaultKubeadmConfigSpec(&s.KubeadmConfigSpec)
+
 	s.RolloutStrategy = defaultRolloutStrategy(s.RolloutStrategy)
 }
 

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -62,6 +62,7 @@ func TestKubeadmControlPlaneDefault(t *testing.T) {
 	t.Run("for KubeadmControlPlane", utildefaulting.DefaultValidateTest(updateDefaultingValidationKCP))
 	kcp.Default()
 
+	g.Expect(kcp.Spec.KubeadmConfigSpec.Format).To(Equal(bootstrapv1.CloudConfig))
 	g.Expect(kcp.Spec.MachineTemplate.InfrastructureRef.Namespace).To(Equal(kcp.Namespace))
 	g.Expect(kcp.Spec.Version).To(Equal("v1.18.3"))
 	g.Expect(kcp.Spec.RolloutStrategy.Type).To(Equal(RollingUpdateStrategyType))

--- a/controlplane/kubeadm/api/v1beta1/kubeadmcontrolplanetemplate_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadmcontrolplanetemplate_webhook.go
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
 )
 
@@ -43,6 +44,8 @@ var _ webhook.Defaulter = &KubeadmControlPlaneTemplate{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
 func (r *KubeadmControlPlaneTemplate) Default() {
+	bootstrapv1.DefaultKubeadmConfigSpec(&r.Spec.Template.Spec.KubeadmConfigSpec)
+
 	r.Spec.Template.Spec.RolloutStrategy = defaultRolloutStrategy(r.Spec.Template.Spec.RolloutStrategy)
 }
 

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -2923,7 +2923,6 @@ spec:
                       type: object
                     type: array
                   format:
-                    default: cloud-config
                     description: Format specifies the output format of the bootstrap
                       data
                     enum:

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -1707,7 +1707,6 @@ spec:
                               type: object
                             type: array
                           format:
-                            default: cloud-config
                             description: Format specifies the output format of the
                               bootstrap data
                             enum:

--- a/controlplane/kubeadm/internal/filters.go
+++ b/controlplane/kubeadm/internal/filters.go
@@ -162,6 +162,13 @@ func matchInitOrJoinConfiguration(machineConfig *bootstrapv1.KubeadmConfig, kcp 
 	// to allow a comparison with the KubeadmConfig referenced from the machine.
 	kcpConfig := getAdjustedKcpConfig(kcp, machineConfig)
 
+	// Default both KubeadmConfigSpecs before comparison.
+	// *Note* This assumes that newly added default values never
+	// introduce a semantic difference to the unset value.
+	// But that is something that is ensured by our API guarantees.
+	bootstrapv1.DefaultKubeadmConfigSpec(kcpConfig)
+	bootstrapv1.DefaultKubeadmConfigSpec(&machineConfig.Spec)
+
 	// cleanups all the fields that are not relevant for the comparison.
 	cleanupConfigFields(kcpConfig, machineConfig)
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Similar to https://github.com/kubernetes-sigs/cluster-api/pull/6095, but this time a better solution for main / the future.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6093
