### PR TITLE
:book: update supported Kubernetes versions

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -63,16 +63,17 @@ These diagrams show the relationships between components in a Cluster API releas
 
 #### Core Provider (`cluster-api-controller`)
 
-|                  |  CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload |  CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload |  CAPI v1beta1 (v1.x) Management | CAPI v1beta1 (v1.x) Workload |
-| ---------------- | -------------------------------- | ----------------------------- | -------------------------------- | ----------------------------- | -------------------------------- | ----------------------------- |
-| Kubernetes v1.16 | ✓                                | ✓                             |                                  |                               |                                  |                               |
-| Kubernetes v1.17 | ✓                                | ✓                             |                                  |                               |                                  |                               |
-| Kubernetes v1.18 | ✓                                | ✓                             |                                  | ✓                             |                                  | ✓                             |
-| Kubernetes v1.19 | ✓                                | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
-| Kubernetes v1.20 | ✓                                | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
-| Kubernetes v1.21 | ✓                                | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
-| Kubernetes v1.22 |                                  | ✓                             | ✓                                | ✓                             | ✓                                | ✓                             |
-| Kubernetes v1.23* |                                  |                               | ✓                                | ✓                             | ✓                                | ✓                             |
+|                  |  CAPI v0.3 (v1alpha3) |  CAPI v0.4 (v1alpha4)  |  CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
+| ---------------- | --------------------- | ---------------------- | -------------------- | ------------------------ |
+| Kubernetes v1.16 | ✓                     |                        |                      |                          |
+| Kubernetes v1.17 | ✓                     |                        |                      |                          |
+| Kubernetes v1.18 | ✓                     | ✓ (only workload)      | ✓ (only workload)    | ✓ (only workload)        |
+| Kubernetes v1.19 | ✓                     | ✓                      | ✓                    | ✓                        |
+| Kubernetes v1.20 | ✓                     | ✓                      | ✓                    | ✓                        |
+| Kubernetes v1.21 | ✓                     | ✓                      | ✓                    | ✓                        |
+| Kubernetes v1.22 | ✓ (only workload)     | ✓                      | ✓                    | ✓                        |
+| Kubernetes v1.23* |                      | ✓                      | ✓                    | ✓                        |
+| Kubernetes v1.24 |                       |                        |                      | ✓                        |
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
    Previous Kubernetes **minor** versions are not affected.
@@ -81,31 +82,33 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 
 #### Kubeadm Bootstrap Provider (`kubeadm-bootstrap-controller`)
 
-|                                    |  CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload | CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload | CAPI v1beta1 (v1.x) Management | CAPI v1beta1 (v1.x) Workload |
-| ---------------------------------- | -------------------------------- | ----------------------------- | ------------------------------- | ----------------------------- | ------------------------------- | ----------------------------- |
-| Kubernetes v1.16 + kubeadm/v1beta2 | ✓                                | ✓                             |                                 |                               |                                 |                               |
-| Kubernetes v1.17 + kubeadm/v1beta2 | ✓                                | ✓                             |                                 |                               |                                 |                               |
-| Kubernetes v1.18 + kubeadm/v1beta2 | ✓                                | ✓                             |                                 | ✓                             |                                 | ✓                             |
-| Kubernetes v1.19 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.20 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.21 + kubeadm/v1beta2 | ✓                                | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) |   | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.23 + kubeadm/v1beta3 |                                  |                               | ✓                               | ✓                             | ✓                               | ✓                             |
+|                                    |  CAPI v0.3 (v1alpha3)            | CAPI v0.4 (v1alpha4) | CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
+| ---------------------------------- | -------------------------------- | -------------------- | ------------------- | ------------------------ |
+| Kubernetes v1.16 + kubeadm/v1beta2 | ✓                                |                      |                     |                          |
+| Kubernetes v1.17 + kubeadm/v1beta2 | ✓                                |                      |                     |                          |
+| Kubernetes v1.18 + kubeadm/v1beta2 | ✓                                | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
+| Kubernetes v1.19 + kubeadm/v1beta2 | ✓                                | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.20 + kubeadm/v1beta2 | ✓                                | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.21 + kubeadm/v1beta2 | ✓                                | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) | ✓ (only workload) |  ✓   | ✓                   | ✓                        |
+| Kubernetes v1.23 + kubeadm/v1beta3 |                                  | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.24 + kubeadm/v1beta3 |                                  |                      |                     | ✓                        |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
-|                            | CAPI v1alpha3 (v0.3) Management | CAPI v1alpha3 (v0.3) Workload | CAPI v1alpha4 (v0.4) Management | CAPI v1alpha4 (v0.4) Workload | CAPI v1beta1 (v1.x) Management | CAPI v1beta1 (v1.x) Workload |
-| -------------------------- | ------------------------------- |-------------------------------|---------------------------------|-------------------------------| ------------------------------- | ----------------------------- |
-| Kubernetes v1.16 + etcd/v3 | ✓                               | ✓                             |                                 |                               |                                 |                               |
-| Kubernetes v1.17 + etcd/v3 | ✓                               | ✓                             |                                 |                               |                                 |                               |
-| Kubernetes v1.18 + etcd/v3 | ✓                               | ✓                             |                                 | ✓                             |                                 | ✓                             |
-| Kubernetes v1.19 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.20 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.21 + etcd/v3 | ✓                               | ✓                             | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.22 + etcd/v3 |                                 | ✓*                            | ✓                               | ✓                             | ✓                               | ✓                             |
-| Kubernetes v1.23 + etcd/v3 |                                 |                               | ✓*                              | ✓*                            | ✓                               | ✓                             |
+|                            | CAPI v0.3 (v1alpha3) | CAPI v0.4 (v1alpha4) | CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
+| -------------------------- | -------------------- |----------------------| ------------------- | ------------------------ |
+| Kubernetes v1.16 + etcd/v3 | ✓                    |                      |                     |                          |
+| Kubernetes v1.17 + etcd/v3 | ✓                    |                      |                     |                          |
+| Kubernetes v1.18 + etcd/v3 | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
+| Kubernetes v1.19 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.20 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.21 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.22 + etcd/v3 | ✓* (only workload)   | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.23 + etcd/v3 |                      | ✓*                   | ✓*                  | ✓                        |
+| Kubernetes v1.24 + etcd/v3 |                      |                      |                     | ✓                        |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 
@@ -120,6 +123,16 @@ The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 | v1.0 (v1beta1)  | v1.8.5                          | 
 | v1.1 (v1beta1)  | v1.8.6                          |
 | v1.2 (v1beta1)  | v1.9.2                          |
+
+#### Kubernetes version specific notes
+
+**1.24**:
+
+* Kubeadm Bootstrap Provider:
+    * `kubeadm` now sets both the `node-role.kubernetes.io/control-plane` and `node-role.kubernetes.io/master` taints on control plane nodes.
+    * `kubeadm` now only sets the `node-role.kubernetes.io/control-plane` label on control plane nodes (the `node-role.kubernetes.io/master` label is not set anymore).
+* Kubeadm Bootstrap Provider and Kubeadm Control Plane Provider
+    * `criSocket` without a scheme prefix has been deprecated in the kubelet since a while. `kubeadm` now shows a warning if no scheme is present and eventually the support for `criSocket`'s without prefix will be dropped. Please adjust the `criSocket` accordingly (e.g. `unix:///var/run/containerd/containerd.sock`) if you are configuring the `criSocket` in CABPK or KCP resources.
 
 #### clusterctl
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Update supported versions in the book to include 1.24.
I refactored the table a bit to improve readability + to be able to include v1.24 without adding another two columns.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #5968
Fixes #6155
