### PR TITLE
🐛 Carry over metadata.uid at ServerSidePatchHelper

### DIFF
--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -1660,7 +1660,7 @@ func TestReconcileMachineDeployments(t *testing.T) {
 	md8Update := newFakeMachineDeploymentTopologyState("md-8-update", infrastructureMachineTemplate8Update, bootstrapTemplate8Update, nil)
 	infrastructureMachineTemplate8UpdateWithChanges := infrastructureMachineTemplate8Update.DeepCopy()
 	g.Expect(unstructured.SetNestedField(infrastructureMachineTemplate8UpdateWithChanges.Object, "foo", "spec", "template", "spec", "foo")).To(Succeed())
-	bootstrapTemplate8UpdateWithChanges := bootstrapTemplate3.DeepCopy()
+	bootstrapTemplate8UpdateWithChanges := bootstrapTemplate8Update.DeepCopy()
 	g.Expect(unstructured.SetNestedField(bootstrapTemplate8UpdateWithChanges.Object, "foo", "spec", "template", "spec", "foo")).To(Succeed())
 	md8UpdateWithRotatedTemplates := newFakeMachineDeploymentTopologyState("md-8-update", infrastructureMachineTemplate8UpdateWithChanges, bootstrapTemplate8UpdateWithChanges, nil)
 

--- a/internal/controllers/topology/cluster/structuredmerge/options.go
+++ b/internal/controllers/topology/cluster/structuredmerge/options.go
@@ -31,6 +31,8 @@ var (
 		{"kind"},
 		{"metadata", "name"},
 		{"metadata", "namespace"},
+		// uid is optional for a server side apply intent but sets the expectation of an object getting created or a specific one updated.
+		{"metadata", "uid"},
 		// the topology controller controls/has an opinion for labels, annotation, ownerReferences and spec only.
 		{"metadata", "labels"},
 		{"metadata", "annotations"},
@@ -49,6 +51,8 @@ var (
 		{"kind"},
 		{"metadata", "name"},
 		{"metadata", "namespace"},
+		// uid is optional for a server side apply intent but sets the expectation of an object getting created or a specific one updated.
+		{"metadata", "uid"},
 		// the topology controller controls/has an opinion for the labels ClusterLabelName
 		// and ClusterTopologyOwnedLabel as well as infrastructureRef and controlPlaneRef in spec.
 		{"metadata", "labels", clusterv1.ClusterLabelName},

--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
@@ -81,6 +81,14 @@ func NewServerSidePatchHelper(original, modified client.Object, c client.Client,
 	}
 	filterObject(modifiedUnstructured, helperOptions)
 
+	// Carry over uid to match the intent to:
+	// * create (uid==""): Setting no uid ensures an object gets created, not updated.
+	// * update (uid!=""): Setting an uid ensures an object which has the same uid gets updated.
+	modifiedUnstructured.SetUID("")
+	if originalUnstructured != nil {
+		modifiedUnstructured.SetUID(originalUnstructured.GetUID())
+	}
+
 	// Determine if the intent defined in the modified object is going to trigger
 	// an actual change when running server side apply, and if this change might impact the object spec or not.
 	var hasChanges, hasSpecChanges bool


### PR DESCRIPTION
**What this PR does / why we need it**:

This prevents the race condition of running server side apply on an object which got:

* deleted in the meantime
* recreated in the meantime

and the topology controller won't apply using outdated information anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6741 
