### PR TITLE
📖 add disclaimer about clusterctl topology dryrun RuntimeSDK support

### DIFF
--- a/docs/book/src/clusterctl/commands/alpha-topology-plan.md
+++ b/docs/book/src/clusterctl/commands/alpha-topology-plan.md
@@ -24,7 +24,7 @@ the input should have all the objects needed.
 
 <aside class="note">
 
-<h1>Limitations</h1>
+<h1>Limitations: Server Side Apply</h1>
 
 The topology controllers uses [Server Side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/)
 to support use cases where other controllers are co-authoring the same objects, but this kind of interactions can't be recreated
@@ -40,6 +40,14 @@ More specifically:
 - DryRun doesn't consider existing metadata.managedFields, and this can lead to false negatives when topology dry run
   is simulating a change where a field is dropped from a template (DryRun always preserve dropped fields, like 
   server side apply when the field has more than one manager).
+
+</aside>
+
+<aside class="note">
+
+<h1>Limitations: RuntimeSDK</h1>
+
+Please note that `clusterctl` doesn't support Runtime SDK yet. This means that ClusterClasses with external patches are not yet supported.
 
 </aside>
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adds a disclaimer that clusterctl topology dryrun doesn't support RuntimeSDK yet.

When using the command with a ClusterClass with external patching the following error is produced:
> ➜ ${CAPI_HOME}/bin/clusterctl alpha topology plan -f docker-cluster.yaml -f docker-clusterclass.yaml --output-directory=/tmp/test
Detected a cluster with Cluster API installed. Will use it to fetch missing objects.
Error: failed defaulting and validation on input objects: failed to run defaulting and validation on ClusterClasses: failed validation of cluster.x-k8s.io/v1beta1, Kind=ClusterClass default/quick-start: ClusterClass.cluster.x-k8s.io "quick-start" is invalid: spec.patches[0].external: Forbidden: patch.external can be used only if the RuntimeSDK feature flag is enabled

I can change/improve that but it would require ~ something like this: https://github.com/kubernetes-sigs/cluster-api/compare/main...sbueringer:cluster-api:poc-clusterctl-runtimesdk?expand=1

Please note adding the disclaimer is just a stop gap solution until we got around to implementing it correctly in clusterctl (see #6545)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #6330
