### PR TITLE
🌱 chore: removing old aws-eks providers from clusterctl

### DIFF
--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -57,14 +57,12 @@ const (
 const (
 	KubeadmBootstrapProviderName = "kubeadm"
 	TalosBootstrapProviderName   = "talos"
-	AWSEKSBootstrapProviderName  = "aws-eks"
 )
 
 // ControlPlane providers.
 const (
 	KubeadmControlPlaneProviderName = "kubeadm"
 	TalosControlPlaneProviderName   = "talos"
-	AWSEKSControlPlaneProviderName  = "aws-eks"
 	NestedControlPlaneProviderName  = "nested"
 )
 
@@ -208,11 +206,6 @@ func (p *providersClient) defaults() []Provider {
 			url:          "https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/bootstrap-components.yaml",
 			providerType: clusterctlv1.BootstrapProviderType,
 		},
-		&provider{
-			name:         AWSEKSBootstrapProviderName,
-			url:          "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/eks-bootstrap-components.yaml",
-			providerType: clusterctlv1.BootstrapProviderType,
-		},
 		// ControlPlane providers
 		&provider{
 			name:         KubeadmControlPlaneProviderName,
@@ -222,11 +215,6 @@ func (p *providersClient) defaults() []Provider {
 		&provider{
 			name:         TalosControlPlaneProviderName,
 			url:          "https://github.com/siderolabs/cluster-api-control-plane-provider-talos/releases/latest/control-plane-components.yaml",
-			providerType: clusterctlv1.ControlPlaneProviderType,
-		},
-		&provider{
-			name:         AWSEKSControlPlaneProviderName,
-			url:          "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/eks-controlplane-components.yaml",
 			providerType: clusterctlv1.ControlPlaneProviderType,
 		},
 		&provider{

--- a/cmd/clusterctl/client/config_test.go
+++ b/cmd/clusterctl/client/config_test.go
@@ -56,10 +56,8 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 			// note: these will be sorted by name by the Providers() call, so be sure they are in alphabetical order here too
 			wantProviders: []string{
 				config.ClusterAPIProviderName,
-				config.AWSEKSBootstrapProviderName,
 				config.KubeadmBootstrapProviderName,
 				config.TalosBootstrapProviderName,
-				config.AWSEKSControlPlaneProviderName,
 				config.KubeadmControlPlaneProviderName,
 				config.NestedControlPlaneProviderName,
 				config.TalosControlPlaneProviderName,
@@ -90,11 +88,9 @@ func Test_clusterctlClient_GetProvidersConfig(t *testing.T) {
 			// note: these will be sorted by name by the Providers() call, so be sure they are in alphabetical order here too
 			wantProviders: []string{
 				config.ClusterAPIProviderName,
-				config.AWSEKSBootstrapProviderName,
 				customProviderConfig.Name(),
 				config.KubeadmBootstrapProviderName,
 				config.TalosBootstrapProviderName,
-				config.AWSEKSControlPlaneProviderName,
 				config.KubeadmControlPlaneProviderName,
 				config.NestedControlPlaneProviderName,
 				config.TalosControlPlaneProviderName,

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -102,10 +102,8 @@ providers:
 var expectedOutputText = `NAME                TYPE                     URL                                                                                       FILE
 cluster-api         CoreProvider             https://github.com/myorg/myforkofclusterapi/releases/latest/                              core_components.yaml
 another-provider    BootstrapProvider        ./                                                                                        bootstrap-components.yaml
-aws-eks             BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/              eks-bootstrap-components.yaml
 kubeadm             BootstrapProvider        https://github.com/kubernetes-sigs/cluster-api/releases/latest/                           bootstrap-components.yaml
 talos               BootstrapProvider        https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/       bootstrap-components.yaml
-aws-eks             ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/              eks-controlplane-components.yaml
 kubeadm             ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api/releases/latest/                           control-plane-components.yaml
 nested              ControlPlaneProvider     https://github.com/kubernetes-sigs/cluster-api-provider-nested/releases/latest/           control-plane-components.yaml
 talos               ControlPlaneProvider     https://github.com/siderolabs/cluster-api-control-plane-provider-talos/releases/latest/   control-plane-components.yaml
@@ -136,10 +134,6 @@ var expectedOutputYaml = `- File: core_components.yaml
   Name: another-provider
   ProviderType: BootstrapProvider
   URL: ./
-- File: eks-bootstrap-components.yaml
-  Name: aws-eks
-  ProviderType: BootstrapProvider
-  URL: https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/
 - File: bootstrap-components.yaml
   Name: kubeadm
   ProviderType: BootstrapProvider
@@ -148,10 +142,6 @@ var expectedOutputYaml = `- File: core_components.yaml
   Name: talos
   ProviderType: BootstrapProvider
   URL: https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/
-- File: eks-controlplane-components.yaml
-  Name: aws-eks
-  ProviderType: ControlPlaneProvider
-  URL: https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/latest/
 - File: control-plane-components.yaml
   Name: kubeadm
   ProviderType: ControlPlaneProvider


### PR DESCRIPTION
**What this PR does / why we need it**:

When CAPA graduated EKS support we combined the the separate EKS
providers into the main AWS infra provider. So this change removed the
separate `aws-eks` controlplane and bootstrap providers from
**clusterctl**.

This is a replacement for #5073 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2656
