### PR TITLE
:seedling: Bubble up machines permanent failure as MS/MD conditions

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -250,6 +250,10 @@ const (
 	// ResizedCondition documents a MachineSet is resizing the set of controlled machines.
 	ResizedCondition ConditionType = "Resized"
 
+	// MachinesSucceededCondition reports if any Machine didn't succeed because of a permanent failure.
+	MachinesSucceededCondition ConditionType = "MachinesSucceeded"
+	PermanentFailureReason                   = "PermanentFailure"
+
 	// ScalingUpReason (Severity=Info) documents a MachineSet is increasing the number of replicas.
 	ScalingUpReason = "ScalingUp"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There's a UX lack to signal permanent machine failures in MachineSet and MachineDeployments.
This PR solves that by bubbling up permanent Machine failures aka FailureMessage/FailureReason as a MachineSet and MachineDeployment condition: MachinesSucceededCondition.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/5635

Needs https://github.com/kubernetes-sigs/cluster-api/pull/6025 for the conditions to be set in updateStatus
