### PR TITLE
⚠️ Bump mink8s mgmt cluster version to 1.20.2

### DIFF
--- a/cmd/clusterctl/client/cluster/client.go
+++ b/cmd/clusterctl/client/cluster/client.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	minimumKubernetesVersion = "v1.19.1"
+	minimumKubernetesVersion = "v1.20.0"
 )
 
 var (

--- a/docs/book/src/developer/providers/v1.1-to-v1.2.md
+++ b/docs/book/src/developer/providers/v1.1-to-v1.2.md
@@ -3,6 +3,10 @@
 This document provides an overview over relevant changes between ClusterAPI v1.1 and v1.2 for
 maintainers of providers and consumers of our Go API.
 
+## Minimum Kubernetes version for the management cluster
+
+* The minimum Kubernetes version that can be used for a management cluster by Cluster API is now Go 1.20.0
+
 ## Minimum Go version
 
 * The Go version used by Cluster API is now Go 1.17.x

--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -46,7 +46,7 @@ The Core Provider, Kubeadm Bootstrap Provider, and Kubeadm Control Plane Provide
 In some cases, the Management Cluster is separate from the Workload Clusters. The Kubernetes version of the Management and Workload Clusters are allowed to be different.
 
 Management Clusters and Workload Clusters can be upgraded independently and in any order, however, if you are additionally moving from
-v1alpha3 (v0.3.x) to v1beta1 (v1.x) as part of the upgrade rollout, the management cluster will need to be upgraded to at least v1.19.x,
+v1alpha3 (v0.3.x) to v1beta1 (v1.x) as part of the upgrade rollout, the management cluster will need to be upgraded to at least v1.20.x,
 prior to upgrading any workload cluster using Cluster API v1beta1 (v1.x)
 
 These diagrams show the relationships between components in a Cluster API release (yellow), and other components (white).
@@ -68,7 +68,7 @@ These diagrams show the relationships between components in a Cluster API releas
 | Kubernetes v1.16 | ✓                     |                        |                      |                          |
 | Kubernetes v1.17 | ✓                     |                        |                      |                          |
 | Kubernetes v1.18 | ✓                     | ✓ (only workload)      | ✓ (only workload)    | ✓ (only workload)        |
-| Kubernetes v1.19 | ✓                     | ✓                      | ✓                    | ✓                        |
+| Kubernetes v1.19 | ✓                     | ✓                      | ✓                    | ✓ (only workload v1.2)   |
 | Kubernetes v1.20 | ✓                     | ✓                      | ✓                    | ✓                        |
 | Kubernetes v1.21 | ✓                     | ✓                      | ✓                    | ✓                        |
 | Kubernetes v1.22 | ✓ (only workload)     | ✓                      | ✓                    | ✓                        |
@@ -87,7 +87,7 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 | Kubernetes v1.16 + kubeadm/v1beta2 | ✓                                |                      |                     |                          |
 | Kubernetes v1.17 + kubeadm/v1beta2 | ✓                                |                      |                     |                          |
 | Kubernetes v1.18 + kubeadm/v1beta2 | ✓                                | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
-| Kubernetes v1.19 + kubeadm/v1beta2 | ✓                                | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.19 + kubeadm/v1beta2 | ✓                                | ✓                    | ✓                   | ✓ (only workload v1.2)   |
 | Kubernetes v1.20 + kubeadm/v1beta2 | ✓                                | ✓                    | ✓                   | ✓                        |
 | Kubernetes v1.21 + kubeadm/v1beta2 | ✓                                | ✓                    | ✓                   | ✓                        |
 | Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) | ✓ (only workload) |  ✓   | ✓                   | ✓                        |
@@ -103,7 +103,7 @@ The Kubeadm Bootstrap Provider generates kubeadm configuration using the API ver
 | Kubernetes v1.16 + etcd/v3 | ✓                    |                      |                     |                          |
 | Kubernetes v1.17 + etcd/v3 | ✓                    |                      |                     |                          |
 | Kubernetes v1.18 + etcd/v3 | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
-| Kubernetes v1.19 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.19 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓ (only workload v1.2)   |
 | Kubernetes v1.20 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                        |
 | Kubernetes v1.21 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                        |
 | Kubernetes v1.22 + etcd/v3 | ✓* (only workload)   | ✓                    | ✓                   | ✓                        |

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -30,7 +30,7 @@ a target [management cluster] on the selected [infrastructure provider].
 
 1. **Existing Management Cluster**
 
-   For production use-cases a "real" Kubernetes cluster should be used with appropriate backup and DR policies and procedures in place. The Kubernetes cluster must be at least v1.19.1.
+   For production use-cases a "real" Kubernetes cluster should be used with appropriate backup and DR policies and procedures in place. The Kubernetes cluster must be at least v1.20.0.
 
    ```bash
    export KUBECONFIG=<...>


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to fix failures on https://github.com/kubernetes-sigs/cluster-api/pull/6495 I discovered that we need a fix for a SSA apply issue that merged in Kubernetes 1.20 (https://github.com/kubernetes/kubernetes/issues/95680), so bumping CAPI mink8s version to 1.20.2

This will allow tests to pass.
We are considering if to add an additional restriction when using CC, to require management cluster >= v1.22 (the version where SSA went GA), but this will be discussed as part of https://github.com/kubernetes-sigs/cluster-api/pull/6495 

/cc @sbueringer