### PR TITLE
📖 doc: drop Prow build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 <a href="https://cluster-api.sigs.k8s.io"><img alt="capi" src="./docs/book/src/images/introduction.png" width="160x" /></a>
 <p>
-<a href="https://prow.k8s.io/?job=post-cluster-api-push-images">
-<img alt="Build Status" src="https://prow.k8s.io/badge.svg?jobs=post-cluster-api-push-images"></a>
 <a href="https://godoc.org/sigs.k8s.io/cluster-api"><img src="https://godoc.org/sigs.k8s.io/cluster-api?status.svg"></a>
 <!-- join kubernetes slack channel for cluster-api -->
 <a href="http://slack.k8s.io/">


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR drops the Prow build badge from our top-level README.

I think we should drop it because:
* I think the postsubmit image push job is not a good proxy to show the overall build/CI status of CAPI. We have literally dozens of jobs today which can be seen in testgrid: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api
* The badge is "grey" if the job didn't run in the last 24h (which means it's just grey from Saturday to Monday). Not sure which message that sends to our users :)
* If the job actually fails, it has usually nothing to do with the "health" of our CI/CD jobs. In all cases that I saw it was an issue with [GCR](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cluster-api-push-images/1494369469173075968) or [GCB](https://storage.googleapis.com/kubernetes-jenkins/logs/post-cluster-api-push-images/1494162657685540864/artifacts/build.log). The chances that we merge something which break our image push jobs are very low.
* We are not using the badge at all to track build health. For that we have the testgrid and the mail alerts.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
