### PR TITLE
✨ clusterctl: allow Namespace objects in topology plan input

### DIFF
--- a/cmd/clusterctl/client/cluster/assets/topology-test/new-clusterclass-and-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/new-clusterclass-and-cluster.yaml
@@ -1,3 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+spec: {}
+---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for `Namespace` objects in `clusterctl alpha topology plan` input. Previously it would have counted as another unique namespace, but now we just add the `metadata.name` of the `Namespace` into the set of unique namespaces.

**Which issue(s) this PR fixes**:
Fixes #6236
