### PR TITLE
📖 mention json register import for --logging-format=json

### DIFF
--- a/docs/book/src/developer/providers/v1.1-to-v1.2.md
+++ b/docs/book/src/developer/providers/v1.1-to-v1.2.md
@@ -149,6 +149,12 @@ NOTES:
       <summary>View <code>main.go</code> diff</summary>
 
       ```diff
+      import (
+        ...
+      + "k8s.io/component-base/logs"
+      + _ "k8s.io/component-base/logs/json/register"
+      )
+
       var (
       	...
       +	logOptions = logs.NewOptions()


### PR DESCRIPTION

**What this PR does / why we need it**:
 
I encountered an issue while implementing json logging for CAPO because the `json/register` import was missing and the manager immediately crashed without logging anything. Adding the import fixed this for me, and CAPI also has the import.

Documenting this here will help other provider who want to migrate to `component-base/logs` and json logging.
