### PR TITLE
📖 Use semverCompare to enable patches based on k8s version

### DIFF
--- a/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
+++ b/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md
@@ -643,7 +643,12 @@ Of course the same is possible by adding a boolean variable to a configuration o
 
 Builtin variables can be leveraged to apply a patch only for a specific Kubernetes version.
 ```yaml
-    enabledIf: "{{ if eq "v1.21.1" .builtin.controlPlane.version }}true{{end}}"
+    enabledIf: '{{ semverCompare "1.21.1" .builtin.controlPlane.version }}'
+```
+
+With `semverCompare` and `coalesce` a feature can be enabled in newer versions of Kubernetes for both KubeadmConfigTemplate and KubeadmControlPlane.
+```yaml
+    enabledIf: '{{ semverCompare "^1.22.0" (coalesce .builtin.controlPlane.version .builtin.machineDeployment.version )}}'
 ```
 
 <!-- links -->


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Cleans up the existing example on `.builtin` variables to use `semverCompare` which was introduced in #6131

I am currently implementing ClusterClass for our internal usage and had a usecase where I wanted to activate a specific feature flag for Kubernetes 1.22+ (as it was introduced then). This specific usecase was missing from the docs, and I stumbled upon some issues when I tried to patch both the `KubeadmConfigTemplate` for my machine deployment, as well as the `KubeadmControlPlane` in one patch with one `enabledIf` based on the example provided here, because `.builtin.controlPlane.version` was only defined for half of the definitions.

By using `semverCompare` to enable only on 1.22+ and `coalesce` to select the appropriate kubernetes version based on the current definition, I was able to combine these changes into one `patch`.
