### PR TITLE
🌱 Bump actions/cache from 3.0.2 to 3.0.3

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,7 +21,7 @@ jobs:
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
-    - uses: actions/cache@v3.0.2
+    - uses: actions/cache@v3.0.3
       name: Restore go cache
       with:
         path: |


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Manual bump, as dependabot workflow is broken: #6598

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
