### PR TITLE
:seedling: Add network builtins to topology controller

### DIFF
--- a/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
+++ b/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
@@ -382,6 +382,7 @@ In addition to variables specified in the ClusterClass, the following builtin va
 referenced in patches:
 - `builtin.cluster.{name,namespace}`
 - `builtin.cluster.topology.{version,class}`
+- `builtin.cluster.network.{serviceDomain,services,pods,ipFamily}`
 - `builtin.controlPlane.{replicas,version,name}`
     - Please note, these variables are only available when patching control plane or control plane 
       machine templates.

--- a/docs/proposals/202105256-cluster-class-and-managed-topologies.md
+++ b/docs/proposals/202105256-cluster-class-and-managed-topologies.md
@@ -649,6 +649,7 @@ Note: Builtin variables are defined in [Builtin variables](#builtin-variables) b
 It’s also possible to use so-called builtin variables in addition to user-defined variables. The following builtin variables are available:
 - `builtin.cluster.{name,namespace}`
 - `builtin.cluster.topology.{version,class}`
+- `builtin.cluster.network.{serviceDomain,services,pods,ipFamily}`
 - `builtin.controlPlane.{replicas,version,name}`
     - **Note**: these variables are only available when patching control plane or control plane machine templates.
 - `builtin.controlPlane.machineTemplate.infrastructureRef.name`

--- a/internal/controllers/topology/cluster/patches/engine_test.go
+++ b/internal/controllers/topology/cluster/patches/engine_test.go
@@ -476,6 +476,19 @@ func setupTestObjects() (*scope.ClusterBlueprint, *scope.ClusterState) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: clusterv1.ClusterSpec{
+			Paused: false,
+			ClusterNetwork: &clusterv1.ClusterNetwork{
+				APIServerPort: pointer.Int32(8),
+				Services: &clusterv1.NetworkRanges{
+					CIDRBlocks: []string{"10.10.10.1/24"},
+				},
+				Pods: &clusterv1.NetworkRanges{
+					CIDRBlocks: []string{"11.10.10.1/24"},
+				},
+				ServiceDomain: "lark",
+			},
+			ControlPlaneRef:   nil,
+			InfrastructureRef: nil,
 			Topology: &clusterv1.Topology{
 				Version: "v1.21.2",
 				Class:   clusterClass.Name,

--- a/internal/webhooks/patch_validation.go
+++ b/internal/webhooks/patch_validation.go
@@ -336,6 +336,13 @@ var builtinVariables = sets.NewString(
 	"builtin.cluster.topology.class",
 	"builtin.cluster.topology.version",
 
+	// ClusterNetwork builtins
+	"builtin.cluster.network",
+	"builtin.cluster.network.serviceDomain",
+	"builtin.cluster.network.services",
+	"builtin.cluster.network.pods",
+	"builtin.cluster.network.ipFamily",
+
 	// ControlPlane builtins.
 	"builtin.controlPlane",
 	"builtin.controlPlane.name",


### PR DESCRIPTION
This PR adds a new set of builtin variables from the Cluster's `.spec.clusterNetwork` field. 


Fixes #5578 
