### PR TITLE
🌱 Remove code deprecated in v1.2

### DIFF
--- a/controllers/remote/cluster_cache_reconciler.go
+++ b/controllers/remote/cluster_cache_reconciler.go
@@ -19,7 +19,6 @@ package remote
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -34,8 +33,6 @@ import (
 // ClusterCacheReconciler is responsible for stopping remote cluster caches when
 // the cluster for the remote cache is being deleted.
 type ClusterCacheReconciler struct {
-	// Deprecated: this field is unused and will be dropped in an upcoming release.
-	Log     logr.Logger
 	Client  client.Client
 	Tracker *ClusterCacheTracker
 

--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -22,7 +22,8 @@ in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controlle
 
 ### Removals
 
--
+- `MachinesByCreationTimestamp` type has been removed.
+- `ClusterCacheReconciler.Log` has been removed. Use the logger from the context instead.
 
 ### API Changes
 

--- a/util/util.go
+++ b/util/util.go
@@ -489,19 +489,6 @@ func (k KubeAwareAPIVersions) Less(i, j int) bool {
 	return k8sversion.CompareKubeAwareVersionStrings(k[i], k[j]) < 0
 }
 
-// MachinesByCreationTimestamp sorts a list of Machine by creation timestamp, using their names as a tie breaker.
-// Deprecated: This struct will be removed in a future release.
-type MachinesByCreationTimestamp []*clusterv1.Machine
-
-func (o MachinesByCreationTimestamp) Len() int      { return len(o) }
-func (o MachinesByCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
-func (o MachinesByCreationTimestamp) Less(i, j int) bool {
-	if o[i].CreationTimestamp.Equal(&o[j].CreationTimestamp) {
-		return o[i].Name < o[j].Name
-	}
-	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
-}
-
 // ClusterToObjectsMapper returns a mapper function that gets a cluster and lists all objects for the object passed in
 // and returns a list of requests.
 // NB: The objects are required to have `clusterv1.ClusterLabelName` applied.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR cleans up the code that is deprecated in v1.2 release.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Part of #6615

/kind cleanup