### PR TITLE
🌱 KCP: improve validation webhooks

### DIFF
--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_webhook.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_webhook.go
@@ -63,7 +63,7 @@ func (c *KubeadmConfig) ValidateDelete() error {
 }
 
 func (c *KubeadmConfigSpec) validate(name string) error {
-	allErrs := c.Validate()
+	allErrs := c.Validate(field.NewPath("spec"))
 
 	if len(allErrs) == 0 {
 		return nil
@@ -73,16 +73,16 @@ func (c *KubeadmConfigSpec) validate(name string) error {
 }
 
 // Validate ensures the KubeadmConfigSpec is valid.
-func (c *KubeadmConfigSpec) Validate() field.ErrorList {
+func (c *KubeadmConfigSpec) Validate(pathPrefix *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, c.validateFiles()...)
-	allErrs = append(allErrs, c.validateIgnition()...)
+	allErrs = append(allErrs, c.validateFiles(pathPrefix)...)
+	allErrs = append(allErrs, c.validateIgnition(pathPrefix)...)
 
 	return allErrs
 }
 
-func (c *KubeadmConfigSpec) validateFiles() field.ErrorList {
+func (c *KubeadmConfigSpec) validateFiles(pathPrefix *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	knownPaths := map[string]struct{}{}
@@ -93,7 +93,7 @@ func (c *KubeadmConfigSpec) validateFiles() field.ErrorList {
 			allErrs = append(
 				allErrs,
 				field.Invalid(
-					field.NewPath("spec", "files").Index(i),
+					pathPrefix.Child("files").Index(i),
 					file,
 					conflictingFileSourceMsg,
 				),
@@ -107,7 +107,7 @@ func (c *KubeadmConfigSpec) validateFiles() field.ErrorList {
 				allErrs = append(
 					allErrs,
 					field.Invalid(
-						field.NewPath("spec", "files").Index(i).Child("contentFrom", "secret", "name"),
+						pathPrefix.Child("files").Index(i).Child("contentFrom", "secret", "name"),
 						file,
 						missingSecretNameMsg,
 					),
@@ -117,7 +117,7 @@ func (c *KubeadmConfigSpec) validateFiles() field.ErrorList {
 				allErrs = append(
 					allErrs,
 					field.Invalid(
-						field.NewPath("spec", "files").Index(i).Child("contentFrom", "secret", "key"),
+						pathPrefix.Child("files").Index(i).Child("contentFrom", "secret", "key"),
 						file,
 						missingSecretKeyMsg,
 					),
@@ -129,7 +129,7 @@ func (c *KubeadmConfigSpec) validateFiles() field.ErrorList {
 			allErrs = append(
 				allErrs,
 				field.Invalid(
-					field.NewPath("spec", "files").Index(i).Child("path"),
+					pathPrefix.Child("files").Index(i).Child("path"),
 					file,
 					pathConflictMsg,
 				),
@@ -141,18 +141,18 @@ func (c *KubeadmConfigSpec) validateFiles() field.ErrorList {
 	return allErrs
 }
 
-func (c *KubeadmConfigSpec) validateIgnition() field.ErrorList {
+func (c *KubeadmConfigSpec) validateIgnition(pathPrefix *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	if !feature.Gates.Enabled(feature.KubeadmBootstrapFormatIgnition) {
 		if c.Format == Ignition {
 			allErrs = append(allErrs, field.Forbidden(
-				field.NewPath("spec", "format"), kubeadmBootstrapFormatIgnitionFeatureDisabledMsg))
+				pathPrefix.Child("format"), kubeadmBootstrapFormatIgnitionFeatureDisabledMsg))
 		}
 
 		if c.Ignition != nil {
 			allErrs = append(allErrs, field.Forbidden(
-				field.NewPath("spec", "ignition"), kubeadmBootstrapFormatIgnitionFeatureDisabledMsg))
+				pathPrefix.Child("ignition"), kubeadmBootstrapFormatIgnitionFeatureDisabledMsg))
 		}
 
 		return allErrs
@@ -163,7 +163,7 @@ func (c *KubeadmConfigSpec) validateIgnition() field.ErrorList {
 			allErrs = append(
 				allErrs,
 				field.Invalid(
-					field.NewPath("spec", "format"),
+					pathPrefix.Child("format"),
 					c.Format,
 					fmt.Sprintf("must be set to %q if spec.ignition is set", Ignition),
 				),
@@ -178,7 +178,7 @@ func (c *KubeadmConfigSpec) validateIgnition() field.ErrorList {
 			allErrs = append(
 				allErrs,
 				field.Forbidden(
-					field.NewPath("spec", "users").Index(i).Child("inactive"),
+					pathPrefix.Child("users").Index(i).Child("inactive"),
 					cannotUseWithIgnition,
 				),
 			)
@@ -189,7 +189,7 @@ func (c *KubeadmConfigSpec) validateIgnition() field.ErrorList {
 		allErrs = append(
 			allErrs,
 			field.Forbidden(
-				field.NewPath("spec", "useExperimentalRetryJoin"),
+				pathPrefix.Child("useExperimentalRetryJoin"),
 				cannotUseWithIgnition,
 			),
 		)
@@ -204,7 +204,7 @@ func (c *KubeadmConfigSpec) validateIgnition() field.ErrorList {
 			allErrs = append(
 				allErrs,
 				field.Invalid(
-					field.NewPath("spec", "diskSetup", "partitions").Index(i).Child("tableType"),
+					pathPrefix.Child("diskSetup", "partitions").Index(i).Child("tableType"),
 					*partition.TableType,
 					fmt.Sprintf(
 						"only partition type %q is supported when spec.format is set to %q",
@@ -221,7 +221,7 @@ func (c *KubeadmConfigSpec) validateIgnition() field.ErrorList {
 			allErrs = append(
 				allErrs,
 				field.Forbidden(
-					field.NewPath("spec", "diskSetup", "filesystems").Index(i).Child("replaceFS"),
+					pathPrefix.Child("diskSetup", "filesystems").Index(i).Child("replaceFS"),
 					cannotUseWithIgnition,
 				),
 			)
@@ -231,7 +231,7 @@ func (c *KubeadmConfigSpec) validateIgnition() field.ErrorList {
 			allErrs = append(
 				allErrs,
 				field.Forbidden(
-					field.NewPath("spec", "diskSetup", "filesystems").Index(i).Child("partition"),
+					pathPrefix.Child("diskSetup", "filesystems").Index(i).Child("partition"),
 					cannotUseWithIgnition,
 				),
 			)

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_webhook.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_webhook.go
@@ -106,9 +106,8 @@ func (c *KubeadmConfigSpec) validateFiles(pathPrefix *field.Path) field.ErrorLis
 			if file.ContentFrom.Secret.Name == "" {
 				allErrs = append(
 					allErrs,
-					field.Invalid(
+					field.Required(
 						pathPrefix.Child("files").Index(i).Child("contentFrom", "secret", "name"),
-						file,
 						missingSecretNameMsg,
 					),
 				)
@@ -116,9 +115,8 @@ func (c *KubeadmConfigSpec) validateFiles(pathPrefix *field.Path) field.ErrorLis
 			if file.ContentFrom.Secret.Key == "" {
 				allErrs = append(
 					allErrs,
-					field.Invalid(
+					field.Required(
 						pathPrefix.Child("files").Index(i).Child("contentFrom", "secret", "key"),
-						file,
 						missingSecretKeyMsg,
 					),
 				)

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
@@ -52,7 +52,7 @@ func (r *KubeadmConfigTemplate) ValidateDelete() error {
 func (r *KubeadmConfigTemplateSpec) validate(name string) error {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, r.Template.Spec.Validate()...)
+	allErrs = append(allErrs, r.Template.Spec.Validate(field.NewPath("spec", "template", "spec"))...)
 
 	if len(allErrs) == 0 {
 		return nil

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -83,6 +83,9 @@ func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
 					Name:       "infraTemplate",
 				},
 			},
+			KubeadmConfigSpec: bootstrapv1.KubeadmConfigSpec{
+				ClusterConfiguration: &bootstrapv1.ClusterConfiguration{},
+			},
 			Replicas: pointer.Int32Ptr(1),
 			Version:  "v1.19.0",
 			RolloutStrategy: &RolloutStrategy{
@@ -128,6 +131,9 @@ func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
 
 	invalidVersion2 := valid.DeepCopy()
 	invalidVersion2.Spec.Version = "1.16.6"
+
+	invalidCoreDNSVersion := valid.DeepCopy()
+	invalidCoreDNSVersion.Spec.KubeadmConfigSpec.ClusterConfiguration.DNS.ImageTag = "v1.7" // not a valid semantic version
 
 	invalidIgnitionConfiguration := valid.DeepCopy()
 	invalidIgnitionConfiguration.Spec.KubeadmConfigSpec.Ignition = &bootstrapv1.IgnitionSpec{}
@@ -186,6 +192,11 @@ func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
 			name:      "should return error when given an invalid semantic version",
 			expectErr: true,
 			kcp:       invalidVersion1,
+		},
+		{
+			name:      "should return error when given an invalid semantic CoreDNS version",
+			expectErr: true,
+			kcp:       invalidCoreDNSVersion,
 		},
 		{
 			name:      "should return error when maxSurge is not 1",

--- a/controlplane/kubeadm/api/v1beta1/kubeadmcontrolplanetemplate_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadmcontrolplanetemplate_webhook.go
@@ -64,6 +64,7 @@ func (r *KubeadmControlPlaneTemplate) ValidateCreate() error {
 	spec := r.Spec.Template.Spec
 	allErrs := validateKubeadmControlPlaneTemplateResourceSpec(spec, field.NewPath("spec", "template", "spec"))
 	allErrs = append(allErrs, validateClusterConfiguration(spec.KubeadmConfigSpec.ClusterConfiguration, nil, field.NewPath("spec", "template", "spec", "kubeadmConfigSpec", "clusterConfiguration"))...)
+	allErrs = append(allErrs, spec.KubeadmConfigSpec.Validate(field.NewPath("spec", "template", "spec", "kubeadmConfigSpec"))...)
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(GroupVersion.WithKind("KubeadmControlPlaneTemplate").GroupKind(), r.Name, allErrs)
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
While investigating #6113 I found out that our KCP validation has a few issues:
* field paths in KubeadmConfigSpec.Validate weren't correct in all cases (prefix)
* semantic version validation of CoreDNS image tag was only done on update, not on create
* errors in semantic version parsing weren't propagated in some cases
* KubeadmConfigSpec was not validated on KubeadmControlPlaneTemplate create

Overall I think that should make especially ClusterClass/KubeadmControlPlaneTemplate safer to use as the errors are already returned on creation of KubeadmControlPlaneTemplate. Not during topology reconcile when KubeadmControlPlane cannot be created.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #6113
