### PR TITLE
:seedling:  update dependabot modules command

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -31,7 +31,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Update all modules
-      run: make modules
+      run: make generate-modules
     - name: Update generated code
       run: make generate
     - uses: EndBug/add-and-commit@v7


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fix an issue in the dependabot config where it was using out of date make target. Dependabot was reactivated in #6340 

These targets are not actually really necessary given we're only using dependabot for github actions right now, but I'd prefer to leave them for now as we think about whether to add new directories to dependabot.
