### PR TITLE
🐛  fix log formatting in runtime client

### DIFF
--- a/internal/runtime/client/client.go
+++ b/internal/runtime/client/client.go
@@ -369,7 +369,7 @@ func (c *client) CallExtension(ctx context.Context, hook runtimecatalog.Hook, fo
 	}
 
 	if retryResponse, ok := response.(runtimehooksv1.RetryResponseObject); ok && retryResponse.GetRetryAfterSeconds() != 0 {
-		log.Info(fmt.Sprintf("extension handler returned blocking response with retryAfterSeconds of %q", retryResponse.GetRetryAfterSeconds()))
+		log.Info(fmt.Sprintf("extension handler returned blocking response with retryAfterSeconds of %d", retryResponse.GetRetryAfterSeconds()))
 	} else {
 		log.Info("extension handler returned success response")
 	}


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fixes a small error in formatting in one of our client log lines.
