### PR TITLE
🌱 Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,8 +2,14 @@ name: golangci-lint
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+permissions:
+  contents: read
+
 jobs:
   golangci:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
     name: lint
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,13 @@ on:
 
 name: release
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     name: create draft release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-homebrew-formula-on-release.yml
+++ b/.github/workflows/update-homebrew-formula-on-release.yml
@@ -4,8 +4,13 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 jobs:
   update-homebrew-formula-on-release:
+    permissions:
+      contents: none
     runs-on: macos-latest
     steps:
       - name: Update Homebrew formula


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
