### PR TITLE
:bug:  Downgrade golangci-lint to address gci autolint issues

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,5 +17,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.44.0
           working-directory: ${{matrix.working-directory}}

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -46,7 +46,9 @@ func TestClusterDefaultNamespaces(t *testing.T) {
 		},
 	}
 	webhook := &Cluster{}
-	t.Run("for Cluster", customDefaultValidateTest(ctx, c, webhook))
+	tFunc := customDefaultValidateTest(ctx, c, webhook)
+
+	t.Run("for Cluster", tFunc)
 	g.Expect(webhook.Default(ctx, c)).To(Succeed())
 
 	g.Expect(c.Spec.InfrastructureRef.Namespace).To(Equal(c.Namespace))
@@ -348,7 +350,8 @@ func TestClusterDefaultTopologyVersion(t *testing.T) {
 
 	// Create the webhook and add the fakeClient as its client.
 	webhook := &Cluster{Client: fakeClient}
-	t.Run("for Cluster", customDefaultValidateTest(ctx, c, webhook))
+	tFunc := customDefaultValidateTest(ctx, c, webhook)
+	t.Run("for Cluster", tFunc)
 	g.Expect(webhook.Default(ctx, c)).To(Succeed())
 
 	g.Expect(c.Spec.Topology.Version).To(HavePrefix("v"))

--- a/internal/webhooks/clusterclass_test.go
+++ b/internal/webhooks/clusterclass_test.go
@@ -76,7 +76,9 @@ func TestClusterClassDefaultNamespaces(t *testing.T) {
 
 	// Create the webhook and add the fakeClient as its client.
 	webhook := &ClusterClass{Client: fakeClient}
-	t.Run("for ClusterClass", customDefaultValidateTest(ctx, in, webhook))
+	tFunc := customDefaultValidateTest(ctx, in, webhook)
+
+	t.Run("for ClusterClass", tFunc)
 
 	g := NewWithT(t)
 	g.Expect(webhook.Default(ctx, in)).To(Succeed())

--- a/util/container/image.go
+++ b/util/container/image.go
@@ -18,8 +18,10 @@ limitations under the License.
 package container
 
 import (
+
 	//  Import the crypto sha256 algorithm for the docker image parser to work
 	_ "crypto/sha256"
+
 	//  Import the crypto/sha512 algorithm for the docker image parser to work with 384 and 512 sha hashes
 	_ "crypto/sha512"
 	"fmt"


### PR DESCRIPTION
Downgrade golanglint-ci version to a state where gci linter autofix is in working order. This should be reverted and upgrades should continue as soon as a release with autofix enabled is merged.

Related to #6350 

This should be reverted once there's a working path for the gci linter, or an alternative is implemented.