### PR TITLE
:seedling: Use 'Byf' instead of 'By(fmt.Sprintf())' across e2e tests

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -482,7 +482,7 @@ type deleteClusterV1alpha3Input struct {
 
 // deleteClusterV1alpha3 deletes the cluster and waits for everything the cluster owned to actually be gone using the older API.
 func deleteClusterV1alpha3(ctx context.Context, input deleteClusterV1alpha3Input) {
-	By(fmt.Sprintf("Deleting cluster %s", input.Cluster.GetName()))
+	Byf("Deleting cluster %s", input.Cluster.GetName())
 	Expect(input.Deleter.Delete(ctx, input.Cluster)).To(Succeed())
 }
 
@@ -494,7 +494,7 @@ type waitForClusterDeletedV1alpha3Input struct {
 
 // waitForClusterDeletedV1alpha3 waits until the cluster object has been deleted using the older API.
 func waitForClusterDeletedV1alpha3(ctx context.Context, input waitForClusterDeletedV1alpha3Input, intervals ...interface{}) {
-	By(fmt.Sprintf("Waiting for cluster %s to be deleted", input.Cluster.GetName()))
+	Byf("Waiting for cluster %s to be deleted", input.Cluster.GetName())
 	Eventually(func() bool {
 		cluster := &clusterv1alpha3.Cluster{}
 		key := client.ObjectKey{
@@ -552,7 +552,7 @@ type deleteClusterV1alpha4Input struct {
 
 // deleteClusterV1alpha4 deletes the cluster and waits for everything the cluster owned to actually be gone using the older API.
 func deleteClusterV1alpha4(ctx context.Context, input deleteClusterV1alpha4Input) {
-	By(fmt.Sprintf("Deleting cluster %s", input.Cluster.GetName()))
+	Byf("Deleting cluster %s", input.Cluster.GetName())
 	Expect(input.Deleter.Delete(ctx, input.Cluster)).To(Succeed())
 }
 
@@ -564,7 +564,7 @@ type waitForClusterDeletedV1alpha4Input struct {
 
 // waitForClusterDeletedV1alpha4 waits until the cluster object has been deleted using the older API.
 func waitForClusterDeletedV1alpha4(ctx context.Context, input waitForClusterDeletedV1alpha4Input, intervals ...interface{}) {
-	By(fmt.Sprintf("Waiting for cluster %s to be deleted", input.Cluster.GetName()))
+	Byf("Waiting for cluster %s to be deleted", input.Cluster.GetName())
 	Eventually(func() bool {
 		cluster := &clusterv1alpha4.Cluster{}
 		key := client.ObjectKey{

--- a/test/framework/alltypes_helpers.go
+++ b/test/framework/alltypes_helpers.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 )
 
 // GetCAPIResourcesInput is the input for GetCAPIResources.
@@ -167,7 +168,7 @@ func CreateRelatedResources(ctx context.Context, input CreateRelatedResourcesInp
 	By("creating related resources")
 	for i := range input.RelatedResources {
 		obj := input.RelatedResources[i]
-		By(fmt.Sprintf("creating a/an %s resource", obj.GetObjectKind().GroupVersionKind()))
+		Byf("creating a/an %s resource", obj.GetObjectKind().GroupVersionKind())
 		Eventually(func() error {
 			return input.Creator.Create(ctx, obj)
 		}, intervals...).Should(Succeed())

--- a/test/framework/cluster_helpers.go
+++ b/test/framework/cluster_helpers.go
@@ -18,7 +18,6 @@ package framework
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -27,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
@@ -152,7 +152,7 @@ type DeleteClusterInput struct {
 
 // DeleteCluster deletes the cluster and waits for everything the cluster owned to actually be gone.
 func DeleteCluster(ctx context.Context, input DeleteClusterInput) {
-	By(fmt.Sprintf("Deleting cluster %s", input.Cluster.GetName()))
+	Byf("Deleting cluster %s", input.Cluster.GetName())
 	Expect(input.Deleter.Delete(ctx, input.Cluster)).To(Succeed())
 }
 
@@ -164,7 +164,7 @@ type WaitForClusterDeletedInput struct {
 
 // WaitForClusterDeleted waits until the cluster object has been deleted.
 func WaitForClusterDeleted(ctx context.Context, input WaitForClusterDeletedInput, intervals ...interface{}) {
-	By(fmt.Sprintf("Waiting for cluster %s to be deleted", input.Cluster.GetName()))
+	Byf("Waiting for cluster %s to be deleted", input.Cluster.GetName())
 	Eventually(func() bool {
 		cluster := &clusterv1.Cluster{}
 		key := client.ObjectKey{

--- a/test/framework/clusterctl/repository.go
+++ b/test/framework/clusterctl/repository.go
@@ -28,12 +28,12 @@ import (
 	"regexp"
 	"strings"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/test/framework/exec"
+	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 )
 
 const (
@@ -58,7 +58,7 @@ type CreateRepositoryInput struct {
 //
 // NOTE: this transformation is specifically designed for replacing "data: ${envSubstVar}".
 func (i *CreateRepositoryInput) RegisterClusterResourceSetConfigMapTransformation(manifestPath, envSubstVar string) {
-	By(fmt.Sprintf("Reading the ClusterResourceSet manifest %s", manifestPath))
+	Byf("Reading the ClusterResourceSet manifest %s", manifestPath)
 	manifestData, err := os.ReadFile(manifestPath) //nolint:gosec
 	Expect(err).ToNot(HaveOccurred(), "Failed to read the ClusterResourceSet manifest file")
 	Expect(manifestData).ToNot(BeEmpty(), "ClusterResourceSet manifest file should not be empty")

--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 )
 
@@ -61,7 +62,7 @@ type WaitForDeploymentsAvailableInput struct {
 // all the desired replicas are in place.
 // This can be used to check if Cluster API controllers installed in the management cluster are working.
 func WaitForDeploymentsAvailable(ctx context.Context, input WaitForDeploymentsAvailableInput, intervals ...interface{}) {
-	By(fmt.Sprintf("Waiting for deployment %s/%s to be available", input.Deployment.GetNamespace(), input.Deployment.GetName()))
+	Byf("Waiting for deployment %s/%s to be available", input.Deployment.GetNamespace(), input.Deployment.GetName())
 	deployment := &appsv1.Deployment{}
 	Eventually(func() bool {
 		key := client.ObjectKey{

--- a/test/framework/machine_helpers.go
+++ b/test/framework/machine_helpers.go
@@ -18,9 +18,7 @@ package framework
 
 import (
 	"context"
-	"fmt"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -128,7 +127,7 @@ func WaitForControlPlaneMachinesToBeUpgraded(ctx context.Context, input WaitForC
 	Expect(input.KubernetesUpgradeVersion).ToNot(BeEmpty(), "Invalid argument. input.KubernetesUpgradeVersion can't be empty when calling WaitForControlPlaneMachinesToBeUpgraded")
 	Expect(input.MachineCount).To(BeNumerically(">", 0), "Invalid argument. input.MachineCount can't be smaller than 1 when calling WaitForControlPlaneMachinesToBeUpgraded")
 
-	By(fmt.Sprintf("Ensuring all control-plane machines have upgraded kubernetes version %s", input.KubernetesUpgradeVersion))
+	Byf("Ensuring all control-plane machines have upgraded kubernetes version %s", input.KubernetesUpgradeVersion)
 
 	Eventually(func() (int, error) {
 		machines := GetControlPlaneMachinesByCluster(ctx, GetControlPlaneMachinesByClusterInput{

--- a/test/framework/machinedeployment_helpers.go
+++ b/test/framework/machinedeployment_helpers.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -145,7 +146,7 @@ func AssertMachineDeploymentFailureDomains(ctx context.Context, input AssertMach
 
 	machineDeploymentFD := pointer.StringDeref(input.MachineDeployment.Spec.Template.Spec.FailureDomain, "<None>")
 
-	By(fmt.Sprintf("Checking all the machines controlled by %s are in the %q failure domain", input.MachineDeployment.Name, machineDeploymentFD))
+	Byf("Checking all the machines controlled by %s are in the %q failure domain", input.MachineDeployment.Name, machineDeploymentFD)
 	selectorMap, err := metav1.LabelSelectorAsMap(&input.MachineDeployment.Spec.Selector)
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Remove uses of `By(fmt.Sprintf())` across e2e tests and replace the the purpose-made `Byf()` function. 
