### PR TITLE
[WIP] 🐛 test: fix clusterctl v1alpha3 upgrade test

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -224,9 +224,9 @@ variables:
   # NOTE: INIT_WITH_BINARY and INIT_WITH_KUBERNETES_VERSION are only used by the clusterctl upgrade test to initialize
   # the management cluster to be upgraded.
   # NOTE: We test the latest release with a previous contract.
-  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-{OS}-{ARCH}"
-  INIT_WITH_PROVIDERS_CONTRACT: "v1alpha4"
-  INIT_WITH_KUBERNETES_VERSION: "v1.24.0"
+  INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.25/clusterctl-{OS}-{ARCH}"
+  INIT_WITH_PROVIDERS_CONTRACT: "v1alpha3"
+  INIT_WITH_KUBERNETES_VERSION: "v1.21.12"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

Hey folks, 
please ignore this PR, I'm just using it to figure out how to fix the clusterctl v1alpha3 => main e2e test (https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-upgrade-v0-3-to-main).

Probably bumping the init Kubernetes version to v1.21.12 is enough (as it hopefully supports systemd)