### PR TITLE
🌱 RuntimeSDK: enforce https for extensions

### DIFF
--- a/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
+++ b/config/crd/bases/runtime.cluster.x-k8s.io_extensionconfigs.yaml
@@ -85,8 +85,7 @@ spec:
                       of `url` or `service` must be specified. \n The `host` should
                       not refer to a service running in the cluster; use the `service`
                       field instead. \n The scheme should be \"https\"; the URL should
-                      begin with \"https://\". \"http\" is supported for insecure
-                      development purposes only. \n A path is optional, and if present
+                      begin with \"https://\". \n A path is optional, and if present
                       may be any string permissible in a URL. If a path is set it
                       will be used as prefix and the hook-specific path will be appended.
                       \n Attempting to use a user or basic auth e.g. \"user:password@\"

--- a/exp/runtime/api/v1alpha1/extensionconfig_types.go
+++ b/exp/runtime/api/v1alpha1/extensionconfig_types.go
@@ -47,7 +47,6 @@ type ClientConfig struct {
 	// the `service` field instead.
 	//
 	// The scheme should be "https"; the URL should begin with "https://".
-	// "http" is supported for insecure development purposes only.
 	//
 	// A path is optional, and if present may be any string permissible in
 	// a URL. If a path is set it will be used as prefix and the hook-specific

--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -220,6 +220,7 @@ func TestExtensionReconciler_discoverExtensionConfig(t *testing.T) {
 		})
 
 		extensionConfig := fakeExtensionConfigForURL(ns.Name, extensionName, srv1.URL)
+		extensionConfig.Spec.ClientConfig.CABundle = testcerts.CACert
 
 		discoveredExtensionConfig, err := discoverExtensionConfig(ctx, runtimeClient, extensionConfig)
 		g.Expect(err).To(BeNil())
@@ -252,7 +253,8 @@ func TestExtensionReconciler_discoverExtensionConfig(t *testing.T) {
 			Registry: registry,
 		})
 
-		extensionConfig := fakeExtensionConfigForURL(ns.Name, extensionName, "http://localhost:31239")
+		extensionConfig := fakeExtensionConfigForURL(ns.Name, extensionName, "https://localhost:31239")
+		extensionConfig.Spec.ClientConfig.CABundle = testcerts.CACert
 
 		discoveredExtensionConfig, err := discoverExtensionConfig(ctx, runtimeClient, extensionConfig)
 		g.Expect(err).ToNot(BeNil())

--- a/exp/runtime/internal/controllers/warmup_test.go
+++ b/exp/runtime/internal/controllers/warmup_test.go
@@ -123,7 +123,7 @@ func Test_warmupRunnable_Start(t *testing.T) {
 		brokenExtension := "ext2"
 		for _, name := range []string{"ext1", "ext2", "ext3"} {
 			if name == brokenExtension {
-				g.Expect(env.CreateAndWait(ctx, fakeExtensionConfigForURL(ns.Name, name, "http://localhost:1234"))).To(Succeed())
+				g.Expect(env.CreateAndWait(ctx, fakeExtensionConfigForURL(ns.Name, name, "https://localhost:1234"))).To(Succeed())
 				continue
 			}
 			server, err := fakeSecureExtensionServer(discoveryHandler("first", "second", "third"))

--- a/internal/webhooks/runtime/extensionconfig_webhook.go
+++ b/internal/webhooks/runtime/extensionconfig_webhook.go
@@ -143,11 +143,11 @@ func validateExtensionConfigSpec(e *runtimev1.ExtensionConfig) field.ErrorList {
 				*e.Spec.ClientConfig.URL,
 				fmt.Sprintf("must be a valid URL, e.g. https://example.com: %v", err),
 			))
-		} else if uri.Scheme != "http" && uri.Scheme != "https" {
+		} else if uri.Scheme != "https" {
 			allErrs = append(allErrs, field.Invalid(
 				specPath.Child("clientConfig", "url"),
 				*e.Spec.ClientConfig.URL,
-				"'https' and 'http' are the only allowed URL schemes, e.g. https://example.com",
+				"'https' is the only allowed URL scheme, e.g. https://example.com",
 			))
 		}
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR does:
* adjusts the Runtime SDKs hook client to enforce usage of TLS for calling Hooks
* adjusts the validation for ExtensionConfigs to block an `ExtensionConfig` which defines an url having `http` scheme
* adjusts tests because they now have to use https

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of:
* #6330

Follow-up of
* #6632 
