### PR TITLE
:sparkles:  auto-approve kubelet serving CSRs

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -898,6 +898,19 @@ func (r *KubeadmConfigReconciler) reconcileTopLevelObjectSettings(ctx context.Co
 		}
 	}
 
+	// TODO: We should add a Spec.Security.KubeletAuthentication field to Cluster and conditionally set this
+	// Make sure that kubelet requests a kubernetes.io/kubelet-serving CSR on startup
+	if config.Spec.InitConfiguration.NodeRegistration.KubeletExtraArgs["rotate-server-certificates"] == "" {
+		config.Spec.InitConfiguration.NodeRegistration.KubeletExtraArgs["rotate-server-certificates"] = "true"
+	}
+
+	// TODO: We should add a Spec.Security.KubeletAuthentication field to Cluster and conditionally set this
+	// Make sure that we verify kubelet serving certificates instead of blindly trusting them.
+	if config.Spec.ClusterConfiguration.APIServer.ExtraArgs["kubelet-certificate-authority"] == "" {
+		config.Spec.InitConfiguration.NodeRegistration.KubeletExtraArgs["rotate-server-certificates"] = "true"
+		config.Spec.ClusterConfiguration.APIServer.ExtraArgs["kubelet-certificate-authority"] = "/etc/kubernetes/pki/ca.rt"
+	}
+
 	// If there are no KubernetesVersion settings defined in ClusterConfiguration, use Version from machine, if defined
 	if config.Spec.ClusterConfiguration.KubernetesVersion == "" && machine.Spec.Version != nil {
 		config.Spec.ClusterConfiguration.KubernetesVersion = *machine.Spec.Version

--- a/internal/controllers/machine/machine_controller_kubelet_serving_csr.go
+++ b/internal/controllers/machine/machine_controller_kubelet_serving_csr.go
@@ -21,9 +21,6 @@ import (
 )
 
 const (
-	// KubeletServingSignerName defines the name for the kubelet serving certificate signer
-	KubeletServingSignerName = "kubernetes.io/kubelet-serving"
-
 	// NodesPrefix defines the prefix name for a node.
 	NodesPrefix = "system:node:"
 
@@ -59,7 +56,7 @@ func (r *Reconciler) reconcileKubletServingCertificateSigningRequest(ctx context
 	if err := remoteClient.List(ctx, &csrList, &client.ListOptions{
 		FieldSelector: fields.AndSelectors(
 			fields.OneTermEqualSelector("spec.username", NodesPrefix+node.Name),
-			fields.OneTermEqualSelector("spec.signer", KubeletServingSignerName),
+			fields.OneTermEqualSelector("spec.signer", certificatesv1.KubeletServingSignerName),
 		),
 	}); err != nil {
 		return ctrl.Result{}, err

--- a/internal/controllers/machine/machine_controller_kubelet_serving_csr.go
+++ b/internal/controllers/machine/machine_controller_kubelet_serving_csr.go
@@ -1,0 +1,161 @@
+package machine
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"time"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/remote"
+	"sigs.k8s.io/cluster-api/util"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// KubeletServingSignerName defines the name for the kubelet serving certificate signer
+	KubeletServingSignerName = "kubernetes.io/kubelet-serving"
+
+	// NodesPrefix defines the prefix name for a node.
+	NodesPrefix = "system:node:"
+
+	// NodesGroup defines the group name for a node.
+	NodesGroup = "system:nodes"
+)
+
+func (r *Reconciler) reconcileKubletServingCertificateSigningRequest(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx, "machine", machine.Name, "namespace", machine.Namespace)
+	log = log.WithValues("cluster", cluster.Name)
+
+	// TODO can NodeRef be nil at this point?
+	nodeRef := machine.Status.NodeRef
+
+	remoteClient, err := r.Tracker.GetClient(ctx, util.ObjectKey(cluster))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	restConfig, err := remote.RESTConfig(ctx, controllerName, r.Client, util.ObjectKey(cluster))
+	if err != nil {
+		return ctrl.Result{}, nil
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+
+	node := corev1.Node{}
+	if err := remoteClient.Get(ctx, client.ObjectKey{Name: nodeRef.Name}, &node); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Find the corresponding CSRs for this node
+	// TODO: Add filter options
+	csrList := certificatesv1.CertificateSigningRequestList{}
+	if err := remoteClient.List(ctx, &csrList, &client.ListOptions{
+		FieldSelector: fields.AndSelectors(
+			fields.OneTermEqualSelector("spec.username", NodesPrefix+node.Name),
+			fields.OneTermEqualSelector("spec.signer", KubeletServingSignerName),
+		),
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	for _, csr := range csrList.Items {
+
+		block, _ := pem.Decode(csr.Spec.Request)
+		if block.Type != "CERTIFICATE REQUEST" {
+			return ctrl.Result{}, fmt.Errorf("Unexpected PEM type")
+		}
+		cr, err := x509.ParseCertificateRequest(block.Bytes)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// TODO: Does this case happen where we have a CSR whose contents dont match the object?
+		if cr.Subject.CommonName != csr.Spec.Username {
+			return ctrl.Result{}, fmt.Errorf("csr Username didnt match CN")
+		}
+		for i, org := range cr.Subject.OrganizationalUnit {
+			if org != csr.Spec.Groups[i] {
+				return ctrl.Result{}, fmt.Errorf("csr Groups didn't match O")
+			}
+		}
+
+		condition := certificatesv1.CertificateSigningRequestCondition{
+			LastUpdateTime: metav1.Time{Time: time.Now()},
+		}
+		if err := validateCSR(cr, machine.Status.Addresses); err != nil {
+			// TODO: we do not want to fail early, just skip this CSR
+			condition.Type = certificatesv1.CertificateDenied
+			condition.Reason = "CSRValidationFailed"
+			condition.Status = "True"
+			condition.Message = fmt.Sprintf("Validation failed: %s", err)
+		} else {
+			condition.Type = certificatesv1.CertificateApproved
+			condition.Reason = "CSRValidationSucceed"
+			condition.Status = "True"
+			condition.Message = "Validation was successful"
+
+		}
+		csr.Status.Conditions = append(csr.Status.Conditions, condition)
+
+		if _, err := kubeClient.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, csr.Name, &csr, metav1.UpdateOptions{}); err != nil {
+			return ctrl.Result{}, err
+		}
+
+	}
+	return ctrl.Result{}, nil
+}
+
+// validateCSR checks that all IPAddresses and DNSNames in csr are what we expect from the Machine definition and that the CSR is part of NodesGroup
+// TODO:
+func validateCSR(csr *x509.CertificateRequest, addresses []clusterv1.MachineAddress) error {
+	containsGroup := false
+
+	for _, group := range csr.Subject.OrganizationalUnit {
+		if group == NodesGroup {
+			containsGroup = true
+			break
+		}
+	}
+	if !containsGroup {
+		return fmt.Errorf("need to have %s as group", NodesGroup)
+	}
+	// At least one DNS or IP subjectAltName must be present.
+	if len(csr.IPAddresses)+len(csr.DNSNames) == 0 {
+		return fmt.Errorf("need at least one of DNSNames or IPAddresses")
+	}
+	for _, ipAddress := range csr.IPAddresses {
+		found := false
+		for _, address := range addresses {
+			switch address.Type {
+			case clusterv1.MachineExternalIP:
+			case clusterv1.MachineInternalIP:
+				found = found || ipAddress.Equal(net.IP(address.Address))
+			}
+		}
+		if !found {
+			return fmt.Errorf("ip address %s was not allowed", ipAddress)
+		}
+	}
+	for _, dnsName := range csr.DNSNames {
+		found := false
+		for _, address := range addresses {
+			switch address.Type {
+			case clusterv1.MachineExternalDNS:
+			case clusterv1.MachineInternalDNS:
+			case clusterv1.MachineHostName:
+				found = found || dnsName == address.Address
+			}
+		}
+		if !found {
+			return fmt.Errorf("dns name %s was not allowed", dnsName)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This watches CSRs in the target cluster, checks if their DNSNames
and IPAddresses match up with the cluster's Machine, and then approves
the serving certificate

This implements (parts of) https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210222-kubelet-authentication.md#serving-csr-handling

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Implements (parts of) https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20210222-kubelet-authentication.md#serving-csr-handling

**Still TODO**

* ship a template where `rotate-server-certificates` is set on `kubelet` and `kubelet-certificate-authority` is set on `apiserver` so that the CSRs are created and the apiserver can talk to the kubelets after they get their certificate signed
* tests
*  Some TODOs still in the code