### PR TITLE
🌱 Migrate more topology tests to Test* CRD

### DIFF
--- a/internal/controllers/topology/cluster/cluster_controller_test.go
+++ b/internal/controllers/topology/cluster/cluster_controller_test.go
@@ -547,19 +547,19 @@ func setupTestEnvForIntegrationTests(ns *corev1.Namespace) (func() error, error)
 	// Cluster given a skeletal Cluster object and a ClusterClass. The objects include:
 
 	// 1) Templates for Machine, Cluster, ControlPlane and Bootstrap.
-	infrastructureMachineTemplate1 := builder.InfrastructureMachineTemplate(ns.Name, infrastructureMachineTemplateName1).Build()
-	infrastructureMachineTemplate2 := builder.InfrastructureMachineTemplate(ns.Name, infrastructureMachineTemplateName2).
+	infrastructureMachineTemplate1 := builder.TestInfrastructureMachineTemplate(ns.Name, infrastructureMachineTemplateName1).Build()
+	infrastructureMachineTemplate2 := builder.TestInfrastructureMachineTemplate(ns.Name, infrastructureMachineTemplateName2).
 		WithSpecFields(map[string]interface{}{"spec.template.spec.fakeSetting": true}).
 		Build()
-	infrastructureClusterTemplate1 := builder.InfrastructureClusterTemplate(ns.Name, "infraclustertemplate1").
+	infrastructureClusterTemplate1 := builder.TestInfrastructureClusterTemplate(ns.Name, "infraclustertemplate1").
 		Build()
-	infrastructureClusterTemplate2 := builder.InfrastructureClusterTemplate(ns.Name, "infraclustertemplate2").
+	infrastructureClusterTemplate2 := builder.TestInfrastructureClusterTemplate(ns.Name, "infraclustertemplate2").
 		WithSpecFields(map[string]interface{}{"spec.template.spec.alteredSetting": true}).
 		Build()
-	controlPlaneTemplate := builder.ControlPlaneTemplate(ns.Name, "cp1").
+	controlPlaneTemplate := builder.TestControlPlaneTemplate(ns.Name, "cp1").
 		WithInfrastructureMachineTemplate(infrastructureMachineTemplate1).
 		Build()
-	bootstrapTemplate := builder.BootstrapTemplate(ns.Name, "bootstraptemplate").Build()
+	bootstrapTemplate := builder.TestBootstrapTemplate(ns.Name, "bootstraptemplate").Build()
 
 	// 2) ClusterClass definitions including definitions of MachineDeploymentClasses used inside the ClusterClass.
 	machineDeploymentClass1 := builder.MachineDeploymentClass(workerClassName1).
@@ -676,14 +676,14 @@ func assertClusterReconcile(cluster *clusterv1.Cluster) error {
 
 	// Check if InfrastructureRef exists and is of the expected Kind and APIVersion.
 	if err := referenceExistsWithCorrectKindAndAPIVersion(cluster.Spec.InfrastructureRef,
-		builder.GenericInfrastructureClusterKind,
+		builder.TestInfrastructureClusterKind,
 		builder.InfrastructureGroupVersion); err != nil {
 		return err
 	}
 
 	// Check if ControlPlaneRef exists is of the expected Kind and APIVersion.
 	if err := referenceExistsWithCorrectKindAndAPIVersion(cluster.Spec.ControlPlaneRef,
-		builder.GenericControlPlaneKind,
+		builder.TestControlPlaneKind,
 		builder.ControlPlaneGroupVersion); err != nil {
 		return err
 	}
@@ -742,7 +742,7 @@ func assertControlPlaneReconcile(cluster *clusterv1.Cluster) error {
 			return err
 		}
 		if err := referenceExistsWithCorrectKindAndAPIVersion(cpInfra,
-			builder.GenericInfrastructureMachineTemplateKind,
+			builder.TestInfrastructureMachineTemplateKind,
 			builder.InfrastructureGroupVersion); err != nil {
 			return err
 		}
@@ -824,7 +824,7 @@ func assertMachineDeploymentsReconcile(cluster *clusterv1.Cluster) error {
 
 			// Check if the InfrastructureReference exists.
 			if err := referenceExistsWithCorrectKindAndAPIVersion(&md.Spec.Template.Spec.InfrastructureRef,
-				builder.GenericInfrastructureMachineTemplateKind,
+				builder.TestInfrastructureMachineTemplateKind,
 				builder.InfrastructureGroupVersion); err != nil {
 				return err
 			}
@@ -836,7 +836,7 @@ func assertMachineDeploymentsReconcile(cluster *clusterv1.Cluster) error {
 
 			// Check if the Bootstrap reference has the expected Kind and APIVersion.
 			if err := referenceExistsWithCorrectKindAndAPIVersion(md.Spec.Template.Spec.Bootstrap.ConfigRef,
-				builder.GenericBootstrapConfigTemplateKind,
+				builder.TestBootstrapConfigTemplateKind,
 				builder.BootstrapGroupVersion); err != nil {
 				return err
 			}

--- a/internal/test/builder/bootstrap.go
+++ b/internal/test/builder/bootstrap.go
@@ -50,6 +50,11 @@ var (
 
 func testBootstrapConfigTemplateCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
 	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"metadata": {
+			// NOTE: in CRD there is only a partial definition of metadata schema.
+			// Ref https://github.com/kubernetes-sigs/controller-tools/blob/59485af1c1f6a664655dad49543c474bb4a0d2a2/pkg/crd/gen.go#L185
+			Type: "object",
+		},
 		"spec": {
 			Type: "object",
 			Properties: map[string]apiextensionsv1.JSONSchemaProps{
@@ -67,6 +72,11 @@ func testBootstrapConfigTemplateCRD(gvk schema.GroupVersionKind) *apiextensionsv
 
 func testBootstrapConfigCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
 	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"metadata": {
+			// NOTE: in CRD there is only a partial definition of metadata schema.
+			// Ref https://github.com/kubernetes-sigs/controller-tools/blob/59485af1c1f6a664655dad49543c474bb4a0d2a2/pkg/crd/gen.go#L185
+			Type: "object",
+		},
 		"spec": bootstrapConfigSpecSchema,
 		"status": {
 			Type: "object",

--- a/internal/test/builder/controlplane.go
+++ b/internal/test/builder/controlplane.go
@@ -37,63 +37,47 @@ var (
 
 	// TODO: drop generic CRDs in favour of typed test CRDs.
 
+	// TestControlPlaneTemplateKind is the Kind for the TestControlPlaneTemplate.
+	TestControlPlaneTemplateKind = "TestControlPlaneTemplate"
+	// TestControlPlaneTemplateCRD is a test control plane template CRD.
+	TestControlPlaneTemplateCRD = testControlPlaneTemplateCRD(ControlPlaneGroupVersion.WithKind(TestControlPlaneTemplateKind))
+
 	// TestControlPlaneKind is the Kind for the TestControlPlane.
 	TestControlPlaneKind = "TestControlPlane"
 	// TestControlPlaneCRD is a test control plane CRD.
 	TestControlPlaneCRD = testControlPlaneCRD(ControlPlaneGroupVersion.WithKind(TestControlPlaneKind))
 )
 
-func testControlPlaneCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+func testControlPlaneTemplateCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
 	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"metadata": {
+			// NOTE: in CRD there is only a partial definition of metadata schema.
+			// Ref https://github.com/kubernetes-sigs/controller-tools/blob/59485af1c1f6a664655dad49543c474bb4a0d2a2/pkg/crd/gen.go#L185
+			Type: "object",
+		},
 		"spec": {
 			Type: "object",
 			Properties: map[string]apiextensionsv1.JSONSchemaProps{
-				// Mandatory field from the Cluster API contract - version support
-				"version": {
-					Type: "string",
-				},
-				// mandatory field from the Cluster API contract - replicas support
-				"replicas": {
-					Type:   "integer",
-					Format: "int32",
-				},
-				// mandatory field from the Cluster API contract - using Machines support
-				"machineTemplate": {
+				// Mandatory field from the Cluster API contract
+				"template": {
 					Type: "object",
 					Properties: map[string]apiextensionsv1.JSONSchemaProps{
-						"metadata":            metadataSchema,
-						"infrastructureRef":   refSchema,
-						"nodeDeletionTimeout": {Type: "string"},
-						"nodeDrainTimeout":    {Type: "string"},
-					},
-				},
-				// General purpose fields to be used in different test scenario.
-				"foo": {Type: "string"},
-				"bar": {Type: "string"},
-				// Copy of a subset of KCP spec fields to test server side apply on deep nested structs
-				"kubeadmConfigSpec": {
-					Type: "object",
-					Properties: map[string]apiextensionsv1.JSONSchemaProps{
-						"clusterConfiguration": {
-							Type: "object",
-							Properties: map[string]apiextensionsv1.JSONSchemaProps{
-								"controllerManager": {
-									Type: "object",
-									Properties: map[string]apiextensionsv1.JSONSchemaProps{
-										"extraArgs": {
-											Type: "object",
-											AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
-												Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
-											},
-										},
-									},
-								},
-							},
-						},
+						"spec": controPlaneSpecSchema,
 					},
 				},
 			},
 		},
+	})
+}
+
+func testControlPlaneCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"metadata": {
+			// NOTE: in CRD there is only a partial definition of metadata schema.
+			// Ref https://github.com/kubernetes-sigs/controller-tools/blob/59485af1c1f6a664655dad49543c474bb4a0d2a2/pkg/crd/gen.go#L185
+			Type: "object",
+		},
+		"spec": controPlaneSpecSchema,
 		"status": {
 			Type: "object",
 			Properties: map[string]apiextensionsv1.JSONSchemaProps{
@@ -114,3 +98,55 @@ func testControlPlaneCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomRes
 		},
 	})
 }
+
+var (
+	controPlaneSpecSchema = apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			// Mandatory field from the Cluster API contract - version support
+			"version": {
+				Type: "string",
+			},
+			// mandatory field from the Cluster API contract - replicas support
+			"replicas": {
+				Type:   "integer",
+				Format: "int32",
+			},
+			// mandatory field from the Cluster API contract - using Machines support
+			"machineTemplate": {
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"metadata":            metadataSchema,
+					"infrastructureRef":   refSchema,
+					"nodeDeletionTimeout": {Type: "string"},
+					"nodeDrainTimeout":    {Type: "string"},
+				},
+			},
+			// General purpose fields to be used in different test scenario.
+			"foo": {Type: "string"},
+			"bar": {Type: "string"},
+			// Copy of a subset of KCP spec fields to test server side apply on deep nested structs
+			"kubeadmConfigSpec": {
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"clusterConfiguration": {
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"controllerManager": {
+								Type: "object",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"extraArgs": {
+										Type: "object",
+										AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+											Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)

--- a/internal/test/builder/infrastructure.go
+++ b/internal/test/builder/infrastructure.go
@@ -47,6 +47,11 @@ var (
 
 	// TODO: drop generic CRDs in favour of typed test CRDs.
 
+	// TestInfrastructureClusterTemplateKind is the kind for the TestInfrastructureClusterTemplate type.
+	TestInfrastructureClusterTemplateKind = "TestInfrastructureClusterTemplate"
+	// TestInfrastructureClusterTemplateCRD is a test infrastructure machine template CRD.
+	TestInfrastructureClusterTemplateCRD = testInfrastructureClusterTemplateCRD(InfrastructureGroupVersion.WithKind(TestInfrastructureClusterTemplateKind))
+
 	// TestInfrastructureClusterKind is the kind for the TestInfrastructureCluster type.
 	TestInfrastructureClusterKind = "TestInfrastructureCluster"
 	// TestInfrastructureClusterCRD is a test infrastructure machine CRD.
@@ -63,43 +68,36 @@ var (
 	TestInfrastructureMachineCRD = testInfrastructureMachineCRD(InfrastructureGroupVersion.WithKind(TestInfrastructureMachineKind))
 )
 
-func testInfrastructureClusterCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+func testInfrastructureClusterTemplateCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
 	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"metadata": {
+			// NOTE: in CRD there is only a partial definition of metadata schema.
+			// Ref https://github.com/kubernetes-sigs/controller-tools/blob/59485af1c1f6a664655dad49543c474bb4a0d2a2/pkg/crd/gen.go#L185
+			Type: "object",
+		},
 		"spec": {
 			Type: "object",
 			Properties: map[string]apiextensionsv1.JSONSchemaProps{
 				// Mandatory field from the Cluster API contract
-				"controlPlaneEndpoint": {
+				"template": {
 					Type: "object",
 					Properties: map[string]apiextensionsv1.JSONSchemaProps{
-						"host": {Type: "string"},
-						"port": {Type: "integer"},
-					},
-					Required: []string{"host", "port"},
-				},
-				// General purpose fields to be used in different test scenario.
-				"foo": {Type: "string"},
-				"bar": {Type: "string"},
-				"fooMap": {
-					Type: "object",
-					Properties: map[string]apiextensionsv1.JSONSchemaProps{
-						"foo": {Type: "string"},
+						"spec": clusterSpecSchema,
 					},
 				},
-				"fooList": {
-					Type: "array",
-					Items: &apiextensionsv1.JSONSchemaPropsOrArray{
-						Schema: &apiextensionsv1.JSONSchemaProps{
-							Type: "object",
-							Properties: map[string]apiextensionsv1.JSONSchemaProps{
-								"foo": {Type: "string"},
-							},
-						},
-					},
-				},
-				// Field for testing
 			},
 		},
+	})
+}
+
+func testInfrastructureClusterCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
+	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"metadata": {
+			// NOTE: in CRD there is only a partial definition of metadata schema.
+			// Ref https://github.com/kubernetes-sigs/controller-tools/blob/59485af1c1f6a664655dad49543c474bb4a0d2a2/pkg/crd/gen.go#L185
+			Type: "object",
+		},
+		"spec": clusterSpecSchema,
 		"status": {
 			Type: "object",
 			Properties: map[string]apiextensionsv1.JSONSchemaProps{
@@ -116,6 +114,11 @@ func testInfrastructureClusterCRD(gvk schema.GroupVersionKind) *apiextensionsv1.
 
 func testInfrastructureMachineTemplateCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
 	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"metadata": {
+			// NOTE: in CRD there is only a partial definition of metadata schema.
+			// Ref https://github.com/kubernetes-sigs/controller-tools/blob/59485af1c1f6a664655dad49543c474bb4a0d2a2/pkg/crd/gen.go#L185
+			Type: "object",
+		},
 		"spec": {
 			Type: "object",
 			Properties: map[string]apiextensionsv1.JSONSchemaProps{
@@ -134,6 +137,11 @@ func testInfrastructureMachineTemplateCRD(gvk schema.GroupVersionKind) *apiexten
 
 func testInfrastructureMachineCRD(gvk schema.GroupVersionKind) *apiextensionsv1.CustomResourceDefinition {
 	return generateCRD(gvk, map[string]apiextensionsv1.JSONSchemaProps{
+		"metadata": {
+			// NOTE: in CRD there is only a partial definition of metadata schema.
+			// Ref https://github.com/kubernetes-sigs/controller-tools/blob/59485af1c1f6a664655dad49543c474bb4a0d2a2/pkg/crd/gen.go#L185
+			Type: "object",
+		},
 		"spec": machineSpecSchema,
 		"status": {
 			Type: "object",
@@ -149,6 +157,42 @@ func testInfrastructureMachineCRD(gvk schema.GroupVersionKind) *apiextensionsv1.
 }
 
 var (
+	clusterSpecSchema = apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			// Mandatory field from the Cluster API contract
+			"controlPlaneEndpoint": {
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"host": {Type: "string"},
+					"port": {Type: "integer"},
+				},
+				Required: []string{"host", "port"},
+			},
+			// General purpose fields to be used in different test scenario.
+			"foo": {Type: "string"},
+			"bar": {Type: "string"},
+			"fooMap": {
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"foo": {Type: "string"},
+				},
+			},
+			"fooList": {
+				Type: "array",
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+					Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"foo": {Type: "string"},
+						},
+					},
+				},
+			},
+			// Field for testing
+		},
+	}
+
 	machineSpecSchema = apiextensionsv1.JSONSchemaProps{
 		Type: "object",
 		Properties: map[string]apiextensionsv1.JSONSchemaProps{

--- a/internal/test/envtest/environment.go
+++ b/internal/test/envtest/environment.go
@@ -188,11 +188,13 @@ func newEnvironment(uncachedObjs ...client.Object) *Environment {
 			builder.GenericInfrastructureClusterTemplateCRD.DeepCopy(),
 			builder.GenericRemediationCRD.DeepCopy(),
 			builder.GenericRemediationTemplateCRD.DeepCopy(),
+			builder.TestInfrastructureClusterTemplateCRD.DeepCopy(),
 			builder.TestInfrastructureClusterCRD.DeepCopy(),
 			builder.TestInfrastructureMachineTemplateCRD.DeepCopy(),
 			builder.TestInfrastructureMachineCRD.DeepCopy(),
 			builder.TestBootstrapConfigTemplateCRD.DeepCopy(),
 			builder.TestBootstrapConfigCRD.DeepCopy(),
+			builder.TestControlPlaneTemplateCRD.DeepCopy(),
 			builder.TestControlPlaneCRD.DeepCopy(),
 		},
 		// initialize webhook here to be able to test the envtest install via webhookOptions


### PR DESCRIPTION
**What this PR does / why we need it**:
Migrate more topology tests to Test* CRD which are using a fully defined OpenAPI spec (vs using XPreserveUnknownFields); thus providing better signal now that we are using SSA