### PR TITLE
📖 allow up to 20 tabs in book

### DIFF
--- a/docs/book/theme/css/custom.css
+++ b/docs/book/theme/css/custom.css
@@ -396,7 +396,17 @@ cite.literate-source > a::before {
 .tabset > input:nth-child(13):checked ~ .tab-panels > .tab-panel:nth-child(7),
 .tabset > input:nth-child(15):checked ~ .tab-panels > .tab-panel:nth-child(8),
 .tabset > input:nth-child(17):checked ~ .tab-panels > .tab-panel:nth-child(9),
-.tabset > input:nth-child(19):checked ~ .tab-panels > .tab-panel:nth-child(10){
+.tabset > input:nth-child(19):checked ~ .tab-panels > .tab-panel:nth-child(10),
+.tabset > input:nth-child(21):checked ~ .tab-panels > .tab-panel:nth-child(11),
+.tabset > input:nth-child(23):checked ~ .tab-panels > .tab-panel:nth-child(12),
+.tabset > input:nth-child(25):checked ~ .tab-panels > .tab-panel:nth-child(13),
+.tabset > input:nth-child(27):checked ~ .tab-panels > .tab-panel:nth-child(14),
+.tabset > input:nth-child(29):checked ~ .tab-panels > .tab-panel:nth-child(15),
+.tabset > input:nth-child(31):checked ~ .tab-panels > .tab-panel:nth-child(16),
+.tabset > input:nth-child(33):checked ~ .tab-panels > .tab-panel:nth-child(17),
+.tabset > input:nth-child(35):checked ~ .tab-panels > .tab-panel:nth-child(18),
+.tabset > input:nth-child(37):checked ~ .tab-panels > .tab-panel:nth-child(19),
+.tabset > input:nth-child(39):checked ~ .tab-panels > .tab-panel:nth-child(20){
   display: block;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The current CSS only supports up to 10 tabs, but we already have some selections with 13 tabs. This adds CSS rules for up to 20 tabs.

This does not really fix the root cause, which is the static css for a limited number of tabs, if anyone knows a better solution, I am happy to close this PR and let someone else implement a proper fix.

**Which issue(s) this PR fixes**:
Fixes #6434
