### PR TITLE
🐛 [e2e framework] fix node drain output

### DIFF
--- a/test/framework/controlplane_helpers.go
+++ b/test/framework/controlplane_helpers.go
@@ -383,8 +383,9 @@ func ScaleAndWaitControlPlane(ctx context.Context, input ScaleAndWaitControlPlan
 
 	patchHelper, err := patch.NewHelper(input.ControlPlane, input.ClusterProxy.GetClient())
 	Expect(err).ToNot(HaveOccurred())
+	scaleBefore := pointer.Int32Deref(input.ControlPlane.Spec.Replicas, 0)
 	input.ControlPlane.Spec.Replicas = pointer.Int32Ptr(input.Replicas)
-	log.Logf("Scaling controlplane %s/%s from %v to %v replicas", input.ControlPlane.Namespace, input.ControlPlane.Name, input.ControlPlane.Spec.Replicas, input.Replicas)
+	log.Logf("Scaling controlplane %s/%s from %v to %v replicas", input.ControlPlane.Namespace, input.ControlPlane.Name, scaleBefore, input.Replicas)
 	Expect(patchHelper.Patch(ctx, input.ControlPlane)).To(Succeed())
 
 	log.Logf("Waiting for correct number of replicas to exist")


### PR DESCRIPTION
**What this PR does / why we need it**:

Current output during the node drain test includes:
```
INFO: Scaling controlplane node-drain-luvzog/node-drain-1oqo30-control-plane from 0xc00132465c to 1 replicas
```
This PR fixes the log output to properly show the correct number of replicas before the scaling operation and not display a pointer address

