### PR TITLE
🌱 Run dependabot action outside of GOPATH again

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -19,15 +19,8 @@ jobs:
       with:
         go-version: '1.18'
       id: go
-    # Note: We have to run everything in the GOPATH as `make generate-go-openapi`
-    # currently does not work outside of the GOPATH, see:
-    # https://github.com/kubernetes-sigs/cluster-api/issues/6526
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
-      with:
-        path: './src/sigs.k8s.io/cluster-api'
-    - name: Set env
-      run:  echo "GOPATH=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
     - uses: actions/cache@v3.0.4
       name: Restore go cache
       with:
@@ -39,10 +32,8 @@ jobs:
           ${{ runner.os }}-go-
     - name: Update all modules
       run: make generate-modules
-      working-directory: './src/sigs.k8s.io/cluster-api'
     - name: Update generated code
       run: make generate
-      working-directory: './src/sigs.k8s.io/cluster-api'
     - uses: EndBug/add-and-commit@v9
       name: Commit changes
       with:
@@ -50,4 +41,3 @@ jobs:
         author_email: 49699333+dependabot[bot]@users.noreply.github.com
         default_author: github_actor
         message: 'Update generated code'
-        cwd: './src/sigs.k8s.io/cluster-api'


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Now that #6815 made it possible to run `make generate` outside of GOPATH again, let's revert the workaround in the dependabot action.

Will be verified via: https://github.com/sbueringer/cluster-api/pull/65

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6526
