### PR TITLE
📖 Remove Alibaba and Baidu Cloud from providers list

### DIFF
--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -11,11 +11,9 @@ updated info about which API version they are supporting.
 - [EKS](https://github.com/kubernetes-sigs/cluster-api-provider-aws/tree/main/bootstrap/eks)
 
 ## Infrastructure
-- [Alibaba Cloud](https://github.com/oam-oss/cluster-api-provider-alicloud)
 - [AWS](https://cluster-api-aws.sigs.k8s.io/)
 - [Azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure)
 - [Azure Stack HCI](https://github.com/microsoft/cluster-api-provider-azurestackhci)
-- [Baidu Cloud](https://github.com/baidu/cluster-api-provider-baiducloud)
 - [BYOH](https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost)
 - [CloudStack](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack)
 - [Metal3](https://github.com/metal3-io/cluster-api-provider-metal3)


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes two seemingly abandoned providers as discussed in issue #6714