### PR TITLE
🌱 Improve clusterctl generate cluster error message

### DIFF
--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
@@ -88,7 +89,12 @@ var generateClusterClusterCmd = &cobra.Command{
 		# Prints the list of variables required by the yaml file for creating workload cluster.
 		clusterctl generate cluster my-cluster --list-variables`),
 
-	Args: cobra.ExactArgs(1),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return errors.New("please specify a cluster name")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGenerateClusterTemplate(cmd, args[0])
 	},


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the error message of `clusterctl generate cluster` from
```
$ clusterctl generate cluster
Error: accepts 1 arg(s), received 0
```

To the following:

```
$ clusterctl generate cluster
Error: please specify a cluster name
```

As a side note `clusterctl generate cluster --help` describes usage as:

```
Usage:
  clusterctl generate cluster [flags]
```

Maybe this should be: 
```
Usage:
  clusterctl generate cluster NAME [flags]
```

Since NAME is a required argument.