### PR TITLE
🌱 Make MachinesByCreationTimestamp private to machine collections

### DIFF
--- a/docs/book/src/developer/providers/v1.1-to-v1.2.md
+++ b/docs/book/src/developer/providers/v1.1-to-v1.2.md
@@ -18,7 +18,7 @@ in ClusterAPI are kept in sync with the versions used by `sigs.k8s.io/controller
 
 ### Deprecation
 
--
+* `util.MachinesByCreationTimestamp` has been deprecated and will be removed in a future release.
 
 ### Removals
 

--- a/util/util.go
+++ b/util/util.go
@@ -486,6 +486,7 @@ func (k KubeAwareAPIVersions) Less(i, j int) bool {
 }
 
 // MachinesByCreationTimestamp sorts a list of Machine by creation timestamp, using their names as a tie breaker.
+// Deprecated: This struct will be removed in a future release.
 type MachinesByCreationTimestamp []*clusterv1.Machine
 
 func (o MachinesByCreationTimestamp) Len() int      { return len(o) }


### PR DESCRIPTION
**What this PR does / why we need it**: 

- Copy `util.MachinesByCreationTimestamp` to `util/collections` and make it private over there. 
- Deprecate `util.MachinesByCreationTimestamp` to remove it in a future release.
- Update release notes.


Fixes #5091 
