### PR TITLE
🌱 [WIP] make topology upgrade sequential

### DIFF
--- a/internal/controllers/topology/cluster/scope/state.go
+++ b/internal/controllers/topology/cluster/scope/state.go
@@ -68,6 +68,16 @@ func (mds MachineDeploymentsStateMap) RollingOut() []string {
 	return names
 }
 
+// AreAtVersion return true if all the machine deployments are the desired version.
+func (mds MachineDeploymentsStateMap) AreAtVersion(version string) bool {
+	for _, md := range mds {
+		if !md.IsAtVersion(version) {
+			return false
+		}
+	}
+	return true
+}
+
 // IsAnyRollingOut returns true if at least one of the
 // machine deployments is rolling out. False, otherwise.
 func (mds MachineDeploymentsStateMap) IsAnyRollingOut() bool {
@@ -95,4 +105,13 @@ type MachineDeploymentState struct {
 // - if any of the replicas of the the machine deployment is not ready.
 func (md *MachineDeploymentState) IsRollingOut() bool {
 	return !mdutil.DeploymentComplete(md.Object, &md.Object.Status) || *md.Object.Spec.Replicas != md.Object.Status.ReadyReplicas
+}
+
+// IsAtVersion return true if the MachineDeployment spec version matches the version.
+// If the MachineDeployment does not support version then it returns false.
+func (md *MachineDeploymentState) IsAtVersion(version string) bool {
+	if md.Object.Spec.Template.Spec.Version != nil {
+		return version == *md.Object.Spec.Template.Spec.Version
+	}
+	return false
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR fixes the Kubernetes version upgrade propagation logic in managed topologies so that the upgrades are always done sequentially.

TODO: 
- [ ] Add unit tests
- [ ] Check to see if any of the `TopologyReconciled` condition's messaging needs to be adjusted to reflect the new possible state

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6651 
