### PR TITLE
📖 add OCI to infra provider list

### DIFF
--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -29,6 +29,7 @@ updated info about which API version they are supporting.
 - [vcluster](https://github.com/loft-sh/cluster-api-provider-vcluster)
 - [Nested](https://github.com/kubernetes-sigs/cluster-api-provider-nested)
 - [Nutanix](https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix)
+- [OCI](https://github.com/oracle/cluster-api-provider-oci)
 - [OpenStack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack)
 - [Equinix Metal (formerly Packet)](https://github.com/kubernetes-sigs/cluster-api-provider-packet)
 - [Sidero](https://github.com/siderolabs/sidero)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the OCI infra provider to the providers list to the 1.1 release. This change is already landed on main, but couldn't be merged into `release-1.1` branch due to conflict https://github.com/kubernetes-sigs/cluster-api/pull/6288

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No open issues related to this PR.

