### PR TITLE
:book: More generic explanation about issue getting kubeconfig on certain systems using Docker

### DIFF
--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -189,10 +189,9 @@ The command for getting the kubeconfig file for connecting to a workload cluster
 clusterctl get kubeconfig capi-quickstart > capi-quickstart.kubeconfig
 ```
 
-### Fix kubeconfig (when using docker on macOS)
+### Fix kubeconfig when using Docker Desktop
 
-When using docker on macOS, you will need to do a couple of additional
-steps to get the correct kubeconfig for a workload cluster created with the Docker provider:
+When using using Docker Desktop on macOS or Docker Desktop (Docker Engine works fine) on Linux, you'll need to take a few extra steps to get the kubeconfig for a workload cluster created with the Docker provider.
 
 ```bash
 # Point the kubeconfig to the exposed port of the load balancer, rather than the inaccessible container IP.

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -975,9 +975,7 @@ clusterctl get kubeconfig capi-quickstart > capi-quickstart.kubeconfig
 
 <h1>Warning</h1>
 
-If you are using Docker on MacOS, you will need to do a couple of additional
-steps to get the correct kubeconfig for a workload cluster created with the Docker provider.
-See [Additional Notes for the Docker Provider](../clusterctl/developers.md#additional-notes-for-the-docker-provider).
+If you're using Docker Desktop on macOS, or Docker Desktop (Docker Engine works fine) on Linux, you'll need to take a few extra steps to get the kubeconfig for a workload cluster created with the Docker provider. See [Additional Notes for the Docker provider](../clusterctl/developers.md#additional-notes-for-the-docker-provider).
 
 </aside>
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Following the comment of @sbueringer https://github.com/kubernetes-sigs/cluster-api/issues/6595#issuecomment-1150079224 I have updated the documentation regarding an issue when using Docker (Desktop) on macOS, or when using Docker Desktop on Linux (Docker Enginer works fine).
The documentation only mentioned the fix for Mac users, now the more generic explanation targets all the appriopriate users.

**Which issue(s) this PR fixes**:  
The issue is already closed, but resulted from the lack of this information: https://github.com/kubernetes-sigs/cluster-api/issues/6595
