### PR TITLE
 📖  docs: add initial documentation for backup and restore commands

### DIFF
--- a/docs/book/src/clusterctl/commands/backup.md
+++ b/docs/book/src/clusterctl/commands/backup.md
@@ -1,0 +1,13 @@
+# clusterctl backup
+
+The `clusterctl backup` command allows to backup Cluster API objects and all dependencies from a management cluster.
+
+You can use:
+
+```shell
+clusterctl backup --directory=/tmp/backup-directory
+```
+
+That will back the current namespace and output the objects to the destination directory.
+
+To restore a backup, please check [restore](restore.md)

--- a/docs/book/src/clusterctl/commands/commands.md
+++ b/docs/book/src/clusterctl/commands/commands.md
@@ -11,3 +11,5 @@
 * [`clusterctl completion`](completion.md)
 * [`clusterctl alpha rollout`](alpha-rollout.md)
 * [`clusterctl alpha topology plan`](alpha-topology-plan.md)
+* [`clusterctl backup`](backup.md)
+* [`clusterctl restore`](restore.md)

--- a/docs/book/src/clusterctl/commands/restore.md
+++ b/docs/book/src/clusterctl/commands/restore.md
@@ -1,0 +1,13 @@
+# clusterctl restore
+
+The `clusterctl restore` command allows to restore Cluster API objects and all dependencies from a management cluster.
+
+You can use:
+
+```shell
+clusterctl restore --directory=/tmp/backup-directory
+```
+
+That will restore the objects in the management cluster and create the namespace if that does not exist.
+
+To create a backup, please check [backup](backup.md)


### PR DESCRIPTION

**What this PR does / why we need it**:

- docs: add initial documentation for backup and restore commands

very very initial docs for restore/backup commands


/assign @fabriziopandini 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
