### PR TITLE
🌱 Add Dockerfile linter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@
 # Build the manager binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
+
+# Ignore Hadolint rule "Always tag the version of an image explicitly."
+# It's an invalid finding since the image is explicitly set in the Makefile.
+# https://github.com/hadolint/hadolint/wiki/DL3006
+# hadolint ignore=DL3006
 FROM ${builder_image} as builder
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ GO_APIDIFF_BIN := go-apidiff
 GO_APIDIFF := $(abspath $(TOOLS_BIN_DIR)/$(GO_APIDIFF_BIN)-$(GO_APIDIFF_VER))
 GO_APIDIFF_PKG := github.com/joelanford/go-apidiff
 
+HADOLINT_VER := v2.10.0
+HADOLINT_FAILURE_THRESHOLD = warning
+
 KPROMO_VER := v3.4.4
 KPROMO_BIN := kpromo
 KPROMO :=  $(abspath $(TOOLS_BIN_DIR)/$(KPROMO_BIN)-$(KPROMO_VER))
@@ -443,6 +446,11 @@ lint: $(GOLANGCI_LINT) ## Lint the codebase
 	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
 	cd $(TEST_DIR); $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
 	cd $(TOOLS_DIR); $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
+	./scripts/ci-lint-dockerfiles.sh $(HADOLINT_VER) $(HADOLINT_FAILURE_THRESHOLD)
+
+.PHONY: lint-dockerfiles
+lint-dockerfiles:
+	./scripts/ci-lint-dockerfiles.sh $(HADOLINT_VER) $(HADOLINT_FAILURE_THRESHOLD)
 
 .PHONY: lint-fix
 lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported by the linter

--- a/cmd/clusterctl/Dockerfile
+++ b/cmd/clusterctl/Dockerfile
@@ -17,6 +17,11 @@
 # Build the clusterctl binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
+
+# Ignore Hadolint rule "Always tag the version of an image explicitly."
+# It's an invalid finding since the image is explicitly set in the Makefile.
+# https://github.com/hadolint/hadolint/wiki/DL3006
+# hadolint ignore=DL3006
 FROM ${builder_image} as builder
 WORKDIR /workspace
 

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -31,7 +31,7 @@
 
 FROM maven:3-jdk-8
 
-RUN apt-get update && apt-get install -y --no-install-recommends graphviz fonts-symbola fonts-wqy-zenhei && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends graphviz=2.42.2-5 fonts-symbola=2.60-1.1 fonts-wqy-zenhei=0.9.45-8 && rm -rf /var/lib/apt/lists/*
 RUN wget -O /plantuml.jar http://sourceforge.net/projects/plantuml/files/plantuml.1.2019.6.jar/download
 
 # By default, java writes a 'hsperfdata_<username>' directory in the work dir.

--- a/scripts/ci-lint-dockerfiles.sh
+++ b/scripts/ci-lint-dockerfiles.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+HADOLINT_VER=${1:-latest}
+HADOLINT_FAILURE_THRESHOLD=${2:-warning}
+
+FILES=$(find -- * -name Dockerfile)
+while read -r file; do
+  echo "Linting: ${file}"
+  # Configure the linter to fail for warnings and errors. Can be set to: error | warning | info | style | ignore | none
+  docker run --rm -i ghcr.io/hadolint/hadolint:"${HADOLINT_VER}" hadolint --failure-threshold "${HADOLINT_FAILURE_THRESHOLD}" - < "${file}"
+done <<< "${FILES}"

--- a/test/extension/Dockerfile
+++ b/test/extension/Dockerfile
@@ -17,6 +17,11 @@
 # Build the extension binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
+
+# Ignore Hadolint rule "Always tag the version of an image explicitly."
+# It's an invalid finding since the image is explicitly set in the Makefile.
+# https://github.com/hadolint/hadolint/wiki/DL3006
+# hadolint ignore=DL3006
 FROM ${builder_image} as builder
 WORKDIR /workspace
 

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -16,6 +16,11 @@
 
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
+
+# Ignore Hadolint rule "Always tag the version of an image explicitly."
+# It's an invalid finding since the image is explicitly set in the Makefile.
+# https://github.com/hadolint/hadolint/wiki/DL3006
+# hadolint ignore=DL3006
 FROM ${builder_image} as builder
 
 # Run this with docker build --build-arg goproxy=$(go env GOPROXY) to override the goproxy
@@ -58,6 +63,10 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -trimpath -a -o /workspace/manager main.go
 
 # NOTE: CAPD can't use non-root because docker requires access to the docker socket
+
+# Ignore Hadolint rule "Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag."
+# https://github.com/hadolint/hadolint/wiki/DL3007
+# hadolint ignore=DL3007
 FROM gcr.io/distroless/static:latest
 
 WORKDIR /


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a Dockerfile linter to the make lint target. This is done via a script which finds all files named "Dockerfile" and runs [Hadolint](https://github.com/hadolint/hadolint) on them. I've configured it to only fail on the highest severity. 

The new output is:

```
 make lint
(...)
./scripts/ci-lint-dockerfiles.sh
Linting: cmd/clusterctl/Dockerfile
-:20 DL3006 warning: Always tag the version of an image explicitly
Linting: Dockerfile
-:20 DL3006 warning: Always tag the version of an image explicitly
Linting: docs/Dockerfile
-:34 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
-:35 DL3047 info: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`.Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
Linting: scripts/Dockerfile
-:1 DL3006 warning: Always tag the version of an image explicitly
Linting: test/extension/Dockerfile
-:20 DL3006 warning: Always tag the version of an image explicitly
Linting: test/infrastructure/docker/Dockerfile
-:19 DL3006 warning: Always tag the version of an image explicitly
-:28 SC2086 info: Double quote to prevent globbing and word splitting.
-:61 DL3007 warning: Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag
```

If you want to verify a failure, here is a failing Dockerfile that you can add:

```Dockerfile
FROM ubuntu

RUN sudo ls
```

And verify exitcode with `echo $?`