### PR TITLE
🌱 ClusterClass: add ref and controlPlane name builtin variables

### DIFF
--- a/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
+++ b/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
@@ -382,11 +382,17 @@ In addition to variables specified in the ClusterClass, the following builtin va
 referenced in patches:
 - `builtin.cluster.{name,namespace}`
 - `builtin.cluster.topology.{version,class}`
-- `builtin.controlPlane.{replicas,version}`
+- `builtin.controlPlane.{replicas,version,name}`
     - Please note, these variables are only available when patching control plane or control plane 
       machine templates.
+- `builtin.controlPlane.machineTemplate.infrastructureRef.name`
+    - Please note, these variables are only available when using a control plane with machines and 
+      when patching control plane or control plane machine templates.
 - `builtin.machineDeployment.{replicas,version,class,name,topologyName}`
     - Please note, these variables are only available when patching the templates of a MachineDeployment 
+      and contain the values of the current `MachineDeployment` topology.
+- `builtin.machineDeployment.{infrastructureRef.name,bootstrap.configRef.name}`
+    - Please note, these variables are only available when patching the templates of a MachineDeployment
       and contain the values of the current `MachineDeployment` topology.
 
 Builtin variables can be referenced just like regular variables, e.g.:

--- a/docs/proposals/202105256-cluster-class-and-managed-topologies.md
+++ b/docs/proposals/202105256-cluster-class-and-managed-topologies.md
@@ -649,11 +649,17 @@ Note: Builtin variables are defined in [Builtin variables](#builtin-variables) b
 It’s also possible to use so-called builtin variables in addition to user-defined variables. The following builtin variables are available:
 - `builtin.cluster.{name,namespace}`
 - `builtin.cluster.topology.{version,class}`
-- `builtin.controlPlane.{replicas,version}`
+- `builtin.controlPlane.{replicas,version,name}`
     - **Note**: these variables are only available when patching control plane or control plane machine templates.
+- `builtin.controlPlane.machineTemplate.infrastructureRef.name`
+    - **Note**: these variables are only available when using a control plane with machines and
+      when patching control plane or control plane machine templates.
 - `builtin.machineDeployment.{replicas,version,class,name,topologyName}`
     - **Note**: these variables are only available when patching MachineDeployment templates and contain the values 
       of the current `MachineDeploymentTopology`.
+- `builtin.machineDeployment.{infrastructureRef.name,bootstrap.configRef.name}`
+    - **Note**: these variables are only available when patching the templates of a MachineDeployment
+      and contain the values of the current `MachineDeployment` topology.
 
 Builtin variables are available under the `builtin.` prefix. Some examples:
 - Usage of `cluster.name` via variable:

--- a/internal/controllers/topology/cluster/patches/engine.go
+++ b/internal/controllers/topology/cluster/patches/engine.go
@@ -138,7 +138,7 @@ func createRequest(blueprint *scope.ClusterBlueprint, desired *scope.ClusterStat
 	req.Items = append(req.Items, t)
 
 	// Calculate controlPlane variables.
-	controlPlaneVariables, err := variables.ControlPlane(&blueprint.Topology.ControlPlane, desired.ControlPlane.Object)
+	controlPlaneVariables, err := variables.ControlPlane(&blueprint.Topology.ControlPlane, desired.ControlPlane.Object, desired.ControlPlane.InfrastructureMachineTemplate)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to calculate ControlPlane variables")
 	}
@@ -188,7 +188,7 @@ func createRequest(blueprint *scope.ClusterBlueprint, desired *scope.ClusterStat
 		}
 
 		// Calculate MachineDeployment variables.
-		mdVariables, err := variables.MachineDeployment(mdTopology, md.Object)
+		mdVariables, err := variables.MachineDeployment(mdTopology, md.Object, md.BootstrapTemplate, md.InfrastructureMachineTemplate)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to calculate variables for %s", tlog.KObj{Obj: md.Object})
 		}

--- a/internal/controllers/topology/cluster/patches/inline/json_patch_generator_test.go
+++ b/internal/controllers/topology/cluster/patches/inline/json_patch_generator_test.go
@@ -102,6 +102,14 @@ func TestGenerate(t *testing.T) {
 									Variable: pointer.String("builtin.controlPlane.replicas"),
 								},
 							},
+							// test .builtin.controlPlane.machineTemplate.InfrastructureRef.name var.
+							{
+								Op:   "replace",
+								Path: "/spec/template/spec/files",
+								ValueFrom: &clusterv1.JSONPatchValue{
+									Template: pointer.String(`[{"contentFrom":{"secret":{"key":"control-plane-azure.json","name":"{{ .builtin.controlPlane.machineTemplate.infrastructureRef.name }}-azure-json"}}}]`),
+								},
+							},
 						},
 					},
 				},
@@ -121,7 +129,7 @@ func TestGenerate(t *testing.T) {
 							TemplateType: api.ControlPlaneTemplateType,
 						},
 						Variables: map[string]apiextensionsv1.JSON{
-							"builtin":   {Raw: []byte(`{"controlPlane":{"replicas":3}}`)},
+							"builtin":   {Raw: []byte(`{"controlPlane":{"replicas":3,"machineTemplate":{"infrastructureRef":{"name":"controlPlaneInfrastructureMachineTemplate1"}}}}`)},
 							"variableC": {Raw: []byte(`"C-template"`)},
 						},
 					},
@@ -141,8 +149,15 @@ func TestGenerate(t *testing.T) {
 {"op":"replace","path":"/spec/valueFrom/template","value":"template bbbbb"},
 {"op":"replace","path":"/spec/templatePrecedent","value":"C-template"},
 {"op":"replace","path":"/spec/builtinClusterName","value":"cluster-name"},
-{"op":"replace","path":"/spec/builtinControlPlaneReplicas","value":3}
-]`),
+{"op":"replace","path":"/spec/builtinControlPlaneReplicas","value":3},
+{"op":"replace","path":"/spec/template/spec/files","value":[{
+  "contentFrom":{
+    "secret":{
+      "key":"control-plane-azure.json",
+      "name":"controlPlaneInfrastructureMachineTemplate1-azure-json"
+    }
+  }
+}]}]`),
 						PatchType: api.JSONPatchType,
 					},
 				},

--- a/internal/controllers/topology/cluster/patches/variables/variables.go
+++ b/internal/controllers/topology/cluster/patches/variables/variables.go
@@ -73,8 +73,28 @@ type ControlPlaneBuiltins struct {
 	// being orchestrated.
 	Version string `json:"version,omitempty"`
 
+	// Name is the name of the ControlPlane,
+	// to which the current template belongs to.
+	Name string `json:"name,omitempty"`
+
 	// Replicas is the value of the replicas field of the ControlPlane object.
 	Replicas *int64 `json:"replicas,omitempty"`
+
+	// MachineTemplate is the value of the .spec.machineTemplate field of the ControlPlane object.
+	MachineTemplate *ControlPlaneMachineTemplateBuiltins `json:"machineTemplate,omitempty"`
+}
+
+// ControlPlaneMachineTemplateBuiltins is the value of the .spec.machineTemplate field of the ControlPlane object.
+type ControlPlaneMachineTemplateBuiltins struct {
+	// InfrastructureRef is the value of the infrastructureRef field of ControlPlane.spec.machineTemplate.
+	InfrastructureRef ControlPlaneMachineTemplateInfrastructureRefBuiltins `json:"infrastructureRef,omitempty"`
+}
+
+// ControlPlaneMachineTemplateInfrastructureRefBuiltins is the value of the infrastructureRef field of
+// ControlPlane.spec.machineTemplate.
+type ControlPlaneMachineTemplateInfrastructureRefBuiltins struct {
+	// Name of the infrastructureRef.
+	Name string `json:"name,omitempty"`
 }
 
 // MachineDeploymentBuiltins represents builtin MachineDeployment variables.
@@ -102,6 +122,33 @@ type MachineDeploymentBuiltins struct {
 	// Replicas is the value of the replicas field of the MachineDeployment,
 	// to which the current template belongs to.
 	Replicas *int64 `json:"replicas,omitempty"`
+
+	// Bootstrap is the value of the .spec.template.spec.bootstrap field of the MachineDeployment.
+	Bootstrap *MachineDeploymentBootstrapBuiltins `json:"bootstrap,omitempty"`
+
+	// InfrastructureRef is the value of the .spec.template.spec.bootstrap field of the MachineDeployment.
+	InfrastructureRef *MachineDeploymentInfrastructureRefBuiltins `json:"infrastructureRef,omitempty"`
+}
+
+// MachineDeploymentBootstrapBuiltins is the value of the .spec.template.spec.bootstrap field
+// of the MachineDeployment.
+type MachineDeploymentBootstrapBuiltins struct {
+	// ConfigRef is the value of the .spec.template.spec.bootstrap.configRef field of the MachineDeployment.
+	ConfigRef *MachineDeploymentBootstrapConfigRefBuiltins `json:"configRef,omitempty"`
+}
+
+// MachineDeploymentBootstrapConfigRefBuiltins is the value of the .spec.template.spec.bootstrap.configRef
+// field of the MachineDeployment.
+type MachineDeploymentBootstrapConfigRefBuiltins struct {
+	// Name of the bootstrap.configRef.
+	Name string `json:"name,omitempty"`
+}
+
+// MachineDeploymentInfrastructureRefBuiltins is the value of the .spec.template.spec.infrastructureRef field
+// of the MachineDeployment.
+type MachineDeploymentInfrastructureRefBuiltins struct {
+	// Name of the infrastructureRef.
+	Name string `json:"name,omitempty"`
 }
 
 // VariableMap is a name/value map of variables.
@@ -139,31 +186,41 @@ func Global(clusterTopology *clusterv1.Topology, cluster *clusterv1.Cluster) (Va
 }
 
 // ControlPlane returns variables that apply to templates belonging to the ControlPlane.
-func ControlPlane(controlPlaneTopology *clusterv1.ControlPlaneTopology, controlPlane *unstructured.Unstructured) (VariableMap, error) {
+func ControlPlane(cpTopology *clusterv1.ControlPlaneTopology, cp, cpInfrastructureMachineTemplate *unstructured.Unstructured) (VariableMap, error) {
 	variables := VariableMap{}
 
 	// Construct builtin variable.
 	builtin := Builtins{
-		ControlPlane: &ControlPlaneBuiltins{},
+		ControlPlane: &ControlPlaneBuiltins{
+			Name: cp.GetName(),
+		},
 	}
 
 	// If it is required to manage the number of replicas for the ControlPlane, set the corresponding variable.
 	// NOTE: If the Cluster.spec.topology.controlPlane.replicas field is nil, the topology reconciler won't set
 	// the replicas field on the ControlPlane. This happens either when the ControlPlane provider does
 	// not implement support for this field or the default value of the ControlPlane is used.
-	if controlPlaneTopology.Replicas != nil {
-		replicas, err := contract.ControlPlane().Replicas().Get(controlPlane)
+	if cpTopology.Replicas != nil {
+		replicas, err := contract.ControlPlane().Replicas().Get(cp)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get spec.replicas from the ControlPlane")
 		}
 		builtin.ControlPlane.Replicas = replicas
 	}
 
-	version, err := contract.ControlPlane().Version().Get(controlPlane)
+	version, err := contract.ControlPlane().Version().Get(cp)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get spec.version from the ControlPlane")
 	}
 	builtin.ControlPlane.Version = *version
+
+	if cpInfrastructureMachineTemplate != nil {
+		builtin.ControlPlane.MachineTemplate = &ControlPlaneMachineTemplateBuiltins{
+			InfrastructureRef: ControlPlaneMachineTemplateInfrastructureRefBuiltins{
+				Name: cpInfrastructureMachineTemplate.GetName(),
+			},
+		}
+	}
 
 	if err := setVariable(variables, BuiltinsName, builtin); err != nil {
 		return nil, err
@@ -173,7 +230,7 @@ func ControlPlane(controlPlaneTopology *clusterv1.ControlPlaneTopology, controlP
 }
 
 // MachineDeployment returns variables that apply to templates belonging to a MachineDeployment.
-func MachineDeployment(mdTopology *clusterv1.MachineDeploymentTopology, md *clusterv1.MachineDeployment) (VariableMap, error) {
+func MachineDeployment(mdTopology *clusterv1.MachineDeploymentTopology, md *clusterv1.MachineDeployment, mdBootstrapTemplate, mdInfrastructureMachineTemplate *unstructured.Unstructured) (VariableMap, error) {
 	variables := VariableMap{}
 
 	// Add variables overrides for the MachineDeployment.
@@ -194,6 +251,20 @@ func MachineDeployment(mdTopology *clusterv1.MachineDeploymentTopology, md *clus
 	}
 	if md.Spec.Replicas != nil {
 		builtin.MachineDeployment.Replicas = pointer.Int64(int64(*md.Spec.Replicas))
+	}
+
+	if mdBootstrapTemplate != nil {
+		builtin.MachineDeployment.Bootstrap = &MachineDeploymentBootstrapBuiltins{
+			ConfigRef: &MachineDeploymentBootstrapConfigRefBuiltins{
+				Name: mdBootstrapTemplate.GetName(),
+			},
+		}
+	}
+
+	if mdInfrastructureMachineTemplate != nil {
+		builtin.MachineDeployment.InfrastructureRef = &MachineDeploymentInfrastructureRefBuiltins{
+			Name: mdInfrastructureMachineTemplate.GetName(),
+		}
 	}
 
 	if err := setVariable(variables, BuiltinsName, builtin); err != nil {

--- a/internal/webhooks/patch_validation.go
+++ b/internal/webhooks/patch_validation.go
@@ -333,21 +333,27 @@ var builtinVariables = sets.NewString(
 
 	// ClusterTopology builtins.
 	"builtin.cluster.topology",
-	"builtin.cluster.topology.version",
 	"builtin.cluster.topology.class",
+	"builtin.cluster.topology.version",
 
 	// ControlPlane builtins.
 	"builtin.controlPlane",
-	"builtin.controlPlane.version",
+	"builtin.controlPlane.name",
 	"builtin.controlPlane.replicas",
+	"builtin.controlPlane.version",
+	// ControlPlane ref builtins.
+	"builtin.controlPlane.machineTemplate.infrastructureRef.name",
 
 	// MachineDeployment builtins.
 	"builtin.machineDeployment",
-	"builtin.machineDeployment.version",
 	"builtin.machineDeployment.class",
 	"builtin.machineDeployment.name",
-	"builtin.machineDeployment.topologyName",
 	"builtin.machineDeployment.replicas",
+	"builtin.machineDeployment.topologyName",
+	"builtin.machineDeployment.version",
+	// MachineDeployment ref builtins.
+	"builtin.machineDeployment.bootstrap.configRef.name",
+	"builtin.machineDeployment.infrastructureRef.name",
 )
 
 // validateIndexAccess checks to see if the jsonPath is attempting to add an element in the array i.e. access by number


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
While writing ClusterClasses for CAPZ, we discovered that additional builtin variables are needed.

CAPZ has a controller which generates secrets which are eventually used for Machines. These secrets then have to be configured in KCP.spec..kubeadmConfigSpec and in KubeadmConfigTemplates.

The secrets are generated with the names of the corresponding current AzureMachineTemplates. So essentially CAPZ has to be able to take the name of the currently referenced AzureMachineTemplate of KCP/MD and then patch KCP / the KubeadmConfigTemplate accordingly.

To make this possible we introduce builtin variables for all references in KCP / MD.

We additionally add `builtin.controlPlane.name` because it seems to be a good variable to have.


For additional context, please see this Slack thread: https://kubernetes.slack.com/archives/CEX9HENG7/p1645731252682719

The plan is to cherry-pick this PR to release-1.1 too. This way it will be possible to experiment
with CAPZ ClusterClasses after the next CAPZ and CAPI core release. 
**This does not block the CAPZ release** (because the next CAPZ release won't include cluster-templates using ClusterClasses)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
