### PR TITLE
📖 Add short description for each clusterctl command in CAPI book

### DIFF
--- a/docs/book/src/clusterctl/commands/commands.md
+++ b/docs/book/src/clusterctl/commands/commands.md
@@ -1,19 +1,22 @@
 # clusterctl commands
 
-* [`clusterctl alpha rollout`](alpha-rollout.md)
-* [`clusterctl alpha topology plan`](alpha-topology-plan.md)
-* [`clusterctl backup`](additional-commands.md#clusterctl-backup)
-* [`clusterctl completion`](completion.md)
-* [`clusterctl config`](additional-commands.md#clusterctl-config-repositories)
-* [`clusterctl delete`](delete.md)
-* [`clusterctl describe cluster`](describe-cluster.md)
-* [`clusterctl generate cluster`](generate-cluster.md)
-* [`clusterctl generate provider`](generate-provider.md)
-* [`clusterctl generate yaml`](generate-yaml.md)
-* [`clusterctl get kubeconfig`](get-kubeconfig.md)
-* [`clusterctl help`](additional-commands.md#clusterctl-help)
-* [`clusterctl init`](init.md)
-* [`clusterctl move`](move.md)
-* [`clusterctl restore`](additional-commands.md#clusterctl-restore)
-* [`clusterctl upgrade`](upgrade.md)
-* [`clusterctl version`](additional-commands.md#clusterctl-version)
+| Command                                                                      | Description                                                                                                |
+|------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| [`clusterctl alpha rollout`](alpha-rollout.md)                               | Manages the rollout of Cluster API resources. For example: MachineDeployments.                             |
+| [`clusterctl alpha topology plan`](alpha-topology-plan.md)                   | Describes the changes to a cluster topology for a given input.                                             |
+| [`clusterctl backup`](additional-commands.md#clusterctl-backup)              | Backup Cluster API objects and all their dependencies from a management cluster.                           |
+| [`clusterctl completion`](completion.md)                                     | Output shell completion code for the specified shell (bash or zsh).                                        |
+| [`clusterctl config`](additional-commands.md#clusterctl-config-repositories) | Display clusterctl configuration.                                                                          |
+| [`clusterctl delete`](delete.md)                                             | Delete one or more providers from the management cluster.                                                  |
+| [`clusterctl describe cluster`](describe-cluster.md)                         | Describe workload clusters.                                                                                |
+| [`clusterctl generate cluster`](generate-cluster.md)                         | Generate templates for creating workload clusters.                                                         |
+| [`clusterctl generate provider`](generate-provider.md)                       | Generate templates for provider components.                                                                |
+| [`clusterctl generate yaml`](generate-yaml.md)                               | Process yaml using clusterctl's yaml processor.                                                            |
+| [`clusterctl get kubeconfig`](get-kubeconfig.md)                             | Gets the kubeconfig file for accessing a workload cluster.                                                 |
+| [`clusterctl help`](additional-commands.md#clusterctl-help)                  | Help about any command.                                                                                    |
+| [`clusterctl init`](init.md)                                                 | Initialize a management cluster.                                                                           |
+| [`clusterctl move`](move.md)                                                 | Move Cluster API objects and all their dependencies between management clusters.                           |
+| [`clusterctl restore`](additional-commands.md#clusterctl-restore)            | Restore Cluster API objects from file by glob.                                                             |
+| [`clusterctl upgrade plan`](upgrade.md#upgrade-plan)                         | Provide a list of recommended target versions for upgrading Cluster API providers in a management cluster. |
+| [`clusterctl upgrade apply`](upgrade.md#upgrade-apply)                       | Apply new versions of Cluster API core and providers in a management cluster.                              |
+| [`clusterctl version`](additional-commands.md#clusterctl-version)            | Print clusterctl version.                                                                                  |

--- a/docs/book/src/clusterctl/overview.md
+++ b/docs/book/src/clusterctl/overview.md
@@ -8,16 +8,22 @@ quick start with Cluster API. It automates fetching the YAML files defining [pro
 Additionally it encodes a set of best practices in managing providers, that helps the user in avoiding
 mis-configurations or in managing day 2 operations such as upgrades.
 
-* use [`clusterctl init`](commands/init.md) to install Cluster API providers
-* use [`clusterctl upgrade`](commands/upgrade.md) to upgrade Cluster API providers
-* use [`clusterctl delete`](commands/delete.md) to delete Cluster API providers
+Below you can find a list of main clusterctl commands:
 
-* use [`clusterctl generate cluster`](commands/generate-cluster.md) to spec out workload clusters
-* use [`clusterctl generate yaml`](commands/generate-yaml.md) to process yaml
-* use [`clusterctl get kubeconfig`](commands/get-kubeconfig.md) to get the kubeconfig of an existing workload cluster.
-  using clusterctl's internal yaml processor.
-* use [`clusterctl move`](commands/move.md) to migrate objects defining a workload clusters (e.g. Cluster, Machines) from a management cluster to another management cluster
-* use [`clusterctl alpha rollout`](commands/alpha-rollout.md) to rollout Cluster API resources such as MachineDeployments. Note that this is currently an alpha level feature. 
+* [`clusterctl init`](commands/init.md) Initialize a management cluster.
+* [`clusterctl upgrade plan`](commands/upgrade.md#upgrade-plan) Provide a list of recommended target versions for upgrading Cluster API providers in a management cluster.
+* [`clusterctl upgrade apply`](commands/upgrade.md#upgrade-apply) Apply new versions of Cluster API core and providers in a management cluster.
+* [`clusterctl delete`](commands/delete.md) Delete one or more providers from the management cluster.
+* [`clusterctl generate cluster`](commands/generate-cluster.md) Generate templates for creating workload clusters.
+* [`clusterctl generate yaml`](commands/generate-yaml.md) Process yaml using clusterctl's yaml processor.
+* [`clusterctl get kubeconfig`](commands/get-kubeconfig.md) Gets the kubeconfig file for accessing a workload cluster.
+* [`clusterctl move`](commands/move.md) Move Cluster API objects and all their dependencies between management clusters.
+* [`clusterctl alpha rollout`](commands/alpha-rollout.md) Manages the rollout of Cluster API resources. For example: MachineDeployments.
+
+For the full list of clusterctl commands please refer to [commands](commands/commands.md).
+
+# Installing clusterctl
+Instructions are available in the [Quick Start](../user/quick-start.md#install-clusterctl).
 
 <!-- links -->
 [management cluster]: ../reference/glossary.md#management-cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds link to clusterctl installation in the overview to make it simpler to find. 
* Adds `clusterctl upgrade plan` and `clusterctl upgrade apply` to the commands list. 
* Adds a short description to each command.

As discussed in the issue, it does not remove the commands from the overview.

Fixes #6804