### PR TITLE
🌱 Update kustomize and use go install insted of go get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ endif
 # Binaries.
 #
 # Note: Need to use abspath so we can invoke these from subdirectories
-KUSTOMIZE_VER := v4.4.1
+KUSTOMIZE_VER := v4.5.2
 KUSTOMIZE_BIN := kustomize
 KUSTOMIZE := $(abspath $(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)-$(KUSTOMIZE_VER))
 KUSTOMIZE_PKG := sigs.k8s.io/kustomize/kustomize/v4

--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -37,20 +37,9 @@ if [ -z "${GOBIN}" ]; then
   exit 1
 fi
 
-tmp_dir=$(mktemp -d -t goinstall_XXXXXXXXXX)
-function clean {
-  rm -rf "${tmp_dir}"
-}
-trap clean EXIT
-
 rm "${GOBIN}/${2}"* || true
 
-cd "${tmp_dir}"
-
-# create a new module in the tmp directory
-go mod init fake/mod
-
 # install the golang module specified as the first argument
-go get -tags tools "${1}@${3}"
+go install -tags tools "${1}@${3}"
 mv "${GOBIN}/${2}" "${GOBIN}/${2}-${3}"
 ln -sf "${GOBIN}/${2}-${3}" "${GOBIN}/${2}"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Bump up the version of kustomize to v4.5.2
Use go install instead of go get to install binaries .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6008 
