### PR TITLE
🌱 Improve dry run for topology changes to dry run server side apply

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -117,6 +117,15 @@ const (
 	// An external controller must fulfill the contract of the InfraCluster resource.
 	// External infrastructure providers should ensure that the annotation, once set, cannot be removed.
 	ManagedByAnnotation = "cluster.x-k8s.io/managed-by"
+
+	// TopologyDryRunAnnotation is an annotation that gets set on objects by the topology controller
+	// only during a server side dry run apply operation. It is used for validating
+	// update webhooks for objects which get updated by template rotation (e.g. InfrastructureMachineTemplate).
+	// When the annotation is set and the admission request is a dry run, the webhook should
+	// deny validation due to immutability. By that the request will succeed (without
+	// any changes to the actual object because it is a dry run) and the topology controller
+	// will receive the resulting object.
+	TopologyDryRunAnnotation = "topology.cluster.x-k8s.io/dry-run"
 )
 
 const (

--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,7 +34,6 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
-	"sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/structuredmerge"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -853,9 +851,6 @@ func (o *objectMover) createTargetObject(nodeToCreate *node, toProxy Proxy) erro
 	// Rebuild the owne reference chain
 	o.buildOwnerChain(obj, nodeToCreate)
 
-	// Save the old managed fields for topology managed fields migration
-	oldManagedFields := obj.GetManagedFields()
-
 	// FIXME Workaround for https://github.com/kubernetes/kubernetes/issues/32220. Remove when the issue is fixed.
 	// If the resource already exists, the API server ordinarily returns an AlreadyExists error. Due to the above issue, if the resource has a non-empty metadata.generateName field, the API server returns a ServerTimeoutError. To ensure that the API server returns an AlreadyExists error, we set the metadata.generateName field to an empty string.
 	if len(obj.GetName()) > 0 && len(obj.GetGenerateName()) > 0 {
@@ -901,10 +896,6 @@ func (o *objectMover) createTargetObject(nodeToCreate *node, toProxy Proxy) erro
 
 	// Stores the newUID assigned to the newly created object.
 	nodeToCreate.newUID = obj.GetUID()
-
-	if err := patchTopologyManagedFields(ctx, oldManagedFields, obj, cTo); err != nil {
-		return err
-	}
 
 	return nil
 }
@@ -1172,33 +1163,4 @@ func (o *objectMover) checkTargetProviders(toInventory InventoryClient) error {
 	}
 
 	return kerrors.NewAggregate(errList)
-}
-
-// patchTopologyManagedFields patches the managed fields of obj if parts of it are owned by the topology controller.
-// This is necessary to ensure the managed fields created by the topology controller are still present and thus to
-// prevent unnecessary machine rollouts. Without patching the managed fields, clusterctl would be the owner of the fields
-// which would lead to co-ownership and also additional machine rollouts.
-func patchTopologyManagedFields(ctx context.Context, oldManagedFields []metav1.ManagedFieldsEntry, obj *unstructured.Unstructured, cTo client.Client) error {
-	var containsTopologyManagedFields bool
-	// Check if the object was owned by the topology controller.
-	for _, m := range oldManagedFields {
-		if m.Operation == metav1.ManagedFieldsOperationApply &&
-			m.Manager == structuredmerge.TopologyManagerName &&
-			m.Subresource == "" {
-			containsTopologyManagedFields = true
-			break
-		}
-	}
-	// Return early if the object was not owned by the topology controller.
-	if !containsTopologyManagedFields {
-		return nil
-	}
-	base := obj.DeepCopy()
-	obj.SetManagedFields(oldManagedFields)
-
-	if err := cTo.Patch(ctx, obj, client.MergeFrom(base)); err != nil {
-		return errors.Wrapf(err, "error patching managed fields %q %s/%s",
-			obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName())
-	}
-	return nil
 }

--- a/docs/book/src/developer/providers/v1.1-to-v1.2.md
+++ b/docs/book/src/developer/providers/v1.1-to-v1.2.md
@@ -21,6 +21,7 @@ NOTE: compliance with minimum Kubernetes version is enforced both by clusterctl 
 **Note**: Only the most relevant dependencies are listed, `k8s.io/` and `ginkgo`/`gomega` dependencies
 in ClusterAPI are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
 
+- sigs.k8s.io/controller-runtime: v0.11.x => v0.12.3
 - sigs.k8s.io/controller-tools: v0.8.x => v0.9.x
 - sigs.k8s.io/kind: v0.11.x => v0.14.x
 - k8s.io/*: v0.23.x => v0.24.x (derived from controller-runtime)
@@ -55,20 +56,88 @@ in ClusterAPI are kept in sync with the versions used by `sigs.k8s.io/controller
   [merge-strategy](https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy).
   NOTE: the change will cause a rollout on existing clusters created with ClusterClass
 
-E.g. in CAPA
+  E.g. in CAPA
 
-```go
-// +optional
-Subnets Subnets `json:"subnets,omitempty"
-```
-Must be modified into:
+  ```go
+  // +optional
+  Subnets Subnets `json:"subnets,omitempty"
+  ```
+  Must be modified into:
 
-```go
-// +optional
-// +listType=map
-// +listMapKey=id
-Subnets Subnets `json:"subnets,omitempty"
-```
+  ```go
+  // +optional
+  // +listType=map
+  // +listMapKey=id
+  Subnets Subnets `json:"subnets,omitempty"
+  ```
+
+- [Server Side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) implementation in ClusterClass and managed topologies
+  requires to dry-run changes on templates. If infrastructure or bootstrap providers have implemented immutability checks
+  in their InfrastructureMachineTemplate or BootstrapConfigTemplate webhooks,
+  it is required to implement the following changes in order to prevent dry-run to return errors.
+  The implementation requires `sigs.k8s.io/controller-runtime` in version `>= v0.12.3`.
+
+  E.g. in CAPD following changes should be applied to the DockerMachineTemplate webhook:
+
+  ```diff
+  + type DockerMachineTemplateWebhook struct{}
+
+  + func (m *DockerMachineTemplateWebhook) SetupWebhookWithManager(mgr ctrl.Manager) error {
+  - func (m *DockerMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+        return ctrl.NewWebhookManagedBy(mgr).
+  -         For(m).
+  +         For(&DockerMachineTemplate{}).
+  +         WithValidator(m).
+            Complete()
+  }
+
+    // +kubebuilder:webhook:verbs=create;update,path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-dockermachinetemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=infrastructure.cluster.x-k8s.io,resources=dockermachinetemplates,versions=v1beta1,name=validation.dockermachinetemplate.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+  + var _ webhook.CustomValidator = &DockerMachineTemplateWebhook{}
+  - var _ webhook.Validator = &DockerMachineTemplate{}
+
+  + func (*DockerMachineTemplateWebhook) ValidateCreate(ctx context.Context, _ runtime.Object) error {
+  - func (m *DockerMachineTemplate) ValidateCreate() error {
+        ...
+    }
+
+  + func (*DockerMachineTemplateWebhook) ValidateUpdate(ctx context.Context, oldRaw runtime.Object, newRaw runtime.Object) error {
+  +     newObj, ok := newRaw.(*DockerMachineTemplate)
+  +     if !ok {
+  +         return apierrors.NewBadRequest(fmt.Sprintf("expected a DockerMachineTemplate but got a %T", newRaw))
+  +     }
+  - func (m *DockerMachineTemplate) ValidateUpdate(oldRaw runtime.Object) error {
+        oldObj, ok := oldRaw.(*DockerMachineTemplate)
+        if !ok {
+            return apierrors.NewBadRequest(fmt.Sprintf("expected a DockerMachineTemplate but got a %T", oldRaw))
+        }
+  +     req, err := admission.RequestFromContext(ctx)
+  +     if err != nil {
+  +       return apierrors.NewBadRequest(fmt.Sprintf("expected a admission.Request inside context: %v", err))
+  +     }
+        ...
+        // Immutability check
+  +     if !topology.ShouldSkipImmutabilityChecks(req, newObj) &&
+  +        !reflect.DeepEqual(newObj.Spec.Template.Spec, oldObj.Spec.Template.Spec) {
+  -     if !reflect.DeepEqual(m.Spec.Template.Spec, old.Spec.Template.Spec) {
+            allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "template", "spec"), m, dockerMachineTemplateImmutableMsg))
+        }
+        ...
+    }
+
+  + func (*DockerMachineTemplateWebhook) ValidateDelete(ctx context.Context, _ runtime.Object) error {
+  - func (m *DockerMachineTemplate) ValidateDelete() error {
+        ...
+    }
+  ```
+
+NOTES:
+- We are introducing a `DockerMachineTemplateWebhook` struct because we are going to use a controller runtime
+  `CustomValidator`. This will allow to skip the immutability check only when the topology controller is dry running
+  while preserving the validation behaviour for all other cases.
+- By using `CustomValidators` it is possible to move webhooks to other packages, thus removing some controller
+  runtime dependency from the API types. However, choosing to do so or not is up to the provider implementers
+  and independent of this change.
 
 ### Other
 

--- a/internal/controllers/topology/cluster/cluster_controller.go
+++ b/internal/controllers/topology/cluster/cluster_controller.go
@@ -362,14 +362,14 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cluster *clusterv1.Clu
 
 // serverSideApplyPatchHelperFactory makes use of managed fields provided by server side apply and is used by the controller.
 func serverSideApplyPatchHelperFactory(c client.Client) structuredmerge.PatchHelperFactoryFunc {
-	return func(original, modified client.Object, opts ...structuredmerge.HelperOption) (structuredmerge.PatchHelper, error) {
-		return structuredmerge.NewServerSidePatchHelper(original, modified, c, opts...)
+	return func(ctx context.Context, original, modified client.Object, opts ...structuredmerge.HelperOption) (structuredmerge.PatchHelper, error) {
+		return structuredmerge.NewServerSidePatchHelper(ctx, original, modified, c, opts...)
 	}
 }
 
 // dryRunPatchHelperFactory makes use of a two-ways patch and is used in situations where we cannot rely on managed fields.
 func dryRunPatchHelperFactory(c client.Client) structuredmerge.PatchHelperFactoryFunc {
-	return func(original, modified client.Object, opts ...structuredmerge.HelperOption) (structuredmerge.PatchHelper, error) {
+	return func(ctx context.Context, original, modified client.Object, opts ...structuredmerge.HelperOption) (structuredmerge.PatchHelper, error) {
 		return structuredmerge.NewTwoWaysPatchHelper(original, modified, c, opts...)
 	}
 }

--- a/internal/controllers/topology/cluster/structuredmerge/dryrun_test.go
+++ b/internal/controllers/topology/cluster/structuredmerge/dryrun_test.go
@@ -18,871 +18,149 @@ package structuredmerge
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"sigs.k8s.io/cluster-api/internal/contract"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-func Test_dryRunPatch(t *testing.T) {
+func Test_cleanupTopologyDryRunAnnotation(t *testing.T) {
+	rawManagedFieldWithAnnotation := `{"f:metadata":{"f:annotations":{"f:topology.cluster.x-k8s.io/dry-run":{}}}}`
+	rawManagedFieldWithAnnotationSpecLabels := `{"f:metadata":{"f:annotations":{"f:topology.cluster.x-k8s.io/dry-run":{}},"f:labels":{}},"f:spec":{"f:foo":{}}}`
+	rawManagedFieldWithSpecLabels := `{"f:metadata":{"f:labels":{}},"f:spec":{"f:foo":{}}}`
+
 	tests := []struct {
-		name               string
-		ctx                *dryRunInput
-		wantHasChanges     bool
-		wantHasSpecChanges bool
+		name    string
+		obj     *unstructured.Unstructured
+		wantErr bool
+		want    *unstructured.Unstructured
 	}{
 		{
-			name: "DryRun detects no changes on managed fields",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:metadata": map[string]interface{}{
-						"f:labels": map[string]interface{}{
-							"f:foo": map[string]interface{}{},
-						},
-					},
-					"f:spec": map[string]interface{}{
-						"f:foo": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-					"spec": map[string]interface{}{
-						"foo": "bar",
-					},
-				},
-				modified: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-					"spec": map[string]interface{}{
-						"foo": "bar",
-					},
-				},
-			},
-			wantHasChanges:     false,
-			wantHasSpecChanges: false,
+			name:    "no-op",
+			obj:     newObjectBuilder().Build(),
+			wantErr: false,
 		},
 		{
-			name: "apiVersion, kind, metadata.name and metadata.namespace fields in modified are not detected as changes",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					// apiVersion, kind, metadata.name and metadata.namespace are not tracked in managedField.
-					// NOTE: We are simulating a real object with something in spec and labels, so both
-					// the top level object and metadata are considered as granular maps.
-					"f:metadata": map[string]interface{}{
-						"f:labels": map[string]interface{}{
-							"f:foo": map[string]interface{}{},
-						},
-					},
-					"f:spec": map[string]interface{}{
-						"f:foo": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
-					"kind":       "Foo",
-					"metadata": map[string]interface{}{
-						"name":      "foo",
-						"namespace": "bar",
-						"labels": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-					"spec": map[string]interface{}{
-						"foo": "bar",
-					},
-				},
-				modified: map[string]interface{}{
-					"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
-					"kind":       "Foo",
-					"metadata": map[string]interface{}{
-						"name":      "foo",
-						"namespace": "bar",
-						"labels": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-					"spec": map[string]interface{}{
-						"foo": "bar",
-					},
-				},
-			},
-			wantHasChanges:     false,
-			wantHasSpecChanges: false,
+			name: "filter out annotation",
+			obj: newObjectBuilder().
+				WithAnnotation(clusterv1.TopologyDryRunAnnotation, "").
+				Build(),
+			wantErr: false,
+			want: newObjectBuilder().
+				Build(),
 		},
 		{
-			name: "apiVersion, kind, metadata.name and metadata.namespace fields in modified are not detected as changes (edge case)",
-			ctx: &dryRunInput{
-				path:     contract.Path{},
-				fieldsV1: map[string]interface{}{
-					// apiVersion, kind, metadata.name and metadata.namespace are not tracked in managedField.
-					// NOTE: we are simulating an edge case where we are not tracking managed fields
-					// in metadata or in spec; this could lead to edge case because server side applies required
-					// apiVersion, kind, metadata.name and metadata.namespace but those are not tracked in managedFields.
-					// If this case is not properly handled, dryRun could report false positives assuming those field
-					// have been added to modified.
-				},
-				original: map[string]interface{}{
-					"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
-					"kind":       "Foo",
-					"metadata": map[string]interface{}{
-						"name":      "foo",
-						"namespace": "bar",
-					},
-				},
-				modified: map[string]interface{}{
-					"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
-					"kind":       "Foo",
-					"metadata": map[string]interface{}{
-						"name":      "foo",
-						"namespace": "bar",
-					},
-				},
-			},
-			wantHasChanges:     false,
-			wantHasSpecChanges: false,
+			name: "managedFields: manager does not match",
+			obj: newObjectBuilder().
+				WithManagedFieldsEntry("other", "", metav1.ManagedFieldsOperationApply, []byte(`{}`), nil).
+				Build(),
+			wantErr: false,
+			want: newObjectBuilder().
+				WithManagedFieldsEntry("other", "", metav1.ManagedFieldsOperationApply, []byte(`{}`), nil).
+				Build(),
 		},
 		{
-			name: "DryRun detects metadata only change on managed fields",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:metadata": map[string]interface{}{
-						"f:labels": map[string]interface{}{
-							"f:foo": map[string]interface{}{},
-						},
-					},
-					"f:spec": map[string]interface{}{
-						"f:foo": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-					"spec": map[string]interface{}{
-						"foo": "bar",
-					},
-				},
-				modified: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{
-							"foo": "bar-changed",
-						},
-					},
-					"spec": map[string]interface{}{
-						"foo": "bar",
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: false,
+			name: "managedFields: subresource does not match",
+			obj: newObjectBuilder().
+				WithManagedFieldsEntry(TopologyManagerName, "status", metav1.ManagedFieldsOperationApply, []byte(`{}`), nil).
+				Build(),
+			wantErr: false,
+			want: newObjectBuilder().
+				WithManagedFieldsEntry(TopologyManagerName, "status", metav1.ManagedFieldsOperationApply, []byte(`{}`), nil).
+				Build(),
 		},
 		{
-			name: "DryRun spec only change on managed fields",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:metadata": map[string]interface{}{
-						"f:labels": map[string]interface{}{
-							"f:foo": map[string]interface{}{},
-						},
-					},
-					"f:spec": map[string]interface{}{
-						"f:foo": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-					"spec": map[string]interface{}{
-						"foo": "bar",
-					},
-				},
-				modified: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"labels": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-					"spec": map[string]interface{}{
-						"foo": "bar-changed",
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
+			name: "managedFields: operation does not match",
+			obj: newObjectBuilder().
+				WithManagedFieldsEntry(TopologyManagerName, "", metav1.ManagedFieldsOperationUpdate, []byte(`{}`), nil).
+				Build(),
+			wantErr: false,
+			want: newObjectBuilder().
+				WithManagedFieldsEntry(TopologyManagerName, "", metav1.ManagedFieldsOperationUpdate, []byte(`{}`), nil).
+				Build(),
 		},
 		{
-			name: "identifies changes when modified has a value not previously managed",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:foo": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"foo": "bar",
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"foo": "bar",
-						"bar": "baz", // new value not previously managed
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
+			name: "managedFields: cleanup up the managed field entry",
+			obj: newObjectBuilder().
+				WithManagedFieldsEntry(TopologyManagerName, "", metav1.ManagedFieldsOperationApply, []byte(rawManagedFieldWithAnnotation), nil).
+				Build(),
+			wantErr: false,
+			want: newObjectBuilder().
+				WithManagedFieldsEntry(TopologyManagerName, "", metav1.ManagedFieldsOperationApply, []byte(`{}`), nil).
+				Build(),
 		},
 		{
-			name: "identifies changes when modified drops a value previously managed",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:foo": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"foo": "bar",
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						// foo (previously managed) has been dropped
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
+			name: "managedFields: cleanup the managed field entry but preserve other ownership",
+			obj: newObjectBuilder().
+				WithManagedFieldsEntry(TopologyManagerName, "", metav1.ManagedFieldsOperationApply, []byte(rawManagedFieldWithAnnotationSpecLabels), nil).
+				Build(),
+			wantErr: false,
+			want: newObjectBuilder().
+				WithManagedFieldsEntry(TopologyManagerName, "", metav1.ManagedFieldsOperationApply, []byte(rawManagedFieldWithSpecLabels), nil).
+				Build(),
 		},
 		{
-			name: "No changes in an atomic map",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:atomicMap": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"atomicMap": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"atomicMap": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-				},
-			},
-			wantHasChanges:     false,
-			wantHasSpecChanges: false,
-		},
-		{
-			name: "identifies changes in an atomic map",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:atomicMap": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"atomicMap": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"atomicMap": map[string]interface{}{
-							"foo": "bar-changed",
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "No changes on managed atomic list",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:atomicList": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"atomicList": []interface{}{
-							map[string]interface{}{
-								"foo": "bar",
-							},
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"atomicList": []interface{}{
-							map[string]interface{}{
-								"foo": "bar",
-							},
-						},
-					},
-				},
-			},
-			wantHasChanges:     false,
-			wantHasSpecChanges: false,
-		},
-		{
-			name: "Identifies changes on managed atomic list",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:atomicList": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"atomicList": []interface{}{
-							map[string]interface{}{
-								"foo": "bar",
-							},
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"atomicList": []interface{}{
-							map[string]interface{}{
-								"foo": "bar-changed",
-							},
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "No changes on managed listMap",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listMap": map[string]interface{}{
-							"k:{\"foo\":\"id1\"}": map[string]interface{}{
-								"f:foo": map[string]interface{}{},
-								"f:bar": map[string]interface{}{},
-							},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{
-								"foo": "id1",
-								"bar": "baz",
-							},
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{
-								"foo": "id1",
-								"bar": "baz",
-							},
-						},
-					},
-				},
-			},
-			wantHasChanges:     false,
-			wantHasSpecChanges: false,
-		},
-		{
-			name: "Identified value added on a empty managed listMap",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listMap": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{},
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{
-								"foo": "id1",
-							},
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "Identified value added on a managed listMap",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listMap": map[string]interface{}{
-							"k:{\"foo\":\"id1\"}": map[string]interface{}{
-								"f:foo": map[string]interface{}{},
-							},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{
-								"foo": "id1",
-							},
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{
-								"foo": "id1",
-							},
-							map[string]interface{}{
-								"foo": "id2",
-							},
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "Identified value removed on a managed listMap",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listMap": map[string]interface{}{
-							"k:{\"foo\":\"id1\"}": map[string]interface{}{
-								"f:foo": map[string]interface{}{},
-							},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{
-								"foo": "id1",
-							},
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "Identified changes on a managed listMap",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listMap": map[string]interface{}{
-							"k:{\"foo\":\"id1\"}": map[string]interface{}{
-								"f:foo": map[string]interface{}{},
-								"f:bar": map[string]interface{}{},
-							},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{
-								"foo": "id1",
-								"bar": "baz",
-							},
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{
-								"foo": "id1",
-								"baz": "baz-changed",
-							},
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "Identified changes on a managed listMap (same number of items, different keys)",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listMap": map[string]interface{}{
-							"k:{\"foo\":\"id1\"}": map[string]interface{}{
-								"f:foo": map[string]interface{}{},
-								"f:bar": map[string]interface{}{},
-							},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{
-								"foo": "id1",
-								"bar": "baz",
-							},
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listMap": []interface{}{
-							map[string]interface{}{
-								"foo": "id2",
-								"bar": "baz",
-							},
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "no changes on a managed listSet",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listSet": map[string]interface{}{
-							"v:foo": map[string]interface{}{},
-							"v:bar": map[string]interface{}{},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listSet": []interface{}{
-							"foo",
-							"bar",
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listSet": []interface{}{
-							"foo",
-							"bar",
-						},
-					},
-				},
-			},
-			wantHasChanges:     false,
-			wantHasSpecChanges: false,
-		},
-		{
-			name: "Identified value added on a empty managed listSet",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listSet": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listSet": []interface{}{},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listSet": []interface{}{
-							"foo",
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "Identified value added on a managed listSet",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listSet": map[string]interface{}{
-							"v:foo": map[string]interface{}{},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listSet": []interface{}{
-							"foo",
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listSet": []interface{}{
-							"foo",
-							"bar",
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "Identified value removed on a managed listSet",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listSet": map[string]interface{}{
-							"v:foo": map[string]interface{}{},
-							"v:bar": map[string]interface{}{},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listSet": []interface{}{
-							"foo",
-							"bar",
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listSet": []interface{}{
-							"foo",
-							// bar removed
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "Identified changes on a managed listSet",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:listSet": map[string]interface{}{
-							"v:foo": map[string]interface{}{},
-							"v:bar": map[string]interface{}{},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listSet": []interface{}{
-							"foo",
-							"bar",
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"spec": map[string]interface{}{
-						"listSet": []interface{}{
-							"foo",
-							"bar-changed",
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "Identified nested field got added",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					// apiVersion, kind, metadata.name and metadata.namespace are not tracked in managedField.
-					// NOTE: We are simulating a real object with something in spec and labels, so both
-					// the top level object and metadata are considered as granular maps.
-					"f:metadata": map[string]interface{}{
-						"f:labels": map[string]interface{}{
-							"f:foo": map[string]interface{}{},
-						},
-					},
-					"f:spec": map[string]interface{}{
-						"f:another": map[string]interface{}{},
-					},
-				},
-				original: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"name":      "foo",
-						"namespace": "bar",
-						"labels": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-					"spec": map[string]interface{}{
-						"another": "value",
-					},
-				},
-				modified: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"name":      "foo",
-						"namespace": "bar",
-						"labels": map[string]interface{}{
-							"foo": "bar",
-						},
-					},
-					"spec": map[string]interface{}{
-						"another": "value",
-						"foo": map[string]interface{}{
-							"bar": true,
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "Nested type gets changed",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"f:foo": map[string]interface{}{
-							"v:bar": map[string]interface{}{},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"name":      "foo",
-						"namespace": "bar",
-					},
-					"spec": map[string]interface{}{
-						"foo": []interface{}{
-							"bar",
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"name":      "foo",
-						"namespace": "bar",
-					},
-					"spec": map[string]interface{}{
-						"foo": map[string]interface{}{
-							"bar": true,
-						},
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
-		},
-		{
-			name: "Nested field is getting removed",
-			ctx: &dryRunInput{
-				path: contract.Path{},
-				fieldsV1: map[string]interface{}{
-					"f:spec": map[string]interface{}{
-						"v:keep": map[string]interface{}{},
-						"f:foo": map[string]interface{}{
-							"v:bar": map[string]interface{}{},
-						},
-					},
-				},
-				original: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"name":      "foo",
-						"namespace": "bar",
-					},
-					"spec": map[string]interface{}{
-						"keep": "me",
-						"foo": []interface{}{
-							"bar",
-						},
-					},
-				},
-				modified: map[string]interface{}{
-					"metadata": map[string]interface{}{
-						"name":      "foo",
-						"namespace": "bar",
-					},
-					"spec": map[string]interface{}{
-						"keep": "me",
-					},
-				},
-			},
-			wantHasChanges:     true,
-			wantHasSpecChanges: true,
+			name: "managedFields: remove time",
+			obj: newObjectBuilder().
+				WithManagedFieldsEntry(TopologyManagerName, "", metav1.ManagedFieldsOperationApply, []byte(`{}`), &metav1.Time{Time: time.Time{}}).
+				Build(),
+			wantErr: false,
+			want: newObjectBuilder().
+				WithManagedFieldsEntry(TopologyManagerName, "", metav1.ManagedFieldsOperationApply, []byte(`{}`), nil).
+				Build(),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			gotHasChanges, gotHasSpecChanges := dryRunPatch(tt.ctx)
-
-			g.Expect(gotHasChanges).To(Equal(tt.wantHasChanges))
-			g.Expect(gotHasSpecChanges).To(Equal(tt.wantHasSpecChanges))
+			if err := cleanupTopologyDryRunAnnotation(tt.obj); (err != nil) != tt.wantErr {
+				t.Errorf("cleanupTopologyDryRunAnnotation() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.want != nil {
+				g.Expect(tt.obj).To(BeEquivalentTo(tt.want))
+			}
 		})
 	}
+}
+
+type objectBuilder struct {
+	u *unstructured.Unstructured
+}
+
+func newObjectBuilder() objectBuilder {
+	return objectBuilder{&unstructured.Unstructured{Object: map[string]interface{}{}}}
+}
+
+func (b objectBuilder) DeepCopy() objectBuilder {
+	return objectBuilder{b.u.DeepCopy()}
+}
+
+func (b objectBuilder) Build() *unstructured.Unstructured {
+	return b.u.DeepCopy()
+}
+
+func (b objectBuilder) WithAnnotation(k, v string) objectBuilder {
+	annotations := b.u.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[k] = v
+	b.u.SetAnnotations(annotations)
+	return b
+}
+
+func (b objectBuilder) WithManagedFieldsEntry(manager, subresource string, operation metav1.ManagedFieldsOperationType, fieldsV1 []byte, time *metav1.Time) objectBuilder {
+	managedFields := append(b.u.GetManagedFields(), metav1.ManagedFieldsEntry{
+		Manager:     manager,
+		Operation:   operation,
+		Subresource: subresource,
+		FieldsV1:    &metav1.FieldsV1{Raw: fieldsV1},
+		Time:        time,
+	})
+	b.u.SetManagedFields(managedFields)
+	return b
 }

--- a/internal/controllers/topology/cluster/structuredmerge/interfaces.go
+++ b/internal/controllers/topology/cluster/structuredmerge/interfaces.go
@@ -23,7 +23,7 @@ import (
 )
 
 // PatchHelperFactoryFunc defines a func that returns a new PatchHelper.
-type PatchHelperFactoryFunc func(original, modified client.Object, opts ...HelperOption) (PatchHelper, error)
+type PatchHelperFactoryFunc func(ctx context.Context, original, modified client.Object, opts ...HelperOption) (PatchHelper, error)
 
 // PatchHelper define the behavior for component responsible for managing  patches for Kubernetes objects
 // owned by the topology controller.

--- a/test/infrastructure/docker/api/v1beta1/dockermachinetemplate_webhook_test.go
+++ b/test/infrastructure/docker/api/v1beta1/dockermachinetemplate_webhook_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"testing"
 
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 func TestDockerMachineTemplateInvalid(t *testing.T) {
@@ -32,29 +38,60 @@ func TestDockerMachineTemplateInvalid(t *testing.T) {
 
 	newTemplate := oldTemplate.DeepCopy()
 	newTemplate.Spec.Template.Spec.ExtraMounts = append(newTemplate.Spec.Template.Spec.ExtraMounts, []Mount{{ContainerPath: "/var/run/docker.sock", HostPath: "/var/run/docker.sock"}}...)
+	newTemplateSkipImmutabilityAnnotationSet := newTemplate.DeepCopy()
+	newTemplateSkipImmutabilityAnnotationSet.SetAnnotations(map[string]string{clusterv1.TopologyDryRunAnnotation: ""})
 
 	tests := []struct {
 		name        string
 		newTemplate *DockerMachineTemplate
 		oldTemplate *DockerMachineTemplate
+		req         *admission.Request
 		wantError   bool
 	}{
 		{
 			name:        "return no error if no modification",
 			newTemplate: newTemplate,
 			oldTemplate: newTemplate,
+			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(false)}},
 			wantError:   false,
 		},
 		{
 			name:        "don't allow modification",
 			newTemplate: newTemplate,
 			oldTemplate: &oldTemplate,
+			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(false)}},
 			wantError:   true,
+		},
+		{
+			name:        "don't allow modification, skip immutability annotation set",
+			newTemplate: newTemplateSkipImmutabilityAnnotationSet,
+			oldTemplate: &oldTemplate,
+			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(false)}},
+			wantError:   true,
+		},
+		{
+			name:        "don't allow modification, dry run, no skip immutability annotation set",
+			newTemplate: newTemplate,
+			oldTemplate: &oldTemplate,
+			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(true)}},
+			wantError:   true,
+		},
+		{
+			name:        "skip immutability check",
+			newTemplate: newTemplateSkipImmutabilityAnnotationSet,
+			oldTemplate: &oldTemplate,
+			req:         &admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(true)}},
+			wantError:   false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.newTemplate.ValidateUpdate(tt.oldTemplate)
+			wh := &DockerMachineTemplateWebhook{}
+			ctx := context.Background()
+			if tt.req != nil {
+				ctx = admission.NewContextWithRequest(ctx, *tt.req)
+			}
+			err := wh.ValidateUpdate(ctx, tt.oldTemplate, tt.newTemplate)
 			if (err != nil) != tt.wantError {
 				t.Errorf("unexpected result - wanted %+v, got %+v", tt.wantError, err)
 			}

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -240,7 +240,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := (&infrav1.DockerMachineTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&infrav1.DockerMachineTemplateWebhook{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "DockerMachineTemplate")
 		os.Exit(1)
 	}

--- a/util/defaulting/defaulting.go
+++ b/util/defaulting/defaulting.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package defaulting implements defaulting webhook functionality.
 package defaulting
 
 import (

--- a/util/defaulting/doc.go
+++ b/util/defaulting/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package defaulting implements defaulting webhook functionality.
+package defaulting

--- a/util/topology/topology.go
+++ b/util/topology/topology.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package topology implements topology utility functions.
+package topology
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// ShouldSkipImmutabilityChecks returns true if it is a dry-run request and the object has the
+// TopologyDryRunAnnotation annotation set, false otherwise.
+// This ensures that the immutability check is skipped only when dry-running and when the operations has been invoked by the topology controller.
+// Instead, kubectl dry-run behavior remains consistent with the one user gets when doing kubectl apply (immutability is enforced).
+func ShouldSkipImmutabilityChecks(req admission.Request, obj metav1.Object) bool {
+	// Check if the request is a dry-run
+	if req.DryRun == nil || !*req.DryRun {
+		return false
+	}
+
+	if obj == nil {
+		return false
+	}
+
+	// Check for the TopologyDryRunAnnotation
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	if _, ok := annotations[clusterv1.TopologyDryRunAnnotation]; ok {
+		return true
+	}
+	return false
+}

--- a/util/topology/topology_test.go
+++ b/util/topology/topology_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package topology implements topology utility functions.
+package topology
+
+import (
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestShouldSkipImmutabilityChecks(t *testing.T) {
+	tests := []struct {
+		name string
+		req  admission.Request
+		obj  metav1.Object
+		want bool
+	}{
+		{
+			name: "false - dryRun pointer is nil",
+			req:  admission.Request{},
+			obj:  nil,
+			want: false,
+		},
+		{
+			name: "false - dryRun pointer is false",
+			req:  admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(false)}},
+			obj:  nil,
+			want: false,
+		},
+		{
+			name: "false - nil obj",
+			req:  admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(true)}},
+			obj:  nil,
+			want: false,
+		},
+		{
+			name: "false - no annotations",
+			req:  admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(true)}},
+			obj:  &unstructured.Unstructured{},
+			want: false,
+		},
+		{
+			name: "false - annotation not set",
+			req:  admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(true)}},
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{},
+				},
+			}},
+			want: false,
+		},
+		{
+			name: "true",
+			req:  admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{DryRun: pointer.Bool(true)}},
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						clusterv1.TopologyDryRunAnnotation: "",
+					},
+				},
+			}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldSkipImmutabilityChecks(tt.req, tt.obj); got != tt.want {
+				t.Errorf("ShouldSkipImmutabilityChecks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This proposes an improvement on how we implement dry run for detecting changes by actually using dry run server side apply.

The proposed implementation has the following advantages

* It uses the same logic as using the real server side apply patch operation
* The diff logic relies on comparing the current object to the object how it would look like after server side apply
* The diff logic does not rely on how managed fields are used by the kube-apiserver and requires no knowledge about the handled object or used schema.

Disadvantages:

* Using dry run server side apply requires more requests to the kube-apiserver because it requires an additional request for each comparison.

TODOs:
- [x] Add provider implementation documentation:
  - for template resources which get rotated (known types are: `InfrastructureMachineTemplate` or `BootstrapTemplate`): If there are existing validating webhooks which block due to immutability when a resource gets updated (`ValidateUpdate`) they need to implement the `sigs.k8s.io/cluster-aip/util/webhooks.TopologyAwareValidator` instead which provides a bool to decide skipping immutability checks