### PR TITLE
📖 Fix grammar and spelling in clusterctl documentation

### DIFF
--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -143,7 +143,7 @@ The user should ensure the variables required by a provider are set in advance.
 
 <aside class="note">
 
-<h1> How can I known which variables a provider requires? </h1>
+<h1> How can I know which variables a provider requires? </h1>
 
 Users can refer to the provider documentation for the list of variables to be set or use the
 `clusterctl generate provider --<provider-type> <provider-name> --describe` command to get a list of expected variable names.

--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -138,7 +138,7 @@ See [Install and/or configure a kubernetes cluster] for more information.
 *Before* running clusterctl init, you must ensure all the required images are available in the kind cluster.
 
 This is always the case for images published in some image repository like docker hub or gcr.io, but it can't be
-the case for images built locally; in this case, you can use `kind load` to move the images built locally. e.g
+the case for images built locally; in this case, you can use `kind load` to move the images built locally. e.g.
 
 ```
 kind load docker-image gcr.io/k8s-staging-cluster-api/cluster-api-controller-amd64:dev
@@ -187,9 +187,9 @@ The command for getting the kubeconfig file for connecting to a workload cluster
 clusterctl get kubeconfig capi-quickstart > capi-quickstart.kubeconfig
 ```
 
-### Fix kubeconfig (when using docker on MacOS)
+### Fix kubeconfig (when using docker on macOS)
 
-When using docker on MacOS, you will need to do a couple of additional
+When using docker on macOS, you will need to do a couple of additional
 steps to get the correct kubeconfig for a workload cluster created with the Docker provider:
 
 ```bash

--- a/docs/book/src/clusterctl/provider-contract.md
+++ b/docs/book/src/clusterctl/provider-contract.md
@@ -44,7 +44,7 @@ You can use a GitHub release to package your provider artifacts for other people
 A GitHub release can be used as a provider repository if:
 
 * The release tag is a valid semantic version number
-* The components YAML, the metadata YAML and eventually the workload cluster templates are include into the release assets.
+* The components YAML, the metadata YAML and eventually the workload cluster templates are included into the release assets.
 
 See the [GitHub docs](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) for more information
 about how to create a release.
@@ -123,7 +123,7 @@ are not namespaced, like ClusterRoles/ClusterRoleBinding and CRD objects.
 
 <h1>Warning</h1>
 
-If the generated component YAML does't contain a Namespace object, the user will be required to provide one to `clusterctl init`
+If the generated component YAML doesn't contain a Namespace object, the user will be required to provide one to `clusterctl init`
 using the `--target-namespace` flag.
 
 In case there is more than one Namespace object in the components YAML, `clusterctl` will generate an error and abort


### PR DESCRIPTION
**What this PR does / why we need it**:

Just some minor spelling and grammar fixes in the documentation. 