### PR TITLE
🌱  Update promote-images to filter by image and sort by tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ GO_APIDIFF_BIN := go-apidiff
 GO_APIDIFF := $(abspath $(TOOLS_BIN_DIR)/$(GO_APIDIFF_BIN)-$(GO_APIDIFF_VER))
 GO_APIDIFF_PKG := github.com/joelanford/go-apidiff
 
-KPROMO_VER := v3.3.0-beta.3
+KPROMO_VER := v3.4.1
 KPROMO_BIN := kpromo
 KPROMO :=  $(abspath $(TOOLS_BIN_DIR)/$(KPROMO_BIN)-$(KPROMO_VER))
 KPROMO_PKG := sigs.k8s.io/promo-tools/v3/cmd/kpromo
@@ -655,7 +655,7 @@ release-notes: $(RELEASE_NOTES_DIR) $(RELEASE_NOTES)
 
 .PHONY: promote-images
 promote-images: $(KPROMO)
-	$(KPROMO) pr --project cluster-api --tag $(RELEASE_TAG) --reviewers "$(IMAGE_REVIEWERS)" --fork $(USER_FORK)
+	$(KPROMO) pr --project cluster-api --tag $(RELEASE_TAG) --reviewers "$(IMAGE_REVIEWERS)" --fork $(USER_FORK) --image cluster-api-controller --image kubeadm-control-plane-controller --image kubeadm-bootstrap-controller --digests ""
 
 ## --------------------------------------
 ## Docker

--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -40,6 +40,6 @@ fi
 rm "${GOBIN}/${2}"* || true
 
 # install the golang module specified as the first argument
-go install -tags tools "${1}@${3}"
+go install "${1}@${3}"
 mv "${GOBIN}/${2}" "${GOBIN}/${2}-${3}"
 ln -sf "${GOBIN}/${2}-${3}" "${GOBIN}/${2}"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Updates `kpromo` to the latest release so we can take advantage of 1) filtering by promotion by image to exclude CAPD images and 2) sorting by tag instead of by digest.

https://github.com/kubernetes-sigs/promo-tools/releases/tag/v3.4.1

Test PR to promote fake v0.99.99 tag from this branch: https://github.com/kubernetes/k8s.io/pull/3683/files

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
