### PR TITLE
:book: document setting feature flags for tilt dev env

### DIFF
--- a/docs/book/src/developer/testing.md
+++ b/docs/book/src/developer/testing.md
@@ -216,6 +216,15 @@ The e2e tests also create a local clusterctl repository. After it has been creat
 skipped by setting `-e2e.cluster-config=<ARTIFACTS>/repository/clusterctl-config.yaml`. This also works with a clusterctl repository created 
 via [Create the local repository](http://localhost:3000/clusterctl/developers.html#create-the-local-repository).
 
+**Feature gates**: E2E tests often use features which need to be enabled first. Make sure to enable the feature gates in the tilt settings file:
+```yaml
+kustomize_substitutions:
+  CLUSTER_TOPOLOGY: "true"
+  EXP_MACHINE_POOL: "true"
+  EXP_CLUSTER_RESOURCE_SET: "true"
+  EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
+```
+
 </aside>
 
 ### Running specific tests

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -70,7 +70,14 @@ documentation](https://docs.tilt.dev/api.html#api.default_registry) for more det
 for more details.
 
 **kustomize_substitutions** (Map{String: String}, default={}): An optional map of substitutions for `${}`-style placeholders in the
-provider's yaml.
+provider's yaml. **Note**: It's recommended to enable the following feature flags for local dev environment to ensure e2e tests run through:
+```yaml
+kustomize_substitutions:
+  CLUSTER_TOPOLOGY: "true"
+  EXP_MACHINE_POOL: "true"
+  EXP_CLUSTER_RESOURCE_SET: "true"
+  EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION: "true"
+```
 
 **deploy_observability** ([string], default=[]): If set, installs on the dev cluster one of more observability
 tools. Supported values are `grafana`, `loki`, `promtail` and/or `prometheus` (Note: the UI for `grafana` and `prometheus` will be accessible via a link in the tilt console).


### PR DESCRIPTION
**What this PR does / why we need it**:
I had an issue running e2e tests locally using tilt because I didn't enable all feature flags. A [discussion on Slack](https://kubernetes.slack.com/archives/C8TSNPY4T/p1646140199311849) clarified this. This documentation change should ensure future contributors don't stumble upon the same issue. 
