### PR TITLE
📖 Update cert-manager links after migration

### DIFF
--- a/cmd/clusterctl/client/config/cert_manager.go
+++ b/cmd/clusterctl/client/config/cert_manager.go
@@ -19,7 +19,7 @@ package config
 // CertManager defines cert-manager configuration.
 type CertManager interface {
 	// URL returns the name of the cert-manager repository.
-	// If empty, "https://github.com/jetstack/cert-manager/releases/latest/cert-manager.yaml" will be used.
+	// If empty, "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml" will be used.
 	URL() string
 
 	// Version returns the cert-manager version to install.

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -57,7 +57,7 @@ the environment variable takes precedence.
 While doing init, clusterctl checks if there is a version of cert-manager already installed. If not, clusterctl will
 install a default version.
 
-By default, cert-manager will be fetched from `https://github.com/jetstack/cert-manager/releases`; however, if the user
+By default, cert-manager will be fetched from `https://github.com/cert-manager/cert-manager/releases`; however, if the user
 wants to use a different repository, it is possible to use the following configuration:
 
 ```yaml

--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -81,7 +81,7 @@ The generated binary can be found at ./hack/tools/bin/envsubst
 You'll need to deploy [cert-manager] components on your [management cluster][mcluster], using `kubectl`
 
 ```bash
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.5.3/cert-manager.yaml
 ```
 
 Ensure the cert-manager webhook service is ready before creating the Cluster API components.
@@ -92,7 +92,7 @@ This can be done by running:
 kubectl wait --for=condition=Available --timeout=300s apiservice v1beta1.webhook.cert-manager.io
 ```
 
-[cert-manager]: https://github.com/jetstack/cert-manager
+[cert-manager]: https://github.com/cert-manager/cert-manager
 
 ## Development
 

--- a/docs/book/src/developer/providers/implementers-guide/building_running_and_testing.md
+++ b/docs/book/src/developer/providers/implementers-guide/building_running_and_testing.md
@@ -19,11 +19,11 @@ The approach most Cluster API projects is using [a `Makefile` that uses `sed` to
 Cluster API uses [cert-manager] to manage the certificates it needs for its webhooks.
 Before you apply Cluster API's yaml, you should [install `cert-manager`][cm-install]
 
-[cert-manager]: https://github.com/jetstack/cert-manager
+[cert-manager]: https://github.com/cert-manager/cert-manager
 [cm-install]: https://cert-manager.io/docs/installation/
 
 ```
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/<version>/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<version>/cert-manager.yaml
 ```
 
 ### Cluster API


### PR DESCRIPTION
**What this PR does / why we need it**:

cert-manager was migrated from the `jetstack` github organisation to a new `cert-manager` github organisation. While we already fixed the bug that this caused in #6050, the documentation was not updated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -
