### PR TITLE
:seedling:  Use quiet mode on markdown link checker

### DIFF
--- a/.github/workflows/lint-docs.yaml
+++ b/.github/workflows/lint-docs.yaml
@@ -14,4 +14,5 @@ jobs:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
+        use-quiet-mode: 'yes'
         config-file: .markdownlinkcheck.json


### PR DESCRIPTION
This updates the markdown lint checker config to only produce errors.


Fixes #
