### PR TITLE
🐛 Fix panic in node drain

### DIFF
--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -545,7 +545,7 @@ func (r *Reconciler) drainNode(ctx context.Context, cluster *clusterv1.Cluster, 
 		},
 		Out: writer{log.Info},
 		ErrOut: writer{func(msg string, keysAndValues ...interface{}) {
-			log.Error(nil, msg, keysAndValues)
+			log.Error(nil, msg, keysAndValues...)
 		}},
 	}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
e2e tests are currently broken on main. This PR should fix it.

Found this panic in our test logs: https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-cluster-api-e2e-main/1496705192203128832/artifacts/clusters/bootstrap/controllers/capi-controller-manager/capi-controller-manager-5ddddd567d-fmdpj/manager.log

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
