### PR TITLE
:seedling: update talos/sidero references

### DIFF
--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -168,7 +168,7 @@ func (p *providersClient) defaults() []Provider {
 		},
 		&provider{
 			name:         SideroProviderName,
-			url:          "https://github.com/talos-systems/sidero/releases/latest/infrastructure-components.yaml",
+			url:          "https://github.com/siderolabs/sidero/releases/latest/infrastructure-components.yaml",
 			providerType: clusterctlv1.InfrastructureProviderType,
 		},
 		&provider{
@@ -205,7 +205,7 @@ func (p *providersClient) defaults() []Provider {
 		},
 		&provider{
 			name:         TalosBootstrapProviderName,
-			url:          "https://github.com/talos-systems/cluster-api-bootstrap-provider-talos/releases/latest/bootstrap-components.yaml",
+			url:          "https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/bootstrap-components.yaml",
 			providerType: clusterctlv1.BootstrapProviderType,
 		},
 		&provider{
@@ -221,7 +221,7 @@ func (p *providersClient) defaults() []Provider {
 		},
 		&provider{
 			name:         TalosControlPlaneProviderName,
-			url:          "https://github.com/talos-systems/cluster-api-control-plane-provider-talos/releases/latest/control-plane-components.yaml",
+			url:          "https://github.com/siderolabs/cluster-api-control-plane-provider-talos/releases/latest/control-plane-components.yaml",
 			providerType: clusterctlv1.ControlPlaneProviderType,
 		},
 		&provider{

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -99,33 +99,33 @@ providers:
     type: "CoreProvider"
 `
 
-var expectedOutputText = `NAME                TYPE                     URL                                                                                          FILE
-cluster-api         CoreProvider             https://github.com/myorg/myforkofclusterapi/releases/latest/                                 core_components.yaml
-another-provider    BootstrapProvider        ./                                                                                           bootstrap-components.yaml
-aws-eks             BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/                 eks-bootstrap-components.yaml
-kubeadm             BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api/releases/latest/                              bootstrap-components.yaml
-talos               BootstrapProvider        https://github.com/talos-systems/cluster-api-bootstrap-provider-talos/releases/latest/       bootstrap-components.yaml
-aws-eks             ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/                 eks-controlplane-components.yaml
-kubeadm             ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api/releases/latest/                              control-plane-components.yaml
-nested              ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api-provider-nested/releases/latest/              control-plane-components.yaml
-talos               ControlPlaneProvider     https://github.com/talos-systems/cluster-api-control-plane-provider-talos/releases/latest/   control-plane-components.yaml
-aws                 InfrastructureProvider                                                                                                my-aws-infrastructure-components.yaml
-azure               InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/latest/               infrastructure-components.yaml
-byoh                InfrastructureProvider   https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/releases/latest/       infrastructure-components.yaml
-digitalocean        InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/releases/latest/        infrastructure-components.yaml
-docker              InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api/releases/latest/                              infrastructure-components-development.yaml
-gcp                 InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/latest/                 infrastructure-components.yaml
-hetzner             InfrastructureProvider   https://github.com/syself/cluster-api-provider-hetzner/releases/latest/                      infrastructure-components.yaml
-ibmcloud            InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/latest/            infrastructure-components.yaml
-maas                InfrastructureProvider   https://github.com/spectrocloud/cluster-api-provider-maas/releases/latest/                   infrastructure-components.yaml
-metal3              InfrastructureProvider   https://github.com/metal3-io/cluster-api-provider-metal3/releases/latest/                    infrastructure-components.yaml
-my-infra-provider   InfrastructureProvider   /home/.cluster-api/overrides/infrastructure-docker/latest/                                   infrastructure-components.yaml
-nested              InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-nested/releases/latest/              infrastructure-components.yaml
-oci                 InfrastructureProvider   https://github.com/oracle/cluster-api-provider-oci/releases/latest/                          infrastructure-components.yaml
-openstack           InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/latest/           infrastructure-components.yaml
-packet              InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-packet/releases/latest/              infrastructure-components.yaml
-sidero              InfrastructureProvider   https://github.com/talos-systems/sidero/releases/latest/                                     infrastructure-components.yaml
-vsphere             InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/latest/             infrastructure-components.yaml
+var expectedOutputText = `NAME                TYPE                     URL                                                                                       FILE
+cluster-api         CoreProvider             https://github.com/myorg/myforkofclusterapi/releases/latest/                              core_components.yaml
+another-provider    BootstrapProvider        ./                                                                                        bootstrap-components.yaml
+aws-eks             BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/              eks-bootstrap-components.yaml
+kubeadm             BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api/releases/latest/                           bootstrap-components.yaml
+talos               BootstrapProvider        https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/       bootstrap-components.yaml
+aws-eks             ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/              eks-controlplane-components.yaml
+kubeadm             ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api/releases/latest/                           control-plane-components.yaml
+nested              ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api-provider-nested/releases/latest/           control-plane-components.yaml
+talos               ControlPlaneProvider     https://github.com/siderolabs/cluster-api-control-plane-provider-talos/releases/latest/   control-plane-components.yaml
+aws                 InfrastructureProvider                                                                                             my-aws-infrastructure-components.yaml
+azure               InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/latest/            infrastructure-components.yaml
+byoh                InfrastructureProvider   https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/releases/latest/    infrastructure-components.yaml
+digitalocean        InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/releases/latest/     infrastructure-components.yaml
+docker              InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api/releases/latest/                           infrastructure-components-development.yaml
+gcp                 InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/latest/              infrastructure-components.yaml
+hetzner             InfrastructureProvider   https://github.com/syself/cluster-api-provider-hetzner/releases/latest/                   infrastructure-components.yaml
+ibmcloud            InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/releases/latest/         infrastructure-components.yaml
+maas                InfrastructureProvider   https://github.com/spectrocloud/cluster-api-provider-maas/releases/latest/                infrastructure-components.yaml
+metal3              InfrastructureProvider   https://github.com/metal3-io/cluster-api-provider-metal3/releases/latest/                 infrastructure-components.yaml
+my-infra-provider   InfrastructureProvider   /home/.cluster-api/overrides/infrastructure-docker/latest/                                infrastructure-components.yaml
+nested              InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-nested/releases/latest/           infrastructure-components.yaml
+oci                 InfrastructureProvider   https://github.com/oracle/cluster-api-provider-oci/releases/latest/                       infrastructure-components.yaml
+openstack           InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/latest/        infrastructure-components.yaml
+packet              InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-packet/releases/latest/           infrastructure-components.yaml
+sidero              InfrastructureProvider   https://github.com/siderolabs/sidero/releases/latest/                                     infrastructure-components.yaml
+vsphere             InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/releases/latest/          infrastructure-components.yaml
 `
 
 var expectedOutputYaml = `- File: core_components.yaml
@@ -147,7 +147,7 @@ var expectedOutputYaml = `- File: core_components.yaml
 - File: bootstrap-components.yaml
   Name: talos
   ProviderType: BootstrapProvider
-  URL: https://github.com/talos-systems/cluster-api-bootstrap-provider-talos/releases/latest/
+  URL: https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/
 - File: eks-controlplane-components.yaml
   Name: aws-eks
   ProviderType: ControlPlaneProvider
@@ -163,7 +163,7 @@ var expectedOutputYaml = `- File: core_components.yaml
 - File: control-plane-components.yaml
   Name: talos
   ProviderType: ControlPlaneProvider
-  URL: https://github.com/talos-systems/cluster-api-control-plane-provider-talos/releases/latest/
+  URL: https://github.com/siderolabs/cluster-api-control-plane-provider-talos/releases/latest/
 - File: my-aws-infrastructure-components.yaml
   Name: aws
   ProviderType: InfrastructureProvider
@@ -227,7 +227,7 @@ var expectedOutputYaml = `- File: core_components.yaml
 - File: infrastructure-components.yaml
   Name: sidero
   ProviderType: InfrastructureProvider
-  URL: https://github.com/talos-systems/sidero/releases/latest/
+  URL: https://github.com/siderolabs/sidero/releases/latest/
 - File: infrastructure-components.yaml
   Name: vsphere
   ProviderType: InfrastructureProvider

--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -7,7 +7,7 @@ updated info about which API version they are supporting.
 
 ## Bootstrap
 - [Kubeadm](https://github.com/kubernetes-sigs/cluster-api/tree/main/bootstrap/kubeadm)
-- [Talos](https://github.com/talos-systems/cluster-api-bootstrap-provider-talos)
+- [Talos](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos)
 - [EKS](https://github.com/kubernetes-sigs/cluster-api-provider-aws/tree/main/bootstrap/eks)
 
 ## Infrastructure
@@ -29,7 +29,7 @@ updated info about which API version they are supporting.
 - [OCI](https://github.com/oracle/cluster-api-provider-oci)
 - [OpenStack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack)
 - [Equinix Metal (formerly Packet)](https://github.com/kubernetes-sigs/cluster-api-provider-packet)
-- [Sidero](https://github.com/talos-systems/sidero)
+- [Sidero](https://github.com/siderolabs/sidero)
 - [Tencent Cloud](https://github.com/TencentCloud/cluster-api-provider-tencent)
 - [vSphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Talos Systems is now Sidero Labs and we just renamed our github org.
This PR updates all of the references to make sure they align with the
new org name. Saw an issue where clusterctl couldn't follow the
redirects to the yaml assets, which appears to also occur when manually
curling (assuming a github bug).

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>
