### PR TITLE
✨ Implements AfterControlPlaneInitialized, AfterControlPlaneUpgrade and AfterClusterUpgrade hooks

### DIFF
--- a/exp/runtime/api/v1alpha1/extensionconfig_types.go
+++ b/exp/runtime/api/v1alpha1/extensionconfig_types.go
@@ -209,5 +209,7 @@ const (
 	InjectCAFromSecretAnnotation string = "runtime.cluster.x-k8s.io/inject-ca-from-secret"
 
 	// PendingHooksAnnotation is the annotation used to keep a track of pending runtime hooks.
-	PendingHooksAnnotation string = "hooks.x-cluster.k8s.io/pending-hooks"
+	// The annotation will be used to track the intent to call a hook as soon as an operation completes;
+	// the intent will be removed as soon as the hook call completes successfully.
+	PendingHooksAnnotation string = "runtime.cluster.x-k8s.io/pending-hooks"
 )

--- a/exp/runtime/api/v1alpha1/extensionconfig_types.go
+++ b/exp/runtime/api/v1alpha1/extensionconfig_types.go
@@ -207,4 +207,7 @@ const (
 	// object wants injection of CAs. It takes the form of a reference to a Secret
 	// as namespace/name.
 	InjectCAFromSecretAnnotation string = "runtime.cluster.x-k8s.io/inject-ca-from-secret"
+
+	// PendingHooksAnnotation is the annotation used to keep a track of pending runtime hooks.
+	PendingHooksAnnotation string = "hooks.x-cluster.k8s.io/pending-hooks"
 )

--- a/exp/runtime/hooks/api/v1alpha1/common_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/common_types.go
@@ -20,6 +20,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// PendingHooksAnnotation is the annotation used to keep a track of pending runtime hooks.
+const PendingHooksAnnotation = "hooks.x-cluster.k8s.io/pending-hooks"
+
 // ResponseObject is a runtime object extended with methods to handle response-specific fields.
 // +kubebuilder:object:generate=false
 type ResponseObject interface {

--- a/exp/runtime/hooks/api/v1alpha1/common_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/common_types.go
@@ -20,9 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// PendingHooksAnnotation is the annotation used to keep a track of pending runtime hooks.
-const PendingHooksAnnotation = "hooks.x-cluster.k8s.io/pending-hooks"
-
 // ResponseObject is a runtime object extended with methods to handle response-specific fields.
 // +kubebuilder:object:generate=false
 type ResponseObject interface {

--- a/exp/runtime/hooks/api/v1alpha1/lifecyclehooks_types.go
+++ b/exp/runtime/hooks/api/v1alpha1/lifecyclehooks_types.go
@@ -188,7 +188,7 @@ func init() {
 	catalogBuilder.RegisterHook(AfterControlPlaneInitialized, &runtimecatalog.HookMeta{
 		Tags:        []string{"Lifecycle Hooks"},
 		Summary:     "Called after the Control Plane is available for the first time",
-		Description: "This non-blocking hook is called after the ControlPlane for the Cluster is marked as available for the first time",
+		Description: "This non-blocking hook is called after the ControlPlane for the Cluster reachable for the first time",
 	})
 
 	catalogBuilder.RegisterHook(BeforeClusterUpgrade, &runtimecatalog.HookMeta{

--- a/internal/controllers/topology/cluster/desired_state.go
+++ b/internal/controllers/topology/cluster/desired_state.go
@@ -315,7 +315,7 @@ func (r *Reconciler) computeControlPlaneVersion(ctx context.Context, s *scope.Sc
 		// to know if the control plane is being upgraded. This information
 		// is required when updating the TopologyReconciled condition on the cluster.
 
-		// Let's call the AfterControlPlaneUpgrade now that the control plane is upgraded.
+		// Call the AfterControlPlaneUpgrade now that the control plane is upgraded.
 		if feature.Gates.Enabled(feature.RuntimeSDK) {
 			// Call the hook only if it is marked. If it is not marked it means we don't need ot call the
 			// hook because we didn't go through an upgrade or we already called the hook after the upgrade.

--- a/internal/controllers/topology/cluster/desired_state_test.go
+++ b/internal/controllers/topology/cluster/desired_state_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/feature"
 	"sigs.k8s.io/cluster-api/internal/contract"
@@ -955,7 +956,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 								Name:      "test-cluster",
 								Namespace: "test-ns",
 								Annotations: map[string]string{
-									runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
+									runtimev1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
 								},
 							},
 							Spec: clusterv1.ClusterSpec{},
@@ -986,7 +987,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 								Name:      "test-cluster",
 								Namespace: "test-ns",
 								Annotations: map[string]string{
-									runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
+									runtimev1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
 								},
 							},
 							Spec: clusterv1.ClusterSpec{},
@@ -1017,7 +1018,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 								Name:      "test-cluster",
 								Namespace: "test-ns",
 								Annotations: map[string]string{
-									runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
+									runtimev1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
 								},
 							},
 							Spec: clusterv1.ClusterSpec{},
@@ -1050,7 +1051,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 								Name:      "test-cluster",
 								Namespace: "test-ns",
 								Annotations: map[string]string{
-									runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
+									runtimev1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
 								},
 							},
 							Spec: clusterv1.ClusterSpec{},
@@ -1083,7 +1084,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 								Name:      "test-cluster",
 								Namespace: "test-ns",
 								Annotations: map[string]string{
-									runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
+									runtimev1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
 								},
 							},
 							Spec: clusterv1.ClusterSpec{},

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/internal/contract"
 	"sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/scope"
@@ -325,7 +326,7 @@ func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
 					Name:      "test-cluster",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneInitialized",
+						runtimev1.PendingHooksAnnotation: "AfterControlPlaneInitialized",
 					},
 				},
 				Spec: clusterv1.ClusterSpec{
@@ -353,7 +354,7 @@ func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
 					Name:      "test-cluster",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneInitialized",
+						runtimev1.PendingHooksAnnotation: "AfterControlPlaneInitialized",
 					},
 				},
 				Spec: clusterv1.ClusterSpec{
@@ -381,7 +382,7 @@ func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
 					Name:      "test-cluster",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneInitialized",
+						runtimev1.PendingHooksAnnotation: "AfterControlPlaneInitialized",
 					},
 				},
 				Spec: clusterv1.ClusterSpec{
@@ -586,7 +587,7 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 							Name:      "test-cluster",
 							Namespace: "test-ns",
 							Annotations: map[string]string{
-								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+								runtimev1.PendingHooksAnnotation: "AfterClusterUpgrade",
 							},
 						},
 						Spec: clusterv1.ClusterSpec{},
@@ -619,7 +620,7 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 							Name:      "test-cluster",
 							Namespace: "test-ns",
 							Annotations: map[string]string{
-								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+								runtimev1.PendingHooksAnnotation: "AfterClusterUpgrade",
 							},
 						},
 						Spec: clusterv1.ClusterSpec{},
@@ -652,7 +653,7 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 							Name:      "test-cluster",
 							Namespace: "test-ns",
 							Annotations: map[string]string{
-								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+								runtimev1.PendingHooksAnnotation: "AfterClusterUpgrade",
 							},
 						},
 						Spec: clusterv1.ClusterSpec{},
@@ -689,7 +690,7 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 							Name:      "test-cluster",
 							Namespace: "test-ns",
 							Annotations: map[string]string{
-								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+								runtimev1.PendingHooksAnnotation: "AfterClusterUpgrade",
 							},
 						},
 						Spec: clusterv1.ClusterSpec{},
@@ -727,7 +728,7 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 							Name:      "test-cluster",
 							Namespace: "test-ns",
 							Annotations: map[string]string{
-								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+								runtimev1.PendingHooksAnnotation: "AfterClusterUpgrade",
 							},
 						},
 						Spec: clusterv1.ClusterSpec{},
@@ -765,7 +766,7 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 							Name:      "test-cluster",
 							Namespace: "test-ns",
 							Annotations: map[string]string{
-								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+								runtimev1.PendingHooksAnnotation: "AfterClusterUpgrade",
 							},
 						},
 						Spec: clusterv1.ClusterSpec{
@@ -802,7 +803,7 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 							Name:      "test-cluster",
 							Namespace: "test-ns",
 							Annotations: map[string]string{
-								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+								runtimev1.PendingHooksAnnotation: "AfterClusterUpgrade",
 							},
 						},
 						Spec: clusterv1.ClusterSpec{

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -31,12 +31,18 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/internal/contract"
 	"sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/scope"
 	"sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/structuredmerge"
+	"sigs.k8s.io/cluster-api/internal/hooks"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	fakeruntimeclient "sigs.k8s.io/cluster-api/internal/runtime/client/fake"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 	. "sigs.k8s.io/cluster-api/internal/test/matchers"
 )
@@ -267,6 +273,583 @@ func TestReconcileShim(t *testing.T) {
 
 		g.Expect(env.CleanupAndWait(ctx, cluster1Shim)).To(Succeed())
 	})
+}
+
+func TestReconcile_callAfterControlPlaneInitialized(t *testing.T) {
+	catalog := runtimecatalog.New()
+	_ = runtimehooksv1.AddToCatalog(catalog)
+
+	afterControlPlaneInitializedGVH, err := catalog.GroupVersionHook(runtimehooksv1.AfterControlPlaneInitialized)
+	if err != nil {
+		panic(err)
+	}
+
+	successResponse := &runtimehooksv1.AfterControlPlaneInitializedResponse{
+
+		CommonResponse: runtimehooksv1.CommonResponse{
+			Status: runtimehooksv1.ResponseStatusSuccess,
+		},
+	}
+	failureResponse := &runtimehooksv1.AfterControlPlaneInitializedResponse{
+		CommonResponse: runtimehooksv1.CommonResponse{
+			Status: runtimehooksv1.ResponseStatusFailure,
+		},
+	}
+
+	tests := []struct {
+		name               string
+		cluster            *clusterv1.Cluster
+		hookResponse       *runtimehooksv1.AfterControlPlaneInitializedResponse
+		wantMarked         bool
+		wantHookToBeCalled bool
+		wantError          bool
+	}{
+		{
+			name: "hook should be marked if the cluster is about to be created",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+				Spec: clusterv1.ClusterSpec{},
+			},
+			hookResponse:       successResponse,
+			wantMarked:         true,
+			wantHookToBeCalled: false,
+			wantError:          false,
+		},
+		{
+			name: "hook should be called if it is marked and the control plane is ready - the hook should become unmarked for a success response",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneInitialized",
+					},
+				},
+				Spec: clusterv1.ClusterSpec{
+					ControlPlaneRef:   &corev1.ObjectReference{},
+					InfrastructureRef: &corev1.ObjectReference{},
+				},
+				Status: clusterv1.ClusterStatus{
+					Conditions: clusterv1.Conditions{
+						clusterv1.Condition{
+							Type:   clusterv1.ControlPlaneInitializedCondition,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			hookResponse:       successResponse,
+			wantMarked:         false,
+			wantHookToBeCalled: true,
+			wantError:          false,
+		},
+		{
+			name: "hook should be called if it is marked and the control plane is ready - the hook should remain marked for a failure response",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneInitialized",
+					},
+				},
+				Spec: clusterv1.ClusterSpec{
+					ControlPlaneRef:   &corev1.ObjectReference{},
+					InfrastructureRef: &corev1.ObjectReference{},
+				},
+				Status: clusterv1.ClusterStatus{
+					Conditions: clusterv1.Conditions{
+						clusterv1.Condition{
+							Type:   clusterv1.ControlPlaneInitializedCondition,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			hookResponse:       failureResponse,
+			wantMarked:         true,
+			wantHookToBeCalled: true,
+			wantError:          true,
+		},
+		{
+			name: "hook should not be called if it is marked and the control plane is not ready - the hook should remain marked",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneInitialized",
+					},
+				},
+				Spec: clusterv1.ClusterSpec{
+					ControlPlaneRef:   &corev1.ObjectReference{},
+					InfrastructureRef: &corev1.ObjectReference{},
+				},
+				Status: clusterv1.ClusterStatus{
+					Conditions: clusterv1.Conditions{
+						clusterv1.Condition{
+							Type:   clusterv1.ControlPlaneInitializedCondition,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			hookResponse:       failureResponse,
+			wantMarked:         true,
+			wantHookToBeCalled: false,
+			wantError:          false,
+		},
+		{
+			name: "hook should not be called if it is not marked",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+				Spec: clusterv1.ClusterSpec{
+					ControlPlaneRef:   &corev1.ObjectReference{},
+					InfrastructureRef: &corev1.ObjectReference{},
+				},
+				Status: clusterv1.ClusterStatus{
+					Conditions: clusterv1.Conditions{
+						clusterv1.Condition{
+							Type:   clusterv1.ControlPlaneInitializedCondition,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			hookResponse:       failureResponse,
+			wantMarked:         false,
+			wantHookToBeCalled: false,
+			wantError:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			s := &scope.Scope{
+				Current: &scope.ClusterState{
+					Cluster: tt.cluster,
+				},
+				HookResponseTracker: scope.NewHookResponseTracker(),
+			}
+
+			fakeRuntimeClient := fakeruntimeclient.NewRuntimeClientBuilder().
+				WithCallAllExtensionResponses(map[runtimecatalog.GroupVersionHook]runtimehooksv1.ResponseObject{
+					afterControlPlaneInitializedGVH: tt.hookResponse,
+				}).
+				WithCatalog(catalog).
+				Build()
+
+			fakeClient := fake.NewClientBuilder().WithObjects(tt.cluster).Build()
+
+			r := &Reconciler{
+				Client:        fakeClient,
+				APIReader:     fakeClient,
+				RuntimeClient: fakeRuntimeClient,
+			}
+
+			err := r.callAfterControlPlaneInitialized(ctx, s)
+			g.Expect(fakeRuntimeClient.CallAllCount(runtimehooksv1.AfterControlPlaneInitialized) == 1).To(Equal(tt.wantHookToBeCalled))
+			g.Expect(hooks.IsPending(runtimehooksv1.AfterControlPlaneInitialized, tt.cluster)).To(Equal(tt.wantMarked))
+			g.Expect(err != nil).To(Equal(tt.wantError))
+		})
+	}
+}
+
+func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
+	catalog := runtimecatalog.New()
+	_ = runtimehooksv1.AddToCatalog(catalog)
+
+	afterClusterUpgradeGVH, err := catalog.GroupVersionHook(runtimehooksv1.AfterClusterUpgrade)
+	if err != nil {
+		panic(err)
+	}
+
+	successResponse := &runtimehooksv1.AfterClusterUpgradeResponse{
+
+		CommonResponse: runtimehooksv1.CommonResponse{
+			Status: runtimehooksv1.ResponseStatusSuccess,
+		},
+	}
+	failureResponse := &runtimehooksv1.AfterClusterUpgradeResponse{
+		CommonResponse: runtimehooksv1.CommonResponse{
+			Status: runtimehooksv1.ResponseStatusFailure,
+		},
+	}
+
+	topologyVersion := "v1.2.3"
+	lowerVersion := "v1.2.2"
+	controlPlaneStableAtTopologyVersion := builder.ControlPlane("test1", "cp1").
+		WithSpecFields(map[string]interface{}{
+			"spec.version":  topologyVersion,
+			"spec.replicas": int64(2),
+		}).
+		WithStatusFields(map[string]interface{}{
+			"status.version":         topologyVersion,
+			"status.replicas":        int64(2),
+			"status.updatedReplicas": int64(2),
+			"status.readyReplicas":   int64(2),
+		}).
+		Build()
+	controlPlaneStableAtLowerVersion := builder.ControlPlane("test1", "cp1").
+		WithSpecFields(map[string]interface{}{
+			"spec.version":  lowerVersion,
+			"spec.replicas": int64(2),
+		}).
+		WithStatusFields(map[string]interface{}{
+			"status.version":         lowerVersion,
+			"status.replicas":        int64(2),
+			"status.updatedReplicas": int64(2),
+			"status.readyReplicas":   int64(2),
+		}).
+		Build()
+	controlPlaneUpgrading := builder.ControlPlane("test1", "cp1").
+		WithSpecFields(map[string]interface{}{
+			"spec.version":  topologyVersion,
+			"spec.replicas": int64(2),
+		}).
+		WithStatusFields(map[string]interface{}{
+			"status.version":         lowerVersion,
+			"status.replicas":        int64(2),
+			"status.updatedReplicas": int64(2),
+			"status.readyReplicas":   int64(2),
+		}).
+		Build()
+	controlPlaneScaling := builder.ControlPlane("test1", "cp1").
+		WithSpecFields(map[string]interface{}{
+			"spec.version":  topologyVersion,
+			"spec.replicas": int64(2),
+		}).
+		WithStatusFields(map[string]interface{}{
+			"status.version":         topologyVersion,
+			"status.replicas":        int64(1),
+			"status.updatedReplicas": int64(1),
+			"status.readyReplicas":   int64(1),
+		}).
+		Build()
+
+	tests := []struct {
+		name               string
+		s                  *scope.Scope
+		hookResponse       *runtimehooksv1.AfterClusterUpgradeResponse
+		wantMarked         bool
+		wantHookToBeCalled bool
+		wantError          bool
+	}{
+		{
+			name: "hook should not be called if it is not marked",
+			s: &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{
+					Topology: &clusterv1.Topology{
+						ControlPlane: clusterv1.ControlPlaneTopology{
+							Replicas: pointer.Int32(2),
+						},
+					},
+				},
+				Current: &scope.ClusterState{
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-cluster",
+							Namespace: "test-ns",
+						},
+						Spec: clusterv1.ClusterSpec{},
+					},
+				},
+				HookResponseTracker: scope.NewHookResponseTracker(),
+				UpgradeTracker:      scope.NewUpgradeTracker(),
+			},
+			wantMarked:         false,
+			hookResponse:       successResponse,
+			wantHookToBeCalled: false,
+			wantError:          false,
+		},
+		{
+			name: "hook should not be called if the control plane is upgrading - hook is marked",
+			s: &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{
+					Topology: &clusterv1.Topology{
+						ControlPlane: clusterv1.ControlPlaneTopology{
+							Replicas: pointer.Int32(2),
+						},
+					},
+				},
+				Current: &scope.ClusterState{
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-cluster",
+							Namespace: "test-ns",
+							Annotations: map[string]string{
+								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+							},
+						},
+						Spec: clusterv1.ClusterSpec{},
+					},
+					ControlPlane: &scope.ControlPlaneState{
+						Object: controlPlaneUpgrading,
+					},
+				},
+				HookResponseTracker: scope.NewHookResponseTracker(),
+				UpgradeTracker:      scope.NewUpgradeTracker(),
+			},
+			wantMarked:         true,
+			hookResponse:       successResponse,
+			wantHookToBeCalled: false,
+			wantError:          false,
+		},
+		{
+			name: "hook should not be called if the control plane is scaling - hook is marked",
+			s: &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{
+					Topology: &clusterv1.Topology{
+						ControlPlane: clusterv1.ControlPlaneTopology{
+							Replicas: pointer.Int32(2),
+						},
+					},
+				},
+				Current: &scope.ClusterState{
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-cluster",
+							Namespace: "test-ns",
+							Annotations: map[string]string{
+								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+							},
+						},
+						Spec: clusterv1.ClusterSpec{},
+					},
+					ControlPlane: &scope.ControlPlaneState{
+						Object: controlPlaneScaling,
+					},
+				},
+				HookResponseTracker: scope.NewHookResponseTracker(),
+				UpgradeTracker:      scope.NewUpgradeTracker(),
+			},
+			wantMarked:         true,
+			hookResponse:       successResponse,
+			wantHookToBeCalled: false,
+			wantError:          false,
+		},
+		{
+			name: "hook should not be called if the control plane is stable at a lower version and is pending an upgrade - hook is marked",
+			s: &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{
+					Topology: &clusterv1.Topology{
+						ControlPlane: clusterv1.ControlPlaneTopology{
+							Replicas: pointer.Int32(2),
+						},
+					},
+				},
+				Current: &scope.ClusterState{
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-cluster",
+							Namespace: "test-ns",
+							Annotations: map[string]string{
+								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+							},
+						},
+						Spec: clusterv1.ClusterSpec{},
+					},
+					ControlPlane: &scope.ControlPlaneState{
+						Object: controlPlaneStableAtLowerVersion,
+					},
+				},
+				HookResponseTracker: scope.NewHookResponseTracker(),
+				UpgradeTracker: func() *scope.UpgradeTracker {
+					ut := scope.NewUpgradeTracker()
+					ut.ControlPlane.PendingUpgrade = true
+					return ut
+				}(),
+			},
+			wantMarked:         true,
+			hookResponse:       successResponse,
+			wantHookToBeCalled: false,
+			wantError:          false,
+		},
+		{
+			name: "hook should not be called if the control plane is stable at desired version but MDs are rolling out - hook is marked",
+			s: &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{
+					Topology: &clusterv1.Topology{
+						ControlPlane: clusterv1.ControlPlaneTopology{
+							Replicas: pointer.Int32(2),
+						},
+					},
+				},
+				Current: &scope.ClusterState{
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-cluster",
+							Namespace: "test-ns",
+							Annotations: map[string]string{
+								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+							},
+						},
+						Spec: clusterv1.ClusterSpec{},
+					},
+					ControlPlane: &scope.ControlPlaneState{
+						Object: controlPlaneStableAtTopologyVersion,
+					},
+				},
+				HookResponseTracker: scope.NewHookResponseTracker(),
+				UpgradeTracker: func() *scope.UpgradeTracker {
+					ut := scope.NewUpgradeTracker()
+					ut.ControlPlane.PendingUpgrade = false
+					ut.MachineDeployments.MarkRollingOut("md1")
+					return ut
+				}(),
+			},
+			wantMarked:         true,
+			hookResponse:       successResponse,
+			wantHookToBeCalled: false,
+			wantError:          false,
+		},
+		{
+			name: "hook should not be called if the control plane is stable at desired version but MDs are pending upgrade - hook is marked",
+			s: &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{
+					Topology: &clusterv1.Topology{
+						ControlPlane: clusterv1.ControlPlaneTopology{
+							Replicas: pointer.Int32(2),
+						},
+					},
+				},
+				Current: &scope.ClusterState{
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-cluster",
+							Namespace: "test-ns",
+							Annotations: map[string]string{
+								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+							},
+						},
+						Spec: clusterv1.ClusterSpec{},
+					},
+					ControlPlane: &scope.ControlPlaneState{
+						Object: controlPlaneStableAtTopologyVersion,
+					},
+				},
+				HookResponseTracker: scope.NewHookResponseTracker(),
+				UpgradeTracker: func() *scope.UpgradeTracker {
+					ut := scope.NewUpgradeTracker()
+					ut.ControlPlane.PendingUpgrade = false
+					ut.MachineDeployments.MarkPendingUpgrade("md1")
+					return ut
+				}(),
+			},
+			wantMarked:         true,
+			hookResponse:       successResponse,
+			wantHookToBeCalled: false,
+			wantError:          false,
+		},
+		{
+			name: "hook should be called if the control plane and MDs are stable at the topology version - success response should unmark the hook",
+			s: &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{
+					Topology: &clusterv1.Topology{
+						ControlPlane: clusterv1.ControlPlaneTopology{
+							Replicas: pointer.Int32(2),
+						},
+					},
+				},
+				Current: &scope.ClusterState{
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-cluster",
+							Namespace: "test-ns",
+							Annotations: map[string]string{
+								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+							},
+						},
+						Spec: clusterv1.ClusterSpec{
+							Topology: &clusterv1.Topology{
+								Version: topologyVersion,
+							},
+						},
+					},
+					ControlPlane: &scope.ControlPlaneState{
+						Object: controlPlaneStableAtTopologyVersion,
+					},
+				},
+				HookResponseTracker: scope.NewHookResponseTracker(),
+				UpgradeTracker:      scope.NewUpgradeTracker(),
+			},
+			wantMarked:         false,
+			hookResponse:       successResponse,
+			wantHookToBeCalled: true,
+			wantError:          false,
+		},
+		{
+			name: "hook should be called if the control plane and MDs are stable at the topology version - failure response should leave the hook marked",
+			s: &scope.Scope{
+				Blueprint: &scope.ClusterBlueprint{
+					Topology: &clusterv1.Topology{
+						ControlPlane: clusterv1.ControlPlaneTopology{
+							Replicas: pointer.Int32(2),
+						},
+					},
+				},
+				Current: &scope.ClusterState{
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-cluster",
+							Namespace: "test-ns",
+							Annotations: map[string]string{
+								runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+							},
+						},
+						Spec: clusterv1.ClusterSpec{
+							Topology: &clusterv1.Topology{
+								Version: topologyVersion,
+							},
+						},
+					},
+					ControlPlane: &scope.ControlPlaneState{
+						Object: controlPlaneStableAtTopologyVersion,
+					},
+				},
+				HookResponseTracker: scope.NewHookResponseTracker(),
+				UpgradeTracker:      scope.NewUpgradeTracker(),
+			},
+			wantMarked:         true,
+			hookResponse:       failureResponse,
+			wantHookToBeCalled: true,
+			wantError:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			fakeRuntimeClient := fakeruntimeclient.NewRuntimeClientBuilder().
+				WithCallAllExtensionResponses(map[runtimecatalog.GroupVersionHook]runtimehooksv1.ResponseObject{
+					afterClusterUpgradeGVH: tt.hookResponse,
+				}).
+				WithCatalog(catalog).
+				Build()
+
+			fakeClient := fake.NewClientBuilder().WithObjects(tt.s.Current.Cluster).Build()
+
+			r := &Reconciler{
+				Client:        fakeClient,
+				APIReader:     fakeClient,
+				RuntimeClient: fakeRuntimeClient,
+			}
+
+			err := r.callAfterClusterUpgrade(ctx, tt.s)
+			g.Expect(fakeRuntimeClient.CallAllCount(runtimehooksv1.AfterClusterUpgrade) == 1).To(Equal(tt.wantHookToBeCalled))
+			g.Expect(hooks.IsPending(runtimehooksv1.AfterClusterUpgrade, tt.s.Current.Cluster)).To(Equal(tt.wantMarked))
+			g.Expect(err != nil).To(Equal(tt.wantError))
+		})
+	}
 }
 
 func TestReconcileCluster(t *testing.T) {

--- a/internal/controllers/topology/cluster/scope/upgradetracker.go
+++ b/internal/controllers/topology/cluster/scope/upgradetracker.go
@@ -78,7 +78,8 @@ func (m *MachineDeploymentUpgradeTracker) RolloutNames() []string {
 	return m.rollingOutNames.List()
 }
 
-// HoldUpgrades is used to set if any subsequent upgrade operations should be paused.
+// HoldUpgrades is used to set if any subsequent upgrade operations should be paused,
+// e.g. because a AfterControlPlaneUpgrade hook response asked to do so.
 // If HoldUpgrades is called with `true` then AllowUpgrade would return false.
 func (m *MachineDeploymentUpgradeTracker) HoldUpgrades(val bool) {
 	m.holdUpgrades = val

--- a/internal/hooks/tracking.go
+++ b/internal/hooks/tracking.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package hooks has helper functions for Runtime Hooks.
+package hooks
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	"sigs.k8s.io/cluster-api/util/patch"
+)
+
+// MarkAsPending sets the information on the object to signify that the hook is marked.
+func MarkAsPending(ctx context.Context, c client.Client, obj client.Object, hooks ...runtimecatalog.Hook) (retErr error) {
+	patchHelper, err := patch.NewHelper(obj, c)
+	if err != nil {
+		return errors.Wrap(err, "failed to create patch helper")
+	}
+
+	// read the annotation of the objects and add the hook to the comma separated list
+	hookNames := []string{}
+	for _, hook := range hooks {
+		hookNames = append(hookNames, runtimecatalog.HookName(hook))
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[runtimehooksv1.PendingHooksAnnotation] = addToCommaSeparatedList(annotations[runtimehooksv1.PendingHooksAnnotation], hookNames...)
+	obj.SetAnnotations(annotations)
+
+	if err := patchHelper.Patch(ctx, obj); err != nil {
+		return errors.Wrap(err, "failed to apply patch")
+	}
+
+	return nil
+}
+
+// IsPending returns true if the hook is marked on the object.
+func IsPending(hook runtimecatalog.Hook, obj client.Object) bool {
+	hookName := runtimecatalog.HookName(hook)
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	return isInCommaSeparatedList(annotations[runtimehooksv1.PendingHooksAnnotation], hookName)
+}
+
+// MarkAsDone remove the information on the object that represents tha hook is marked.
+func MarkAsDone(ctx context.Context, c client.Client, obj client.Object, hooks ...runtimecatalog.Hook) (retErr error) {
+	patchHelper, err := patch.NewHelper(obj, c)
+	if err != nil {
+		return errors.Wrap(err, "failed to create patch helper")
+	}
+
+	// read the annotation of the objects and add the hook to the comma separated list
+	hookNames := []string{}
+	for _, hook := range hooks {
+		hookNames = append(hookNames, runtimecatalog.HookName(hook))
+	}
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[runtimehooksv1.PendingHooksAnnotation] = removeFromCommaSeparatedList(annotations[runtimehooksv1.PendingHooksAnnotation], hookNames...)
+	if annotations[runtimehooksv1.PendingHooksAnnotation] == "" {
+		delete(annotations, runtimehooksv1.PendingHooksAnnotation)
+	}
+	obj.SetAnnotations(annotations)
+
+	if err := patchHelper.Patch(ctx, obj); err != nil {
+		return errors.Wrap(err, "failed to apply patch")
+	}
+
+	return nil
+}
+
+func addToCommaSeparatedList(list string, items ...string) string {
+	set := sets.NewString(strings.Split(list, ",")...)
+	set.Insert(items...)
+	return strings.Join(set.List(), ",")
+}
+
+func isInCommaSeparatedList(list, item string) bool {
+	set := sets.NewString(strings.Split(list, ",")...)
+	return set.Has(item)
+}
+
+func removeFromCommaSeparatedList(list string, items ...string) string {
+	set := sets.NewString(strings.Split(list, ",")...)
+	set.Delete(items...)
+	return strings.Join(set.List(), ",")
+}

--- a/internal/hooks/tracking.go
+++ b/internal/hooks/tracking.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
 	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
@@ -46,7 +46,7 @@ func MarkAsPending(ctx context.Context, c client.Client, obj client.Object, hook
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations[runtimehooksv1.PendingHooksAnnotation] = addToCommaSeparatedList(annotations[runtimehooksv1.PendingHooksAnnotation], hookNames...)
+	annotations[runtimev1.PendingHooksAnnotation] = addToCommaSeparatedList(annotations[runtimev1.PendingHooksAnnotation], hookNames...)
 	obj.SetAnnotations(annotations)
 
 	if err := patchHelper.Patch(ctx, obj); err != nil {
@@ -63,10 +63,10 @@ func IsPending(hook runtimecatalog.Hook, obj client.Object) bool {
 	if annotations == nil {
 		return false
 	}
-	return isInCommaSeparatedList(annotations[runtimehooksv1.PendingHooksAnnotation], hookName)
+	return isInCommaSeparatedList(annotations[runtimev1.PendingHooksAnnotation], hookName)
 }
 
-// MarkAsDone remove the information on the object that represents tha hook is marked.
+// MarkAsDone removes the information on the object that represents that the hook is pending.
 func MarkAsDone(ctx context.Context, c client.Client, obj client.Object, hooks ...runtimecatalog.Hook) (retErr error) {
 	patchHelper, err := patch.NewHelper(obj, c)
 	if err != nil {
@@ -82,9 +82,9 @@ func MarkAsDone(ctx context.Context, c client.Client, obj client.Object, hooks .
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations[runtimehooksv1.PendingHooksAnnotation] = removeFromCommaSeparatedList(annotations[runtimehooksv1.PendingHooksAnnotation], hookNames...)
-	if annotations[runtimehooksv1.PendingHooksAnnotation] == "" {
-		delete(annotations, runtimehooksv1.PendingHooksAnnotation)
+	annotations[runtimev1.PendingHooksAnnotation] = removeFromCommaSeparatedList(annotations[runtimev1.PendingHooksAnnotation], hookNames...)
+	if annotations[runtimev1.PendingHooksAnnotation] == "" {
+		delete(annotations, runtimev1.PendingHooksAnnotation)
 	}
 	obj.SetAnnotations(annotations)
 

--- a/internal/hooks/tracking_test.go
+++ b/internal/hooks/tracking_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
+)
+
+func TestIsMarked(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		hook runtimecatalog.Hook
+		want bool
+	}{
+		{
+			name: "should return true if the hook is marked",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+					},
+				},
+			},
+			hook: runtimehooksv1.AfterClusterUpgrade,
+			want: true,
+		},
+		{
+			name: "should return true if the hook is marked - other hooks are marked too",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade,AfterControlPlaneUpgrade",
+					},
+				},
+			},
+			hook: runtimehooksv1.AfterClusterUpgrade,
+			want: true,
+		},
+		{
+			name: "should return false if the hook is not marked",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+			},
+			hook: runtimehooksv1.AfterClusterUpgrade,
+			want: false,
+		},
+		{
+			name: "should return false if the hook is not marked - other hooks are marked",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
+					},
+				},
+			},
+			hook: runtimehooksv1.AfterClusterUpgrade,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(IsPending(tt.hook, tt.obj)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestMark(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		hook runtimecatalog.Hook
+	}{
+		{
+			name: "should add the marker if not already present",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+			},
+			hook: runtimehooksv1.AfterClusterUpgrade,
+		},
+		{
+			name: "should add the marker if not already present - other hooks are present",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						runtimehooksv1.PendingHooksAnnotation: "AfterControlPlaneUpgrade",
+					},
+				},
+			},
+			hook: runtimehooksv1.AfterClusterUpgrade,
+		},
+		{
+			name: "should pass if the marker is already present",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+					},
+				},
+			},
+			hook: runtimehooksv1.AfterClusterUpgrade,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			fakeClient := fake.NewClientBuilder().WithObjects(tt.obj).Build()
+			ctx := context.Background()
+			g.Expect(MarkAsPending(ctx, fakeClient, tt.obj, tt.hook)).To(Succeed())
+			annotations := tt.obj.GetAnnotations()
+			g.Expect(annotations[runtimehooksv1.PendingHooksAnnotation]).To(ContainSubstring(runtimecatalog.HookName(tt.hook)))
+		})
+	}
+}
+
+func TestUnmark(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  client.Object
+		hook runtimecatalog.Hook
+	}{
+		{
+			name: "should pass if the marker is not already present",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+			},
+			hook: runtimehooksv1.AfterClusterUpgrade,
+		},
+		{
+			name: "should remove if the marker is already present",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade",
+					},
+				},
+			},
+			hook: runtimehooksv1.AfterClusterUpgrade,
+		},
+		{
+			name: "should remove if the marker is already present among multiple hooks",
+			obj: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+					Annotations: map[string]string{
+						runtimehooksv1.PendingHooksAnnotation: "AfterClusterUpgrade,AfterControlPlaneUpgrade",
+					},
+				},
+			},
+			hook: runtimehooksv1.AfterClusterUpgrade,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			fakeClient := fake.NewClientBuilder().WithObjects(tt.obj).Build()
+			ctx := context.Background()
+			g.Expect(MarkAsDone(ctx, fakeClient, tt.obj, tt.hook)).To(Succeed())
+			annotations := tt.obj.GetAnnotations()
+			g.Expect(annotations[runtimehooksv1.PendingHooksAnnotation]).NotTo(ContainSubstring(runtimecatalog.HookName(tt.hook)))
+		})
+	}
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR implements the following hooks:
* AfterControlPlaneInitialized
* AfterControlPlaneUpgrade
* AfterClusterUpgrade

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #6546


**Important Links**:
* https://github.com/kubernetes-sigs/cluster-api/pull/6181
* https://github.com/kubernetes-sigs/cluster-api/pull/6418
* https://github.com/kubernetes-sigs/cluster-api/issues/6330
* https://github.com/kubernetes-sigs/cluster-api/issues/6546


/area runtime-sdk