### PR TITLE
🌱 Run makefile in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -434,6 +434,7 @@ verify-gen: generate  ## Verfiy go generated files are up to date
 	fi
 
 .PHONY: verify-conversions
+.NOTPARALLEL: verify-conversions
 verify-conversions: $(CONVERSION_VERIFIER)  ## Verifies expected API conversion are in place
 	$(CONVERSION_VERIFIER)
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ SHELL:=/usr/bin/env bash
 
 .DEFAULT_GOAL:=help
 
+# Enable parallel make
+MAKEFLAGS += -j
+
 #
 # Go.
 #
@@ -190,7 +193,11 @@ ALL_GENERATE_MODULES = core kubeadm-bootstrap kubeadm-control-plane
 
 .PHONY: generate
 generate: ## Run all generate-manifests-*, generate-go-deepcopy-*, generate-go-conversions-* and generate-go-openapi targets
-	$(MAKE) generate-modules generate-manifests generate-go-deepcopy generate-go-conversions generate-go-openapi
+	$(MAKE) generate-modules
+	$(MAKE) generate-manifests
+	$(MAKE) generate-go-deepcopy
+	$(MAKE) generate-go-conversions
+	$(MAKE) generate-go-openapi
 	$(MAKE) -C $(CAPD_DIR) generate
 
 .PHONY: generate-manifests

--- a/Makefile
+++ b/Makefile
@@ -408,8 +408,12 @@ apidiff: $(GO_APIDIFF) ## Check for API differences
 ALL_VERIFY_CHECKS = doctoc boilerplate shellcheck tiltfile modules gen conversions docker-provider
 
 .PHONY: verify
-.NOTPARALLEL: verify
-verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS)) ## Run all verify-* targets
+verify:
+	$(MAKE) verify-doctoc verify-boilerplate verify-shellcheck verify-tiltfile
+	$(MAKE) verify-modules
+	$(MAKE) verify-gen
+	$(MAKE) verify-conversions
+	$(MAKE) verify-docker-provider
 
 .PHONY: verify-modules
 verify-modules: generate-modules  ## Verify go modules are up to date

--- a/Makefile
+++ b/Makefile
@@ -408,6 +408,7 @@ apidiff: $(GO_APIDIFF) ## Check for API differences
 ALL_VERIFY_CHECKS = doctoc boilerplate shellcheck tiltfile modules gen conversions docker-provider
 
 .PHONY: verify
+.NOTPARALLEL: verify
 verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS)) ## Run all verify-* targets
 
 .PHONY: verify-modules


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems build times can be reduced by running multiple jobs in parallel. Here are some not so scientific (aka I ran each target a few times to ensure the numbers were consistent) numbers from my machine:

- `make generate`
    **main branch**
    ```shell
    git clean -xdf -e .idea && git reset --hard HEAD && time make generate
    
    real	6m3,064s
    user	14m58,879s
    sys	3m35,418s
    ```

    **pr branch with parallel**
    ```shell
    git clean -xdf -e .idea && git reset --hard HEAD && time make generate
    
    real	4m7,970s
    user	15m20,455s
    sys	3m49,791s
    ```

- `make docker-build-all`
   **main branch**
    ```shell
    git clean -xdf -e .idea && git reset --hard HEAD && time make docker-build-all
    
    real	1m20,485s
    user	0m21,709s
    sys	0m3,678s
    ```
    
    **pr branch with parallel**
    ```shell
    git clean -xdf -e .idea && git reset --hard HEAD && time make docker-build-all
    
    real	0m18,991s
    user	0m35,935s
    sys	0m5,992s
    ```

Now since I haven't been able to build all targets (on main) yet, I can't grantee that nothing has been broken by this pr. I'm still investigating why `make test-e2e` doesn't work for me. If anyone would like to cooperate on this pr I would be more than happy to work together on it. 