### PR TITLE
✨ Add nodeVolumeDetachTimeout property to Machine

### DIFF
--- a/api/v1alpha3/conversion.go
+++ b/api/v1alpha3/conversion.go
@@ -98,6 +98,7 @@ func (src *Machine) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	dst.Spec.NodeDeletionTimeout = restored.Spec.NodeDeletionTimeout
+	dst.Spec.NodeVolumeDetachTimeout = restored.Spec.NodeVolumeDetachTimeout
 	dst.Status.NodeInfo = restored.Status.NodeInfo
 	dst.Status.CertificatesExpiryDate = restored.Status.CertificatesExpiryDate
 	return nil
@@ -142,6 +143,7 @@ func (src *MachineSet) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 	dst.Spec.Template.Spec.NodeDeletionTimeout = restored.Spec.Template.Spec.NodeDeletionTimeout
+	dst.Spec.Template.Spec.NodeVolumeDetachTimeout = restored.Spec.Template.Spec.NodeVolumeDetachTimeout
 	dst.Status.Conditions = restored.Status.Conditions
 	return nil
 }
@@ -196,6 +198,7 @@ func (src *MachineDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	dst.Spec.Template.Spec.NodeDeletionTimeout = restored.Spec.Template.Spec.NodeDeletionTimeout
+	dst.Spec.Template.Spec.NodeVolumeDetachTimeout = restored.Spec.Template.Spec.NodeVolumeDetachTimeout
 	dst.Status.Conditions = restored.Status.Conditions
 	return nil
 }

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -1221,6 +1221,7 @@ func autoConvert_v1beta1_MachineSpec_To_v1alpha3_MachineSpec(in *v1beta1.Machine
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))
 	out.FailureDomain = (*string)(unsafe.Pointer(in.FailureDomain))
 	out.NodeDrainTimeout = (*metav1.Duration)(unsafe.Pointer(in.NodeDrainTimeout))
+	// WARNING: in.NodeVolumeDetachTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.NodeDeletionTimeout requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -160,6 +160,7 @@ func (src *Machine) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.NodeDeletionTimeout = restored.Spec.NodeDeletionTimeout
 	dst.Status.CertificatesExpiryDate = restored.Status.CertificatesExpiryDate
+	dst.Spec.NodeVolumeDetachTimeout = restored.Spec.NodeVolumeDetachTimeout
 	return nil
 }
 
@@ -204,6 +205,7 @@ func (src *MachineSet) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	dst.Spec.Template.Spec.NodeDeletionTimeout = restored.Spec.Template.Spec.NodeDeletionTimeout
+	dst.Spec.Template.Spec.NodeVolumeDetachTimeout = restored.Spec.Template.Spec.NodeVolumeDetachTimeout
 	return nil
 }
 
@@ -244,6 +246,7 @@ func (src *MachineDeployment) ConvertTo(dstRaw conversion.Hub) error {
 	}
 
 	dst.Spec.Template.Spec.NodeDeletionTimeout = restored.Spec.Template.Spec.NodeDeletionTimeout
+	dst.Spec.Template.Spec.NodeVolumeDetachTimeout = restored.Spec.Template.Spec.NodeVolumeDetachTimeout
 	return nil
 }
 

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -1602,6 +1602,7 @@ func autoConvert_v1beta1_MachineSpec_To_v1alpha4_MachineSpec(in *v1beta1.Machine
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))
 	out.FailureDomain = (*string)(unsafe.Pointer(in.FailureDomain))
 	out.NodeDrainTimeout = (*metav1.Duration)(unsafe.Pointer(in.NodeDrainTimeout))
+	// WARNING: in.NodeVolumeDetachTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.NodeDeletionTimeout requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -33,6 +33,9 @@ const (
 	// ExcludeNodeDrainingAnnotation annotation explicitly skips node draining if set.
 	ExcludeNodeDrainingAnnotation = "machine.cluster.x-k8s.io/exclude-node-draining"
 
+	// ExcludeWaitForNodeVolumeDetachAnnotation annotation explicitly skips the waiting for node volume detaching if set.
+	ExcludeWaitForNodeVolumeDetachAnnotation = "machine.cluster.x-k8s.io/exclude-wait-for-node-volume-detach"
+
 	// MachineSetLabelName is the label set on machines if they're controlled by MachineSet.
 	MachineSetLabelName = "cluster.x-k8s.io/set-name"
 
@@ -102,6 +105,11 @@ type MachineSpec struct {
 	// NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
+
+	// NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+	// to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+	// +optional
+	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
 	// hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1378,6 +1378,11 @@ func (in *MachineSpec) DeepCopyInto(out *MachineSpec) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.NodeVolumeDetachTimeout != nil {
+		in, out := &in.NodeVolumeDetachTimeout, &out.NodeVolumeDetachTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.NodeDeletionTimeout != nil {
 		in, out := &in.NodeDeletionTimeout, &out.NodeDeletionTimeout
 		*out = new(metav1.Duration)

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -2406,6 +2406,12 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineSpec(ref common.ReferenceCa
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"nodeVolumeDetachTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 					"nodeDeletionTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds.",

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -1316,6 +1316,12 @@ spec:
                           any time limitations. NOTE: NodeDrainTimeout is different
                           from `kubectl drain --timeout`'
                         type: string
+                      nodeVolumeDetachTimeout:
+                        description: NodeVolumeDetachTimeout is the total amount of
+                          time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the
+                          volumes can be detached without any time limitations.
+                        type: string
                       providerID:
                         description: ProviderID is the identification ID of the machine
                           provided by the provider. This field must match the provider

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -1193,6 +1193,12 @@ spec:
                           any time limitations. NOTE: NodeDrainTimeout is different
                           from `kubectl drain --timeout`'
                         type: string
+                      nodeVolumeDetachTimeout:
+                        description: NodeVolumeDetachTimeout is the total amount of
+                          time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the
+                          volumes can be detached without any time limitations.
+                        type: string
                       providerID:
                         description: ProviderID is the identification ID of the machine
                           provided by the provider. This field must match the provider

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -906,6 +906,12 @@ spec:
                   meaning that the node can be drained without any time limitations.
                   NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
                 type: string
+              nodeVolumeDetachTimeout:
+                description: NodeVolumeDetachTimeout is the total amount of time that
+                  the controller will spend on waiting for all volumes to be detached.
+                  The default value is 0, meaning that the volumes can be detached
+                  without any time limitations.
+                type: string
               providerID:
                 description: ProviderID is the identification ID of the machine provided
                   by the provider. This field must match the provider ID as seen on

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -1122,6 +1122,12 @@ spec:
                           any time limitations. NOTE: NodeDrainTimeout is different
                           from `kubectl drain --timeout`'
                         type: string
+                      nodeVolumeDetachTimeout:
+                        description: NodeVolumeDetachTimeout is the total amount of
+                          time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the
+                          volumes can be detached without any time limitations.
+                        type: string
                       providerID:
                         description: ProviderID is the identification ID of the machine
                           provided by the provider. This field must match the provider

--- a/controlplane/kubeadm/api/v1alpha3/conversion.go
+++ b/controlplane/kubeadm/api/v1alpha3/conversion.go
@@ -42,6 +42,7 @@ func (src *KubeadmControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.MachineTemplate.NodeDeletionTimeout = restored.Spec.MachineTemplate.NodeDeletionTimeout
 	dst.Spec.KubeadmConfigSpec.Files = restored.Spec.KubeadmConfigSpec.Files
 	dst.Spec.KubeadmConfigSpec.Users = restored.Spec.KubeadmConfigSpec.Users
+	dst.Spec.MachineTemplate.NodeVolumeDetachTimeout = restored.Spec.MachineTemplate.NodeVolumeDetachTimeout
 	dst.Status.Version = restored.Status.Version
 
 	if restored.Spec.KubeadmConfigSpec.Users != nil {

--- a/controlplane/kubeadm/api/v1alpha4/conversion.go
+++ b/controlplane/kubeadm/api/v1alpha4/conversion.go
@@ -68,6 +68,7 @@ func (src *KubeadmControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.MachineTemplate.NodeDeletionTimeout = restored.Spec.MachineTemplate.NodeDeletionTimeout
 	dst.Spec.RolloutBefore = restored.Spec.RolloutBefore
+	dst.Spec.MachineTemplate.NodeVolumeDetachTimeout = restored.Spec.MachineTemplate.NodeVolumeDetachTimeout
 
 	return nil
 }
@@ -139,6 +140,7 @@ func (src *KubeadmControlPlaneTemplate) ConvertTo(dstRaw conversion.Hub) error {
 		dst.Spec.Template.Spec.MachineTemplate = restored.Spec.Template.Spec.MachineTemplate
 	} else if restored.Spec.Template.Spec.MachineTemplate != nil {
 		dst.Spec.Template.Spec.MachineTemplate.NodeDeletionTimeout = restored.Spec.Template.Spec.MachineTemplate.NodeDeletionTimeout
+		dst.Spec.Template.Spec.MachineTemplate.NodeVolumeDetachTimeout = restored.Spec.Template.Spec.MachineTemplate.NodeVolumeDetachTimeout
 	}
 
 	dst.Spec.Template.Spec.RolloutBefore = restored.Spec.Template.Spec.RolloutBefore

--- a/controlplane/kubeadm/api/v1alpha4/zz_generated.conversion.go
+++ b/controlplane/kubeadm/api/v1alpha4/zz_generated.conversion.go
@@ -259,6 +259,7 @@ func autoConvert_v1beta1_KubeadmControlPlaneMachineTemplate_To_v1alpha4_KubeadmC
 	}
 	out.InfrastructureRef = in.InfrastructureRef
 	out.NodeDrainTimeout = (*v1.Duration)(unsafe.Pointer(in.NodeDrainTimeout))
+	// WARNING: in.NodeVolumeDetachTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.NodeDeletionTimeout requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_types.go
@@ -106,6 +106,11 @@ type KubeadmControlPlaneMachineTemplate struct {
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
+	// NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+	// to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+	// +optional
+	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
+
 	// NodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
 	// hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
 	// If no value is provided, the default value for this property of the Machine resource will be used.

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -161,6 +161,7 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, "machineTemplate", "infrastructureRef", "name"},
 		{spec, "machineTemplate", "infrastructureRef", "kind"},
 		{spec, "machineTemplate", "nodeDrainTimeout"},
+		{spec, "machineTemplate", "nodeVolumeDetachTimeout"},
 		{spec, "machineTemplate", "nodeDeletionTimeout"},
 		{spec, "replicas"},
 		{spec, "version"},

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -271,8 +271,9 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 					Namespace:  "foo",
 					Name:       "infraTemplate",
 				},
-				NodeDrainTimeout:    &metav1.Duration{Duration: time.Second},
-				NodeDeletionTimeout: &metav1.Duration{Duration: time.Second},
+				NodeDrainTimeout:        &metav1.Duration{Duration: time.Second},
+				NodeVolumeDetachTimeout: &metav1.Duration{Duration: time.Second},
+				NodeDeletionTimeout:     &metav1.Duration{Duration: time.Second},
 			},
 			Replicas: pointer.Int32Ptr(1),
 			RolloutStrategy: &RolloutStrategy{
@@ -398,6 +399,7 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	validUpdate.Spec.MachineTemplate.InfrastructureRef.APIVersion = "test/v1alpha2"
 	validUpdate.Spec.MachineTemplate.InfrastructureRef.Name = "orange"
 	validUpdate.Spec.MachineTemplate.NodeDrainTimeout = &metav1.Duration{Duration: 10 * time.Second}
+	validUpdate.Spec.MachineTemplate.NodeVolumeDetachTimeout = &metav1.Duration{Duration: 10 * time.Second}
 	validUpdate.Spec.MachineTemplate.NodeDeletionTimeout = &metav1.Duration{Duration: 10 * time.Second}
 	validUpdate.Spec.Replicas = pointer.Int32Ptr(5)
 	now := metav1.NewTime(time.Now())

--- a/controlplane/kubeadm/api/v1beta1/kubeadmcontrolplanetemplate_types.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadmcontrolplanetemplate_types.go
@@ -106,6 +106,11 @@ type KubeadmControlPlaneTemplateMachineTemplate struct {
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
+	// NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+	// to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+	// +optional
+	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
+
 	// NodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
 	// hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
 	// If no value is provided, the default value for this property of the Machine resource will be used.

--- a/controlplane/kubeadm/api/v1beta1/zz_generated.deepcopy.go
+++ b/controlplane/kubeadm/api/v1beta1/zz_generated.deepcopy.go
@@ -97,6 +97,11 @@ func (in *KubeadmControlPlaneMachineTemplate) DeepCopyInto(out *KubeadmControlPl
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.NodeVolumeDetachTimeout != nil {
+		in, out := &in.NodeVolumeDetachTimeout, &out.NodeVolumeDetachTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.NodeDeletionTimeout != nil {
 		in, out := &in.NodeDeletionTimeout, &out.NodeDeletionTimeout
 		*out = new(v1.Duration)
@@ -245,6 +250,11 @@ func (in *KubeadmControlPlaneTemplateMachineTemplate) DeepCopyInto(out *KubeadmC
 	*out = *in
 	if in.NodeDrainTimeout != nil {
 		in, out := &in.NodeDrainTimeout, &out.NodeDrainTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.NodeVolumeDetachTimeout != nil {
+		in, out := &in.NodeVolumeDetachTimeout, &out.NodeVolumeDetachTimeout
 		*out = new(v1.Duration)
 		**out = **in
 	}

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -3577,6 +3577,12 @@ spec:
                       any time limitations. NOTE: NodeDrainTimeout is different from
                       `kubectl drain --timeout`'
                     type: string
+                  nodeVolumeDetachTimeout:
+                    description: NodeVolumeDetachTimeout is the total amount of time
+                      that the controller will spend on waiting for all volumes to
+                      be detached. The default value is 0, meaning that the volumes
+                      can be detached without any time limitations.
+                    type: string
                 required:
                 - infrastructureRef
                 type: object

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -2337,6 +2337,13 @@ spec:
                               be drained without any time limitations. NOTE: NodeDrainTimeout
                               is different from `kubectl drain --timeout`'
                             type: string
+                          nodeVolumeDetachTimeout:
+                            description: NodeVolumeDetachTimeout is the total amount
+                              of time that the controller will spend on waiting for
+                              all volumes to be detached. The default value is 0,
+                              meaning that the volumes can be detached without any
+                              time limitations.
+                            type: string
                         type: object
                       rolloutAfter:
                         description: RolloutAfter is a field to indicate a rollout

--- a/docs/book/src/developer/architecture/controllers/control-plane.md
+++ b/docs/book/src/developer/architecture/controllers/control-plane.md
@@ -98,6 +98,10 @@ documentation][scale].
   that the controller will spend on draining a control plane node.
   The default value is 0, meaning that the node can be drained without any time limitations.
 
+* `machineTemplate.nodeVolumeDetachTimeout` - is a *metav1.Duration defining how long the controller
+  will spend on waiting for all volumes to be detached.
+  The default value is 0, meaning that the volume can be detached without any time limitations.
+
 * `machineTemplate.nodeDeletionTimeout` - is a *metav1.Duration defining how long the controller
   will attempt to delete the Node that is hosted by a Machine after the Machine is marked for
   deletion. A duration of 0 will retry deletion indefinitely. It defaults to 10 seconds on the

--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -28,7 +28,9 @@ in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controlle
 
 ### API Changes
 
--
+- A new timeout `nodeVolumeDetachTimeout` has been introduced that defines how long the controller will spend on waiting for all volumes to be detached.
+The default value is 0, meaning that the volume can be detached without any time limitations.
+- A new annotation `machine.cluster.x-k8s.io/exclude-wait-for-node-volume-detach` has been introduced that allows explicitly skip the waiting for node volume detaching.
 
 ### Other
 

--- a/exp/api/v1alpha3/conversion.go
+++ b/exp/api/v1alpha3/conversion.go
@@ -71,6 +71,7 @@ func (src *MachinePool) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 	dst.Spec.Template.Spec.NodeDeletionTimeout = restored.Spec.Template.Spec.NodeDeletionTimeout
+	dst.Spec.Template.Spec.NodeVolumeDetachTimeout = restored.Spec.Template.Spec.NodeVolumeDetachTimeout
 	return nil
 }
 

--- a/exp/api/v1alpha4/conversion.go
+++ b/exp/api/v1alpha4/conversion.go
@@ -36,6 +36,7 @@ func (src *MachinePool) ConvertTo(dstRaw conversion.Hub) error {
 		return err
 	}
 	dst.Spec.Template.Spec.NodeDeletionTimeout = restored.Spec.Template.Spec.NodeDeletionTimeout
+	dst.Spec.Template.Spec.NodeVolumeDetachTimeout = restored.Spec.Template.Spec.NodeVolumeDetachTimeout
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- introduces a new timeout called `nodeVolumeDetachTimeout` to the machine and other CRDs, which can be used to wait for volume detachment to happen within the timeout limit
- introduces a new annotation called `ExcludeWaitForNodeVolumeDetachAnnotation` to be able to skip `shouldWaitForNodeVolumes` check entirely if needed
- moves out `shouldWaitForNodeVolumes` from node drain logic (`isNodeDrainAllowed`) and adds new check only for volume related checks called `isNodeVolumeDetachingAllowed` to  to keep a cleaner separation for API
- adds unit tests
- documents introduced  new timeout  `nodeVolumeDetachTimeout` and annotation `ExcludeWaitForNodeVolumeDetachAnnotation` as a breaking changes in the provider's migration v1.2 to v1.3 document
- ~~Renames `VolumeDetachSucceededCondition` to `VolumeDetachFinishedCondition` so it is clearer for the user, because we have to mark `VolumeDetachSucceededCondition`  as True when `volumeDetachTimeoutExceeded` condition met even though **in fact** volumes are not detached. For that reason, I renamed it to `VolumeDetachFinishedCondition` (open to suggestions on this) to make it a bit generic and less confusing for the user.~~
- ~~Adds `VolumeDetachTimedOutCondition` to indicate volume detaching timeout exceeded~~
- ~~Adds `WaitingForVolumeDetachTimeoutReason` to indicate the reason for detach timeout~~


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6285 
