### PR TITLE
🌱 make clusterctl init idempotent

### DIFF
--- a/cmd/clusterctl/api/v1alpha3/provider_type.go
+++ b/cmd/clusterctl/api/v1alpha3/provider_type.go
@@ -161,6 +161,13 @@ func (l *ProviderList) FilterByProviderNameAndType(provider string, providerType
 	})
 }
 
+// FilterByProviderNameNamespaceTypeVersion returns a new list of provider that match the name, namespace, type and version.
+func (l *ProviderList) FilterByProviderNameNamespaceTypeVersion(provider, namespace string, providerType ProviderType, version string) []Provider {
+	return l.filterBy(func(p Provider) bool {
+		return p.ProviderName == provider && p.Namespace == namespace && p.Type == string(providerType) && p.Version == version
+	})
+}
+
 // FilterByType returns a new list of providers that match the given type.
 func (l *ProviderList) FilterByType(providerType ProviderType) []Provider {
 	return l.filterBy(func(p Provider) bool {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR make the `clusterctl init` command idempotent. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6471 
