### PR TITLE
:seedling: Remove CI image pull and tagging for kubeadm injection script

### DIFF
--- a/test/framework/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
+++ b/test/framework/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
@@ -65,12 +65,6 @@ if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
   CI_DIR=/tmp/k8s-ci
   mkdir -p "$${CI_DIR}"
   declare -a PACKAGES_TO_TEST=("kubectl" "kubelet" "kubeadm")
-  {{- if .IsControlPlaneMachine }}
-  declare -a CONTAINERS_TO_TEST=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
-  {{- else }}
-  declare -a CONTAINERS_TO_TEST=("kube-proxy")
-  {{- end }}
-  CONTAINER_EXT="tar"
   echo "* testing CI version $${KUBERNETES_VERSION}"
   # Check for semver
   if [[ "$${KUBERNETES_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -102,17 +96,6 @@ if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
     done
     systemctl restart kubelet
   fi
-  for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do
-    # Redirect: https://dl.k8s.io/release/{path}
-    # e.g. https://dl.k8s.io/release/v1.20.4/bin/linux/amd64/kube-apiserver.tar
-    # Browser: https://gcsweb.k8s.io/gcs/kubernetes-release/
-    # e.g. https://gcsweb.k8s.io/gcs/kubernetes-release/release/v1.20.4/bin/linux/amd64
-    echo "* downloading package: $${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-    wget "$${CI_URL}/$${CI_CONTAINER}.$${CONTAINER_EXT}" -O "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}"
-    $${SUDO} ctr -n k8s.io images import "$${CI_DIR}/$${CI_CONTAINER}.$${CONTAINER_EXT}" || echo "* ignoring expected 'ctr images import' result"
-    $${SUDO} ctr -n k8s.io images tag "k8s.gcr.io/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "k8s.gcr.io/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
-    $${SUDO} ctr -n k8s.io images tag "k8s.gcr.io/$${CI_CONTAINER}-amd64:$${KUBERNETES_VERSION//+/_}" "gcr.io/k8s-staging-ci-images/$${CI_CONTAINER}:$${KUBERNETES_VERSION//+/_}"
-  done
 fi
 echo "* checking binary versions"
 echo "ctr version: " "$(ctr version)"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
After the switch from k8s.gcr.io to registry.k8s.io (see https://github.com/kubernetes/kubernetes/pull/109938 for details), the CI jobs are outputting the following when trying to extract the ci images:

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/capz-conformance-master/1532465763934277632

```
[2022-06-02 21:09:45] 
[2022-06-02 21:09:49] unpacking registry.k8s.io/kube-apiserver-amd64:v1.25.0-alpha.0.734_ba502ee555924a (sha256:4600d5b413457521bd7c01d24c0b21288c63f05137aa7547b6e0cb5e9a654bef)...done
[2022-06-02 21:09:49] ctr: image "k8s.gcr.io/kube-apiserver-amd64:v1.25.0-alpha.0.734_ba502ee555924a": not found`
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2351

### other info
I found [our jobs](https://testgrid.k8s.io/provider-azure-master-signal#capz-conformance) are not failing since kubeadm is smart enough because we give it the `kubernetesversion` in the job config, even without this to pull the correct images so our jobs are still passing.  

See https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/9e793b42f79b65cbc830e711dce63a2c1e7c82c0/templates/test/ci/cluster-template-prow-ci-version-windows-containerd-2022.yaml#L90

Is there a reason to pull these images?
