### PR TITLE
🌱 test: actually retry controller-runtime client instantiation

### DIFF
--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -176,15 +176,17 @@ func (p *clusterProxy) GetClient() client.Client {
 	config := p.GetRESTConfig()
 
 	var c client.Client
+	var newClientErr error
 	err := wait.PollImmediate(retryableOperationInterval, retryableOperationTimeout, func() (bool, error) {
-		var newClientErr error
 		c, newClientErr = client.New(config, client.Options{Scheme: p.scheme})
 		if newClientErr != nil {
-			return false, newClientErr
+			return false, nil //nolint:nilerr
 		}
 		return true, nil
 	})
-	Expect(err).ToNot(HaveOccurred(), "Failed to get controller-runtime client")
+	errorString := "Failed to get controller-runtime client"
+	Expect(newClientErr).ToNot(HaveOccurred(), errorString)
+	Expect(err).ToNot(HaveOccurred(), errorString)
 
 	return c
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This is a follow-up from PR #6431 that actually enables retries when receiving an error establishing a k8s controller-runtime client during E2E tests. Without this change the `wait.PollImmediate` implementation just returns from the first error response, essentially making it a thin wrapper that doesn't add any value.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
