### PR TITLE
:seedling: KCP webhook - compare maxSurge using IntValue

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -338,7 +338,7 @@ func validateRolloutStrategy(rolloutStrategy *RolloutStrategy, replicas *int32, 
 	ios1 := intstr.FromInt(1)
 	ios0 := intstr.FromInt(0)
 
-	if *rolloutStrategy.RollingUpdate.MaxSurge == ios0 && (replicas != nil && *replicas < int32(3)) {
+	if rolloutStrategy.RollingUpdate.MaxSurge.IntValue() == ios0.IntValue() && (replicas != nil && *replicas < int32(3)) {
 		allErrs = append(
 			allErrs,
 			field.Required(
@@ -348,7 +348,7 @@ func validateRolloutStrategy(rolloutStrategy *RolloutStrategy, replicas *int32, 
 		)
 	}
 
-	if *rolloutStrategy.RollingUpdate.MaxSurge != ios1 && *rolloutStrategy.RollingUpdate.MaxSurge != ios0 {
+	if rolloutStrategy.RollingUpdate.MaxSurge.IntValue() != ios1.IntValue() && rolloutStrategy.RollingUpdate.MaxSurge.IntValue() != ios0.IntValue() {
 		allErrs = append(
 			allErrs,
 			field.Required(

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -103,6 +103,10 @@ func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
 	invalidMaxSurge := valid.DeepCopy()
 	invalidMaxSurge.Spec.RolloutStrategy.RollingUpdate.MaxSurge.IntVal = int32(3)
 
+	stringMaxSurge := valid.DeepCopy()
+	val := intstr.FromString("1")
+	stringMaxSurge.Spec.RolloutStrategy.RollingUpdate.MaxSurge = &val
+
 	invalidNamespace := valid.DeepCopy()
 	invalidNamespace.Spec.MachineTemplate.InfrastructureRef.Namespace = "bar"
 
@@ -204,6 +208,12 @@ func TestKubeadmControlPlaneValidateCreate(t *testing.T) {
 			expectErr: true,
 			kcp:       invalidMaxSurge,
 		},
+		{
+			name:      "should succeed when maxSurge is a string",
+			expectErr: false,
+			kcp:       stringMaxSurge,
+		},
+
 		{
 			name:                  "should return error when Ignition configuration is invalid",
 			enableIgnitionFeature: true,


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Allow the Kubeadm Control Plane webhook to accept intOrString types where the base type is a string by comparing using the IntValue() method.

