### PR TITLE
:warning: Follow XDG Directory standard for config/data/... files

### DIFF
--- a/cmd/clusterctl/client/config.go
+++ b/cmd/clusterctl/client/config.go
@@ -134,7 +134,7 @@ type GetClusterTemplateOptions struct {
 	ClusterName string
 
 	// KubernetesVersion to use for the workload cluster. If unspecified, the value from os env variables
-	// or the .cluster-api/clusterctl.yaml config file will be used.
+	// or the $XDG_CONFIG_HOME/cluster-api/clusterctl.yaml or .cluster-api/clusterctl.yaml config file will be used.
 	KubernetesVersion string
 
 	// ControlPlaneMachineCount defines the number of control plane machines to be added to the workload cluster.

--- a/cmd/clusterctl/client/config/client.go
+++ b/cmd/clusterctl/client/config/client.go
@@ -86,9 +86,12 @@ func newConfigClient(path string, options ...Option) (*configClient, error) {
 	}
 
 	// if there is an injected reader, use it, otherwise use a default one
+	var err error
 	if client.reader == nil {
-		client.reader = newViperReader()
-		if err := client.reader.Init(path); err != nil {
+		if client.reader, err = newViperReader(); err != nil {
+			return nil, errors.Wrap(err, "failed to create the configuration reader")
+		}
+		if err = client.reader.Init(path); err != nil {
 			return nil, errors.Wrap(err, "failed to initialize the configuration reader")
 		}
 	}

--- a/cmd/clusterctl/client/config/reader_viper.go
+++ b/cmd/clusterctl/client/config/reader_viper.go
@@ -27,17 +27,19 @@ import (
 	"strings"
 	"time"
 
+	"github.com/adrg/xdg"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-	"k8s.io/client-go/util/homedir"
 
 	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
 const (
-	// ConfigFolder defines the name of the config folder under $home.
+	// ConfigFolder defines the old name of the config folder under $HOME.
 	ConfigFolder = ".cluster-api"
-	// ConfigName defines the name of the config file under ConfigFolder.
+	// ConfigFolderXDG defines the name of the config folder under $XDG_CONFIG_HOME.
+	ConfigFolderXDG = "cluster-api"
+	// ConfigName defines the name of the config file under ConfigFolderXDG.
 	ConfigName = "clusterctl"
 	// DownloadConfigFile is the config file when fetching the config from a remote location.
 	DownloadConfigFile = "clusterctl-download.yaml"
@@ -58,14 +60,18 @@ func injectConfigPaths(configPaths []string) viperReaderOption {
 }
 
 // newViperReader returns a viperReader.
-func newViperReader(opts ...viperReaderOption) Reader {
+func newViperReader(opts ...viperReaderOption) (Reader, error) {
+	configDirectory, err := xdg.ConfigFile(ConfigFolderXDG)
+	if err != nil {
+		return nil, err
+	}
 	vr := &viperReader{
-		configPaths: []string{filepath.Join(homedir.HomeDir(), ConfigFolder)},
+		configPaths: []string{configDirectory, filepath.Join(xdg.Home, ConfigFolder)},
 	}
 	for _, o := range opts {
 		o(vr)
 	}
-	return vr
+	return vr, nil
 }
 
 // Init initialize the viperReader.
@@ -89,15 +95,17 @@ func (v *viperReader) Init(path string) error {
 
 		switch {
 		case url.Scheme == "https" || url.Scheme == "http":
-			configPath := filepath.Join(homedir.HomeDir(), ConfigFolder)
+			var configDirectory string
 			if len(v.configPaths) > 0 {
-				configPath = v.configPaths[0]
-			}
-			if err := os.MkdirAll(configPath, os.ModePerm); err != nil {
-				return err
+				configDirectory = v.configPaths[0]
+			} else {
+				configDirectory, err = xdg.ConfigFile(ConfigFolderXDG)
+				if err != nil {
+					return err
+				}
 			}
 
-			downloadConfigFile := filepath.Join(configPath, DownloadConfigFile)
+			downloadConfigFile := filepath.Join(configDirectory, DownloadConfigFile)
 			err = downloadFile(url.String(), downloadConfigFile)
 			if err != nil {
 				return err
@@ -112,14 +120,14 @@ func (v *viperReader) Init(path string) error {
 			viper.SetConfigFile(path)
 		}
 	} else {
-		// Checks if there is a default .cluster-api/clusterctl{.extension} file in home directory
+		// Checks if there is a default $XDG_CONFIG_HOME/cluster-api/clusterctl{.extension} or $HOME/.cluster-api/clusterctl{.extension} file
 		if !v.checkDefaultConfig() {
 			// since there is no default config to read from, just skip
 			// reading in config
 			log.V(5).Info("No default config file available")
 			return nil
 		}
-		// Configure viper for reading .cluster-api/clusterctl{.extension} in home directory
+		// Configure viper for reading $XDG_CONFIG_HOME/cluster-api/clusterctl{.extension} or $HOME/.cluster-api/clusterctl{.extension} file
 		viper.SetConfigName(ConfigName)
 		for _, p := range v.configPaths {
 			viper.AddConfigPath(p)

--- a/cmd/clusterctl/client/config/reader_viper_test.go
+++ b/cmd/clusterctl/client/config/reader_viper_test.go
@@ -108,7 +108,7 @@ func Test_viperReader_Init(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gg := NewWithT(t)
-			v := newViperReader(injectConfigPaths(tt.configDirs))
+			v, _ := newViperReader(injectConfigPaths(tt.configDirs))
 			if tt.expectErr {
 				gg.Expect(v.Init(tt.configPath)).ToNot(Succeed())
 				return
@@ -168,7 +168,7 @@ func Test_viperReader_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gs := NewWithT(t)
 
-			v := newViperReader(injectConfigPaths([]string{dir}))
+			v, _ := newViperReader(injectConfigPaths([]string{dir}))
 
 			gs.Expect(v.Init(configFile)).To(Succeed())
 
@@ -192,7 +192,8 @@ func Test_viperReader_GetWithoutDefaultConfig(t *testing.T) {
 
 	_ = os.Setenv("FOO_FOO", "bar")
 
-	v := newViperReader(injectConfigPaths([]string{dir}))
+	v, err := newViperReader(injectConfigPaths([]string{dir}))
+	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(v.Init("")).To(Succeed())
 
 	got, err := v.Get("FOO_FOO")

--- a/cmd/clusterctl/client/repository/overrides.go
+++ b/cmd/clusterctl/client/repository/overrides.go
@@ -23,9 +23,9 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/adrg/xdg"
 	"github.com/drone/envsubst/v2"
 	"github.com/pkg/errors"
-	"k8s.io/client-go/util/homedir"
 
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 )
@@ -68,7 +68,11 @@ func newOverride(o *newOverrideInput) Overrider {
 // Path returns the fully formed path to the file within the specified
 // overrides config.
 func (o *overrides) Path() (string, error) {
-	basepath := filepath.Join(homedir.HomeDir(), config.ConfigFolder, overrideFolder)
+	configDirectory, err := xdg.ConfigFile(config.ConfigFolderXDG)
+	if err != nil {
+		return "", err
+	}
+	basepath := filepath.Join(configDirectory, overrideFolder)
 	f, err := o.configVariablesClient.Get(overrideFolderKey)
 	if err == nil && strings.TrimSpace(f) != "" {
 		basepath = f

--- a/cmd/clusterctl/client/repository/overrides_test.go
+++ b/cmd/clusterctl/client/repository/overrides_test.go
@@ -21,8 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/adrg/xdg"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/util/homedir"
 
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
@@ -30,6 +30,9 @@ import (
 )
 
 func TestOverrides(t *testing.T) {
+	configDirectory, err := xdg.ConfigFile(config.ConfigFolderXDG)
+	NewWithT(t).Expect(err).To(BeNil())
+
 	tests := []struct {
 		name            string
 		configVarClient config.VariablesClient
@@ -39,17 +42,17 @@ func TestOverrides(t *testing.T) {
 		{
 			name:            "returns default overrides path if no config provided",
 			configVarClient: test.NewFakeVariableClient(),
-			expectedPath:    filepath.Join(homedir.HomeDir(), config.ConfigFolder, overrideFolder, "infrastructure-myinfra", "v1.0.1", "infra-comp.yaml"),
+			expectedPath:    filepath.Join(configDirectory, overrideFolder, "infrastructure-myinfra", "v1.0.1", "infra-comp.yaml"),
 		},
 		{
 			name:            "returns default overrides path if config variable is empty",
 			configVarClient: test.NewFakeVariableClient().WithVar(overrideFolderKey, ""),
-			expectedPath:    filepath.Join(homedir.HomeDir(), config.ConfigFolder, overrideFolder, "infrastructure-myinfra", "v1.0.1", "infra-comp.yaml"),
+			expectedPath:    filepath.Join(configDirectory, overrideFolder, "infrastructure-myinfra", "v1.0.1", "infra-comp.yaml"),
 		},
 		{
 			name:            "returns default overrides path if config variable is whitespace",
 			configVarClient: test.NewFakeVariableClient().WithVar(overrideFolderKey, "   "),
-			expectedPath:    filepath.Join(homedir.HomeDir(), config.ConfigFolder, overrideFolder, "infrastructure-myinfra", "v1.0.1", "infra-comp.yaml"),
+			expectedPath:    filepath.Join(configDirectory, overrideFolder, "infrastructure-myinfra", "v1.0.1", "infra-comp.yaml"),
 		},
 		{
 			name:            "uses overrides folder from the config variables",
@@ -86,7 +89,9 @@ func TestOverrides(t *testing.T) {
 				filePath:              "infra-comp.yaml",
 			})
 
-			g.Expect(override.Path()).To(Equal(tt.expectedPath))
+			overridePath, err := override.Path()
+			g.Expect(err).To(BeNil())
+			g.Expect(overridePath).To(Equal(tt.expectedPath))
 		})
 	}
 }

--- a/cmd/clusterctl/cmd/config_repositories.go
+++ b/cmd/clusterctl/cmd/config_repositories.go
@@ -56,7 +56,7 @@ var configRepositoryCmd = &cobra.Command{
 		Display the list of providers and their repository configurations.
 
 		clusterctl ships with a list of known providers; if necessary, edit
-		$HOME/.cluster-api/clusterctl.yaml file to add a new provider or to customize existing ones.`),
+		$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml file to add a new provider or to customize existing ones.`),
 
 	Example: Examples(`
 		# Displays the list of available providers.

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -86,7 +86,7 @@ var template = `---
 providers:
   # add a custom provider
   - name: "my-infra-provider"
-    url: "/home/.cluster-api/overrides/infrastructure-docker/latest/infrastructure-components.yaml"
+    url: "/home/.config/cluster-api/overrides/infrastructure-docker/latest/infrastructure-components.yaml"
     type: "InfrastructureProvider"
   # add a custom provider
   - name: "another-provider"
@@ -129,7 +129,7 @@ kubekey             InfrastructureProvider   https://github.com/kubesphere/kubek
 kubevirt            InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/releases/latest/           infrastructure-components.yaml
 maas                InfrastructureProvider   https://github.com/spectrocloud/cluster-api-provider-maas/releases/latest/                  infrastructure-components.yaml
 metal3              InfrastructureProvider   https://github.com/metal3-io/cluster-api-provider-metal3/releases/latest/                   infrastructure-components.yaml
-my-infra-provider   InfrastructureProvider   /home/.cluster-api/overrides/infrastructure-docker/latest/                                  infrastructure-components.yaml
+my-infra-provider   InfrastructureProvider   /home/.config/cluster-api/overrides/infrastructure-docker/latest/                           infrastructure-components.yaml
 nested              InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-nested/releases/latest/             infrastructure-components.yaml
 nutanix             InfrastructureProvider   https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/releases/latest/       infrastructure-components.yaml
 oci                 InfrastructureProvider   https://github.com/oracle/cluster-api-provider-oci/releases/latest/                         infrastructure-components.yaml
@@ -251,7 +251,7 @@ var expectedOutputYaml = `- File: core_components.yaml
 - File: infrastructure-components.yaml
   Name: my-infra-provider
   ProviderType: InfrastructureProvider
-  URL: /home/.cluster-api/overrides/infrastructure-docker/latest/
+  URL: /home/.config/cluster-api/overrides/infrastructure-docker/latest/
 - File: infrastructure-components.yaml
   Name: nested
   ProviderType: InfrastructureProvider

--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -55,7 +55,7 @@ var generateClusterClusterCmd = &cobra.Command{
 		Generate templates for creating workload clusters.
 
 		clusterctl ships with a list of known providers; if necessary, edit
-		$HOME/.cluster-api/clusterctl.yaml to add new provider or to customize existing ones.
+		$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml to add new provider or to customize existing ones.
 
 		Each provider configuration links to a repository; clusterctl uses this information
 		to fetch templates when creating a new cluster.`),
@@ -112,7 +112,7 @@ func init() {
 	generateClusterClusterCmd.Flags().StringVarP(&gc.targetNamespace, "target-namespace", "n", "",
 		"The namespace to use for the workload cluster. If unspecified, the current namespace will be used.")
 	generateClusterClusterCmd.Flags().StringVar(&gc.kubernetesVersion, "kubernetes-version", "",
-		"The Kubernetes version to use for the workload cluster. If unspecified, the value from OS environment variables or the .cluster-api/clusterctl.yaml config file will be used.")
+		"The Kubernetes version to use for the workload cluster. If unspecified, the value from OS environment variables or the $XDG_CONFIG_HOME/cluster-api/clusterctl.yaml config file will be used.")
 	generateClusterClusterCmd.Flags().Int64Var(&gc.controlPlaneMachineCount, "control-plane-machine-count", 1,
 		"The number of control plane machines for the workload cluster.")
 	generateClusterClusterCmd.Flags().Int64Var(&gc.workerMachineCount, "worker-machine-count", 0,

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -56,7 +56,7 @@ var initCmd = &cobra.Command{
 		to have enough privileges to install the desired components.
 
 		Use 'clusterctl config repositories' to get a list of available providers; if necessary, edit
-		$HOME/.cluster-api/clusterctl.yaml file to add new provider or to customize existing ones.
+		$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml file to add new provider or to customize existing ones.
 
 		Some providers require environment variables to be set before running clusterctl init.
 		Refer to the provider documentation, or use 'clusterctl config provider [name]' to get a list of required variables.

--- a/docs/book/src/clusterctl/commands/additional-commands.md
+++ b/docs/book/src/clusterctl/commands/additional-commands.md
@@ -3,7 +3,7 @@
 Display the list of providers and their repository configurations.
 
 clusterctl ships with a list of known providers; if necessary, edit
-$HOME/.cluster-api/clusterctl.yaml file to add a new provider or to customize existing ones.
+$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml file to add a new provider or to customize existing ones.
 
 # clusterctl help
 

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -127,10 +127,10 @@ See [clusterctl configuration](../configuration.md) for more info about provider
 <h1> Is it possible to override files read from a provider repository? </h1>
 
 If, for any reasons, the user wants to replace the assets available on a provider repository with a locally available asset,
-the user is required to save the file under `$HOME/.cluster-api/overrides/<provider-label>/<version>/<file-name.yaml>`.
+the user is required to save the file under `$XDG_CONFIG_HOME/cluster-api/overrides/<provider-label>/<version>/<file-name.yaml>`.
 
 ```bash
-$HOME/.cluster-api/overrides/infrastructure-aws/v0.5.2/infrastructure-components.yaml
+$XDG_CONFIG_HOME/cluster-api/overrides/infrastructure-aws/v0.5.2/infrastructure-components.yaml
 ```
 
 </aside>

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -1,6 +1,6 @@
 # clusterctl Configuration File
 
-The `clusterctl` config file is located at `$HOME/.cluster-api/clusterctl.yaml`.
+The `clusterctl` config file is located at `$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml`.
 It can be used to:
 
 - Customize the list of providers and provider repositories.
@@ -72,7 +72,7 @@ wants to use a different repository, it is possible to use the following configu
 
 ```yaml
 cert-manager:
-  url: "/Users/foo/.cluster-api/dev-repository/cert-manager/latest/cert-manager.yaml"
+  url: "/Users/foo/.config/cluster-api/dev-repository/cert-manager/latest/cert-manager.yaml"
 ```
 
 **Note**: It is possible to use the `${HOME}` and `${CLUSTERCTL_REPOSITORY_PATH}` environment variables in `url`.
@@ -134,7 +134,7 @@ Overrides only provide file replacements; instead, provider version resolution i
 
 `clusterctl` uses an overrides layer to read in injected provider components,
 cluster templates and metadata. By default, it reads the files from
-`$HOME/.cluster-api/overrides`.
+`$XDG_CONFIG_HOME/cluster-api/overrides`.
 
 The directory structure under the `overrides` directory should follow the
 template:
@@ -262,9 +262,9 @@ images:
 
 To have more verbose logs you can use the `-v` flag when running the `clusterctl` and set the level of the logging verbose with a positive integer number, ie. `-v 3`.
 
-If you do not want to use the flag every time you issue a command you can set the environment variable `CLUSTERCTL_LOG_LEVEL` or set the variable in the `clusterctl` config file located by default at `$HOME/.cluster-api/clusterctl.yaml`.
+If you do not want to use the flag every time you issue a command you can set the environment variable `CLUSTERCTL_LOG_LEVEL` or set the variable in the `clusterctl` config file located by default at `$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml`.
 
 
 ## Skip checking for updates
 
-`clusterctl` automatically checks for new versions every time it is used. If you do not want `clusterctl` to check for new updates you can set the environment variable `CLUSTERCTL_DISABLE_VERSIONCHECK` to `"true"` or set the variable in the `clusterctl` config file located by default at `$HOME/.cluster-api/clusterctl.yaml`.
+`clusterctl` automatically checks for new versions every time it is used. If you do not want `clusterctl` to check for new updates you can set the environment variable `CLUSTERCTL_DISABLE_VERSIONCHECK` to `"true"` or set the variable in the `clusterctl` config file located by default at `$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml`.

--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -66,7 +66,7 @@ cmd/clusterctl/hack/create-local-repository.py
 ```
 
 The script reads from the source folders for the providers you want to install, builds the providers' assets,
-and places them in a local repository folder located under `$HOME/.cluster-api/dev-repository/`.
+and places them in a local repository folder located under `$XDG_CONFIG_HOME/cluster-api/dev-repository/`.
 Additionally, the command output provides you the `clusterctl init` command with all the necessary flags.
 The output should be similar to:
 
@@ -83,7 +83,7 @@ clusterctl init \
    --config ~/.cluster-api/dev-repository/config.yaml
 ```
 
-As you might notice, the command is using the `$HOME/.cluster-api/dev-repository/config.yaml` config file,
+As you might notice, the command is using the `$XDG_CONFIG_HOME/cluster-api/dev-repository/config.yaml` config file,
 containing all the required setting to make clusterctl use the local repository.
 
 <aside class="note warning">

--- a/docs/book/src/tasks/experimental-features/experimental-features.md
+++ b/docs/book/src/tasks/experimental-features/experimental-features.md
@@ -13,7 +13,7 @@ export EXP_CLUSTER_RESOURCE_SET=true
 clusterctl init --infrastructure vsphere
 ```
 
-As an alternative to environment variables, it is also possible to set variables in the clusterctl config file located at `$HOME/.cluster-api/clusterctl.yaml`, e.g.:
+As an alternative to environment variables, it is also possible to set variables in the clusterctl config file located at `$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml`, e.g.:
 ```yaml
 # Values for environment variable substitution
 EXP_CLUSTER_RESOURCE_SET: "true"

--- a/docs/book/src/user/troubleshooting.md
+++ b/docs/book/src/user/troubleshooting.md
@@ -42,7 +42,7 @@ Cluster/capi-quickstart                                        False  Warning   
     └─3 Machines...                                            False  Info      Bootstrapping                77s    See capi-quickstart-md-0-5whtj-5d8c9746c9-f8sw8, capi-quickstart-md-0-5whtj-5d8c9746c9-hzxc2, ...
 ```
 
-In the example above we can see that the Machine `capi-quickstart-6587k-xtvnz` has failed to start. The reason provided is `BootstrapFailed`. 
+In the example above we can see that the Machine `capi-quickstart-6587k-xtvnz` has failed to start. The reason provided is `BootstrapFailed`.
 
 To investigate why a machine fails to start you can inspect the conditions of the objects using `clusterctl describe --show-conditions all cluster capi-quickstart`. You can get more detailed information about the status of the machines using `kubectl describe machines`.
 
@@ -63,8 +63,8 @@ To resolve this specific error please read [Cluster API with Docker  - "too many
 
 ## Node bootstrap failures when using CABPK with cloud-init
 
-Failures during Node bootstrapping can have a lot of different causes. For example, Cluster API resources might be 
-misconfigured or there might be problems with the network. The following steps describe how bootstrap failures can 
+Failures during Node bootstrapping can have a lot of different causes. For example, Cluster API resources might be
+misconfigured or there might be problems with the network. The following steps describe how bootstrap failures can
 be troubleshooted systematically.
 
 1. Access the Node via ssh.
@@ -74,9 +74,9 @@ be troubleshooted systematically.
 1. If you see that kubeadm times out waiting for the static Pods to come up, take a look at:
    1. containerd: `crictl ps -a`, `crictl logs`, `journalctl -u containerd`
    1. Kubelet: `journalctl -u kubelet --since "1 day ago"`
-      (Note: it might be helpful to increase the Kubelet log level by e.g. setting `--v=8` via 
+      (Note: it might be helpful to increase the Kubelet log level by e.g. setting `--v=8` via
       `systemctl edit --full kubelet && systemctl restart kubelet`)
-1. If Node bootstrapping consistently fails and the kubeadm logs are not verbose enough, the `kubeadm` verbosity 
+1. If Node bootstrapping consistently fails and the kubeadm logs are not verbose enough, the `kubeadm` verbosity
    can be increased via `KubeadmConfigSpec.Verbosity`.
 
 ## Labeling nodes with reserved labels such as `node-role.kubernetes.io` fails with kubeadm error during bootstrap
@@ -98,22 +98,22 @@ For convenience, here is an example one-liner to do this post installation
 ```bash
 # Kubernetes 1.19 (kubeadm 1.19 sets only the node-role.kubernetes.io/master label)
 kubectl get nodes --no-headers -l '!node-role.kubernetes.io/master' -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | xargs -I{} kubectl label node {} node-role.kubernetes.io/worker=''
-# Kubernetes >= 1.20 (kubeadm >= 1.20 sets the node-role.kubernetes.io/control-plane label) 
+# Kubernetes >= 1.20 (kubeadm >= 1.20 sets the node-role.kubernetes.io/control-plane label)
 kubectl get nodes --no-headers -l '!node-role.kubernetes.io/control-plane' -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | xargs -I{} kubectl label node {} node-role.kubernetes.io/worker=''
-```                  
+```
 
 ## Cluster API with Docker
 
 When provisioning workload clusters using Cluster API with the Docker infrastructure provider,
-provisioning might be stuck: 
- 
-1. if there are stopped containers on your machine from previous runs. Clean unused containers with [docker rm -f ](https://docs.docker.com/engine/reference/commandline/rm/). 
+provisioning might be stuck:
 
-2. if the Docker space on your disk is being exhausted 
+1. if there are stopped containers on your machine from previous runs. Clean unused containers with [docker rm -f ](https://docs.docker.com/engine/reference/commandline/rm/).
+
+2. if the Docker space on your disk is being exhausted
     * Run [docker system df](https://docs.docker.com/engine/reference/commandline/system_df/) to inspect the disk space consumed by Docker resources.
     * Run [docker system prune --volumes](https://docs.docker.com/engine/reference/commandline/system_prune/) to prune dangling images, containers, volumes and networks.
 
-   
+
 ## Cluster API with Docker  - "too many open files"
 When creating many nodes using Cluster API and Docker infrastructure, either by creating large Clusters or a number of small Clusters, the OS may run into inotify limits which prevent new nodes from being provisioned.
 If the error  `Failed to create inotify object: Too many open files` is present in the logs of the Docker Infrastructure provider this limit is being hit.
@@ -127,7 +127,7 @@ sysctl fs.inotify.max_user_instances=8192
 
 Newly created clusters should be able to take advantage of the increased limits.
 
-### MacOS and Docker Desktop -  "too many open files" 
+### MacOS and Docker Desktop -  "too many open files"
 This error was also observed in Docker Desktop 4.3 and 4.4 on MacOS. It can be resolved by updating to Docker Desktop for Mac 4.5 or using a version lower than 4.3.
 
 [The upstream issue for this error is closed as of the release of Docker 4.5.0](https://github.com/docker/for-mac/issues/6071)
@@ -173,7 +173,7 @@ cert-manager:
   url: "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"
 ```
 
-Alternatively a Cert Manager yaml file can be placed in the [clusterctl overrides layer](../clusterctl/configuration.md#overrides-layer) which is by default in `$HOME/.cluster-api/overrides`. A Cert Manager yaml file can be placed at e.g. `$(HOME)/.cluster-api/overrides/cert-manager/v1.11.0/cert-manager.yaml`
+Alternatively a Cert Manager yaml file can be placed in the [clusterctl overrides layer](../clusterctl/configuration.md#overrides-layer) which is by default in `$XDG_CONFIG_HOME/cluster-api/overrides`. A Cert Manager yaml file can be placed at e.g. `$XDG_CONFIG_HOME/cluster-api/overrides/cert-manager/v1.11.0/cert-manager.yaml`
 
 More information on the clusterctl config file can be found at [its page in the book](../clusterctl/configuration.md#clusterctl-configuration-file)
 
@@ -208,8 +208,8 @@ clusterctl allows users to configure [image overrides](../clusterctl/configurati
 However, when the image override is pinning a provider image to a specific version, it could happen that this
 conflicts with clusterctl behavior of picking the latest version of a provider.
 
-E.g., if you are pinning KCP images to version v1.0.2 but then clusterctl init fetches yamls for version v1.1.0 or greater KCP will 
-fail to start with the following error: 
+E.g., if you are pinning KCP images to version v1.0.2 but then clusterctl init fetches yamls for version v1.1.0 or greater KCP will
+fail to start with the following error:
 
 ```bash
 invalid argument "ClusterTopology=false,KubeadmBootstrapFormatIgnition=false" for "--feature-gates" flag: unrecognized feature gate: KubeadmBootstrapFormatIgnition

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Masterminds/sprig/v3 v3.2.3
+	github.com/adrg/xdg v0.4.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/coredns/corefile-migration v1.0.20
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYr
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/ajeddeloh/go-json v0.0.0-20160803184958-73d058cf8437/go.mod h1:otnto4/Icqn88WCcM4bhIJNSgsh9VLBuspyyCfvof9c=
 github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 h1:4SPQljF/GJ8Q+QlCWMWxRBepub4DresnOm4eI2ebFGc=
 github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559/go.mod h1:otnto4/Icqn88WCcM4bhIJNSgsh9VLBuspyyCfvof9c=
@@ -709,6 +711,7 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -65,6 +65,8 @@ github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v
 github.com/Microsoft/hcsshim v0.9.6 h1:VwnDOgLeoi2du6dAznfmspNqTiwczvjv4K7NxuY9jsY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -724,6 +726,7 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/test/go.mod
+++ b/test/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Microsoft/go-winio v0.5.0 // indirect
+	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -53,6 +53,8 @@ github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBa
 github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/ajeddeloh/go-json v0.0.0-20160803184958-73d058cf8437/go.mod h1:otnto4/Icqn88WCcM4bhIJNSgsh9VLBuspyyCfvof9c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -685,6 +687,7 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This PR switches the hardcoded paths (`$HOME/.cluster-api`) to be [XDG](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) conform (`$XDG_CONFIG_HOME/cluster-api`).

This removes clutter in the users' home directory.

Open questions:
  - I tried adding backwards compatibility to the old path inside the `reader_viper.go` but I'm not sure if this works for everything
  - The script `cmd/clusterctl/hack/create-local-repository.py` creates a `dev-repository` at `$HOME/.cluster-api/dev-repository`. I see three solutions to this;
    - The script uses an [xdg library](https://github.com/srstevenson/xdg), which has to be installed on the users' system, which we'll mention in the docs
    - The script does everything by itself, without needing dependencies
      - This could be a lot of work, especially for Windows and macOS, as I can't test these systems
    - The documentation will mention to overwrite `XDG_CONFIG_HOME` while using the script, this could be weird

    I personally vote for the first possibility