### PR TITLE
🌱 tilt: switch to yaml for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ vendor
 # User-supplied Tiltfile extensions, settings, and builds
 tilt.d
 tilt-settings.json
+tilt-settings.yaml
 .tiltbuild
 
 # User-supplied clusterctl hacks settings

--- a/Tiltfile
+++ b/Tiltfile
@@ -11,8 +11,8 @@ settings = {
 }
 
 # global settings
-settings.update(read_json(
-    "tilt-settings.json",
+settings.update(read_yaml(
+    "./tilt-settings.yaml" if os.path.exists("./tilt-settings.yaml") else "./tilt-settings.json",
     default = {},
 ))
 
@@ -119,8 +119,10 @@ def load_provider_tiltfiles():
     provider_repos = settings.get("provider_repos", [])
 
     for repo in provider_repos:
-        file = repo + "/tilt-provider.json"
-        provider_details = read_json(file, default = {})
+        file = repo + "/tilt-provider.yaml" if os.path.exists(repo + "/tilt-provider.yaml") else repo + "/tilt-provider.json"
+        if not os.path.exists(file):
+            fail("Failed to load provider. No tilt-provider.{yaml|json} file found in " + repo)
+        provider_details = read_yaml(file, default = {})
         if type(provider_details) != type([]):
             provider_details = [provider_details]
         for item in provider_details:
@@ -350,6 +352,8 @@ def prepare_all():
     providers_arg = ""
     for name in get_providers():
         p = providers.get(name)
+        if p == None:
+            fail("Provider with name " + name + " not found")
         if p.get("kustomize_config", True):
             context = p.get("context")
             debug = ""

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -35,19 +35,28 @@ You can see the status of the cluster with:
 kubectl cluster-info --context kind-capi-test
 ```
 
-### Create a tilt-settings.json file
+### Create a tilt-settings file
 
-Next, create a `tilt-settings.json` file and place it in your local copy of `cluster-api`. Here is an example:
+Next, create a `tilt-settings.yaml` file and place it in your local copy of `cluster-api`. Here is an example:
 
-```json
-{
-  "default_registry": "gcr.io/your-project-name-here",
-  "provider_repos": ["../cluster-api-provider-aws"],
-  "enable_providers": ["aws", "docker", "kubeadm-bootstrap", "kubeadm-control-plane"]
-}
+```yaml
+default_registry: gcr.io/your-project-name-here
+provider_repos:
+- ../cluster-api-provider-aws
+enable_providers": 
+- aws
+- docker
+- kubeadm-bootstrap
+- kubeadm-control-plane
 ```
 
-#### tilt-settings.json fields
+<aside class="note">
+
+If you prefer JSON, you can create a `tilt-settings.json` file instead. YAML will be preferred if both files are present.
+
+</aside>
+
+#### tilt-settings fields
 
 **allowed_contexts** (Array, default=[]): A list of kubeconfig contexts Tilt is allowed to use. See the Tilt documentation on
 [allow_k8s_contexts](https://docs.tilt.dev/api.html#api.allow_k8s_contexts) for more details.
@@ -56,7 +65,7 @@ Next, create a `tilt-settings.json` file and place it in your local copy of `clu
 documentation](https://docs.tilt.dev/api.html#api.default_registry) for more details.
 
 **provider_repos** (Array[]String, default=[]): A list of paths to all the providers you want to use. Each provider must have a
-`tilt-provider.json` file describing how to build the provider.
+`tilt-provider.yaml` or `tilt-provider.json` file describing how to build the provider.
 
 **enable_providers** (Array[]String, default=['docker']): A list of the providers to enable. See [available providers](#available-providers)
 for more details.
@@ -94,15 +103,13 @@ Supported settings:
 
     Example: Using the configuration below:
 
-    ```json
-      "debug": {
-        "core": {
-          "continue": false,
-          "port": 30000,
-          "profiler_port": 40000,
-          "metrics_port": 40001
-        }
-      },
+    ```yaml
+      debug:
+        core:
+          continue: false
+          port: 30000
+          profiler_port: 40000
+          metrics_port: 40001
     ```
 
     ##### Wiring up debuggers
@@ -140,10 +147,9 @@ Supported settings:
 
 For example, if the yaml contains `${AWS_B64ENCODED_CREDENTIALS}`, you could do the following:
 
-```json
-"kustomize_substitutions": {
-  "AWS_B64ENCODED_CREDENTIALS": "your credentials here"
-}
+```yaml
+kustomize_substitutions:
+  AWS_B64ENCODED_CREDENTIALS: "your credentials here"
 ```
 
 {{#/tab }}
@@ -172,26 +178,24 @@ An Azure Service Principal is needed for populating the controller manifests. Th
   AZURE_CLIENT_ID=$(az ad sp show --id http://$AZURE_SERVICE_PRINCIPAL_NAME --query appId --output tsv)
   ```
 
-Add the output of the following as a section in your `tilt-settings.json`:
+Add the output of the following as a section in your `tilt-settings.yaml`:
 
   ```shell
   cat <<EOF
-  "kustomize_substitutions": {
-     "AZURE_SUBSCRIPTION_ID_B64": "$(echo "${AZURE_SUBSCRIPTION_ID}" | tr -d '\n' | base64 | tr -d '\n')",
-     "AZURE_TENANT_ID_B64": "$(echo "${AZURE_TENANT_ID}" | tr -d '\n' | base64 | tr -d '\n')",
-     "AZURE_CLIENT_SECRET_B64": "$(echo "${AZURE_CLIENT_SECRET}" | tr -d '\n' | base64 | tr -d '\n')",
-     "AZURE_CLIENT_ID_B64": "$(echo "${AZURE_CLIENT_ID}" | tr -d '\n' | base64 | tr -d '\n')"
-    }
+  kustomize_substitutions:
+     AZURE_SUBSCRIPTION_ID_B64: "$(echo "${AZURE_SUBSCRIPTION_ID}" | tr -d '\n' | base64 | tr -d '\n')"
+     AZURE_TENANT_ID_B64: "$(echo "${AZURE_TENANT_ID}" | tr -d '\n' | base64 | tr -d '\n')"
+     AZURE_CLIENT_SECRET_B64: "$(echo "${AZURE_CLIENT_SECRET}" | tr -d '\n' | base64 | tr -d '\n')"
+     AZURE_CLIENT_ID_B64: "$(echo "${AZURE_CLIENT_ID}" | tr -d '\n' | base64 | tr -d '\n')"
   EOF
 ```
 
 {{#/tab }}
 {{#tab DigitalOcean}}
 
-```json
-"kustomize_substitutions": {
-  "DO_B64ENCODED_CREDENTIALS": "your credentials here"
-}
+```yaml
+kustomize_substitutions:
+  DO_B64ENCODED_CREDENTIALS: "your credentials here"
 ```
 
 {{#/tab }}
@@ -202,10 +206,9 @@ You can generate a base64 version of your GCP json credentials file using:
 base64 -i ~/path/to/gcp/credentials.json
 ```
 
-```json
-"kustomize_substitutions": {
-  "GCP_B64ENCODED_CREDENTIALS": "your credentials here"
-}
+```yaml
+kustomize_substitutions:
+  GCP_B64ENCODED_CREDENTIALS: "your credentials here"
 ```
 
 {{#/tab }}
@@ -223,14 +226,11 @@ for this provider. Each item in the array will be passed in to the manager for t
 
 Example:
 
-```json
-{
-    "extra_args": {
-        "core": ["--feature-gates=MachinePool=true"],
-        "kubeadm-bootstrap": ["--feature-gates=MachinePool=true"],
-        "azure": ["--feature-gates=MachinePool=true"]
-    }
-}
+```yaml
+extra_args:
+  core: ["--feature-gates=MachinePool=true"]
+  kubeadm-bootstrap: ["--feature-gates=MachinePool=true"]
+  azure: ["--feature-gates=MachinePool=true"]
 ```
 
 With this config, the respective managers will be invoked with:
@@ -274,22 +274,24 @@ The following providers are currently defined in the Tiltfile:
 * **core**: cluster-api itself (Cluster/Machine/MachineDeployment/MachineSet/KubeadmConfig/KubeadmControlPlane)
 * **docker**: Docker provider (DockerCluster/DockerMachine)
 
-### tilt-provider.json
+### tilt-provider configuration
 
-A provider must supply a `tilt-provider.json` file describing how to build it. Here is an example:
+A provider must supply a `tilt-provider.yaml` file describing how to build it. Here is an example:
 
-```json
-{
-    "name": "aws",
-    "config": {
-        "image": "gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller",
-        "live_reload_deps": [
-            "main.go", "go.mod", "go.sum", "api", "cmd", "controllers", "pkg"
-        ]
-    },
-    "label": "CAPA"
-}
+```yaml
+name: aws
+label: CAPA
+config:
+  image: "gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller",
+  live_reload_deps: ["main.go", "go.mod", "go.sum", "api", "cmd", "controllers", "pkg"]
 ```
+
+
+<aside class="note">
+
+If you prefer JSON, you can create a `tilt-provider.json` file instead. YAML will be preferred if both files are present.
+
+</aside>
 
 #### config fields
 
@@ -337,13 +339,13 @@ is immediately before the "real work" happens.
 
 At a high level, the Tiltfile performs the following actions:
 
-1. Read `tilt-settings.json`
+1. Read `tilt-settings.yaml`
 1. Configure the allowed Kubernetes contexts
 1. Set the default registry
 1. Define the `providers` map
 1. Include user-defined Tilt files
 1. Deploy cert-manager
-1. Enable providers (`core` + what is listed in `tilt-settings.json`)
+1. Enable providers (`core` + what is listed in `tilt-settings.yaml`)
     1. Build the manager binary locally as a `local_resource`
     1. Invoke `docker_build` for the provider
     1. Invoke `kustomize` for the provider's `config/` directory


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
During development it can be necessary to switch between different providers. JSON doesn't support comments, so disabling a provider requires to remove it from the file entirely. This is a bit inconvenient.
This PR allows to use yaml for configuration, which supports comments and allows to easily disable providers by commenting it out. It's also just more pleasant to read and write.

It will prefer `./tilt-settings.yaml` over `./tilt-settings.json`. Both files are loaded with `read_yaml` since valid json is also valid yaml. This also allows to use yaml comments (`#`) in the json file.

It also allows to use `./tilt-provider.yaml` in provder repos, it'll prefer yaml here as well.

Finally I've switched the docs to yaml instead of json.

example:
```json
{
    "default_registry": "localhost:5000",
    "allowed_contexts": ["kind-kind"],
    "provider_repos": [
       "../cluster-api-provider-vsphere",
       "../cluster-api-ipam-provider-in-cluster"
    ],
    "enable_providers": [
        "docker",
        "kubeadm-bootstrap",
        "kubeadm-control-plane",
        "ipam-in-cluster"
    ],
    "extra_args": {
        "core": ["--feature-gates=ClusterTopology=true"],
        "kubeadm-bootstrap": ["--feature-gates=ClusterTopology=true"],
        "kubeadm-control-plane": ["--feature-gates=ClusterTopology=true"],
        "docker": ["--feature-gates=ClusterTopology=true"]
    }
}
```
```yaml
default_registry: localhost:5000
allowed_contexts: ["kind-kind"]
provider_repos:
# - ../cluster-api-provider-vsphere
# - ../metal3-ip-address-manager
# - ../cluster-api-provider-metal3
- ../cluster-api-ipam-provider-in-cluster
enable_providers:
- docker
- ipam-in-cluster
# - vsphere
- kubeadm-bootstrap
- kubeadm-control-plane
# - metal3-ipam
# - metal3
extra_args: 
  core: ["--feature-gates=ClusterTopology=true"]
  kubeadm-bootstrap: ["--feature-gates=ClusterTopology=true"]
  kubeadm-control-plane: ["--feature-gates=ClusterTopology=true"]
  docker: ["--feature-gates=ClusterTopology=true"]
```