### PR TITLE
:seedling: [controllers/external] Accept narrower interfaces

### DIFF
--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -31,7 +31,7 @@ import (
 )
 
 // Get uses the client and reference to get an external, unstructured object.
-func Get(ctx context.Context, c client.Client, ref *corev1.ObjectReference, namespace string) (*unstructured.Unstructured, error) {
+func Get(ctx context.Context, c client.Reader, ref *corev1.ObjectReference, namespace string) (*unstructured.Unstructured, error) {
 	if ref == nil {
 		return nil, errors.Errorf("cannot get object - object reference not set")
 	}
@@ -47,7 +47,7 @@ func Get(ctx context.Context, c client.Client, ref *corev1.ObjectReference, name
 }
 
 // Delete uses the client and reference to delete an external, unstructured object.
-func Delete(ctx context.Context, c client.Client, ref *corev1.ObjectReference) error {
+func Delete(ctx context.Context, c client.Writer, ref *corev1.ObjectReference) error {
 	obj := new(unstructured.Unstructured)
 	obj.SetAPIVersion(ref.APIVersion)
 	obj.SetKind(ref.Kind)


### PR DESCRIPTION
**What this PR does / why we need it**:
The Get function only uses methods defined in client.Reader.

The Delete function only uses methods defined in client.Writer.

Therefore they can accept client.Reader and client.Writer, instead
of client.Client, which combines both client.Reader and client.Writer.

This change allows callers that can only pass in a client.Reader
or client.Writer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
