### PR TITLE
[release-1.1] :seedling:  Update verify action to ignore cherry-picks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,5 +15,8 @@ jobs:
     - name: Verifier action
       id: verifier
       uses: kubernetes-sigs/kubebuilder-release-tools@v0.2.0
+      # Don't run this step on PRs created by the cherry-pick bot,
+      # as the PR description is too short, but otherwise the PRs are fine.
+      if: ${{ github.event.pull_request.head.repo.owner.login != 'k8s-infra-cherrypick-robot' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update the verifier action to ignore PRs made by the cherry-pick robot.
