### PR TITLE
🌱 patching Docker-based nodes provider ID using client-runtime

### DIFF
--- a/test/infrastructure/docker/controllers/alias.go
+++ b/test/infrastructure/docker/controllers/alias.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
+	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/test/infrastructure/container"
 	dockercontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/internal/controllers"
 )
@@ -35,6 +36,7 @@ import (
 type DockerMachineReconciler struct {
 	Client           client.Client
 	ContainerRuntime container.Runtime
+	Tracker          *remote.ClusterCacheTracker
 }
 
 // SetupWithManager sets up the reconciler with the Manager.
@@ -42,6 +44,7 @@ func (r *DockerMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl
 	return (&dockercontrollers.DockerMachineReconciler{
 		Client:           r.Client,
 		ContainerRuntime: r.ContainerRuntime,
+		Tracker:          r.Tracker,
 	}).SetupWithManager(ctx, mgr, options)
 }
 

--- a/test/infrastructure/docker/exp/controllers/alias.go
+++ b/test/infrastructure/docker/exp/controllers/alias.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
+	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/test/infrastructure/container"
 	dockermachinepoolcontrollers "sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/internal/controllers"
 )
@@ -34,6 +35,7 @@ type DockerMachinePoolReconciler struct {
 	Client           client.Client
 	Scheme           *runtime.Scheme
 	ContainerRuntime container.Runtime
+	Tracker          *remote.ClusterCacheTracker
 }
 
 // SetupWithManager will add watches for this controller.
@@ -42,5 +44,6 @@ func (r *DockerMachinePoolReconciler) SetupWithManager(ctx context.Context, mgr 
 		Client:           r.Client,
 		Scheme:           r.Scheme,
 		ContainerRuntime: r.ContainerRuntime,
+		Tracker:          r.Tracker,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/test/infrastructure/docker/internal/docker/types/node.go
+++ b/test/infrastructure/docker/internal/docker/types/node.go
@@ -18,8 +18,6 @@ limitations under the License.
 package types
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"io"
 	"path/filepath"
@@ -162,22 +160,6 @@ type ContainerCmd struct {
 	stdin    io.Reader
 	stdout   io.Writer
 	stderr   io.Writer
-}
-
-// RunLoggingOutputOnFail runs the cmd, logging error output if Run returns an error.
-func (c *ContainerCmd) RunLoggingOutputOnFail(ctx context.Context) ([]string, error) {
-	var buff bytes.Buffer
-	c.SetStdout(&buff)
-	c.SetStderr(&buff)
-	err := c.Run(ctx)
-	out := make([]string, 0)
-	if err != nil {
-		scanner := bufio.NewScanner(&buff)
-		for scanner.Scan() {
-			out = append(out, scanner.Text())
-		}
-	}
-	return out, errors.WithStack(err)
 }
 
 // Run will run a configured ContainerCmd inside a container instance.


### PR DESCRIPTION
**What this PR does / why we need it**:

Discussion started [here](https://github.com/kubernetes-sigs/cluster-api/pull/6640#discussion_r897542990).

Rather than using the base `kubectl` command from the command, the patching can be done by the managed cluster client.

**Which issue(s) this PR fixes**:

Not yet tracked.
