### PR TITLE
:bug: Use APIReader to fix flaky MachinePool test

### DIFF
--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -1200,7 +1200,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(machinepool.Status.GetTypedPhase()).To(Equal(expv1.MachinePoolPhaseRunning))
 
 		delNode := &corev1.Node{}
-		err = env.Get(ctx, client.ObjectKeyFromObject(node), delNode)
+		err = env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(node), delNode)
 		g.Expect(err).ToNot(BeNil())
 		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Use APIReader in MachinePool scale to zero test. 

This is targeted at fixing a flake in the test noticed on a recent PR: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/6619/pull-cluster-api-test-main/1536370857771798528  

