### PR TITLE
:sparkles:Bump to golangci-lint v1.45.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,5 +17,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44.0
+          version: v1.45.2
           working-directory: ${{matrix.working-directory}}

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -46,10 +46,7 @@ func TestClusterDefaultNamespaces(t *testing.T) {
 		},
 	}
 	webhook := &Cluster{}
-	// TODO(sbueringer) We are storing the func in testFunc temporarily to work around
-	// an issue in thelper: https://github.com/kulti/thelper/issues/31
-	testFunc := customDefaultValidateTest(ctx, c, webhook)
-	t.Run("for Cluster", testFunc)
+	t.Run("for Cluster", customDefaultValidateTest(ctx, c, webhook))
 	g.Expect(webhook.Default(ctx, c)).To(Succeed())
 
 	g.Expect(c.Spec.InfrastructureRef.Namespace).To(Equal(c.Namespace))
@@ -351,10 +348,7 @@ func TestClusterDefaultTopologyVersion(t *testing.T) {
 
 	// Create the webhook and add the fakeClient as its client.
 	webhook := &Cluster{Client: fakeClient}
-	// TODO(sbueringer) We are storing the func in testFunc temporarily to work around
-	// an issue in thelper: https://github.com/kulti/thelper/issues/31
-	testFunc := customDefaultValidateTest(ctx, c, webhook)
-	t.Run("for Cluster", testFunc)
+	t.Run("for Cluster", customDefaultValidateTest(ctx, c, webhook))
 	g.Expect(webhook.Default(ctx, c)).To(Succeed())
 
 	g.Expect(c.Spec.Topology.Version).To(HavePrefix("v"))

--- a/internal/webhooks/clusterclass_test.go
+++ b/internal/webhooks/clusterclass_test.go
@@ -76,10 +76,7 @@ func TestClusterClassDefaultNamespaces(t *testing.T) {
 
 	// Create the webhook and add the fakeClient as its client.
 	webhook := &ClusterClass{Client: fakeClient}
-	// TODO(sbueringer) We are storing the func in testFunc temporarily to work around
-	// an issue in thelper: https://github.com/kulti/thelper/issues/31
-	testFunc := customDefaultValidateTest(ctx, in, webhook)
-	t.Run("for ClusterClass", testFunc)
+	t.Run("for ClusterClass", customDefaultValidateTest(ctx, in, webhook))
 
 	g := NewWithT(t)
 	g.Expect(webhook.Default(ctx, in)).To(Succeed())

--- a/util/container/image.go
+++ b/util/container/image.go
@@ -18,10 +18,8 @@ limitations under the License.
 package container
 
 import (
-
 	//  Import the crypto sha256 algorithm for the docker image parser to work
 	_ "crypto/sha256"
-
 	//  Import the crypto/sha512 algorithm for the docker image parser to work with 384 and 512 sha hashes
 	_ "crypto/sha512"
 	"fmt"


### PR DESCRIPTION
Signed-off-by: Prajyot-Parab <prajyot.parab2@ibm.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- Bump to golangci-lint v1.44.2
- Fix lint findings
- Revert panic workaround

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6163 
