### PR TITLE
🌱 Update CoreDNS migration library to v1.0.17

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -63,17 +63,17 @@ These diagrams show the relationships between components in a Cluster API releas
 
 #### Core Provider (`cluster-api-controller`)
 
-|                  |  CAPI v0.3 (v1alpha3) |  CAPI v0.4 (v1alpha4)  |  CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
-| ---------------- | --------------------- | ---------------------- | -------------------- | ------------------------ |
-| Kubernetes v1.16 | ✓                     |                        |                      |                          |
-| Kubernetes v1.17 | ✓                     |                        |                      |                          |
-| Kubernetes v1.18 | ✓                     | ✓ (only workload)      | ✓ (only workload)    | ✓ (only workload)        |
-| Kubernetes v1.19 | ✓                     | ✓                      | ✓                    | ✓                        |
-| Kubernetes v1.20 | ✓                     | ✓                      | ✓                    | ✓                        |
-| Kubernetes v1.21 | ✓                     | ✓                      | ✓                    | ✓                        |
-| Kubernetes v1.22 | ✓ (only workload)     | ✓                      | ✓                    | ✓                        |
-| Kubernetes v1.23* |                      | ✓                      | ✓                    | ✓                        |
-| Kubernetes v1.24 |                       |                        |                      | ✓                        |
+|                   | CAPI v0.3 (v1alpha3) | CAPI v0.4 (v1alpha4) | CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
+|-------------------|----------------------|----------------------|---------------------|--------------------------|
+| Kubernetes v1.16  | ✓                    |                      |                     |                          |
+| Kubernetes v1.17  | ✓                    |                      |                     |                          |
+| Kubernetes v1.18  | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
+| Kubernetes v1.19  | ✓                    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.20  | ✓                    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.21  | ✓                    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.22  | ✓ (only workload)    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.23* |                      | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.24  |                      |                      |                     | ✓                        |
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
    Previous Kubernetes **minor** versions are not affected.
@@ -82,24 +82,24 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 
 #### Kubeadm Bootstrap Provider (`kubeadm-bootstrap-controller`)
 
-|                                    |  CAPI v0.3 (v1alpha3)            | CAPI v0.4 (v1alpha4) | CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
-| ---------------------------------- | -------------------------------- | -------------------- | ------------------- | ------------------------ |
-| Kubernetes v1.16 + kubeadm/v1beta2 | ✓                                |                      |                     |                          |
-| Kubernetes v1.17 + kubeadm/v1beta2 | ✓                                |                      |                     |                          |
-| Kubernetes v1.18 + kubeadm/v1beta2 | ✓                                | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
-| Kubernetes v1.19 + kubeadm/v1beta2 | ✓                                | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.20 + kubeadm/v1beta2 | ✓                                | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.21 + kubeadm/v1beta2 | ✓                                | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) | ✓ (only workload) |  ✓   | ✓                   | ✓                        |
-| Kubernetes v1.23 + kubeadm/v1beta3 |                                  | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.24 + kubeadm/v1beta3 |                                  |                      |                     | ✓                        |
+|                                                                   | CAPI v0.3 (v1alpha3) | CAPI v0.4 (v1alpha4) | CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
+|-------------------------------------------------------------------|----------------------|----------------------|---------------------|--------------------------|
+| Kubernetes v1.16 + kubeadm/v1beta2                                | ✓                    |                      |                     |                          |
+| Kubernetes v1.17 + kubeadm/v1beta2                                | ✓                    |                      |                     |                          |
+| Kubernetes v1.18 + kubeadm/v1beta2                                | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
+| Kubernetes v1.19 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.20 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.21 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) | ✓ (only workload)    | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.23 + kubeadm/v1beta3                                |                      | ✓                    | ✓                   | ✓                        |
+| Kubernetes v1.24 + kubeadm/v1beta3                                |                      |                      |                     | ✓                        |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
 |                            | CAPI v0.3 (v1alpha3) | CAPI v0.4 (v1alpha4) | CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
-| -------------------------- | -------------------- |----------------------| ------------------- | ------------------------ |
+|----------------------------|----------------------|----------------------|---------------------|--------------------------|
 | Kubernetes v1.16 + etcd/v3 | ✓                    |                      |                     |                          |
 | Kubernetes v1.17 + etcd/v3 | ✓                    |                      |                     |                          |
 | Kubernetes v1.18 + etcd/v3 | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
@@ -121,7 +121,7 @@ The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 | v0.3 (v1alpha3) | v1.8.4                          |
 | v0.4 (v1alpha4) | v1.8.4                          |
 | v1.0 (v1beta1)  | v1.8.5                          | 
-| v1.1 (v1beta1)  | v1.8.6                          |
+| v1.1 (v1beta1)  | v1.9.3                          |
 
 #### Kubernetes version specific notes
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/coredns/corefile-migration v1.0.14
+	github.com/coredns/corefile-migration v1.0.17
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/coredns/caddy v1.1.0 h1:ezvsPrT/tA/7pYDBZxu0cT0VmWk75AfIaf6GSYCNMf0=
 github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
-github.com/coredns/corefile-migration v1.0.14 h1:Tz3WZhoj2NdP8drrQH86NgnCng+VrPjNeg2Oe1ALKag=
-github.com/coredns/corefile-migration v1.0.14/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
+github.com/coredns/corefile-migration v1.0.17 h1:tNwh8+4WOANV6NjSljwgW7qViJfhvPUt1kosj4rR8yg=
+github.com/coredns/corefile-migration v1.0.17/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -321,8 +321,8 @@ github.com/containers/ocicrypt v1.1.0/go.mod h1:b8AOe0YR67uU8OqfVNcznfFpAzu3rdgU
 github.com/containers/ocicrypt v1.1.1/go.mod h1:Dm55fwWm1YZAjYRaJ94z2mfZikIyIN4B0oB3dj3jFxY=
 github.com/coredns/caddy v1.1.0 h1:ezvsPrT/tA/7pYDBZxu0cT0VmWk75AfIaf6GSYCNMf0=
 github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
-github.com/coredns/corefile-migration v1.0.14 h1:Tz3WZhoj2NdP8drrQH86NgnCng+VrPjNeg2Oe1ALKag=
-github.com/coredns/corefile-migration v1.0.14/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
+github.com/coredns/corefile-migration v1.0.17 h1:tNwh8+4WOANV6NjSljwgW7qViJfhvPUt1kosj4rR8yg=
+github.com/coredns/corefile-migration v1.0.17/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/test/go.mod
+++ b/test/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/coredns/caddy v1.1.0 // indirect
-	github.com/coredns/corefile-migration v1.0.14 // indirect
+	github.com/coredns/corefile-migration v1.0.17 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -136,8 +136,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/coredns/caddy v1.1.0 h1:ezvsPrT/tA/7pYDBZxu0cT0VmWk75AfIaf6GSYCNMf0=
 github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
-github.com/coredns/corefile-migration v1.0.14 h1:Tz3WZhoj2NdP8drrQH86NgnCng+VrPjNeg2Oe1ALKag=
-github.com/coredns/corefile-migration v1.0.14/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
+github.com/coredns/corefile-migration v1.0.17 h1:tNwh8+4WOANV6NjSljwgW7qViJfhvPUt1kosj4rR8yg=
+github.com/coredns/corefile-migration v1.0.17/go.mod h1:XnhgULOEouimnzgn0t4WPuFDN2/PJQcTxdWKC5eXNGE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Cherry pick of https://github.com/kubernetes-sigs/cluster-api/pull/6600 

With custom changes to docs
