### PR TITLE
:seedling:  Add more patches to test extension

### DIFF
--- a/internal/controllers/topology/cluster/patches/variables/errors.go
+++ b/internal/controllers/topology/cluster/patches/variables/errors.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package variables
+
+const notFoundReason = "variable not found"
+
+type errorWithReason interface {
+	Reason() string
+}
+
+// IsNotFoundError checks if the passed error is a notFoundError.
+func IsNotFoundError(err error) bool {
+	if e, ok := err.(errorWithReason); ok {
+		return e.Reason() == notFoundReason
+	}
+	return false
+}
+
+// notFoundError is used when a variable is not found.
+type notFoundError struct {
+	reason  string
+	message string
+}
+
+func (e notFoundError) Error() string {
+	return e.message
+}
+
+// Reason returns the notFoundReason.
+func (e notFoundError) Reason() string {
+	return e.reason
+}

--- a/internal/controllers/topology/cluster/patches/variables/value.go
+++ b/internal/controllers/topology/cluster/patches/variables/value.go
@@ -17,6 +17,7 @@ limitations under the License.
 package variables
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -46,7 +47,7 @@ func GetVariableValue(variables map[string]apiextensionsv1.JSON, variablePath st
 	// Get the variable.
 	value, ok := variables[variableNameSegment.path]
 	if !ok {
-		return nil, errors.Errorf("variable %q does not exist", variableName)
+		return nil, notFoundError{reason: notFoundReason, message: fmt.Sprintf("variable %q does not exist", variableName)}
 	}
 
 	// Return the value, if variablePath points to a top-level variable, i.e. hos no relativePath and no
@@ -88,7 +89,7 @@ func GetVariableValue(variables map[string]apiextensionsv1.JSON, variablePath st
 
 		// Return if the variable does not exist.
 		if !variable.Exists(pathSegment.path) {
-			return nil, errors.Errorf("variable %q does not exist: failed to lookup segment %q", variablePath, pathSegment.path)
+			return nil, notFoundError{reason: notFoundReason, message: fmt.Sprintf("variable %q does not exist: failed to lookup segment %q", variablePath, pathSegment.path)}
 		}
 
 		// Get the variable from the variable object.

--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -488,7 +488,7 @@ func runtimeHookTestHandler(ctx context.Context, c client.Client, namespace, clu
 	Eventually(func() bool {
 		return blockingCondition()
 	}, intervals...).Should(BeFalse(),
-		fmt.Sprintf("ClusterTopology reconcile did proceed as expected when calling %s", hookName))
+		fmt.Sprintf("ClusterTopology reconcile did not proceed as expected when calling %s", hookName))
 }
 
 // clusterConditionShowsHookBlocking checks if the TopologyReconciled condition message contains both the hook name and hookFailedMessage.

--- a/test/e2e/data/infrastructure-docker/v1beta1/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/bases/cluster-with-topology.yaml
@@ -27,9 +27,9 @@ spec:
         replicas: ${WORKER_MACHINE_COUNT}
         failureDomain: fd4
     variables:
+      # We set an empty value to use the default tag kubeadm init is using.
     - name: etcdImageTag
-      # We set an empty value to use the default tag kubeadm init is using.
       value: ""
-    - name: coreDNSImageTag
       # We set an empty value to use the default tag kubeadm init is using.
+    - name: coreDNSImageTag
       value: ""

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk-cgroupfs/cluster-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk-cgroupfs/cluster-runtimesdk.yaml
@@ -1,8 +1,0 @@
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
-  name: '${CLUSTER_NAME}'
-  namespace: default
-spec:
-  topology:
-    class: "quick-start-runtimesdk"

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk-cgroupfs/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk-cgroupfs/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
-- ../cluster-template-upgrades-cgroupfs
+- ../cluster-template-upgrades-runtimesdk
+- ./mp-cgroupfs.yaml
 
 patches:
-- ./cluster-runtimesdk.yaml
+- ./mp-default-cgroupfs.yaml

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk-cgroupfs/mp-cgroupfs.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk-cgroupfs/mp-cgroupfs.yaml
@@ -1,0 +1,13 @@
+# KubeadmConfigTemplate referenced by the MachinePool for cgroupfs
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfig
+metadata:
+  name: "${CLUSTER_NAME}-mp-0-config-cgroupfs"
+spec:
+  joinConfiguration:
+    nodeRegistration:
+      kubeletExtraArgs:
+        # We have to pin the cgroupDriver to cgroupfs as kubeadm >=1.21 defaults to systemd
+        # kind will implement systemd support in: https://github.com/kubernetes-sigs/kind/issues/1726
+        cgroup-driver: cgroupfs
+        eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk-cgroupfs/mp-default-cgroupfs.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk-cgroupfs/mp-default-cgroupfs.yaml
@@ -1,0 +1,10 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachinePool
+metadata:
+  name: "${CLUSTER_NAME}-mp-0"
+spec:
+  template:
+    spec:
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-mp-0-config-cgroupfs"

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk/cluster-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk/cluster-runtimesdk.yaml
@@ -3,6 +3,29 @@ kind: Cluster
 metadata:
   name: '${CLUSTER_NAME}'
   namespace: default
+  labels:
+    cni: "${CLUSTER_NAME}-crs-0"
 spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ['${DOCKER_SERVICE_CIDRS}']
+    pods:
+      cidrBlocks: ['${DOCKER_POD_CIDRS}']
+    serviceDomain: '${DOCKER_SERVICE_DOMAIN}'
   topology:
     class: "quick-start-runtimesdk"
+    version: "${KUBERNETES_VERSION}"
+    controlPlane:
+      metadata: {}
+      nodeDeletionTimeout: "30s"
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    workers:
+      machineDeployments:
+        - class: "default-worker"
+          name: "md-0"
+          nodeDeletionTimeout: "30s"
+          replicas: ${WORKER_MACHINE_COUNT}
+          failureDomain: fd4
+    variables:
+      - name: kubeadmControlPlaneMaxSurge
+        value: "1"

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-upgrades-runtimesdk/kustomization.yaml
@@ -1,5 +1,4 @@
 resources:
-- ../cluster-template-upgrades
-
-patches:
-- ./cluster-runtimesdk.yaml
+  - ../bases/crs.yaml
+  - ../bases/mp.yaml
+  - ./cluster-runtimesdk.yaml

--- a/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start-runtimesdk.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start-runtimesdk.yaml
@@ -34,27 +34,19 @@ spec:
             name: quick-start-default-worker-machinetemplate
   variables:
   - name: lbImageRepository
-    required: true
+    required: false
     schema:
       openAPIV3Schema:
         type: string
         default: kindest
-  - name: etcdImageTag
+  - name: imageRepository
     required: true
     schema:
       openAPIV3Schema:
         type: string
-        default: ""
-        example: "3.5.3-0"
-        description: "etcdImageTag sets the tag for the etcd image."
-  - name: coreDNSImageTag
-    required: true
-    schema:
-      openAPIV3Schema:
-        type: string
-        default: ""
-        example: "v1.8.5"
-        description: "coreDNSImageTag sets the tag for the coreDNS image."
+        default: "k8s.gcr.io"
+        example: "k8s.gcr.io"
+        description: "imageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default."
   - name: kubeadmControlPlaneMaxSurge
     required: false
     schema:
@@ -68,114 +60,6 @@ spec:
     external:
       generateExtension: generate-patches.k8s-upgrade-with-runtimesdk
       validateExtension: validate-topology.k8s-upgrade-with-runtimesdk
-  # We have to pin the cgroupDriver to cgroupfs for Kubernetes < v1.24 because kind does not support systemd for those versions, but kubeadm >= 1.21 defaults to systemd.
-  - name: cgroupDriver-controlPlane
-    description: |
-      Sets the cgroupDriver to cgroupfs if a Kubernetes version < v1.24 is referenced.
-      This is required because kind and the node images do not support the default
-      systemd cgroupDriver for kubernetes < v1.24.
-    enabledIf: '{{ semverCompare "<= v1.23" .builtin.controlPlane.version }}'
-    definitions:
-    - selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-        kind: KubeadmControlPlaneTemplate
-        matchResources:
-          controlPlane: true
-      jsonPatches:
-      - op: add
-        path: "/spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs/cgroup-driver"
-        value: cgroupfs
-      - op: add
-        path: "/spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs/cgroup-driver"
-        value: cgroupfs
-  - name: cgroupDriver-machineDeployment
-    description: |
-      Sets the cgroupDriver to cgroupfs if a Kubernetes version < v1.24 is referenced.
-      This is required because kind and the node images do not support the default
-      systemd cgroupDriver for kubernetes < v1.24.
-    enabledIf: '{{ semverCompare "<= v1.23" .builtin.machineDeployment.version }}'
-    definitions:
-    - selector:
-        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-        kind: KubeadmConfigTemplate
-        matchResources:
-          machineDeploymentClass:
-            names:
-            - default-worker
-      jsonPatches:
-      - op: add
-        path: "/spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/cgroup-driver"
-        value: cgroupfs
-  - name: etcdImageTag
-    description: "Sets tag to use for the etcd image in the KubeadmControlPlane."
-    definitions:
-    - selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-        kind: KubeadmControlPlaneTemplate
-        matchResources:
-          controlPlane: true
-      jsonPatches:
-      - op: add
-        path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd"
-        valueFrom:
-          template: |
-            local:
-              imageTag: {{ .etcdImageTag }}
-  - name: coreDNSImageTag
-    description: "Sets tag to use for the etcd image in the KubeadmControlPlane."
-    definitions:
-    - selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-        kind: KubeadmControlPlaneTemplate
-        matchResources:
-          controlPlane: true
-      jsonPatches:
-      - op: add
-        path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/dns"
-        valueFrom:
-          template: |
-            imageTag: {{ .coreDNSImageTag }}
-  - name: customImage
-    description: "Sets the container image that is used for running dockerMachines for the controlPlane and default-worker machineDeployments."
-    definitions:
-    - selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: DockerMachineTemplate
-        matchResources:
-          machineDeploymentClass:
-            names:
-            - default-worker
-      jsonPatches:
-      - op: add
-        path: "/spec/template/spec/customImage"
-        valueFrom:
-          template: |
-            kindest/node:{{ .builtin.machineDeployment.version | replace "+" "_" }}
-    - selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        kind: DockerMachineTemplate
-        matchResources:
-          controlPlane: true
-      jsonPatches:
-      - op: add
-        path: "/spec/template/spec/customImage"
-        valueFrom:
-          template: |
-            kindest/node:{{ .builtin.controlPlane.version | replace "+" "_" }}
-  - name: kubeadmControlPlaneMaxSurge
-    description: "Sets the maxSurge value used for rolloutStrategy in the KubeadmControlPlane."
-    enabledIf: '{{ ne .kubeadmControlPlaneMaxSurge "" }}'
-    definitions:
-    - selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-        kind: KubeadmControlPlaneTemplate
-        matchResources:
-          controlPlane: true
-      jsonPatches:
-      - op: add
-        path: /spec/template/spec/rolloutStrategy/rollingUpdate/maxSurge
-        valueFrom:
-          template: "{{ .kubeadmControlPlaneMaxSurge }}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate

--- a/test/extension/config/tilt/hookresponses-configmap.yaml
+++ b/test/extension/config/tilt/hookresponses-configmap.yaml
@@ -6,11 +6,7 @@ metadata:
 data:
   AfterClusterUpgrade-preloadedResponse: '{"Status": "Success"}'
   AfterControlPlaneInitialized-preloadedResponse: '{"Status": "Success"}'
-  AfterControlPlaneUpgrade-preloadedResponse: '{"Status": "Success", "RetryAfterSeconds":
-    5}'
-  BeforeClusterCreate-preloadedResponse: '{"Status": "Success", "RetryAfterSeconds":
-    5}'
-  BeforeClusterDelete-preloadedResponse: '{"Status": "Success", "RetryAfterSeconds":
-    5}'
-  BeforeClusterUpgrade-preloadedResponse: '{"Status": "Success", "RetryAfterSeconds":
-    5}'
+  AfterControlPlaneUpgrade-preloadedResponse: '{"Status": "Success"}'
+  BeforeClusterCreate-preloadedResponse: '{"Status": "Success"}'
+  BeforeClusterDelete-preloadedResponse: '{"Status": "Success"}'
+  BeforeClusterUpgrade-preloadedResponse: '{"Status": "Success"}'

--- a/test/extension/handlers/topologymutation/handler.go
+++ b/test/extension/handlers/topologymutation/handler.go
@@ -19,64 +19,265 @@ package topologymutation
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"strings"
 
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	patchvariables "sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/patches/variables"
 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/version"
 )
 
 // NewHandler returns a new topology mutation Handler.
 func NewHandler(scheme *runtime.Scheme) *Handler {
 	return &Handler{
+		// Add the apiGroups being handled to the decoder
 		decoder: serializer.NewCodecFactory(scheme).UniversalDecoder(
 			infrav1.GroupVersion,
+			controlplanev1.GroupVersion,
+			bootstrapv1.GroupVersion,
 		),
 	}
 }
+
+var (
+	cgroupDriverCgroupfs            = "cgroupfs"
+	cgroupDriverPatchVersionCeiling = semver.Version{Major: 1, Minor: 24}
+)
 
 // Handler is a topology mutation handler.
 type Handler struct {
 	decoder runtime.Decoder
 }
 
-// GeneratePatches returns a function that generates patches for the given request.
+// GeneratePatches generates patches for the given request.
 func (h *Handler) GeneratePatches(ctx context.Context, req *runtimehooksv1.GeneratePatchesRequest, resp *runtimehooksv1.GeneratePatchesResponse) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("GeneratePatches called")
+	log.Info("GeneratePatches is called")
+	walkTemplates(h.decoder, req, resp, func(obj runtime.Object, variables map[string]apiextensionsv1.JSON, holderRef runtimehooksv1.HolderReference) error {
+		holderRefGV, err := schema.ParseGroupVersion(holderRef.APIVersion)
+		if err != nil {
+			return errors.Wrapf(err, "error generating patches - HolderReference apiVersion %q is not in valid format", holderRef.APIVersion)
+		}
+		log = log.WithValues(
+			"template", logRef{
+				Group:   obj.GetObjectKind().GroupVersionKind().Group,
+				Version: obj.GetObjectKind().GroupVersionKind().Version,
+				Kind:    obj.GetObjectKind().GroupVersionKind().Kind,
+			},
+			"holder", logRef{
+				Group:     holderRefGV.Group,
+				Version:   holderRefGV.Version,
+				Kind:      holderRef.Kind,
+				Namespace: holderRef.Namespace,
+				Name:      holderRef.Name,
+			},
+		)
+		log.Info("Patching template")
 
-	walkTemplates(h.decoder, req, resp, func(obj runtime.Object, variables map[string]apiextensionsv1.JSON) error {
-		if dockerClusterTemplate, ok := obj.(*infrav1.DockerClusterTemplate); ok {
-			if err := patchDockerClusterTemplate(dockerClusterTemplate, variables); err != nil {
-				return err
+		switch obj := obj.(type) {
+		case *infrav1.DockerClusterTemplate:
+			if err := patchDockerClusterTemplate(ctx, obj, variables); err != nil {
+				log.Error(err, "error patching DockerClusterTemplate")
+				return errors.Wrap(err, "error patching DockerClusterTemplate")
+			}
+		case *controlplanev1.KubeadmControlPlaneTemplate:
+			err := patchKubeadmControlPlaneTemplate(ctx, obj, variables)
+			if err != nil {
+				log.Error(err, "error patching KubeadmControlPlaneTemplate")
+				return errors.Wrapf(err, "error patching KubeadmControlPlaneTemplate")
+			}
+
+		case *bootstrapv1.KubeadmConfigTemplate:
+			if err := patchKubeadmConfigTemplate(ctx, obj, variables); err != nil {
+				log.Error(err, "error patching KubeadmConfigTemplate")
+				return errors.Wrap(err, "error patching KubeadmConfigTemplate")
+			}
+		case *infrav1.DockerMachineTemplate:
+			if err := patchDockerMachineTemplate(ctx, obj, variables); err != nil {
+				log.Error(err, "error patching DockerMachineTemplate")
+				return errors.Wrap(err, "error patching DockerMachineTemplate")
 			}
 		}
-
 		return nil
 	})
 }
 
-// patchDockerClusterTemplate patches the DockerClusterTepmlate.
-func patchDockerClusterTemplate(dockerClusterTemplate *infrav1.DockerClusterTemplate, templateVariables map[string]apiextensionsv1.JSON) error {
-	// Get the variable value as JSON string.
-	value, err := patchvariables.GetVariableValue(templateVariables, "lbImageRepository")
+func patchKubeadmControlPlaneTemplate(ctx context.Context, kcpTemplate *controlplanev1.KubeadmControlPlaneTemplate, templateVariables map[string]apiextensionsv1.JSON) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// 1) If the Kubernetes version from builtin.controlPlane.version is below 1.24.0 set "cgroup-driver": "cgroupfs" to
+	//    - kubeadmConfigSpec.InitConfiguration.NodeRegistration.KubeletExtraArgs
+	//    - kubeadmConfigSpec.JoinConfiguration.NodeRegistration.KubeletExtraArgs
+	found, cpVersion, err := getStringValueForVariable(templateVariables, "builtin.controlPlane.version")
+	if err != nil {
+		return errors.Wrap(err, "could not set cgroup-driver to control plane template kubeletExtraArgs")
+	}
+	// This is a required variable. Return an error if it's not found.
+	if !found {
+		return errors.New("could not set cgroup-driver to control plane template kubeletExtraArgs: variable \"builtin.controlPlane.version\" not found")
+	}
+
+	controlPlaneVersion, err := version.ParseMajorMinorPatchTolerant(cpVersion)
 	if err != nil {
 		return err
 	}
+	if version.Compare(controlPlaneVersion, cgroupDriverPatchVersionCeiling) == -1 {
+		log.Info(fmt.Sprintf("Setting KubeadmControlPlaneTemplate cgroup-driver to %q", cgroupDriverCgroupfs))
+		// Set the cgroupDriver in the InitConfiguration.
+		if kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration == nil {
+			kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration = &bootstrapv1.InitConfiguration{}
+		}
+		if kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.NodeRegistration.KubeletExtraArgs == nil {
+			kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{}
+		}
+		kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.InitConfiguration.NodeRegistration.KubeletExtraArgs["cgroup-driver"] = cgroupDriverCgroupfs
 
-	// Unquote the JSON string.
-	stringValue, err := strconv.Unquote(string(value.Raw))
-	if err != nil {
-		return err
+		// Set the cgroupDriver in the JoinConfiguration.
+		if kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration == nil {
+			kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
+		}
+		if kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.KubeletExtraArgs == nil {
+			kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{}
+		}
+		kcpTemplate.Spec.Template.Spec.KubeadmConfigSpec.JoinConfiguration.NodeRegistration.KubeletExtraArgs["cgroup-driver"] = cgroupDriverCgroupfs
 	}
 
-	dockerClusterTemplate.Spec.Template.Spec.LoadBalancer.ImageRepository = stringValue
+	// 2) Patch RolloutStrategy RollingUpdate MaxSurge with the value from the Cluster Topology variable.
+	//    If this is unset continue as this variable is not required.
+	found, kcpControlPlaneMaxSurge, err := getStringValueForVariable(templateVariables, "kubeadmControlPlaneMaxSurge")
+	if err != nil {
+		return errors.Wrap(err, "could not set KubeadmControlPlaneTemplate MaxSurge")
+	}
+	if found {
+		// This has to be converted to IntOrString type.
+		kubeadmControlPlaneMaxSurgeIntOrString := intstrutil.Parse(kcpControlPlaneMaxSurge)
+		log.Info(fmt.Sprintf("Setting KubeadmControlPlaneMaxSurge to %q", kubeadmControlPlaneMaxSurgeIntOrString.String()))
+		if kcpTemplate.Spec.Template.Spec.RolloutStrategy == nil {
+			kcpTemplate.Spec.Template.Spec.RolloutStrategy = &controlplanev1.RolloutStrategy{}
+		}
+		if kcpTemplate.Spec.Template.Spec.RolloutStrategy.RollingUpdate == nil {
+			kcpTemplate.Spec.Template.Spec.RolloutStrategy.RollingUpdate = &controlplanev1.RollingUpdate{}
+		}
+		kcpTemplate.Spec.Template.Spec.RolloutStrategy.RollingUpdate.MaxSurge = &kubeadmControlPlaneMaxSurgeIntOrString
+	}
 	return nil
+}
+
+// patchDockerClusterTemplate patches the DockerClusterTemplate.
+func patchDockerClusterTemplate(_ context.Context, dockerClusterTemplate *infrav1.DockerClusterTemplate, templateVariables map[string]apiextensionsv1.JSON) error {
+	found, lbImageRepo, err := getStringValueForVariable(templateVariables, "lbImageRepository")
+	if err != nil {
+		return errors.Wrap(err, "could not set DockerClusterTemplate loadBalancer imageRepository")
+	}
+	if found {
+		dockerClusterTemplate.Spec.Template.Spec.LoadBalancer.ImageRepository = lbImageRepo
+	}
+	return nil
+}
+
+func patchKubeadmConfigTemplate(ctx context.Context, k *bootstrapv1.KubeadmConfigTemplate, templateVariables map[string]apiextensionsv1.JSON) error {
+	log := ctrl.LoggerFrom(ctx)
+	// Only patch the customImage if this DockerMachineTemplate belongs to a MachineDeployment with class "default-class"
+	found, mdClass, err := getStringValueForVariable(templateVariables, "builtin.machineDeployment.class")
+	if err != nil {
+		return errors.Wrap(err, "could not set cgroup-driver to KubeadmConfigTemplate template kubeletExtraArgs")
+	}
+
+	// This is a required variable. Return an error if it's not found.
+	if !found {
+		return errors.New("could not set cgroup-driver to KubeadmConfigTemplate template kubeletExtraArgs: variable \"builtin.machineDeployment.class\" not found")
+	}
+
+	if mdClass == "default-worker" {
+		// If the Kubernetes version from builtin.machineDeployment.version is below 1.24.0 set "cgroup-driver": "cgroupDriverCgroupfs" to
+		//    - InitConfiguration.KubeletExtraArgs
+		//    - JoinConfiguration.KubeletExtraArgs
+		found, mdVersion, err := getStringValueForVariable(templateVariables, "builtin.machineDeployment.version")
+		if err != nil {
+			return errors.Wrap(err, "could not set cgroup-driver to KubeadmConfigTemplate template kubeletExtraArgs")
+		}
+
+		// This is a required variable. Return an error if it's not found.
+		if !found {
+			return errors.New("could not set cgroup-driver to KubeadmConfigTemplate template kubeletExtraArgs: variable \"builtin.machineDeployment.version\" not found")
+		}
+		machineDeploymentVersion, err := version.ParseMajorMinorPatchTolerant(mdVersion)
+		if err != nil {
+			return errors.Wrap(err, "could not set cgroup-driver to KubeadmConfigTemplate template kubeletExtraArgs")
+		}
+		if version.Compare(machineDeploymentVersion, cgroupDriverPatchVersionCeiling) == -1 {
+			log.Info(fmt.Sprintf("Setting KubeadmConfigTemplate cgroup-driver to %q", cgroupDriverCgroupfs))
+			// Set the cgroupDriver in the InitConfiguration.
+			if k.Spec.Template.Spec.InitConfiguration == nil {
+				k.Spec.Template.Spec.InitConfiguration = &bootstrapv1.InitConfiguration{}
+			}
+			if k.Spec.Template.Spec.InitConfiguration.NodeRegistration.KubeletExtraArgs == nil {
+				k.Spec.Template.Spec.InitConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{}
+			}
+			k.Spec.Template.Spec.InitConfiguration.NodeRegistration.KubeletExtraArgs["cgroup-driver"] = cgroupDriverCgroupfs
+
+			// Set the cgroupDriver in the JoinConfiguration.
+			if k.Spec.Template.Spec.JoinConfiguration == nil {
+				k.Spec.Template.Spec.JoinConfiguration = &bootstrapv1.JoinConfiguration{}
+			}
+			if k.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs == nil {
+				k.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{}
+			}
+
+			k.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs["cgroup-driver"] = cgroupDriverCgroupfs
+		}
+	}
+	return nil
+}
+
+func patchDockerMachineTemplate(ctx context.Context, dockerMachineTemplate *infrav1.DockerMachineTemplate, templateVariables map[string]apiextensionsv1.JSON) error {
+	log := ctrl.LoggerFrom(ctx)
+	found, cpVersion, err := getStringValueForVariable(templateVariables, "builtin.controlPlane.version")
+	if err != nil {
+		return errors.Wrap(err, "could not set customImage to control plane dockerMachineTemplate")
+	}
+	if found {
+		_, err := version.ParseMajorMinorPatchTolerant(cpVersion)
+		if err != nil {
+			return errors.Wrap(err, "could not parse control plane version")
+		}
+		customImage := fmt.Sprintf("kindest/node:%s", strings.ReplaceAll(cpVersion, "+", "_"))
+		log.Info(fmt.Sprintf("Setting MachineDeployment custom image to %q", customImage))
+		dockerMachineTemplate.Spec.Template.Spec.CustomImage = customImage
+		// return early if we have successfully patched a control plane dockerMachineTemplate
+		return nil
+	}
+
+	// If the DockerMachineTemplate does not belong to a ControlPlane check if it belongs to a MachineDeployment
+	found, mdVersion, err := getStringValueForVariable(templateVariables, "builtin.machineDeployment.version")
+	if err != nil {
+		return errors.Wrap(err, "could not set customImage to MachineDeployment DockerMachineTemplate")
+	}
+	if found {
+		_, err := version.ParseMajorMinorPatchTolerant(mdVersion)
+		if err != nil {
+			return errors.Wrap(err, "could not parse MachineDeployment version")
+		}
+		customImage := fmt.Sprintf("kindest/node:%s", strings.ReplaceAll(mdVersion, "+", "_"))
+		log.Info(fmt.Sprintf("Setting MachineDeployment customImage to %q", customImage))
+		dockerMachineTemplate.Spec.Template.Spec.CustomImage = customImage
+		return nil
+	}
+	// If the Docker Machine didn't have variables for either a control plane or a machineDeployment return an error.
+	return errors.New("no version variables found for DockerMachineTemplate patch")
 }
 
 // ValidateTopology returns a function that validates the given request.
@@ -85,4 +286,21 @@ func (h *Handler) ValidateTopology(ctx context.Context, _ *runtimehooksv1.Valida
 	log.Info("ValidateTopology called")
 
 	resp.Status = runtimehooksv1.ResponseStatusSuccess
+}
+
+// getStringValueForVariable Get the variable value as JSON string.
+func getStringValueForVariable(templateVariables map[string]apiextensionsv1.JSON, variableName string) (bool, string, error) {
+	value, err := patchvariables.GetVariableValue(templateVariables, variableName)
+	if err != nil {
+		if patchvariables.IsNotFoundError(err) {
+			return false, "", nil
+		}
+		return false, "", err
+	}
+	// Unquote the JSON string.
+	stringValue, err := strconv.Unquote(string(value.Raw))
+	if err != nil {
+		return true, "", err
+	}
+	return true, stringValue, nil
 }

--- a/test/extension/handlers/topologymutation/handler_test.go
+++ b/test/extension/handlers/topologymutation/handler_test.go
@@ -1,0 +1,391 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymutation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+	. "sigs.k8s.io/cluster-api/internal/test/matchers"
+	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = infrav1.AddToScheme(testScheme)
+	_ = controlplanev1.AddToScheme(testScheme)
+	_ = bootstrapv1.AddToScheme(testScheme)
+}
+
+func TestHandler_GeneratePatches(t *testing.T) {
+	g := NewWithT(t)
+	h := NewHandler(testScheme)
+	emptyVars := []runtimehooksv1.Variable{}
+	controlPlaneVarsV123WithMaxSurge := []runtimehooksv1.Variable{
+		builtInVariablesForControlPlane("v1.23.0"),
+		newVariable("kubeadmControlPlaneMaxSurge", "3"),
+	}
+	controlPlaneVarsV123 := []runtimehooksv1.Variable{
+		builtInVariablesForControlPlane("v1.23.0"),
+	}
+	controlPlaneVarsInvalidVersion := []runtimehooksv1.Variable{
+		builtInVariablesForControlPlane("v1.23.x"),
+	}
+	machineDeploymentVarsInvalidVersion := []runtimehooksv1.Variable{
+		builtInVariablesForControlPlane("v1.23.x"),
+	}
+	lbImageRepositoryVar := []runtimehooksv1.Variable{
+		newVariable("lbImageRepository", "docker.io"),
+	}
+	controlPlaneVarsV124 := []runtimehooksv1.Variable{
+		builtInVariablesForControlPlane("v1.24.0"),
+	}
+	machineDeploymentVars123 := []runtimehooksv1.Variable{
+		builtInVariablesForMachineDeployment("default-worker", "v1.23.0"),
+	}
+	machineDeploymentVars124 := []runtimehooksv1.Variable{
+		builtInVariablesForMachineDeployment("default-worker", "v1.24.0"),
+	}
+	kubeadmControlPlaneTemplate := controlplanev1.KubeadmControlPlaneTemplate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeadmControlPlaneTemplate",
+			APIVersion: controlplanev1.GroupVersion.String(),
+		},
+	}
+	dockerMachineTemplate := infrav1.DockerMachineTemplate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DockerMachineTemplate",
+			APIVersion: infrav1.GroupVersion.String(),
+		},
+	}
+	dockerClusterTemplate := infrav1.DockerClusterTemplate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DockerClusterTemplate",
+			APIVersion: infrav1.GroupVersion.String(),
+		},
+	}
+	kubeadmConfigTemplate := bootstrapv1.KubeadmConfigTemplate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KubeadmConfigTemplate",
+			APIVersion: bootstrapv1.GroupVersion.String(),
+		},
+	}
+	tests := []struct {
+		name             string
+		requestItems     []runtimehooksv1.GeneratePatchesRequestItem
+		expectedResponse *runtimehooksv1.GeneratePatchesResponse
+	}{
+		{
+			name: "With version 1.23 for all objects KubeadmControlPlane, KubeadmConfigTemplate, DockerClusterTemplate and DockerMachineTemplate",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", kubeadmControlPlaneTemplate, controlPlaneVarsV123WithMaxSurge),
+				requestItem("2", dockerMachineTemplate, controlPlaneVarsV123WithMaxSurge),
+				requestItem("3", dockerMachineTemplate, machineDeploymentVars123),
+				requestItem("4", dockerClusterTemplate, lbImageRepositoryVar),
+				requestItem("5", kubeadmConfigTemplate, machineDeploymentVars123),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusSuccess,
+				},
+				Items: []runtimehooksv1.GeneratePatchesResponseItem{
+					responseItem("1", `[
+{"op":"add","path":"/spec/template/spec/kubeadmConfigSpec/initConfiguration","value":{"localAPIEndpoint":{},"nodeRegistration":{"kubeletExtraArgs":{"cgroup-driver":"cgroupfs"}}}},
+{"op":"add","path":"/spec/template/spec/kubeadmConfigSpec/joinConfiguration","value":{"discovery":{},"nodeRegistration":{"kubeletExtraArgs":{"cgroup-driver":"cgroupfs"}}}},
+{"op":"add","path":"/spec/template/spec/rolloutStrategy","value":{"rollingUpdate":{"maxSurge":3}}}
+]`),
+					responseItem("2", `[
+{"op":"add","path":"/spec/template/spec/customImage","value":"kindest/node:v1.23.0"}
+]`),
+					responseItem("3", `[
+{"op":"add","path":"/spec/template/spec/customImage","value":"kindest/node:v1.23.0"}
+]`),
+
+					responseItem("4", `[
+{"op":"add","path":"/spec/template/spec/loadBalancer/imageRepository","value":"docker.io"}
+]`),
+					responseItem("5", `[
+{"op":"add","path":"/spec/template/spec/joinConfiguration","value":{"discovery":{},"nodeRegistration":{"kubeletExtraArgs":{"cgroup-driver":"cgroupfs"}}}},
+{"op":"add","path":"/spec/template/spec/initConfiguration","value":{"localAPIEndpoint":{},"nodeRegistration":{"kubeletExtraArgs":{"cgroup-driver":"cgroupfs"}}}}
+]`),
+				},
+			},
+		},
+		{
+			name: "With version 1.24 for CP and MD no patch for KubeadmControlPlane, KubeadmConfigTemplate",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", kubeadmControlPlaneTemplate, controlPlaneVarsV124),
+				requestItem("4", kubeadmConfigTemplate, machineDeploymentVars124),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusSuccess,
+				},
+				Items: []runtimehooksv1.GeneratePatchesResponseItem{
+					responseItem("1", `[]`),
+					responseItem("4", `[]`),
+				},
+			},
+		},
+		{
+			name: "With version 1.24 for CP and v1.23 for MD no patch for KubeadmControlPlane, patch KubeadmConfigTemplate",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", kubeadmControlPlaneTemplate, controlPlaneVarsV124),
+				requestItem("4", kubeadmConfigTemplate, machineDeploymentVars123),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusSuccess,
+				},
+				Items: []runtimehooksv1.GeneratePatchesResponseItem{
+					responseItem("1", `[]`),
+					responseItem("4", `[
+{"op":"add","path":"/spec/template/spec/joinConfiguration","value":{"discovery":{},"nodeRegistration":{"kubeletExtraArgs":{"cgroup-driver":"cgroupfs"}}}},
+{"op":"add","path":"/spec/template/spec/initConfiguration","value":{"localAPIEndpoint":{},"nodeRegistration":{"kubeletExtraArgs":{"cgroup-driver":"cgroupfs"}}}}
+]`),
+				},
+			},
+		},
+		{
+			name: "With version 1.23 for CP and v1.24 for MD patch KubeadmControlPlane, no patch for KubeadmConfigTemplate",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", kubeadmControlPlaneTemplate, controlPlaneVarsV123),
+				requestItem("4", kubeadmConfigTemplate, machineDeploymentVars124),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusSuccess,
+				},
+				Items: []runtimehooksv1.GeneratePatchesResponseItem{
+					responseItem("1", `[
+{"op":"add","path":"/spec/template/spec/kubeadmConfigSpec/initConfiguration","value":{"localAPIEndpoint":{},"nodeRegistration":{"kubeletExtraArgs":{"cgroup-driver":"cgroupfs"}}}},
+{"op":"add","path":"/spec/template/spec/kubeadmConfigSpec/joinConfiguration","value":{"discovery":{},"nodeRegistration":{"kubeletExtraArgs":{"cgroup-driver":"cgroupfs"}}}}
+]`),
+					responseItem("4", `[]`),
+				},
+			},
+		},
+		{
+			name: "Error with an invalid version for the KubeadmControlPlane patch",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("2", kubeadmControlPlaneTemplate, controlPlaneVarsInvalidVersion),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusFailure,
+				},
+			},
+		},
+		{
+			name: "Error with an invalid version for the machine deployment KubeadmConfigTemplate patch",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", kubeadmConfigTemplate, machineDeploymentVarsInvalidVersion),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusFailure,
+				},
+			},
+		},
+		{
+			name: "Error with an invalid version for the machine deployment DockerMachineTemplate patch",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", dockerMachineTemplate, machineDeploymentVarsInvalidVersion),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusFailure,
+				},
+			},
+		},
+		{
+			name: "Error with an invalid version for the control plane DockerMachineTemplate patch",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", dockerMachineTemplate, controlPlaneVarsInvalidVersion),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusFailure,
+				},
+			},
+		},
+		{
+			name: "Error with no variables found the control plane DockerMachineTemplate patch",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", dockerMachineTemplate, emptyVars),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusFailure,
+				},
+			},
+		},
+		{
+			name: "Error with no variables found for the MachineDeployment DockerMachineTemplate patch",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", dockerMachineTemplate, emptyVars),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusFailure,
+				},
+			},
+		},
+		{
+			name: "Error with no variables found for the KubeadmControlPlane patch",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", kubeadmControlPlaneTemplate, emptyVars),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusFailure,
+				},
+			},
+		},
+		{
+			name: "Error with no variables found for the KubeadmConfigTemplate patch",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", kubeadmConfigTemplate, emptyVars),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusFailure,
+				},
+			},
+		},
+		{
+			name: "No error and no patch with no variables found for the DockerCluster patch",
+			requestItems: []runtimehooksv1.GeneratePatchesRequestItem{
+				requestItem("1", dockerClusterTemplate, emptyVars),
+			},
+			expectedResponse: &runtimehooksv1.GeneratePatchesResponse{
+				CommonResponse: runtimehooksv1.CommonResponse{
+					Status: runtimehooksv1.ResponseStatusSuccess,
+				},
+				Items: []runtimehooksv1.GeneratePatchesResponseItem{
+					responseItem("1", `[]`),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &runtimehooksv1.GeneratePatchesResponse{}
+			request := &runtimehooksv1.GeneratePatchesRequest{Items: tt.requestItems}
+			h.GeneratePatches(context.Background(), request, response)
+
+			// Expect all response fields to be as expected. responseItems are ignored here and tested below.
+			// Ignore the message to not compare error strings.
+			g.Expect(tt.expectedResponse).To(EqualObject(response, IgnorePaths{{"items"}, {"message"}}))
+			// For each item in the response check that the patches are the same.
+			// Note that the order of the individual patch operations in Items[].Patch is not determinate so we unmarshal
+			// to an array and check that the arrays hold equivalent items.
+			for i, item := range response.Items {
+				expectedItem := tt.expectedResponse.Items[i]
+				g.Expect(item.PatchType).To(Equal(expectedItem.PatchType))
+				g.Expect(item.UID).To(Equal(expectedItem.UID))
+
+				var actualPatchOps []map[string]interface{}
+				var expectedPatchOps []map[string]interface{}
+				g.Expect(json.Unmarshal(item.Patch, &actualPatchOps)).To(Succeed())
+				g.Expect(json.Unmarshal(expectedItem.Patch, &expectedPatchOps)).To(Succeed())
+				g.Expect(actualPatchOps).To(ConsistOf(expectedPatchOps))
+			}
+		})
+	}
+}
+
+// toJSONCompact is used to be able to write JSON values in a readable manner.
+func toJSONCompact(value string) []byte {
+	var compactValue bytes.Buffer
+	if err := json.Compact(&compactValue, []byte(value)); err != nil {
+		panic(err)
+	}
+	return compactValue.Bytes()
+}
+
+// toJSON marshals the object and returns a byte array. This function panics on any error.
+func toJSON(val interface{}) []byte {
+	jsonStr, err := json.Marshal(val)
+	if err != nil {
+		panic(err)
+	}
+	return jsonStr
+}
+
+// requestItem returns a GeneratePatchesRequestItem with the given uid, variables and object.
+func requestItem(uid string, object interface{}, variables []runtimehooksv1.Variable) runtimehooksv1.GeneratePatchesRequestItem {
+	return runtimehooksv1.GeneratePatchesRequestItem{
+		UID:       types.UID(uid),
+		Variables: variables,
+		Object: runtime.RawExtension{
+			Raw: toJSON(object),
+		},
+	}
+}
+
+// responseItem returns a GeneratePatchesResponseItem of PatchType JSONPatch with the passed uid and patch.
+func responseItem(uid, patch string) runtimehooksv1.GeneratePatchesResponseItem {
+	return runtimehooksv1.GeneratePatchesResponseItem{
+		UID:       types.UID(uid),
+		PatchType: runtimehooksv1.JSONPatchType,
+		Patch:     toJSONCompact(patch),
+	}
+}
+
+// builtInVariablesForControlPlane returns a runtimehooksv1.Variable for a control plane with the passed version.
+func builtInVariablesForControlPlane(version string) runtimehooksv1.Variable {
+	vars := map[string]interface{}{
+		"controlPlane": map[string]interface{}{
+			"version": version,
+		},
+	}
+	return newVariable("builtin", vars)
+}
+
+// newVariable returns a runtimehooksv1.Variable with the passed name and value.
+func newVariable(name string, value interface{}) runtimehooksv1.Variable {
+	return runtimehooksv1.Variable{
+		Name:  name,
+		Value: apiextensionsv1.JSON{Raw: toJSON(value)},
+	}
+}
+
+// builtInVariablesForMachineDeployment returns a runtimehooksv1.Variable for a machineDeployment with the passed class and version.
+func builtInVariablesForMachineDeployment(class, version string) runtimehooksv1.Variable {
+	vars := map[string]interface{}{
+		"machineDeployment": map[string]interface{}{
+			"version": version,
+			"class":   class,
+		},
+	}
+	return newVariable("builtin", vars)
+}

--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -28,11 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
+	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 	"sigs.k8s.io/cluster-api/exp/runtime/server"
@@ -57,6 +60,8 @@ var (
 
 func init() {
 	_ = infrav1.AddToScheme(scheme)
+	_ = controlplanev1.AddToScheme(scheme)
+	_ = bootstrapv1.AddToScheme(scheme)
 
 	// Register the RuntimeHook types into the catalog.
 	_ = runtimehooksv1.AddToCatalog(catalog)
@@ -113,6 +118,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Add the scheme with registered types to the topologyMutationHandler
 	topologyMutationHandler := topologymutation.NewHandler(scheme)
 
 	if err := webhookServer.AddExtensionHandler(server.ExtensionHandler{


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>
Work in progress - no need to review

This PR moves patches in the runtime SDK end to end test to the test extension. 

Two patches - for etcd and coredns image tags - have been dropped as they add a complication to the running of the test, causing a double rollout when set on update with a blocking cluster upgrade webhook.

Fixes #6859 