### PR TITLE
📖 Toleration of v1.24 control plane taints

### DIFF
--- a/docs/book/src/developer/providers/v1.1-to-v1.2.md
+++ b/docs/book/src/developer/providers/v1.1-to-v1.2.md
@@ -92,3 +92,10 @@ in ClusterAPI are kept in sync with the versions used by `sigs.k8s.io/controller
   - The check for `cluster.status.infrastructureReady=true` usually existing at the beginning of the reconcile loop for control-plane providers is implemented after setting external objects ref;
   - The check for `cluster.status.infrastructureReady=true` usually existing  at the beginning of the reconcile loop for infrastructure provider does not prevent the object to be deleted  
 rif. [PR #6183](https://github.com/kubernetes-sigs/cluster-api/pull/6183)
+
+- CAPI added support for the new control plane label and taint introduced by v1.24 with [PR#5919](https://github.com/kubernetes-sigs/cluster-api/pull/5919).
+  Providers should tolerate _both_ `control-plane` and `master` taints for compatibility with v1.24 control planes.
+  Further, if they use the label in their `manager.yaml`, it should be adjusted since v1.24 only adds the `node-role.kubernetes.io/control-plane` label.
+  An example of such an accommodation can be seen in the capi-provider-aws [manager.yaml][aws-manager-yaml-a69181]
+
+[aws-manager-yaml-a69181]: https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/a691817f0ea6e8e6624e3c748b33d0058c061fd7/config/manager/manager.yaml?rgh-link-date=2022-02-17T20%3A09%3A43Z#L52


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Documents toleration of control plane taints for compatibility with Kubernetes 1.24 control plane nodes. Also documents the need to adjust manager.yaml so providers can work with the new control-plane label introduced by v1.24.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6172
