### PR TITLE
🌱 hack/release-notes: trim [release-*] in PR titles

### DIFF
--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 )
 
@@ -57,6 +58,8 @@ var (
 	}
 
 	fromTag = flag.String("from", "", "The tag or commit to start from.")
+
+	tagRegex = regexp.MustCompile(`^\[release-[\w-\.]*\]`)
 )
 
 func main() {
@@ -122,7 +125,7 @@ func run() int {
 	}
 
 	for _, c := range commits {
-		body := strings.TrimSpace(c.body)
+		body := trimTitle(c.body)
 		var key, prNumber, fork string
 		switch {
 		case strings.HasPrefix(body, ":sparkles:"), strings.HasPrefix(body, "✨"):
@@ -194,6 +197,13 @@ func run() int {
 	fmt.Println("_Thanks to all our contributors!_ 😊")
 
 	return 0
+}
+
+func trimTitle(title string) string {
+	// Remove a tag prefix if found.
+	title = tagRegex.ReplaceAllString(title, "")
+
+	return strings.TrimSpace(title)
 }
 
 type commit struct {

--- a/hack/tools/release/notes_test.go
+++ b/hack/tools/release/notes_test.go
@@ -1,0 +1,63 @@
+//go:build tools
+// +build tools
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func Test_trimTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{
+			name:  "regular PR title",
+			title: "📖 book: Use relative links in generate CRDs doc",
+			want:  "📖 book: Use relative links in generate CRDs doc",
+		},
+		{
+			name:  "PR title with WIP",
+			title: "WIP 📖 book: Use relative links in generate CRDs doc",
+			want:  "WIP 📖 book: Use relative links in generate CRDs doc",
+		},
+		{
+			name:  "PR title with [WIP]",
+			title: "[WIP] 📖 book: Use relative links in generate CRDs doc",
+			want:  "[WIP] 📖 book: Use relative links in generate CRDs doc",
+		},
+		{
+			name:  "PR title with [release-1.0]",
+			title: "[release-1.0] 📖 book: Use relative links in generate CRDs doc",
+			want:  "📖 book: Use relative links in generate CRDs doc",
+		},
+		{
+			name:  "PR title with [WIP][release-1.0]",
+			title: "[WIP][release-1.0] 📖 book: Use relative links in generate CRDs doc",
+			want:  "[WIP][release-1.0] 📖 book: Use relative links in generate CRDs doc",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trimTitle(tt.title); got != tt.want {
+				t.Errorf("trimTitle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6160
