### PR TITLE
🐛 topology: set apiVersion to avoid diff in patchHelper

### DIFF
--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -127,6 +127,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
 	}
+	cluster.APIVersion = clusterv1.GroupVersion.String()
 	cluster.Kind = "Cluster"
 
 	// Return early, if the Cluster does not use a managed topology.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
We currently only set the kind and not the apiVersion. We're then updating the cluster resource during reconcile to add kind and apiVersion at some point.

Then we end up with a diff in the apiVersion between before/after in the patchHelper. This is not really a problem yet as we don't try to patch apiVersion of a resource (which is impossible anyway). But if we start logging if there are changes in the patch helper we would always get a diff.

I think it's only consequential to set both apiVersion and kind and not only kind, but we can also talk about an additional more holistic change in the patchHelper, e.g. to ignore kind and apiVersion entirely.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
