### PR TITLE
:seedling: use cluster level lock instead of global lock for cluster accessor initialization

### DIFF
--- a/controllers/remote/cluster_cache.go
+++ b/controllers/remote/cluster_cache.go
@@ -169,13 +169,13 @@ func (t *ClusterCacheTracker) getClusterAccessor(ctx context.Context, cluster cl
 	}
 
 	// We are the one who needs to initialize it.
-	log.V(4).Info("creating new cluster accessor")
+	log.V(4).Info("Creating new cluster accessor")
 	a, err := t.newClusterAccessor(ctx, cluster, indexes...)
 	if err != nil {
 		log.V(4).Info("error creating new cluster accessor")
 		return nil, errors.Wrap(err, "error creating client and cache for remote cluster")
 	}
-	log.V(4).Info("storing new cluster accessor")
+	log.V(4).Info("Storing new cluster accessor")
 	storeAccessor(a)
 	return a, nil
 }

--- a/controllers/remote/keyedmutex.go
+++ b/controllers/remote/keyedmutex.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import "sync"
+
+// keyedMutex is a mutex locking on the key provided to the Lock function.
+// Only one caller can hold the lock for a specific key at a time.
+type keyedMutex struct {
+	locksMtx sync.Mutex
+	locks    map[interface{}]*keyLock
+}
+
+// newKeyedMutex creates a new keyed mutex ready for use.
+func newKeyedMutex() *keyedMutex {
+	return &keyedMutex{
+		locks: make(map[interface{}]*keyLock),
+	}
+}
+
+// keyLock is the lock for a single specific key.
+type keyLock struct {
+	sync.Mutex
+	// users is the number of callers attempting to acquire the mutex, including the one currently holding it.
+	users uint
+}
+
+// unlock unlocks a currently locked key.
+type unlock func()
+
+// Lock locks the passed in key, blocking if the key is locked.
+// Returns the unlock function to release the lock on the key.
+func (k *keyedMutex) Lock(key interface{}) unlock {
+	// Get an existing keyLock for the key or create a new one and increase the number of users.
+	l := func() *keyLock {
+		k.locksMtx.Lock()
+		defer k.locksMtx.Unlock()
+
+		l, ok := k.locks[key]
+		if !ok {
+			l = &keyLock{}
+			k.locks[key] = l
+		}
+		l.users++
+		return l
+	}()
+
+	l.Lock()
+
+	// Unlocks the keyLock for the key, decreases the counter and removes the keyLock from the map if there are no more users left.
+	return func() {
+		k.locksMtx.Lock()
+		defer k.locksMtx.Unlock()
+
+		l.Unlock()
+		l.users--
+		if l.users == 0 {
+			delete(k.locks, key)
+		}
+	}
+}

--- a/controllers/remote/keyedmutex_test.go
+++ b/controllers/remote/keyedmutex_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestKeyedMutex(t *testing.T) {
+	t.Run("blocks on a locked key until unlocked", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+
+		routineStarted := make(chan bool)
+		routineCompleted := make(chan bool)
+		key := "key1"
+
+		km := newKeyedMutex()
+		unlock := km.Lock(key)
+
+		// start a routine which tries to lock the same key
+		go func() {
+			routineStarted <- true
+			unlock := km.Lock(key)
+			unlock()
+			routineCompleted <- true
+		}()
+
+		<-routineStarted
+		g.Consistently(routineCompleted).ShouldNot(Receive())
+
+		// routine should be able to acquire the lock for the key after we unlock
+		unlock()
+		g.Eventually(routineCompleted).Should(Receive())
+
+		// ensure that the lock was cleaned up from the internal map
+		g.Expect(km.locks).To(HaveLen(0))
+	})
+
+	t.Run("can lock different keys without blocking", func(t *testing.T) {
+		g := NewWithT(t)
+		km := newKeyedMutex()
+		keys := []string{"a", "b", "c", "d"}
+		unlocks := make([]unlock, 0, len(keys))
+
+		// lock all keys
+		for _, key := range keys {
+			unlocks = append(unlocks, km.Lock(key))
+		}
+
+		// unlock all keys
+		for _, unlock := range unlocks {
+			unlock()
+		}
+
+		// ensure that the lock was cleaned up from the internal map
+		g.Expect(km.locks).To(HaveLen(0))
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, initialization of a cluster accessor requires a global lock to be held. Initializing an accessor includes creating the dynamic rest mapper for the workload cluster and waiting for caches to populate. On a high latency connection to a workload cluster this can take a significant amount of time, because there are 10s of requests sent to the API-server for initializing the dynamic rest mapper and populating caches. During this time all reconciliation loops which require an accessor for any workload cluster are fully blocked, effectively blocking reconciliation of all clusters.

This PR allows multiple accessors for different clusters to be initialized in parallel by splitting the global lock into one lock per cluster. The implemented locking mechanism ensures that:

1. only one cluster accessor can exist for a particular cluster
2. initialization of cluster accessors for *different* clusters do not block each other