### PR TITLE
🐛 tilt: fix infinite reload issue

### DIFF
--- a/hack/observability/grafana/values.yaml
+++ b/hack/observability/grafana/values.yaml
@@ -1,5 +1,9 @@
 # Configuration for grafana chart, see https://github.com/grafana/helm-charts/tree/main/charts/grafana
 
+# Set a password explicitly to avoid infinite tilt reloads because
+# of a random password.
+adminPassword: admin
+
 grafana.ini:
   # Disable the grafana login form.
   auth:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
From time to time tilt starts to consistently reload everything. This was triggered by a random admin password in the Grafana Helm chart. This PR sets the Grafana pw so it's not random

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
