### PR TITLE
📖 Replace :warning: with ⚠️  in Contributing Guidelines documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Help and contributions are very welcome in the form of code contributions but al
 
 ### Codebase and Go Modules
 
-> :warning: The project does not follow Go Modules guidelines for compatibility requirements for 1.x semver releases.
+> ⚠ The project does not follow Go Modules guidelines for compatibility requirements for 1.x semver releases.
 
 Cluster API follows upstream Kubernetes semantic versioning. With the v1 release of our codebase, we guarantee the following:
 

--- a/docs/book/src/developer/providers/v0.3-to-v0.4.md
+++ b/docs/book/src/developer/providers/v0.3-to-v0.4.md
@@ -18,7 +18,7 @@
 
 - The KIND version used for this release is v0.11.x
 
-## :warning: Go Module changes :warning:
+## ⚠ Go Module changes ⚠
 
 - The `test` folder now ships with its own Go module `sigs.k8s.io/cluster-api/test`.
 - The module is going to be tagged and versioned as part of the release.

--- a/docs/book/src/developer/providers/v0.4-to-v1.0.md
+++ b/docs/book/src/developer/providers/v0.4-to-v1.0.md
@@ -59,7 +59,7 @@ The `serving-cert` certificates now have organization set to `k8s-sig-cluster-li
   controllers can use labels and annotations from template infrastructure resources to do external provisioning or
   provide configuration information, e.g. [IPAM support for vSphere / bare-metal][capv-ipam].
 
-## :warning: LeaderElectionResourceLock change :warning:
+## ⚠ LeaderElectionResourceLock change ⚠
 
 The v1beta1 release uses "leases" instead of "configmapsleases" as the LeaderElectionResourceLock for all managers leader election including the core controllers, bootstrap and control plane kubeadm and the Docker provider.
 This has no user facing impact on brand-new clusters created as v1beta1.


### PR DESCRIPTION
**What this PR does / why we need it**:

Looks like `:warning:` isn't rendered in the Contributing Guidelines document (as shown below) so I suggest replacing it with the ⚠️ emoji. As a small side note: the commit message and diff preview look a little odd since Github seems to always render `:warning:` as  ⚠️.

![Screenshot from 2022-05-25 23-09-33](https://user-images.githubusercontent.com/1570691/170368753-5a6a1974-0cad-43c2-ad3e-30ffb38b5c3f.png)

https://cluster-api.sigs.k8s.io/contributing#codebase-and-go-modules


