### PR TITLE
🌱 RuntimeSDK: change webhook default port to 443

### DIFF
--- a/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
+++ b/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
@@ -70,9 +70,9 @@ spec:
                           be used as prefix and the hook-specific path will be appended.
                         type: string
                       port:
-                        description: Port is the port on the service that hosting
-                          ExtensionHandler. Default to 8443. `port` should be a valid
-                          port number (1-65535, inclusive).
+                        description: Port is the port on the service that's hosting
+                          the ExtensionHandler. Default to 443. `port` should be a
+                          valid port number (1-65535, inclusive).
                         format: int32
                         type: integer
                     required:

--- a/exp/runtime/api/v1alpha1/extensionconfig_types.go
+++ b/exp/runtime/api/v1alpha1/extensionconfig_types.go
@@ -87,8 +87,8 @@ type ServiceReference struct {
 	// +optional
 	Path *string `json:"path,omitempty"`
 
-	// Port is the port on the service that hosting ExtensionHandler.
-	// Default to 8443.
+	// Port is the port on the service that's hosting the ExtensionHandler.
+	// Default to 443.
 	// `port` should be a valid port number (1-65535, inclusive).
 	// +optional
 	Port *int32 `json:"port,omitempty"`

--- a/internal/runtime/registry/registry.go
+++ b/internal/runtime/registry/registry.go
@@ -206,7 +206,7 @@ func (r *extensionRegistry) Get(name string) (*ExtensionRegistration, error) {
 	defer r.lock.RUnlock()
 
 	if !r.ready {
-		return nil, errors.New("invalid operation: Get cannot called on a registry not yet ready")
+		return nil, errors.New("invalid operation: Get cannot be called on a registry not yet ready")
 	}
 
 	registration, ok := r.items[name]

--- a/internal/webhooks/runtime/extensionconfig_webhook.go
+++ b/internal/webhooks/runtime/extensionconfig_webhook.go
@@ -64,7 +64,7 @@ func (webhook *ExtensionConfig) Default(ctx context.Context, obj runtime.Object)
 	}
 	if extensionConfig.Spec.ClientConfig.Service != nil {
 		if extensionConfig.Spec.ClientConfig.Service.Port == nil {
-			extensionConfig.Spec.ClientConfig.Service.Port = pointer.Int32(8443)
+			extensionConfig.Spec.ClientConfig.Service.Port = pointer.Int32(443)
 		}
 	}
 	return nil

--- a/internal/webhooks/runtime/extensionconfig_webhook_test.go
+++ b/internal/webhooks/runtime/extensionconfig_webhook_test.go
@@ -128,7 +128,7 @@ func TestExtensionConfigDefault(t *testing.T) {
 
 	g.Expect(extensionConfigWebhook.Default(ctx, extensionConfig)).To(Succeed())
 	g.Expect(extensionConfig.Spec.NamespaceSelector).To(Equal(&metav1.LabelSelector{}))
-	g.Expect(extensionConfig.Spec.ClientConfig.Service.Port).To(Equal(pointer.Int32(8443)))
+	g.Expect(extensionConfig.Spec.ClientConfig.Service.Port).To(Equal(pointer.Int32(443)))
 }
 
 func TestExtensionConfigValidate(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
We initially chose 8443 (instead of 443 like the admission webhook configuration resources) as a default port as we thought it might be a good idea as 443 is one of the ports below 1024 which cannot be easily used in containers with restricted privileges.

But I missed at that point that we are not referencing the Pod directly but the Service. The standard for the service port is 443 (I would use the same default port for Extensions as we do for provider webhooks).



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
