### PR TITLE
:book:  Move ClusterClass index to ensure old links are functional

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -18,7 +18,7 @@
     - [Experimental Features](./tasks/experimental-features/experimental-features.md)
         - [MachinePools](./tasks/experimental-features/machine-pools.md)
         - [ClusterResourceSet](./tasks/experimental-features/cluster-resource-set.md)
-        - [ClusterClass](./tasks/experimental-features/cluster-class/index.md)
+        - [ClusterClass](./tasks/experimental-features/cluster-classes.md)
             - [Writing a ClusterClass](./tasks/experimental-features/cluster-class/write-clusterclass.md)
             - [Changing a ClusterClass](./tasks/experimental-features/cluster-class/change-clusterclass.md)
             - [Operating a managed Cluster](./tasks/experimental-features/cluster-class/operate-cluster.md)

--- a/docs/book/src/tasks/experimental-features/cluster-classes.md
+++ b/docs/book/src/tasks/experimental-features/cluster-classes.md
@@ -10,16 +10,16 @@ ClusterClass is a powerful abstraction implemented on top of existing interfaces
 Additional documentation:
 * Background information:  [ClusterClass and Managed Topologies CAEP](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/202105256-cluster-class-and-managed-topologies.md)
 * For ClusterClass authors:
-    * [Writing a ClusterClass](./write-clusterclass.md)
-    * [Changing a ClusterClass](./change-clusterclass.md)
+    * [Writing a ClusterClass](cluster-class/write-clusterclass.md)
+    * [Changing a ClusterClass](cluster-class/change-clusterclass.md)
     * Publishing a ClusterClass for clusterctl usage: [clusterctl Provider contract]
 * For Cluster operators:
     * Creating a Cluster: [Quick Start guide]
         Please note that the experience for creating a Cluster using ClusterClass is very similar to the one for creating a standalone Cluster. Infrastructure providers supporting ClusterClass provide Cluster templates leveraging this feature (e.g the Docker infrastructure provider has a development-topology template).
-    * [Operating a managed Cluster](./operate-cluster.md)
+    * [Operating a managed Cluster](cluster-class/operate-cluster.md)
     * Planning topology rollouts: [clusterctl alpha topology plan]
 
 <!-- links -->
-[Quick Start guide]: ../../../user/quick-start.md
-[clusterctl Provider contract]: ../../../clusterctl/provider-contract.md
-[clusterctl alpha topology plan]: ../../../clusterctl/commands/alpha-topology-plan.md
+[Quick Start guide]: ../../user/quick-start.md
+[clusterctl Provider contract]: ../../clusterctl/provider-contract.md
+[clusterctl alpha topology plan]: ../../clusterctl/commands/alpha-topology-plan.md

--- a/docs/book/src/tasks/experimental-features/experimental-features.md
+++ b/docs/book/src/tasks/experimental-features/experimental-features.md
@@ -78,7 +78,7 @@ Similarly, to **validate** if a particular feature is enabled, see cluster-api-p
 
 * [MachinePools](./machine-pools.md)
 * [ClusterResourceSet](./cluster-resource-set.md)
-* [ClusterClass](./cluster-class/index.md)
+* [ClusterClass](./cluster-classes.md)
 * [Ignition Bootstrap configuration](./ignition.md)
 
 **Warning**: Experimental features are unreliable, i.e., some may one day be promoted to the main repository, or they may be modified arbitrarily or even disappear altogether.


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Move the ClusterClass index link to its old location in order to ensure the link at (https://v1-22.docs.kubernetes.io/blog/2021/10/08/capi-clusterclass-and-managed-topologies/) continues to work.

I think this change will have to be backported to 1.1 in order to make the link actually work as the default version of the book served is now from the 1.1 branch.

Discovered in #6234 
