### PR TITLE
🌱 tilt: remove unused options

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -4,9 +4,7 @@ version_settings(True, ">=0.22.2")
 
 settings = {
     "deploy_cert_manager": True,
-    "preload_images_for_kind": True,
     "enable_providers": ["docker"],
-    "kind_cluster_name": "kind",
     "debug": {},
 }
 

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -8,8 +8,7 @@ workflow that offers easy deployments and rapid iterative builds.
 ## Prerequisites
 
 1. [Docker](https://docs.docker.com/install/): v19.03 or newer
-1. [kind](https://kind.sigs.k8s.io): v0.9 or newer (other clusters can be
-   used if `preload_images_for_kind` is set to false)
+1. [kind](https://kind.sigs.k8s.io): v0.9 or newer
 1. [Tilt](https://docs.tilt.dev/install.html): v0.22.2 or newer
 1. [kustomize](https://github.com/kubernetes-sigs/kustomize): provided via `make kustomize`
 1. [envsubst](https://github.com/drone/envsubst): provided via `make envsubst`
@@ -69,8 +68,6 @@ documentation](https://docs.tilt.dev/api.html#api.default_registry) for more det
 
 **enable_providers** (Array[]String, default=['docker']): A list of the providers to enable. See [available providers](#available-providers)
 for more details.
-
-**kind_cluster_name** (String, default="kind"): The name of the kind cluster to use when preloading images.
 
 **kustomize_substitutions** (Map{String: String}, default={}): An optional map of substitutions for `${}`-style placeholders in the
 provider's yaml.
@@ -215,8 +212,6 @@ kustomize_substitutions:
 {{#/tabs }}
 
 **deploy_cert_manager** (Boolean, default=`true`): Deploys cert-manager into the cluster for use for webhook registration.
-
-**preload_images_for_kind** (Boolean, default=`true`): Uses `kind load docker-image` to preload images into a kind cluster.
 
 **trigger_mode** (String, default=`auto`): Optional setting to configure if tilt should automatically rebuild on changes.
 Set to `manual` to disable auto-rebuilding and require users to trigger rebuilds of individual changed components through the UI.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
`preload_images_for_kind` and `kind_cluster_name` are not used anymore (probably since a while).
Right now we're always preloading cert-manager images based on `CAPI_KIND_CLUSTER_NAME`.
I think if there is demand to run tilt with a non-kind cluster we can reconsider our current handling 
and maybe just auto-discover if the current cluster is a kind cluster and act accordingly.

The last few months since we had this hard dependency to kind nobody complained.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
