### PR TITLE
🌱 clusterctl: support disable version check

### DIFF
--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -67,6 +67,11 @@ var RootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		disable, err := configClient.Variables().Get("CLUSTERCTL_DISABLE_VERSIONCHECK")
+		if err == nil && disable == "true" {
+			// version check is disabled. Return early.
+			return nil
+		}
 		output, err := newVersionChecker(configClient.Variables()).Check()
 		if err != nil {
 			return errors.Wrap(err, "unable to verify clusterctl version")

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -215,3 +215,8 @@ images:
 To have more verbose logs you can use the `-v` flag when running the `clusterctl` and set the level of the logging verbose with a positive integer number, ie. `-v 3`.
 
 If you do not want to use the flag every time you issue a command you can set the environment variable `CLUSTERCTL_LOG_LEVEL` or set the variable in the `clusterctl` config file located by default at `$HOME/.cluster-api/clusterctl.yaml`.
+
+
+## Skip checking for updates
+
+`clusterctl` automatically checks for new versions every time it is used. If you do not want `clusterctl` to check for new updates you can set the environment variable `CLUSTERCTL_DISABLE_VERSIONCHECK` to `"true"` or set the variable in the `clusterctl` config file located by default at `$HOME/.cluster-api/clusterctl.yaml`.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds support to disable clusterctl from checking for updates. This is useful when clusterctl is used in a air-gapped environments. 

Usage: To disable the version checking add `DISABLE_VERSIONCHECK: "true"` to `clusterctl.yaml` or set an environment variable `DISABLE_VERSIONCHECK="true"`.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6381 
