### PR TITLE
:seedling: Move command and arg handling of manager.yaml to tilt-prepare

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -9,8 +9,9 @@ settings = {
 }
 
 # global settings
+tilt_file = "./tilt-settings.yaml" if os.path.exists("./tilt-settings.yaml") else "./tilt-settings.json"
 settings.update(read_yaml(
-    "./tilt-settings.yaml" if os.path.exists("./tilt-settings.yaml") else "./tilt-settings.json",
+    tilt_file,
     default = {},
 ))
 
@@ -25,7 +26,6 @@ if settings.get("trigger_mode") == "manual":
 default_registry(settings.get("default_registry"))
 
 always_enable_providers = ["core"]
-extra_args = settings.get("extra_args", {})
 
 providers = {
     "core": {
@@ -232,13 +232,7 @@ def enable_provider(name, debug):
     links = []
 
     if debug_port != 0:
-        # Add delve when debugging. Delve will always listen on the pod side on port 30000.
-        entrypoint = ["sh", "/start.sh", "/dlv", "--listen=:" + str(30000), "--accept-multiclient", "--api-version=2", "--headless=true", "exec", "--", "/manager"]
         port_forwards.append(port_forward(debug_port, 30000))
-        if debug.get("continue", True):
-            entrypoint.insert(8, "--continue")
-    else:
-        entrypoint = ["sh", "/start.sh", "/manager"]
 
     metrics_port = int(debug.get("metrics_port", 0))
     profiler_port = int(debug.get("profiler_port", 0))
@@ -248,21 +242,15 @@ def enable_provider(name, debug):
 
     if profiler_port != 0:
         port_forwards.append(port_forward(profiler_port, 6060))
-        entrypoint.extend(["--profiler-address", ":6060"])
         links.append(link("http://localhost:" + str(profiler_port) + "/debug/pprof", "profiler"))
 
     # Set up an image build for the provider. The live update configuration syncs the output from the local_resource
     # build into the container.
-    provider_args = extra_args.get(name)
-    if provider_args:
-        entrypoint.extend(provider_args)
-
     docker_build(
         ref = p.get("image"),
         context = context + "/.tiltbuild/bin/",
         dockerfile_contents = dockerfile_contents,
         target = "tilt",
-        entrypoint = entrypoint,
         only = "manager",
         live_update = [
             sync(context + "/.tiltbuild/bin/manager", "/manager"),
@@ -365,20 +353,20 @@ def prepare_all():
         if p.get("kustomize_config", True):
             context = p.get("context")
             debug = ""
-            if name in settings.get("debug"):
-                debug = ":debug"
-            providers_arg = providers_arg + "--providers {name}:{context}{debug} ".format(
+            providers_arg = providers_arg + "--providers {name}:{context} ".format(
                 name = name,
                 context = context,
-                debug = debug,
             )
 
-    cmd = "make -B tilt-prepare && ./hack/tools/bin/tilt-prepare {allow_k8s_arg}{tools_arg}{cert_manager_arg}{kustomize_build_arg}{providers_arg}".format(
+    tilt_settings_file_arg = "--tilt-settings-file " + tilt_file
+
+    cmd = "make -B tilt-prepare && ./hack/tools/bin/tilt-prepare {allow_k8s_arg}{tools_arg}{cert_manager_arg}{kustomize_build_arg}{providers_arg}{tilt_settings_file_arg}".format(
         allow_k8s_arg = allow_k8s_arg,
         tools_arg = tools_arg,
         cert_manager_arg = cert_manager_arg,
         kustomize_build_arg = kustomize_build_arg,
         providers_arg = providers_arg,
+        tilt_settings_file_arg = tilt_settings_file_arg,
     )
     local(cmd, env = settings.get("kustomize_substitutions", {}))
 

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/apimachinery v0.23.0
 	k8s.io/client-go v0.23.0
 	k8s.io/klog/v2 v2.30.0
+	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 	sigs.k8s.io/cluster-api v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/cluster-api/test v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/controller-runtime v0.11.1
@@ -115,7 +116,6 @@ require (
 	k8s.io/cluster-bootstrap v0.23.0 // indirect
 	k8s.io/component-base v0.23.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
-	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/hack/tools/tilt-prepare/main.go
+++ b/hack/tools/tilt-prepare/main.go
@@ -22,6 +22,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,9 +39,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -57,7 +60,7 @@ Example call for tilt up:
 	--cert-manager
 	--kustomize-builds clusterctl.crd:./cmd/clusterctl/config/crd/
 	--kustomize-builds observability.tools:./hack/observability/
-	--providers core:.:debug
+	--providers core:.
 	--providers kubeadm-bootstrap:./bootstrap/kubeadm
 	--providers kubeadm-control-plane:./controlplane/kubeadm
 	--providers docker:./test/infrastructure/docker
@@ -70,9 +73,24 @@ var (
 	toolsFlag            = pflag.StringSlice("tools", []string{}, "list of tools to be created; each value should correspond to a make target")
 	certManagerFlag      = pflag.Bool("cert-manager", false, "prepare cert-manager")
 	kustomizeBuildsFlag  = pflag.StringSlice("kustomize-builds", []string{}, "list of kustomize build to be run; each value should be in the form name:path")
-	providersBuildsFlag  = pflag.StringSlice("providers", []string{}, "list of providers to be installed; each value should be in the form name:path[:debug]")
+	providersBuildsFlag  = pflag.StringSlice("providers", []string{}, "list of providers to be installed; each value should be in the form name:path")
 	allowK8SContextsFlag = pflag.StringSlice("allow-k8s-contexts", []string{}, "Specifies that Tilt is allowed to run against the specified k8s context name; Kind is automatically allowed")
+	tiltSettingsFileFlag = pflag.String("tilt-settings-file", "./tilt-settings.yaml", "Path to a tilt-settings.(json|yaml) file")
 )
+
+type tiltSettings struct {
+	Debug     map[string]debugConfig `json:"debug,omitempty"`
+	ExtraArgs map[string]extraArgs   `json:"extra_args,omitempty"`
+}
+
+type debugConfig struct {
+	Continue     *bool `json:"continue"`
+	Port         *int  `json:"port"`
+	ProfilerPort *int  `json:"profiler_port"`
+	MetricsPort  *int  `json:"metrics_port"`
+}
+
+type extraArgs []string
 
 const (
 	kustomizePath = "./hack/tools/bin/kustomize"
@@ -106,17 +124,66 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
+	ts, err := readTiltSettings(*tiltSettingsFileFlag)
+	if err != nil {
+		klog.Exit(fmt.Sprintf("[main] failed to read tilt settings: %v", err))
+	}
+
 	// Execute a first group of tilt prepare tasks, building all the tools required in subsequent steps/by tilt.
 	if err := tiltTools(ctx); err != nil {
 		klog.Exit(fmt.Sprintf("[main] failed to prepare tilt tools: %v", err))
 	}
 
 	// execute a second group of tilt prepare tasks, building all the resources required by tilt.
-	if err := tiltResources(ctx); err != nil {
+	if err := tiltResources(ctx, ts); err != nil {
 		klog.Exit(fmt.Sprintf("[main] failed to prepare tilt resources: %v", err))
 	}
 
 	klog.Infof("[main] completed, elapsed: %s\n", time.Since(start))
+}
+
+// readTiltSettings reads a tilt-settings.(json|yaml) file from the given path and sets debug defaults for certain
+// fields that are not present.
+func readTiltSettings(path string) (*tiltSettings, error) {
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to open tilt-settings file for path: %s", path))
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read tilt-settings content")
+	}
+
+	ts := &tiltSettings{}
+	if err := yaml.Unmarshal(data, ts); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal tilt-settings content")
+	}
+
+	setDebugDefaults(ts)
+	return ts, nil
+}
+
+// setDebugDefaults sets default values for debug related fields in tiltSettings.
+func setDebugDefaults(ts *tiltSettings) {
+	for k := range ts.Debug {
+		p := ts.Debug[k]
+		if p.Continue == nil {
+			p.Continue = pointer.BoolPtr(true)
+		}
+		if p.Port == nil {
+			p.Port = pointer.IntPtr(0)
+		}
+		if p.ProfilerPort == nil {
+			p.ProfilerPort = pointer.IntPtr(0)
+		}
+		if p.MetricsPort == nil {
+			p.MetricsPort = pointer.IntPtr(0)
+		}
+
+		ts.Debug[k] = p
+	}
 }
 
 // allowK8sConfig mimics allow_k8s_contexts; only kind is enabled by default but more can be added.
@@ -157,7 +224,7 @@ func tiltTools(ctx context.Context) error {
 }
 
 // tiltResources runs tasks required for building all the resources required by tilt.
-func tiltResources(ctx context.Context) error {
+func tiltResources(ctx context.Context, ts *tiltSettings) error {
 	tasks := map[string]taskFunction{}
 
 	// If required, all the task to install cert manager.
@@ -184,16 +251,12 @@ func tiltResources(ctx context.Context) error {
 	// Add a provider task for each name/path defined using the --provider flag.
 	for _, p := range *providersBuildsFlag {
 		pValues := strings.Split(p, ":")
-		if len(pValues) != 2 && len(pValues) != 3 {
-			return errors.Errorf("[resources] failed to parse --provider flag %s: value should be in the form of name:path[:debug]", p)
+		if len(pValues) != 2 {
+			return errors.Errorf("[resources] failed to parse --provider flag %s: value should be in the form of name:path", p)
 		}
 		name := pValues[0]
 		path := pValues[1]
-		debug := false
-		if len(pValues) == 3 && pValues[2] == "debug" {
-			debug = true
-		}
-		tasks[name] = providerTask(fmt.Sprintf("%s/config/default", path), fmt.Sprintf("%s.provider.yaml", name), debug)
+		tasks[name] = providerTask(name, fmt.Sprintf("%s/config/default", path), ts)
 	}
 
 	return runTaskGroup(ctx, "resources", tasks)
@@ -380,7 +443,7 @@ func kustomizeTask(path, out string) taskFunction {
 // providerTask generates a task for creating the component yal for a provider and saving the output on a file.
 // NOTE: This task has several sub steps including running kustomize, envsubst, fixing components for debugging,
 // and adding the Provider resource mimicking what clusterctl init does.
-func providerTask(path, out string, debug bool) taskFunction {
+func providerTask(name, path string, ts *tiltSettings) taskFunction {
 	return func(ctx context.Context, prefix string, errCh chan error) {
 		kustomizeCmd := exec.CommandContext(ctx, kustomizePath, "build", path)
 		var stdout1, stderr1 bytes.Buffer
@@ -408,15 +471,7 @@ func providerTask(path, out string, debug bool) taskFunction {
 			errCh <- errors.Wrapf(err, "[%s] failed parse components yaml", prefix)
 			return
 		}
-
-		if debug {
-			if err := prepareDeploymentForDebug(prefix, objs); err != nil {
-				errCh <- err
-				return
-			}
-		}
-
-		if err := prepareDeploymentForObservability(prefix, objs); err != nil {
+		if err := prepareManagerDeployment(name, prefix, objs, ts); err != nil {
 			errCh <- err
 			return
 		}
@@ -434,7 +489,7 @@ func providerTask(path, out string, debug bool) taskFunction {
 			return
 		}
 
-		if err := writeIfChanged(prefix, filepath.Join(tiltBuildPath, "yaml", out), yaml); err != nil {
+		if err := writeIfChanged(prefix, filepath.Join(tiltBuildPath, "yaml", fmt.Sprintf("%s.provider.yaml", name)), yaml); err != nil {
 			errCh <- err
 		}
 	}
@@ -470,9 +525,12 @@ func writeIfChanged(prefix string, path string, yaml []byte) error {
 	return nil
 }
 
-// prepareDeploymentForDebug alter controller deployments for working nicely with delve debugger;
-// most specifically, liveness and readiness probes are dropper and leader election turned off.
-func prepareDeploymentForDebug(prefix string, objs []unstructured.Unstructured) error {
+// prepareManagerDeployment sets the Command and Args for the manager container according to the given tiltSettings.
+// If there is a debug config given for the provider, we modify Command and Args to work nicely with the delve debugger.
+// If there are extra_args given for the provider, we append those to the ones that already exist in the deployment.
+// This has the affect that the appended ones will take precedence, as those are read last.
+// Finally, we modify the deployment to enable prometheus metrics scraping.
+func prepareManagerDeployment(name, prefix string, objs []unstructured.Unstructured, ts *tiltSettings) error {
 	return updateDeployment(prefix, objs, func(d *appsv1.Deployment) {
 		for j, container := range d.Spec.Template.Spec.Containers {
 			if container.Name != "manager" {
@@ -480,52 +538,60 @@ func prepareDeploymentForDebug(prefix string, objs []unstructured.Unstructured) 
 				continue
 			}
 
-			// Drop liveness and readiness probes.
-			container.LivenessProbe = nil
-			container.ReadinessProbe = nil
+			cmd := []string{"sh", "/start.sh", "/manager"}
+			args := append(container.Args, []string(ts.ExtraArgs[name])...)
 
-			// Drop leader election.
-			debugArgs := make([]string, 0, len(container.Args))
-			for _, a := range container.Args {
-				if a == "--leader-elect" || a == "--leader-elect=true" {
-					continue
+			// alter controller deployment for working nicely with delve debugger;
+			// most specifically, configuring delve, starting the manager with profiling enabled, dropping liveness and
+			// readiness probes and disabling leader election.
+			if d, ok := ts.Debug[name]; ok {
+				cmd = []string{"sh", "/start.sh", "/dlv", "--accept-multiclient", "--api-version=2", "--headless=true", "exec"}
+
+				if d.Port != nil && *d.Port > 0 {
+					cmd = append(cmd, "--listen=:30000")
 				}
-				debugArgs = append(debugArgs, a)
+				if d.Continue != nil && *d.Continue {
+					cmd = append(cmd, "--continue")
+				}
+
+				cmd = append(cmd, []string{"--", "/manager"}...)
+
+				if d.ProfilerPort != nil && *d.ProfilerPort > 0 {
+					args = append(args, []string{"--profiler-address=:6060"}...)
+				}
+
+				debugArgs := make([]string, 0, len(args))
+				for _, a := range args {
+					if a == "--leader-elect" || a == "--leader-elect=true" {
+						continue
+					}
+					debugArgs = append(debugArgs, a)
+				}
+				args = debugArgs
+
+				container.LivenessProbe = nil
+				container.ReadinessProbe = nil
 			}
-			container.Args = debugArgs
 
-			d.Spec.Template.Spec.Containers[j] = container
-		}
-	})
-}
-
-// prepareDeploymentForObservability alters controller deployments for working
-// nicely with prometheus metrics scraping. Specifically, the metrics endpoint is set to
-// listen on all interfaces instead of only localhost, and another port is added to the
-// container to expose the metrics endpoint.
-func prepareDeploymentForObservability(prefix string, objs []unstructured.Unstructured) error {
-	return updateDeployment(prefix, objs, func(d *appsv1.Deployment) {
-		for j, container := range d.Spec.Template.Spec.Containers {
-			if container.Name != "manager" {
-				// as defined in clusterctl Provider Contract "Controllers & Watching namespace"
-				continue
-			}
-
-			args := make([]string, 0, len(container.Args))
-			for _, a := range container.Args {
+			// alter the controller deployment for working nicely with prometheus metrics scraping. Specifically, the
+			// metrics endpoint is set to listen on all interfaces instead of only localhost, and another port is added
+			// to the container to expose the metrics endpoint.
+			finalArgs := make([]string, 0, len(args))
+			for _, a := range args {
 				if strings.HasPrefix(a, "--metrics-bind-addr=") {
-					args = append(args, "--metrics-bind-addr=0.0.0.0:8080")
+					finalArgs = append(finalArgs, "--metrics-bind-addr=0.0.0.0:8080")
 					continue
 				}
-				args = append(args, a)
+				finalArgs = append(finalArgs, a)
 			}
-			container.Args = args
 
 			container.Ports = append(container.Ports, corev1.ContainerPort{
 				Name:          "metrics",
 				ContainerPort: 8080,
 				Protocol:      "TCP",
 			})
+			container.Command = cmd
+			container.Args = finalArgs
 
 			d.Spec.Template.Spec.Containers[j] = container
 		}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Move the calculation of command and args of the manager deployment image to tilt-prepare and clean up the Tiltfile accordingly. This solves the issue that some extra_args given by the user won't be respected in the current solution. See: https://github.com/kubernetes-sigs/cluster-api/issues/6202

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6202

Signed-off-by: Johannes Frey <johannes.frey@daimler.com>
<sub>Johannes Frey <[johannes.frey@daimler.com](mailto:johannes.frey@daimler.com)>, Daimler TSS GmbH ([Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))</sub>