### PR TITLE
✨ RuntimeSDK: Add extension config controller skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ generate-manifests-core: $(CONTROLLER_GEN) $(KUSTOMIZE) ## Generate manifests e.
 		paths=./$(EXP_DIR)/addons/api/... \
 		paths=./$(EXP_DIR)/addons/internal/controllers/... \
 		paths=./$(EXP_DIR)/runtime/api/... \
+		paths=./$(EXP_DIR)/runtime/internal/controllers/... \
 		crd:crdVersions=v1 \
 		rbac:roleName=manager-role \
 		output:crd:dir=./config/crd/bases \

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -282,3 +282,15 @@ rules:
   - list
   - patch
   - watch
+- apiGroups:
+  - runtime.cluster.x-k8s.io
+  resources:
+  - extensionconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/exp/runtime/controllers/alias.go
+++ b/exp/runtime/controllers/alias.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	extensionconfigs "sigs.k8s.io/cluster-api/exp/runtime/internal/controllers"
+)
+
+// ExtensionConfigReconciler reconciles an ExtensionConfig object.
+type ExtensionConfigReconciler struct {
+	Client    client.Client
+	APIReader client.Reader
+
+	// WatchFilterValue is the label value used to filter events prior to reconciliation.
+	WatchFilterValue string
+}
+
+func (r *ExtensionConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	return (&extensionconfigs.Reconciler{
+		Client:           r.Client,
+		APIReader:        r.APIReader,
+		WatchFilterValue: r.WatchFilterValue,
+	}).SetupWithManager(ctx, mgr, options)
+}

--- a/exp/runtime/controllers/doc.go
+++ b/exp/runtime/controllers/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllers implements the exp/runtime controllers.
+package controllers

--- a/exp/runtime/internal/controllers/doc.go
+++ b/exp/runtime/internal/controllers/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controllers implements the exp/runtime controllers.
+package controllers

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
+	"sigs.k8s.io/cluster-api/util/predicates"
+)
+
+// +kubebuilder:rbac:groups=runtime.cluster.x-k8s.io,resources=extensionconfigs,verbs=get;list;watch;create;update;patch;delete
+
+// Reconciler reconciles an Extension object.
+type Reconciler struct {
+	Client    client.Client
+	APIReader client.Reader
+	// WatchFilterValue is the label value used to filter events prior to reconciliation.
+	WatchFilterValue string
+}
+
+func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&runtimev1.ExtensionConfig{}).
+		WithOptions(options).
+		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		Complete(r)
+	if err != nil {
+		return errors.Wrap(err, "failed setting up with a controller manager")
+	}
+	return nil
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	extension := &runtimev1.ExtensionConfig{}
+	err := r.Client.Get(ctx, req.NamespacedName, extension)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}


### PR DESCRIPTION
This PR adds a skeleton controller to handle the ExtensionConfig object added in #6383. This controller will eventually be used to handle status updates to the ExtensionConfig CRD.

Note: This PR includes #6383 and should not be merged until that PR is merged. This PR will require a rebase before merging.

Part of: https://github.com/kubernetes-sigs/cluster-api/issues/6330
