### PR TITLE
🐛 dependabot: implement workaround to run generate-go-openapi in GOPATH

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -19,8 +19,15 @@ jobs:
       with:
         go-version: '1.17'
       id: go
+    # Note: We have to run everything in the GOPATH as `make generate-go-openapi`
+    # currently does not work outside of the GOPATH, see:
+    # https://github.com/kubernetes-sigs/cluster-api/issues/6526
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
+      with:
+        path: './src/sigs.k8s.io/cluster-api'
+    - name: Set env
+      run:  echo "GOPATH=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
     - uses: actions/cache@v3.0.3
       name: Restore go cache
       with:
@@ -32,8 +39,10 @@ jobs:
           ${{ runner.os }}-go-
     - name: Update all modules
       run: make generate-modules
+      working-directory: './src/sigs.k8s.io/cluster-api'
     - name: Update generated code
       run: make generate
+      working-directory: './src/sigs.k8s.io/cluster-api'
     - uses: EndBug/add-and-commit@v9
       name: Commit changes
       with:
@@ -41,3 +50,4 @@ jobs:
         author_email: 49699333+dependabot[bot]@users.noreply.github.com
         default_author: github_actor
         message: 'Update generated code'
+        cwd: './src/sigs.k8s.io/cluster-api'


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Implements workaround for #6526 so that the dependabot action works again.

I pushed this fix on the main branch of my fork. This PR proves that the dependabot job now works again (aka doesn't generate a diff via generate-go-openapi):
* PR: https://github.com/sbueringer/cluster-api/pull/47
* Action logs: https://github.com/sbueringer/cluster-api/runs/6779721721?check_suite_focus=true

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

