### PR TITLE
🐛 Adjust structuredmerge patch helper options to set correct allow list for Cluster objects to prevent co-ownership

### DIFF
--- a/internal/controllers/topology/cluster/reconcile_state.go
+++ b/internal/controllers/topology/cluster/reconcile_state.go
@@ -439,9 +439,7 @@ func (r *Reconciler) reconcileCluster(ctx context.Context, s *scope.Scope) error
 	ctx, log := tlog.LoggerFrom(ctx).WithObject(s.Desired.Cluster).Into(ctx)
 
 	// Check differences between current and desired state, and eventually patch the current object.
-	patchHelper, err := r.patchHelperFactory(s.Current.Cluster, s.Desired.Cluster, structuredmerge.IgnorePaths{
-		{"spec", "controlPlaneEndpoint"}, // this is a well known field that is managed by the Cluster controller, topology should not express opinions on it.
-	})
+	patchHelper, err := r.patchHelperFactory(s.Current.Cluster, s.Desired.Cluster)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create patch helper for %s", tlog.KObj{Obj: s.Current.Cluster})
 	}

--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper.go
@@ -42,20 +42,8 @@ type serverSidePatchHelper struct {
 
 // NewServerSidePatchHelper returns a new PatchHelper using server side apply.
 func NewServerSidePatchHelper(original, modified client.Object, c client.Client, opts ...HelperOption) (PatchHelper, error) {
-	helperOptions := &HelperOptions{}
-	helperOptions = helperOptions.ApplyOptions(opts)
-	helperOptions.allowedPaths = []contract.Path{
-		// apiVersion, kind, name and namespace are required field for a server side apply intent.
-		{"apiVersion"},
-		{"kind"},
-		{"metadata", "name"},
-		{"metadata", "namespace"},
-		// the topology controller controls/has an opinion for labels, annotation, ownerReferences and spec only.
-		{"metadata", "labels"},
-		{"metadata", "annotations"},
-		{"metadata", "ownerReferences"},
-		{"spec"},
-	}
+	// Create helperOptions for filtering the original and modified objects to the desired intent.
+	helperOptions := newHelperOptions(modified, opts...)
 
 	// If required, convert the original and modified objects to unstructured and filter out all the information
 	// not relevant for the topology controller.


### PR DESCRIPTION
Reopens #6738 due to accidental close + force push which made it impossible to reopen the old PR 😢 

**What this PR does / why we need it**:

Prior to this fix, the topology controller added all spec fields of the incoming Cluster object to the intent to patch.
This lead to the capi-topology controller / manager taking ownership of fields it should not have an intention to set / should never set because they are changed by e.g. the user or git ops mechanisms, etc.

This resulted in the topology controller taking co-ownership of the fields (due to server side apply) and results in the following race condition:

* Topology Controller starts reconciling a Cluster
* Gets the current Cluster object (from its cache)
* Meanwhile an external change happens, e.g. changing the replicas of KCP from 3 to 5
* Topology Controller finishes reconciliation and patches the object, which also patches the replicas of KCP back from 5 to 3

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6736 

/test all