### PR TITLE
🌱 bump to v1.2.0 tag for clusterctl upgrade tests

### DIFF
--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -50,7 +50,7 @@ providers:
     files:
     - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
   - name: v1.2.0 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0-beta.2/core-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -88,7 +88,7 @@ providers:
     files:
     - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
   - name: v1.2.0 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0-beta.2/bootstrap-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -126,7 +126,7 @@ providers:
     files:
     - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
   - name: v1.2.0 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0-beta.2/control-plane-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -166,7 +166,7 @@ providers:
     - sourcePath: "../data/shared/v1alpha4/metadata.yaml"
     - sourcePath: "../data/infrastructure-docker/v1alpha4/cluster-template.yaml"
   - name: v1.2.0 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0-beta.2/infrastructure-components-development.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/infrastructure-components-development.yaml"
     type: "url"
     contract: v1beta1
     replacements:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR update the clusterctl upgrade test to use the v1.2.0 tag. (Currently using the beta tag)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubernetes-sigs/cluster-api/issues/6833

Part of : #6615 

/area testing
