### PR TITLE
🌱  Initial e2e test for Runtime SDK lifecycle hook

### DIFF
--- a/test/extension/config/default/extension.yaml
+++ b/test/extension/config/default/extension.yaml
@@ -19,6 +19,7 @@ spec:
         image: controller:latest
         name: extension
       terminationGracePeriodSeconds: 10
+      serviceAccountName: test-extension
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master

--- a/test/extension/config/default/kustomization.yaml
+++ b/test/extension/config/default/kustomization.yaml
@@ -3,6 +3,9 @@ commonLabels:
 resources:
 - extension.yaml
 - service.yaml
+- role.yaml
+- rolebinding.yaml
+- service_account.yaml
 
 bases:
 - ../certmanager

--- a/test/extension/config/default/role.yaml
+++ b/test/extension/config/default/role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-extension
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - create

--- a/test/extension/config/default/rolebinding.yaml
+++ b/test/extension/config/default/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-extension
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: test-extension
+subjects:
+  - kind: ServiceAccount
+    name: test-extension
+    namespace: ${SERVICE_NAMESPACE}

--- a/test/extension/config/default/service_account.yaml
+++ b/test/extension/config/default/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-extension

--- a/test/extension/handlers/lifecycle/handlers.go
+++ b/test/extension/handlers/lifecycle/handlers.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lifecycle contains the handlers for the lifecycle hooks.
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
+)
+
+// Handler is the handler for the lifecycle hooks.
+type Handler struct {
+	Client client.Client
+}
+
+// DoBeforeClusterCreate implements the BeforeClusterCreate hook.
+func (h *Handler) DoBeforeClusterCreate(ctx context.Context, request *runtimehooksv1.BeforeClusterCreateRequest, response *runtimehooksv1.BeforeClusterCreateResponse) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("BeforeClusterCreate is called")
+	cluster := request.Cluster
+	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.BeforeClusterCreate); err != nil {
+		response.Status = runtimehooksv1.ResponseStatusFailure
+		response.Message = err.Error()
+		return
+	}
+	log.Info("BeforeClusterCreate has been recorded in configmap", "cm", cluster.Name+"-hookresponses")
+
+	err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.BeforeClusterCreate, response)
+	if err != nil {
+		response.Status = runtimehooksv1.ResponseStatusFailure
+		response.Message = err.Error()
+		return
+	}
+}
+
+// DoBeforeClusterUpgrade implements the BeforeClusterUpgrade hook.
+func (h *Handler) DoBeforeClusterUpgrade(ctx context.Context, request *runtimehooksv1.BeforeClusterUpgradeRequest, response *runtimehooksv1.BeforeClusterUpgradeResponse) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("BeforeClusterUpgrade is called")
+	cluster := request.Cluster
+	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.BeforeClusterUpgrade); err != nil {
+		response.Status = runtimehooksv1.ResponseStatusFailure
+		response.Message = err.Error()
+		return
+	}
+	err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.BeforeClusterUpgrade, response)
+	if err != nil {
+		response.Status = runtimehooksv1.ResponseStatusFailure
+		response.Message = err.Error()
+		return
+	}
+}
+
+// DoAfterControlPlaneInitialized implements the AfterControlPlaneInitialized hook.
+func (h *Handler) DoAfterControlPlaneInitialized(ctx context.Context, request *runtimehooksv1.AfterControlPlaneInitializedRequest, response *runtimehooksv1.AfterControlPlaneInitializedResponse) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("AfterControlPlaneInitialized is called")
+	cluster := request.Cluster
+	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterControlPlaneInitialized); err != nil {
+		response.Status = runtimehooksv1.ResponseStatusFailure
+		response.Message = err.Error()
+		return
+	}
+	err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterControlPlaneInitialized, response)
+	if err != nil {
+		response.Status = runtimehooksv1.ResponseStatusFailure
+		response.Message = err.Error()
+		return
+	}
+}
+
+// DoAfterControlPlaneUpgrade implements the AfterControlPlaneUpgrade hook.
+func (h *Handler) DoAfterControlPlaneUpgrade(ctx context.Context, request *runtimehooksv1.AfterControlPlaneUpgradeRequest, response *runtimehooksv1.AfterControlPlaneUpgradeResponse) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("AfterControlPlaneUpgrade is called")
+	cluster := request.Cluster
+	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterControlPlaneUpgrade); err != nil {
+		response.Status = runtimehooksv1.ResponseStatusFailure
+		response.Message = err.Error()
+		return
+	}
+	err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterControlPlaneUpgrade, response)
+	if err != nil {
+		response.Status = runtimehooksv1.ResponseStatusFailure
+		response.Message = err.Error()
+		return
+	}
+}
+
+// DoAfterClusterUpgrade implements the AfterClusterUpgrade hook.
+func (h *Handler) DoAfterClusterUpgrade(ctx context.Context, request *runtimehooksv1.AfterClusterUpgradeRequest, response *runtimehooksv1.AfterClusterUpgradeResponse) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("AfterClusterUpgrade is called")
+	cluster := request.Cluster
+	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterClusterUpgrade); err != nil {
+		response.Status = runtimehooksv1.ResponseStatusFailure
+		response.Message = err.Error()
+		return
+	}
+	err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterClusterUpgrade, response)
+	if err != nil {
+		response.Status = runtimehooksv1.ResponseStatusFailure
+		response.Message = err.Error()
+		return
+	}
+}
+
+func (h *Handler) readResponseFromConfigMap(ctx context.Context, name, namespace string, hook runtimecatalog.Hook, response runtimehooksv1.ResponseObject) error {
+	hookName := runtimecatalog.HookName(hook)
+	configMap := &corev1.ConfigMap{}
+	configMapName := name + "-hookresponses"
+	if err := h.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: configMapName}, configMap); err != nil {
+		return errors.Wrapf(err, "failed to read the ConfigMap %s/%s", namespace, configMapName)
+	}
+	if err := yaml.Unmarshal([]byte(configMap.Data[hookName+"-response"]), response); err != nil {
+		return errors.Wrapf(err, "failed to read %q response information from ConfigMap", hook)
+	}
+	return nil
+}
+
+func (h *Handler) recordCallInConfigMap(ctx context.Context, name, namespace string, hook runtimecatalog.Hook) error {
+	hookName := runtimecatalog.HookName(hook)
+	configMap := &corev1.ConfigMap{}
+	configMapName := name + "-hookresponses"
+	if err := h.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: configMapName}, configMap); err != nil {
+		return errors.Wrapf(err, "failed to read the ConfigMap %s/%s", namespace, configMapName)
+	}
+
+	patch := client.RawPatch(types.MergePatchType,
+		[]byte(fmt.Sprintf(`{"data":{"%s-called":"true"}}`, hookName)))
+	if err := h.Client.Patch(ctx, configMap, patch); err != nil {
+		return errors.Wrapf(err, "failed to update the ConfigMap %s/%s", namespace, configMapName)
+	}
+	return nil
+}

--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -28,9 +28,11 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	runtimecatalog "sigs.k8s.io/cluster-api/internal/runtime/catalog"
+	"sigs.k8s.io/cluster-api/test/extension/handlers/lifecycle"
 	"sigs.k8s.io/cluster-api/test/extension/handlers/topologymutation"
 	"sigs.k8s.io/cluster-api/test/extension/server"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
@@ -122,6 +124,72 @@ func main() {
 		Hook:           runtimehooksv1.ValidateTopology,
 		Name:           "validate-topology",
 		HandlerFunc:    topologyMutationHandler.ValidateTopology,
+		TimeoutSeconds: pointer.Int32(5),
+		FailurePolicy:  toPtr(runtimehooksv1.FailurePolicyFail),
+	}); err != nil {
+		setupLog.Error(err, "error adding handler")
+		os.Exit(1)
+	}
+
+	restConfig, err := ctrl.GetConfig()
+	if err != nil {
+		setupLog.Error(err, "error getting config for the cluster")
+		os.Exit(1)
+	}
+
+	c, err := client.New(restConfig, client.Options{})
+	if err != nil {
+		setupLog.Error(err, "error creating client to the cluster")
+		os.Exit(1)
+	}
+	lifecycleHandler := lifecycle.Handler{Client: c}
+
+	// Lifecycle Hooks
+	if err := webhookServer.AddExtensionHandler(server.ExtensionHandler{
+		Hook:           runtimehooksv1.BeforeClusterCreate,
+		Name:           "before-cluster-create",
+		HandlerFunc:    lifecycleHandler.DoBeforeClusterCreate,
+		TimeoutSeconds: pointer.Int32(5),
+		FailurePolicy:  toPtr(runtimehooksv1.FailurePolicyFail),
+	}); err != nil {
+		setupLog.Error(err, "error adding handler")
+		os.Exit(1)
+	}
+	if err := webhookServer.AddExtensionHandler(server.ExtensionHandler{
+		Hook:           runtimehooksv1.AfterControlPlaneInitialized,
+		Name:           "after-control-plane-initialized",
+		HandlerFunc:    lifecycleHandler.DoAfterControlPlaneInitialized,
+		TimeoutSeconds: pointer.Int32(5),
+		FailurePolicy:  toPtr(runtimehooksv1.FailurePolicyFail),
+	}); err != nil {
+		setupLog.Error(err, "error adding handler")
+		os.Exit(1)
+	}
+	if err := webhookServer.AddExtensionHandler(server.ExtensionHandler{
+		Hook:           runtimehooksv1.BeforeClusterUpgrade,
+		Name:           "before-cluster-upgrade",
+		HandlerFunc:    lifecycleHandler.DoBeforeClusterUpgrade,
+		TimeoutSeconds: pointer.Int32(5),
+		FailurePolicy:  toPtr(runtimehooksv1.FailurePolicyFail),
+	}); err != nil {
+		setupLog.Error(err, "error adding handler")
+		os.Exit(1)
+	}
+
+	if err := webhookServer.AddExtensionHandler(server.ExtensionHandler{
+		Hook:           runtimehooksv1.AfterControlPlaneUpgrade,
+		Name:           "after-control-plane-upgrade",
+		HandlerFunc:    lifecycleHandler.DoAfterControlPlaneUpgrade,
+		TimeoutSeconds: pointer.Int32(5),
+		FailurePolicy:  toPtr(runtimehooksv1.FailurePolicyFail),
+	}); err != nil {
+		setupLog.Error(err, "error adding handler")
+		os.Exit(1)
+	}
+	if err := webhookServer.AddExtensionHandler(server.ExtensionHandler{
+		Hook:           runtimehooksv1.AfterClusterUpgrade,
+		Name:           "after-cluster-upgrade",
+		HandlerFunc:    lifecycleHandler.DoAfterClusterUpgrade,
 		TimeoutSeconds: pointer.Int32(5),
 		FailurePolicy:  toPtr(runtimehooksv1.FailurePolicyFail),
 	}); err != nil {


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>
Co-authored-by: ykakarap <kakaraparthy@vmware.com>

This PR extends the Cluster upgrade with Runtime SDK end to end test by adding registrations for lifecycle hooks. The handlers record that they've been called to a configMap and the test checks that each of the hooks has been called at least once during the test flow.

Note, BeforeClusterDelete is currently left out pending #6644 , but is simple to add in once that has merged.
Part of https://github.com/kubernetes-sigs/cluster-api/issues/6546
