### PR TITLE
✨  Allow ApplyAlways mode for ClusterResourceSets

### DIFF
--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -438,6 +438,7 @@ spec:
                   Defaults to ApplyOnce. This field is immutable.
                 enum:
                 - ApplyOnce
+                - ApplyAlways
                 type: string
             required:
             - clusterSelector

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -112,6 +112,7 @@ spec:
                   Defaults to ApplyOnce. This field is immutable.
                 enum:
                 - ApplyOnce
+                - ApplyAlways
                 type: string
             required:
             - clusterSelector

--- a/exp/addons/api/v1beta1/clusterresourceset_types.go
+++ b/exp/addons/api/v1beta1/clusterresourceset_types.go
@@ -46,7 +46,7 @@ type ClusterResourceSetSpec struct {
 	Resources []ResourceRef `json:"resources,omitempty"`
 
 	// Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.
-	// +kubebuilder:validation:Enum=ApplyOnce
+	// +kubebuilder:validation:Enum=ApplyOnce;ApplyAlways
 	// +optional
 	Strategy string `json:"strategy,omitempty"`
 }
@@ -80,6 +80,9 @@ const (
 	// ClusterResourceSetStrategyApplyOnce is the default strategy a ClusterResourceSet strategy is assigned by
 	// ClusterResourceSet controller after being created if not specified by user.
 	ClusterResourceSetStrategyApplyOnce ClusterResourceSetStrategy = "ApplyOnce"
+	// ClusterResourceSetStrategyApplyAlways is the strategy where changes to the ClusterResourceSet
+	// are applied always if they exist already in clusters or created if they do not.
+	ClusterResourceSetStrategyApplyAlways ClusterResourceSetStrategy = "ApplyAlways"
 )
 
 // SetTypedStrategy sets the Strategy field to the string representation of ClusterResourceSetStrategy.

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -268,7 +268,6 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 
 	// Iterate all resources and apply them to the cluster and update the resource status in the ClusterResourceSetBinding object.
 	for _, resource := range clusterResourceSet.Spec.Resources {
-
 		strategy := addonsv1.ClusterResourceSetStrategy(clusterResourceSet.Spec.Strategy)
 
 		// If resource is already applied successfully and clusterResourceSet mode is "ApplyOnce", continue. (No need to check hash changes here)

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -79,6 +79,7 @@ func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr
 		Watches(
 			&source.Kind{Type: &corev1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(r.resourceToClusterResourceSet),
+			builder.OnlyMetadata,
 			builder.WithPredicates(
 				resourcepredicates.ResourceCreateUpdate(ctrl.LoggerFrom(ctx)),
 			),
@@ -86,6 +87,7 @@ func (r *ClusterResourceSetReconciler) SetupWithManager(ctx context.Context, mgr
 		Watches(
 			&source.Kind{Type: &corev1.Secret{}},
 			handler.EnqueueRequestsFromMapFunc(r.resourceToClusterResourceSet),
+			builder.OnlyMetadata,
 			builder.WithPredicates(
 				resourcepredicates.ResourceCreateUpdate(ctrl.LoggerFrom(ctx)),
 			),

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	timeout = time.Second * 15
+	timeout          = time.Second * 15
+	reconcileTimeout = time.Second * 15
 )
 
 func TestClusterResourceSetReconciler(t *testing.T) {
@@ -70,11 +71,11 @@ func TestClusterResourceSetReconciler(t *testing.T) {
 				Namespace: ns.Name,
 			},
 			Data: map[string]string{
-				"cm": `metadata:
- name: resource-configmap
- namespace: default
-kind: ConfigMap
-apiVersion: v1`,
+				"cm": `kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: resource-configmap
+  namespace: default`,
 			},
 		}
 		testSecret := &corev1.Secret{
@@ -84,12 +85,11 @@ apiVersion: v1`,
 			},
 			Type: "addons.cluster.x-k8s.io/resource-set",
 			StringData: map[string]string{
-				"cm": `metadata:
-kind: ConfigMap
+				"cm": `kind: ConfigMap
 apiVersion: v1
 metadata:
- name: resource-configmap
- namespace: default`,
+  name: resource-configmap
+  namespace: default`,
 			},
 		}
 		t.Log("Creating a Secret and a ConfigMap with ConfigMap in their data field")
@@ -587,5 +587,219 @@ metadata:
 			}
 			return false
 		}, timeout).Should(BeTrue())
+	})
+
+	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile when configmap changes data", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := setup(t, g)
+		defer teardown(t, g, ns)
+
+		t.Log("Updating the cluster with labels")
+		testCluster.SetLabels(labels)
+		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterResourceSetName,
+				Namespace: ns.Name,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy:  "ApplyAlways",
+				Resources: []addonsv1.ResourceRef{{Name: configmapName, Kind: "ConfigMap"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		g.Expect(env.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+
+		t.Log("Getting ClusterResourceSetBinding")
+		oldHash := ""
+		var lastApplied *metav1.Time
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			oldHash = resource.Hash
+			lastApplied = resource.LastAppliedTime
+
+			return resource.Applied
+
+		}, timeout).Should(BeTrue())
+
+		// Get configmap obj, update the configmap
+		cmKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      configmapName,
+		}
+		cm := &corev1.ConfigMap{}
+		g.Expect(env.Get(ctx, cmKey, cm)).To(Succeed())
+
+		cmUpdate := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            cm.GetName(),
+				Namespace:       cm.GetNamespace(),
+				ResourceVersion: cm.ResourceVersion,
+				UID:             cm.GetUID(),
+			},
+			Data: map[string]string{
+				"cm": `kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: resource-configmap
+  namespace: default
+data: 
+  hello: "world!"`,
+			},
+		}
+
+		// update the configmap data
+		t.Log("Updating the configmap resource")
+		g.Expect(env.Update(ctx, cmUpdate)).To(Succeed())
+
+		t.Log("Check if reconciled hash has updated for the changed configmap resource")
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			return resource.Hash != oldHash && resource.Applied && !lastApplied.Equal(resource.LastAppliedTime)
+
+		}, reconcileTimeout).Should(BeTrue())
+	})
+
+	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile when secret changes data", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := setup(t, g)
+		defer teardown(t, g, ns)
+
+		t.Log("Updating the cluster with labels")
+		testCluster.SetLabels(labels)
+		g.Expect(env.Update(ctx, testCluster)).To(Succeed())
+
+		clusterResourceSetInstance := &addonsv1.ClusterResourceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterResourceSetName,
+				Namespace: ns.Name,
+			},
+			Spec: addonsv1.ClusterResourceSetSpec{
+				ClusterSelector: metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Strategy:  "ApplyAlways",
+				Resources: []addonsv1.ResourceRef{{Name: secretName, Kind: "Secret"}},
+			},
+		}
+		// Create the ClusterResourceSet.
+		g.Expect(env.Create(ctx, clusterResourceSetInstance)).To(Succeed())
+
+		// Wait until ClusterResourceSetBinding is created for the Cluster
+		clusterResourceSetBindingKey := client.ObjectKey{
+			Namespace: testCluster.Namespace,
+			Name:      testCluster.Name,
+		}
+
+		t.Log("Getting ClusterResourceSetBinding")
+		oldHash := ""
+		var lastApplied *metav1.Time
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			oldHash = resource.Hash
+			lastApplied = resource.LastAppliedTime
+
+			return resource.Applied
+
+		}, timeout).Should(BeTrue())
+
+		secretKey := client.ObjectKey{
+			Namespace: ns.Name,
+			Name:      secretName,
+		}
+		secret := &corev1.Secret{}
+		g.Expect(env.Get(ctx, secretKey, secret)).To(Succeed())
+
+		secretUpdate := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            secret.GetName(),
+				Namespace:       secret.GetNamespace(),
+				ResourceVersion: secret.ResourceVersion,
+				UID:             secret.GetUID(),
+			},
+			Type: "addons.cluster.x-k8s.io/resource-set",
+			StringData: map[string]string{
+				"cm": `kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: resource-configmap
+  namespace: default
+data: 
+  hello: "world!"`,
+			},
+		}
+
+		// update the configmap data
+		t.Log("Updating the secret resource")
+		g.Expect(env.Update(ctx, secretUpdate)).To(Succeed())
+
+		t.Log("Check if reconciled hash has updated for the changed secret resource")
+		g.Eventually(func() bool {
+			binding := &addonsv1.ClusterResourceSetBinding{}
+			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
+			if err != nil {
+				return false
+			}
+
+			bindings := binding.Spec.Bindings
+			// should only have one binding
+			if len(bindings) != 1 {
+				return false
+			}
+
+			// only one resource is applied
+			resource := bindings[0].Resources[0]
+			return resource.Hash != oldHash && resource.Applied && !lastApplied.Equal(resource.LastAppliedTime)
+
+		}, reconcileTimeout).Should(BeTrue())
 	})
 }

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -622,7 +622,6 @@ metadata:
 
 		t.Log("Getting ClusterResourceSetBinding")
 		oldHash := ""
-		var lastApplied *metav1.Time
 		g.Eventually(func() bool {
 			binding := &addonsv1.ClusterResourceSetBinding{}
 			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
@@ -639,8 +638,6 @@ metadata:
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
 			oldHash = resource.Hash
-			lastApplied = resource.LastAppliedTime
-
 			return resource.Applied
 
 		}, timeout).Should(BeTrue())
@@ -691,7 +688,8 @@ data:
 
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
-			return resource.Hash != oldHash && resource.Applied && !lastApplied.Equal(resource.LastAppliedTime)
+			t.Logf("old hash and new binding: %s, %v", oldHash, resource)
+			return resource.Hash != oldHash
 
 		}, reconcileTimeout).Should(BeTrue())
 	})
@@ -729,7 +727,6 @@ data:
 
 		t.Log("Getting ClusterResourceSetBinding")
 		oldHash := ""
-		var lastApplied *metav1.Time
 		g.Eventually(func() bool {
 			binding := &addonsv1.ClusterResourceSetBinding{}
 			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
@@ -746,8 +743,6 @@ data:
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
 			oldHash = resource.Hash
-			lastApplied = resource.LastAppliedTime
-
 			return resource.Applied
 
 		}, timeout).Should(BeTrue())
@@ -783,6 +778,7 @@ data:
 		g.Expect(env.Update(ctx, secretUpdate)).To(Succeed())
 
 		t.Log("Check if reconciled hash has updated for the changed secret resource")
+
 		g.Eventually(func() bool {
 			binding := &addonsv1.ClusterResourceSetBinding{}
 			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
@@ -798,7 +794,8 @@ data:
 
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
-			return resource.Hash != oldHash && resource.Applied && !lastApplied.Equal(resource.LastAppliedTime)
+			t.Logf("old hash and new binding: %s, %v", oldHash, resource)
+			return resource.Hash != oldHash
 
 		}, reconcileTimeout).Should(BeTrue())
 	})

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -34,8 +34,7 @@ import (
 )
 
 const (
-	timeout          = time.Second * 15
-	reconcileTimeout = time.Second * 15
+	timeout = time.Second * 15
 )
 
 func TestClusterResourceSetReconciler(t *testing.T) {
@@ -639,7 +638,6 @@ metadata:
 			resource := bindings[0].Resources[0]
 			oldHash = resource.Hash
 			return resource.Applied
-
 		}, timeout).Should(BeTrue())
 
 		// Get configmap obj, update the configmap
@@ -688,10 +686,8 @@ data:
 
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
-			t.Logf("old hash and new binding: %s, %v", oldHash, resource)
 			return resource.Hash != oldHash
-
-		}, reconcileTimeout).Should(BeTrue())
+		}, timeout).Should(BeTrue())
 	})
 
 	t.Run("Should create ClusterResourceSet with strategy 'AlwaysApply' and reconcile when secret changes data", func(t *testing.T) {
@@ -744,7 +740,6 @@ data:
 			resource := bindings[0].Resources[0]
 			oldHash = resource.Hash
 			return resource.Applied
-
 		}, timeout).Should(BeTrue())
 
 		secretKey := client.ObjectKey{
@@ -778,7 +773,6 @@ data:
 		g.Expect(env.Update(ctx, secretUpdate)).To(Succeed())
 
 		t.Log("Check if reconciled hash has updated for the changed secret resource")
-
 		g.Eventually(func() bool {
 			binding := &addonsv1.ClusterResourceSetBinding{}
 			err := env.Get(ctx, clusterResourceSetBindingKey, binding)
@@ -794,9 +788,7 @@ data:
 
 			// only one resource is applied
 			resource := bindings[0].Resources[0]
-			t.Logf("old hash and new binding: %s, %v", oldHash, resource)
 			return resource.Hash != oldHash
-
-		}, reconcileTimeout).Should(BeTrue())
+		}, timeout).Should(BeTrue())
 	})
 }

--- a/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
+++ b/exp/addons/internal/controllers/clusterresourcesetbinding_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/exp/addons/internal/controllers/predicates/resource_predicates.go
+++ b/exp/addons/internal/controllers/predicates/resource_predicates.go
@@ -32,3 +32,13 @@ func ResourceCreate(logger logr.Logger) predicate.Funcs {
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 }
+
+// ResourceCreateUpdate returns a predicate that returns true for a create or update event.
+func ResourceCreateUpdate(logger logr.Logger) predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This allows an ApplyAlways mode that will apply updated resource sets to all bound clusters whenever a change is recognized. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
