### PR TITLE
🐛 e2e: fix cgroup branching in cluster upgrade test

### DIFF
--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -43,7 +43,7 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass and testi
 		//   when the target version is >= v1.24.
 		// We can remove this as soon as we don't test upgrades from Kubernetes < v1.24 anymore with CAPD
 		// or MachinePools are supported in ClusterClass.
-		version, err := semver.ParseTolerant(e2eConfig.Variables[KubernetesVersionUpgradeFrom])
+		version, err := semver.ParseTolerant(e2eConfig.GetVariable(KubernetesVersionUpgradeFrom))
 		Expect(err).ToNot(HaveOccurred(), "Invalid argument, KUBERNETES_VERSION_UPGRADE_FROM is not a valid version")
 		if version.LT(semver.MustParse("1.24.0")) {
 			// "upgrades-cgroupfs" is the same as the "topology" flavor but with an additional MachinePool


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The cluster upgrade test didn't detect the Kubernetes version correctly.

The `e2eConfig.Variables` map only contains the values from the e2e config / docker.yaml, while `GetVariable` also takes env variables into account.

Concrete error case:
* ci job v1.24 => v1.25 latest
* Actual KubernetesVersionUpgradeFrom was v1.24.1
* Test detected v1.23.6 from e2e config and ignored env var
* Test chose to use the cgroupfs flavor instead of the regular one
* cgroupfs doesn't work with v1.24.1
  * grep for `upgrades-cgroupfs` in https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/6543/pull-cluster-api-e2e-workload-upgrade-1-24-latest-main/1530078512034091008/build-log.txt


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
