### PR TITLE
🌱 cloudbuild: bump to Go 1.18

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220506-774f302a94'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +13,7 @@ steps:
     - DOCKER_BUILDKIT=1
     args:
     - release-staging-nightly
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220506-774f302a94'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
     dir: 'test/infrastructure/docker'
     entrypoint: make
     env:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220506-774f302a94'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +13,7 @@ steps:
     - DOCKER_BUILDKIT=1
     args:
     - release-staging
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220506-774f302a94'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
     dir: 'test/infrastructure/docker'
     entrypoint: make
     env:

--- a/docs/book/src/developer/providers/v1.1-to-v1.2.md
+++ b/docs/book/src/developer/providers/v1.1-to-v1.2.md
@@ -10,6 +10,8 @@ maintainers of providers and consumers of our Go API.
 ## Minimum Go version
 
 * The Go version used by Cluster API is now Go 1.18.x
+  * If you are using the gcb-docker-gcloud image in cloudbuild, bump to an image which is using
+    Go 1.18, e.g.: `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e`.
 
 ## Dependencies
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
As there is now a gcb-docker-gcloud image with Go 1.18 available (https://github.com/kubernetes/test-infra/pull/26540),
let's use it!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #5968
