### PR TITLE
✨ Tilt: Add prometheus to observability deployment

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -336,6 +336,10 @@ def deploy_observability():
         k8s_yaml(read_file("./.tiltbuild/yaml/grafana.observability.yaml"), allow_duplicates = True)
         k8s_resource(workload = "grafana", port_forwards = "3001:3000", extra_pod_selectors = [{"app": "grafana"}], labels = ["observability"])
 
+    if "prometheus" in settings.get("deploy_observability", []):
+        k8s_yaml(read_file("./.tiltbuild/yaml/prometheus.observability.yaml"), allow_duplicates = True)
+        k8s_resource(workload = "prometheus-server", new_name = "prometheus", port_forwards = "9090", extra_pod_selectors = [{"app": "prometheus"}], labels = ["observability"])
+
 def prepare_all():
     allow_k8s_arg = ""
     if settings.get("allowed_contexts"):

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -76,7 +76,7 @@ for more details.
 provider's yaml.
 
 **deploy_observability** ([string], default=[]): If set, installs on the dev cluster one of more observability
-tools. Supported values are `grafana`, `loki` and/or `promtail` (Note: the UI for `grafana` will be accessible via a link in the tilt console).
+tools. Supported values are `grafana`, `loki`, `promtail` and/or `prometheus` (Note: the UI for `grafana` and `prometheus` will be accessible via a link in the tilt console).
 Important! This feature requires the `helm` command to be available in the user's path.
 
 **debug** (Map{string: Map} default{}): A map of named configurations for the provider. The key is the name of the provider.

--- a/hack/observability/grafana/values.yaml
+++ b/hack/observability/grafana/values.yaml
@@ -18,6 +18,9 @@ datasources:
     - name: Loki
       type: loki
       url: http://loki:3100
+    - name: Prometheus
+      type: prometheus
+      url: http://prometheus-server
 
 # Disable grafana test framework
 testFramework:

--- a/hack/observability/prometheus/kustomization.yaml
+++ b/hack/observability/prometheus/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - ../namespace.yaml
+
+helmCharts:
+  - name: prometheus
+    repo: https://prometheus-community.github.io/helm-charts
+    releaseName: prometheus
+    namespace: observability
+    valuesFile: values.yaml

--- a/hack/observability/prometheus/values.yaml
+++ b/hack/observability/prometheus/values.yaml
@@ -1,0 +1,36 @@
+# Configuration for prometheus chart, see https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
+
+# These components do not make sense in a local dev environment
+# and can be disabled.
+alertmanager:
+  enabled: false
+kubeStateMetrics:
+  enabled: false
+nodeExporter:
+  enabled: false
+pushgateway:
+  enabled: false
+
+# Scrape metrics from deployed providers
+extraScrapeConfigs: |
+  - job_name: 'capi-providers'
+    metrics_path: /metrics
+    kubernetes_sd_configs:
+      - role: pod
+
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_labelpresent_cluster_x_k8s_io_provider]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: metrics
+      - source_labels: [__meta_kubernetes_pod_label_cluster_x_k8s_io_provider]
+        action: replace
+        target_label: provider
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod

--- a/hack/observability/promtail/values.yaml
+++ b/hack/observability/promtail/values.yaml
@@ -1,4 +1,4 @@
-# Configuration for grafana chart, see https://github.com/grafana/helm-charts/tree/main/charts/grafana
+# Configuration for promtail chart, see https://github.com/grafana/helm-charts/tree/main/charts/promtail
 
 config:
   # publish data to loki


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds Prometheus to the observability suite of applications installed by Tilt. It also configures prometheus to scrape the cluster-api providers, based on the `cluster.x-k8s.io/provider` label.

**Which issue(s) this PR fixes**:
Fixes #5572
