### PR TITLE
🐛 clusterctl: retry github i/o operations

### DIFF
--- a/cmd/clusterctl/client/repository/repository_github_test.go
+++ b/cmd/clusterctl/client/repository/repository_github_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v33/github"
 	. "github.com/onsi/gomega"
@@ -31,6 +32,8 @@ import (
 )
 
 func Test_githubRepository_newGitHubRepository(t *testing.T) {
+	retryableOperationInterval = 200 * time.Millisecond
+	retryableOperationTimeout = 1 * time.Second
 	type field struct {
 		providerConfig config.Provider
 		variableClient config.VariablesClient
@@ -156,6 +159,8 @@ func Test_githubRepository_getComponentsPath(t *testing.T) {
 }
 
 func Test_githubRepository_getFile(t *testing.T) {
+	retryableOperationInterval = 200 * time.Millisecond
+	retryableOperationTimeout = 1 * time.Second
 	client, mux, teardown := test.NewFakeGitHub()
 	defer teardown()
 
@@ -228,6 +233,8 @@ func Test_githubRepository_getFile(t *testing.T) {
 }
 
 func Test_gitHubRepository_getVersions(t *testing.T) {
+	retryableOperationInterval = 200 * time.Millisecond
+	retryableOperationTimeout = 1 * time.Second
 	client, mux, teardown := test.NewFakeGitHub()
 	defer teardown()
 
@@ -284,6 +291,8 @@ func Test_gitHubRepository_getVersions(t *testing.T) {
 }
 
 func Test_gitHubRepository_getLatestContractRelease(t *testing.T) {
+	retryableOperationInterval = 200 * time.Millisecond
+	retryableOperationTimeout = 1 * time.Second
 	client, mux, teardown := test.NewFakeGitHub()
 	defer teardown()
 
@@ -540,6 +549,8 @@ func Test_gitHubRepository_getLatestPatchRelease(t *testing.T) {
 }
 
 func Test_gitHubRepository_getReleaseByTag(t *testing.T) {
+	retryableOperationInterval = 200 * time.Millisecond
+	retryableOperationTimeout = 1 * time.Second
 	client, mux, teardown := test.NewFakeGitHub()
 	defer teardown()
 
@@ -605,6 +616,8 @@ func Test_gitHubRepository_getReleaseByTag(t *testing.T) {
 }
 
 func Test_gitHubRepository_downloadFilesFromRelease(t *testing.T) {
+	retryableOperationInterval = 200 * time.Millisecond
+	retryableOperationTimeout = 1 * time.Second
 	client, mux, teardown := test.NewFakeGitHub()
 	defer teardown()
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

In response to a test flake, this PR introduces retry tolerance to GitHub API-dependent operations in clusterctl.

The passing (unchanged) UT should prove functional equivalence between this change and existing (no retry) behavior.

Reference test flake:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-provider-azure-e2e-workload-upgrade-1-19-1-20-main/1516508031641194496

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
