### PR TITLE
🌱 Silence error in go_install.sh when trying to remove nonexisting files

### DIFF
--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -37,7 +37,7 @@ if [ -z "${GOBIN}" ]; then
   exit 1
 fi
 
-rm "${GOBIN}/${2}"* || true
+rm -f "${GOBIN}/${2}"* || true
 
 # install the golang module specified as the first argument
 go install "${1}@${3}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Silences the `No such file or directory` message when running `make test` in a new repo or after running `make clean` to reduce noise. 

On my machine:
```shell
make test
(...)
rm: cannot remove '/home/oscar/repo/github/cluster-api/hack/tools/bin/setup-envtest*': No such file or directory
(...)
```