### PR TITLE
:seedling:  [WIP] Update 1.23 Kubernetes references to 1.24.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -392,10 +392,10 @@ Examples:
 ```bash
 $ kubectl get kubeadmcontrolplane
 NAMESPACE            NAME                               INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE     VERSION
-quick-start-d5ufye   quick-start-ntysk0-control-plane   true          true                   1          1       1                       2m44s   v1.23.3
+quick-start-d5ufye   quick-start-ntysk0-control-plane   true          true                   1          1       1                       2m44s   v1.24.0
 $ kubectl get machinedeployment
 NAMESPACE            NAME                      CLUSTER              REPLICAS   READY   UPDATED   UNAVAILABLE   PHASE       AGE     VERSION
-quick-start-d5ufye   quick-start-ntysk0-md-0   quick-start-ntysk0   1                  1         1             ScalingUp   3m28s   v1.23.3
+quick-start-d5ufye   quick-start-ntysk0-md-0   quick-start-ntysk0   1                  1         1             ScalingUp   3m28s   v1.24.0
 ```
 
 ## Google Doc Viewing Permissions

--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -63,16 +63,17 @@ These diagrams show the relationships between components in a Cluster API releas
 
 #### Core Provider (`cluster-api-controller`)
 
-|                  |  CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload |  CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload |  CAPI v1beta1 (v1.x) Management | CAPI v1beta1 (v1.x) Workload |
-| ---------------- | -------------------------------- | ----------------------------- | -------------------------------- | ----------------------------- | -------------------------------- | ----------------------------- |
-| Kubernetes v1.16 | ✓                                | ✓                             |                                  |                               |                                  |                               |
-| Kubernetes v1.17 | ✓                                | ✓                             |                                  |                               |                                  |                               |
-| Kubernetes v1.18 | ✓                                | ✓                             |                                  | ✓                             |                                  | ✓                             |
-| Kubernetes v1.19 | ✓                                | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
-| Kubernetes v1.20 | ✓                                | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
-| Kubernetes v1.21 | ✓                                | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
-| Kubernetes v1.22 |                                  | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
-| Kubernetes v1.23* |                                  |                               | ✓                                | ✓                             | ✓                                | ✓                             |
+|                   | CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload | CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload | CAPI v1beta1 (v1.x) Management | CAPI v1beta1 (v1.x) Workload |
+|-------------------|---------------------------------|-------------------------------|---------------------------------|-------------------------------|--------------------------------|------------------------------|
+| Kubernetes v1.16  | ✓                               | ✓                             |                                 |                               |                                |                              |
+| Kubernetes v1.17  | ✓                               | ✓                             |                                 |                               |                                |                              |
+| Kubernetes v1.18  | ✓                               | ✓                             |                                 | ✓                             |                                | ✓                            |
+| Kubernetes v1.19  | ✓                               | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.20  | ✓                               | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.21  | ✓                               | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.22  |                                 | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.23* |                                 |                               | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.24  |                                 |                               | ✓                               | ✓                             | ✓                              | ✓                            |
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
    Previous Kubernetes **minor** versions are not affected.
@@ -81,31 +82,33 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 
 #### Kubeadm Bootstrap Provider (`kubeadm-bootstrap-controller`)
 
-|                                    |  CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload | CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload | CAPI v1beta1 (v1.x) Management | CAPI v1beta1 (v1.x) Workload |
-| ---------------------------------- | -------------------------------- | ----------------------------- | ------------------------------- | ----------------------------- | ------------------------------- | ----------------------------- |
-| Kubernetes v1.16 + kubeadm/v1beta2 | ✓                                | ✓                             |                                 |                               |                                 |                               |
-| Kubernetes v1.17 + kubeadm/v1beta2 | ✓                                | ✓                             |                                 |                               |                                 |                               |
-| Kubernetes v1.18 + kubeadm/v1beta2 | ✓                                | ✓                             |                                 | ✓                             |                                 | ✓                             |
-| Kubernetes v1.19 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.20 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.21 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) |   | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.23 + kubeadm/v1beta3 |                                  |                               | ✓                               | ✓                             | ✓                               | ✓                             |
+|                                                                   | CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload | CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload | CAPI v1beta1 (v1.x) Management | CAPI v1beta1 (v1.x) Workload |
+|-------------------------------------------------------------------|---------------------------------|-------------------------------|---------------------------------|-------------------------------|--------------------------------|------------------------------|
+| Kubernetes v1.16 + kubeadm/v1beta2                                | ✓                               | ✓                             |                                 |                               |                                |                              |
+| Kubernetes v1.17 + kubeadm/v1beta2                                | ✓                               | ✓                             |                                 |                               |                                |                              |
+| Kubernetes v1.18 + kubeadm/v1beta2                                | ✓                               | ✓                             |                                 | ✓                             |                                | ✓                            |
+| Kubernetes v1.19 + kubeadm/v1beta2                                | ✓                               | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.20 + kubeadm/v1beta2                                | ✓                               | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.21 + kubeadm/v1beta2                                | ✓                               | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) |                                 | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.23 + kubeadm/v1beta3                                |                                 |                               | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.24 + kubeadm/v1beta3                                |                                 |                               | ✓                               | ✓                             | ✓                              | ✓                            |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
 |                            | CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload | CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload | CAPI v1beta1 (v1.x) Management | CAPI v1beta1 (v1.x) Workload |
-| -------------------------- | ------------------------------- |-------------------------------|---------------------------------|-------------------------------| ------------------------------- | ----------------------------- |
-| Kubernetes v1.16 + etcd/v3 | ✓                               | ✓                             |                                 |                               |                                 |                               |
-| Kubernetes v1.17 + etcd/v3 | ✓                               | ✓                             |                                 |                               |                                 |                               |
-| Kubernetes v1.18 + etcd/v3 | ✓                               | ✓                             |                                 | ✓                             |                                 | ✓                             |
-| Kubernetes v1.19 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.20 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.21 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.22 + etcd/v3 |                                 | ✓*                            | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.23 + etcd/v3 |                                 |                               | ✓*                              | ✓*                            | ✓                               | ✓                             |
+|----------------------------|---------------------------------|-------------------------------|---------------------------------|-------------------------------|--------------------------------|------------------------------|
+| Kubernetes v1.16 + etcd/v3 | ✓                               | ✓                             |                                 |                               |                                |                              |
+| Kubernetes v1.17 + etcd/v3 | ✓                               | ✓                             |                                 |                               |                                |                              |
+| Kubernetes v1.18 + etcd/v3 | ✓                               | ✓                             |                                 | ✓                             |                                | ✓                            |
+| Kubernetes v1.19 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.20 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.21 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.22 + etcd/v3 |                                 | ✓*                            | ✓                               | ✓                             | ✓                              | ✓                            |
+| Kubernetes v1.23 + etcd/v3 |                                 |                               | ✓*                              | ✓*                            | ✓                              | ✓                            |
+| Kubernetes v1.24 + etcd/v3 |                                 |                               | ✓*                              | ✓*                            | ✓                              | ✓                            |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -715,7 +715,7 @@ For the purpose of this tutorial, we'll name our cluster capi-quickstart.
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.23.3 \
+  --kubernetes-version v1.24.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -734,7 +734,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.23.3 \
+  --kubernetes-version v1.24.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -744,7 +744,7 @@ To create a Cluster with ClusterClass:
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development-topology \
-  --kubernetes-version v1.23.3 \
+  --kubernetes-version v1.24.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -804,7 +804,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                            INITIALIZED   API SERVER AVAILABLE   VERSION   REPLICAS   READY   UPDATED   UNAVAILABLE
-capi-quickstart-control-plane   true                                 v1.23.3   3                  3         3
+capi-quickstart-control-plane   true                                 v1.24.0   3                  3         3
 ```
 
 <aside class="note warning">

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -70,6 +70,7 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
@@ -1684,7 +1685,7 @@ sigs.k8s.io/controller-tools v0.8.0 h1:uUkfTGEwrguqYYfcI2RRGUnC8mYdCFDqfwPKUcNJh
 sigs.k8s.io/controller-tools v0.8.0/go.mod h1:qE2DXhVOiEq5ijmINcFbqi9GZrrUjzB1TuJU0xa6eoY=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 h1:fD1pz4yfdADVNfFmcP2aBEtudwUQ1AlLnRBALr33v3s=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
-sigs.k8s.io/kind v0.12.0/go.mod h1:EcgDSBVxz8Bvm19fx8xkioFrf9dC30fMJdOTXBSGNoM=
+sigs.k8s.io/kind v0.13.0/go.mod h1:UrFRPHG+2a5j0Q7qiR4gtJ4rEyn8TuMQwuOPf+m4oHg=
 sigs.k8s.io/kubebuilder/docs/book/utils v0.0.0-20211028165026-57688c578b5d h1:KLiQzLW3RZJR19+j4pw2h5iioyAyqCkDBEAFdnGa3N8=
 sigs.k8s.io/kubebuilder/docs/book/utils v0.0.0-20211028165026-57688c578b5d/go.mod h1:NRdZafr4zSCseLQggdvIMXa7umxf+Q+PJzrj3wFwiGE=
 sigs.k8s.io/kustomize/api v0.10.1/go.mod h1:2FigT1QN6xKdcnGS2Ppp1uIWrtWN28Ms8A3OZUZhwr8=

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -199,10 +199,10 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.23.4"
-  KUBERNETES_VERSION: "v1.23.4"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.22.7"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.23.4"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.24.0"
+  KUBERNETES_VERSION: "v1.24.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.23.6"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.24.0"
   ETCD_VERSION_UPGRADE_TO: "3.5.3-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.8.6"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
@@ -225,7 +225,7 @@ variables:
   # NOTE: We test the latest release with a previous contract.
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-{OS}-{ARCH}"
   INIT_WITH_PROVIDERS_CONTRACT: "v1alpha4"
-  INIT_WITH_KUBERNETES_VERSION: "v1.23.4"
+  INIT_WITH_KUBERNETES_VERSION: "v1.24.0"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/e2e/data/infrastructure-docker/v1beta1/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/bases/cluster-with-kcp.yaml
@@ -86,16 +86,10 @@ spec:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-          # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-          # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
   version: "${KUBERNETES_VERSION}"

--- a/test/e2e/data/infrastructure-docker/v1beta1/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/bases/md.yaml
@@ -24,9 +24,6 @@ spec:
         nodeRegistration:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
-            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-            cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 # MachineDeployment object

--- a/test/e2e/data/infrastructure-docker/v1beta1/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/bases/mp.yaml
@@ -42,7 +42,4 @@ spec:
   joinConfiguration:
     nodeRegistration:
       kubeletExtraArgs:
-        # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-        # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-        cgroup-driver: cgroupfs
         eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-kcp-adoption/step1/cluster-with-cp0.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-kcp-adoption/step1/cluster-with-cp0.yaml
@@ -48,17 +48,11 @@ spec:
     nodeRegistration:
       criSocket: unix:///var/run/containerd/containerd.sock
       kubeletExtraArgs:
-        # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-        # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-        cgroup-driver: cgroupfs
         eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
   joinConfiguration:
     nodeRegistration:
       criSocket: unix:///var/run/containerd/containerd.sock
       kubeletExtraArgs:
-        # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-        # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-        cgroup-driver: cgroupfs
         eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 # cp0 Machine

--- a/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
@@ -173,17 +173,11 @@ spec:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-              # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-              cgroup-driver: cgroupfs
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
         joinConfiguration:
           nodeRegistration:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-              # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-              cgroup-driver: cgroupfs
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -219,8 +213,5 @@ spec:
         nodeRegistration:
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
-            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-            cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.23.4"
+	DefaultNodeImageVersion = "v1.24.0"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/go.mod
+++ b/test/go.mod
@@ -24,13 +24,13 @@ require (
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 	sigs.k8s.io/cluster-api v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/controller-runtime v0.11.2
-	sigs.k8s.io/kind v0.12.0
+	sigs.k8s.io/kind v0.13.0
 	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
 	cloud.google.com/go v0.99.0 // indirect
-	github.com/BurntSushi/toml v0.4.1 // indirect
+	github.com/BurntSushi/toml v1.0.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -67,8 +67,8 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
-github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
+github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
@@ -1654,8 +1654,8 @@ sigs.k8s.io/controller-runtime v0.11.2 h1:H5GTxQl0Mc9UjRJhORusqfJCIjBO8UtUxGggCw
 sigs.k8s.io/controller-runtime v0.11.2/go.mod h1:P6QCzrEjLaZGqHsfd+os7JQ+WFZhvB8MRFsn4dWF7O4=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 h1:fD1pz4yfdADVNfFmcP2aBEtudwUQ1AlLnRBALr33v3s=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
-sigs.k8s.io/kind v0.12.0 h1:LFynXwQkH1MrWI8pM1FQty0oUwEKjU5EkMaVZaPld8E=
-sigs.k8s.io/kind v0.12.0/go.mod h1:EcgDSBVxz8Bvm19fx8xkioFrf9dC30fMJdOTXBSGNoM=
+sigs.k8s.io/kind v0.13.0 h1:hXcTJAst3MVGnxs8ZEg+II9bsL+st8sTE5c0Jz5APpY=
+sigs.k8s.io/kind v0.13.0/go.mod h1:UrFRPHG+2a5j0Q7qiR4gtJ4rEyn8TuMQwuOPf+m4oHg=
 sigs.k8s.io/kustomize/api v0.10.1/go.mod h1:2FigT1QN6xKdcnGS2Ppp1uIWrtWN28Ms8A3OZUZhwr8=
 sigs.k8s.io/kustomize/cmd/config v0.10.2/go.mod h1:K2aW7nXJ0AaT+VA/eO0/dzFLxmpFcTzudmAgDwPY1HQ=
 sigs.k8s.io/kustomize/kustomize/v4 v4.4.1/go.mod h1:qOKJMMz2mBP+vcS7vK+mNz4HBLjaQSWRY22EF6Tb7Io=

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -25,7 +25,7 @@ ENV GOPROXY=$goproxy
 # Gets additional CAPD dependencies
 WORKDIR /tmp
 
-RUN curl -LO https://dl.k8s.io/release/v1.23.3/bin/linux/${ARCH}/kubectl && \
+RUN curl -LO https://dl.k8s.io/release/v1.24.0/bin/linux/${ARCH}/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl
 

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -29,7 +29,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.23.3
+  version: v1.24.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -93,7 +93,7 @@ spec:
         kind: DockerMachinePool
         name: worker-dmp-0
         namespace: default
-      version: v1.23.3
+      version: v1.24.0
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePool

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.23.3
+  version: v1.24.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -124,7 +124,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.23.3
+      version: v1.24.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -38,7 +38,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.23.3
+  version: v1.24.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -106,7 +106,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.23.3
+      version: v1.24.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -44,7 +44,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.23.3
+  version: v1.24.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -112,7 +112,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.23.3
+      version: v1.24.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.23.3"
+	defaultImageTag  = "v1.24.0"
 )
 
 type nodeCreator interface {

--- a/test/infrastructure/docker/templates/cluster-template-development.yaml
+++ b/test/infrastructure/docker/templates/cluster-template-development.yaml
@@ -51,18 +51,12 @@ spec:
         # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-          # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
     joinConfiguration:
       nodeRegistration:
         # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
         criSocket: unix:///var/run/containerd/containerd.sock
         kubeletExtraArgs:
-          # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-          # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-          cgroup-driver: cgroupfs
           eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
   version: "${KUBERNETES_VERSION}"
 ---
@@ -103,9 +97,6 @@ spec:
           # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
-            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-            cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -222,18 +222,12 @@ spec:
             # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-              # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-              cgroup-driver: cgroupfs
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
         joinConfiguration:
           nodeRegistration:
             # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
-              # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-              # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-              cgroup-driver: cgroupfs
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -270,8 +264,5 @@ spec:
           # We have to set the criSocket to containerd as kubeadm defaults to docker runtime if both containerd and docker sockets are found
           criSocket: unix:///var/run/containerd/containerd.sock
           kubeletExtraArgs:
-            # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
-            # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
-            cgroup-driver: cgroupfs
             eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
 


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update Kubernetes 1.23 to 1.24 across CAPI docs and test code. 

WIP / hold as we're still waiting for the kind node image to be published.

Part of: https://github.com/kubernetes-sigs/cluster-api/issues/5968