### PR TITLE
🐛 [Tilt] Support using kind cluster from tilt settings automatically

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -8,6 +8,7 @@ version_settings(True, ">=0.22.2")
 settings = {
     "deploy_cert_manager": True,
     "enable_providers": ["docker"],
+    "kind_cluster_name": os.getenv("CAPI_KIND_CLUSTER_NAME", "capi-test"),
     "debug": {},
 }
 
@@ -17,6 +18,8 @@ settings.update(read_yaml(
     tilt_file,
     default = {},
 ))
+
+os.putenv("CAPI_KIND_CLUSTER_NAME", settings.get("kind_cluster_name"))
 
 allow_k8s_contexts(settings.get("allowed_contexts"))
 

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -63,6 +63,8 @@ If you prefer JSON, you can create a `tilt-settings.json` file instead. YAML wil
 **default_registry** (String, default=""): The image registry to use if you need to push images. See the [Tilt
 documentation](https://docs.tilt.dev/api.html#api.default_registry) for more details.
 
+**kind_cluster_name** (String, default="capi-test"): The name of the kind cluster to use when preloading images.
+
 **provider_repos** (Array[]String, default=[]): A list of paths to all the providers you want to use. Each provider must have a
 `tilt-provider.yaml` or `tilt-provider.json` file describing how to build the provider.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently in order to override the default kind cluster name used by tilt, you must override the CAPI_KIND_CLUSTER_NAME env variable, this PR re-introduces the `kind_cluster_name` setting to the tilt settings and makes it so that the kind cluster name can be configured either through the env variable or through the settings.
