### PR TITLE
🐛 Fix panics in conversions

### DIFF
--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -38,8 +38,14 @@ func (src *Cluster) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	if restored.Spec.Topology != nil {
+		if dst.Spec.Topology == nil {
+			dst.Spec.Topology = &clusterv1.Topology{}
+		}
 		dst.Spec.Topology.Variables = restored.Spec.Topology.Variables
 		if restored.Spec.Topology.Workers != nil {
+			if dst.Spec.Topology.Workers == nil {
+				dst.Spec.Topology.Workers = &clusterv1.WorkersTopology{}
+			}
 			for i := range restored.Spec.Topology.Workers.MachineDeployments {
 				dst.Spec.Topology.Workers.MachineDeployments[i].FailureDomain = restored.Spec.Topology.Workers.MachineDeployments[i].FailureDomain
 				dst.Spec.Topology.Workers.MachineDeployments[i].Variables = restored.Spec.Topology.Workers.MachineDeployments[i].Variables

--- a/bootstrap/kubeadm/api/v1alpha3/conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha3/conversion.go
@@ -54,9 +54,15 @@ func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.Ignition = restored.Spec.Ignition
 	if restored.Spec.InitConfiguration != nil {
+		if dst.Spec.InitConfiguration == nil {
+			dst.Spec.InitConfiguration = &bootstrapv1.InitConfiguration{}
+		}
 		dst.Spec.InitConfiguration.Patches = restored.Spec.InitConfiguration.Patches
 	}
 	if restored.Spec.JoinConfiguration != nil {
+		if dst.Spec.JoinConfiguration == nil {
+			dst.Spec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
+		}
 		dst.Spec.JoinConfiguration.Patches = restored.Spec.JoinConfiguration.Patches
 	}
 
@@ -119,9 +125,15 @@ func (src *KubeadmConfigTemplate) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.Template.Spec.Ignition = restored.Spec.Template.Spec.Ignition
 	if restored.Spec.Template.Spec.InitConfiguration != nil {
+		if dst.Spec.Template.Spec.InitConfiguration == nil {
+			dst.Spec.Template.Spec.InitConfiguration = &bootstrapv1.InitConfiguration{}
+		}
 		dst.Spec.Template.Spec.InitConfiguration.Patches = restored.Spec.Template.Spec.InitConfiguration.Patches
 	}
 	if restored.Spec.Template.Spec.JoinConfiguration != nil {
+		if dst.Spec.Template.Spec.JoinConfiguration == nil {
+			dst.Spec.Template.Spec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
+		}
 		dst.Spec.Template.Spec.JoinConfiguration.Patches = restored.Spec.Template.Spec.JoinConfiguration.Patches
 	}
 

--- a/bootstrap/kubeadm/api/v1alpha4/conversion.go
+++ b/bootstrap/kubeadm/api/v1alpha4/conversion.go
@@ -39,9 +39,15 @@ func (src *KubeadmConfig) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.Ignition = restored.Spec.Ignition
 	if restored.Spec.InitConfiguration != nil {
+		if dst.Spec.InitConfiguration == nil {
+			dst.Spec.InitConfiguration = &bootstrapv1.InitConfiguration{}
+		}
 		dst.Spec.InitConfiguration.Patches = restored.Spec.InitConfiguration.Patches
 	}
 	if restored.Spec.JoinConfiguration != nil {
+		if dst.Spec.JoinConfiguration == nil {
+			dst.Spec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
+		}
 		dst.Spec.JoinConfiguration.Patches = restored.Spec.JoinConfiguration.Patches
 	}
 
@@ -85,9 +91,15 @@ func (src *KubeadmConfigTemplate) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.Template.Spec.Ignition = restored.Spec.Template.Spec.Ignition
 	if restored.Spec.Template.Spec.InitConfiguration != nil {
+		if dst.Spec.Template.Spec.InitConfiguration == nil {
+			dst.Spec.Template.Spec.InitConfiguration = &bootstrapv1.InitConfiguration{}
+		}
 		dst.Spec.Template.Spec.InitConfiguration.Patches = restored.Spec.Template.Spec.InitConfiguration.Patches
 	}
 	if restored.Spec.Template.Spec.JoinConfiguration != nil {
+		if dst.Spec.Template.Spec.JoinConfiguration == nil {
+			dst.Spec.Template.Spec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
+		}
 		dst.Spec.Template.Spec.JoinConfiguration.Patches = restored.Spec.Template.Spec.JoinConfiguration.Patches
 	}
 

--- a/controlplane/kubeadm/api/v1alpha3/conversion.go
+++ b/controlplane/kubeadm/api/v1alpha3/conversion.go
@@ -57,9 +57,15 @@ func (src *KubeadmControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.KubeadmConfigSpec.Ignition = restored.Spec.KubeadmConfigSpec.Ignition
 	if restored.Spec.KubeadmConfigSpec.InitConfiguration != nil {
+		if dst.Spec.KubeadmConfigSpec.InitConfiguration == nil {
+			dst.Spec.KubeadmConfigSpec.InitConfiguration = &bootstrapv1.InitConfiguration{}
+		}
 		dst.Spec.KubeadmConfigSpec.InitConfiguration.Patches = restored.Spec.KubeadmConfigSpec.InitConfiguration.Patches
 	}
 	if restored.Spec.KubeadmConfigSpec.JoinConfiguration != nil {
+		if dst.Spec.KubeadmConfigSpec.JoinConfiguration == nil {
+			dst.Spec.KubeadmConfigSpec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
+		}
 		dst.Spec.KubeadmConfigSpec.JoinConfiguration.Patches = restored.Spec.KubeadmConfigSpec.JoinConfiguration.Patches
 	}
 

--- a/controlplane/kubeadm/api/v1alpha4/conversion.go
+++ b/controlplane/kubeadm/api/v1alpha4/conversion.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	bootstrapv1alpha4 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 )
@@ -40,9 +41,15 @@ func (src *KubeadmControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.KubeadmConfigSpec.Ignition = restored.Spec.KubeadmConfigSpec.Ignition
 	if restored.Spec.KubeadmConfigSpec.InitConfiguration != nil {
+		if dst.Spec.KubeadmConfigSpec.InitConfiguration == nil {
+			dst.Spec.KubeadmConfigSpec.InitConfiguration = &bootstrapv1.InitConfiguration{}
+		}
 		dst.Spec.KubeadmConfigSpec.InitConfiguration.Patches = restored.Spec.KubeadmConfigSpec.InitConfiguration.Patches
 	}
 	if restored.Spec.KubeadmConfigSpec.JoinConfiguration != nil {
+		if dst.Spec.KubeadmConfigSpec.JoinConfiguration == nil {
+			dst.Spec.KubeadmConfigSpec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
+		}
 		dst.Spec.KubeadmConfigSpec.JoinConfiguration.Patches = restored.Spec.KubeadmConfigSpec.JoinConfiguration.Patches
 	}
 
@@ -88,9 +95,15 @@ func (src *KubeadmControlPlaneTemplate) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Template.Spec.KubeadmConfigSpec.Ignition = restored.Spec.Template.Spec.KubeadmConfigSpec.Ignition
 	dst.Spec.Template.Spec.MachineTemplate = restored.Spec.Template.Spec.MachineTemplate
 	if restored.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration != nil {
+		if dst.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration == nil {
+			dst.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration = &bootstrapv1.InitConfiguration{}
+		}
 		dst.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.Patches = restored.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.Patches
 	}
 	if restored.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration != nil {
+		if dst.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration == nil {
+			dst.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
+		}
 		dst.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.Patches = restored.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.Patches
 	}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Went through all conversions, that should fix all panics.

I can only guess, but I think our fuzzer didn't hit the case described in the issue where only patches was set because there are so many other fields in that sub-structure. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6142
