### PR TITLE
:book: Correct a typo in the `MachinesSpecUpToDate` condition comment

### DIFF
--- a/controlplane/kubeadm/api/v1alpha3/condition_consts.go
+++ b/controlplane/kubeadm/api/v1alpha3/condition_consts.go
@@ -48,7 +48,7 @@ const (
 
 const (
 	// MachinesSpecUpToDateCondition documents that the spec of the machines controlled by the KubeadmControlPlane
-	// is up to date. Whe this condition is false, the KubeadmControlPlane is executing a rolling upgrade.
+	// is up to date. When this condition is false, the KubeadmControlPlane is executing a rolling upgrade.
 	MachinesSpecUpToDateCondition clusterv1alpha3.ConditionType = "MachinesSpecUpToDate"
 
 	// RollingUpdateInProgressReason (Severity=Warning) documents a KubeadmControlPlane object executing a

--- a/controlplane/kubeadm/api/v1alpha4/condition_consts.go
+++ b/controlplane/kubeadm/api/v1alpha4/condition_consts.go
@@ -48,7 +48,7 @@ const (
 
 const (
 	// MachinesSpecUpToDateCondition documents that the spec of the machines controlled by the KubeadmControlPlane
-	// is up to date. Whe this condition is false, the KubeadmControlPlane is executing a rolling upgrade.
+	// is up to date. When this condition is false, the KubeadmControlPlane is executing a rolling upgrade.
 	MachinesSpecUpToDateCondition clusterv1alpha4.ConditionType = "MachinesSpecUpToDate"
 
 	// RollingUpdateInProgressReason (Severity=Warning) documents a KubeadmControlPlane object executing a

--- a/controlplane/kubeadm/api/v1beta1/condition_consts.go
+++ b/controlplane/kubeadm/api/v1beta1/condition_consts.go
@@ -48,7 +48,7 @@ const (
 
 const (
 	// MachinesSpecUpToDateCondition documents that the spec of the machines controlled by the KubeadmControlPlane
-	// is up to date. Whe this condition is false, the KubeadmControlPlane is executing a rolling upgrade.
+	// is up to date. When this condition is false, the KubeadmControlPlane is executing a rolling upgrade.
 	MachinesSpecUpToDateCondition clusterv1.ConditionType = "MachinesSpecUpToDate"
 
 	// RollingUpdateInProgressReason (Severity=Warning) documents a KubeadmControlPlane object executing a


### PR DESCRIPTION
`Whe` -> `When`.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
