### PR TITLE
🌱 ClusterCacheTracker: drop unused Log field

### DIFF
--- a/controllers/remote/cluster_cache_reconciler.go
+++ b/controllers/remote/cluster_cache_reconciler.go
@@ -34,6 +34,7 @@ import (
 // ClusterCacheReconciler is responsible for stopping remote cluster caches when
 // the cluster for the remote cache is being deleted.
 type ClusterCacheReconciler struct {
+	// Deprecated: this field is unused and will be dropped in an upcoming release.
 	Log     logr.Logger
 	Client  client.Client
 	Tracker *ClusterCacheTracker
@@ -44,6 +45,7 @@ type ClusterCacheReconciler struct {
 
 func (r *ClusterCacheReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	err := ctrl.NewControllerManagedBy(mgr).
+		Named("remote/clustercache").
 		For(&clusterv1.Cluster{}).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).

--- a/controllers/remote/cluster_cache_reconciler_test.go
+++ b/controllers/remote/cluster_cache_reconciler_test.go
@@ -21,14 +21,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -93,7 +91,6 @@ func TestClusterCacheReconciler(t *testing.T) {
 
 			t.Log("Creating the ClusterCacheReconciler")
 			r := &ClusterCacheReconciler{
-				Log:     logr.New(log.NullLogSink{}),
 				Client:  mgr.GetClient(),
 				Tracker: cct,
 			}

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -238,7 +238,6 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 	if err := (&remote.ClusterCacheReconciler{
 		Client:           mgr.GetClient(),
-		Log:              ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
 		Tracker:          tracker,
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, concurrency(kubeadmControlPlaneConcurrency)); err != nil {

--- a/internal/controllers/cluster/suite_test.go
+++ b/internal/controllers/cluster/suite_test.go
@@ -77,7 +77,6 @@ func TestMain(m *testing.M) {
 		}
 		if err := (&remote.ClusterCacheReconciler{
 			Client:  mgr.GetClient(),
-			Log:     ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
 			Tracker: tracker,
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("Failed to start ClusterCacheReconciler: %v", err))

--- a/internal/controllers/machine/suite_test.go
+++ b/internal/controllers/machine/suite_test.go
@@ -80,7 +80,6 @@ func TestMain(m *testing.M) {
 		}
 		if err := (&remote.ClusterCacheReconciler{
 			Client:  mgr.GetClient(),
-			Log:     ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
 			Tracker: tracker,
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("Failed to start ClusterCacheReconciler: %v", err))

--- a/internal/controllers/machinedeployment/suite_test.go
+++ b/internal/controllers/machinedeployment/suite_test.go
@@ -84,7 +84,6 @@ func TestMain(m *testing.M) {
 		}
 		if err := (&remote.ClusterCacheReconciler{
 			Client:  mgr.GetClient(),
-			Log:     ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
 			Tracker: tracker,
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("Failed to start ClusterCacheReconciler: %v", err))

--- a/internal/controllers/machinehealthcheck/suite_test.go
+++ b/internal/controllers/machinehealthcheck/suite_test.go
@@ -80,7 +80,6 @@ func TestMain(m *testing.M) {
 		}
 		if err := (&remote.ClusterCacheReconciler{
 			Client:  mgr.GetClient(),
-			Log:     ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
 			Tracker: tracker,
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("Failed to start ClusterCacheReconciler: %v", err))

--- a/internal/controllers/machineset/suite_test.go
+++ b/internal/controllers/machineset/suite_test.go
@@ -84,7 +84,6 @@ func TestMain(m *testing.M) {
 		}
 		if err := (&remote.ClusterCacheReconciler{
 			Client:  mgr.GetClient(),
-			Log:     ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
 			Tracker: tracker,
 		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 			panic(fmt.Sprintf("Failed to start ClusterCacheReconciler: %v", err))

--- a/main.go
+++ b/main.go
@@ -283,7 +283,6 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	}
 	if err := (&remote.ClusterCacheReconciler{
 		Client:           mgr.GetClient(),
-		Log:              ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
 		Tracker:          tracker,
 		WatchFilterValue: watchFilterValue,
 	}).SetupWithManager(ctx, mgr, concurrency(clusterConcurrency)); err != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
As we are always using the logger from context we don't have to set the Log field anymore, so let's drop it.

Note: before this PR the fields was written a few times, but never read.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
