### PR TITLE
🌱 Add support for 'ipam' and 'other' providers to tilt

### DIFF
--- a/hack/tools/tilt-prepare/main.go
+++ b/hack/tools/tilt-prepare/main.go
@@ -655,6 +655,14 @@ func getProviderObj(prefix string, objs []unstructured.Unstructured) (*unstructu
 		providerType = "ControlPlaneProvider"
 		providerName = manifestLabel[len("control-plane-"):]
 	}
+	if strings.HasPrefix(manifestLabel, "ipam-") {
+		providerType = "UnknownProvider"
+		providerName = manifestLabel[len("ipam-"):]
+	}
+	if strings.HasPrefix(manifestLabel, "other-") {
+		providerType = "UnknownProvider"
+		providerName = manifestLabel[len("other-"):]
+	}
 
 	provider := &clusterctlv1.Provider{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This adds support for 'ipam-' and 'other-' providers to `tilt-prepare` to allow using ipam or any other new providers with our tilt setup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

