### PR TITLE
🌱 Improve clusterctl get help grammar

### DIFF
--- a/cmd/clusterctl/cmd/get.go
+++ b/cmd/clusterctl/cmd/get.go
@@ -22,8 +22,8 @@ import (
 
 var getCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Get info from a management or a workload cluster",
-	Long:  `Get info from a management or a workload cluster`,
+	Short: "Get info from a management or workload cluster",
+	Long:  `Get info from a management or workload cluster`,
 }
 
 func init() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Minor grammatical fix for `clusterctl get` help.

```shell
clusterctl get --help
Get info from a management or a workload cluster
```