### PR TITLE
✨ Provider repositories on GitLab

### DIFF
--- a/cmd/clusterctl/client/repository/client_test.go
+++ b/cmd/clusterctl/client/repository/client_test.go
@@ -44,20 +44,37 @@ func Test_newRepositoryClient_LocalFileSystemRepository(t *testing.T) {
 		provider config.Provider
 	}
 	tests := []struct {
-		name   string
-		fields fields
+		name     string
+		fields   fields
+		expected Repository
 	}{
 		{
 			name: "successfully creates repository client with local filesystem backend and scheme == \"\"",
 			fields: fields{
 				provider: config.NewProvider("foo", dst1, clusterctlv1.BootstrapProviderType),
 			},
+			expected: &localRepository{},
 		},
 		{
 			name: "successfully creates repository client with local filesystem backend and scheme == \"file\"",
 			fields: fields{
 				provider: config.NewProvider("bar", "file://"+dst2, clusterctlv1.BootstrapProviderType),
 			},
+			expected: &localRepository{},
+		},
+		{
+			name: "successfully creates repository client with GitHub backend",
+			fields: fields{
+				provider: config.NewProvider("bar", "https://github.com/o/r/releases/v0.4.1/file.yaml", clusterctlv1.BootstrapProviderType),
+			},
+			expected: &gitHubRepository{},
+		},
+		{
+			name: "successfully creates repository client with GitLab backend",
+			fields: fields{
+				provider: config.NewProvider("bar", "https://gitlab.example.org/api/v4/projects/group%2Fproject/packages/generic/my-package/v1.0/path", clusterctlv1.BootstrapProviderType),
+			},
+			expected: &gitLabRepository{},
 		},
 	}
 	for _, tt := range tests {
@@ -67,8 +84,7 @@ func Test_newRepositoryClient_LocalFileSystemRepository(t *testing.T) {
 			repoClient, err := newRepositoryClient(tt.fields.provider, configClient)
 			gs.Expect(err).NotTo(HaveOccurred())
 
-			var expected *localRepository
-			gs.Expect(repoClient.repository).To(BeAssignableToTypeOf(expected))
+			gs.Expect(repoClient.repository).To(BeAssignableToTypeOf(tt.expected))
 		})
 	}
 }

--- a/cmd/clusterctl/client/repository/repository_gitlab.go
+++ b/cmd/clusterctl/client/repository/repository_gitlab.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repository
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+)
+
+const (
+	gitlabHostPrefix          = "gitlab."
+	gitlabPackagesAPIPrefix   = "/api/v4/projects/"
+	gitlabPackagesAPIPackages = "packages"
+	gitlabPackagesAPIGeneric  = "generic"
+)
+
+// gitLabRepository provides support for providers hosted on GitLab.
+//
+// We support GitLab repositories that use the generic packages feature to publish artifacts and versions.
+// Repositories must use versioned releases.
+type gitLabRepository struct {
+	providerConfig        config.Provider
+	configVariablesClient config.VariablesClient
+	httpClient            *http.Client
+	host                  string
+	projectSlug           string
+	packageName           string
+	defaultVersion        string
+	rootPath              string
+	componentsPath        string
+}
+
+var _ Repository = &gitLabRepository{}
+
+// NewGitLabRepository returns a gitLabRepository implementation.
+func NewGitLabRepository(providerConfig config.Provider, configVariablesClient config.VariablesClient) (Repository, error) {
+	if configVariablesClient == nil {
+		return nil, errors.New("invalid arguments: configVariablesClient can't be nil")
+	}
+
+	rURL, err := url.Parse(providerConfig.URL())
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid url")
+	}
+
+	urlSplit := strings.Split(strings.TrimPrefix(rURL.RawPath, "/"), "/")
+
+	// Check if the url is a Gitlab repository
+	if rURL.Scheme != httpsScheme ||
+		len(urlSplit) != 9 ||
+		!strings.HasPrefix(rURL.RawPath, gitlabPackagesAPIPrefix) ||
+		urlSplit[4] != gitlabPackagesAPIPackages ||
+		urlSplit[5] != gitlabPackagesAPIGeneric {
+		return nil, errors.New("invalid url: a GitLab repository url should be in the form https://{host}/api/v4/projects/{projectSlug}/packages/generic/{packageName}/{defaultVersion}/{componentsPath}")
+	}
+
+	httpClient := http.DefaultClient
+	// Extract all the info from url split.
+	host := rURL.Host
+	projectSlug := urlSplit[3]
+	packageName := urlSplit[6]
+	defaultVersion := urlSplit[7]
+	rootPath := "."
+	componentsPath := urlSplit[8]
+
+	repo := &gitLabRepository{
+		providerConfig:        providerConfig,
+		configVariablesClient: configVariablesClient,
+		httpClient:            httpClient,
+		host:                  host,
+		projectSlug:           projectSlug,
+		packageName:           packageName,
+		defaultVersion:        defaultVersion,
+		rootPath:              rootPath,
+		componentsPath:        componentsPath,
+	}
+
+	return repo, nil
+}
+
+// Host returns host field of gitLabRepository struct.
+func (g *gitLabRepository) Host() string {
+	return g.host
+}
+
+// ProjectSlug returns projectSlug field of gitLabRepository struct.
+func (g *gitLabRepository) ProjectSlug() string {
+	return g.projectSlug
+}
+
+// DefaultVersion returns defaultVersion field of gitLabRepository struct.
+func (g *gitLabRepository) DefaultVersion() string {
+	return g.defaultVersion
+}
+
+// GetVersions returns the list of versions that are available in a provider repository.
+func (g *gitLabRepository) GetVersions() ([]string, error) {
+	// FIXME Get versions from GitLab API
+	return []string{g.defaultVersion}, nil
+}
+
+// RootPath returns rootPath field of gitLabRepository struct.
+func (g *gitLabRepository) RootPath() string {
+	return g.rootPath
+}
+
+// ComponentsPath returns componentsPath field of gitLabRepository struct.
+func (g *gitLabRepository) ComponentsPath() string {
+	return g.componentsPath
+}
+
+// GetFile returns a file for a given provider version.
+func (g *gitLabRepository) GetFile(version, path string) ([]byte, error) {
+	ctx := context.TODO()
+	url := fmt.Sprintf(
+		"https://%s/api/v4/projects/%s/packages/generic/%s/%s/%s",
+		g.host,
+		g.projectSlug,
+		g.packageName,
+		version,
+		path,
+	)
+
+	if content, ok := cacheFiles[url]; ok {
+		return content, nil
+	}
+
+	timeoutctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	request, err := http.NewRequestWithContext(timeoutctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get file %q with version %q from %q: failed to create request", path, version, url)
+	}
+
+	response, err := g.httpClient.Do(request)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get file %q with version %q from %q", path, version, url)
+	}
+
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("failed to get file %q with version %q from %q, got %d", path, version, url, response.StatusCode)
+	}
+
+	content, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get file %q with version %q from %q", path, version, url)
+	}
+
+	cacheFiles[url] = content
+	return content, nil
+}

--- a/cmd/clusterctl/client/repository/repository_gitlab_test.go
+++ b/cmd/clusterctl/client/repository/repository_gitlab_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repository
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/internal/test"
+)
+
+func Test_gitLabRepository_newGitLabRepository(t *testing.T) {
+	type field struct {
+		providerConfig config.Provider
+		variableClient config.VariablesClient
+	}
+	tests := []struct {
+		name      string
+		field     field
+		want      *gitLabRepository
+		wantedErr string
+	}{
+		{
+			name: "can create a new GitLab repo",
+			field: field{
+				providerConfig: config.NewProvider("test", "https://gitlab.example.org/api/v4/projects/group%2Fproject/packages/generic/my-package/v1.0/path", clusterctlv1.CoreProviderType),
+				variableClient: test.NewFakeVariableClient(),
+			},
+			want: &gitLabRepository{
+				providerConfig:        config.NewProvider("test", "https://gitlab.example.org/api/v4/projects/group%2Fproject/packages/generic/my-package/v1.0/path", clusterctlv1.CoreProviderType),
+				configVariablesClient: test.NewFakeVariableClient(),
+				httpClient:            http.DefaultClient,
+				host:                  "gitlab.example.org",
+				projectSlug:           "group%2Fproject",
+				packageName:           "my-package",
+				defaultVersion:        "v1.0",
+				rootPath:              ".",
+				componentsPath:        "path",
+			},
+			wantedErr: "",
+		},
+		{
+			name: "missing variableClient",
+			field: field{
+				providerConfig: config.NewProvider("test", "https://gitlab.example.org/api/v4/projects/group%2Fproject/packages/generic/my-package/v1.0/path", clusterctlv1.CoreProviderType),
+				variableClient: nil,
+			},
+			want:      nil,
+			wantedErr: "invalid arguments: configVariablesClient can't be nil",
+		},
+		{
+			name: "provider url is not valid",
+			field: field{
+				providerConfig: config.NewProvider("test", "%gh&%ij", clusterctlv1.CoreProviderType),
+				variableClient: test.NewFakeVariableClient(),
+			},
+			want:      nil,
+			wantedErr: "invalid url: parse \"%gh&%ij\": invalid URL escape \"%gh\"",
+		},
+		{
+			name: "provider url should be in https",
+			field: field{
+				providerConfig: config.NewProvider("test", "http://gitlab.example.org/api/v4/projects/group%2Fproject/packages/generic/my-package/v1.0/path", clusterctlv1.CoreProviderType),
+				variableClient: test.NewFakeVariableClient(),
+			},
+			want:      nil,
+			wantedErr: "invalid url: a GitLab repository url should be in the form https://{host}/api/v4/projects/{projectSlug}/packages/generic/{packageName}/{defaultVersion}/{componentsPath}",
+		},
+		{
+			name: "provider url should have the correct number of parts",
+			field: field{
+				providerConfig: config.NewProvider("test", "https://gitlab.example.org/api/v4/projects/group%2Fproject/packages/generic/my-package/v1.0/path/grrr", clusterctlv1.CoreProviderType),
+				variableClient: test.NewFakeVariableClient(),
+			},
+			want:      &gitLabRepository{},
+			wantedErr: "invalid url: a GitLab repository url should be in the form https://{host}/api/v4/projects/{projectSlug}/packages/generic/{packageName}/{defaultVersion}/{componentsPath}",
+		},
+		{
+			name: "provider url should have the correct prefix",
+			field: field{
+				providerConfig: config.NewProvider("test", "https://gitlab.example.org/subpath/api/v4/projects/group%2Fproject/packages/generic/my-package/v1.0/path", clusterctlv1.CoreProviderType),
+				variableClient: test.NewFakeVariableClient(),
+			},
+			want:      &gitLabRepository{},
+			wantedErr: "invalid url: a GitLab repository url should be in the form https://{host}/api/v4/projects/{projectSlug}/packages/generic/{packageName}/{defaultVersion}/{componentsPath}",
+		},
+		{
+			name: "provider url should have the packages part",
+			field: field{
+				providerConfig: config.NewProvider("test", "https://gitlab.example.org/api/v4/projects/group%2Fproject/packages-invalid/generic/my-package/v1.0/path", clusterctlv1.CoreProviderType),
+				variableClient: test.NewFakeVariableClient(),
+			},
+			want:      nil,
+			wantedErr: "invalid url: a GitLab repository url should be in the form https://{host}/api/v4/projects/{projectSlug}/packages/generic/{packageName}/{defaultVersion}/{componentsPath}",
+		},
+		{
+			name: "provider url should have the generic part",
+			field: field{
+				providerConfig: config.NewProvider("test", "https://gitlab.example.org/api/v4/projects/group%2Fproject/packages/generic-invalid/my-package/v1.0/path", clusterctlv1.CoreProviderType),
+				variableClient: test.NewFakeVariableClient(),
+			},
+			want:      nil,
+			wantedErr: "invalid url: a GitLab repository url should be in the form https://{host}/api/v4/projects/{projectSlug}/packages/generic/{packageName}/{defaultVersion}/{componentsPath}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			resetCaches()
+
+			gitLab, err := NewGitLabRepository(tt.field.providerConfig, tt.field.variableClient)
+			if tt.wantedErr != "" {
+				g.Expect(err).To(MatchError(tt.wantedErr))
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(gitLab).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_gitLabRepository_getFile(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+	client := server.Client()
+
+	providerURL := fmt.Sprintf("%s/api/v4/projects/group%%2Fproject/packages/generic/my-package/v0.4.1/file.yaml", server.URL)
+	providerConfig := config.NewProvider("test", providerURL, clusterctlv1.CoreProviderType)
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if r.URL.RawPath == "/api/v4/projects/group%2Fproject/packages/generic/my-package/v0.4.1/file.yaml" {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Disposition", "attachment; filename=file.yaml")
+			fmt.Fprint(w, "content")
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	configVariablesClient := test.NewFakeVariableClient()
+
+	tests := []struct {
+		name     string
+		version  string
+		fileName string
+		want     []byte
+		wantErr  bool
+	}{
+		{
+			name:     "Release and file exist",
+			version:  "v0.4.1",
+			fileName: "file.yaml",
+			want:     []byte("content"),
+			wantErr:  false,
+		},
+		{
+			name:     "File does not exist",
+			version:  "v0.4.1",
+			fileName: "404.file",
+			want:     nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			resetCaches()
+
+			gitLab, err := NewGitLabRepository(providerConfig, configVariablesClient)
+			gitLab.(*gitLabRepository).httpClient = client
+			g.Expect(err).NotTo(HaveOccurred())
+
+			got, err := gitLab.GetFile(tt.version, tt.fileName)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
+}

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -29,6 +29,14 @@ providers:
   - name: "cluster-api"
     url: "https://github.com/myorg/myforkofclusterapi/releases/latest/core-components.yaml"
     type: "CoreProvider"
+  # add a custom provider on a self-hosted GitLab (host should start with "gitlab.")
+  - name: "my-other-infra-provider"
+    url: "https://gitlab.example.com/api/v4/projects/myorg%2Fmyrepo/packages/generic/myrepo/v1.2.3/infrastructure-components.yaml"
+    type: "InfrastructureProvider"
+  # override a pre-defined provider on a self-hosted GitLab (host should start with "gitlab.")
+  - name: "kubeadm"
+    url: "https://gitlab.example.com/api/v4/projects/external-packages%2Fcluster-api/packages/generic/cluster-api/v1.1.3/bootstrap-components.yaml"
+    type: "BootstrapProvider"
 ```
 
 See [provider contract](provider-contract.md) for instructions about how to set up a provider repository.
@@ -168,7 +176,7 @@ overridesFolder: /Users/foobar/workspace/dev-releases
 Image override is an advanced feature and wrong configuration can easily lead to non-functional clusters.
 It's strongly recommended to test configurations on dev/test environments before using this functionality in production.
 
-This feature must always be used in conjunction with 
+This feature must always be used in conjunction with
 [version tag](commands/init.md#provider-version) when executing clusterctl commands.
 
 </aside>


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow to defined providers from Gitlab:

```yaml
providers:
  # add a custom provider
  - name: "my-infra-provider"
    url: "https://gitlab.example.com/api/v4/projects/myorg%2Fmyrepo/packages/generic/myrepo/v1.2.3/infrastructure-components.yaml"
    type: "InfrastructureProvider"
  # override a pre-defined provider
  - name: "cluster-api"
    url: "https://gitlab.example.com/api/v4/projects/external-packages%2Fcluster-api/packages/generic/cluster-api/v1.1.3/core-components.yaml"
    type: "CoreProvider"
```

**Testing**

I've [uploaded  test files on Gitlab](https://gitlab.com/sathieu/cluster-api-pr6487/-/packages)

Those can be tested with the following `clusterctl.yaml`:

```yaml
providers:
  # add a custom provider
  - name: "my-infra-provider"
    url: "https://gitlab.com/api/v4/projects/sathieu%2Fcluster-api-pr6487/packages/generic/myrepo/v1.2.3/infrastructure-components.yaml"
    type: "InfrastructureProvider"
  # override a pre-defined provider
  - name: "cluster-api"
    url: "https://gitlab.com/api/v4/projects/sathieu%2Fcluster-api-pr6487/packages/generic/cluster-api/v1.1.3/core-components.yaml"
    type: "CoreProvider"

```

```console
$ ./bin/clusterctl generate provider -n my-ns --infrastructure=my-infra-provider:v1.2.3 
apiVersion: v1
kind: Secret
metadata:
  labels:
    cluster.x-k8s.io/provider: infrastructure-my-infra-provider
    clusterctl.cluster.x-k8s.io: ""
  name: i-am-custom-provider
  namespace: my-ns
type: Opaque
---
kind: Namespace
metadata:
  labels:
    cluster.x-k8s.io/provider: infrastructure-my-infra-provider
    clusterctl.cluster.x-k8s.io: ""
  name: my-ns
$ ./bin/clusterctl generate provider -n my-ns --core=cluster-api 
apiVersion: v1
kind: Secret
metadata:
  labels:
    cluster.x-k8s.io/provider: cluster-api
    clusterctl.cluster.x-k8s.io: ""
  name: i-am-core-provider-override
  namespace: my-ns
type: Opaque
---
kind: Namespace
metadata:
  labels:
    cluster.x-k8s.io/provider: cluster-api
    clusterctl.cluster.x-k8s.io: ""
  name: my-ns

```



**Which issue(s) this PR fixes**:
Fixes #6486
