### PR TITLE
:seedling: Add seedling commit prefix to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
   directory: "/"
   schedule:
       interval: "weekly"
+  commit-message:
+      prefix: ":seedling:"
+


### PR DESCRIPTION
Add seedling commit prefix to dependabot PRs to allow it to pass verify checks.

Examples of this at work in my fork: https://github.com/killianmuldoon/cluster-api/pulls
    
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>
