### PR TITLE
🐛 RuntimeSDK: some bugfixes

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - addons.cluster.x-k8s.io
   resources:
   - '*'

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -36,6 +36,7 @@ import (
 )
 
 // +kubebuilder:rbac:groups=runtime.cluster.x-k8s.io,resources=extensionconfigs;extensionconfigs/status,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 // Reconciler reconciles an ExtensionConfig object.
 type Reconciler struct {

--- a/main.go
+++ b/main.go
@@ -377,6 +377,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 			RuntimeClient: runtimeclient.New(runtimeclient.Options{
 				Catalog:  catalog,
 				Registry: registry,
+				Client:   mgr.GetClient(),
 			}),
 			WatchFilterValue: watchFilterValue,
 		}).SetupWithManager(ctx, mgr, concurrency(extensionConfigConcurrency)); err != nil {

--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -227,8 +227,12 @@ func extensionConfig(specName string, namespace *corev1.Namespace) *runtimev1.Ex
 				},
 			},
 			NamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"kubernetes.io/metadata.name:": namespace.Name,
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "kubernetes.io/metadata.name",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{namespace.Name},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR fixes some bugs which have been introduced by recent PRs:
1. The ExtensionConfig controller need permissions to list namespaces
2. The ExtensionConfig controller requires the client to be set in main.go otherwise we're getting a panic when we try to List namespaces
3. We have to select the namespace via expressions as `/` is not allowed in the label selector

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
