### PR TITLE
:bug: Default the namespace of infra & bootstrap refs in a MachineDeployment

### DIFF
--- a/api/v1beta1/machinedeployment_webhook.go
+++ b/api/v1beta1/machinedeployment_webhook.go
@@ -200,4 +200,11 @@ func PopulateDefaultsMachineDeployment(d *MachineDeployment) {
 	// Make sure selector and template to be in the same cluster.
 	d.Spec.Selector.MatchLabels[ClusterLabelName] = d.Spec.ClusterName
 	d.Spec.Template.Labels[ClusterLabelName] = d.Spec.ClusterName
+
+	if d.Spec.Template.Spec.InfrastructureRef.Namespace == "" {
+		d.Spec.Template.Spec.InfrastructureRef.Namespace = d.Namespace
+	}
+	if d.Spec.Template.Spec.Bootstrap.ConfigRef != nil && d.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace == "" {
+		d.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace = d.Namespace
+	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
A MachineDeployment does not provide a default namespace for its infra and bootstrap references. This seems like an omission, because both [MachinePool](https://github.com/kubernetes-sigs/cluster-api/blob/88ddd8a16a44f5d8724b9c6b1e3669424d98df7f/exp/api/v1beta1/machinepool_webhook.go#L59-L65) ad  [KubeadmControlPlane](https://github.com/kubernetes-sigs/cluster-api/blob/4c44d057743441f60a57e803d6b88b3cce36cde0/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go#L63-L65) provide defaults.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
