### PR TITLE
[release-1.1] seedling Refresh BootstrapToken until Nodes join

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/internal/controllers/kubeadmconfig_controller.go
@@ -246,9 +246,10 @@ func (r *KubeadmConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Status is ready means a config has been generated.
 	case config.Status.Ready:
 		if config.Spec.JoinConfiguration != nil && config.Spec.JoinConfiguration.Discovery.BootstrapToken != nil {
-			if !configOwner.IsInfrastructureReady() {
-				// If the BootstrapToken has been generated for a join and the infrastructure is not ready.
-				// This indicates the token in the join config has not been consumed and it may need a refresh.
+			if !configOwner.HasNodeRefs() {
+				// If the BootstrapToken has been generated for a join but the config owner has no nodeRefs,
+				// this indicates that the node has not yet joined and the token in the join config has not
+				// been consumed and it may need a refresh.
 				return r.refreshBootstrapToken(ctx, config, cluster)
 			}
 			if configOwner.IsMachinePool() {

--- a/bootstrap/util/configowner_test.go
+++ b/bootstrap/util/configowner_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -270,6 +270,7 @@ func TestHasNodeRefs(t *testing.T) {
 		}
 
 		for _, mp := range machinePools {
+			mp := mp
 			content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&mp)
 			if err != nil {
 				g.Fail(err.Error())
@@ -347,6 +348,7 @@ func TestHasNodeRefs(t *testing.T) {
 		}
 
 		for _, mp := range machinePools {
+			mp := mp
 			content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&mp)
 			if err != nil {
 				g.Fail(err.Error())


### PR DESCRIPTION
This is an "automated" cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/6395

A bit more text for the PR verify action.

Trying to fix linting issue found in https://github.com/kubernetes-sigs/cluster-api/pull/6654
