### PR TITLE
🐛 cloudbuild: upgrade to latest cloudbuild image to fix image push

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220506-774f302a94'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +13,7 @@ steps:
     - DOCKER_BUILDKIT=1
     args:
     - release-staging-nightly
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220506-774f302a94'
     dir: 'test/infrastructure/docker'
     entrypoint: make
     env:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220506-774f302a94'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +13,7 @@ steps:
     - DOCKER_BUILDKIT=1
     args:
     - release-staging
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211013-1be7868d8b'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220506-774f302a94'
     dir: 'test/infrastructure/docker'
     entrypoint: make
     env:


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Our image push / cloudbuild is broken since 14th May (https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/cluster-api-push-images-nightly). Not sure what happened then but looks like we can't compile kustomize with Go 1.16. This PR tries to fix this issue by bumping to a recent cloud build image which includes Go 1.17.

Notes:
* I can reproduce locally that kustomize can't be build with Go 1.16 but works with Go 1.17
* Just got the alert mail from Prow today, not sure if I/we missed an earlier one or there was an issue with alerting as well

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
