### PR TITLE
📖 book: document component-base/logs change in migration doc

### DIFF
--- a/docs/book/src/developer/providers/v1.1-to-v1.2.md
+++ b/docs/book/src/developer/providers/v1.1-to-v1.2.md
@@ -34,4 +34,43 @@ in ClusterAPI are kept in sync with the versions used by `sigs.k8s.io/controller
 
 ### Other
 
--
+- Logging:
+    - To align with the upstream Kubernetes community CAPI now configures logging via `component-base/logs`. 
+      This provides advantages like support for the JSON logging format (via `--logging-format=json`) and automatic
+      deprecation of klog flags aligned to the upstream Kubernetes deprecation period.
+      <details>
+      <summary>View <code>main.go</code> diff</summary>
+
+      ```diff
+      var (
+      	...
+      +	logOptions = logs.NewOptions()
+      )
+
+      func init() {
+      -	klog.InitFlags(nil)
+
+      func InitFlags(fs *pflag.FlagSet) {
+      +	logs.AddFlags(fs, logs.SkipLoggingConfigurationFlags())
+      +	logOptions.AddFlags(fs)
+      
+      func main() {
+      	...
+      	pflag.Parse()
+      
+      +	if err := logOptions.ValidateAndApply(); err != nil {
+      +		setupLog.Error(err, "unable to start manager")
+      +		os.Exit(1)
+      +	}
+      +
+      +	// Set the Klog format, as the Serialize format shouldn't be used anymore.
+      +	// This makes sure that the logs are formatted correctly, i.e.:
+      +	// * JSON logging format: msg isn't serialized twice
+      +	// * text logging format: values are formatted with their .String() func.
+      +	ctrl.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+      -	ctrl.SetLogger(klogr.New())
+      ```
+      </details>
+
+      This change has been introduced in CAPI in the following PRs: [#6072](https://github.com/kubernetes-sigs/cluster-api/pull/6072), [#6190](https://github.com/kubernetes-sigs/cluster-api/pull/6190).</br>
+      **Note**: This change is not mandatory for providers, but highly recommended.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Follow-up to: https://github.com/kubernetes-sigs/cluster-api/pull/6072

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
