### PR TITLE
🌱 Refresh BootstrapToken until Nodes join

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -246,9 +246,10 @@ func (r *KubeadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Status is ready means a config has been generated.
 	case config.Status.Ready:
 		if config.Spec.JoinConfiguration != nil && config.Spec.JoinConfiguration.Discovery.BootstrapToken != nil {
-			if !configOwner.IsInfrastructureReady() {
-				// If the BootstrapToken has been generated for a join and the infrastructure is not ready.
-				// This indicates the token in the join config has not been consumed and it may need a refresh.
+			if !configOwner.HasNodeRefs() {
+				// If the BootstrapToken has been generated for a join but the config owner has no nodeRefs,
+				// this indicates that the node has not yet joined and the token in the join config has not
+				// been consumed and it may need a refresh.
 				return r.refreshBootstrapToken(ctx, config, cluster)
 			}
 			if configOwner.IsMachinePool() {

--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller_test.go
@@ -980,7 +980,7 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 		tokenExpires[i] = item.Data[bootstrapapi.BootstrapTokenExpirationKey]
 	}
 
-	// ...until the infrastructure is marked "ready"
+	// ...the infrastructure is marked "ready", but token should still be refreshed...
 	patchHelper, err := patch.NewHelper(workerMachine, myclient)
 	g.Expect(err).ShouldNot(HaveOccurred())
 	workerMachine.Status.InfrastructureReady = true
@@ -989,6 +989,56 @@ func TestBootstrapTokenTTLExtension(t *testing.T) {
 	patchHelper, err = patch.NewHelper(controlPlaneJoinMachine, myclient)
 	g.Expect(err).ShouldNot(HaveOccurred())
 	controlPlaneJoinMachine.Status.InfrastructureReady = true
+	g.Expect(patchHelper.Patch(ctx, controlPlaneJoinMachine)).To(Succeed())
+
+	<-time.After(1 * time.Second)
+
+	for _, req := range []ctrl.Request{
+		{
+			NamespacedName: client.ObjectKey{
+				Namespace: metav1.NamespaceDefault,
+				Name:      "worker-join-cfg",
+			},
+		},
+		{
+			NamespacedName: client.ObjectKey{
+				Namespace: metav1.NamespaceDefault,
+				Name:      "control-plane-join-cfg",
+			},
+		},
+	} {
+		result, err := k.Reconcile(ctx, req)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.RequeueAfter).NotTo(BeNumerically(">=", k.TokenTTL))
+	}
+
+	l = &corev1.SecretList{}
+	err = myclient.List(ctx, l, client.ListOption(client.InNamespace(metav1.NamespaceSystem)))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(l.Items)).To(Equal(2))
+
+	for i, item := range l.Items {
+		g.Expect(bytes.Equal(tokenExpires[i], item.Data[bootstrapapi.BootstrapTokenExpirationKey])).To(BeFalse())
+		tokenExpires[i] = item.Data[bootstrapapi.BootstrapTokenExpirationKey]
+	}
+
+	// ...until the Nodes have actually joined the cluster and we get a nodeRef
+	patchHelper, err = patch.NewHelper(workerMachine, myclient)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	workerMachine.Status.NodeRef = &corev1.ObjectReference{
+		APIVersion: "v1",
+		Kind:       "Node",
+		Name:       "worker-node",
+	}
+	g.Expect(patchHelper.Patch(ctx, workerMachine)).To(Succeed())
+
+	patchHelper, err = patch.NewHelper(controlPlaneJoinMachine, myclient)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	controlPlaneJoinMachine.Status.NodeRef = &corev1.ObjectReference{
+		APIVersion: "v1",
+		Kind:       "Node",
+		Name:       "control-plane-node",
+	}
 	g.Expect(patchHelper.Patch(ctx, controlPlaneJoinMachine)).To(Succeed())
 
 	<-time.After(1 * time.Second)
@@ -1108,10 +1158,42 @@ func TestBootstrapTokenRotationMachinePool(t *testing.T) {
 		tokenExpires[i] = item.Data[bootstrapapi.BootstrapTokenExpirationKey]
 	}
 
-	// ...until the infrastructure is marked "ready"
+	// ...the infrastructure is marked "ready", but token should still be refreshed...
 	patchHelper, err := patch.NewHelper(workerMachinePool, myclient)
 	g.Expect(err).ShouldNot(HaveOccurred())
 	workerMachinePool.Status.InfrastructureReady = true
+	g.Expect(patchHelper.Patch(ctx, workerMachinePool, patch.WithStatusObservedGeneration{})).To(Succeed())
+
+	<-time.After(1 * time.Second)
+
+	request = ctrl.Request{
+		NamespacedName: client.ObjectKey{
+			Namespace: metav1.NamespaceDefault,
+			Name:      "workerpool-join-cfg",
+		},
+	}
+	result, err = k.Reconcile(ctx, request)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.RequeueAfter).NotTo(BeNumerically(">=", k.TokenTTL))
+
+	l = &corev1.SecretList{}
+	err = myclient.List(ctx, l, client.ListOption(client.InNamespace(metav1.NamespaceSystem)))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(len(l.Items)).To(Equal(1))
+
+	for i, item := range l.Items {
+		g.Expect(bytes.Equal(tokenExpires[i], item.Data[bootstrapapi.BootstrapTokenExpirationKey])).To(BeFalse())
+		tokenExpires[i] = item.Data[bootstrapapi.BootstrapTokenExpirationKey]
+	}
+
+	// ...until all nodes have joined
+	workerMachinePool.Status.NodeRefs = []corev1.ObjectReference{
+		{
+			Kind:      "Node",
+			Namespace: metav1.NamespaceDefault,
+			Name:      "node-0",
+		},
+	}
 	g.Expect(patchHelper.Patch(ctx, workerMachinePool, patch.WithStatusObservedGeneration{})).To(Succeed())
 
 	<-time.After(1 * time.Second)


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously the token was only refreshed until the infrastructure was
ready. But in some cases it can take time for the Node to join also
after this. Therefore we now wait until the Machine or MachinePool has
nodeRefs, indicating that the Node has joined.

**Which issue(s) this PR fixes**:
Fixes #3734 I believe.

**Special notes for reviewers**:

I'm pondering if it would be good to check both that the infrastructure is ready and that the node has joined. Please let me know if you think there is a point in doing so. My intuition is that it would be unnecessary to check both, but it could possible provide an early return if the infrastructure is not ready.

For MachinePools, I'm checking that the slice of node refs is the same length as the number of replicas specified. Does this make sense? Could there be situations where the two are not matching even though all nodes have joined?