### PR TITLE
:sparkles: Move machinepool and CRS feature gate checks to webhooks

### DIFF
--- a/exp/api/v1alpha3/webhook_test.go
+++ b/exp/api/v1alpha3/webhook_test.go
@@ -20,17 +20,23 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestMachinePoolConversion(t *testing.T) {
+	// NOTE: MachinePool feature flag is disabled by default, thus preventing to create or update MachinePool.
+	// Enabling the feature flag temporarily for this test.
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.MachinePool, true)()
 	g := NewWithT(t)
 	ns, err := env.CreateNamespace(ctx, fmt.Sprintf("conversion-webhook-%s", util.RandomString(5)))
 	g.Expect(err).ToNot(HaveOccurred())

--- a/exp/api/v1beta1/machinepool_webhook.go
+++ b/exp/api/v1beta1/machinepool_webhook.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/util/version"
 )
 
@@ -93,6 +94,14 @@ func (m *MachinePool) ValidateDelete() error {
 }
 
 func (m *MachinePool) validate(old *MachinePool) error {
+	// NOTE: MachinePool is behind MachinePool feature gate flag; the web hook
+	// must prevent creating new objects new case the feature flag is disabled.
+	if !feature.Gates.Enabled(feature.MachinePool) {
+		return field.Forbidden(
+			field.NewPath("spec"),
+			"can be set only if the MachinePool feature flag is enabled",
+		)
+	}
 	var allErrs field.ErrorList
 	if m.Spec.Template.Spec.Bootstrap.ConfigRef == nil && m.Spec.Template.Spec.Bootstrap.DataSecretName == nil {
 		allErrs = append(

--- a/exp/api/v1beta1/machinepool_webhook_test.go
+++ b/exp/api/v1beta1/machinepool_webhook_test.go
@@ -19,16 +19,23 @@ package v1beta1
 import (
 	"testing"
 
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/component-base/featuregate/testing"
 	"k8s.io/utils/pointer"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/feature"
 	utildefaulting "sigs.k8s.io/cluster-api/util/defaulting"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestMachinePoolDefault(t *testing.T) {
+	// NOTE: MachinePool feature flag is disabled by default, thus preventing to create or update MachinePool.
+	// Enabling the feature flag temporarily for this test.
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.MachinePool, true)()
+
 	g := NewWithT(t)
 
 	m := &MachinePool{
@@ -56,6 +63,9 @@ func TestMachinePoolDefault(t *testing.T) {
 }
 
 func TestMachinePoolBootstrapValidation(t *testing.T) {
+	// NOTE: MachinePool feature flag is disabled by default, thus preventing to create or update MachinePool.
+	// Enabling the feature flag temporarily for this test.
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.MachinePool, true)()
 	tests := []struct {
 		name      string
 		bootstrap clusterv1.Bootstrap
@@ -102,6 +112,9 @@ func TestMachinePoolBootstrapValidation(t *testing.T) {
 }
 
 func TestMachinePoolNamespaceValidation(t *testing.T) {
+	// NOTE: MachinePool feature flag is disabled by default, thus preventing to create or update MachinePool.
+	// Enabling the feature flag temporarily for this test.
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.MachinePool, true)()
 	tests := []struct {
 		name      string
 		expectErr bool
@@ -167,6 +180,9 @@ func TestMachinePoolNamespaceValidation(t *testing.T) {
 }
 
 func TestMachinePoolClusterNameImmutable(t *testing.T) {
+	// NOTE: MachinePool feature flag is disabled by default, thus preventing to create or update MachinePool.
+	// Enabling the feature flag temporarily for this test.
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.MachinePool, true)()
 	tests := []struct {
 		name           string
 		oldClusterName string
@@ -223,6 +239,9 @@ func TestMachinePoolClusterNameImmutable(t *testing.T) {
 }
 
 func TestMachinePoolVersionValidation(t *testing.T) {
+	// NOTE: MachinePool feature flag is disabled by default, thus preventing to create or update MachinePool.
+	// Enabling the feature flag temporarily for this test.
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.MachinePool, true)()
 	tests := []struct {
 		name      string
 		expectErr bool

--- a/main.go
+++ b/main.go
@@ -447,18 +447,16 @@ func setupWebhooks(mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 
-	if feature.Gates.Enabled(feature.MachinePool) {
-		if err := (&expv1.MachinePool{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "MachinePool")
-			os.Exit(1)
-		}
+	// NOTE: MachinePool is behind MachinePool feature gate flag; the webhook
+	// is going to prevent creating or updating new objects in case the feature flag is disabled
+	if err := (&expv1.MachinePool{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "MachinePool")
+		os.Exit(1)
 	}
 
-	if feature.Gates.Enabled(feature.ClusterResourceSet) {
-		if err := (&addonsv1.ClusterResourceSet{}).SetupWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "ClusterResourceSet")
-			os.Exit(1)
-		}
+	if err := (&addonsv1.ClusterResourceSet{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "ClusterResourceSet")
+		os.Exit(1)
 	}
 
 	if err := (&clusterv1.MachineHealthCheck{}).SetupWebhookWithManager(mgr); err != nil {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

 This PR contains the changes to move the feature gate checks for Machinepool and CRS from main.go file to respective webhooks, This helps in better display of error messages for users incase they are trying to create resources without enabling the feature flags.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6331
