### PR TITLE
✨ clusterctl: add flag to force color output on `describe cluster`

### DIFF
--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -65,6 +65,7 @@ type describeClusterOptions struct {
 	disableNoEcho           bool
 	grouping                bool
 	disableGrouping         bool
+	color                   bool
 }
 
 var dc = &describeClusterOptions{}
@@ -135,6 +136,7 @@ func init() {
 		"Disable grouping machines when ready condition has the same Status, Severity and Reason.")
 	_ = describeClusterClusterCmd.Flags().MarkDeprecated("disable-grouping",
 		"use --grouping instead.")
+	describeClusterClusterCmd.Flags().BoolVarP(&dc.color, "color", "c", false, "Enable color output, even when stdout is not a tty.")
 
 	// completions
 	describeClusterClusterCmd.ValidArgsFunction = resourceNameCompletionFunc(
@@ -168,6 +170,10 @@ func runDescribeCluster(name string) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	if dc.color {
+		color.NoColor = false
 	}
 
 	printObjectTree(tree)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a new flag `--color` to `clusterctl describe cluster` that forces the color output, even when stdout is not a tty. This can be useful when e.g. using `watch`.

The default from `github.com/fatih/color` is to disable color output when not writing to a terminal, see: https://github.com/fatih/color#disableenable-color

You can try this feature with these commands:

```shell
make clusterctl
watch --color ./bin/clusterctl describe cluster --color my-cluster
watch -c ./bin/clusterctl describe cluster -c my-cluster
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
