### PR TITLE
🌱 Add field.Path aggregation for MachineSet webhook

### DIFF
--- a/api/v1beta1/machineset_webhook.go
+++ b/api/v1beta1/machineset_webhook.go
@@ -120,9 +120,8 @@ func (m *MachineSet) validate(old *MachineSet) error {
 	if old != nil && old.Spec.ClusterName != m.Spec.ClusterName {
 		allErrs = append(
 			allErrs,
-			field.Invalid(
+			field.Forbidden(
 				specPath.Child("clusterName"),
-				m.Spec.ClusterName,
 				"field is immutable",
 			),
 		)

--- a/api/v1beta1/machineset_webhook.go
+++ b/api/v1beta1/machineset_webhook.go
@@ -95,17 +95,22 @@ func (m *MachineSet) ValidateDelete() error {
 
 func (m *MachineSet) validate(old *MachineSet) error {
 	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
 	selector, err := metav1.LabelSelectorAsSelector(&m.Spec.Selector)
 	if err != nil {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "selector"), m.Spec.Selector, err.Error()),
+			field.Invalid(
+				specPath.Child("selector"),
+				m.Spec.Selector,
+				err.Error(),
+			),
 		)
 	} else if !selector.Matches(labels.Set(m.Spec.Template.Labels)) {
 		allErrs = append(
 			allErrs,
 			field.Invalid(
-				field.NewPath("spec", "template", "metadata", "labels"),
+				specPath.Child("template", "metadata", "labels"),
 				m.Spec.Template.ObjectMeta.Labels,
 				fmt.Sprintf("must match spec.selector %q", selector.String()),
 			),
@@ -115,13 +120,24 @@ func (m *MachineSet) validate(old *MachineSet) error {
 	if old != nil && old.Spec.ClusterName != m.Spec.ClusterName {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "clusterName"), m.Spec.ClusterName, "field is immutable"),
+			field.Invalid(
+				specPath.Child("clusterName"),
+				m.Spec.ClusterName,
+				"field is immutable",
+			),
 		)
 	}
 
 	if m.Spec.Template.Spec.Version != nil {
 		if !version.KubeSemver.MatchString(*m.Spec.Template.Spec.Version) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "template", "spec", "version"), *m.Spec.Template.Spec.Version, "must be a valid semantic version"))
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					specPath.Child("template", "spec", "version"),
+					*m.Spec.Template.Spec.Version,
+					"must be a valid semantic version",
+				),
+			)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Sachin Kumar Singh <sachinkumarsingh092@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Update the `MachinSet` webhook to use `fieldPath.Child` where appropriate instead of redefining paths for each error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Realated to #6249 
