### PR TITLE
🌱 rename CloneTemplate to CreateFromTemplate

### DIFF
--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -60,6 +60,7 @@ func Delete(ctx context.Context, c client.Writer, ref *corev1.ObjectReference) e
 }
 
 // CloneTemplateInput is the input to CloneTemplate.
+// Deprecated: use CreateFromTemplateInput instead. This type will be removed in a future release.
 type CloneTemplateInput struct {
 	// Client is the controller runtime client.
 	Client client.Client
@@ -87,7 +88,63 @@ type CloneTemplateInput struct {
 }
 
 // CloneTemplate uses the client and the reference to create a new object from the template.
+// Deprecated: use CreateFromTemplate instead. This function will be removed in a future release.
 func CloneTemplate(ctx context.Context, in *CloneTemplateInput) (*corev1.ObjectReference, error) {
+	from, err := Get(ctx, in.Client, in.TemplateRef, in.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	generateTemplateInput := &GenerateTemplateInput{
+		Template:    from,
+		TemplateRef: in.TemplateRef,
+		Namespace:   in.Namespace,
+		ClusterName: in.ClusterName,
+		OwnerRef:    in.OwnerRef,
+		Labels:      in.Labels,
+		Annotations: in.Annotations,
+	}
+	to, err := GenerateTemplate(generateTemplateInput)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the external clone.
+	if err := in.Client.Create(ctx, to); err != nil {
+		return nil, err
+	}
+
+	return GetObjectReference(to), nil
+}
+
+// CreateFromTemplateInput is the input to CreateFromTemplate.
+type CreateFromTemplateInput struct {
+	// Client is the controller runtime client.
+	Client client.Client
+
+	// TemplateRef is a reference to the template that needs to be cloned.
+	TemplateRef *corev1.ObjectReference
+
+	// Namespace is the Kubernetes namespace the cloned object should be created into.
+	Namespace string
+
+	// ClusterName is the cluster this object is linked to.
+	ClusterName string
+
+	// OwnerRef is an optional OwnerReference to attach to the cloned object.
+	// +optional
+	OwnerRef *metav1.OwnerReference
+
+	// Labels is an optional map of labels to be added to the object.
+	// +optional
+	Labels map[string]string
+
+	// Annotations is an optional map of annotations to be added to the object.
+	// +optional
+	Annotations map[string]string
+}
+
+// CreateFromTemplate uses the client and the reference to create a new object from the template.
+func CreateFromTemplate(ctx context.Context, in *CreateFromTemplateInput) (*corev1.ObjectReference, error) {
 	from, err := Get(ctx, in.Client, in.TemplateRef, in.Namespace)
 	if err != nil {
 		return nil, err

--- a/controllers/external/util_test.go
+++ b/controllers/external/util_test.go
@@ -97,7 +97,7 @@ func TestCloneTemplateResourceNotFound(t *testing.T) {
 	}
 
 	fakeClient := fake.NewClientBuilder().Build()
-	_, err := CloneTemplate(ctx, &CloneTemplateInput{
+	_, err := CreateFromTemplate(ctx, &CreateFromTemplateInput{
 		Client:      fakeClient,
 		TemplateRef: testResourceReference,
 		Namespace:   metav1.NamespaceDefault,
@@ -169,7 +169,7 @@ func TestCloneTemplateResourceFound(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithObjects(template.DeepCopy()).Build()
 
-	ref, err := CloneTemplate(ctx, &CloneTemplateInput{
+	ref, err := CreateFromTemplate(ctx, &CreateFromTemplateInput{
 		Client:      fakeClient,
 		TemplateRef: templateRef.DeepCopy(),
 		Namespace:   metav1.NamespaceDefault,
@@ -261,7 +261,7 @@ func TestCloneTemplateResourceFoundNoOwner(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithObjects(template.DeepCopy()).Build()
 
-	ref, err := CloneTemplate(ctx, &CloneTemplateInput{
+	ref, err := CreateFromTemplate(ctx, &CreateFromTemplateInput{
 		Client:      fakeClient,
 		TemplateRef: templateRef,
 		Namespace:   metav1.NamespaceDefault,
@@ -315,7 +315,7 @@ func TestCloneTemplateMissingSpecTemplate(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithObjects(template.DeepCopy()).Build()
 
-	_, err := CloneTemplate(ctx, &CloneTemplateInput{
+	_, err := CreateFromTemplate(ctx, &CreateFromTemplateInput{
 		Client:      fakeClient,
 		TemplateRef: templateRef,
 		Namespace:   metav1.NamespaceDefault,

--- a/controlplane/kubeadm/internal/controllers/helpers.go
+++ b/controlplane/kubeadm/internal/controllers/helpers.go
@@ -166,7 +166,7 @@ func (r *KubeadmControlPlaneReconciler) cloneConfigsAndGenerateMachine(ctx conte
 	}
 
 	// Clone the infrastructure template
-	infraRef, err := external.CloneTemplate(ctx, &external.CloneTemplateInput{
+	infraRef, err := external.CreateFromTemplate(ctx, &external.CreateFromTemplateInput{
 		Client:      r.Client,
 		TemplateRef: &kcp.Spec.MachineTemplate.InfrastructureRef,
 		Namespace:   kcp.Namespace,

--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -18,7 +18,7 @@ in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controlle
 
 ### Deprecation
 
--
+- `sigs.k8s.io/cluster-api/controllers/external.CloneTemplate` has been deprecated and will be removed in a future release. Please use `sigs.k8s.io/cluster-api/controllers/external.CreateFromTemplate` instead.
 
 ### Removals
 

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -371,7 +371,7 @@ func (r *Reconciler) syncReplicas(ctx context.Context, ms *clusterv1.MachineSet,
 			)
 
 			if machine.Spec.Bootstrap.ConfigRef != nil {
-				bootstrapRef, err = external.CloneTemplate(ctx, &external.CloneTemplateInput{
+				bootstrapRef, err = external.CreateFromTemplate(ctx, &external.CreateFromTemplateInput{
 					Client:      r.Client,
 					TemplateRef: machine.Spec.Bootstrap.ConfigRef,
 					Namespace:   machine.Namespace,
@@ -392,7 +392,7 @@ func (r *Reconciler) syncReplicas(ctx context.Context, ms *clusterv1.MachineSet,
 				machine.Spec.Bootstrap.ConfigRef = bootstrapRef
 			}
 
-			infraRef, err = external.CloneTemplate(ctx, &external.CloneTemplateInput{
+			infraRef, err = external.CreateFromTemplate(ctx, &external.CreateFromTemplateInput{
 				Client:      r.Client,
 				TemplateRef: &machine.Spec.InfrastructureRef,
 				Namespace:   machine.Namespace,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR renames [`CloneTemplate`](https://github.com/kubernetes-sigs/cluster-api/blob/main/controllers/external/util.go#L90) to `CreateFromTemplate` and adds a deprecation notice on `CloneTemplate` function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/6407
