### PR TITLE
🌱 Sync owners alias on release-1.1 with main

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,6 +22,7 @@ aliases:
   - CecileRobertMichon
   - enxebre
   - fabriziopandini
+  - sbueringer
   - vincepri
 
   # folks who can review and LGTM any PRs in the repo
@@ -45,6 +46,7 @@ aliases:
 
   cluster-api-bootstrap-provider-kubeadm-maintainers:
   cluster-api-bootstrap-provider-kubeadm-reviewers:
+    - killianmuldoon
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for bootstrap/kubeadm/internal/ignition
@@ -69,6 +71,7 @@ aliases:
 
   cluster-api-clusterctl-maintainers:
   cluster-api-clusterctl-reviewers:
+  - ykakarap
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for test
@@ -76,7 +79,6 @@ aliases:
 
   cluster-api-test-reviewers:
   cluster-api-test-maintainers:
-  - sbueringer
 
   # -----------------------------------------------------------
   # OWNER_ALIASES for test/framework
@@ -97,4 +99,5 @@ aliases:
   # -----------------------------------------------------------
 
   cluster-api-docs-reviewers:
+    - killianmuldoon
   cluster-api-docs-maintainers:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Syncs the OWNER_ALIASES file of release-1.1 with main. I think it makes sense to have them sync as the reviewer/approver rights are CAPI-wide not per-release. 

Note:
* release-1.1 is our only supported release, so I wouldn't backport this further.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
