### PR TITLE
:bug:  Add nil pointer check in UnstructuredUnmarshalField

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -389,6 +389,10 @@ func refersTo(ref *metav1.OwnerReference, obj client.Object) bool {
 // UnstructuredUnmarshalField is a wrapper around json and unstructured objects to decode and copy a specific field
 // value into an object.
 func UnstructuredUnmarshalField(obj *unstructured.Unstructured, v interface{}, fields ...string) error {
+	if obj == nil || obj.Object == nil {
+		return errors.Errorf("failed to unmarshal unstructured object: object is nil")
+	}
+
 	value, found, err := unstructured.NestedFieldNoCopy(obj.Object, fields...)
 	if err != nil {
 		return errors.Wrapf(err, "failed to retrieve field %q from %q", strings.Join(fields, "."), obj.GroupVersionKind())

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -881,3 +881,28 @@ func TestRemoveOwnerRef(t *testing.T) {
 		})
 	}
 }
+
+func TestUnstructuredUnmarshalField(t *testing.T) {
+	tests := []struct {
+		name    string
+		obj     *unstructured.Unstructured
+		v       interface{}
+		fields  []string
+		wantErr bool
+	}{
+		{
+			"return error if object is nil",
+			nil,
+			nil,
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := UnstructuredUnmarshalField(tt.obj, tt.v, tt.fields...); (err != nil) != tt.wantErr {
+				t.Errorf("UnstructuredUnmarshalField() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix a nil pointer in the UnstructuredUnmarshalField function which gets thrown if the Object supplied is equal to nil.

Signed-off-by: killianmuldoon <kmuldoon@vmware.com>


Fixes #6333 
