### PR TITLE
✨ Add Cluster API Visualizer to Tilt observability

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -354,6 +354,15 @@ def deploy_observability():
         k8s_yaml(read_file("./.tiltbuild/yaml/prometheus.observability.yaml"), allow_duplicates = True)
         k8s_resource(workload = "prometheus-server", new_name = "prometheus", port_forwards = "9090", extra_pod_selectors = [{"app": "prometheus"}], labels = ["observability"])
 
+    if "visualizer" in settings.get("deploy_observability", []):
+        k8s_yaml(read_file("./.tiltbuild/yaml/visualizer.observability.yaml"), allow_duplicates = True)
+        k8s_resource(
+            workload = "capi-visualizer",
+            new_name = "visualizer",
+            port_forwards = [port_forward(local_port = 8000, container_port = 8081, name = "View visualization")],
+            labels = ["observability"],
+        )
+
 def prepare_all():
     allow_k8s_arg = ""
     if settings.get("allowed_contexts"):

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -173,7 +173,7 @@ kustomize_substitutions:
 {{#/tabs }}
 
 **deploy_observability** ([string], default=[]): If set, installs on the dev cluster one of more observability
-tools. Supported values are `grafana`, `loki`, `promtail` and/or `prometheus` (Note: the UI for `grafana` and `prometheus` will be accessible via a link in the tilt console).
+tools. Supported values are `grafana`, `loki`, `visualizer`, `promtail` and/or `prometheus` (Note: the UI for `grafana`, `prometheus`, and `visualizer` will be accessible via a link in the tilt console).
 Important! This feature requires the `helm` command to be available in the user's path.
 
 **debug** (Map{string: Map} default{}): A map of named configurations for the provider. The key is the name of the provider.

--- a/hack/observability/visualizer/kustomization.yaml
+++ b/hack/observability/visualizer/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - ../namespace.yaml
+
+helmCharts:
+  - name: cluster-api-visualizer
+    repo: https://raw.githubusercontent.com/Jont828/cluster-api-visualizer/main/helm/repo
+    releaseName: visualizer
+    namespace: observability
+    valuesFile: values.yaml

--- a/hack/observability/visualizer/values.yaml
+++ b/hack/observability/visualizer/values.yaml
@@ -1,0 +1,12 @@
+replicas: 1
+
+image:
+  repository: ghcr.io/jont828
+  name: cluster-api-visualizer
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0.1.0-alpha.2"
+
+label: 
+  key: app
+  value: visualizer


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This PR adds the Cluster API Visualizer app to Tilt under the observability section. It can be enabled by adding "cluster-api-visualizer" to the "deploy_observability" array. The Tilt UI looks as follows and the "View visualization" link opens it in the browser.

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/17480384/171965198-52003a8d-683e-4957-9d16-fa2894709b5e.png">


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
