### PR TITLE
🌱 clusterctl: always use -n as the shorthand for --[target-]namespace

### DIFF
--- a/cmd/clusterctl/cmd/generate_provider.go
+++ b/cmd/clusterctl/cmd/generate_provider.go
@@ -82,7 +82,7 @@ func init() {
 		"Bootstrap provider and version (e.g. kubeadm:v0.3.0)")
 	generateProviderCmd.Flags().StringVarP(&gpo.controlPlaneProvider, "control-plane", "c", "",
 		"ControlPlane provider and version (e.g. kubeadm:v0.3.0)")
-	generateProviderCmd.Flags().StringVar(&gpo.targetNamespace, "target-namespace", "",
+	generateProviderCmd.Flags().StringVarP(&gpo.targetNamespace, "target-namespace", "n", "",
 		"The target namespace where the provider should be deployed. If unspecified, the components default namespace is used.")
 	generateProviderCmd.Flags().BoolVar(&gpo.textOutput, "describe", false,
 		"Generate configuration without variable substitution.")

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -102,7 +102,7 @@ func init() {
 		"Bootstrap providers and versions (e.g. kubeadm:v0.3.0) to add to the management cluster. If unspecified, Kubeadm bootstrap provider's latest release is used.")
 	initCmd.Flags().StringSliceVarP(&initOpts.controlPlaneProviders, "control-plane", "c", nil,
 		"Control plane providers and versions (e.g. kubeadm:v0.3.0) to add to the management cluster. If unspecified, the Kubeadm control plane provider's latest release is used.")
-	initCmd.Flags().StringVar(&initOpts.targetNamespace, "target-namespace", "",
+	initCmd.Flags().StringVarP(&initOpts.targetNamespace, "target-namespace", "n", "",
 		"The target namespace where the providers should be deployed. If unspecified, the provider components' default namespace is used.")
 	initCmd.Flags().BoolVar(&initOpts.waitProviders, "wait-providers", false,
 		"Wait for providers to be installed.")

--- a/cmd/clusterctl/cmd/rollout/pause.go
+++ b/cmd/clusterctl/cmd/rollout/pause.go
@@ -62,7 +62,7 @@ func NewCmdRolloutPause(cfgFile string) *cobra.Command {
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
 	cmd.Flags().StringVar(&pauseOpt.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
-	cmd.Flags().StringVar(&pauseOpt.namespace, "namespace", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
+	cmd.Flags().StringVarP(&pauseOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
 
 	return cmd
 }

--- a/cmd/clusterctl/cmd/rollout/restart.go
+++ b/cmd/clusterctl/cmd/rollout/restart.go
@@ -60,7 +60,7 @@ func NewCmdRolloutRestart(cfgFile string) *cobra.Command {
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
 	cmd.Flags().StringVar(&restartOpt.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
-	cmd.Flags().StringVar(&restartOpt.namespace, "namespace", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
+	cmd.Flags().StringVarP(&restartOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
 
 	return cmd
 }

--- a/cmd/clusterctl/cmd/rollout/resume.go
+++ b/cmd/clusterctl/cmd/rollout/resume.go
@@ -60,7 +60,7 @@ func NewCmdRolloutResume(cfgFile string) *cobra.Command {
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
 	cmd.Flags().StringVar(&resumeOpt.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
-	cmd.Flags().StringVar(&resumeOpt.namespace, "namespace", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
+	cmd.Flags().StringVarP(&resumeOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
 
 	return cmd
 }

--- a/cmd/clusterctl/cmd/rollout/undo.go
+++ b/cmd/clusterctl/cmd/rollout/undo.go
@@ -62,7 +62,7 @@ func NewCmdRolloutUndo(cfgFile string) *cobra.Command {
 		"Path to the kubeconfig file to use for accessing the management cluster. If unspecified, default discovery rules apply.")
 	cmd.Flags().StringVar(&undoOpt.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
-	cmd.Flags().StringVar(&undoOpt.namespace, "namespace", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
+	cmd.Flags().StringVarP(&undoOpt.namespace, "namespace", "n", "", "Namespace where the resource(s) reside. If unspecified, the defult namespace will be used.")
 	cmd.Flags().Int64Var(&undoOpt.toRevision, "to-revision", undoOpt.toRevision, "The revision to rollback to. Default to 0 (last revision).")
 
 	return cmd


### PR DESCRIPTION
**What this PR does / why we need it**:

Consistently use `-n` as the shorthand for `--[target-]namespace`. The shorthand is a default in the kubernetes ecosystem, and many of the clusterctl cmds were already using it.

