### PR TITLE
:seedling:  Update golangci-lint action to 3.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.17
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.1.0
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
           version: v1.44.0
           working-directory: ${{matrix.working-directory}}


### PR DESCRIPTION
Manual update of the golangci-lint action to version 3.2. The recent dependabot attempts to update this dependency resulted to a change in the OpenAPI definition.

c/f #6522
