### PR TITLE
🐛 RuntimeSDK: include ExtensionConfig CRD in generated core manifest

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
 - bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
 - bases/cluster.x-k8s.io_machinehealthchecks.yaml
+- bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Follow-up PR to the PR which added the CRD to include the CRD in the generated core manifest

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
