### PR TITLE
✨ Introduce typed CRDs for testing purposes to replace the untyped ones

### DIFF
--- a/internal/test/builder/bootstrap.go
+++ b/internal/test/builder/bootstrap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package builder
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -27,10 +28,67 @@ var (
 	// GenericBootstrapConfigKind is the Kind for the GenericBootstrapConfig.
 	GenericBootstrapConfigKind = "GenericBootstrapConfig"
 	// GenericBootstrapConfigCRD is a generic boostrap CRD.
-	GenericBootstrapConfigCRD = generateCRD(BootstrapGroupVersion.WithKind(GenericBootstrapConfigKind))
+	GenericBootstrapConfigCRD = untypedCRD(BootstrapGroupVersion.WithKind(GenericBootstrapConfigKind))
 
 	// GenericBootstrapConfigTemplateKind is the Kind for the GenericBoostrapConfigTemplate.
 	GenericBootstrapConfigTemplateKind = "GenericBootstrapConfigTemplate"
 	// GenericBootstrapConfigTemplateCRD is a generic boostrap template CRD.
-	GenericBootstrapConfigTemplateCRD = generateCRD(BootstrapGroupVersion.WithKind(GenericBootstrapConfigTemplateKind))
+	GenericBootstrapConfigTemplateCRD = untypedCRD(BootstrapGroupVersion.WithKind(GenericBootstrapConfigTemplateKind))
+
+	// TODO: drop generic CRDs in favour of typed test CRDs.
+
+	// TestBootstrapConfigTemplateKind is the kind for the TestBootstrapConfigTemplate type.
+	TestBootstrapConfigTemplateKind = "TestBootstrapConfigTemplate"
+	// TestBootstrapConfigTemplateCRD is a test bootstrap config template CRD.
+	TestBootstrapConfigTemplateCRD = testBootstrapConfigTemplateCRD(BootstrapGroupVersion.WithKind(TestBootstrapConfigTemplateKind))
+
+	// TestBootstrapConfigKind is the kind for the TestBootstrapConfig type.
+	TestBootstrapConfigKind = "TestBootstrapConfig"
+	// TestBootstrapConfigCRD is a test bootstrap config CRD.
+	TestBootstrapConfigCRD = testBootstrapConfigCRD(BootstrapGroupVersion.WithKind(TestBootstrapConfigKind))
+)
+
+func testBootstrapConfigTemplateCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"spec": {
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				// Mandatory field from the Cluster API contract
+				"template": {
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"spec": bootstrapConfigSpecSchema,
+					},
+				},
+			},
+		},
+	})
+}
+
+func testBootstrapConfigCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"spec": bootstrapConfigSpecSchema,
+		"status": {
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				// mandatory field from the Cluster API contract
+				"ready":          {Type: "boolean"},
+				"dataSecretName": {Type: "string"},
+				// General purpose fields to be used in different test scenario.
+				"foo": {Type: "string"},
+				"bar": {Type: "string"},
+			},
+		},
+	})
+}
+
+var (
+	bootstrapConfigSpecSchema = apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			// General purpose fields to be used in different test scenario.
+			"foo": {Type: "string"},
+			"bar": {Type: "string"},
+		},
+	}
 )

--- a/internal/test/builder/builders.go
+++ b/internal/test/builder/builders.go
@@ -446,6 +446,51 @@ func (i *InfrastructureMachineTemplateBuilder) Build() *unstructured.Unstructure
 	return obj
 }
 
+// TestInfrastructureMachineTemplateBuilder holds the variables and objects needed to build an TestInfrastructureMachineTemplate.
+// +kubebuilder:object:generate=false
+type TestInfrastructureMachineTemplateBuilder struct {
+	namespace  string
+	name       string
+	specFields map[string]interface{}
+}
+
+// TestInfrastructureMachineTemplate creates an TestInfrastructureMachineTemplateBuilder with the given name and namespace.
+func TestInfrastructureMachineTemplate(namespace, name string) *TestInfrastructureMachineTemplateBuilder {
+	return &TestInfrastructureMachineTemplateBuilder{
+		namespace: namespace,
+		name:      name,
+	}
+}
+
+// WithSpecFields sets a map of spec fields on the unstructured object. The keys in the map represent the path and the value corresponds
+// to the value of the spec field.
+//
+// Note: all the paths should start with "spec."; the path should correspond to a field defined in the CRD.
+//
+// Example map: map[string]interface{}{
+//     "spec.version": "v1.2.3",
+// }.
+func (i *TestInfrastructureMachineTemplateBuilder) WithSpecFields(fields map[string]interface{}) *TestInfrastructureMachineTemplateBuilder {
+	i.specFields = fields
+	return i
+}
+
+// Build takes the objects and variables in the  InfrastructureMachineTemplateBuilder and generates an unstructured object.
+func (i *TestInfrastructureMachineTemplateBuilder) Build() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(InfrastructureGroupVersion.String())
+	obj.SetKind(TestInfrastructureMachineTemplateKind)
+	obj.SetNamespace(i.namespace)
+	obj.SetName(i.name)
+
+	// Initialize the spec.template.spec to make the object valid in reconciliation.
+	setSpecFields(obj, map[string]interface{}{"spec.template.spec": map[string]interface{}{}})
+
+	setSpecFields(obj, i.specFields)
+
+	return obj
+}
+
 // BootstrapTemplateBuilder holds the variables needed to build a generic BootstrapTemplate.
 // +kubebuilder:object:generate=false
 type BootstrapTemplateBuilder struct {
@@ -475,10 +520,50 @@ func (b *BootstrapTemplateBuilder) Build() *unstructured.Unstructured {
 	obj.SetKind(GenericBootstrapConfigTemplateKind)
 	obj.SetNamespace(b.namespace)
 	obj.SetName(b.name)
-	setSpecFields(obj, b.specFields)
 
 	// Initialize the spec.template.spec to make the object valid in reconciliation.
 	setSpecFields(obj, map[string]interface{}{"spec.template.spec": map[string]interface{}{}})
+
+	setSpecFields(obj, b.specFields)
+
+	return obj
+}
+
+// TestBootstrapTemplateBuilder holds the variables needed to build a generic TestBootstrapTemplate.
+// +kubebuilder:object:generate=false
+type TestBootstrapTemplateBuilder struct {
+	namespace  string
+	name       string
+	specFields map[string]interface{}
+}
+
+// TestBootstrapTemplate creates a TestBootstrapTemplateBuilder with the given name and namespace.
+func TestBootstrapTemplate(namespace, name string) *TestBootstrapTemplateBuilder {
+	return &TestBootstrapTemplateBuilder{
+		namespace: namespace,
+		name:      name,
+	}
+}
+
+// WithSpecFields will add fields of any type to the object spec. It takes an argument, fields, which is of the form path: object.
+// NOTE: The path should correspond to a field defined in the CRD.
+func (b *TestBootstrapTemplateBuilder) WithSpecFields(fields map[string]interface{}) *TestBootstrapTemplateBuilder {
+	b.specFields = fields
+	return b
+}
+
+// Build creates a new Unstructured object with the information passed to the BootstrapTemplateBuilder.
+func (b *TestBootstrapTemplateBuilder) Build() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(BootstrapGroupVersion.String())
+	obj.SetKind(TestBootstrapConfigTemplateKind)
+	obj.SetNamespace(b.namespace)
+	obj.SetName(b.name)
+
+	// Initialize the spec.template.spec to make the object valid in reconciliation.
+	setSpecFields(obj, map[string]interface{}{"spec.template.spec": map[string]interface{}{}})
+
+	setSpecFields(obj, b.specFields)
 
 	return obj
 }
@@ -626,6 +711,47 @@ func (i *InfrastructureClusterBuilder) Build() *unstructured.Unstructured {
 	return obj
 }
 
+// TestInfrastructureClusterBuilder holds the variables and objects needed to build a generic TestInfrastructureCluster.
+// +kubebuilder:object:generate=false
+type TestInfrastructureClusterBuilder struct {
+	namespace  string
+	name       string
+	specFields map[string]interface{}
+}
+
+// WithSpecFields sets a map of spec fields on the unstructured object. The keys in the map represent the path and the value corresponds
+// to the value of the spec field.
+//
+// Note: all the paths should start with "spec."; the path should correspond to a field defined in the CRD.
+//
+// Example map: map[string]interface{}{
+//     "spec.version": "v1.2.3",
+// }.
+func (i *TestInfrastructureClusterBuilder) WithSpecFields(fields map[string]interface{}) *TestInfrastructureClusterBuilder {
+	i.specFields = fields
+	return i
+}
+
+// TestInfrastructureCluster returns and TestInfrastructureClusterBuilder with the given name and namespace.
+func TestInfrastructureCluster(namespace, name string) *TestInfrastructureClusterBuilder {
+	return &TestInfrastructureClusterBuilder{
+		namespace: namespace,
+		name:      name,
+	}
+}
+
+// Build returns an Unstructured object with the information passed to the InfrastructureClusterBuilder.
+func (i *TestInfrastructureClusterBuilder) Build() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(InfrastructureGroupVersion.String())
+	obj.SetKind(TestInfrastructureClusterKind)
+	obj.SetNamespace(i.namespace)
+	obj.SetName(i.name)
+
+	setSpecFields(obj, i.specFields)
+	return obj
+}
+
 // ControlPlaneBuilder holds the variables and objects needed to build a generic object for cluster.spec.controlPlaneRef.
 // +kubebuilder:object:generate=false
 type ControlPlaneBuilder struct {
@@ -695,6 +821,101 @@ func (f *ControlPlaneBuilder) Build() *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
 	obj.SetAPIVersion(ControlPlaneGroupVersion.String())
 	obj.SetKind(GenericControlPlaneKind)
+	obj.SetNamespace(f.namespace)
+	obj.SetName(f.name)
+
+	setSpecFields(obj, f.specFields)
+	setStatusFields(obj, f.statusFields)
+
+	// TODO(killianmuldoon): Update to use the internal/contract package, when it is importable from here
+	if f.infrastructureMachineTemplate != nil {
+		if err := setNestedRef(obj, f.infrastructureMachineTemplate, "spec", "machineTemplate", "infrastructureRef"); err != nil {
+			panic(err)
+		}
+	}
+	if f.replicas != nil {
+		if err := unstructured.SetNestedField(obj.UnstructuredContent(), *f.replicas, "spec", "replicas"); err != nil {
+			panic(err)
+		}
+	}
+	if f.version != nil {
+		if err := unstructured.SetNestedField(obj.UnstructuredContent(), *f.version, "spec", "version"); err != nil {
+			panic(err)
+		}
+	}
+
+	return obj
+}
+
+// TestControlPlaneBuilder holds the variables and objects needed to build a generic object for cluster.spec.controlPlaneRef.
+// +kubebuilder:object:generate=false
+type TestControlPlaneBuilder struct {
+	namespace                     string
+	name                          string
+	infrastructureMachineTemplate *unstructured.Unstructured
+	replicas                      *int64
+	version                       *string
+	specFields                    map[string]interface{}
+	statusFields                  map[string]interface{}
+}
+
+// TestControlPlane returns a TestControlPlaneBuilder with the given name and Namespace.
+func TestControlPlane(namespace, name string) *TestControlPlaneBuilder {
+	return &TestControlPlaneBuilder{
+		namespace: namespace,
+		name:      name,
+	}
+}
+
+// WithInfrastructureMachineTemplate adds the given unstructured object to the ControlPlaneBuilder as its InfrastructureMachineTemplate.
+func (f *TestControlPlaneBuilder) WithInfrastructureMachineTemplate(t *unstructured.Unstructured) *TestControlPlaneBuilder {
+	f.infrastructureMachineTemplate = t
+	return f
+}
+
+// WithReplicas sets the number of replicas for the ControlPlaneBuilder.
+func (f *TestControlPlaneBuilder) WithReplicas(replicas int64) *TestControlPlaneBuilder {
+	f.replicas = &replicas
+	return f
+}
+
+// WithVersion adds the passed version to the ControlPlaneBuilder.
+func (f *TestControlPlaneBuilder) WithVersion(version string) *TestControlPlaneBuilder {
+	f.version = &version
+	return f
+}
+
+// WithSpecFields sets a map of spec fields on the unstructured object. The keys in the map represent the path and the value corresponds
+// to the value of the spec field.
+//
+// Note: all the paths should start with "spec."; the path should correspond to a field defined in the CRD.
+//
+// Example map: map[string]interface{}{
+//     "spec.version": "v1.2.3",
+// }.
+func (f *TestControlPlaneBuilder) WithSpecFields(m map[string]interface{}) *TestControlPlaneBuilder {
+	f.specFields = m
+	return f
+}
+
+// WithStatusFields sets a map of status fields on the unstructured object. The keys in the map represent the path and the value corresponds
+// to the value of the status field.
+//
+// Note: all the paths should start with "status."; the path should correspond to a field defined in the CRD.
+//
+// Example map: map[string]interface{}{
+//     "status.version": "v1.2.3",
+// }.
+func (f *TestControlPlaneBuilder) WithStatusFields(m map[string]interface{}) *TestControlPlaneBuilder {
+	f.statusFields = m
+	return f
+}
+
+// Build generates an Unstructured object from the information passed to the ControlPlaneBuilder.
+func (f *TestControlPlaneBuilder) Build() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(ControlPlaneGroupVersion.String())
+	obj.SetKind(TestControlPlaneKind)
 	obj.SetNamespace(f.namespace)
 	obj.SetName(f.name)
 

--- a/internal/test/builder/controlplane.go
+++ b/internal/test/builder/controlplane.go
@@ -17,6 +17,7 @@ limitations under the License.
 package builder
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -27,10 +28,89 @@ var (
 	// GenericControlPlaneKind is the Kind for the GenericControlPlane.
 	GenericControlPlaneKind = "GenericControlPlane"
 	// GenericControlPlaneCRD is a generic control plane CRD.
-	GenericControlPlaneCRD = generateCRD(ControlPlaneGroupVersion.WithKind(GenericControlPlaneKind))
+	GenericControlPlaneCRD = untypedCRD(ControlPlaneGroupVersion.WithKind(GenericControlPlaneKind))
 
 	// GenericControlPlaneTemplateKind is the Kind for the GenericControlPlaneTemplate.
 	GenericControlPlaneTemplateKind = "GenericControlPlaneTemplate"
 	// GenericControlPlaneTemplateCRD is a generic control plane template CRD.
-	GenericControlPlaneTemplateCRD = generateCRD(ControlPlaneGroupVersion.WithKind(GenericControlPlaneTemplateKind))
+	GenericControlPlaneTemplateCRD = untypedCRD(ControlPlaneGroupVersion.WithKind(GenericControlPlaneTemplateKind))
+
+	// TODO: drop generic CRDs in favour of typed test CRDs.
+
+	// TestControlPlaneKind is the Kind for the TestControlPlane.
+	TestControlPlaneKind = "TestControlPlane"
+	// TestControlPlaneCRD is a test control plane CRD.
+	TestControlPlaneCRD = testControlPlaneCRD(ControlPlaneGroupVersion.WithKind(TestControlPlaneKind))
 )
+
+func testControlPlaneCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"spec": {
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				// Mandatory field from the Cluster API contract - version support
+				"version": {
+					Type: "string",
+				},
+				// mandatory field from the Cluster API contract - replicas support
+				"replicas": {
+					Type:   "integer",
+					Format: "int32",
+				},
+				// mandatory field from the Cluster API contract - using Machines support
+				"machineTemplate": {
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"metadata":            metadataSchema,
+						"infrastructureRef":   refSchema,
+						"nodeDeletionTimeout": {Type: "string"},
+						"nodeDrainTimeout":    {Type: "string"},
+					},
+				},
+				// General purpose fields to be used in different test scenario.
+				"foo": {Type: "string"},
+				"bar": {Type: "string"},
+				// Copy of a subset of KCP spec fields to test server side apply on deep nested structs
+				"kubeadmConfigSpec": {
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"clusterConfiguration": {
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"controllerManager": {
+									Type: "object",
+									Properties: map[string]apiextensionsv1.JSONSchemaProps{
+										"extraArgs": {
+											Type: "object",
+											AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+												Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"status": {
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				// mandatory field from the Cluster API contract
+				"ready": {Type: "boolean"},
+				// mandatory field from the Cluster API contract - replicas support
+				"replicas":            {Type: "integer", Format: "int32"},
+				"selector":            {Type: "string"},
+				"readyReplicas":       {Type: "integer", Format: "int32"},
+				"unavailableReplicas": {Type: "integer", Format: "int32"},
+				"updatedReplicas":     {Type: "integer", Format: "int32"},
+				// Mandatory field from the Cluster API contract - version support
+				"version": {Type: "string"},
+				// General purpose fields to be used in different test scenario.
+				"foo": {Type: "string"},
+				"bar": {Type: "string"},
+			},
+		},
+	})
+}

--- a/internal/test/builder/infrastructure.go
+++ b/internal/test/builder/infrastructure.go
@@ -17,6 +17,7 @@ limitations under the License.
 package builder
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -27,20 +28,117 @@ var (
 	// GenericInfrastructureMachineKind is the Kind for the GenericInfrastructureMachine.
 	GenericInfrastructureMachineKind = "GenericInfrastructureMachine"
 	// GenericInfrastructureMachineCRD is a generic infrastructure machine CRD.
-	GenericInfrastructureMachineCRD = generateCRD(InfrastructureGroupVersion.WithKind(GenericInfrastructureMachineKind))
+	GenericInfrastructureMachineCRD = untypedCRD(InfrastructureGroupVersion.WithKind(GenericInfrastructureMachineKind))
 
 	// GenericInfrastructureMachineTemplateKind is the Kind for the GenericInfrastructureMachineTemplate.
 	GenericInfrastructureMachineTemplateKind = "GenericInfrastructureMachineTemplate"
 	// GenericInfrastructureMachineTemplateCRD is a generic infrastructure machine template CRD.
-	GenericInfrastructureMachineTemplateCRD = generateCRD(InfrastructureGroupVersion.WithKind(GenericInfrastructureMachineTemplateKind))
+	GenericInfrastructureMachineTemplateCRD = untypedCRD(InfrastructureGroupVersion.WithKind(GenericInfrastructureMachineTemplateKind))
 
 	// GenericInfrastructureClusterKind is the kind for the GenericInfrastructureCluster type.
 	GenericInfrastructureClusterKind = "GenericInfrastructureCluster"
 	// GenericInfrastructureClusterCRD is a generic infrastructure machine CRD.
-	GenericInfrastructureClusterCRD = generateCRD(InfrastructureGroupVersion.WithKind(GenericInfrastructureClusterKind))
+	GenericInfrastructureClusterCRD = untypedCRD(InfrastructureGroupVersion.WithKind(GenericInfrastructureClusterKind))
 
 	// GenericInfrastructureClusterTemplateKind is the kind for the GenericInfrastructureClusterTemplate type.
 	GenericInfrastructureClusterTemplateKind = "GenericInfrastructureClusterTemplate"
 	// GenericInfrastructureClusterTemplateCRD is a generic infrastructure machine template CRD.
-	GenericInfrastructureClusterTemplateCRD = generateCRD(InfrastructureGroupVersion.WithKind(GenericInfrastructureClusterTemplateKind))
+	GenericInfrastructureClusterTemplateCRD = untypedCRD(InfrastructureGroupVersion.WithKind(GenericInfrastructureClusterTemplateKind))
+
+	// TODO: drop generic CRDs in favour of typed test CRDs.
+
+	// TestInfrastructureClusterKind is the kind for the TestInfrastructureCluster type.
+	TestInfrastructureClusterKind = "TestInfrastructureCluster"
+	// TestInfrastructureClusterCRD is a test infrastructure machine CRD.
+	TestInfrastructureClusterCRD = testInfrastructureClusterCRD(InfrastructureGroupVersion.WithKind(TestInfrastructureClusterKind))
+
+	// TestInfrastructureMachineTemplateKind is the kind for the TestInfrastructureMachineTemplate type.
+	TestInfrastructureMachineTemplateKind = "TestInfrastructureMachineTemplate"
+	// TestInfrastructureMachineTemplateCRD is a test infrastructure machine template CRD.
+	TestInfrastructureMachineTemplateCRD = testInfrastructureMachineTemplateCRD(InfrastructureGroupVersion.WithKind(TestInfrastructureMachineTemplateKind))
+
+	// TestInfrastructureMachineKind is the kind for the TestInfrastructureMachine type.
+	TestInfrastructureMachineKind = "TestInfrastructureMachine"
+	// TestInfrastructureMachineCRD is a test infrastructure machine CRD.
+	TestInfrastructureMachineCRD = testInfrastructureMachineCRD(InfrastructureGroupVersion.WithKind(TestInfrastructureMachineKind))
+)
+
+func testInfrastructureClusterCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"spec": {
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				// Mandatory field from the Cluster API contract
+				"controlPlaneEndpoint": {
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"host": {Type: "string"},
+						"port": {Type: "integer"},
+					},
+					Required: []string{"host", "port"},
+				},
+				// General purpose fields to be used in different test scenario.
+				"foo": {Type: "string"},
+				"bar": {Type: "string"},
+			},
+		},
+		"status": {
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				// mandatory field from the Cluster API contract
+				"ready": {Type: "boolean"},
+				// General purpose fields to be used in different test scenario.
+				"foo": {Type: "string"},
+				"bar": {Type: "string"},
+			},
+			Required: []string{"ready"},
+		},
+	})
+}
+
+func testInfrastructureMachineTemplateCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"spec": {
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				// Mandatory field from the Cluster API contract
+				"template": {
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"metadata": metadataSchema,
+						"spec":     machineSpecSchema,
+					},
+				},
+			},
+		},
+	})
+}
+
+func testInfrastructureMachineCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"spec": machineSpecSchema,
+		"status": {
+			Type: "object",
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{
+				// mandatory field from the Cluster API contract
+				"ready": {Type: "boolean"},
+				// General purpose fields to be used in different test scenario.
+				"foo": {Type: "string"},
+				"bar": {Type: "string"},
+			},
+		},
+	})
+}
+
+var (
+	machineSpecSchema = apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			// Mandatory field from the Cluster API contract
+			"providerID": {Type: "string"},
+			// General purpose fields to be used in different test scenario.
+			"foo": {Type: "string"},
+			"bar": {Type: "string"},
+		},
+	}
 )

--- a/internal/test/builder/remediation.go
+++ b/internal/test/builder/remediation.go
@@ -25,8 +25,8 @@ var (
 	RemediationGroupVersion = schema.GroupVersion{Group: "remediation.external.io", Version: "v1beta1"}
 
 	// GenericRemediationCRD is a generic infrastructure remediation CRD.
-	GenericRemediationCRD = generateCRD(RemediationGroupVersion.WithKind("GenericExternalRemediation"))
+	GenericRemediationCRD = untypedCRD(RemediationGroupVersion.WithKind("GenericExternalRemediation"))
 
 	// GenericRemediationTemplateCRD is a generic infrastructure remediation template CRD.
-	GenericRemediationTemplateCRD = generateCRD(RemediationGroupVersion.WithKind("GenericExternalRemediationTemplate"))
+	GenericRemediationTemplateCRD = untypedCRD(RemediationGroupVersion.WithKind("GenericExternalRemediationTemplate"))
 )

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -176,6 +176,12 @@ func newEnvironment(uncachedObjs ...client.Object) *Environment {
 			builder.GenericInfrastructureClusterTemplateCRD.DeepCopy(),
 			builder.GenericRemediationCRD.DeepCopy(),
 			builder.GenericRemediationTemplateCRD.DeepCopy(),
+			builder.TestInfrastructureClusterCRD.DeepCopy(),
+			builder.TestInfrastructureMachineTemplateCRD.DeepCopy(),
+			builder.TestInfrastructureMachineCRD.DeepCopy(),
+			builder.TestBootstrapConfigTemplateCRD.DeepCopy(),
+			builder.TestBootstrapConfigCRD.DeepCopy(),
+			builder.TestControlPlaneCRD.DeepCopy(),
 		},
 		// initialize webhook here to be able to test the envtest install via webhookOptions
 		// This should set LocalServingCertDir and LocalServingPort that are used below.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR introduces new CRDs which are meant to get used in tests:
* `TestBootstrapConfigTemplate`
* `TestBootstrapConfig `
* `TestControlPlane`
* `TestInfrastructureCluster`
* `TestInfrastructureMachineTemplate`
* `TestInfrastructureMachine`

Compared to their `Generic*` equivalents the `Test*` CRDs are typed (instead of being untyped).
Using typed CRDs in tests instead of untyped ones prevents unexpected behaviour in tests when using Server-Side apply with regards to how managed managed-fields get handled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
part of https://github.com/kubernetes-sigs/cluster-api/issues/6320
