### PR TITLE
:bug: fix: no nodeRefs when empty providerIDList is ok

### DIFF
--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -221,7 +221,7 @@ func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, c client.
 		}
 	}
 
-	if len(nodeRefs) == 0 {
+	if len(nodeRefs) == 0 && len(providerIDList) != 0 {
 		return getNodeReferencesResult{}, errNoAvailableNodes
 	}
 	return getNodeReferencesResult{nodeRefs, available, ready}, nil

--- a/exp/internal/controllers/machinepool_controller_noderef_test.go
+++ b/exp/internal/controllers/machinepool_controller_noderef_test.go
@@ -128,6 +128,15 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 			expected:       nil,
 			err:            errNoAvailableNodes,
 		},
+		{
+			name:           "no provider id, no node found",
+			providerIDList: []string{},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{},
+				available:  0,
+				ready:      0,
+			},
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes MachinePool reconciliation when an empty providerIDList is
given. Previously it would always return an error in this case,
preventing the MachinePool readyReplicas etc. to go to 0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
kubernetes-sigs/cluster-api-provider-aws#3253 requires this fix because otherwise the e2e test does not complete. 
