### PR TITLE
🌱 Add support for "other" providers to clusterctl and tilt

### DIFF
--- a/cmd/clusterctl/api/v1alpha3/labels.go
+++ b/cmd/clusterctl/api/v1alpha3/labels.go
@@ -50,6 +50,8 @@ func ManifestLabel(name string, providerType ProviderType) string {
 		return fmt.Sprintf("control-plane-%s", name)
 	case InfrastructureProviderType:
 		return fmt.Sprintf("infrastructure-%s", name)
+	case OtherProviderType:
+		return fmt.Sprintf("other-%s", name)
 	default:
 		return name
 	}

--- a/cmd/clusterctl/api/v1alpha3/provider_type.go
+++ b/cmd/clusterctl/api/v1alpha3/provider_type.go
@@ -92,7 +92,8 @@ func (p *Provider) GetProviderType() ProviderType {
 		CoreProviderType,
 		BootstrapProviderType,
 		InfrastructureProviderType,
-		ControlPlaneProviderType:
+		ControlPlaneProviderType,
+		OtherProviderType:
 		return t
 	default:
 		return ProviderTypeUnknown
@@ -118,6 +119,10 @@ const (
 	// control-plane capabilities.
 	ControlPlaneProviderType = ProviderType("ControlPlaneProvider")
 
+	// OtherProviderType is the type associated with other codebases that provide
+	// generic capabilities that do not require any special handling.
+	OtherProviderType = ProviderType("OtherProvider")
+
 	// ProviderTypeUnknown is used when the type is unknown.
 	ProviderTypeUnknown = ProviderType("")
 )
@@ -133,8 +138,10 @@ func (p ProviderType) Order() int {
 		return 2
 	case InfrastructureProviderType:
 		return 3
-	default:
+	case OtherProviderType:
 		return 4
+	default:
+		return 5
 	}
 }
 

--- a/hack/tools/tilt-prepare/main.go
+++ b/hack/tools/tilt-prepare/main.go
@@ -655,6 +655,14 @@ func getProviderObj(prefix string, objs []unstructured.Unstructured) (*unstructu
 		providerType = "ControlPlaneProvider"
 		providerName = manifestLabel[len("control-plane-"):]
 	}
+	if strings.HasPrefix(manifestLabel, "ipam-") {
+		providerType = "OtherProvider"
+		providerName = manifestLabel[len("ipam-"):]
+	}
+	if strings.HasPrefix(manifestLabel, "other-") {
+		providerType = "OtherProvider"
+		providerName = manifestLabel[len("other-"):]
+	}
 
 	provider := &clusterctlv1.Provider{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adds support for a new "other" type of providers to clusterctl and tilt. Not sure if the naming is good.

The provider could be used for anything that should be installed, but doesn't require any validation or special handling as with the other providers (assuming that's the reason for having types?).

The primary goal of this PR is to allow using IPAM providers with the tilt setup in this project. There might be another way to do so that doesn't involve clusterctl, which might be a better approach here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Resolves #6154
