### PR TITLE
📖 Docs fix, duplicated ```yaml

### DIFF
--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -76,8 +76,6 @@ cert-manager:
 For situations when resources are limited or the network is slow, the cert-manager wait time to be running can be customized by adding a field to the clusterctl config file, for example:
 
 ```yaml
-
-```yaml
 cert-manager:
   ...
   timeout: 15m


### PR DESCRIPTION
Duplicated ```yaml at cert-manager-configuration

**What this PR does / why we need it**:

Fix yaml code section in docs

**Which issue(s) this PR fixes**:
None
