### PR TITLE
🐛  fix typo in clusterctl function name

### DIFF
--- a/cmd/clusterctl/client/alpha/machinedeployment.go
+++ b/cmd/clusterctl/client/alpha/machinedeployment.go
@@ -49,8 +49,8 @@ func getMachineDeployment(proxy cluster.Proxy, name, namespace string) (*cluster
 	return mdObj, nil
 }
 
-// patchMachineDeployemt applies a patch to a machinedeployment.
-func patchMachineDeployemt(proxy cluster.Proxy, name, namespace string, patch client.Patch) error {
+// patchMachineDeployment applies a patch to a machinedeployment.
+func patchMachineDeployment(proxy cluster.Proxy, name, namespace string, patch client.Patch) error {
 	cFrom, err := proxy.NewClient()
 	if err != nil {
 		return err

--- a/cmd/clusterctl/client/alpha/rollout_pauser.go
+++ b/cmd/clusterctl/client/alpha/rollout_pauser.go
@@ -50,5 +50,5 @@ func (r *rollout) ObjectPauser(proxy cluster.Proxy, ref corev1.ObjectReference) 
 // pauseMachineDeployment sets Paused to true in the MachineDeployment's spec.
 func pauseMachineDeployment(proxy cluster.Proxy, name, namespace string) error {
 	patch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"spec\":{\"paused\":%t}}", true)))
-	return patchMachineDeployemt(proxy, name, namespace, patch)
+	return patchMachineDeployment(proxy, name, namespace, patch)
 }

--- a/cmd/clusterctl/client/alpha/rollout_restarter.go
+++ b/cmd/clusterctl/client/alpha/rollout_restarter.go
@@ -51,5 +51,5 @@ func (r *rollout) ObjectRestarter(proxy cluster.Proxy, ref corev1.ObjectReferenc
 // setRestartedAtAnnotation sets the restartedAt annotation in the MachineDeployment's spec.template.objectmeta.
 func setRestartedAtAnnotation(proxy cluster.Proxy, name, namespace string) error {
 	patch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"spec\":{\"template\":{\"metadata\":{\"annotations\":{\"cluster.x-k8s.io/restartedAt\":\"%v\"}}}}}", time.Now().Format(time.RFC3339))))
-	return patchMachineDeployemt(proxy, name, namespace, patch)
+	return patchMachineDeployment(proxy, name, namespace, patch)
 }

--- a/cmd/clusterctl/client/alpha/rollout_resumer.go
+++ b/cmd/clusterctl/client/alpha/rollout_resumer.go
@@ -51,5 +51,5 @@ func (r *rollout) ObjectResumer(proxy cluster.Proxy, ref corev1.ObjectReference)
 func resumeMachineDeployment(proxy cluster.Proxy, name, namespace string) error {
 	patch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"spec\":{\"paused\":%t}}", false)))
 
-	return patchMachineDeployemt(proxy, name, namespace, patch)
+	return patchMachineDeployment(proxy, name, namespace, patch)
 }


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fix a typo in the word MachineDeployment in one of the functions in clusterctl.
