### PR TITLE
🌱   use env value to set kustomize path in test

### DIFF
--- a/test/framework/clusterctl/repository.go
+++ b/test/framework/clusterctl/repository.go
@@ -149,8 +149,13 @@ func YAMLForComponentSource(ctx context.Context, source ProviderVersionSource) (
 		}
 		data = buf
 	case KustomizeSource:
+		// Set Path of kustomize binary using CAPI_KUSTOMIZE_PATH env
+		kustomizePath, ok := os.LookupEnv("CAPI_KUSTOMIZE_PATH")
+		if !ok {
+			kustomizePath = "kustomize"
+		}
 		kustomize := exec.NewCommand(
-			exec.WithCommand("kustomize"),
+			exec.WithCommand(kustomizePath),
 			exec.WithArgs("build", source.Value))
 		stdout, stderr, err := kustomize.Run(ctx)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: DiptoChakrabarty <diptochuck123@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Makes use of an KUSTOMIZE_PATH env variable to use in package clusterctl in test. If env variable is not present it takes default value. This helps in overriding kustomize path in call to ```clusterctl.CreateRepository```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6173 
