### PR TITLE
🐛 fix structuredmerge filterintent to cleanup nested empty maps

### DIFF
--- a/internal/controllers/topology/cluster/structuredmerge/filterintent.go
+++ b/internal/controllers/topology/cluster/structuredmerge/filterintent.go
@@ -79,6 +79,7 @@ func filterIntent(ctx *filterIntentInput) bool {
 			// Ensure we are not leaving empty maps around.
 			if v, ok := fieldCtx.value.(map[string]interface{}); ok && len(v) == 0 {
 				delete(value, field)
+				gotDeletions = true
 			}
 		}
 	}

--- a/internal/controllers/topology/cluster/structuredmerge/filterintent_test.go
+++ b/internal/controllers/topology/cluster/structuredmerge/filterintent_test.go
@@ -167,6 +167,27 @@ func Test_filterIgnoredPaths(t *testing.T) {
 				// we are filtering out spec.foo and then spec given that it is an empty map
 			},
 		},
+		{
+			name: "Cleanup empty nested maps",
+			ctx: &filterIntentInput{
+				path: contract.Path{},
+				value: map[string]interface{}{
+					"spec": map[string]interface{}{
+						"bar": map[string]interface{}{
+							"foo": "123",
+						},
+					},
+				},
+				shouldFilter: isIgnorePath(
+					[]contract.Path{
+						{"spec", "bar", "foo"},
+					},
+				),
+			},
+			wantValue: map[string]interface{}{
+				// we are filtering out spec.bar.foo and then spec given that it is an empty map
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

FilterIntent is supposed to remove all empty maps including nested maps to get consistent objects for comparison.

Currently it did only remove empty leaf maps which exist due to field removal.
Now it also removes new empty leaf maps which result from removing an empty leaf map.

Example:

* Consider the following input
  ```go
  map[string]interface{}{
    "a": map[string]interface{}{
      "b": map[string]interface{}{
        "c": map[string]interface{}{
          "d": "123",
        },
      },
    },
  }
  ```

* Consider FilterIntent to remove the path `a.b.c.d` (due to ignorePath).

* The current implementation would only remove the resulting empty leaf map at `a.b.c` which would result in:

  ```go
  map[string]interface{}{
    "a": map[string]interface{}{
      "b": map[string]interface{}{
      },
    },
  }
  ```

* Actually FilterIntent should also remove `a.b` and then `a` because while bubbling up they also get empty leaf maps.

* The result including this fix is:

  ```go
  map[string]interface{}{
  }
  ```

/test all

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
