### PR TITLE
🌱 Makefile: re-enable hack/tools on make help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ LDFLAGS := $(shell hack/version.sh)
 all: test managers clusterctl
 
 help:  # Display this help
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[0-9A-Za-z_-]+:.*?##/ { printf "  \033[36m%-45s\033[0m %s\n", $$1, $$2 } /^\$$\([0-9A-Za-z_-]+\):.*?##/ { gsub("_","-", $$1); printf "  \033[36m%-45s\033[0m %s\n", tolower(substr($$1, 3, length($$1)-7)), $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ## --------------------------------------
 ## Generate / Manifests


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

* Fixes regression for make help introduced in #5741

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

fixes #6444

**What else to add**

Before:
```
$ make
...
  clean-release-git                              Restores the git files usually modified during a release
  clean-generated-conversions                    Remove files generated by conversion-gen from the mentioned dirs. Example SRC_DIRS="./api/v1alpha4"

hack/tools:
```

After:
```
$ make
...
  clean-release-git                              Restores the git files usually modified during a release
  clean-generated-conversions                    Remove files generated by conversion-gen from the mentioned dirs. Example SRC_DIRS="./api/v1alpha4"

hack/tools:
  controller-gen                                 Build a local copy of controller-gen.
  conversion-gen                                 Build a local copy of conversion-gen.
  conversion-verifier                            Build a local copy of conversion-verifier.
  gotestsum                                      Build a local copy of gotestsum.
  go-apidiff                                     Build a local copy of go-apidiff
  envsubst                                       Build a local copy of envsubst.
  kustomize                                      Build a local copy of kustomize.
  setup-envtest                                  Build a local copy of setup-envtest.
  kpromo                                         Build a local copy of kpromo
  tilt-prepare                                   Build a local copy of tilt-prepare.
  golangci-lint                                  Build a local copy of golangci-lint
```