### PR TITLE
:bug: Fix/panic in webhook

### DIFF
--- a/api/v1beta1/cluster_webhook.go
+++ b/api/v1beta1/cluster_webhook.go
@@ -197,6 +197,18 @@ func (c *Cluster) validateTopology(old *Cluster) field.ErrorList {
 			)
 		}
 	default: // On update
+		if old.Spec.Topology == nil || old.Spec.Topology.Class == "" {
+			allErrs = append(
+				allErrs,
+				field.Forbidden(
+					field.NewPath("spec", "topology", "class"),
+					"class cannot be set on an existing Cluster",
+				),
+			)
+			// return early here if there is no class to compare.
+			return allErrs
+		}
+
 		// Class could not be mutated.
 		if c.Spec.Topology.Class != old.Spec.Topology.Class {
 			allErrs = append(

--- a/api/v1beta1/cluster_webhook_test.go
+++ b/api/v1beta1/cluster_webhook_test.go
@@ -391,6 +391,24 @@ func TestClusterTopologyValidation(t *testing.T) {
 			},
 		},
 		{
+			name:      "should return error on update when old has no Topology and new adds Topology",
+			expectErr: true,
+			old: &Cluster{
+				Spec: ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{},
+				},
+			},
+			in: &Cluster{
+				Spec: ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{},
+					Topology: &Topology{
+						Class:   "bar",
+						Version: "v1.19.1",
+					},
+				},
+			},
+		},
+		{
 			name:      "should return error on update when Topology version is downgraded",
 			expectErr: true,
 			old: &Cluster{


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>
This change fixes an issue where the cluster webhook panicked when `spec.topology` was added in an update.

Fixes #6222 
