### PR TITLE
🐛 CAPD: Add containerd socket to worker nodes

### DIFF
--- a/test/infrastructure/docker/templates/cluster-template-development.yaml
+++ b/test/infrastructure/docker/templates/cluster-template-development.yaml
@@ -48,6 +48,7 @@ spec:
         certSANs: [localhost, 127.0.0.1, 0.0.0.0]
     initConfiguration:
       nodeRegistration:
+        # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
           # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
@@ -56,6 +57,7 @@ spec:
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
     joinConfiguration:
       nodeRegistration:
+        # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
           # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
@@ -98,6 +100,7 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd

--- a/test/infrastructure/docker/templates/cluster-template-development.yaml
+++ b/test/infrastructure/docker/templates/cluster-template-development.yaml
@@ -98,6 +98,7 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
             # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -265,6 +265,7 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
             # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -219,6 +219,7 @@ spec:
             certSANs: [localhost, 127.0.0.1, 0.0.0.0]
         initConfiguration:
           nodeRegistration:
+            # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
@@ -227,6 +228,7 @@ spec:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
         joinConfiguration:
           nodeRegistration:
+            # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
@@ -265,6 +267,7 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
             # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd


### PR DESCRIPTION
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
PR #6460 causes the worker nodes to default to docker as container runtime. The `kubeadm join` command fails on the worker node because the kubelet tries to use docker as runtime. Therefore the worker node will never be added to the cluster.
Adding the containerd CRI socket to the join configuration of the worker node will fix this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
