### PR TITLE
:book: Update Quickstart for GCP Image

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -515,7 +515,9 @@ export WORKER_NODE_TYPE="t1.small"
 export GCP_REGION="<GCP_REGION>"
 export GCP_PROJECT="<GCP_PROJECT>"
 # Make sure to use same kubernetes version here as building the GCE image
-export KUBERNETES_VERSION=1.20.9
+export KUBERNETES_VERSION=1.23.3
+# This is the image you built. See https://github.com/kubernetes-sigs/image-builder
+export IMAGE_ID=projects/$GCP_PROJECT/global/images/<built image>
 export GCP_CONTROL_PLANE_MACHINE_TYPE=n1-standard-2
 export GCP_NODE_MACHINE_TYPE=n1-standard-2
 export GCP_NETWORK_NAME=<GCP_NETWORK_NAME or default>


### PR DESCRIPTION
**What this PR does / why we need it**:

You need to export `IMAGE_ID` in order for the `clusterctl generate cluster ...` command to work on GCP.