### PR TITLE
🐛  test/e2e add tag to e2e tests which use ClusterClass

### DIFF
--- a/docs/book/src/developer/testing.md
+++ b/docs/book/src/developer/testing.md
@@ -235,6 +235,7 @@ Each of these can be used to match tests, for example:
 - `[PR-Blocking]` => Sanity tests run before each PR merge
 - `[K8s-Upgrade]` => Tests which verify k8s component version upgrades on workload clusters
 - `[Conformance]` => Tests which run the k8s conformance suite on workload clusters
+- `[ClusterClass]` => Tests which use a ClusterClass to create a workload cluster
 - `When testing KCP.*` => Tests which start with `When testing KCP`
 
 For example:

--- a/docs/book/src/reference/jobs.md
+++ b/docs/book/src/reference/jobs.md
@@ -43,13 +43,13 @@ Prow Postsubmits:
 Prow Periodics:
 * [periodic-cluster-api-test-main] `./scripts/ci-test.sh`
 * [periodic-cluster-api-e2e-main] `./scripts/ci-e2e.sh`
-  * GINKGO_SKIP: `[Conformance] [K8s-Upgrade]`
+  * GINKGO_SKIP: `[Conformance] [K8s-Upgrade]|[IPv6]`
 * [periodic-cluster-api-e2e-upgrade-v0-3-to-main] `./scripts/ci-e2e.sh`
   * GINKGO_FOCUS: `[clusterctl-Upgrade]`
 * [periodic-cluster-api-e2e-upgrade-v1-0-to-main] `./scripts/ci-e2e.sh`
   * GINKGO_FOCUS: `[clusterctl-Upgrade]`
 * [periodic-cluster-api-e2e-mink8s-main] `./scripts/ci-e2e.sh`
-  * GINKGO_SKIP: `[Conformance] [K8s-Upgrade]`
+  * GINKGO_SKIP: `[Conformance] [K8s-Upgrade]|[IPv6]|[ClusterClass]`
 * [periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-main] `./scripts/ci-e2e.sh` FROM: `stable-1.18` TO: `stable-1.19`
   * GINKGO_FOCUS: `[K8s-Upgrade]`
 * [periodic-cluster-api-e2e-workload-upgrade-1-19-1-20-main] `./scripts/ci-e2e.sh` FROM: `stable-1.19` TO: `stable-1.20`

--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var _ = Describe("When upgrading a workload cluster using ClusterClass and testing K8S conformance [Conformance] [K8s-Upgrade]", func() {
+var _ = Describe("When upgrading a workload cluster using ClusterClass and testing K8S conformance [Conformance] [K8s-Upgrade] [ClusterClass]", func() {
 	ClusterUpgradeConformanceSpec(ctx, func() ClusterUpgradeConformanceSpecInput {
 		// "upgrades" is the same as the "topology" flavor but with an additional MachinePool.
 		flavor := pointer.String("upgrades")
@@ -62,7 +62,7 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass and testi
 	})
 })
 
-var _ = Describe("When upgrading a workload cluster using ClusterClass", func() {
+var _ = Describe("When upgrading a workload cluster using ClusterClass [ClusterClass]", func() {
 	ClusterUpgradeConformanceSpec(ctx, func() ClusterUpgradeConformanceSpecInput {
 		return ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,
@@ -80,7 +80,7 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass", func() 
 	})
 })
 
-var _ = Describe("When upgrading a workload cluster using ClusterClass with a HA control plane", func() {
+var _ = Describe("When upgrading a workload cluster using ClusterClass with a HA control plane [ClusterClass]", func() {
 	ClusterUpgradeConformanceSpec(ctx, func() ClusterUpgradeConformanceSpecInput {
 		return ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,
@@ -98,7 +98,7 @@ var _ = Describe("When upgrading a workload cluster using ClusterClass with a HA
 	})
 })
 
-var _ = Describe("When upgrading a workload cluster using ClusterClass with a HA control plane using scale-in rollout", func() {
+var _ = Describe("When upgrading a workload cluster using ClusterClass with a HA control plane using scale-in rollout [ClusterClass]", func() {
 	ClusterUpgradeConformanceSpec(ctx, func() ClusterUpgradeConformanceSpecInput {
 		return ClusterUpgradeConformanceSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/clusterclass_changes_test.go
+++ b/test/e2e/clusterclass_changes_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = Describe("When testing ClusterClass changes", func() {
+var _ = Describe("When testing ClusterClass changes [ClusterClass]", func() {
 	ClusterClassChangesSpec(ctx, func() ClusterClassChangesSpecInput {
 		return ClusterClassChangesSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/quick_start_test.go
+++ b/test/e2e/quick_start_test.go
@@ -36,7 +36,7 @@ var _ = Describe("When following the Cluster API quick-start [PR-Blocking]", fun
 	})
 })
 
-var _ = Describe("When following the Cluster API quick-start with ClusterClass [PR-Informing]", func() {
+var _ = Describe("When following the Cluster API quick-start with ClusterClass [PR-Informing] [ClusterClass]", func() {
 	QuickStartSpec(ctx, func() QuickStartSpecInput {
 		return QuickStartSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -35,7 +35,7 @@ var _ = Describe("When testing Cluster API working on self-hosted clusters", fun
 	})
 })
 
-var _ = Describe("When testing Cluster API working on self-hosted clusters using ClusterClass", func() {
+var _ = Describe("When testing Cluster API working on self-hosted clusters using ClusterClass [ClusterClass]", func() {
 	SelfHostedSpec(ctx, func() SelfHostedSpecInput {
 		return SelfHostedSpecInput{
 			E2EConfig:             e2eConfig,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the tag `[ClusterClass]` to all e2e tests which use the ClusterClass/topology feature to allow skipping them easily.

Also documents that we skip tests using `ClusterClass`  at the test `periodic-cluster-api-e2e-mink8s-main`.

xref: PR for test-infra: https://github.com/kubernetes/test-infra/pull/26509

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

The Server-Side apply functionality went to GA in kubernetes v1.22 and did behave differently for older versions (e.g. v1.19 vs v1.20). 

#6495 will introduce Server-Side Apply for the topology controller which will fail to work on management clusters running kubernetes <= v1.20 (v1.21 seems to work but Server-Side Apply was still beta in this version).

Part of #6320 

Required for #6495
