### PR TITLE
:seedling: Add client defaulting and validation for DiscoveryResponse

### DIFF
--- a/exp/runtime/hooks/api/v1alpha1/discovery_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/discovery_types.go
@@ -54,9 +54,11 @@ type ExtensionHandler struct {
 	RequestHook GroupVersionHook `json:"requestHook"`
 
 	// TimeoutSeconds defines the timeout duration for client calls to the ExtensionHandler.
+	// This is defaulted to 10 if left undefined.
 	TimeoutSeconds *int32 `json:"timeoutSeconds,omitempty"`
 
 	// FailurePolicy defines how failures in calls to the ExtensionHandler should be handled by a client.
+	// This is defaulted to FailurePolicyFail if not defined.
 	FailurePolicy *FailurePolicy `json:"failurePolicy,omitempty"`
 }
 

--- a/exp/runtime/hooks/api/v1alpha1/zz_generated.openapi.go
+++ b/exp/runtime/hooks/api/v1alpha1/zz_generated.openapi.go
@@ -797,14 +797,14 @@ func schema_runtime_hooks_api_v1alpha1_ExtensionHandler(ref common.ReferenceCall
 					},
 					"timeoutSeconds": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TimeoutSeconds defines the timeout duration for client calls to the ExtensionHandler.",
+							Description: "TimeoutSeconds defines the timeout duration for client calls to the ExtensionHandler. This is defaulted to 10 if left undefined.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"failurePolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "FailurePolicy defines how failures in calls to the ExtensionHandler should be handled by a client.",
+							Description: "FailurePolicy defines how failures in calls to the ExtensionHandler should be handled by a client. This is defaulted to FailurePolicyFail if not defined.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -38,6 +38,7 @@ import (
 	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
 	runtimeregistry "sigs.k8s.io/cluster-api/internal/runtime/registry"
+	fakev1alpha1 "sigs.k8s.io/cluster-api/internal/runtime/test/v1alpha1"
 	"sigs.k8s.io/cluster-api/util"
 )
 
@@ -50,6 +51,8 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 
 	cat := runtimecatalog.New()
+	g.Expect(fakev1alpha1.AddToCatalog(cat)).To(Succeed())
+
 	registry := runtimeregistry.New()
 	runtimeClient := runtimeclient.New(runtimeclient.Options{
 		Catalog:  cat,
@@ -187,6 +190,8 @@ func TestExtensionReconciler_discoverExtensionConfig(t *testing.T) {
 
 	t.Run("test discovery of a single extension", func(t *testing.T) {
 		cat := runtimecatalog.New()
+		g.Expect(fakev1alpha1.AddToCatalog(cat)).To(Succeed())
+
 		registry := runtimeregistry.New()
 		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 		extensionName := "ext1"
@@ -217,6 +222,7 @@ func TestExtensionReconciler_discoverExtensionConfig(t *testing.T) {
 	})
 	t.Run("fail discovery for non-running extension", func(t *testing.T) {
 		cat := runtimecatalog.New()
+		g.Expect(fakev1alpha1.AddToCatalog(cat)).To(Succeed())
 		registry := runtimeregistry.New()
 		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 		extensionName := "ext1"
@@ -254,8 +260,8 @@ func discoveryHandler(handlerList ...string) func(http.ResponseWriter, *http.Req
 		handlers = append(handlers, runtimehooksv1.ExtensionHandler{
 			Name: name,
 			RequestHook: runtimehooksv1.GroupVersionHook{
-				Hook:       name,
-				APIVersion: runtimehooksv1.GroupVersion.String(),
+				Hook:       "FakeHook",
+				APIVersion: fakev1alpha1.GroupVersion.String(),
 			},
 		})
 	}

--- a/exp/runtime/internal/controllers/warmup_test.go
+++ b/exp/runtime/internal/controllers/warmup_test.go
@@ -32,6 +32,7 @@ import (
 	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
 	runtimeregistry "sigs.k8s.io/cluster-api/internal/runtime/registry"
+	fakev1alpha1 "sigs.k8s.io/cluster-api/internal/runtime/test/v1alpha1"
 )
 
 func Test_warmupRunnable_Start(t *testing.T) {
@@ -44,6 +45,8 @@ func Test_warmupRunnable_Start(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		cat := runtimecatalog.New()
+		g.Expect(fakev1alpha1.AddToCatalog(cat)).To(Succeed())
+
 		registry := runtimeregistry.New()
 		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 
@@ -93,6 +96,7 @@ func Test_warmupRunnable_Start(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 
 		cat := runtimecatalog.New()
+		g.Expect(fakev1alpha1.AddToCatalog(cat)).To(Succeed())
 		registry := runtimeregistry.New()
 		g.Expect(runtimehooksv1.AddToCatalog(cat)).To(Succeed())
 

--- a/internal/runtime/catalog/catalog.go
+++ b/internal/runtime/catalog/catalog.go
@@ -315,6 +315,12 @@ func (c *Catalog) ValidateResponse(hook GroupVersionHook, obj runtime.Object) er
 	return nil
 }
 
+// IsHookRegistered returns true if the GroupVersionHook is registered with the catalog.
+func (c *Catalog) IsHookRegistered(gvh GroupVersionHook) bool {
+	_, found := c.gvhToType[gvh]
+	return found
+}
+
 // GroupVersionHook unambiguously identifies a Hook.
 type GroupVersionHook struct {
 	Group   string


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Adds some basic validation and defaulting rules to the runtime SDK client on Discovery of Extension Handlers.

Part of #6330 
