### PR TITLE
:bug: permit empty/not set providerIDList

### DIFF
--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -68,7 +68,7 @@ func (r *MachinePoolReconciler) reconcileNodeRefs(ctx context.Context, cluster *
 	log = log.WithValues("cluster", cluster.Name)
 
 	// Check that the MachinePool has valid ProviderIDList.
-	if len(mp.Spec.ProviderIDList) == 0 {
+	if len(mp.Spec.ProviderIDList) == 0 && (mp.Spec.Replicas == nil || *mp.Spec.Replicas != 0) {
 		log.V(2).Info("MachinePool doesn't have any ProviderIDs yet")
 		return ctrl.Result{}, nil
 	}

--- a/exp/internal/controllers/machinepool_controller_phases.go
+++ b/exp/internal/controllers/machinepool_controller_phases.go
@@ -274,11 +274,8 @@ func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, clu
 
 	var providerIDList []string
 	// Get Spec.ProviderIDList from the infrastructure provider.
-	if err := util.UnstructuredUnmarshalField(infraConfig, &providerIDList, "spec", "providerIDList"); err != nil {
+	if err := util.UnstructuredUnmarshalField(infraConfig, &providerIDList, "spec", "providerIDList"); err != nil && !errors.Is(err, util.ErrUnstructuredFieldNotFound) {
 		return ctrl.Result{}, errors.Wrapf(err, "failed to retrieve data from infrastructure provider for MachinePool %q in namespace %q", mp.Name, mp.Namespace)
-	} else if len(providerIDList) == 0 {
-		log.Info("Retrieved empty Spec.ProviderIDList from infrastructure provider")
-		return ctrl.Result{RequeueAfter: externalReadyWait}, nil
 	}
 
 	// Get and set Status.Replicas from the infrastructure provider.
@@ -287,8 +284,10 @@ func (r *MachinePoolReconciler) reconcileInfrastructure(ctx context.Context, clu
 		if err != util.ErrUnstructuredFieldNotFound {
 			return ctrl.Result{}, errors.Wrapf(err, "failed to retrieve replicas from infrastructure provider for MachinePool %q in namespace %q", mp.Name, mp.Namespace)
 		}
-	} else if mp.Status.Replicas == 0 {
-		log.Info("Retrieved unset Status.Replicas from infrastructure provider")
+	}
+
+	if len(providerIDList) == 0 && mp.Status.Replicas != 0 {
+		log.Info("Retrieved empty Spec.ProviderIDList from infrastructure provider but Status.Replicas is not zero.", "replicas", mp.Status.Replicas)
 		return ctrl.Result{RequeueAfter: externalReadyWait}, nil
 	}
 

--- a/test/e2e/machine_pool.go
+++ b/test/e2e/machine_pool.go
@@ -113,6 +113,15 @@ func MachinePoolSpec(ctx context.Context, inputGetter func() MachinePoolInput) {
 			WaitForMachinePoolToScale: input.E2EConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
 		})
 
+		By("Scaling the machine pool to zero")
+		framework.ScaleMachinePoolAndWait(ctx, framework.ScaleMachinePoolAndWaitInput{
+			ClusterProxy:              input.BootstrapClusterProxy,
+			Cluster:                   clusterResources.Cluster,
+			Replicas:                  0,
+			MachinePools:              clusterResources.MachinePools,
+			WaitForMachinePoolToScale: input.E2EConfig.GetIntervals(specName, "wait-machine-pool-nodes"),
+		})
+
 		By("PASSED!")
 	})
 

--- a/test/framework/machinepool_helpers.go
+++ b/test/framework/machinepool_helpers.go
@@ -69,7 +69,7 @@ func WaitForMachinePoolNodesToExist(ctx context.Context, input WaitForMachinePoo
 	Expect(input.Getter).ToNot(BeNil(), "Invalid argument. input.Getter can't be nil when calling WaitForMachinePoolNodesToExist")
 	Expect(input.MachinePool).ToNot(BeNil(), "Invalid argument. input.MachinePool can't be nil when calling WaitForMachinePoolNodesToExist")
 
-	By("Waiting for the machine pool workload nodes to exist")
+	By("Waiting for the machine pool workload nodes")
 	Eventually(func() (int, error) {
 		nn := client.ObjectKey{
 			Namespace: input.MachinePool.Namespace,


### PR DESCRIPTION
**What this PR does / why we need it**:
to enable scaling a MachinePool to zero, an empty or not set
providerIDList should be considered valid.
additionally, Replicas 0 of the infrastructure MachinePool should also
be considered valid.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6210

This issue is required for kubernetes-sigs/cluster-api-provider-aws#3242 to be fixable. 
