### PR TITLE
🌱 RuntimeSDK: standardize import names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,6 +113,16 @@ linters-settings:
         alias: runtimev1
       - pkg: sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1
         alias: runtimehooksv1
+      - pkg: sigs.k8s.io/cluster-api/exp/runtime/controllers
+        alias: runtimecontrollers
+      - pkg: sigs.k8s.io/cluster-api/internal/runtime/catalog
+        alias: runtimecatalog
+      - pkg: sigs.k8s.io/cluster-api/internal/runtime/client
+        alias: runtimeclient
+      - pkg: sigs.k8s.io/cluster-api/internal/runtime/registry
+        alias: runtimeregistry
+      - pkg: sigs.k8s.io/cluster-api/internal/webhooks/runtime
+        alias: runtimewebhooks
       # CAPD
       - pkg: sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3
         alias: infrav1alpha3

--- a/exp/runtime/controllers/alias.go
+++ b/exp/runtime/controllers/alias.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
-	extensionconfigs "sigs.k8s.io/cluster-api/exp/runtime/internal/controllers"
+	runtimecontrollers "sigs.k8s.io/cluster-api/exp/runtime/internal/controllers"
 	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
 )
 
@@ -38,7 +38,7 @@ type ExtensionConfigReconciler struct {
 }
 
 func (r *ExtensionConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
-	return (&extensionconfigs.Reconciler{
+	return (&runtimecontrollers.Reconciler{
 		Client:           r.Client,
 		APIReader:        r.APIReader,
 		RuntimeClient:    r.RuntimeClient,

--- a/exp/runtime/hooks/api/v1alpha1/discovery_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/discovery_types.go
@@ -19,7 +19,7 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 )
 
 // DiscoveryRequest represents the object of a discovery request.
@@ -85,7 +85,7 @@ const (
 func Discovery(*DiscoveryRequest, *DiscoveryResponse) {}
 
 func init() {
-	catalogBuilder.RegisterHook(Discovery, &catalog.HookMeta{
+	catalogBuilder.RegisterHook(Discovery, &runtimecatalog.HookMeta{
 		Tags:        []string{"Discovery"},
 		Summary:     "Discovery endpoint",
 		Description: "Discovery endpoint discovers the supported hooks of a RuntimeExtension",

--- a/exp/runtime/hooks/api/v1alpha1/groupversion_info.go
+++ b/exp/runtime/hooks/api/v1alpha1/groupversion_info.go
@@ -19,7 +19,7 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 )
 
 var (
@@ -29,7 +29,7 @@ var (
 
 	// catalogBuilder is used to add RuntimeHooks and their request and response types
 	// to a Catalog.
-	catalogBuilder = &catalog.Builder{GroupVersion: GroupVersion}
+	catalogBuilder = &runtimecatalog.Builder{GroupVersion: GroupVersion}
 
 	// AddToCatalog adds RuntimeHooks defined in this package and their request and
 	// response types to a catalog.

--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -35,9 +35,9 @@ import (
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/feature"
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
-	runtimev1registry "sigs.k8s.io/cluster-api/internal/runtime/registry"
+	runtimeregistry "sigs.k8s.io/cluster-api/internal/runtime/registry"
 	"sigs.k8s.io/cluster-api/util"
 )
 
@@ -49,8 +49,8 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 	ns, err := env.CreateNamespace(ctx, "test-extension-config")
 	g.Expect(err).ToNot(HaveOccurred())
 
-	cat := catalog.New()
-	registry := runtimev1registry.New()
+	cat := runtimecatalog.New()
+	registry := runtimeregistry.New()
 	runtimeClient := runtimeclient.New(runtimeclient.Options{
 		Catalog:  cat,
 		Registry: registry,
@@ -186,8 +186,8 @@ func TestExtensionReconciler_discoverExtensionConfig(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	t.Run("test discovery of a single extension", func(t *testing.T) {
-		cat := catalog.New()
-		registry := runtimev1registry.New()
+		cat := runtimecatalog.New()
+		registry := runtimeregistry.New()
 		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 		extensionName := "ext1"
 		srv1 := fakeExtensionServer(discoveryHandler("first"))
@@ -216,8 +216,8 @@ func TestExtensionReconciler_discoverExtensionConfig(t *testing.T) {
 		g.Expect(conditions[0].Type).To(Equal(runtimev1.RuntimeExtensionDiscoveredCondition))
 	})
 	t.Run("fail discovery for non-running extension", func(t *testing.T) {
-		cat := catalog.New()
-		registry := runtimev1registry.New()
+		cat := runtimecatalog.New()
+		registry := runtimeregistry.New()
 		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 		extensionName := "ext1"
 

--- a/exp/runtime/internal/controllers/warmup_test.go
+++ b/exp/runtime/internal/controllers/warmup_test.go
@@ -28,9 +28,9 @@ import (
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/feature"
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
-	runtimev1registry "sigs.k8s.io/cluster-api/internal/runtime/registry"
+	runtimeregistry "sigs.k8s.io/cluster-api/internal/runtime/registry"
 )
 
 func Test_warmupRunnable_Start(t *testing.T) {
@@ -42,8 +42,8 @@ func Test_warmupRunnable_Start(t *testing.T) {
 		ns, err := env.CreateNamespace(ctx, "test-runtime-extension")
 		g.Expect(err).ToNot(HaveOccurred())
 
-		cat := catalog.New()
-		registry := runtimev1registry.New()
+		cat := runtimecatalog.New()
+		registry := runtimeregistry.New()
 		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 
 		for _, name := range []string{"ext1", "ext2", "ext3"} {
@@ -91,8 +91,8 @@ func Test_warmupRunnable_Start(t *testing.T) {
 		ns, err := env.CreateNamespace(ctx, "test-runtime-extension")
 		g.Expect(err).ToNot(HaveOccurred())
 
-		cat := catalog.New()
-		registry := runtimev1registry.New()
+		cat := runtimecatalog.New()
+		registry := runtimeregistry.New()
 		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 
 		// Do not create an extension server for an extension with this name, but do create an extensionconfig.

--- a/hack/tools/runtime-openapi-gen/main.go
+++ b/hack/tools/runtime-openapi-gen/main.go
@@ -27,7 +27,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 )
 
 var (
@@ -50,7 +50,7 @@ func main() {
 		klog.Exit("--output-file must have either 'yaml' or 'json' extension")
 	}
 
-	c := catalog.New()
+	c := runtimecatalog.New()
 	_ = runtimehooksv1.AddToCatalog(c)
 
 	c.AddOpenAPIDefinitions(clusterv1.GetOpenAPIDefinitions)

--- a/internal/runtime/catalog/test/catalog_test.go
+++ b/internal/runtime/catalog/test/catalog_test.go
@@ -28,12 +28,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 	"sigs.k8s.io/cluster-api/internal/runtime/catalog/test/v1alpha1"
 	"sigs.k8s.io/cluster-api/internal/runtime/catalog/test/v1alpha2"
 )
 
-var c = catalog.New()
+var c = runtimecatalog.New()
 
 func init() {
 	_ = v1alpha1.AddToCatalog(c)
@@ -43,7 +43,7 @@ func init() {
 func TestCatalog(t *testing.T) {
 	g := NewWithT(t)
 
-	verify := func(hook catalog.Hook, expectedGV schema.GroupVersion) {
+	verify := func(hook runtimecatalog.Hook, expectedGV schema.GroupVersion) {
 		// Test GroupVersionHook
 		hookGVH, err := c.GroupVersionHook(hook)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -96,7 +96,7 @@ func TestValidateRequest(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		hook      catalog.GroupVersionHook
+		hook      runtimecatalog.GroupVersionHook
 		request   runtime.Object
 		wantError bool
 	}{
@@ -144,7 +144,7 @@ func TestValidateResponse(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		hook      catalog.GroupVersionHook
+		hook      runtimecatalog.GroupVersionHook
 		response  runtime.Object
 		wantError bool
 	}{
@@ -220,42 +220,42 @@ func HookWithThreeInputs(*GoodRequest, *GoodRequest, *GoodResponse) {}
 func HookWithBadRequestAndResponse(*BadRequest, *BadResponse) {}
 
 func TestAddHook(t *testing.T) {
-	c := catalog.New()
+	c := runtimecatalog.New()
 
 	tests := []struct {
 		name      string
-		hook      catalog.Hook
-		hookMeta  *catalog.HookMeta
+		hook      runtimecatalog.Hook
+		hookMeta  *runtimecatalog.HookMeta
 		wantPanic bool
 	}{
 		{
 			name:      "should pass for valid hook",
 			hook:      GoodHook,
-			hookMeta:  &catalog.HookMeta{},
+			hookMeta:  &runtimecatalog.HookMeta{},
 			wantPanic: false,
 		},
 		{
 			name:      "should fail for hook with a return value",
 			hook:      HookWithReturn,
-			hookMeta:  &catalog.HookMeta{},
+			hookMeta:  &runtimecatalog.HookMeta{},
 			wantPanic: true,
 		},
 		{
 			name:      "should fail for a hook with no inputs",
 			hook:      HookWithNoInputs,
-			hookMeta:  &catalog.HookMeta{},
+			hookMeta:  &runtimecatalog.HookMeta{},
 			wantPanic: true,
 		},
 		{
 			name:      "should fail for a hook with more than two arguments",
 			hook:      HookWithThreeInputs,
-			hookMeta:  &catalog.HookMeta{},
+			hookMeta:  &runtimecatalog.HookMeta{},
 			wantPanic: true,
 		},
 		{
 			name:      "should fail for hook with bad request and response arguments",
 			hook:      HookWithBadRequestAndResponse,
-			hookMeta:  &catalog.HookMeta{},
+			hookMeta:  &runtimecatalog.HookMeta{},
 			wantPanic: true,
 		},
 		{

--- a/internal/runtime/catalog/test/v1alpha1/conversion.go
+++ b/internal/runtime/catalog/test/v1alpha1/conversion.go
@@ -21,7 +21,7 @@ import (
 
 	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	v1alpha2 "sigs.k8s.io/cluster-api/internal/runtime/catalog/test/v1alpha2"
+	"sigs.k8s.io/cluster-api/internal/runtime/catalog/test/v1alpha2"
 )
 
 func Convert_v1alpha1_FakeResponse_To_v1alpha2_FakeResponse(in *FakeResponse, out *v1alpha2.FakeResponse, s conversion.Scope) error {

--- a/internal/runtime/catalog/test/v1alpha1/conversion_test.go
+++ b/internal/runtime/catalog/test/v1alpha1/conversion_test.go
@@ -24,14 +24,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 	"sigs.k8s.io/cluster-api/internal/runtime/catalog/test/v1alpha2"
 )
 
 func TestConversion(t *testing.T) {
 	g := NewWithT(t)
 
-	var c = catalog.New()
+	var c = runtimecatalog.New()
 	_ = AddToCatalog(c)
 	_ = v1alpha2.AddToCatalog(c)
 

--- a/internal/runtime/catalog/test/v1alpha1/fake_types.go
+++ b/internal/runtime/catalog/test/v1alpha1/fake_types.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	clusterv1alpha4 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 )
 
 var (
@@ -35,7 +35,7 @@ var (
 
 	// catalogBuilder is used to add rpc services and their request and response types
 	// to a Catalog.
-	catalogBuilder = &catalog.Builder{GroupVersion: GroupVersion}
+	catalogBuilder = &runtimecatalog.Builder{GroupVersion: GroupVersion}
 
 	// AddToCatalog adds rpc services defined in this package and their request and
 	// response types to a catalog.
@@ -75,7 +75,7 @@ func (in *FakeResponse) DeepCopyObject() runtime.Object {
 }
 
 func init() {
-	catalogBuilder.RegisterHook(FakeHook, &catalog.HookMeta{
+	catalogBuilder.RegisterHook(FakeHook, &runtimecatalog.HookMeta{
 		Tags:        []string{"fake-tag"},
 		Summary:     "Fake summary",
 		Description: "Fake description",

--- a/internal/runtime/catalog/test/v1alpha2/fake_types.go
+++ b/internal/runtime/catalog/test/v1alpha2/fake_types.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 )
 
 var (
@@ -35,7 +35,7 @@ var (
 
 	// catalogBuilder is used to add rpc services and their request and response types
 	// to a Catalog.
-	catalogBuilder = &catalog.Builder{GroupVersion: GroupVersion}
+	catalogBuilder = &runtimecatalog.Builder{GroupVersion: GroupVersion}
 
 	// AddToCatalog adds rpc services defined in this package and their request and
 	// response types to a catalog.
@@ -69,7 +69,7 @@ func (in *FakeResponse) DeepCopyObject() runtime.Object {
 }
 
 func init() {
-	catalogBuilder.RegisterHook(FakeHook, &catalog.HookMeta{
+	catalogBuilder.RegisterHook(FakeHook, &runtimecatalog.HookMeta{
 		Tags:        []string{"fake-tag"},
 		Summary:     "Fake summary",
 		Description: "Fake description",

--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -36,16 +36,16 @@ import (
 
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
-	"sigs.k8s.io/cluster-api/internal/runtime/registry"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimeregistry "sigs.k8s.io/cluster-api/internal/runtime/registry"
 )
 
 const defaultDiscoveryTimeout = 10 * time.Second
 
 // Options are creation options for a Client.
 type Options struct {
-	Catalog  *catalog.Catalog
-	Registry registry.ExtensionRegistry
+	Catalog  *runtimecatalog.Catalog
+	Registry runtimeregistry.ExtensionRegistry
 }
 
 // New returns a new Client.
@@ -80,8 +80,8 @@ type Client interface {
 var _ Client = &client{}
 
 type client struct {
-	catalog  *catalog.Catalog
-	registry registry.ExtensionRegistry
+	catalog  *runtimecatalog.Catalog
+	registry runtimeregistry.ExtensionRegistry
 }
 
 func (c *client) WarmUp(extensionConfigList *runtimev1.ExtensionConfigList) error {
@@ -154,9 +154,9 @@ func (c *client) Unregister(extensionConfig *runtimev1.ExtensionConfig) error {
 }
 
 type httpCallOptions struct {
-	catalog *catalog.Catalog
+	catalog *runtimecatalog.Catalog
 	config  runtimev1.ClientConfig
-	gvh     catalog.GroupVersionHook
+	gvh     runtimecatalog.GroupVersionHook
 	name    string
 	timeout time.Duration
 }
@@ -268,7 +268,7 @@ func httpCall(ctx context.Context, request, response runtime.Object, opts *httpC
 	return nil
 }
 
-func urlForExtension(config runtimev1.ClientConfig, gvh catalog.GroupVersionHook, name string) (*url.URL, error) {
+func urlForExtension(config runtimev1.ClientConfig, gvh runtimecatalog.GroupVersionHook, name string) (*url.URL, error) {
 	var u *url.URL
 	if config.Service != nil {
 		// The Extension's ClientConfig points ot a service. Construct the URL to the service.
@@ -299,6 +299,6 @@ func urlForExtension(config runtimev1.ClientConfig, gvh catalog.GroupVersionHook
 		}
 	}
 	// Add the subpatch to the ExtensionHandler for the given hook.
-	u.Path = path.Join(u.Path, catalog.GVHToPath(gvh, name))
+	u.Path = path.Join(u.Path, runtimecatalog.GVHToPath(gvh, name))
 	return u, nil
 }

--- a/internal/runtime/client/client_test.go
+++ b/internal/runtime/client/client_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 	fakev1alpha1 "sigs.k8s.io/cluster-api/internal/runtime/catalog/test/v1alpha1"
 	fakev1alpha2 "sigs.k8s.io/cluster-api/internal/runtime/catalog/test/v1alpha2"
 )
@@ -65,7 +65,7 @@ func TestClient_httpCall(t *testing.T) {
 			request:  &fakev1alpha1.FakeRequest{},
 			response: &fakev1alpha1.FakeResponse{},
 			opts: &httpCallOptions{
-				catalog: catalog.New(),
+				catalog: runtimecatalog.New(),
 			},
 			wantErr: true,
 		},
@@ -79,7 +79,7 @@ func TestClient_httpCall(t *testing.T) {
 			},
 			response: &fakev1alpha1.FakeResponse{},
 			opts: func() *httpCallOptions {
-				c := catalog.New()
+				c := runtimecatalog.New()
 				g.Expect(fakev1alpha1.AddToCatalog(c)).To(Succeed())
 
 				// get same gvh for hook by using the FakeHook and catalog
@@ -103,7 +103,7 @@ func TestClient_httpCall(t *testing.T) {
 			},
 			response: &fakev1alpha2.FakeResponse{},
 			opts: func() *httpCallOptions {
-				c := catalog.New()
+				c := runtimecatalog.New()
 				// register fakev1alpha1 and fakev1alpha2 to enable conversion
 				g.Expect(fakev1alpha1.AddToCatalog(c)).To(Succeed())
 				g.Expect(fakev1alpha2.AddToCatalog(c)).To(Succeed())
@@ -164,7 +164,7 @@ func fakeHookHandler(w http.ResponseWriter, r *http.Request) {
 func TestURLForExtension(t *testing.T) {
 	type args struct {
 		config               runtimev1.ClientConfig
-		gvh                  catalog.GroupVersionHook
+		gvh                  runtimecatalog.GroupVersionHook
 		extensionHandlerName string
 	}
 
@@ -174,7 +174,7 @@ func TestURLForExtension(t *testing.T) {
 		path   string
 	}
 
-	gvh := catalog.GroupVersionHook{
+	gvh := runtimecatalog.GroupVersionHook{
 		Group:   "test.runtime.cluster.x-k8s.io",
 		Version: "v1alpha1",
 		Hook:    "testhook.test-extension",
@@ -202,7 +202,7 @@ func TestURLForExtension(t *testing.T) {
 			want: want{
 				scheme: "http",
 				host:   "extension-service.test1.svc:8443",
-				path:   catalog.GVHToPath(gvh, "test-handler"),
+				path:   runtimecatalog.GVHToPath(gvh, "test-handler"),
 			},
 			wantErr: false,
 		},
@@ -223,7 +223,7 @@ func TestURLForExtension(t *testing.T) {
 			want: want{
 				scheme: "https",
 				host:   "extension-service.test1.svc:8443",
-				path:   catalog.GVHToPath(gvh, "test-handler"),
+				path:   runtimecatalog.GVHToPath(gvh, "test-handler"),
 			},
 			wantErr: false,
 		},
@@ -239,7 +239,7 @@ func TestURLForExtension(t *testing.T) {
 			want: want{
 				scheme: "https",
 				host:   "extension-host.com",
-				path:   catalog.GVHToPath(gvh, "test-handler"),
+				path:   runtimecatalog.GVHToPath(gvh, "test-handler"),
 			},
 			wantErr: false,
 		},

--- a/internal/runtime/registry/registry.go
+++ b/internal/runtime/registry/registry.go
@@ -24,7 +24,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 )
 
 // ExtensionRegistry defines the funcs of a RuntimeExtension registry.
@@ -48,7 +48,7 @@ type ExtensionRegistry interface {
 	Remove(extensionConfig *runtimev1.ExtensionConfig) error
 
 	// List all registered RuntimeExtensions for a given catalog.GroupHook.
-	List(gh catalog.GroupHook) ([]*ExtensionRegistration, error)
+	List(gh runtimecatalog.GroupHook) ([]*ExtensionRegistration, error)
 
 	// Get the RuntimeExtensions with the given name.
 	Get(name string) (*ExtensionRegistration, error)
@@ -63,7 +63,7 @@ type ExtensionRegistration struct {
 	ExtensionConfigName string
 
 	// GroupVersionHook is the GroupVersionHook that the RuntimeExtension implements.
-	GroupVersionHook catalog.GroupVersionHook
+	GroupVersionHook runtimecatalog.GroupVersionHook
 
 	// ClientConfig is the ClientConfig to communicate with the RuntimeExtension.
 	ClientConfig runtimev1.ClientConfig
@@ -176,7 +176,7 @@ func (r *extensionRegistry) remove(extensionConfig *runtimev1.ExtensionConfig) {
 }
 
 // List all registered RuntimeExtensions for a given catalog.GroupHook.
-func (r *extensionRegistry) List(gh catalog.GroupHook) ([]*ExtensionRegistration, error) {
+func (r *extensionRegistry) List(gh runtimecatalog.GroupHook) ([]*ExtensionRegistration, error) {
 	if gh.Group == "" {
 		return nil, errors.New("invalid argument: when calling List gh.Group must not be empty")
 	}
@@ -233,7 +233,7 @@ func (r *extensionRegistry) add(extensionConfig *runtimev1.ExtensionConfig) erro
 		registrations = append(registrations, &ExtensionRegistration{
 			ExtensionConfigName: extensionConfig.Name,
 			Name:                e.Name,
-			GroupVersionHook: catalog.GroupVersionHook{
+			GroupVersionHook: runtimecatalog.GroupVersionHook{
 				Group:   gv.Group,
 				Version: gv.Version,
 				Hook:    e.RequestHook.Hook,

--- a/internal/runtime/registry/registry_test.go
+++ b/internal/runtime/registry/registry_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
-	"sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 )
 
 func TestColdRegistry(t *testing.T) {
@@ -39,7 +39,7 @@ func TestColdRegistry(t *testing.T) {
 	// Add, Remove, List and Get should fail with a cold registry.
 	g.Expect(r.Add(&runtimev1.ExtensionConfig{})).ToNot(Succeed())
 	g.Expect(r.Remove(&runtimev1.ExtensionConfig{})).ToNot(Succeed())
-	_, err := r.List(catalog.GroupHook{Group: "foo", Hook: "bak"})
+	_, err := r.List(runtimecatalog.GroupHook{Group: "foo", Hook: "bak"})
 	g.Expect(err).To(HaveOccurred())
 	_, err = r.Get("foo")
 	g.Expect(err).To(HaveOccurred())
@@ -82,7 +82,7 @@ func TestWarmUpRegistry(t *testing.T) {
 	g.Expect(r.Add(&runtimev1.ExtensionConfig{})).To(Succeed())
 	g.Expect(r.Remove(&runtimev1.ExtensionConfig{})).To(Succeed())
 
-	registrations, err := r.List(catalog.GroupHook{Group: "foo", Hook: "bak"})
+	registrations, err := r.List(runtimecatalog.GroupHook{Group: "foo", Hook: "bak"})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(registrations).To(HaveLen(1))
 	g.Expect(registrations[0].Name).To(Equal("handler.test-extension"))
@@ -165,14 +165,14 @@ func TestRegistry(t *testing.T) {
 	g.Expect(registration.Name).To(Equal("foo.extension1"))
 
 	// List all BeforeClusterUpgrade extensions
-	registrations, err := e.List(catalog.GroupHook{Group: "hook.runtime.cluster.x-k8s.io", Hook: "BeforeClusterUpgrade"})
+	registrations, err := e.List(runtimecatalog.GroupHook{Group: "hook.runtime.cluster.x-k8s.io", Hook: "BeforeClusterUpgrade"})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(registrations).To(HaveLen(2))
 	g.Expect(registrations).To(ContainExtension("foo.extension1"))
 	g.Expect(registrations).To(ContainExtension("bar.extension1"))
 
 	// List all AfterClusterUpgrade extensions
-	registrations, err = e.List(catalog.GroupHook{Group: "hook.runtime.cluster.x-k8s.io", Hook: "AfterClusterUpgrade"})
+	registrations, err = e.List(runtimecatalog.GroupHook{Group: "hook.runtime.cluster.x-k8s.io", Hook: "AfterClusterUpgrade"})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(registrations).To(HaveLen(1))
 	g.Expect(registrations).To(ContainExtension("baz.extension1"))
@@ -180,7 +180,7 @@ func TestRegistry(t *testing.T) {
 	// Add extension2 with one more AfterClusterUpgrade and check it is there
 	g.Expect(e.Add(extension2)).To(Succeed())
 
-	registrations, err = e.List(catalog.GroupHook{Group: "hook.runtime.cluster.x-k8s.io", Hook: "AfterClusterUpgrade"})
+	registrations, err = e.List(runtimecatalog.GroupHook{Group: "hook.runtime.cluster.x-k8s.io", Hook: "AfterClusterUpgrade"})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(registrations).To(HaveLen(2))
 	g.Expect(registrations).To(ContainExtension("baz.extension1"))
@@ -189,11 +189,11 @@ func TestRegistry(t *testing.T) {
 	// Remove extension1 and check everything is updated
 	g.Expect(e.Remove(extension1)).To(Succeed())
 
-	registrations, err = e.List(catalog.GroupHook{Group: "hook.runtime.cluster.x-k8s.io", Hook: "BeforeClusterUpgrade"})
+	registrations, err = e.List(runtimecatalog.GroupHook{Group: "hook.runtime.cluster.x-k8s.io", Hook: "BeforeClusterUpgrade"})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(registrations).To(HaveLen(0))
 
-	registrations, err = e.List(catalog.GroupHook{Group: "hook.runtime.cluster.x-k8s.io", Hook: "AfterClusterUpgrade"})
+	registrations, err = e.List(runtimecatalog.GroupHook{Group: "hook.runtime.cluster.x-k8s.io", Hook: "AfterClusterUpgrade"})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(registrations).To(HaveLen(1))
 	g.Expect(registrations).To(ContainExtension("qux.extension2"))

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -56,7 +56,7 @@ import (
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
-	runtimev1webhooks "sigs.k8s.io/cluster-api/internal/webhooks/runtime"
+	runtimewebhooks "sigs.k8s.io/cluster-api/internal/webhooks/runtime"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 	"sigs.k8s.io/cluster-api/webhooks"
 )
@@ -256,7 +256,7 @@ func newEnvironment(uncachedObjs ...client.Object) *Environment {
 	if err := (&expv1.MachinePool{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("unable to create webhook for machinepool: %+v", err)
 	}
-	if err := (&runtimev1webhooks.ExtensionConfig{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&runtimewebhooks.ExtensionConfig{}).SetupWebhookWithManager(mgr); err != nil {
 		klog.Fatalf("unable to create webhook for extensionconfig: %+v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ import (
 	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
 	runtimeregistry "sigs.k8s.io/cluster-api/internal/runtime/registry"
-	runtimev1webhooks "sigs.k8s.io/cluster-api/internal/webhooks/runtime"
+	runtimewebhooks "sigs.k8s.io/cluster-api/internal/webhooks/runtime"
 	"sigs.k8s.io/cluster-api/version"
 	"sigs.k8s.io/cluster-api/webhooks"
 )
@@ -502,7 +502,7 @@ func setupWebhooks(mgr ctrl.Manager) {
 
 	// NOTE: ExtensionConfig is behind the RuntimeSDK feature gate flag. The webhook will prevent creating or updating
 	// new objects if the feature flag is disabled.
-	if err := (&runtimev1webhooks.ExtensionConfig{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&runtimewebhooks.ExtensionConfig{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "ExtensionConfig")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR standardizes import names for RuntimeSDK packages.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
