### PR TITLE
🌱 CAPD: Add docker mount to worker nodes

### DIFF
--- a/test/infrastructure/docker/templates/cluster-template-development.yaml
+++ b/test/infrastructure/docker/templates/cluster-template-development.yaml
@@ -83,7 +83,10 @@ metadata:
   namespace: "${NAMESPACE}"
 spec:
   template:
-    spec: {}
+    spec:
+      extraMounts:
+      - containerPath: "/var/run/docker.sock"
+        hostPath: "/var/run/docker.sock"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -183,7 +183,10 @@ metadata:
   name: "quick-start-default-worker-machinetemplate"
 spec:
   template:
-    spec: {}
+    spec:
+      extraMounts:
+      - containerPath: "/var/run/docker.sock"
+        hostPath: "/var/run/docker.sock"
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
With our current templates it's not possible to create a cluster on which CAPD can also run on worker nodes.

Found here: https://github.com/kubernetes-sigs/cluster-api/issues/6321#issuecomment-1110540975

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
