### PR TITLE
 :seedling: integrate controller for ExtensionConfig

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -286,9 +286,8 @@ rules:
   - runtime.cluster.x-k8s.io
   resources:
   - extensionconfigs
+  - extensionconfigs/status
   verbs:
-  - create
-  - delete
   - get
   - list
   - patch

--- a/exp/runtime/api/v1alpha1/extensionconfig_types.go
+++ b/exp/runtime/api/v1alpha1/extensionconfig_types.go
@@ -193,6 +193,9 @@ func init() {
 }
 
 const (
-	// RuntimeExtensionDiscovered is a condition set on an ExtensionConfig object once it has been discovered by the Runtime SDK client.
-	RuntimeExtensionDiscovered clusterv1.ConditionType = "Discovered"
+	// RuntimeExtensionDiscoveredCondition is a condition set on an ExtensionConfig object once it has been discovered by the Runtime SDK client.
+	RuntimeExtensionDiscoveredCondition clusterv1.ConditionType = "Discovered"
+
+	// DiscoveryFailedReason documents failure of a Discovery call.
+	DiscoveryFailedReason string = "DiscoveryFailed"
 )

--- a/exp/runtime/controllers/alias.go
+++ b/exp/runtime/controllers/alias.go
@@ -24,12 +24,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	extensionconfigs "sigs.k8s.io/cluster-api/exp/runtime/internal/controllers"
+	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
 )
 
 // ExtensionConfigReconciler reconciles an ExtensionConfig object.
 type ExtensionConfigReconciler struct {
-	Client    client.Client
-	APIReader client.Reader
+	Client        client.Client
+	APIReader     client.Reader
+	RuntimeClient runtimeclient.Client
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
@@ -39,6 +41,7 @@ func (r *ExtensionConfigReconciler) SetupWithManager(ctx context.Context, mgr ct
 	return (&extensionconfigs.Reconciler{
 		Client:           r.Client,
 		APIReader:        r.APIReader,
+		RuntimeClient:    r.RuntimeClient,
 		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -21,20 +21,27 @@ import (
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
+	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
 )
 
-// +kubebuilder:rbac:groups=runtime.cluster.x-k8s.io,resources=extensionconfigs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=runtime.cluster.x-k8s.io,resources=extensionconfigs;extensionconfigs/status,verbs=get;list;watch;patch;update
 
-// Reconciler reconciles an Extension object.
+// Reconciler reconciles an ExtensionConfig object.
 type Reconciler struct {
-	Client    client.Client
-	APIReader client.Reader
+	Client        client.Client
+	APIReader     client.Reader
+	RuntimeClient runtimeclient.Client
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
 }
@@ -43,23 +50,116 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&runtimev1.ExtensionConfig{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ResourceHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")
 	}
+
+	// warmupRunnable will attempt to sync the RuntimeSDK registry with existing ExtensionConfig objects to ensure extensions
+	// are discovered before controllers begin reconciling.
+	err = mgr.Add(&warmupRunnable{
+		Client:        r.Client,
+		APIReader:     r.APIReader,
+		RuntimeClient: r.RuntimeClient,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed adding warmupRunnable to controller manager")
+	}
 	return nil
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	extension := &runtimev1.ExtensionConfig{}
-	err := r.Client.Get(ctx, req.NamespacedName, extension)
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var errs []error
+	log := ctrl.LoggerFrom(ctx)
+	// Requeue events when the registry is not ready.
+	if !r.RuntimeClient.IsReady() {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	extensionConfig := &runtimev1.ExtensionConfig{}
+	err := r.Client.Get(ctx, req.NamespacedName, extensionConfig)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
+			// ExtensionConfig not found. Remove from registry.
+			// First need to add Namespace/Name to empty extensionConfig object.
+			extensionConfig.Name = req.Name
+			extensionConfig.Namespace = req.Namespace
+			return r.reconcileDelete(ctx, extensionConfig)
 		}
 		// Error reading the object - requeue the request.
 		return ctrl.Result{}, err
 	}
+
+	// Return early if the ExtensionConfig is paused.
+	if annotations.HasPaused(extensionConfig) {
+		log.Info("Reconciliation is paused for this object")
+		return ctrl.Result{}, nil
+	}
+
+	// Handle deletion reconciliation loop.
+	if !extensionConfig.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, extensionConfig)
+	}
+
+	// discoverExtensionConfig will return a discovered ExtensionConfig with the appropriate conditions.
+	discoveredExtensionConfig, err := discoverExtensionConfig(ctx, r.RuntimeClient, extensionConfig)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	// Always patch the ExtensionConfig as it may contain updates in conditions.
+	if err = patchExtensionConfig(ctx, r.Client, extensionConfig, discoveredExtensionConfig); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) != 0 {
+		return ctrl.Result{}, kerrors.NewAggregate(errs)
+	}
+
+	// Register the extensionConfig if it was found and patched without error.
+	if err = r.RuntimeClient.Register(discoveredExtensionConfig); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to register ExtensionConfig %s/%s", extensionConfig.Namespace, extensionConfig.Name)
+	}
 	return ctrl.Result{}, nil
+}
+
+func patchExtensionConfig(ctx context.Context, client client.Client, original, modified *runtimev1.ExtensionConfig, options ...patch.Option) error {
+	patchHelper, err := patch.NewHelper(original, client)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create PatchHelper for ExtensionConfig %s/%s", modified.Namespace, modified.Name)
+	}
+
+	options = append(options, patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
+		runtimev1.RuntimeExtensionDiscoveredCondition,
+	}})
+	err = patchHelper.Patch(ctx, modified, options...)
+	if err != nil {
+		return errors.Wrapf(err, "failed to patch ExtensionConfig %s/%s", modified.Namespace, modified.Name)
+	}
+	return nil
+}
+
+// reconcileDelete will remove the ExtensionConfig from the registry on deletion of the object. Note this is a best
+// effort deletion that may not catch all cases.
+func (r *Reconciler) reconcileDelete(_ context.Context, extensionConfig *runtimev1.ExtensionConfig) (ctrl.Result, error) {
+	if err := r.RuntimeClient.Unregister(extensionConfig); err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to unregister ExtensionConfig %s/%s", extensionConfig.Namespace, extensionConfig.Name)
+	}
+	return ctrl.Result{}, nil
+}
+
+// discoverExtensionConfig attempts to discover the Handlers for an ExtensionConfig.
+// If discovery succeeds it returns the ExtensionConfig with Handlers updated in Status and an updated Condition.
+// If discovery fails it returns the ExtensionConfig with no update to Handlers and a Failed Condition.
+func discoverExtensionConfig(ctx context.Context, runtimeClient runtimeclient.Client, extensionConfig *runtimev1.ExtensionConfig) (*runtimev1.ExtensionConfig, error) {
+	discoveredExtension, err := runtimeClient.Discover(ctx, extensionConfig.DeepCopy())
+	if err != nil {
+		modifiedExtensionConfig := extensionConfig.DeepCopy()
+		conditions.MarkFalse(modifiedExtensionConfig, runtimev1.RuntimeExtensionDiscoveredCondition, runtimev1.DiscoveryFailedReason, clusterv1.ConditionSeverityError, "error in discovery: %v", err)
+		return modifiedExtensionConfig, errors.Wrapf(err, "failed to discover ExtensionConfig %s/%s", extensionConfig.Namespace, extensionConfig.Name)
+	}
+
+	conditions.MarkTrue(discoveredExtension, runtimev1.RuntimeExtensionDiscoveredCondition)
+	return discoveredExtension, nil
 }

--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -1,0 +1,304 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
+	runtimev1registry "sigs.k8s.io/cluster-api/internal/runtime/registry"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+func TestExtensionReconciler_Reconcile(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, true)()
+
+	g := NewWithT(t)
+	ns, err := env.CreateNamespace(ctx, "test-extension-config")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cat := catalog.New()
+	registry := runtimev1registry.New()
+	runtimeClient := runtimeclient.New(runtimeclient.Options{
+		Catalog:  cat,
+		Registry: registry,
+	})
+
+	g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
+
+	r := &Reconciler{
+		Client:        env.GetClient(),
+		APIReader:     env.GetAPIReader(),
+		RuntimeClient: runtimeClient,
+	}
+
+	server := fakeExtensionServer(discoveryHandler("first", "second", "third"))
+	extensionConfig := fakeExtensionConfigForURL(ns.Name, "ext1", server.URL)
+	defer server.Close()
+	// Create the ExtensionConfig.
+	g.Expect(env.CreateAndWait(ctx, extensionConfig)).To(Succeed())
+	defer func() {
+		g.Expect(env.CleanupAndWait(ctx, extensionConfig)).To(Succeed())
+	}()
+	t.Run("fail reconcile if registry has not been warmed up", func(t *testing.T) {
+		// Attempt to reconcile. This will be an error as the registry has not been warmed up at this point.
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
+		g.Expect(err).To(BeNil())
+		// If the registry isn't warm the reconcile loop will return Requeue: True
+		g.Expect(res.Requeue).To(Equal(true))
+	})
+
+	t.Run("successful reconcile and discovery on ExtensionConfig create", func(t *testing.T) {
+		// Warm up the registry before trying reconciliation again.
+		warmup := &warmupRunnable{
+			Client:        env.GetClient(),
+			APIReader:     env.GetAPIReader(),
+			RuntimeClient: runtimeClient,
+		}
+		g.Expect(warmup.Start(ctx)).To(Succeed())
+
+		// Reconcile the extension and assert discovery has succeeded.
+		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
+		g.Expect(err).To(BeNil())
+
+		config := &runtimev1.ExtensionConfig{}
+		g.Expect(env.GetAPIReader().Get(ctx, util.ObjectKey(extensionConfig), config)).To(Succeed())
+
+		// Expect three handlers for the extension and expect the name to be the handler name plus the extension name.
+		handlers := config.Status.Handlers
+		g.Expect(len(handlers)).To(Equal(3))
+		g.Expect(handlers[0].Name).To(Equal("first.ext1"))
+		g.Expect(handlers[1].Name).To(Equal("second.ext1"))
+		g.Expect(handlers[2].Name).To(Equal("third.ext1"))
+
+		conditions := config.GetConditions()
+		g.Expect(len(conditions)).To(Equal(1))
+		g.Expect(conditions[0].Status).To(Equal(corev1.ConditionTrue))
+		g.Expect(conditions[0].Type).To(Equal(runtimev1.RuntimeExtensionDiscoveredCondition))
+		_, err = registry.Get("first.ext1")
+		g.Expect(err).To(BeNil())
+		_, err = registry.Get("second.ext1")
+		g.Expect(err).To(BeNil())
+		_, err = registry.Get("third.ext1")
+		g.Expect(err).To(BeNil())
+	})
+
+	t.Run("Successful reconcile and discovery on Extension update", func(t *testing.T) {
+		// Start a new ExtensionServer where the second handler is removed.
+		updatedServer := fakeExtensionServer(discoveryHandler("first", "third"))
+		defer updatedServer.Close()
+		// Close the original server  it's no longer serving.
+		server.Close()
+
+		// Patch the extension with the new server endpoint.
+		patch := client.MergeFrom(extensionConfig.DeepCopy())
+		extensionConfig.Spec.ClientConfig.URL = &updatedServer.URL
+
+		g.Expect(env.Patch(ctx, extensionConfig, patch)).To(Succeed())
+
+		// Wait until the object is updated in the client cache before continuing.
+		g.Eventually(func() error {
+			conf := &runtimev1.ExtensionConfig{}
+			err := env.Get(ctx, util.ObjectKey(extensionConfig), conf)
+			if err != nil {
+				return err
+			}
+			if *conf.Spec.ClientConfig.URL != updatedServer.URL {
+				return fmt.Errorf("URL not set on updated object: got: %s, want: %s", *conf.Spec.ClientConfig.URL, updatedServer.URL)
+			}
+			return nil
+		}, 30*time.Second, 100*time.Millisecond).Should(BeNil())
+
+		// Reconcile the extension and assert discovery has succeeded.
+		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
+		g.Expect(err).To(BeNil())
+
+		var config runtimev1.ExtensionConfig
+		g.Expect(env.GetAPIReader().Get(ctx, util.ObjectKey(extensionConfig), &config)).To(Succeed())
+
+		// Expect two handlers for the extension and expect the name to be the handler name plus the extension name.
+		handlers := config.Status.Handlers
+		g.Expect(len(handlers)).To(Equal(2))
+		g.Expect(handlers[0].Name).To(Equal("first.ext1"))
+		g.Expect(handlers[1].Name).To(Equal("third.ext1"))
+		conditions := config.GetConditions()
+		g.Expect(len(conditions)).To(Equal(1))
+		g.Expect(conditions[0].Status).To(Equal(corev1.ConditionTrue))
+		g.Expect(conditions[0].Type).To(Equal(runtimev1.RuntimeExtensionDiscoveredCondition))
+
+		_, err = registry.Get("first.ext1")
+		g.Expect(err).To(BeNil())
+		_, err = registry.Get("third.ext1")
+		g.Expect(err).To(BeNil())
+
+		// Second should not be found in the registry:
+		_, err = registry.Get("second.ext1")
+		g.Expect(err).ToNot(BeNil())
+	})
+	t.Run("Successful reconcile and deregister on ExtensionConfig delete", func(t *testing.T) {
+		g.Expect(env.CleanupAndWait(ctx, extensionConfig)).To(Succeed())
+		_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
+		g.Expect(env.Get(ctx, util.ObjectKey(extensionConfig), extensionConfig)).To(Not(Succeed()))
+		_, err = registry.Get("first.ext1")
+		g.Expect(err).ToNot(BeNil())
+		_, err = registry.Get("third.ext1")
+		g.Expect(err).ToNot(BeNil())
+	})
+}
+
+func TestExtensionReconciler_discoverExtensionConfig(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, true)()
+	g := NewWithT(t)
+	ns, err := env.CreateNamespace(ctx, "test-runtime-extension")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	t.Run("test discovery of a single extension", func(t *testing.T) {
+		cat := catalog.New()
+		registry := runtimev1registry.New()
+		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
+		extensionName := "ext1"
+		srv1 := fakeExtensionServer(discoveryHandler("first"))
+		defer srv1.Close()
+
+		runtimeClient := runtimeclient.New(runtimeclient.Options{
+			Catalog:  cat,
+			Registry: registry,
+		})
+
+		extensionConfig := fakeExtensionConfigForURL(ns.Name, extensionName, srv1.URL)
+
+		discoveredExtensionConfig, err := discoverExtensionConfig(ctx, runtimeClient, extensionConfig)
+		g.Expect(err).To(BeNil())
+
+		// Expect exactly one handler and expect the name to be the handler name plus the extension name.
+		handlers := discoveredExtensionConfig.Status.Handlers
+		g.Expect(len(handlers)).To(Equal(1))
+		g.Expect(handlers[0].Name).To(Equal("first.ext1"))
+
+		// Expect exactly one condition and expect the condition to have type RuntimeExtensionDiscoveredCondition and
+		// Status true.
+		conditions := discoveredExtensionConfig.GetConditions()
+		g.Expect(len(conditions)).To(Equal(1))
+		g.Expect(conditions[0].Status).To(Equal(corev1.ConditionTrue))
+		g.Expect(conditions[0].Type).To(Equal(runtimev1.RuntimeExtensionDiscoveredCondition))
+	})
+	t.Run("fail discovery for non-running extension", func(t *testing.T) {
+		cat := catalog.New()
+		registry := runtimev1registry.New()
+		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
+		extensionName := "ext1"
+
+		// Don't set up a server to run the extensionDiscovery handler.
+		// srv1 := fakeExtensionServer(discoveryHandler("first"))
+		// defer srv1.Close()
+
+		runtimeClient := runtimeclient.New(runtimeclient.Options{
+			Catalog:  cat,
+			Registry: registry,
+		})
+
+		extensionConfig := fakeExtensionConfigForURL(ns.Name, extensionName, "http://localhost:31239")
+
+		discoveredExtensionConfig, err := discoverExtensionConfig(ctx, runtimeClient, extensionConfig)
+		g.Expect(err).ToNot(BeNil())
+
+		// Expect exactly one handler and expect the name to be the handler name plus the extension name.
+		handlers := discoveredExtensionConfig.Status.Handlers
+		g.Expect(len(handlers)).To(Equal(0))
+
+		// Expect exactly one condition and expect the condition to have type RuntimeExtensionDiscoveredCondition and
+		// Status false.
+		conditions := discoveredExtensionConfig.GetConditions()
+		g.Expect(len(conditions)).To(Equal(1))
+		g.Expect(conditions[0].Status).To(Equal(corev1.ConditionFalse))
+		g.Expect(conditions[0].Type).To(Equal(runtimev1.RuntimeExtensionDiscoveredCondition))
+	})
+}
+
+func discoveryHandler(handlerList ...string) func(http.ResponseWriter, *http.Request) {
+	handlers := []runtimehooksv1.ExtensionHandler{}
+	for _, name := range handlerList {
+		handlers = append(handlers, runtimehooksv1.ExtensionHandler{
+			Name: name,
+			RequestHook: runtimehooksv1.GroupVersionHook{
+				Hook:       name,
+				APIVersion: runtimehooksv1.GroupVersion.String(),
+			},
+		})
+	}
+	response := &runtimehooksv1.DiscoveryResponse{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DiscoveryResponse",
+			APIVersion: runtimehooksv1.GroupVersion.String(),
+		},
+		Handlers: handlers,
+	}
+	respBody, err := json.Marshal(response)
+	if err != nil {
+		panic(err)
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(respBody)
+	}
+}
+
+func fakeExtensionConfigForURL(namespace, name, url string) *runtimev1.ExtensionConfig {
+	return &runtimev1.ExtensionConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ExtensionConfig",
+			APIVersion: runtimehooksv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: runtimev1.ExtensionConfigSpec{
+			ClientConfig: runtimev1.ClientConfig{
+				URL: pointer.String(url),
+			},
+			NamespaceSelector: nil,
+		},
+	}
+}
+
+func fakeExtensionServer(discoveryHandler func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", discoveryHandler)
+	srv := httptest.NewServer(mux)
+	return srv
+}

--- a/exp/runtime/internal/controllers/suite_test.go
+++ b/exp/runtime/internal/controllers/suite_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/cluster-api/api/v1beta1/index"
+	"sigs.k8s.io/cluster-api/internal/test/envtest"
+)
+
+var (
+	env *envtest.Environment
+	ctx = ctrl.SetupSignalHandler()
+)
+
+func TestMain(m *testing.M) {
+	setupIndexes := func(ctx context.Context, mgr ctrl.Manager) {
+		if err := index.AddDefaultIndexes(ctx, mgr); err != nil {
+			panic(fmt.Sprintf("unable to setup index: %v", err))
+		}
+	}
+
+	os.Exit(envtest.Run(ctx, envtest.RunInput{
+		M:            m,
+		SetupEnv:     func(e *envtest.Environment) { env = e },
+		SetupIndexes: setupIndexes,
+	}))
+}

--- a/exp/runtime/internal/controllers/warmup.go
+++ b/exp/runtime/internal/controllers/warmup.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
+	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
+)
+
+const (
+	defaultWarmupTimeout  = 60 * time.Second
+	defaultWarmupInterval = 2 * time.Second
+)
+
+var _ manager.LeaderElectionRunnable = &warmupRunnable{}
+
+// warmupRunnable is a controller runtime LeaderElectionRunnable. It warms up the registry on controller start.
+type warmupRunnable struct {
+	Client         client.Client
+	APIReader      client.Reader
+	RuntimeClient  runtimeclient.Client
+	warmupTimeout  time.Duration
+	warmupInterval time.Duration
+}
+
+// NeedLeaderElection satisfies the controller runtime LeaderElectionRunnable interface.
+// This helps ensure we warm up the RuntimeSDK registry before controllers begin reconciling.
+func (r *warmupRunnable) NeedLeaderElection() bool {
+	return true
+}
+
+// Start attempts to warm up the registry. It will retry for 60 seconds before returning an error. An error on Start will
+// cause the CAPI controller manager to fail.
+// We are retrying for 60 seconds to mitigate failures when the CAPI controller manager and RuntimeExtensions
+// are started at the same time. After 60 seconds we crash the entire controller to surface the
+// issue which block reconciliation of all Clusters to users in a timely fashion.
+func (r *warmupRunnable) Start(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx)
+	if r.warmupInterval == 0 {
+		r.warmupInterval = defaultWarmupInterval
+	}
+	if r.warmupTimeout == 0 {
+		r.warmupTimeout = defaultWarmupTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, r.warmupTimeout)
+	defer cancel()
+
+	err := wait.PollImmediateWithContext(ctx, r.warmupInterval, r.warmupTimeout, func(ctx context.Context) (done bool, err error) {
+		if err = warmupRegistry(ctx, r.Client, r.APIReader, r.RuntimeClient); err != nil {
+			log.Error(err, "ExtensionConfig registry warmup failed")
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return errors.Wrapf(err, "ExtensionConfig registry warmup timed out after  %s", r.warmupTimeout.String())
+	}
+
+	return nil
+}
+
+// warmupRegistry attempts to discover all existing ExtensionConfigs and patch their Status with discovered Handlers.
+// It warms up the registry by passing it the up-to-date list of ExtensionConfigs.
+func warmupRegistry(ctx context.Context, client client.Client, reader client.Reader, runtimeClient runtimeclient.Client) error {
+	var errs []error
+
+	extensionConfigList := runtimev1.ExtensionConfigList{}
+	if err := reader.List(ctx, &extensionConfigList); err != nil {
+		return err
+	}
+
+	for i := range extensionConfigList.Items {
+		extensionConfig := &extensionConfigList.Items[i]
+		original := extensionConfig.DeepCopy()
+
+		extensionConfig, err := discoverExtensionConfig(ctx, runtimeClient, extensionConfig)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		// Patch the ExtensionConfig with the updated condition and Handlers if discovered.
+		if err = patchExtensionConfig(ctx, client, original, extensionConfig); err != nil {
+			errs = append(errs, err)
+		}
+		extensionConfigList.Items[i] = *extensionConfig
+	}
+
+	// If there was some error in discovery or patching return before committing to the Registry.
+	if len(errs) != 0 {
+		return kerrors.NewAggregate(errs)
+	}
+
+	if err := runtimeClient.WarmUp(&extensionConfigList); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/exp/runtime/internal/controllers/warmup_test.go
+++ b/exp/runtime/internal/controllers/warmup_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	utilfeature "k8s.io/component-base/featuregate/testing"
+
+	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
+	runtimev1registry "sigs.k8s.io/cluster-api/internal/runtime/registry"
+)
+
+func Test_warmupRunnable_Start(t *testing.T) {
+	g := NewWithT(t)
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.ClusterTopology, true)()
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, true)()
+
+	t.Run("succeed to warm up registry on Start", func(t *testing.T) {
+		ns, err := env.CreateNamespace(ctx, "test-runtime-extension")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		cat := catalog.New()
+		registry := runtimev1registry.New()
+		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
+
+		for _, name := range []string{"ext1", "ext2", "ext3"} {
+			server := fakeExtensionServer(discoveryHandler("first", "second", "third"))
+			defer server.Close()
+			g.Expect(env.CreateAndWait(ctx, fakeExtensionConfigForURL(ns.Name, name, server.URL))).To(Succeed())
+
+			defer func(namespace, name, url string) {
+				g.Expect(env.CleanupAndWait(ctx, fakeExtensionConfigForURL(namespace, name, url))).To(Succeed())
+			}(ns.Name, name, server.URL)
+		}
+
+		r := &warmupRunnable{
+			Client:    env.GetClient(),
+			APIReader: env.GetAPIReader(),
+			RuntimeClient: runtimeclient.New(runtimeclient.Options{
+				Catalog:  cat,
+				Registry: registry,
+			}),
+		}
+
+		if err := r.Start(ctx); err != nil {
+			t.Error(err)
+		}
+		list := &runtimev1.ExtensionConfigList{}
+		g.Expect(env.GetAPIReader().List(ctx, list)).To(Succeed())
+		g.Expect(len(list.Items)).To(Equal(3))
+		for i, config := range list.Items {
+			// Expect three handlers for each extension and expect the name to be the handler name plus the extension name.
+			handlers := config.Status.Handlers
+			g.Expect(len(handlers)).To(Equal(3))
+			g.Expect(handlers[0].Name).To(Equal(fmt.Sprintf("first.ext%d", i+1)))
+			g.Expect(handlers[1].Name).To(Equal(fmt.Sprintf("second.ext%d", i+1)))
+			g.Expect(handlers[2].Name).To(Equal(fmt.Sprintf("third.ext%d", i+1)))
+
+			conditions := config.GetConditions()
+			g.Expect(len(conditions)).To(Equal(1))
+			g.Expect(conditions[0].Status).To(Equal(corev1.ConditionTrue))
+			g.Expect(conditions[0].Type).To(Equal(runtimev1.RuntimeExtensionDiscoveredCondition))
+		}
+	})
+
+	t.Run("fail to warm up registry on Start with broken extension", func(t *testing.T) {
+		// This test should time out and throw a failure.
+		ns, err := env.CreateNamespace(ctx, "test-runtime-extension")
+		g.Expect(err).ToNot(HaveOccurred())
+
+		cat := catalog.New()
+		registry := runtimev1registry.New()
+		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
+
+		// Do not create an extension server for an extension with this name, but do create an extensionconfig.
+		brokenExtension := "ext2"
+		for _, name := range []string{"ext1", "ext2", "ext3"} {
+			if name == brokenExtension {
+				g.Expect(env.CreateAndWait(ctx, fakeExtensionConfigForURL(ns.Name, name, "http://localhost:1234"))).To(Succeed())
+				continue
+			}
+			server := fakeExtensionServer(discoveryHandler("first", "second", "third"))
+			g.Expect(env.CreateAndWait(ctx, fakeExtensionConfigForURL(ns.Name, name, server.URL))).To(Succeed())
+			defer server.Close()
+		}
+
+		r := &warmupRunnable{
+			Client:    env.GetClient(),
+			APIReader: env.GetAPIReader(),
+			RuntimeClient: runtimeclient.New(runtimeclient.Options{
+				Catalog:  cat,
+				Registry: registry,
+			}),
+			warmupInterval: 500 * time.Millisecond,
+			warmupTimeout:  5 * time.Second,
+		}
+
+		if err := r.Start(ctx); err == nil {
+			t.Error(fmt.Errorf("expected error on start up"))
+		}
+		list := &runtimev1.ExtensionConfigList{}
+		g.Expect(env.GetAPIReader().List(ctx, list)).To(Succeed())
+		g.Expect(len(list.Items)).To(Equal(3))
+
+		for i, config := range list.Items {
+			handlers := config.Status.Handlers
+			conditions := config.GetConditions()
+
+			// Expect no handlers and a failed condition for the broken extension.
+			if config.Name == brokenExtension {
+				g.Expect(len(conditions)).To(Equal(1))
+				g.Expect(conditions[0].Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(conditions[0].Type).To(Equal(runtimev1.RuntimeExtensionDiscoveredCondition))
+				g.Expect(len(handlers)).To(Equal(0))
+
+				continue
+			}
+
+			// For other extensions expect handler name plus the extension name, and expect the condition to be True.
+			g.Expect(len(handlers)).To(Equal(3))
+			g.Expect(handlers[0].Name).To(Equal(fmt.Sprintf("first.ext%d", i+1)))
+			g.Expect(handlers[1].Name).To(Equal(fmt.Sprintf("second.ext%d", i+1)))
+			g.Expect(handlers[2].Name).To(Equal(fmt.Sprintf("third.ext%d", i+1)))
+
+			g.Expect(len(conditions)).To(Equal(1))
+			g.Expect(conditions[0].Status).To(Equal(corev1.ConditionTrue))
+			g.Expect(conditions[0].Type).To(Equal(runtimev1.RuntimeExtensionDiscoveredCondition))
+		}
+	})
+}

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -54,7 +54,9 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
+	runtimev1webhooks "sigs.k8s.io/cluster-api/internal/webhooks/runtime"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/webhooks"
 )
@@ -78,6 +80,7 @@ func init() {
 	utilruntime.Must(addonsv1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(controlplanev1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(admissionv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(runtimev1.AddToScheme(scheme.Scheme))
 }
 
 // RunInput is the input for Run.
@@ -252,6 +255,9 @@ func newEnvironment(uncachedObjs ...client.Object) *Environment {
 	}
 	if err := (&expv1.MachinePool{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("unable to create webhook for machinepool: %+v", err)
+	}
+	if err := (&runtimev1webhooks.ExtensionConfig{}).SetupWebhookWithManager(mgr); err != nil {
+		klog.Fatalf("unable to create webhook for extensionconfig: %+v", err)
 	}
 
 	return &Environment{


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Adds an implementation of the ExtensionConfig controller. This controller is responsible for:
1) Warming up the registry when the controller starts
2) Discovering newly created and updated extensions
3) Removing Deleted extensions from the registry 
4) Adding conditions that surface the outcome of the most recent Discovery call (Succeeded or Failed with some reason)

Part of #6330 

