### PR TITLE
📖  Fix alignment of 'ClusterClass' in docs

### DIFF
--- a/docs/book/src/developer/architecture/controllers.md
+++ b/docs/book/src/developer/architecture/controllers.md
@@ -14,7 +14,7 @@ Documentation for the CAPI controllers can be found at:
   - [MachineDeployment](./controllers/machine-deployment.md)
   - [MachineHealthCheck](./controllers/machine-health-check.md)
   - [MachinePool](./controllers/machine-pool.md)
- - ClusterClass
+- ClusterClass
   - [Cluster Topology](./controllers/cluster-topology.md)
 - AddOns
    - [ClusterResourceSet](./controllers/cluster-resource-set.md)


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Remove leading space from before ClusterClass in controllers list in the book.

(It doesn't look like much, but thi changes the way this is rendered in the book to correctly align the table.)
