### PR TITLE
:bug: Retry Apply workloadClusterTemplate to fix flake

### DIFF
--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -270,7 +271,9 @@ func ApplyClusterTemplateAndWait(ctx context.Context, input ApplyClusterTemplate
 	Expect(workloadClusterTemplate).ToNot(BeNil(), "Failed to get the cluster template")
 
 	log.Logf("Applying the cluster template yaml to the cluster")
-	Expect(input.ClusterProxy.Apply(ctx, workloadClusterTemplate, input.Args...)).To(Succeed())
+	Eventually(func() error {
+		return input.ClusterProxy.Apply(ctx, workloadClusterTemplate, input.Args...)
+	}, 10*time.Second).Should(Succeed(), "Failed to apply the cluster template")
 
 	log.Logf("Waiting for the cluster infrastructure to be provisioned")
 	result.Cluster = framework.DiscoveryAndWaitForCluster(ctx, framework.DiscoveryAndWaitForClusterInput{


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

This fixes a flake where Applying the cluster template yaml can fail due to the ClusterClass not being present in the cache when the Cluster is being validated in the webhook. The webhook currently checks that the ClusterClass for a Cluster exists. If it can not find it it rejects the cluster creation.
 
Example of the error: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/directory/pull-cluster-api-e2e-full-main/1542219933348270080