### PR TITLE
🌱  Update grafana port forward to prevent clash with 'make serve-book'

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -332,7 +332,7 @@ def deploy_observability():
 
     if "grafana" in settings.get("deploy_observability", []):
         k8s_yaml(read_file("./.tiltbuild/yaml/grafana.observability.yaml"), allow_duplicates = True)
-        k8s_resource(workload = "grafana", port_forwards = "3000", extra_pod_selectors = [{"app": "grafana"}], labels = ["observability"])
+        k8s_resource(workload = "grafana", port_forwards = "3001:3000", extra_pod_selectors = [{"app": "grafana"}], labels = ["observability"])
 
 def prepare_all():
     allow_k8s_arg = ""


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

The tilt Grafana port currently clashes with `make serve-book` so we can't run both at the same time. This change moves the Grafana port to 3001. 