### PR TITLE
🐛 ci: use KUBERNETES_VERSION in kubeadm script

### DIFF
--- a/test/framework/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
+++ b/test/framework/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
@@ -104,7 +104,7 @@ if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
   fi
   IMAGE_REGISTRY_PREFIX=registry.k8s.io
   # Kubernetes builds from 1.20 through 1.24 are tagged with k8s.gcr.io
-  if [[ "$${CI_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
+  if [[ "$${KUBERNETES_VERSION}" =~ ^v1\.(1[0-9]|2[0-4])[\.[0-9]+ ]]; then
     IMAGE_REGISTRY_PREFIX=k8s.gcr.io
   fi
   for CI_CONTAINER in "$${CONTAINERS_TO_TEST[@]}"; do


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR replaces the capz-specific `$CI_VERSION` env var with the capi-standard `$KUBERNETES_VERSION` variable. This was introduced here:

https://github.com/kubernetes-sigs/cluster-api/pull/6711

Folks are seeing such side-effects since the above PR merged:

```
Jul 06 03:40:39 cluster-conformance-98lra3-control-plane-nhfqm cloud-init[611]: [2022-07-06 03:40:15] /usr/local/bin/ci-artifacts.sh: line 103: CI_VERSION: unbound variable
```

Sorry everyone, thanks @sbueringer for triaging!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
