### PR TITLE
🐛 ClusterClass: reconcile InfrastructureCluster controlPlaneEndpoint

### DIFF
--- a/internal/contract/infrastructure_cluster.go
+++ b/internal/contract/infrastructure_cluster.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package contract
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
 
 // InfrastructureClusterContract encodes information about the Cluster API contract for InfrastructureCluster objects
 // like e.g the DockerCluster, AWS Cluster etc.
@@ -33,11 +38,52 @@ func InfrastructureCluster() *InfrastructureClusterContract {
 	return infrastructureCluster
 }
 
-// IgnorePaths returns a list of paths to be ignored when reconciling a topology.
-func (c *InfrastructureClusterContract) IgnorePaths() []Path {
-	return []Path{
-		// NOTE: the controlPlaneEndpoint struct currently contains two mandatory fields (host and port); without this
-		// ignore path they are going to be always reconciled to the default value or to the value set into the template.
-		{"spec", "controlPlaneEndpoint"},
+// ControlPlaneEndpoint provides access to ControlPlaneEndpoint in an InfrastructureCluster object.
+func (c *InfrastructureClusterContract) ControlPlaneEndpoint() *InfrastructureClusterControlPlaneEndpoint {
+	return &InfrastructureClusterControlPlaneEndpoint{}
+}
+
+// InfrastructureClusterControlPlaneEndpoint provides a helper struct for working with ControlPlaneEndpoint
+// in an InfrastructureCluster object.
+type InfrastructureClusterControlPlaneEndpoint struct{}
+
+// Host provides access to the host field in the ControlPlaneEndpoint in an InfrastructureCluster object.
+func (c *InfrastructureClusterControlPlaneEndpoint) Host() *String {
+	return &String{
+		path: []string{"spec", "controlPlaneEndpoint", "host"},
 	}
+}
+
+// Port provides access to the port field in the ControlPlaneEndpoint in an InfrastructureCluster object.
+func (c *InfrastructureClusterControlPlaneEndpoint) Port() *Int64 {
+	return &Int64{
+		path: []string{"spec", "controlPlaneEndpoint", "port"},
+	}
+}
+
+// IgnorePaths returns a list of paths to be ignored when reconciling an InfrastructureCluster.
+// NOTE: The controlPlaneEndpoint struct currently contains two mandatory fields (host and port).
+// As the host and port fields are not using omitempty, they are automatically set to their zero values
+// if they are not set by the user. We don't want to reconcile the zero values as we would then overwrite
+// changes applied by the infrastructure provider controller.
+func (c *InfrastructureClusterContract) IgnorePaths(infrastructureCluster *unstructured.Unstructured) ([]Path, error) {
+	var ignorePaths []Path
+
+	host, ok, err := unstructured.NestedString(infrastructureCluster.UnstructuredContent(), InfrastructureCluster().ControlPlaneEndpoint().Host().Path()...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve %s", InfrastructureCluster().ControlPlaneEndpoint().Host().Path().String())
+	}
+	if ok && host == "" {
+		ignorePaths = append(ignorePaths, InfrastructureCluster().ControlPlaneEndpoint().Host().Path())
+	}
+
+	port, ok, err := unstructured.NestedInt64(infrastructureCluster.UnstructuredContent(), InfrastructureCluster().ControlPlaneEndpoint().Port().Path()...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to retrieve %s", InfrastructureCluster().ControlPlaneEndpoint().Port().Path().String())
+	}
+	if ok && port == 0 {
+		ignorePaths = append(ignorePaths, InfrastructureCluster().ControlPlaneEndpoint().Port().Path())
+	}
+
+	return ignorePaths, nil
 }

--- a/internal/contract/infrastructure_cluster_test.go
+++ b/internal/contract/infrastructure_cluster_test.go
@@ -20,13 +20,168 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestInfrastructureCluster(t *testing.T) {
-	t.Run("Has ignore paths", func(t *testing.T) {
-		g := NewWithT(t)
-		g.Expect(InfrastructureCluster().IgnorePaths()).To(Equal([]Path{
-			{"spec", "controlPlaneEndpoint"},
-		}))
-	})
+	tests := []struct {
+		name                  string
+		infrastructureCluster *unstructured.Unstructured
+		want                  []Path
+		expectErr             bool
+	}{
+		{
+			name: "No ignore paths when controlPlaneEndpoint is not set",
+			infrastructureCluster: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"server": "1.2.3.4",
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "No ignore paths when controlPlaneEndpoint is nil",
+			infrastructureCluster: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"controlPlaneEndpoint": nil,
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "No ignore paths when controlPlaneEndpoint is an empty object",
+			infrastructureCluster: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"controlPlaneEndpoint": map[string]interface{}{},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Don't ignore host when controlPlaneEndpoint.host is set",
+			infrastructureCluster: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"controlPlaneEndpoint": map[string]interface{}{
+							"host": "example.com",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Ignore host when controlPlaneEndpoint.host is set to its zero value",
+			infrastructureCluster: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"controlPlaneEndpoint": map[string]interface{}{
+							"host": "",
+						},
+					},
+				},
+			},
+			want: []Path{
+				{"spec", "controlPlaneEndpoint", "host"},
+			},
+		},
+		{
+			name: "Don't ignore port when controlPlaneEndpoint.port is set",
+			infrastructureCluster: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"controlPlaneEndpoint": map[string]interface{}{
+							"port": int64(6443),
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "Ignore port when controlPlaneEndpoint.port is set to its zero value",
+			infrastructureCluster: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"controlPlaneEndpoint": map[string]interface{}{
+							"port": int64(0),
+						},
+					},
+				},
+			},
+			want: []Path{
+				{"spec", "controlPlaneEndpoint", "port"},
+			},
+		},
+		{
+			name: "Ignore host and port when controlPlaneEndpoint host and port are set to their zero values",
+			infrastructureCluster: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"controlPlaneEndpoint": map[string]interface{}{
+							"host": "",
+							"port": int64(0),
+						},
+					},
+				},
+			},
+			want: []Path{
+				{"spec", "controlPlaneEndpoint", "host"},
+				{"spec", "controlPlaneEndpoint", "port"},
+			},
+		},
+		{
+			name: "Ignore host when controlPlaneEndpoint host is to its zero values, even if port is set",
+			infrastructureCluster: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"controlPlaneEndpoint": map[string]interface{}{
+							"host": "",
+							"port": int64(6443),
+						},
+					},
+				},
+			},
+			want: []Path{
+				{"spec", "controlPlaneEndpoint", "host"},
+			},
+		},
+		{
+			name: "Ignore port when controlPlaneEndpoint port is to its zero values, even if host is set",
+			infrastructureCluster: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"controlPlaneEndpoint": map[string]interface{}{
+							"host": "example.com",
+							"port": int64(0),
+						},
+					},
+				},
+			},
+			want: []Path{
+				{"spec", "controlPlaneEndpoint", "port"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			got, err := InfrastructureCluster().IgnorePaths(tt.infrastructureCluster)
+
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(got).To(Equal(tt.want))
+		})
+	}
 }

--- a/internal/controllers/topology/cluster/reconcile_state.go
+++ b/internal/controllers/topology/cluster/reconcile_state.go
@@ -297,11 +297,17 @@ func (r *Reconciler) callAfterClusterUpgrade(ctx context.Context, s *scope.Scope
 // reconcileInfrastructureCluster reconciles the desired state of the InfrastructureCluster object.
 func (r *Reconciler) reconcileInfrastructureCluster(ctx context.Context, s *scope.Scope) error {
 	ctx, _ = tlog.LoggerFrom(ctx).WithObject(s.Desired.InfrastructureCluster).Into(ctx)
+
+	ignorePaths, err := contract.InfrastructureCluster().IgnorePaths(s.Desired.InfrastructureCluster)
+	if err != nil {
+		return errors.Wrap(err, "failed to calculate ignore paths")
+	}
+
 	return r.reconcileReferencedObject(ctx, reconcileReferencedObjectInput{
 		cluster:     s.Current.Cluster,
 		current:     s.Current.InfrastructureCluster,
 		desired:     s.Desired.InfrastructureCluster,
-		ignorePaths: contract.InfrastructureCluster().IgnorePaths(),
+		ignorePaths: ignorePaths,
 	})
 }
 


### PR DESCRIPTION
fields

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently we never reconcile the controlPlaneEndpoint field of InfrastructureClusters. With this PR we always reconcile the fields if they are set to values different than their zero values.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
