### PR TITLE
:bug: skip templating step if `describe` flag is used

### DIFF
--- a/cmd/clusterctl/cmd/generate_provider.go
+++ b/cmd/clusterctl/cmd/generate_provider.go
@@ -104,7 +104,7 @@ func runGenerateProviderComponents() error {
 
 	options := client.ComponentsOptions{
 		TargetNamespace:     gpo.targetNamespace,
-		SkipTemplateProcess: gpo.raw,
+		SkipTemplateProcess: gpo.raw || gpo.textOutput,
 	}
 
 	components, err := c.GetProviderComponents(providerName, providerType, options)


### PR DESCRIPTION
**What this PR does / why we need it**:

The describe flag is used to show the provider's available environment variables, clusterctl should not interpolate the config when used.

**Which issue(s) this PR fixes**:

Fixes #6316
