### PR TITLE
🌱 logging: use klog.Background

### DIFF
--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -150,11 +149,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set the Klog format, as the Serialize format shouldn't be used anymore.
-	// This makes sure that the logs are formatted correctly, i.e.:
-	// * JSON logging format: msg isn't serialized twice
-	// * text logging format: values are formatted with their .String() func.
-	ctrl.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+	// klog.Background will automatically use the right logger.
+	ctrl.SetLogger(klog.Background())
 
 	if profilerAddress != "" {
 		klog.Infof("Profiler listening for requests at %s", profilerAddress)

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -153,11 +152,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set the Klog format, as the Serialize format shouldn't be used anymore.
-	// This makes sure that the logs are formatted correctly, i.e.:
-	// * JSON logging format: msg isn't serialized twice
-	// * text logging format: values are formatted with their .String() func.
-	ctrl.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+	// klog.Background will automatically use the right logger.
+	ctrl.SetLogger(klog.Background())
 
 	if profilerAddress != "" {
 		klog.Infof("Profiler listening for requests at %s", profilerAddress)

--- a/docs/book/src/developer/providers/v1.1-to-v1.2.md
+++ b/docs/book/src/developer/providers/v1.1-to-v1.2.md
@@ -70,11 +70,8 @@ in ClusterAPI are kept in sync with the versions used by `sigs.k8s.io/controller
       +		os.Exit(1)
       +	}
       +
-      +	// Set the Klog format, as the Serialize format shouldn't be used anymore.
-      +	// This makes sure that the logs are formatted correctly, i.e.:
-      +	// * JSON logging format: msg isn't serialized twice
-      +	// * text logging format: values are formatted with their .String() func.
-      +	ctrl.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+      +	// klog.Background will automatically use the right logger.
+      +	ctrl.SetLogger(klog.Background())
       -	ctrl.SetLogger(klogr.New())
       ```
       </details>

--- a/main.go
+++ b/main.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -208,11 +207,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set the Klog format, as the Serialize format shouldn't be used anymore.
-	// This makes sure that the logs are formatted correctly, i.e.:
-	// * JSON logging format: msg isn't serialized twice
-	// * text logging format: values are formatted with their .String() func.
-	ctrl.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+	// klog.Background will automatically use the right logger.
+	ctrl.SetLogger(klog.Background())
 
 	if profilerAddress != "" {
 		klog.Infof("Profiler listening for requests at %s", profilerAddress)

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/component-base/logs"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
@@ -123,11 +122,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set the Klog format, as the Serialize format shouldn't be used anymore.
-	// This makes sure that the logs are formatted correctly, i.e.:
-	// * JSON logging format: msg isn't serialized twice
-	// * text logging format: values are formatted with their .String() func.
-	ctrl.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
+	// klog.Background will automatically use the right logger.
+	ctrl.SetLogger(klog.Background())
 
 	if profilerAddress != "" {
 		klog.Infof("Profiler listening for requests at %s", profilerAddress)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR updates our log setup code to use klog.Background as suggested here (https://github.com/kubernetes/klog/issues/302#issuecomment-1048555820). The resulting test/JSON logs are exactly the same as before.

Overall it's just a cleanup which is now possible as we're using a current klog version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #5968
