### PR TITLE
🌱 Use consistent punctuation in the clusterctl cmd short descriptions

### DIFF
--- a/cmd/clusterctl/cmd/alpha.go
+++ b/cmd/clusterctl/cmd/alpha.go
@@ -22,7 +22,7 @@ import (
 
 var alphaCmd = &cobra.Command{
 	Use:   "alpha",
-	Short: "Commands for features in alpha.",
+	Short: "Commands for features in alpha",
 	Long:  `These commands correspond to alpha features in clusterctl.`,
 }
 

--- a/cmd/clusterctl/cmd/backup.go
+++ b/cmd/clusterctl/cmd/backup.go
@@ -34,7 +34,7 @@ var buo = &backupOptions{}
 
 var backupCmd = &cobra.Command{
 	Use:   "backup",
-	Short: "Backup Cluster API objects and all dependencies from a management cluster.",
+	Short: "Backup Cluster API objects and all dependencies from a management cluster",
 	Long: LongDesc(`
 		Backup Cluster API objects and all dependencies from a management cluster.`),
 

--- a/cmd/clusterctl/cmd/config.go
+++ b/cmd/clusterctl/cmd/config.go
@@ -22,7 +22,7 @@ import (
 
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Display clusterctl configuration.",
+	Short: "Display clusterctl configuration",
 	Long:  `Display clusterctl configuration.`,
 }
 

--- a/cmd/clusterctl/cmd/config_repositories.go
+++ b/cmd/clusterctl/cmd/config_repositories.go
@@ -51,7 +51,7 @@ var cro = &configRepositoriesOptions{}
 var configRepositoryCmd = &cobra.Command{
 	Use:   "repositories",
 	Args:  cobra.NoArgs,
-	Short: "Display the list of providers and their repository configurations.",
+	Short: "Display the list of providers and their repository configurations",
 	Long: LongDesc(`
 		Display the list of providers and their repository configurations.
 

--- a/cmd/clusterctl/cmd/delete.go
+++ b/cmd/clusterctl/cmd/delete.go
@@ -39,7 +39,7 @@ var dd = &deleteOptions{}
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete [providers]",
-	Short: "Delete one or more providers from the management cluster.",
+	Short: "Delete one or more providers from the management cluster",
 	Long: LongDesc(`
 		Delete one or more providers from the management cluster.`),
 

--- a/cmd/clusterctl/cmd/describe.go
+++ b/cmd/clusterctl/cmd/describe.go
@@ -22,7 +22,7 @@ import (
 
 var describeCmd = &cobra.Command{
 	Use:   "describe",
-	Short: "Describe workload clusters.",
+	Short: "Describe workload clusters",
 	Long:  `Describe the status of workload clusters.`,
 }
 

--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -70,7 +70,7 @@ var dc = &describeClusterOptions{}
 
 var describeClusterClusterCmd = &cobra.Command{
 	Use:   "cluster",
-	Short: "Describe workload clusters.",
+	Short: "Describe workload clusters",
 	Long: LongDesc(`
 		Provide an "at glance" view of a Cluster API cluster designed to help the user in quickly
 		understanding if there are problems and where.

--- a/cmd/clusterctl/cmd/generate.go
+++ b/cmd/clusterctl/cmd/generate.go
@@ -22,7 +22,7 @@ import (
 
 var generateCmd = &cobra.Command{
 	Use:   "generate",
-	Short: "Generate yaml using clusterctl yaml processor.",
+	Short: "Generate yaml using clusterctl yaml processor",
 	Long:  `Generate yaml using clusterctl yaml processor.`,
 }
 

--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -47,7 +47,7 @@ var gc = &generateClusterOptions{}
 
 var generateClusterClusterCmd = &cobra.Command{
 	Use:   "cluster",
-	Short: "Generate templates for creating workload clusters.",
+	Short: "Generate templates for creating workload clusters",
 	Long: LongDesc(`
 		Generate templates for creating workload clusters.
 

--- a/cmd/clusterctl/cmd/generate_provider.go
+++ b/cmd/clusterctl/cmd/generate_provider.go
@@ -39,7 +39,7 @@ var gpo = &generateProvidersOptions{}
 var generateProviderCmd = &cobra.Command{
 	Use:   "provider",
 	Args:  cobra.NoArgs,
-	Short: "Generate templates for provider components.",
+	Short: "Generate templates for provider components",
 	Long: LongDesc(`
 		Generate templates for provider components.
 

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -42,7 +42,7 @@ var initOpts = &initOptions{}
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize a management cluster.",
+	Short: "Initialize a management cluster",
 	Long: LongDesc(`
 		Initialize a management cluster.
 

--- a/cmd/clusterctl/cmd/move.go
+++ b/cmd/clusterctl/cmd/move.go
@@ -36,7 +36,7 @@ var mo = &moveOptions{}
 
 var moveCmd = &cobra.Command{
 	Use:   "move",
-	Short: "Move Cluster API objects and all dependencies between management clusters.",
+	Short: "Move Cluster API objects and all dependencies between management clusters",
 	Long: LongDesc(`
 		Move Cluster API objects and all dependencies between management clusters.
 

--- a/cmd/clusterctl/cmd/topology.go
+++ b/cmd/clusterctl/cmd/topology.go
@@ -22,6 +22,6 @@ import (
 
 var topologyCmd = &cobra.Command{
 	Use:   "topology",
-	Short: "Commands for ClusterClass based clusters.",
+	Short: "Commands for ClusterClass based clusters",
 	Long:  `Commands for ClusterClass based clusters.`,
 }

--- a/cmd/clusterctl/cmd/topology_plan.go
+++ b/cmd/clusterctl/cmd/topology_plan.go
@@ -47,7 +47,7 @@ var tp = &topologyPlanOptions{}
 
 var topologyPlanCmd = &cobra.Command{
 	Use:   "plan",
-	Short: "List the changes to clusters that use managed topologies for a given input.",
+	Short: "List the changes to clusters that use managed topologies for a given input",
 	Long: LongDesc(`
 		Provide the list of objects that would be created, modified and deleted when an input file is applied.
 		The input can be a file with a new/modified cluster, new/modified ClusterClass, new/modified templates.

--- a/cmd/clusterctl/cmd/upgrade.go
+++ b/cmd/clusterctl/cmd/upgrade.go
@@ -26,7 +26,7 @@ import (
 
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "Upgrade core and provider components in a management cluster.",
+	Short: "Upgrade core and provider components in a management cluster",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()

--- a/cmd/clusterctl/cmd/version.go
+++ b/cmd/clusterctl/cmd/version.go
@@ -40,7 +40,7 @@ var vo = &versionOptions{}
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print clusterctl version.",
+	Short: "Print clusterctl version",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runVersion()


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr fixes the inconsistent punctuation in the clusterctl cmd short descriptions. Currently 10 out of 14 descriptions ends with a dot. I chose to remove all dots since that is more in line with how `kubectl` works. 

`clusterctl help` main branch currently:
```
Available Commands:
  alpha       Commands for features in alpha.
  backup      Backup Cluster API objects and all dependencies from a management cluster.
  completion  Output shell completion code for the specified shell (bash or zsh)
  config      Display clusterctl configuration.
  delete      Delete one or more providers from the management cluster.
  describe    Describe workload clusters.
  generate    Generate yaml using clusterctl yaml processor.
  get         Get info from a management or a workload cluster
  help        Help about any command
  init        Initialize a management cluster.
  move        Move Cluster API objects and all dependencies between management clusters.
  restore     Restore Cluster API objects from file by glob. Object files are searched in config directory
  upgrade     Upgrade core and provider components in a management cluster.
  version     Print clusterctl version.
```

`clusterctl help` after the change:
```
Available Commands:
  alpha       Commands for features in alpha
  backup      Backup Cluster API objects and all dependencies from a management cluster
  completion  Output shell completion code for the specified shell (bash or zsh)
  config      Display clusterctl configuration
  delete      Delete one or more providers from the management cluster
  describe    Describe workload clusters
  generate    Generate yaml using clusterctl yaml processor
  get         Get info from a management or workload cluster
  help        Help about any command
  init        Initialize a management cluster
  move        Move Cluster API objects and all dependencies between management clusters
  restore     Restore Cluster API objects from file by glob. Object files are searched in config directory
  upgrade     Upgrade core and provider components in a management cluster
  version     Print clusterctl version
```

Part of `kubectl help` as reference
```
Other Commands:
  alpha           Commands for features in alpha
  api-resources   Print the supported API resources on the server
  api-versions    Print the supported API versions on the server, in the form of "group/version"
  config          Modify kubeconfig files
  plugin          Provides utilities for interacting with plugins
  version         Print the client and server version information
```