### PR TITLE
✨ Make KCP's patches option mutable 

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -115,6 +115,8 @@ const (
 	initConfiguration    = "initConfiguration"
 	joinConfiguration    = "joinConfiguration"
 	nodeRegistration     = "nodeRegistration"
+	patches              = "patches"
+	directory            = "directory"
 	preKubeadmCommands   = "preKubeadmCommands"
 	postKubeadmCommands  = "postKubeadmCommands"
 	files                = "files"
@@ -142,7 +144,9 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, clusterConfiguration, controllerManager, "*"},
 		{spec, kubeadmConfigSpec, clusterConfiguration, scheduler, "*"},
 		{spec, kubeadmConfigSpec, initConfiguration, nodeRegistration, "*"},
+		{spec, kubeadmConfigSpec, initConfiguration, patches, directory},
 		{spec, kubeadmConfigSpec, joinConfiguration, nodeRegistration, "*"},
+		{spec, kubeadmConfigSpec, joinConfiguration, patches, directory},
 		{spec, kubeadmConfigSpec, preKubeadmCommands},
 		{spec, kubeadmConfigSpec, postKubeadmCommands},
 		{spec, kubeadmConfigSpec, files},

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -608,6 +608,16 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 	validIgnitionConfigurationAfter := validIgnitionConfigurationBefore.DeepCopy()
 	validIgnitionConfigurationAfter.Spec.KubeadmConfigSpec.Ignition.ContainerLinuxConfig.AdditionalConfig = "foo: bar"
 
+	updateInitConfigurationPatches := before.DeepCopy()
+	updateInitConfigurationPatches.Spec.KubeadmConfigSpec.InitConfiguration.Patches = &bootstrapv1.Patches{
+		Directory: "/tmp/patches",
+	}
+
+	updateJoinConfigurationPatches := before.DeepCopy()
+	updateJoinConfigurationPatches.Spec.KubeadmConfigSpec.InitConfiguration.Patches = &bootstrapv1.Patches{
+		Directory: "/tmp/patches",
+	}
+
 	tests := []struct {
 		name                  string
 		enableIgnitionFeature bool
@@ -913,6 +923,18 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: false,
 			before:    before,
 			kcp:       disableNTPServers,
+		},
+		{
+			name:      "should disallow changes to initConfiguration.patches",
+			expectErr: true,
+			before:    before,
+			kcp:       updateInitConfigurationPatches,
+		},
+		{
+			name:      "should disallow changes to joinConfiguration.patches",
+			expectErr: true,
+			before:    before,
+			kcp:       updateJoinConfigurationPatches,
 		},
 		{
 			name:                  "should return error when Ignition configuration is invalid",

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -925,14 +925,14 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			kcp:       disableNTPServers,
 		},
 		{
-			name:      "should disallow changes to initConfiguration.patches",
-			expectErr: true,
+			name:      "should allow changes to initConfiguration.patches",
+			expectErr: false,
 			before:    before,
 			kcp:       updateInitConfigurationPatches,
 		},
 		{
-			name:      "should disallow changes to joinConfiguration.patches",
-			expectErr: true,
+			name:      "should allow changes to joinConfiguration.patches",
+			expectErr: false,
 			before:    before,
 			kcp:       updateJoinConfigurationPatches,
 		},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR makes KubeadmControlPlane's patches option mutable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Closes #6576
