### PR TITLE
🌱 e2e: add option to configure both control-plane and workers machine template for k8s upgrade tests

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -154,10 +154,19 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 		} else {
 			// Cluster is not using ClusterClass, upgrade via individual resources.
 			By("Upgrading the Kubernetes control-plane")
-			var upgradeMachineTemplateTo *string
-			if input.E2EConfig.HasVariable(MachineTemplateUpgradeTo) {
-				upgradeMachineTemplateTo = pointer.StringPtr(input.E2EConfig.GetVariable(MachineTemplateUpgradeTo))
+			var (
+				upgradeCPMachineTemplateTo      *string
+				upgradeWorkersMachineTemplateTo *string
+			)
+
+			if input.E2EConfig.HasVariable(CPMachineTemplateUpgradeTo) {
+				upgradeCPMachineTemplateTo = pointer.StringPtr(input.E2EConfig.GetVariable(CPMachineTemplateUpgradeTo))
 			}
+
+			if input.E2EConfig.HasVariable(WorkersMachineTemplateUpgradeTo) {
+				upgradeWorkersMachineTemplateTo = pointer.StringPtr(input.E2EConfig.GetVariable(WorkersMachineTemplateUpgradeTo))
+			}
+
 			framework.UpgradeControlPlaneAndWaitForUpgrade(ctx, framework.UpgradeControlPlaneAndWaitForUpgradeInput{
 				ClusterProxy:                input.BootstrapClusterProxy,
 				Cluster:                     clusterResources.Cluster,
@@ -165,7 +174,7 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 				EtcdImageTag:                input.E2EConfig.GetVariable(EtcdVersionUpgradeTo),
 				DNSImageTag:                 input.E2EConfig.GetVariable(CoreDNSVersionUpgradeTo),
 				KubernetesUpgradeVersion:    input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
-				UpgradeMachineTemplate:      upgradeMachineTemplateTo,
+				UpgradeMachineTemplate:      upgradeCPMachineTemplateTo,
 				WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				WaitForKubeProxyUpgrade:     input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
 				WaitForDNSUpgrade:           input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
@@ -178,7 +187,7 @@ func ClusterUpgradeConformanceSpec(ctx context.Context, inputGetter func() Clust
 					ClusterProxy:                input.BootstrapClusterProxy,
 					Cluster:                     clusterResources.Cluster,
 					UpgradeVersion:              input.E2EConfig.GetVariable(KubernetesVersionUpgradeTo),
-					UpgradeMachineTemplate:      upgradeMachineTemplateTo,
+					UpgradeMachineTemplate:      upgradeWorkersMachineTemplateTo,
 					MachineDeployments:          clusterResources.MachineDeployments,
 					WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 				})

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -33,16 +33,17 @@ import (
 
 // Test suite constants for e2e config variables.
 const (
-	KubernetesVersionManagement  = "KUBERNETES_VERSION_MANAGEMENT"
-	KubernetesVersion            = "KUBERNETES_VERSION"
-	CNIPath                      = "CNI"
-	CNIResources                 = "CNI_RESOURCES"
-	KubernetesVersionUpgradeFrom = "KUBERNETES_VERSION_UPGRADE_FROM"
-	KubernetesVersionUpgradeTo   = "KUBERNETES_VERSION_UPGRADE_TO"
-	MachineTemplateUpgradeTo     = "MACHINE_TEMPLATE_UPGRADE_TO"
-	EtcdVersionUpgradeTo         = "ETCD_VERSION_UPGRADE_TO"
-	CoreDNSVersionUpgradeTo      = "COREDNS_VERSION_UPGRADE_TO"
-	IPFamily                     = "IP_FAMILY"
+	KubernetesVersionManagement     = "KUBERNETES_VERSION_MANAGEMENT"
+	KubernetesVersion               = "KUBERNETES_VERSION"
+	CNIPath                         = "CNI"
+	CNIResources                    = "CNI_RESOURCES"
+	KubernetesVersionUpgradeFrom    = "KUBERNETES_VERSION_UPGRADE_FROM"
+	KubernetesVersionUpgradeTo      = "KUBERNETES_VERSION_UPGRADE_TO"
+	CPMachineTemplateUpgradeTo      = "CONTROL_PLANE_MACHINE_TEMPLATE_UPGRADE_TO"
+	WorkersMachineTemplateUpgradeTo = "WORKERS_MACHINE_TEMPLATE_UPGRADE_TO"
+	EtcdVersionUpgradeTo            = "ETCD_VERSION_UPGRADE_TO"
+	CoreDNSVersionUpgradeTo         = "COREDNS_VERSION_UPGRADE_TO"
+	IPFamily                        = "IP_FAMILY"
 )
 
 func Byf(format string, a ...interface{}) {


### PR DESCRIPTION

**What this PR does / why we need it**:
- add option to configure both control-plane and workers machine template for k8s upgrade tests

/assign @fabriziopandini @sbueringer 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow up of https://github.com/kubernetes-sigs/cluster-api/pull/6075#issuecomment-1038854798
