### PR TITLE
 🌱 docs: add capmvm to the providers list

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -9,7 +9,7 @@
             "Accept-Encoding": "zstd, br, gzip, deflate"
         }
     }],
-    "timeout": "5s",
+    "timeout": "10s",
     "retryOn429": true,
     "retryCount": 5,
     "fallbackRetryDelay": "30s",

--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -33,6 +33,7 @@ updated info about which API version they are supporting.
 - [Sidero](https://github.com/siderolabs/sidero)
 - [Tencent Cloud](https://github.com/TencentCloud/cluster-api-provider-tencent)
 - [vSphere](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere)
+- [Microvm](https://github.com/weaveworks-liquidmetal/cluster-api-provider-microvm)
 
 ## API Adopters
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A small docs change to add CAPMVM to the list of providers.

I also increased the timeout on the markdown links checker as it was failing checking some links due to timeout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
