### PR TITLE
🌱 book: fix typo in tilt-settings.yaml example

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -43,7 +43,7 @@ Next, create a `tilt-settings.yaml` file and place it in your local copy of `clu
 default_registry: gcr.io/your-project-name-here
 provider_repos:
 - ../cluster-api-provider-aws
-enable_providers": 
+enable_providers:
 - aws
 - docker
 - kubeadm-bootstrap


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo in the example `tilt-settings.yaml` that caused the `enable_providers` setting to be ignored by tilt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: /
