### PR TITLE
📖 Reformat shell command and output in the book

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -390,10 +390,16 @@ All our CRD objects should have the following `additionalPrinterColumns` order (
 
 Examples:
 ```bash
-$ kubectl get kubeadmcontrolplane
+kubectl get kubeadmcontrolplane
+```
+```bash
 NAMESPACE            NAME                               INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE     VERSION
 quick-start-d5ufye   quick-start-ntysk0-control-plane   true          true                   1          1       1                       2m44s   v1.23.3
-$ kubectl get machinedeployment
+```
+```bash
+kubectl get machinedeployment
+```
+```bash
 NAMESPACE            NAME                      CLUSTER              REPLICAS   READY   UPDATED   UNAVAILABLE   PHASE       AGE     VERSION
 quick-start-d5ufye   quick-start-ntysk0-md-0   quick-start-ntysk0   1                  1         1             ScalingUp   3m28s   v1.23.3
 ```

--- a/docs/book/src/clusterctl/commands/alpha-rollout.md
+++ b/docs/book/src/clusterctl/commands/alpha-rollout.md
@@ -16,7 +16,7 @@ Currently, only the following Cluster API resources are supported by the rollout
 
 Use the `restart` sub-command to force an immediate rollout. Note that rollout refers to the replacement of existing machines with new machines using the desired rollout strategy (default: rolling update). For example, here the MachineDeployment `my-md-0` will be immediately rolled out:
 
-```
+```bash
 clusterctl alpha rollout restart machinedeployment/my-md-0
 ```
 
@@ -24,7 +24,7 @@ clusterctl alpha rollout restart machinedeployment/my-md-0
 
 Use the `undo` sub-command to rollback to an earlier revision. For example, here the MachineDeployment `my-md-0` will be rolled back to revision number 3. If the `--to-revision` flag is omitted, the MachineDeployment will be rolled back to the revision immediately preceding the current one. If the desired revision does not exist, the undo will return an error.
 
-```
+```bash
 clusterctl alpha rollout undo machinedeployment/my-md-0 --to-revision=3
 ```
 
@@ -32,13 +32,13 @@ clusterctl alpha rollout undo machinedeployment/my-md-0 --to-revision=3
 
 Use the `pause` sub-command to pause a Cluster API resource. The command is a NOP if the resource is already paused. Note that internally, this command sets the `Paused` field within the resource spec (e.g. MachineDeployment.Spec.Paused) to true. 
 
-```
+```bash
 clusterctl alpha rollout pause machinedeployment/my-md-0
 ```
 
 Use the `resume` sub-command to resume a currently paused Cluster API resource. The command is a NOP if the resource is currently not paused. 
 
-```
+```bash
 clusterctl alpha rollout resume machinedeployment/my-md-0
 ```
 

--- a/docs/book/src/clusterctl/commands/alpha-topology-plan.md
+++ b/docs/book/src/clusterctl/commands/alpha-topology-plan.md
@@ -9,7 +9,7 @@ depending on the use case you are going to plan for (see more details below).
 The topology plan output would provide details about objects that will be created, updated and deleted of a target cluster; 
 If instead the command detects that the change impacts many Clusters, the users will be required to select one to focus on (see flags below).
 
-```shell
+```bash
 clusterctl alpha topology plan -f input.yaml -o output/
 ```
 
@@ -50,7 +50,7 @@ More specifically:
 When designing a new ClusterClass users might want to preview the Cluster generated using such ClusterClass. 
 The `clusterctl alpha topology plan command` can be used to do so:
 
-```shell
+```bash
 clusterctl alpha topology plan -f example-cluster-class.yaml -f example-cluster.yaml -o output/
 ```
 
@@ -209,7 +209,7 @@ spec:
 </details>
 
 Produces an output similar to this:
-```shell
+```bash
 The following ClusterClasses will be affected by the changes:
  ＊ default/example-cluster-class
 
@@ -233,7 +233,7 @@ Modified objects are written to directory "output/modified"
 ```
 
 The contents of the output directory are similar to this:
-```
+```bash
 output
 ├── created
 │   ├── DockerCluster_default_example-cluster-rnx2q.yaml
@@ -254,7 +254,7 @@ output
 
 When making changes to a Cluster topology the `clusterctl alpha topology plan` can be used to analyse how the underlying objects will be affected.
 
-```shell
+```bash
 clusterctl alpha topology plan -f modified-example-cluster.yaml -o output/
 ```
 
@@ -297,7 +297,7 @@ spec:
 </details>
 
 Produces an output similar to this:
-```shell
+```bash
 Detected a cluster with Cluster API installed. Will use it to fetch missing objects.
 No ClusterClasses will be affected by the changes.
 The following Clusters will be affected by the changes:
@@ -317,7 +317,7 @@ Modified objects are written to directory "output/modified"
 The command can be used to plan if a Cluster can be successfully rebased to a different ClusterClass.
 
 Rebasing a Cluster to a different ClusterClass:
-```shell
+```bash
 # Rebasing from `example-cluster-class` to `another-cluster-class`.
 clusterctl alpha topology plan -f rebase-example-cluster.yaml -o output/
 ```
@@ -357,7 +357,7 @@ spec:
 </details>
 
 If the target ClusterClass is compatible with the original ClusterClass the output be similar to:
-```shell
+```bash
 Detected a cluster with Cluster API installed. Will use it to fetch missing objects.
 No ClusterClasses will be affected by the changes.
 The following Clusters will be affected by the changes:
@@ -376,7 +376,7 @@ Modified objects are written to directory "output/modified"
 ```
 
 Instead, if the command detects that the rebase operation would lead to a non-functional cluster (ClusterClasses are incompatible), the output will be similar to:
-```shell
+```bash
 Detected a cluster with Cluster API installed. Will use it to fetch missing objects.
 Error: failed defaulting and validation on input objects: failed to run defaulting and validation on Clusters: failed validation of cluster.x-k8s.io/v1beta1, Kind=Cluster default/example-cluster: Cluster.cluster.x-k8s.io "example-cluster" is invalid: spec.topology.workers.machineDeployments[0].class: Invalid value: "default-worker": MachineDeploymentClass with name "default-worker" does not exist in ClusterClass "another-cluster-class"
 ```
@@ -386,11 +386,11 @@ In this example rebasing will lead to a non-functional Cluster because the Clust
 
 When planning for a change on a ClusterClass you might want to understand what effects the change will have on existing clusters.
 
-```shell
+```bash
 clusterctl alpha topology plan -f modified-first-cluster-class.yaml -o output/
 ```
 When multiple clusters are affected, only the list of Clusters and ClusterClasses is presented.
-```shell
+```bash
 Detected a cluster with Cluster API installed. Will use it to fetch missing objects.
 The following ClusterClasses will be affected by the changes:
  ＊ default/first-cluster-class
@@ -403,7 +403,7 @@ No target cluster identified. Use --cluster to specify a target cluster to get d
 ```
 
 To get the full list of changes for the "first-cluster":
-```shell
+```bash
 clusterctl alpha topology plan -f modified-first-cluster-class.yaml -o output/ -c "first-cluster"
 ```
 Output will be similar to the full summary output provided in other examples.

--- a/docs/book/src/clusterctl/commands/completion.md
+++ b/docs/book/src/clusterctl/commands/completion.md
@@ -16,7 +16,7 @@ This requires the bash-completion framework.
 
 To install `bash-completion` on macOS, use Homebrew:
 
-```
+```bash
 brew install bash-completion
 ```
 
@@ -34,11 +34,11 @@ You now have to ensure that the clusterctl completion script gets sourced in
 all your shell sessions. There are multiple ways to achieve this:
 
 - Source the completion script in your `~/.bash_profile` file:
-    ```
+    ```bash
     source <(clusterctl completion bash)
     ```
 - Add the completion script to the /usr/local/etc/bash_completion.d directory:
-    ```
+    ```bash
     clusterctl completion bash >/usr/local/etc/bash_completion.d/clusterctl
     ```
 

--- a/docs/book/src/clusterctl/commands/delete.md
+++ b/docs/book/src/clusterctl/commands/delete.md
@@ -4,7 +4,7 @@ The `clusterctl delete` command deletes the provider components from the managem
 
 The operation is designed to prevent accidental deletion of user created objects. For example:
 
-```shell
+```bash
 clusterctl delete --infrastructure aws
 ```
 
@@ -35,7 +35,7 @@ the aws provider, it deletes all the `AWSCluster`, `AWSMachine` etc.
 
 If you want to delete all the providers in a single operation , you can use the `--all` flag.
 
-```shell
+```bash
 clusterctl delete --all
 ```
 [issue 3119]: https://github.com/kubernetes-sigs/cluster-api/issues/3119

--- a/docs/book/src/clusterctl/commands/generate-cluster.md
+++ b/docs/book/src/clusterctl/commands/generate-cluster.md
@@ -4,7 +4,7 @@ The `clusterctl generate cluster` command returns a YAML template for creating a
 
 For example
 
-```
+```bash
 clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 --control-plane-machine-count=3 --worker-machine-count=3 > my-cluster.yaml
 ```
 
@@ -15,7 +15,7 @@ specify a different target namespace).
 Then, the file can be modified using your editor of choice; when ready, run the following command
 to apply the cluster manifest.
 
-```
+```bash
 kubectl apply -f my-cluster.yaml
 ```
 
@@ -28,14 +28,14 @@ selects a cluster template from the `aws` provider's repository.
 In case there is more than one infrastructure provider, the following syntax can be used to select which infrastructure
 provider to use for the workload cluster:
 
-```
+```bash
 clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
     --infrastructure aws > my-cluster.yaml
 ```
 
 or
 
-```
+```bash
 clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
     --infrastructure aws:v0.4.1 > my-cluster.yaml
 ```
@@ -45,7 +45,7 @@ clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
 The infrastructure provider authors can provide different types of cluster templates, or flavors; use the `--flavor` flag
 to specify which flavor to use; e.g.
 
-```
+```bash
 clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
     --flavor high-availability > my-cluster.yaml
 ```
@@ -61,7 +61,7 @@ for cluster templates can be used as well:
 
 Use the `--from-config-map` flag to read cluster templates stored in a Kubernetes ConfigMap; e.g.
 
-```
+```bash
 clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
     --from-config-map my-templates > my-cluster.yaml
 ```
@@ -73,14 +73,14 @@ Also following flags are available `--from-config-map-namespace` (defaults to cu
 
 Use the `--from` flag to read cluster templates stored in a GitHub repository or in a local file system folder; e.g.
 
-```
+```bash
 clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
    --from https://github.com/my-org/my-repository/blob/main/my-template.yaml > my-cluster.yaml
 ```
 
 or
 
-```
+```bash
 clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
    --from ~/my-template.yaml > my-cluster.yaml
 ```

--- a/docs/book/src/clusterctl/commands/get-kubeconfig.md
+++ b/docs/book/src/clusterctl/commands/get-kubeconfig.md
@@ -7,18 +7,18 @@ This functionality is available in clusterctl v0.3.9 or newer.
 
 Get the kubeconfig of a workload cluster named foo.
 
-```shell
+```bash
 clusterctl get kubeconfig foo
 ```
 
 Get the kubeconfig of a workload cluster named foo in the namespace bar
 
-```shell
+```bash
 clusterctl get kubeconfig foo --namespace bar
 ```
 
 Get the kubeconfig of a workload cluster named foo using a specific context bar
 
-```shell
+```bash
 clusterctl get kubeconfig foo --kubeconfig-context bar
 ```

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -121,7 +121,7 @@ See [clusterctl configuration](../configuration.md) for more info about provider
 If, for any reasons, the user wants to replace the assets available on a provider repository with a locally available asset,
 the user is required to save the file under `$HOME/.cluster-api/overrides/<provider-label>/<version>/<file-name.yaml>`.
 
-```
+```bash
 $HOME/.cluster-api/overrides/infrastructure-aws/v0.5.2/infrastructure-components.yaml
 ```
 

--- a/docs/book/src/clusterctl/commands/move.md
+++ b/docs/book/src/clusterctl/commands/move.md
@@ -17,7 +17,7 @@ corresponding provider in the source cluster.
 
 You can use:
 
-```shell
+```bash
 clusterctl move --to-kubeconfig="path-to-target-kubeconfig.yaml"
 ```
 

--- a/docs/book/src/clusterctl/commands/upgrade.md
+++ b/docs/book/src/clusterctl/commands/upgrade.md
@@ -8,13 +8,13 @@ installed into a management cluster.
 The `clusterctl upgrade plan` command can be used to identify possible targets for upgrades.
 
 
-```shell
+```bash
 clusterctl upgrade plan
 ```
 
 Produces an output similar to this:
 
-```shell
+```bash
 Checking cert-manager version...
 Cert-Manager will be upgraded from "v1.5.0" to "v1.5.3"
 
@@ -27,10 +27,9 @@ bootstrap-kubeadm       capi-kubeadm-bootstrap-system       BootstrapProvider   
 control-plane-kubeadm   capi-kubeadm-control-plane-system   ControlPlaneProvider     v0.4.0           v1.0.0
 cluster-api             capi-system                         CoreProvider             v0.4.0           v1.0.0
 infrastructure-docker   capd-system                         InfrastructureProvider   v0.4.0           v1.0.0
-
-
+```
 You can now apply the upgrade by executing the following command:
-
+```bash
    clusterctl upgrade apply --contract v1beta1
 ```
 
@@ -53,7 +52,7 @@ After choosing the desired option for the upgrade, you can run the following
 command to upgrade all the providers in the management cluster. This upgrades
 all the providers to the latest stable releases.
 
-```shell
+```bash
 clusterctl upgrade apply --contract v1beta1
 ```
 
@@ -85,7 +84,7 @@ User is required to re-apply flag values after the upgrade completes.
 In order to upgrade to a provider's pre-release version, we can do
 the following:
 
-```shell
+```bash
 clusterctl upgrade apply \
     --core capi-system/cluster-api:v1.0.0 \
     --bootstrap capi-kubeadm-bootstrap-system/kubeadm:v1.0.0 \

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -146,6 +146,8 @@ run,
 
 ```bash
 clusterctl init --infrastructure aws:v0.5.0 -v5
+```
+```bash
 ...
 Using Override="infrastructure-components.yaml" Provider="infrastructure-aws" Version="v0.5.0"
 ...

--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -12,7 +12,7 @@ This document describes how to use `clusterctl` during the development workflow.
 
 From the root of the local copy of Cluster API, you can build the `clusterctl` binary by running:
 
-```shell
+```bash
 make clusterctl
 ```
 
@@ -35,13 +35,13 @@ If you want to create a local artifact, follow these instructions:
 
 In order to build artifacts for the CAPI core provider, the kubeadm bootstrap provider and the kubeadm control plane provider:
 
-```
+```bash
 make docker-build REGISTRY=gcr.io/k8s-staging-cluster-api PULL_POLICY=IfNotPresent
 ```
 
 In order to build docker provider artifacts
 
-```
+```bash
 make docker-capd-build REGISTRY=gcr.io/k8s-staging-cluster-api PULL_POLICY=IfNotPresent
 ```
 
@@ -67,7 +67,7 @@ a `clusterctl-settings.json` file describing how to build the provider assets.
 
 Run the create-local-repository hack from the root of the local copy of Cluster API:
 
-```shell
+```bash
 cmd/clusterctl/hack/create-local-repository.py
 ```
 
@@ -76,7 +76,7 @@ and places them in a local repository folder located under `$HOME/.cluster-api/d
 Additionally, the command output provides you the `clusterctl init` command with all the necessary flags.
 The output should be similar to:
 
-```shell
+```bash
 clusterctl local overrides generated from local repositories for the cluster-api, bootstrap-kubeadm, control-plane-kubeadm, infrastructure-docker, infrastructure-aws providers.
 in order to use them, please run:
 
@@ -87,7 +87,6 @@ clusterctl init \
    --infrastructure aws:v0.5.0 \
    --infrastructure docker:v0.3.8 \
    --config ~/.cluster-api/dev-repository/config.yaml
-
 ```
 
 As you might notice, the command is using the `$HOME/.cluster-api/dev-repository/config.yaml` config file,
@@ -140,7 +139,7 @@ See [Install and/or configure a kubernetes cluster] for more information.
 This is always the case for images published in some image repository like docker hub or gcr.io, but it can't be
 the case for images built locally; in this case, you can use `kind load` to move the images built locally. e.g.
 
-```
+```bash
 kind load docker-image gcr.io/k8s-staging-cluster-api/cluster-api-controller-amd64:dev
 kind load docker-image gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller-amd64:dev
 kind load docker-image gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-amd64:dev
@@ -157,9 +156,12 @@ Optionally, you may want to check if the components are running properly. The
 exact components are dependent on which providers you have initialized. Below
 is an example output with the docker provider being installed.
 
-```
+```bash
 kubectl get deploy -A | grep  "cap\|cert"
-capd-system                         capd-controller-manager                         1/1     1            1           25m
+capd-system
+```
+```bash
+capd-controller-manager                         1/1     1            1           25m
 capi-kubeadm-bootstrap-system       capi-kubeadm-bootstrap-controller-manager       1/1     1            1           25m
 capi-kubeadm-control-plane-system   capi-kubeadm-control-plane-controller-manager   1/1     1            1           25m
 capi-system                         capi-controller-manager                         1/1     1            1           25m

--- a/docs/book/src/clusterctl/provider-contract.md
+++ b/docs/book/src/clusterctl/provider-contract.md
@@ -56,7 +56,7 @@ clusterctl supports reading from a repository defined on the local file system.
 A local repository can be defined by creating a `<provider-label>` folder with a `<version>` sub-folder for each hosted release;
 the sub-folder name MUST be a valid semantic version number. e.g.
 
-```
+```bash
 ~/local-repository/infrastructure-aws/v0.5.2
 ```
 

--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -67,7 +67,7 @@ You'll need [`envsubst`][envsubst] or similar to handle clusterctl var replaceme
 
 We provide a make target to generate the `envsubst` binary if desired. See the [provider contract][provider-contract] for more details about how clusterctl uses variables.
 
-```
+```bash
 make envsubst
 ```
 
@@ -111,26 +111,29 @@ Many of the Cluster API engineers use it for quick iteration. Please see our [Ti
 
 You'll need to build two docker images, one for Cluster API itself and one for the Docker provider (CAPD).
 
-```
+```bash
 make docker-build
 make docker-capd-build
 ```
 
 ### Push both images
 
-```shell
-$ make docker-push
+```bash
+make docker-push
+```
+```bash
 docker push gcr.io/cluster-api-242700/cluster-api-controller-amd64:dev
 The push refers to repository [gcr.io/cluster-api-242700/cluster-api-controller-amd64]
 90a39583ad5f: Layer already exists
 932da5156413: Layer already exists
 dev: digest: sha256:263262cfbabd3d1add68172a5a1d141f6481a2bc443672ce80778dc122ee6234 size: 739
+```
+```bash
 $ make docker-capd-push
+```
+```bash
 docker push gcr.io/cluster-api-242700/capd-manager-amd64:dev
 The push refers to repository [gcr.io/cluster-api-242700/capd-manager-amd64]
-5b1e744b2bae: Pushed
-932da5156413: Layer already exists
-dev: digest: sha256:35670a049372ae063dad910c267a4450758a139c4deb248c04c3198865589ab2 size: 739
 ```
 
 Make a note of the URLs and the digests. You'll need them for the next step. In this case, they're...
@@ -143,7 +146,7 @@ and
 
 ### Edit the manifests
 
-```
+```bash
 $EDITOR config/manager/manager_image_patch.yaml
 $EDITOR test/infrastructure/docker/config/manager/manager_image_patch.yaml
 ```
@@ -165,8 +168,10 @@ spec:
 ```
 
 ### Apply the manifests
-```shell
-$ kustomize build config/ | ./hack/tools/bin/envsubst | kubectl apply -f -
+```bash
+kustomize build config/ | ./hack/tools/bin/envsubst | kubectl apply -f -
+```
+```bash
 namespace/capi-system configured
 customresourcedefinition.apiextensions.k8s.io/clusters.cluster.x-k8s.io configured
 customresourcedefinition.apiextensions.k8s.io/kubeadmconfigs.bootstrap.cluster.x-k8s.io configured
@@ -179,8 +184,11 @@ clusterrole.rbac.authorization.k8s.io/capi-manager-role configured
 rolebinding.rbac.authorization.k8s.io/capi-leader-election-rolebinding configured
 clusterrolebinding.rbac.authorization.k8s.io/capi-manager-rolebinding configured
 deployment.apps/capi-controller-manager created
-
-$ kustomize build test/infrastructure/docker/config | ./hack/tools/bin/envsubst | kubectl apply -f -
+```
+```bash
+kustomize build test/infrastructure/docker/config | ./hack/tools/bin/envsubst | kubectl apply -f -
+```
+```bash
 namespace/capd-system configured
 customresourcedefinition.apiextensions.k8s.io/dockerclusters.infrastructure.cluster.x-k8s.io configured
 customresourcedefinition.apiextensions.k8s.io/dockermachines.infrastructure.cluster.x-k8s.io configured
@@ -197,11 +205,13 @@ deployment.apps/capd-controller-manager created
 
 ### Check the status of the clusters
 
-```shell
-$ kubectl get po -n capd-system
+```bash
+kubectl get po -n capd-system
+```
+```bash
 NAME                                       READY   STATUS    RESTARTS   AGE
 capd-controller-manager-7568c55d65-ndpts   2/2     Running   0          71s
-$ kubectl get po -n capi-system
+kubectl get po -n capi-system
 NAME                                      READY   STATUS    RESTARTS   AGE
 capi-controller-manager-bf9c6468c-d6msj   1/1     Running   0          2m9s
 ```

--- a/docs/book/src/developer/providers/implementers-guide/building_running_and_testing.md
+++ b/docs/book/src/developer/providers/implementers-guide/building_running_and_testing.md
@@ -22,7 +22,7 @@ Before you apply Cluster API's yaml, you should [install `cert-manager`][cm-inst
 [cert-manager]: https://github.com/cert-manager/cert-manager
 [cm-install]: https://cert-manager.io/docs/installation/
 
-```
+```bash
 kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/<version>/cert-manager.yaml
 ```
 
@@ -32,15 +32,17 @@ Before you can deploy the infrastructure controller, you'll need to deploy Clust
 
 You can use a precompiled manifest from the release page, or clone [`cluster-api`][capi] and apply its manifests using `kustomize`.
 
-``` shell
+```bash
 cd cluster-api
 kustomize build config/ | kubectl apply -f-
 ```
 
 Check the status of the manager to make sure it's running properly
 
-```shell
-$ kubectl describe -n capi-system pod | grep -A 5 Conditions
+```bash
+kubectl describe -n capi-system pod | grep -A 5 Conditions
+```
+```bash
 Conditions:
   Type              Status
   Initialized       True
@@ -55,10 +57,12 @@ Conditions:
 
 Now you can apply your provider as well:
 
+```bash
+cd cluster-api-provider-mailgun
+kustomize build config/ | envsubst | kubectl apply -f-
+kubectl describe -n cluster-api-provider-mailgun-system pod | grep -A 5 Conditions
 ```
-$ cd cluster-api-provider-mailgun
-$ kustomize build config/ | envsubst | kubectl apply -f-
-$ kubectl describe -n cluster-api-provider-mailgun-system pod | grep -A 5 Conditions
+```bash
 Conditions:
   Type              Status
   Initialized       True

--- a/docs/book/src/developer/providers/implementers-guide/configure.md
+++ b/docs/book/src/developer/providers/implementers-guide/configure.md
@@ -87,7 +87,7 @@ resources:
 
 You can now (hopefully) generate your yaml!
 
-```
+```bash
 kustomize build config/
 ```
 
@@ -142,7 +142,7 @@ You'll need to have those environment variables (`MAILGUN_API_KEY`, `MAILGUN_DOM
 
 Then we call envsubst in line, like so:
 
-```
+```bash
 kustomize build config/ | envsubst
 ```
 

--- a/docs/book/src/developer/providers/implementers-guide/generate_crds.md
+++ b/docs/book/src/developer/providers/implementers-guide/generate_crds.md
@@ -9,7 +9,9 @@ git init
 You'll then need to set up [go modules][gomod]
 
 ```bash
-$ go mod init github.com/liztio/cluster-api-provider-mailgun
+go mod init github.com/liztio/cluster-api-provider-mailgun
+```
+```bash
 go: creating new go.mod: module github.com/liztio/cluster-api-provider-mailgun
 ```
 [gomod]: https://github.com/golang/go/wiki/Modules#how-to-define-a-module
@@ -39,7 +41,7 @@ kubebuilder create api --group infrastructure --version v1alpha3 --kind MailgunC
 kubebuilder create api --group infrastructure --version v1alpha3 --kind MailgunMachine
 ```
 
-```
+```bash
 Create Resource under pkg/apis [y/n]?
 y
 Create Controller under pkg/controller [y/n]?
@@ -71,7 +73,7 @@ type MailgunMachine struct {
 ```
 
 And regenerate the CRDs:
-```shell
+```bash
 make manifests
 ```
 

--- a/docs/book/src/developer/providers/implementers-guide/overview.md
+++ b/docs/book/src/developer/providers/implementers-guide/overview.md
@@ -52,7 +52,7 @@ sudo chmod u+x /usr/local/bin/kustomize
 {{#/tab }}
 {{#/tabs }}
 
-```
+```bash
 # Install Kubebuilder
 os=$(go env GOOS)
 arch=$(go env GOARCH)

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -26,7 +26,7 @@ To create a pre-configured cluster run:
 
 ```bash
 ./hack/kind-install-for-capd.sh
-````
+```
 
 You can see the status of the cluster with:
 
@@ -120,7 +120,7 @@ An Azure Service Principal is needed for populating the controller manifests. Th
 
 Add the output of the following as a section in your `tilt-settings.yaml`:
 
-  ```shell
+```bash
   cat <<EOF
   kustomize_substitutions:
      AZURE_SUBSCRIPTION_ID_B64: "$(echo "${AZURE_SUBSCRIPTION_ID}" | tr -d '\n' | base64 | tr -d '\n')"
@@ -248,7 +248,7 @@ manager --logging-format=json
 
 To launch your development environment, run
 
-``` bash
+```bash
 tilt up
 ```
 

--- a/docs/book/src/tasks/experimental-features/cluster-class/operate-cluster.md
+++ b/docs/book/src/tasks/experimental-features/cluster-class/operate-cluster.md
@@ -17,7 +17,8 @@ Let's assume we have created a CAPD cluster with ClusterClass and specified Kube
 
 ```bash
 > kubectl get kubeadmcontrolplane,machinedeployments
-
+```
+```bash
 NAME                                                                              CLUSTER                   INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE     VERSION
 kubeadmcontrolplane.controlplane.cluster.x-k8s.io/clusterclass-quickstart-XXXX    clusterclass-quickstart   true          true                   1          1       1         0             2m21s   v1.21.2
 
@@ -70,7 +71,7 @@ Assume we have created a CAPD cluster with ClusterClass and Kubernetes v1.23.3 (
 kubectl get machinedeployments
 ```
 Will give us:
-```bash 
+```bash
 NAME                                                            CLUSTER           REPLICAS   READY   UPDATED   UNAVAILABLE   PHASE     AGE   VERSION
 machinedeployment.cluster.x-k8s.io/capi-quickstart-md-0-XXXX   capi-quickstart   3          3       3         0             Running   21m   v1.23.3
 ```
@@ -179,8 +180,7 @@ In order to specify the value of a variable all we have to do is set the value i
 
 We can see the current unset variable with:
 ```bash 
-kubectl get cluster capi-quickstart -o jsonpath='{.spec.topology.variables[1]}'                                                                     
-
+kubectl get cluster capi-quickstart -o jsonpath='{.spec.topology.variables[1]}'                                     
 ```
 Which will return something like:
 ```bash

--- a/docs/book/src/tasks/experimental-features/experimental-features.md
+++ b/docs/book/src/tasks/experimental-features/experimental-features.md
@@ -57,8 +57,10 @@ For more details on setting up a development environment with `tilt`, see [Devel
 To enable/disable features on existing management clusters, users can modify CAPI controller manager deployment which will restart all controllers with requested features.
 
 ```
-#  kubectl edit -n capi-system deployment.apps/capi-controller-manager
-   // Enable/disable available feautures by modifying Args below.
+kubectl edit -n capi-system deployment.apps/capi-controller-manager
+```
+```
+// Enable/disable available feautures by modifying Args below.
     Args:
       --leader-elect
       --feature-gates=MachinePool=true,ClusterResourceSet=true
@@ -66,8 +68,8 @@ To enable/disable features on existing management clusters, users can modify CAP
 
 Similarly, to **validate** if a particular feature is enabled, see cluster-api-provider deployment arguments by:
 
-```
-# kubectl describe -n capi-system deployment.apps/capi-controller-manager
+```bash
+kubectl describe -n capi-system deployment.apps/capi-controller-manager
 ```
 
 ## Active Experimental Features

--- a/docs/book/src/tasks/experimental-features/ignition.md
+++ b/docs/book/src/tasks/experimental-features/ignition.md
@@ -93,7 +93,7 @@ kubectl get kubeadmcontrolplane ignition-cluster-control-plane
 
 This could take a while. When the control plane is initialized, the `INITIALIZED` field should be `true`:
 
-```
+```bash
 NAME                             CLUSTER            INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE    VERSION
 ignition-cluster-control-plane   ignition-cluster   true                                 1                  1         1             7m7s   v1.22.2
 ```
@@ -120,7 +120,7 @@ kubectl cluster-info
 
 Sample output:
 
-```
+```bash
 Kubernetes control plane is running at https://ignition-cluster-apiserver-284992524.us-east-1.elb.amazonaws.com:6443
 CoreDNS is running at https://ignition-cluster-apiserver-284992524.us-east-1.elb.amazonaws.com:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
 
@@ -143,7 +143,7 @@ kubectl get nodes
 
 Sample output:
 
-```
+```bash
 NAME                                            STATUS   ROLES                  AGE   VERSION
 ip-10-0-122-154.us-east-1.compute.internal   Ready    control-plane,master   14m   v1.22.2
 ip-10-0-127-59.us-east-1.compute.internal    Ready    <none>                 13m   v1.22.2

--- a/docs/book/src/tasks/external-etcd.md
+++ b/docs/book/src/tasks/external-etcd.md
@@ -53,7 +53,7 @@ First, you will need to create a Secret containing the API server etcd client ce
 
 ```bash
 # Kubernetes API server etcd client certificate and key
-$ kubectl create secret tls $CLUSTER_NAME-apiserver-etcd-client \
+kubectl create secret tls $CLUSTER_NAME-apiserver-etcd-client \
   --cert apiserver-etcd-client.crt \
   --key apiserver-etcd-client.key \
   --namespace $CLUSTER_NAMESPACE
@@ -63,7 +63,7 @@ Next, create a Secret for the etcd cluster's CA certificate. The `kubectl create
 
 ```bash
 # Etcd's CA crt file to validate the generated client certificates
-$ kubectl create secret generic $CLUSTER_NAME-etcd \
+kubectl create secret generic $CLUSTER_NAME-etcd \
   --from-file tls.crt \
   --namespace $CLUSTER_NAMESPACE
 ```

--- a/docs/book/src/tasks/using-kustomize.md
+++ b/docs/book/src/tasks/using-kustomize.md
@@ -11,7 +11,7 @@ may be integrated into `clusterctl` to help address this need, but in the meanti
 This document provides a few examples of using `kustomize` with Cluster API. All of these examples
 assume that you are using a directory structure that looks something like this:
 
-```
+```bash
 .
 ├── base
 │   ├── base.yaml

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -65,7 +65,7 @@ a target [management cluster] on the selected [infrastructure provider].
    kind create cluster
    ```
    Test to ensure the local kind cluster is ready:
-   ```
+   ```bash
    kubectl cluster-info
    ```
 
@@ -100,19 +100,19 @@ The clusterctl CLI tool handles the lifecycle of a Cluster API management cluste
 
 #### Install clusterctl binary with curl on linux
 Download the latest release; on linux, type:
-```
+```bash
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-amd64" version:"1.1.x"}} -o clusterctl
 ```
 Make the clusterctl binary executable.
-```
+```bash
 chmod +x ./clusterctl
 ```
 Move the binary in to your PATH.
-```
+```bash
 sudo mv ./clusterctl /usr/local/bin/clusterctl
 ```
 Test to ensure the version you installed is up-to-date:
-```
+```bash
 clusterctl version
 ```
 
@@ -121,25 +121,25 @@ clusterctl version
 
 #### Install clusterctl binary with curl on macOS
 Download the latest release; on macOS, type:
-```
+```bash
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-amd64" version:"1.1.x"}} -o clusterctl
 ```
 
 Or if your Mac has an M1 CPU ("Apple Silicon"):
-```
+```bash
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-arm64" version:"1.1.x"}} -o clusterctl
 ```
 
 Make the clusterctl binary executable.
-```
+```bash
 chmod +x ./clusterctl
 ```
 Move the binary in to your PATH.
-```
+```bash
 sudo mv ./clusterctl /usr/local/bin/clusterctl
 ```
 Test to ensure the version you installed is up-to-date:
-```
+```bash
 clusterctl version
 ```
 {{#/tab }}
@@ -154,7 +154,7 @@ brew install clusterctl
 ```
 
 Test to ensure the version you installed is up-to-date:
-```
+```bash
 clusterctl version
 ```
 
@@ -165,13 +165,13 @@ clusterctl version
 Go to the working directory where you want clusterctl downloaded.
 
 Download the latest release; on Windows, type:
-```
+```bash
 curl {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-windows-amd64.exe" version:"1.1.x"}} -o clusterctl.exe
 ```
 Append or prepend the path of that directory to the `PATH` environment variable.
 
 Test to ensure the version you installed is up-to-date:
-```
+```bash
 clusterctl version
 ```
 
@@ -378,7 +378,7 @@ only supporting ClusterClass-based cluster-templates in this quickstart as Clust
 adapt configuration based on Kubernetes version. This is required to install Kubernetes clusters < v1.24 and
 for the upgrade from v1.23 to v1.24 as we have to use different cgroupDrivers depending on Kubernetes version.
 
-```
+```bash
 # Enable the experimental Cluster topology feature.
 export CLUSTER_TOPOLOGY=true
 
@@ -483,7 +483,7 @@ project][vSphere getting started guide].
 
 The output of `clusterctl init` is similar to this:
 
-```shell
+```bash
 Fetching providers
 Installing cert-manager Version="v1.7.2"
 Waiting for cert-manager to be available...

--- a/docs/book/src/user/troubleshooting.md
+++ b/docs/book/src/user/troubleshooting.md
@@ -28,13 +28,13 @@ that kubeadm enables by default.
 
 Assigning such labels to Nodes must be done after the bootstrap process has completed:
 
-```
+```bash
 kubectl label nodes <name> node-role.kubernetes.io/worker=""
 ```
 
 For convenience, here is an example one-liner to do this post installation
 
-```
+```bash
 # Kubernetes 1.19 (kubeadm 1.19 sets only the node-role.kubernetes.io/master label)
 kubectl get nodes --no-headers -l '!node-role.kubernetes.io/master' -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | xargs -I{} kubectl label node {} node-role.kubernetes.io/worker=''
 # Kubernetes >= 1.20 (kubeadm >= 1.20 sets the node-role.kubernetes.io/control-plane label) 
@@ -59,7 +59,7 @@ If the error  `Failed to create inotify object: Too many open files` is present 
 
 On Linux this issue can be resolved by increasing the inotify watch limits with:
 
-```
+```bash
 sysctl fs.inotify.max_user_watches=1048576
 sysctl fs.inotify.max_user_instances=8192
 ```
@@ -78,16 +78,16 @@ If using a version of Docker Desktop for Mac 4.3 or 4.4, the following workaroun
 Increase the maximum inotify file watch settings in the Docker Desktop VM:
 
 1) Enter the Docker Desktop VM
-```
+```bash
 nc -U ~/Library/Containers/com.docker.docker/Data/debug-shell.sock
 ```
 2) Increase the inotify limits using sysctl
-```
+```bash
 sysctl fs.inotify.max_user_watches=1048576
 sysctl fs.inotify.max_user_instances=8192
 ```
 3) Exit the Docker Desktop VM
-```
+```bash
 exit
 ```
 
@@ -96,8 +96,9 @@ exit
 When using older versions of Cluster API 0.4 and 1.0 releases - 0.4.6, 1.0.3 and older respectively - Cert Manager may not be downloadable due to a change in the repository location. This will cause `clusterctl init` to fail with the error:
 
 ```bash
-$ cluster-api % clusterctl init --infrastructure docker
-
+cluster-api % clusterctl init --infrastructure docker
+```
+```bash
 Fetching providers
 Installing cert-manager Version="v1.7.2"
 Error: action failed after 10 attempts: failed to get cert-manager object /, Kind=, /: Object 'Kind' is missing in 'unstructured object has no kind'
@@ -124,14 +125,14 @@ conflicts with clusterctl behavior of picking the latest version of a provider.
 E.g., if you are pinning KCP images to version v1.0.2 but then clusterctl init fetches yamls for version v1.1.0 or greater KCP will 
 fail to start with the following error: 
 
-```
+```bash
 invalid argument "ClusterTopology=false,KubeadmBootstrapFormatIgnition=false" for "--feature-gates" flag: unrecognized feature gate: KubeadmBootstrapFormatIgnition
 ```
 
 In order to solve this problem you should specify the version of the provider you are installing by appending a
 version tag to the provider name:
 
-```shell
+```bash
 clusterctl init -b kubeadm:v1.0.2 -c kubeadm:v1.0.2 --core cluster-api:v1.0.2 -i docker:v1.0.2
 ```
 

--- a/docs/proposals/20191016-clusterctl-redesign.md
+++ b/docs/proposals/20191016-clusterctl-redesign.md
@@ -134,16 +134,16 @@ Behind the scenes clusterctl will apply labels to any and all providers’ compo
 
 The clusterctl CLI is optimized for the “day one” experience of using Cluster API, and it will be possible to create a first cluster with two commands after the pre-requisites are met:
 
-```shell
-$ clusterctl init --infrastructure aws
-$ clusterctl config cluster my-first-cluster | kubectl apply -f -
+```bash
+clusterctl init --infrastructure aws
+clusterctl config cluster my-first-cluster | kubectl apply -f -
 ```
 
 Then, as of today, the CNI of choice should be applied to the new cluster:
 
-```shell
-$ kubectl get secret my-first-cluster-kubeconfig -o=jsonpath='{.data.value}' | base64 -D > my-first-cluster.kubeconfig
-$ kubectl apply --kubeconfig=my-first-cluster.kubeconfig -f MY_CNI
+```bash
+kubectl get secret my-first-cluster-kubeconfig -o=jsonpath='{.data.value}' | base64 -D > my-first-cluster.kubeconfig
+kubectl apply --kubeconfig=my-first-cluster.kubeconfig -f MY_CNI
 ```
 
 The internal flow for the above commands is the following:

--- a/test/infrastructure/docker/exp/README.md
+++ b/test/infrastructure/docker/exp/README.md
@@ -15,7 +15,7 @@ For more information on graduation criteria, see: [Contributing Guidelines](../.
 
 ## Create a new Resource
 Below is an example of creating a `DockerMachinePool` resource in the experimental group.
-```
+```bash
 kubebuilder create api --kind DockerMachinePool --group infrastructure --version v1alpha3 \
   --controller=true --resource=true --make=false
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides a consistent usage of how we present commands and their output throughout our docs. Based on the [comment](https://github.com/kubernetes-sigs/cluster-api/issues/6073#issuecomment-1120488708) we have decided to use different blocks for out input and output commands 
**Which issue(s) this PR fixes**:
Fixes #6073 
