### PR TITLE
:book: tilt: change extra_args example and add note about hard coded args

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -222,21 +222,23 @@ kustomize_substitutions:
 Set to `manual` to disable auto-rebuilding and require users to trigger rebuilds of individual changed components through the UI.
 
 **extra_args** (Object, default={}): A mapping of provider to additional arguments to pass to the main binary configured
-for this provider. Each item in the array will be passed in to the manager for the given provider.
+for this provider. Each item in the array will be passed in to the manager for the given provider. (Note: Some args are already
+set in the provider's `manager.yaml` file, e.g. [docker](https://github.com/kubernetes-sigs/cluster-api/blob/main/test/infrastructure/docker/config/manager/manager.yaml#L20),
+and cannot be overwritten via **extra_args**).
 
 Example:
 
 ```yaml
 extra_args:
-  core: ["--feature-gates=MachinePool=true"]
-  kubeadm-bootstrap: ["--feature-gates=MachinePool=true"]
-  azure: ["--feature-gates=MachinePool=true"]
+  core: ["--v=5", "--logging-format=json"]
+  kubeadm-bootstrap: ["--v=5", "--logging-format=json"]
+  azure: ["--v=5", "--logging-format=json"]
 ```
 
 With this config, the respective managers will be invoked with:
 
 ```bash
-manager --feature-gates=MachinePool=true
+manager --v=5 --logging-format=json
 ```
 
 ### Run Tilt!


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
If this is a good enough solution, this PR changes the example of the Tilt **extra_args** field and adds a note that some hard coded args of the managers cannot be overwritten. See [slack thread](https://kubernetes.slack.com/archives/C8TSNPY4T/p1645705141237239).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6202

Signed-off-by: Johannes Frey <johannes.frey@daimler.com>
<sub>Johannes Frey <[johannes.frey@daimler.com](mailto:johannes.frey@daimler.com)>, Daimler TSS GmbH ([Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))</sub>