### PR TITLE
📖 book: update refs to older books

### DIFF
--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -11,9 +11,18 @@ Started by the Kubernetes Special Interest Group (SIG) [Cluster Lifecycle](https
 * [Developer guide](./developer/guide.md)
 * [Contributing](./CONTRIBUTING.md)
 
-**Using Cluster API v1alpha3 or v1alpha4?** Please see the corresponding documentation:
-* [release-0-3.cluster-api.sigs.k8s.io](https://release-0-3.cluster-api.sigs.k8s.io)
+<aside class="note">
+
+<h1>ClusterAPI documentation versions</h1>
+
+This book documents ClusterAPI v1.2. For other Cluster API versions please see the corresponding documentation:
+* [main.cluster-api.sigs.k8s.io](https://main.cluster-api.sigs.k8s.io)
+* [release-1-1.cluster-api.sigs.k8s.io](https://release-1-1.cluster-api.sigs.k8s.io)
+* [release-1-0.cluster-api.sigs.k8s.io](https://release-1-0.cluster-api.sigs.k8s.io)
 * [release-0-4.cluster-api.sigs.k8s.io](https://release-0-4.cluster-api.sigs.k8s.io)
+* [release-0-3.cluster-api.sigs.k8s.io](https://release-0-3.cluster-api.sigs.k8s.io)
+
+</aside>
 
 ## Why build Cluster API?
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
As discussed in https://github.com/kubernetes-sigs/cluster-api/issues/6017#issuecomment-1048492551 we now have  books of all versions available. This PR updates the references to those books accordingly 

Ref:
* main.cluster-api.sigs.k8s.io => main
* cluster-api.sigs.k8s.io => release-1-1
* release-1-1.cluster-api.sigs.k8s.io => release-1-1
* release-1-0.cluster-api.sigs.k8s.io => release-1-0
* release-0-4.cluster-api.sigs.k8s.io => release-0-4
* release-0-3.cluster-api.sigs.k8s.io => release-0.3

This PR only changes the book on main and is not meant to be backported as is to older branches. But I would also open PRs for release-1.1 and release-1.0 to update the books similarly.

P.S. I add a corresponding task to the housekeeping issue which is ~: When we setup the book for the next version we should update the note accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
