### PR TITLE
🌱 apidiff: deduplicate apidiff logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,9 +310,11 @@ lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported
 tiltfile-fix: ## Format the Tiltfile
 	./hack/verify-starlark.sh fix
 
+APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
+
 .PHONY: apidiff
 apidiff: $(GO_APIDIFF) ## Check for API differences
-	$(GO_APIDIFF) $(shell git rev-parse origin/main) --print-compatible
+	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible
 
 ALL_VERIFY_CHECKS = doctoc boilerplate shellcheck tiltfile modules gen conversions docker-provider book-links
 

--- a/scripts/ci-apidiff.sh
+++ b/scripts/ci-apidiff.sh
@@ -20,9 +20,7 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
-APIDIFF="hack/tools/bin/go-apidiff"
+cd "${REPO_ROOT}"
 
-cd "${REPO_ROOT}" && make ${APIDIFF}
 echo "*** Running go-apidiff ***"
-
-${APIDIFF} "${PULL_BASE_SHA}" --print-compatible
+APIDIFF_OLD_COMMIT="${PULL_BASE_SHA}" make apidiff


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR deduplicates the apidiff "logic". We should use our makefile targets in CI when easily possible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
