### PR TITLE
🐛 Improve TestE2E error output and create artifacts dir if not exists

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -92,16 +92,21 @@ func init() {
 }
 
 func TestE2E(t *testing.T) {
+	g := NewWithT(t)
+
 	// If running in prow, make sure to use the artifacts folder that will be reported in test grid (ignoring the value provided by flag).
 	if prowArtifactFolder, exists := os.LookupEnv("ARTIFACTS"); exists {
 		artifactFolder = prowArtifactFolder
 	}
 
+	// ensure the artifacts folder exists
+	g.Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder) //nolint:gosec
+
 	RegisterFailHandler(Fail)
 
 	if alsoLogToFile {
 		w, err := ginkgoextensions.EnableFileLogging(filepath.Join(artifactFolder, "ginkgo-log.txt"))
-		Expect(err).ToNot(HaveOccurred())
+		g.Expect(err).ToNot(HaveOccurred())
 		defer w.Close()
 	}
 
@@ -115,7 +120,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	// Before all ParallelNodes.
 
 	Expect(configPath).To(BeAnExistingFile(), "Invalid test suite argument. e2e.config should be an existing file.")
-	Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid test suite argument. Can't create e2e.artifacts-folder %q", artifactFolder) //nolint:gosec
 
 	By("Initializing a runtime.Scheme with all the GVK relevant for this test")
 	scheme := initScheme()


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

When following https://cluster-api.sigs.k8s.io/developer/testing.html#running-the-end-to-end-tests-locally , the tests fail without exposing the real error:

```sh
git clone https://github.com/kubernetes-sigs/cluster-api.git
cd cluster-api
make docker-build-e2e
make test-e2e
```

```
        panic:
Your test failed.
Ginkgo panics to prevent subsequent assertions from running.
Normally Ginkgo rescues this panic so you shouldn't see it.

But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
To circumvent this, you should call

        defer GinkgoRecover()

at the top of the goroutine that caused this panic.


goroutine 40 [running]:
testing.tRunner.func1.2({0x1027420c0, 0x102b7ec48})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1389 +0x1c8
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1392 +0x384
panic({0x1027420c0, 0x102b7ec48})
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/runtime/panic.go:838 +0x204
github.com/onsi/ginkgo.Fail({0x1400055f400, 0x3b4}, {0x1400071f5c0?, 0x1400055f400?, 0x140005055f8?})
        /Users/schlotterc/go/pkg/mod/github.com/onsi/ginkgo@v1.16.5/ginkgo_dsl.go:291 +0xa8
github.com/onsi/gomega/internal.(*Assertion).match(0x14000185e00, {0x102b94de0, 0x103d73818}, 0x0, {0x0, 0x0, 0x0})
        /Users/schlotterc/go/pkg/mod/github.com/onsi/gomega@v1.18.1/internal/assertion.go:100 +0x174
github.com/onsi/gomega/internal.(*Assertion).ToNot(0x14000185e00, {0x102b94de0, 0x103d73818}, {0x0, 0x0, 0x0})
        /Users/schlotterc/go/pkg/mod/github.com/onsi/gomega@v1.18.1/internal/assertion.go:63 +0x90
sigs.k8s.io/cluster-api/test/e2e.TestE2E(0x0?)
        /private/tmp/foo/cluster-api/test/e2e/e2e_suite_test.go:104 +0x1a8
testing.tRunner(0x14000103860, 0x102b7dc10)
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1439 +0x110
created by testing.(*T).Run
        /opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1486 +0x300

Ginkgo ran 1 suite in 6.994781792s
Test Suite Failed

...
```

The underying error gets asserted in `test/e2e/e2e_suite_test.go:104` but it does not get put out.
This change results in fixing the error output to look like:

```
        panic:
Your test failed.
Ginkgo panics to prevent subsequent assertions from running.
/Users/schlotterc/fresh/cluster-api/hack/tools/bin/kustomize-v4.5.2 build /Users/schlotterc/fresh/cluster-api/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-ignition --load-restrictor LoadRestrictionsNone > /Users/schlotterc/fresh/cluster-api/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-ignition.yaml
mkdir -p /Users/schlotterc/fresh/cluster-api/test/e2e/data/test-extension
/Users/schlotterc/fresh/cluster-api/hack/tools/bin/kustomize-v4.5.2 build /Users/schlotterc/fresh/cluster-api/test/extension/config/default > /Users/schlotterc/fresh/cluster-api/test/e2e/data/test-extension/deployment.yaml
/Users/schlotterc/fresh/cluster-api/hack/tools/bin/ginkgo-v1.16.5 -v -trace -tags=e2e -focus=""  -nodes=1 --noColor=false  . -- \
            -e2e.artifacts-folder="/Users/schlotterc/fresh/cluster-api/_artifacts" \
            -e2e.config="/Users/schlotterc/fresh/cluster-api/test/e2e/config/docker.yaml" \
            -e2e.skip-resource-cleanup=false -e2e.use-existing-cluster=false
--- FAIL: TestE2E (0.00s)
    e2e_suite_test.go:106:
        Unexpected error:
            <*errors.withStack | 0x14000720330>: {
                error: <*errors.withMessage | 0x14000370c60>{
                    cause: <*errors.withStack | 0x140007202d0>{
                        error: <*errors.withMessage | 0x14000370c40>{
                            cause: <*fs.PathError | 0x140005b24e0>{
                                Op: "open",
                                Path: "/Users/schlotterc/fresh/cluster-api/_artifacts/ginkgo-log.txt",
                                Err: <syscall.Errno>0x2,
                            },
                            msg: "failed to create file",
                        },
                        stack: [0x103164f20, 0x103164d64, 0x10372344c, 0x1021dfd10, 0x102138424],
                    },
                    msg: "failed to create fileWriter",
                },
                stack: [0x103164e3c, 0x10372344c, 0x1021dfd10, 0x102138424],
            }
            failed to create fileWriter: failed to create file: open /Users/schlotterc/fresh/cluster-api/_artifacts/ginkgo-log.txt: no such file or directory
        occurred
FAIL

Ginkgo ran 1 suite in 5.921613458s
Test Suite Failed
...
```

instead.

It also fixes the underlying issue, that the `$(ARTIFACTS)` dir was required to get created manually.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
