### PR TITLE
🌱 Improve clusterctl completion and get kubeconfig error message

### DIFF
--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,7 +83,12 @@ var (
 		Short:   "Output shell completion code for the specified shell (bash or zsh)",
 		Long:    LongDesc(completionLong),
 		Example: completionExample,
-		Args:    cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("please specify a shell")
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCompletion(os.Stdout, cmd, args[0])
 		},

--- a/cmd/clusterctl/cmd/get_kubeconfig.go
+++ b/cmd/clusterctl/cmd/get_kubeconfig.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -46,7 +47,12 @@ var getKubeconfigCmd = &cobra.Command{
 		# Get the workload cluster's kubeconfig in a particular namespace.
 		clusterctl get kubeconfig <name of workload cluster> --namespace foo`),
 
-	Args: cobra.ExactArgs(1),
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return errors.New("please specify a workload cluster name")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGetKubeconfig(args[0])
 	},


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the error message of
- `clusterctl completion`, and 
- `clusterctl get kubeconfig`

Current:
```
clusterctl completion
Error: accepts 1 arg(s), received 0

clusterctl get kubeconfig
Error: accepts 1 arg(s), received 0
```

With PR:
```
./bin/clusterctl completion
Error: please specify a shell

./bin/clusterctl get kubeconfig 
Error: please specify a workload cluster name
```

As requested (in #6868) I've grouped the remaining findings into a single pr.