### PR TITLE
✨ RuntimeSDK: Add caBundle injection to Extension controller

### DIFF
--- a/exp/runtime/api/v1alpha1/extensionconfig_types.go
+++ b/exp/runtime/api/v1alpha1/extensionconfig_types.go
@@ -202,4 +202,9 @@ const (
 
 	// DiscoveryFailedReason documents failure of a Discovery call.
 	DiscoveryFailedReason string = "DiscoveryFailed"
+
+	// InjectCAFromSecretAnnotation is the annotation that specifies that a particular
+	// object wants injection of CAs. It takes the form of a reference to a Secret
+	// as namespace/name.
+	InjectCAFromSecretAnnotation string = "runtime.cluster.x-k8s.io/inject-ca-from-secret"
 )

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -18,13 +18,20 @@ package controllers
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
@@ -33,6 +40,11 @@ import (
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
+)
+
+const (
+	// tlsCAKey is used as a data key in Secret resources to store a CA certificate.
+	tlsCAKey = "ca.crt"
 )
 
 // +kubebuilder:rbac:groups=runtime.cluster.x-k8s.io,resources=extensionconfigs;extensionconfigs/status,verbs=get;list;watch;patch;update
@@ -50,6 +62,11 @@ type Reconciler struct {
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&runtimev1.ExtensionConfig{}).
+		Watches(
+			&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(r.secretToExtensionConfig),
+			builder.OnlyMetadata,
+		).
 		WithOptions(options).
 		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue)).
 		Complete(r)
@@ -103,14 +120,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return r.reconcileDelete(ctx, extensionConfig)
 	}
 
+	// Copy to avoid modifying the original extensionConfig.
+	original := extensionConfig.DeepCopy()
+
+	// Inject CABundle from secret if annotation is set. Otherwise https calls may fail.
+	if err := reconcileCABundle(ctx, r.Client, extensionConfig); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// discoverExtensionConfig will return a discovered ExtensionConfig with the appropriate conditions.
 	discoveredExtensionConfig, err := discoverExtensionConfig(ctx, r.RuntimeClient, extensionConfig)
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	// Always patch the ExtensionConfig as it may contain updates in conditions.
-	if err = patchExtensionConfig(ctx, r.Client, extensionConfig, discoveredExtensionConfig); err != nil {
+	// Always patch the ExtensionConfig as it may contain updates in conditions or clientConfig.caBundle.
+	if err = patchExtensionConfig(ctx, r.Client, original, discoveredExtensionConfig); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -150,6 +175,29 @@ func (r *Reconciler) reconcileDelete(_ context.Context, extensionConfig *runtime
 	return ctrl.Result{}, nil
 }
 
+// secretToExtensionConfig maps a secret to ExtensionConfigs to reconcile them on updates of the secrets.
+func (r *Reconciler) secretToExtensionConfig(secret client.Object) []reconcile.Request {
+	result := []ctrl.Request{}
+
+	extensionConfigs := runtimev1.ExtensionConfigList{}
+	if err := r.Client.List(context.Background(), &extensionConfigs); err != nil {
+		return nil
+	}
+
+	for _, ext := range extensionConfigs.Items {
+		if secretNameRaw, ok := ext.GetAnnotations()[runtimev1.InjectCAFromSecretAnnotation]; ok {
+			secretName := splitNamespacedName(secretNameRaw)
+			// append all extensions to the result which refer the object as secret
+			if secretName.Namespace == secret.GetNamespace() && secretName.Name == secret.GetName() {
+				name := client.ObjectKey{Namespace: ext.GetNamespace(), Name: ext.GetName()}
+				result = append(result, ctrl.Request{NamespacedName: name})
+			}
+		}
+	}
+
+	return result
+}
+
 // discoverExtensionConfig attempts to discover the Handlers for an ExtensionConfig.
 // If discovery succeeds it returns the ExtensionConfig with Handlers updated in Status and an updated Condition.
 // If discovery fails it returns the ExtensionConfig with no update to Handlers and a Failed Condition.
@@ -163,4 +211,42 @@ func discoverExtensionConfig(ctx context.Context, runtimeClient runtimeclient.Cl
 
 	conditions.MarkTrue(discoveredExtension, runtimev1.RuntimeExtensionDiscoveredCondition)
 	return discoveredExtension, nil
+}
+
+// reconcileCABundle reconciles the CA bundle for the ExtensionConfig.
+// cert-manager code: pkg/controller/cainjector/sources.go certificateDataSource.
+func reconcileCABundle(ctx context.Context, client client.Client, config *runtimev1.ExtensionConfig) error {
+	secretNameRaw, ok := config.Annotations[runtimev1.InjectCAFromSecretAnnotation]
+	if !ok {
+		return nil
+	}
+	secretName := splitNamespacedName(secretNameRaw)
+
+	if secretName.Namespace == "" || secretName.Name == "" {
+		return errors.Errorf("secret name %q must be in the form namespace/name", secretNameRaw)
+	}
+
+	var secret corev1.Secret
+	// Note: this is an expensive API call because secrets are explicitly not cached.
+	if err := client.Get(ctx, secretName, &secret); err != nil {
+		return errors.Wrapf(err, "failed to get secret %s", secretNameRaw)
+	}
+
+	caData, hasCAData := secret.Data[tlsCAKey]
+	if !hasCAData {
+		return errors.Errorf("secret %s does not contain a %s", secretNameRaw, tlsCAKey)
+	}
+
+	config.Spec.ClientConfig.CABundle = caData
+	return nil
+}
+
+// splitNamespacedName turns the string form of a namespaced name
+// (<namespace>/<name>) back into a types.NamespacedName.
+func splitNamespacedName(nameStr string) types.NamespacedName {
+	splitPoint := strings.IndexRune(nameStr, types.Separator)
+	if splitPoint == -1 {
+		return types.NamespacedName{Name: nameStr}
+	}
+	return types.NamespacedName{Namespace: nameStr[:splitPoint], Name: nameStr[splitPoint+1:]}
 }

--- a/exp/runtime/internal/controllers/warmup.go
+++ b/exp/runtime/internal/controllers/warmup.go
@@ -98,6 +98,11 @@ func warmupRegistry(ctx context.Context, client client.Client, reader client.Rea
 		extensionConfig := &extensionConfigList.Items[i]
 		original := extensionConfig.DeepCopy()
 
+		// Inject CABundle from secret if annotation is set. Otherwise https calls may fail.
+		if err := reconcileCABundle(ctx, client, extensionConfig); err != nil {
+			errs = append(errs, err)
+		}
+
 		extensionConfig, err := discoverExtensionConfig(ctx, runtimeClient, extensionConfig)
 		if err != nil {
 			errs = append(errs, err)

--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -216,7 +216,7 @@ func extensionConfig(specName string, namespace *corev1.Namespace) *runtimev1.Ex
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
 			Annotations: map[string]string{
-				"cert-manager.io/inject-ca-from-secret": fmt.Sprintf("%s/webhook-service-cert", namespace.Name),
+				runtimev1.InjectCAFromSecretAnnotation: fmt.Sprintf("%s/webhook-service-cert", namespace.Name),
 			},
 		},
 		Spec: runtimev1.ExtensionConfigSpec{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

- injects the `ca.crt` data from a secret referred by the annotation `runtime.cluster.x-k8s.io/inject-ca-from-secret ` into `spec.clientConfig.caBundle`
- adds a watch for secrets **but only their metadata, not secret data** to the extension controller to ensure updates to the  secret referred by an ExtensionConfig annotation triggers updates of the caBundle too.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6507
