### PR TITLE
🐛  Prevent breaking an existing owner reference for MachineHealthChecks of ControlPlanes in topology

### DIFF
--- a/internal/controllers/topology/cluster/reconcile_state.go
+++ b/internal/controllers/topology/cluster/reconcile_state.go
@@ -251,7 +251,8 @@ func (r *Reconciler) reconcileControlPlane(ctx context.Context, s *scope.Scope) 
 	if s.Desired.ControlPlane.MachineHealthCheck != nil || s.Current.ControlPlane.MachineHealthCheck != nil {
 		// Set the ControlPlane Object and the Cluster as owners for the MachineHealthCheck to ensure object garbage collection
 		// in case something happens before the MHC sets ownership to the Cluster.
-		if s.Desired.ControlPlane.MachineHealthCheck != nil {
+		// NOTE: This is only necessary when the ControlPlane Object did not yet exist during computeDesiredState.
+		if s.Current.ControlPlane.Object == nil && s.Desired.ControlPlane.MachineHealthCheck != nil {
 			s.Desired.ControlPlane.MachineHealthCheck.SetOwnerReferences([]metav1.OwnerReference{
 				*ownerReferenceTo(s.Desired.ControlPlane.Object),
 			})

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -969,6 +969,11 @@ func TestReconcileControlPlaneMachineHealthCheck(t *testing.T) {
 			if tt.current != nil && tt.current.Object != nil && tt.desired != nil && tt.desired.Object != nil {
 				tt.desired.Object.SetUID(tt.current.Object.GetUID())
 			}
+			// copy over owner reference of created MHC to wanted MHC
+			// This is normally done by computeDesiredState.
+			if tt.current != nil && tt.desired != nil && tt.current.MachineHealthCheck != nil && tt.desired.MachineHealthCheck != nil {
+				tt.desired.MachineHealthCheck.OwnerReferences = tt.current.MachineHealthCheck.OwnerReferences
+			}
 
 			r := Reconciler{
 				Client:             env,

--- a/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
@@ -13,6 +13,12 @@ spec:
         kind: DockerMachineTemplate
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         name: quick-start-control-plane
+    machineHealthCheck:
+      maxUnhealthy: 100%
+      unhealthyConditions:
+      - type: e2e.remediation.condition
+        status: "False"
+        timeout: 20s
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -32,6 +38,12 @@ spec:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: DockerMachineTemplate
             name: quick-start-default-worker-machinetemplate
+      machineHealthCheck:
+        maxUnhealthy: 100%
+        unhealthyConditions:
+        - type: e2e.remediation.condition
+          status: "False"
+          timeout: 20s
   variables:
   - name: lbImageRepository
     required: true


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds MachineHealthChecks to the ClusterClass used in e2e tests
* Align behaviour in topology controller for handling the owner reference of a MachineHealthCheck: Changes the topology controller to only add the owner reference to a MachineHealthCheck pointing to the ControlPlane when the ControlPlane did not exist before.
* Adjusts MachineHealthCheck test to align to the real behaviour of the topology reconciliation

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6653
