### PR TITLE
🌱 [e2e] Checks unexpected rollouts during clusterctl upgrade

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -292,6 +292,17 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 			input.PreUpgrade(managementClusterProxy)
 		}
 
+		// Get the workloadCluster before the management cluster is upgraded to make sure that the upgrade did not trigger
+		// any unexpected rollouts.
+		preUpgradeMachineList := &clusterv1alpha3.MachineList{}
+		err = managementClusterProxy.GetClient().List(
+			ctx,
+			preUpgradeMachineList,
+			client.InNamespace(testNamespace.Name),
+			client.MatchingLabels{clusterv1.ClusterLabelName: workLoadClusterName},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
 		By("Upgrading providers to the latest version available")
 		clusterctl.UpgradeManagementClusterAndWait(ctx, clusterctl.UpgradeManagementClusterAndWaitInput{
 			ClusterctlConfigPath: input.ClusterctlConfigPath,
@@ -306,6 +317,19 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 			By("Running Post-upgrade steps against the management cluster")
 			input.PostUpgrade(managementClusterProxy)
 		}
+
+		// After the upgrade check that there were no unexpected rollouts.
+		Consistently(func() bool {
+			postUpgradeMachineList := &clusterv1.MachineList{}
+			err = managementClusterProxy.GetClient().List(
+				ctx,
+				postUpgradeMachineList,
+				client.InNamespace(testNamespace.Name),
+				client.MatchingLabels{clusterv1.ClusterLabelName: workLoadClusterName},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			return machinesMatch(preUpgradeMachineList, postUpgradeMachineList)
+		}, "3m", "30s").Should(BeTrue(), "Machines should remain the same after the upgrade")
 
 		// After upgrading we are sure the version is the latest version of the API,
 		// so it is possible to use the standard helpers
@@ -549,4 +573,25 @@ func waitForClusterDeletedV1alpha4(ctx context.Context, input waitForClusterDele
 		}
 		return apierrors.IsNotFound(input.Getter.Get(ctx, key, cluster))
 	}, intervals...).Should(BeTrue())
+}
+
+func machinesMatch(oldMachineList *clusterv1alpha3.MachineList, newMachineList *clusterv1.MachineList) bool {
+	if len(oldMachineList.Items) != len(newMachineList.Items) {
+		return false
+	}
+
+	// Every machine from the old list should be present in the new list
+	for _, oldMachine := range oldMachineList.Items {
+		found := false
+		for _, newMachine := range newMachineList.Items {
+			if oldMachine.Name == newMachine.Name && oldMachine.Namespace == newMachine.Namespace {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Check for unexpected rollouts in the clusterctl upgrade e2e test.

TODO:
- [x] Run this against the v1.1.0 version of Cluster API code to check if the test captures the unexpected rollout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
