### PR TITLE
🌱 Run fuzzers in CI

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'kubernetes-cluster-api'
+        dry-run: false
+        language: go
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'kubernetes-cluster-api'
+        fuzz-seconds: 1200
+        dry-run: false
+        language: go
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds a job for the CI that will run all the OSS-fuzz fuzzers in the CI. The fuzzers can be found here: https://github.com/cncf/cncf-fuzzing/tree/main/projects/cluster-api. Each fuzzer will be run for 1200 seconds.

This serves two purposes:

1. Any easy-to-find bugs will be found at the stage of pull requests instead of after code has beed merged.
2. Breaking changes to the fuzzing suite will be caught.

This is enabled by OSS-Fuzz's CIFuzz: https://google.github.io/oss-fuzz/getting-started/continuous-integration/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
