### PR TITLE
🌱 Add field.Path aggregation for Machine webhook

### DIFF
--- a/api/v1beta1/machine_webhook.go
+++ b/api/v1beta1/machine_webhook.go
@@ -91,11 +91,12 @@ func (m *Machine) ValidateDelete() error {
 
 func (m *Machine) validate(old *Machine) error {
 	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
 	if m.Spec.Bootstrap.ConfigRef == nil && m.Spec.Bootstrap.DataSecretName == nil {
 		allErrs = append(
 			allErrs,
 			field.Required(
-				field.NewPath("spec", "bootstrap", "data"),
+				specPath.Child("bootstrap", "data"),
 				"expected either spec.bootstrap.dataSecretName or spec.bootstrap.configRef to be populated",
 			),
 		)
@@ -105,7 +106,7 @@ func (m *Machine) validate(old *Machine) error {
 		allErrs = append(
 			allErrs,
 			field.Invalid(
-				field.NewPath("spec", "bootstrap", "configRef", "namespace"),
+				specPath.Child("bootstrap", "configRef", "namespace"),
 				m.Spec.Bootstrap.ConfigRef.Namespace,
 				"must match metadata.namespace",
 			),
@@ -116,7 +117,7 @@ func (m *Machine) validate(old *Machine) error {
 		allErrs = append(
 			allErrs,
 			field.Invalid(
-				field.NewPath("spec", "infrastructureRef", "namespace"),
+				specPath.Child("infrastructureRef", "namespace"),
 				m.Spec.InfrastructureRef.Namespace,
 				"must match metadata.namespace",
 			),
@@ -126,13 +127,13 @@ func (m *Machine) validate(old *Machine) error {
 	if old != nil && old.Spec.ClusterName != m.Spec.ClusterName {
 		allErrs = append(
 			allErrs,
-			field.Invalid(field.NewPath("spec", "clusterName"), m.Spec.ClusterName, "field is immutable"),
+			field.Forbidden(specPath.Child("clusterName"), "field is immutable"),
 		)
 	}
 
 	if m.Spec.Version != nil {
 		if !version.KubeSemver.MatchString(*m.Spec.Version) {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "version"), *m.Spec.Version, "must be a valid semantic version"))
+			allErrs = append(allErrs, field.Invalid(specPath.Child("version"), *m.Spec.Version, "must be a valid semantic version"))
 		}
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Update usage of `field.Path` in Machine webhook as part of an effort to make core webhook validation more consistent.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6249
