### PR TITLE
🌱 runtime sdk catalog path fix

### DIFF
--- a/exp/runtime/catalog/catalog.go
+++ b/exp/runtime/catalog/catalog.go
@@ -105,7 +105,7 @@ func New() *Catalog {
 		gvhToHookDescriptor: map[GroupVersionHook]hookDescriptor{},
 		openAPIDefinitions:  []OpenAPIDefinitionsGetter{},
 		// Note: We have to ignore the current file so that GetNameFromCallsite retrieves the name of the caller of New (the parent).
-		catalogName: naming.GetNameFromCallsite("sigs.k8s.io/cluster-api/internal/runtime/catalog/catalog.go"),
+		catalogName: naming.GetNameFromCallsite("sigs.k8s.io/cluster-api/exp/runtime/catalog/catalog.go"),
 	}
 }
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

The PR fixes the catalog to ignore the correct path after the catalog has been moved to `exp/runtime/catalog`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
