### PR TITLE
🌱 handle kubeadm 1.24 kubelet ConfigMap name change

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -75,6 +75,12 @@ var (
 	// NOTE: The following assumes that kubeadm version equals to Kubernetes version.
 	minVerKubeletSystemdDriver = semver.MustParse("1.21.0")
 
+	// Starting from v1.24.0 kubeadm uses "kubelet-config" a ConfigMap name for KubeletConfiguration,
+	// Dropping the X-Y suffix.
+	//
+	// NOTE: The following assumes that kubeadm version equals to Kubernetes version.
+	minVerUnversionedKubeletConfig = semver.MustParse("1.24.0")
+
 	// ErrControlPlaneMinNodes signals that a cluster doesn't meet the minimum required nodes
 	// to remove an etcd member.
 	ErrControlPlaneMinNodes = errors.New("cluster has fewer than 2 control plane nodes; removing an etcd member is not supported")
@@ -179,7 +185,7 @@ func (w *Workload) UpdateKubernetesVersionInKubeadmConfigMap(ctx context.Context
 // This is a necessary process for upgrades.
 func (w *Workload) UpdateKubeletConfigMap(ctx context.Context, version semver.Version) error {
 	// Check if the desired configmap already exists
-	desiredKubeletConfigMapName := fmt.Sprintf("kubelet-config-%d.%d", version.Major, version.Minor)
+	desiredKubeletConfigMapName := generateKubeletConfigName(version)
 	configMapKey := ctrlclient.ObjectKey{Name: desiredKubeletConfigMapName, Namespace: metav1.NamespaceSystem}
 	_, err := w.getConfigMap(ctx, configMapKey)
 	if err == nil {
@@ -190,7 +196,14 @@ func (w *Workload) UpdateKubeletConfigMap(ctx context.Context, version semver.Ve
 		return errors.Wrapf(err, "error determining if kubelet configmap %s exists", desiredKubeletConfigMapName)
 	}
 
-	previousMinorVersionKubeletConfigMapName := fmt.Sprintf("kubelet-config-%d.%d", version.Major, version.Minor-1)
+	previousMinorVersionKubeletConfigMapName := generateKubeletConfigName(semver.Version{Major: version.Major, Minor: version.Minor - 1})
+
+	// If desired and previous ConfigMap name are the same it means we already completed the transition
+	// to the unified KubeletConfigMap name in the previous upgrade; no additional operations are required.
+	if desiredKubeletConfigMapName == previousMinorVersionKubeletConfigMapName {
+		return nil
+	}
+
 	configMapKey = ctrlclient.ObjectKey{Name: previousMinorVersionKubeletConfigMapName, Namespace: metav1.NamespaceSystem}
 	// Returns a copy
 	cm, err := w.getConfigMap(ctx, configMapKey)

--- a/controlplane/kubeadm/internal/workload_cluster_rbac.go
+++ b/controlplane/kubeadm/internal/workload_cluster_rbac.go
@@ -41,8 +41,11 @@ const (
 	// KubeletConfigMapRolePrefix defines base kubelet configuration ConfigMap role prefix.
 	KubeletConfigMapRolePrefix = "kubeadm:"
 
-	// KubeletConfigMapName defines base kubelet configuration ConfigMap name.
+	// KubeletConfigMapName defines base kubelet configuration ConfigMap name for kubeadm < 1.24.
 	KubeletConfigMapName = "kubelet-config-%d.%d"
+
+	// UnversionedKubeletConfigMapName defines base kubelet configuration ConfigMap for kubeadm >= 1.24.
+	UnversionedKubeletConfigMapName = "kubelet-config"
 )
 
 // EnsureResource creates a resoutce if the target resource doesn't exist. If the resource exists already, this function will ignore the resource instead.
@@ -101,6 +104,10 @@ func (w *Workload) AllowBootstrapTokensToGetNodes(ctx context.Context) error {
 }
 
 func generateKubeletConfigName(version semver.Version) string {
+	majorMinor := semver.Version{Major: version.Major, Minor: version.Minor}
+	if majorMinor.GTE(minVerUnversionedKubeletConfig) {
+		return UnversionedKubeletConfigMapName
+	}
 	return fmt.Sprintf(KubeletConfigMapName, version.Major, version.Minor)
 }
 

--- a/controlplane/kubeadm/internal/workload_cluster_rbac_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_rbac_test.go
@@ -24,32 +24,86 @@ import (
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestCluster_ReconcileKubeletRBACBinding_NoError(t *testing.T) {
+	type wantRBAC struct {
+		role        ctrlclient.ObjectKey
+		roleBinding ctrlclient.ObjectKey
+	}
 	tests := []struct {
-		name   string
-		client ctrlclient.Client
+		name    string
+		client  ctrlclient.Client
+		version semver.Version
+		want    *wantRBAC
 	}{
 		{
-			name: "role binding and role already exist",
-			client: &fakeClient{
-				get: map[string]interface{}{
-					"kube-system/kubeadm:kubelet-config-1.12": &rbacv1.RoleBinding{},
-					"kube-system/kubeadm:kubelet-config-1.13": &rbacv1.Role{},
-				},
+			name:    "creates role and role binding for Kubernetes/kubeadm < v1.24",
+			client:  fake.NewClientBuilder().Build(),
+			version: semver.MustParse("1.23.3"),
+			want: &wantRBAC{
+				role:        ctrlclient.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config-1.23"},
+				roleBinding: ctrlclient.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config-1.23"},
 			},
 		},
 		{
-			name:   "role binding and role don't exist",
-			client: &fakeClient{},
+			name: "tolerates existing role binding for Kubernetes/kubeadm < v1.24",
+			client: fake.NewClientBuilder().WithObjects(
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config-1.23"}, RoleRef: rbacv1.RoleRef{
+					Name: "kubeadm:kubelet-config-1.23",
+				}},
+				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config-1.23"}, Rules: []rbacv1.PolicyRule{{
+					Verbs:         []string{"get"},
+					APIGroups:     []string{""},
+					Resources:     []string{"configmaps"},
+					ResourceNames: []string{"kubelet-config-1.23"},
+				}}},
+			).Build(),
+			version: semver.MustParse("1.23.3"),
+			want: &wantRBAC{
+				role:        ctrlclient.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config-1.23"},
+				roleBinding: ctrlclient.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config-1.23"},
+			},
 		},
 		{
-			name: "create returns an already exists error",
-			client: &fakeClient{
-				createErr: apierrors.NewAlreadyExists(schema.GroupResource{}, ""),
+			name:    "creates role and role binding for Kubernetes/kubeadm >= v1.24",
+			client:  fake.NewClientBuilder().Build(),
+			version: semver.MustParse("1.24.0"),
+			want: &wantRBAC{
+				role:        ctrlclient.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config"},
+				roleBinding: ctrlclient.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config"},
+			},
+		},
+		{
+			name:    "creates role and role binding for Kubernetes/kubeadm >= v1.24 ignoring pre-release and build tags",
+			client:  fake.NewClientBuilder().Build(),
+			version: semver.MustParse("1.24.0-alpha.1+xyz.1"),
+			want: &wantRBAC{
+				role:        ctrlclient.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config"},
+				roleBinding: ctrlclient.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config"},
+			},
+		},
+		{
+			name: "tolerates existing role binding for Kubernetes/kubeadm >= v1.24",
+			client: fake.NewClientBuilder().WithObjects(
+				&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config"}, RoleRef: rbacv1.RoleRef{
+					Name: "kubeadm:kubelet-config",
+				}},
+				&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config"}, Rules: []rbacv1.PolicyRule{{
+					Verbs:         []string{"get"},
+					APIGroups:     []string{""},
+					Resources:     []string{"configmaps"},
+					ResourceNames: []string{"kubelet-config"},
+				}}},
+			).Build(),
+			version: semver.MustParse("1.24.1"),
+			want: &wantRBAC{
+				role:        ctrlclient.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config"},
+				roleBinding: ctrlclient.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "kubeadm:kubelet-config"},
 			},
 		},
 	}
@@ -61,8 +115,27 @@ func TestCluster_ReconcileKubeletRBACBinding_NoError(t *testing.T) {
 			c := &Workload{
 				Client: tt.client,
 			}
-			g.Expect(c.ReconcileKubeletRBACBinding(ctx, semver.MustParse("1.12.3"))).To(Succeed())
-			g.Expect(c.ReconcileKubeletRBACRole(ctx, semver.MustParse("1.13.3"))).To(Succeed())
+			g.Expect(c.ReconcileKubeletRBACBinding(ctx, tt.version)).To(Succeed())
+			g.Expect(c.ReconcileKubeletRBACRole(ctx, tt.version)).To(Succeed())
+			if tt.want != nil {
+				r := &rbacv1.Role{}
+				// Role exists
+				g.Expect(tt.client.Get(ctx, tt.want.role, r)).To(Succeed())
+				// Role ensure grants for the KubeletConfig config map
+				g.Expect(r.Rules).To(Equal([]rbacv1.PolicyRule{
+					{
+						Verbs:         []string{"get"},
+						APIGroups:     []string{""},
+						Resources:     []string{"configmaps"},
+						ResourceNames: []string{generateKubeletConfigName(tt.version)},
+					},
+				}))
+				// RoleBinding exists
+				b := &rbacv1.RoleBinding{}
+				// RoleBinding refers to the role
+				g.Expect(tt.client.Get(ctx, tt.want.roleBinding, b)).To(Succeed())
+				g.Expect(b.RoleRef.Name).To(Equal(tt.want.role.Name))
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes KCP handle the kubelet ConfigMap as expected by kubeadm >= 1.24

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5921
