### PR TITLE
📖 Add requirement to squash pr commits to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,7 @@ Cluster API maintains the most recent release branch for all supported API and c
         - 🐛 (`:bug:`, patch and bugfixes)
         - 📖 (`:book:`, documentation or proposals)
         - 🌱 (`:seedling:`, minor or other)
+1. If your PR has multiple commits, you must [squash them into a single commit](https://kubernetes.io/docs/contribute/new-content/open-a-pr/#squashing-commits) before merging your PR.
 
 Individual commits should not be tagged separately, but will generally be
 assumed to match the PR. For instance, if you have a bugfix in with


### PR DESCRIPTION
**What this PR does / why we need it**

Adding the requirement and instructions how to squash commits to CONTRIBUTING.md. I was personally unaware of this requirement until it was mentioned, so I assume that there might be other new contributors that are unaware of this requirement.

