### PR TITLE
🐛 ClusterResourceSet: apply objects in sorted order

### DIFF
--- a/exp/addons/internal/controllers/clusterresourceset_helpers.go
+++ b/exp/addons/internal/controllers/clusterresourceset_helpers.go
@@ -83,7 +83,7 @@ func apply(ctx context.Context, c client.Client, data []byte) error {
 	errList := []error{}
 	sortedObjs := utilresource.SortForCreate(objs)
 	for i := range sortedObjs {
-		if err := applyUnstructured(ctx, c, &objs[i]); err != nil {
+		if err := applyUnstructured(ctx, c, &sortedObjs[i]); err != nil {
 			errList = append(errList, err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Change variable in code to make object created by Cluster Resource Set will follow priority

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6500
