### PR TITLE
:bug: Change tiltfile to work with go 1.18

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -146,7 +146,7 @@ tilt_helper_dockerfile_header = """
 # Tilt image
 FROM golang:1.18.3 as tilt-helper
 # Support live reloading with Tilt
-RUN go get github.com/go-delve/delve/cmd/dlv
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \
     wget --output-document /start.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/start.sh && \
     chmod +x /start.sh && chmod +x /restart.sh && chmod +x /go/bin/dlv


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update the tiltfile so the Dockerfile uses `go install` instead of `go get`. `go get` no longer works outside a go module starting with go 1.18.

