### PR TITLE
🌱 log-push: preserve original timestamp, parse controller too

### DIFF
--- a/docs/book/src/developer/testing.md
+++ b/docs/book/src/developer/testing.md
@@ -289,7 +289,7 @@ analyzing them via Grafana.
 
 * Make sure you query the correct time range via Grafana or `logcli`.
 * The logs are currently uploaded by using now as the timestamp, because otherwise it would
-  take a few minutes until the logs show up in Loki.
+  take a few minutes until the logs show up in Loki. The original timestamp is preserved as `original_ts`.
 
 </aside>
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR extends log-push to:
* also parse the controller k/v pair (so we get a button for it in Loki)
* preserve the timestamp as original_ts so we are still able to correlate the logs to certain other events in e2e tests, etc.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
