### PR TITLE
:seedling:  Add coredns corefile to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,11 @@ updates:
       interval: "weekly"
   commit-message:
       prefix: ":seedling:"
-
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  allow:
+    - dependency-name: "github.com/coredns/corefile-migration"
+  commit-message:
+    prefix: ":seedling:"


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Adds an allow for the coredns corefile to our dependabot config. This change will ensure we get automated updates to this library and is introduced in response to: https://github.com/kubernetes-sigs/cluster-api/issues/2599


