### PR TITLE
🌱 Fix spelling in clusterctl command help text

### DIFF
--- a/cmd/clusterctl/cmd/config_repositories.go
+++ b/cmd/clusterctl/cmd/config_repositories.go
@@ -56,7 +56,7 @@ var configRepositoryCmd = &cobra.Command{
 		Display the list of providers and their repository configurations.
 
 		clusterctl ships with a list of known providers; if necessary, edit
-		$HOME/.cluster-api/clusterctl.yaml file to add new provider or to customize existing ones.`),
+		$HOME/.cluster-api/clusterctl.yaml file to add a new provider or to customize existing ones.`),
 
 	Example: Examples(`
 		# Displays the list of available providers.

--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -46,7 +46,7 @@ var (
 var RootCmd = &cobra.Command{
 	Use:          "clusterctl",
 	SilenceUsage: true,
-	Short:        "clusterctl controls the lifecyle of a Cluster API management cluster",
+	Short:        "clusterctl controls the lifecycle of a Cluster API management cluster",
 	Long: LongDesc(`
 		Get started with Cluster API using clusterctl to create a management cluster,
 		install providers, and create templates for your workload cluster.`),


### PR DESCRIPTION
**What this PR does / why we need it**:

Minor spelling and grammar in the clusterctl help text output.