### PR TITLE
WIP  ✨ [poc] add manifest export command to clusterctl

### DIFF
--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -91,6 +91,7 @@ type AlphaClient interface {
 	RolloutUndo(options RolloutOptions) error
 	// TopologyPlan dry runs the topology reconciler
 	TopologyPlan(options TopologyPlanOptions) (*TopologyPlanOutput, error)
+	Export(options ExportOptions) ([]byte, error)
 }
 
 // YamlPrinter exposes methods that prints the processed template and

--- a/cmd/clusterctl/client/client_test.go
+++ b/cmd/clusterctl/client/client_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -152,6 +153,10 @@ func (f fakeClient) TopologyPlan(options TopologyPlanOptions) (*cluster.Topology
 	return f.internalClient.TopologyPlan(options)
 }
 
+func (f fakeClient) Export(options ExportOptions) ([]byte, error) {
+	return f.internalClient.Export(options)
+}
+
 // newFakeClient returns a clusterctl client that allows to execute tests on a set of fake config, fake repositories and fake clusters.
 // you can use WithCluster and WithRepository to prepare for the test case.
 func newFakeClient(configClient config.Client) *fakeClient {
@@ -261,6 +266,10 @@ func (p *fakeCertManagerClient) PlanUpgrade() (cluster.CertManagerUpgradePlan, e
 
 func (p *fakeCertManagerClient) Images() ([]string, error) {
 	return p.images, p.imagesError
+}
+
+func (p *fakeCertManagerClient) GetManifestObjects() ([]unstructured.Unstructured, error) {
+	return nil, nil
 }
 
 func (p *fakeCertManagerClient) WithCertManagerPlan(plan CertManagerUpgradePlan) *fakeCertManagerClient {

--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -78,6 +78,8 @@ type CertManagerClient interface {
 
 	// Images return the list of images required for installing the cert-manager.
 	Images() ([]string, error)
+
+	GetManifestObjects() ([]unstructured.Unstructured, error)
 }
 
 // certManagerClient implements CertManagerClient .
@@ -164,17 +166,40 @@ func (cm *certManagerClient) EnsureInstalled() error {
 	return cm.install()
 }
 
-func (cm *certManagerClient) install() error {
+func (cm *certManagerClient) GetManifestObjects() ([]unstructured.Unstructured, error) {
 	log := logf.Log
 
 	config, err := cm.configClient.CertManager().Get()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	log.Info("Installing cert-manager", "Version", config.Version())
 
 	// Gets the cert-manager components from the repository.
 	objs, err := cm.getManifestObjs(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return objs, nil
+}
+
+func (cm *certManagerClient) install() error {
+	//log := logf.Log
+
+	// config, err := cm.configClient.CertManager().Get()
+	// if err != nil {
+	// 	return err
+	// }
+	// log.Info("Installing cert-manager", "Version", config.Version())
+
+	// // Gets the cert-manager components from the repository.
+	// objs, err := cm.getManifestObjs(config)
+	// if err != nil {
+	// 	return err
+	// }
+
+	objs, err := cm.GetManifestObjects()
 	if err != nil {
 		return err
 	}

--- a/cmd/clusterctl/client/cluster/installer_test.go
+++ b/cmd/clusterctl/client/cluster/installer_test.go
@@ -247,7 +247,7 @@ func Test_providerInstaller_Validate(t *testing.T) {
 				installQueue: tt.fields.installQueue,
 			}
 
-			err := i.Validate()
+			err := i.Validate(false)
 			if tt.wantErr {
 				g.Expect(err).To(HaveOccurred())
 			} else {

--- a/cmd/clusterctl/client/export.go
+++ b/cmd/clusterctl/client/export.go
@@ -1,0 +1,139 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
+	"sigs.k8s.io/cluster-api/util/yaml"
+)
+
+// ExportOptions carries the options supported by Export.
+type ExportOptions struct {
+	// CoreProvider version (e.g. cluster-api:v0.3.0) to add to the management cluster. If unspecified, the
+	// cluster-api core provider's latest release is used.
+	CoreProvider string
+
+	// BootstrapProviders and versions (e.g. kubeadm:v0.3.0) to add to the management cluster.
+	// If unspecified, the kubeadm bootstrap provider's latest release is used.
+	BootstrapProviders []string
+
+	// InfrastructureProviders and versions (e.g. aws:v0.5.0) to add to the management cluster.
+	InfrastructureProviders []string
+
+	// ControlPlaneProviders and versions (e.g. kubeadm:v0.3.0) to add to the management cluster.
+	// If unspecified, the kubeadm control plane provider latest release is used.
+	ControlPlaneProviders []string
+
+	// TargetNamespace defines the namespace where the providers should be deployed. If unspecified, each provider
+	// will be installed in a provider's default namespace.
+	TargetNamespace string
+
+	// SkipTemplateProcess allows for skipping the call to the template processor, including also variable replacement in the component YAML.
+	// NOTE this works only if the rawYaml is a valid yaml by itself, like e.g when using envsubst/the simple processor.
+	SkipTemplateProcess bool
+}
+
+func (c *clusterctlClient) Export(options ExportOptions) ([]byte, error) {
+	log := logf.Log
+
+	// gets access to the management cluster
+	clusterClient, err := c.clusterClientFactory(ClusterClientFactoryInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("Adding default providers")
+	if options.CoreProvider == "" {
+		options.CoreProvider = config.ClusterAPIProviderName
+	}
+	if len(options.BootstrapProviders) == 0 {
+		options.BootstrapProviders = append(options.BootstrapProviders, config.KubeadmBootstrapProviderName)
+	}
+	if len(options.ControlPlaneProviders) == 0 {
+		options.ControlPlaneProviders = append(options.ControlPlaneProviders, config.KubeadmControlPlaneProviderName)
+	}
+
+	initOptions := InitOptions{
+		skipTemplateProcess:     options.SkipTemplateProcess,
+		CoreProvider:            options.CoreProvider,
+		BootstrapProviders:      options.BootstrapProviders,
+		ControlPlaneProviders:   options.ControlPlaneProviders,
+		InfrastructureProviders: options.InfrastructureProviders,
+		TargetNamespace:         options.TargetNamespace,
+	}
+
+	// create an installer service, add the requested providers to the install queue and then perform validation
+	// of the target state of the management cluster before starting the installation.
+	installer, err := c.setupInstaller(clusterClient, initOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	// Before installing the providers, validates the management cluster resulting by the planned installation. The following checks are performed:
+	// - There should be only one instance of the same provider.
+	// - All the providers must support the same API Version of Cluster API (contract)
+	if err := installer.Validate(true); err != nil {
+		return nil, err
+	}
+
+	// Before installing the providers, ensure the cert-manager Webhook is in place.
+	certManager := clusterClient.CertManager()
+	certManagerComp, err := certManager.GetManifestObjects()
+	if err != nil {
+		return nil, err
+	}
+
+	data := bytes.Buffer{}
+
+	// Write the certmanager
+	data.WriteString("# Start: cert-manager\n")
+	cmData, err := yaml.FromUnstructured(certManagerComp)
+	if err != nil {
+		return nil, err
+	}
+	data.Write(cmData)
+	data.WriteString("\n# End: cert-manager\n")
+	data.WriteString("---\n")
+
+	components := installer.Components()
+	if err != nil {
+		return nil, err
+	}
+
+	// Write the core first
+	for _, comp := range components {
+		if comp.Type() == v1alpha3.CoreProviderType {
+			data.WriteString("# Start: core\n")
+
+			coreData, err := yaml.FromUnstructured(comp.Objs())
+			if err != nil {
+				return nil, err
+			}
+			data.Write(coreData)
+
+			data.WriteString("\n# End: core\n")
+			data.WriteString("---\n")
+		}
+	}
+
+	// Write the rest of the components
+	for _, comp := range components {
+		if comp.Type() != v1alpha3.CoreProviderType {
+			data.WriteString(fmt.Sprintf("# Start: provider %s (%s)\n", comp.Name(), comp.Type()))
+
+			coreData, err := yaml.FromUnstructured(comp.Objs())
+			if err != nil {
+				return nil, err
+			}
+			data.Write(coreData)
+
+			data.WriteString(fmt.Sprintf("\n# End: provider %s (%s)\n", comp.Name(), comp.Type()))
+			data.WriteString("---\n")
+		}
+	}
+
+	return data.Bytes(), nil
+}

--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -107,7 +107,7 @@ func (c *clusterctlClient) Init(options InitOptions) ([]Components, error) {
 	// Before installing the providers, validates the management cluster resulting by the planned installation. The following checks are performed:
 	// - There should be only one instance of the same provider.
 	// - All the providers must support the same API Version of Cluster API (contract)
-	if err := installer.Validate(); err != nil {
+	if err := installer.Validate(false); err != nil {
 		return nil, err
 	}
 

--- a/cmd/clusterctl/cmd/export.go
+++ b/cmd/clusterctl/cmd/export.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+type exportOptions struct {
+	coreProvider            string
+	bootstrapProviders      []string
+	controlPlaneProviders   []string
+	infrastructureProviders []string
+	targetNamespace         string
+	skiptemplateProcess     bool
+}
+
+var exportOpts = &exportOptions{}
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Exports the Cluster API manifests",
+	Long:  "Exports the Cluster API manifests",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runExport()
+	},
+}
+
+func init() {
+	exportCmd.Flags().StringVar(&exportOpts.coreProvider, "core", "",
+		"Core provider version (e.g. cluster-api:v0.3.0) to add to the management cluster. If unspecified, Cluster API's latest release is used.")
+	exportCmd.Flags().StringSliceVarP(&exportOpts.infrastructureProviders, "infrastructure", "i", nil,
+		"Infrastructure providers and versions (e.g. aws:v0.5.0) to add to the management cluster.")
+	exportCmd.Flags().StringSliceVarP(&exportOpts.bootstrapProviders, "bootstrap", "b", nil,
+		"Bootstrap providers and versions (e.g. kubeadm:v0.3.0) to add to the management cluster. If unspecified, Kubeadm bootstrap provider's latest release is used.")
+	exportCmd.Flags().StringSliceVarP(&exportOpts.controlPlaneProviders, "control-plane", "c", nil,
+		"Control plane providers and versions (e.g. kubeadm:v0.3.0) to add to the management cluster. If unspecified, the Kubeadm control plane provider's latest release is used.")
+	exportCmd.Flags().StringVarP(&exportOpts.targetNamespace, "target-namespace", "n", "",
+		"The target namespace where the providers should be deployed. If unspecified, the provider components' default namespace is used.")
+	exportCmd.Flags().BoolVar(&exportOpts.skiptemplateProcess, "skip-template-process", false,
+		"Should the templating process (including variable substitution) be skipped")
+
+	alphaCmd.AddCommand(exportCmd)
+}
+
+func runExport() error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	options := client.ExportOptions{
+		CoreProvider:            exportOpts.coreProvider,
+		BootstrapProviders:      exportOpts.bootstrapProviders,
+		ControlPlaneProviders:   exportOpts.controlPlaneProviders,
+		InfrastructureProviders: exportOpts.infrastructureProviders,
+		TargetNamespace:         exportOpts.targetNamespace,
+	}
+
+	data, err := c.Export(options)
+	if err != nil {
+		return err
+	}
+
+	ioutil.WriteFile("export.yaml", data, 0644)
+
+	return nil
+}


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This is a proof-of-concept that will add a new command to clusterctl that will export the cert-manager, core and provider manifests. This is helpful if you want to manage these by another means (like GitOps).

**This command may be negated when the provider operator is available**

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Relates to  #6767 
