### PR TITLE
🌱 Replace deprecated strings.Title with cases.Title

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/util/record/recorder.go
+++ b/util/record/recorder.go
@@ -18,9 +18,10 @@ limitations under the License.
 package record
 
 import (
-	"strings"
 	"sync"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -45,20 +46,20 @@ func InitFromRecorder(recorder record.EventRecorder) {
 
 // Event constructs an event from the given information and puts it in the queue for sending.
 func Event(object runtime.Object, reason, message string) {
-	defaultRecorder.Event(object, corev1.EventTypeNormal, strings.Title(reason), message)
+	defaultRecorder.Event(object, corev1.EventTypeNormal, cases.Title(language.Und).String(reason), message)
 }
 
 // Eventf is just like Event, but with Sprintf for the message field.
 func Eventf(object runtime.Object, reason, message string, args ...interface{}) {
-	defaultRecorder.Eventf(object, corev1.EventTypeNormal, strings.Title(reason), message, args...)
+	defaultRecorder.Eventf(object, corev1.EventTypeNormal, cases.Title(language.Und).String(reason), message, args...)
 }
 
 // Warn constructs a warning event from the given information and puts it in the queue for sending.
 func Warn(object runtime.Object, reason, message string) {
-	defaultRecorder.Event(object, corev1.EventTypeWarning, strings.Title(reason), message)
+	defaultRecorder.Event(object, corev1.EventTypeWarning, cases.Title(language.Und).String(reason), message)
 }
 
 // Warnf is just like Warn, but with Sprintf for the message field.
 func Warnf(object runtime.Object, reason, message string, args ...interface{}) {
-	defaultRecorder.Eventf(object, corev1.EventTypeWarning, strings.Title(reason), message, args...)
+	defaultRecorder.Eventf(object, corev1.EventTypeWarning, cases.Title(language.Und).String(reason), message, args...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The strings.Title function is being deprecated in Go 1.18 due to issues
with its handling of certain unicode sets. The recommended replacement
is cases.Title.

We only have one location where this was being used in a utility
function. This updates that instance to use the new recommendations.

https://tip.golang.org/doc/go1.18#minor_library_changes