### PR TITLE
:sparkles: ClusterClass patches: Allow matching all MachineDeploymentClasses

### DIFF
--- a/internal/controllers/topology/cluster/patches/inline/json_patch_generator.go
+++ b/internal/controllers/topology/cluster/patches/inline/json_patch_generator.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"text/template"
 
-	sprig "github.com/Masterminds/sprig/v3"
+	"github.com/Masterminds/sprig/v3"
 	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -170,7 +170,14 @@ func matchesSelector(req *runtimehooksv1.GeneratePatchesRequestItem, templateVar
 				// If templateMDClass matches one of the configured MachineDeploymentClasses.
 				for _, mdClass := range selector.MatchResources.MachineDeploymentClass.Names {
 					// We have to quote mdClass as templateMDClassJSON is a JSON string (e.g. "default-worker").
-					if string(templateMDClassJSON.Raw) == strconv.Quote(mdClass) {
+					if mdClass == "*" || string(templateMDClassJSON.Raw) == strconv.Quote(mdClass) {
+						return true
+					}
+					unquoted, _ := strconv.Unquote(string(templateMDClassJSON.Raw))
+					if strings.HasPrefix(mdClass, "*") && strings.HasSuffix(unquoted, strings.TrimPrefix(mdClass, "*")) {
+						return true
+					}
+					if strings.HasSuffix(mdClass, "*") && strings.HasPrefix(unquoted, strings.TrimSuffix(mdClass, "*")) {
 						return true
 					}
 				}

--- a/internal/controllers/topology/cluster/patches/inline/json_patch_generator_test.go
+++ b/internal/controllers/topology/cluster/patches/inline/json_patch_generator_test.go
@@ -618,6 +618,170 @@ func TestMatchesSelector(t *testing.T) {
 			match: true,
 		},
 		{
+			name: "Match all MD BootstrapTemplate",
+			req: &runtimehooksv1.GeneratePatchesRequestItem{
+				Object: runtime.RawExtension{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+							"kind":       "BootstrapTemplate",
+						},
+					},
+				},
+				HolderReference: runtimehooksv1.HolderReference{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "MachineDeployment",
+					Name:       "my-md-0",
+					Namespace:  "default",
+					FieldPath:  "spec.template.spec.bootstrap.configRef",
+				},
+			},
+			templateVariables: map[string]apiextensionsv1.JSON{
+				"builtin": {Raw: []byte(`{"machineDeployment":{"class":"classA"}}`)},
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:       "BootstrapTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"*"},
+					},
+				},
+			},
+			match: true,
+		},
+		{
+			name: "Glob match MD BootstrapTemplate with <string>-*",
+			req: &runtimehooksv1.GeneratePatchesRequestItem{
+				Object: runtime.RawExtension{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+							"kind":       "BootstrapTemplate",
+						},
+					},
+				},
+				HolderReference: runtimehooksv1.HolderReference{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "MachineDeployment",
+					Name:       "my-md-0",
+					Namespace:  "default",
+					FieldPath:  "spec.template.spec.bootstrap.configRef",
+				},
+			},
+			templateVariables: map[string]apiextensionsv1.JSON{
+				"builtin": {Raw: []byte(`{"machineDeployment":{"class":"class-A"}}`)},
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:       "BootstrapTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"class-*"},
+					},
+				},
+			},
+			match: true,
+		},
+		{
+			name: "Glob match MD BootstrapTemplate with *-<string>",
+			req: &runtimehooksv1.GeneratePatchesRequestItem{
+				Object: runtime.RawExtension{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+							"kind":       "BootstrapTemplate",
+						},
+					},
+				},
+				HolderReference: runtimehooksv1.HolderReference{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "MachineDeployment",
+					Name:       "my-md-0",
+					Namespace:  "default",
+					FieldPath:  "spec.template.spec.bootstrap.configRef",
+				},
+			},
+			templateVariables: map[string]apiextensionsv1.JSON{
+				"builtin": {Raw: []byte(`{"machineDeployment":{"class":"class-A"}}`)},
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:       "BootstrapTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"*-A"},
+					},
+				},
+			},
+			match: true,
+		},
+
+		{
+			name: "Don't match BootstrapTemplate, .matchResources.machineDeploymentClass.names is empty",
+			req: &runtimehooksv1.GeneratePatchesRequestItem{
+				Object: runtime.RawExtension{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+							"kind":       "BootstrapTemplate",
+						},
+					},
+				},
+				HolderReference: runtimehooksv1.HolderReference{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "MachineDeployment",
+					Name:       "my-md-0",
+					Namespace:  "default",
+					FieldPath:  "spec.template.spec.bootstrap.configRef",
+				},
+			},
+			templateVariables: map[string]apiextensionsv1.JSON{
+				"builtin": {Raw: []byte(`{"machineDeployment":{"class":"classA"}}`)},
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:       "BootstrapTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{},
+					},
+				},
+			},
+			match: false,
+		},
+		{
+			name: "Do not match BootstrapTemplate, .matchResources.machineDeploymentClass is set to nil",
+			req: &runtimehooksv1.GeneratePatchesRequestItem{
+				Object: runtime.RawExtension{
+					Object: &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+							"kind":       "BootstrapTemplate",
+						},
+					},
+				},
+				HolderReference: runtimehooksv1.HolderReference{
+					APIVersion: clusterv1.GroupVersion.String(),
+					Kind:       "MachineDeployment",
+					Name:       "my-md-0",
+					Namespace:  "default",
+					FieldPath:  "spec.template.spec.bootstrap.configRef",
+				},
+			},
+			templateVariables: map[string]apiextensionsv1.JSON{
+				"builtin": {Raw: []byte(`{"machineDeployment":{"class":"classA"}}`)},
+			},
+			selector: clusterv1.PatchSelector{
+				APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+				Kind:       "BootstrapTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: nil,
+				},
+			},
+			match: false,
+		},
+		{
 			name: "Don't match BootstrapTemplate, .matchResources.machineDeploymentClass not set",
 			req: &runtimehooksv1.GeneratePatchesRequestItem{
 				Object: runtime.RawExtension{

--- a/internal/webhooks/patch_validation_test.go
+++ b/internal/webhooks/patch_validation_test.go
@@ -1810,6 +1810,156 @@ func Test_validateSelectors(t *testing.T) {
 				Build(),
 			wantErr: true,
 		},
+		{
+			name: "error if selector targets an empty MachineDeploymentClass InfrastructureTemplate",
+			selector: clusterv1.PatchSelector{
+				APIVersion:     "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:           "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithWorkerMachineDeploymentClasses(
+					*builder.MachineDeploymentClass("aa").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "InfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+					*builder.MachineDeploymentClass("bb").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "NonMatchingInfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+				).
+				Build(),
+			wantErr: true,
+		},
+		{
+			name: "error if selector targets a bad pattern for matching MachineDeploymentClass InfrastructureTemplate",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"a*a"},
+					},
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithWorkerMachineDeploymentClasses(
+					*builder.MachineDeploymentClass("a-something-a").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "InfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+				).
+				Build(),
+			wantErr: true,
+		},
+		{
+			name: "pass if selector targets an existing MachineDeploymentClass InfrastructureTemplate with prefix *",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"a-*"},
+					},
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithWorkerMachineDeploymentClasses(
+					*builder.MachineDeploymentClass("a-something-a").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "InfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+				).
+				Build(),
+		},
+		{
+			name: "pass if selector targets an existing MachineDeploymentClass InfrastructureTemplate with suffix *",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"*-a"},
+					},
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithWorkerMachineDeploymentClasses(
+					*builder.MachineDeploymentClass("a-something-a").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "InfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+				).
+				Build(),
+		},
+		{
+			name: "pass if selector targets all existing MachineDeploymentClass InfrastructureTemplate with *",
+			selector: clusterv1.PatchSelector{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "InfrastructureMachineTemplate",
+				MatchResources: clusterv1.PatchSelectorMatch{
+					MachineDeploymentClass: &clusterv1.PatchSelectorMatchMachineDeploymentClass{
+						Names: []string{"*"},
+					},
+				},
+			},
+			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithWorkerMachineDeploymentClasses(
+					*builder.MachineDeploymentClass("a-something-a").
+						WithInfrastructureTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+								Kind:       "InfrastructureMachineTemplate",
+							})).
+						WithBootstrapTemplate(
+							refToUnstructured(&corev1.ObjectReference{
+								APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+								Kind:       "BootstrapTemplate",
+							})).
+						Build(),
+				).
+				Build(),
+		},
 		// The following tests have selectors which match multiple resources at the same time.
 		{
 			name: "fail if selector targets a matching infrastructureCluster reference and a not matching control plane",

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -137,7 +137,7 @@ spec:
         matchResources:
           machineDeploymentClass:
             names:
-            - default-worker
+            - '*-worker'
       jsonPatches:
       - op: add
         path: "/spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/cgroup-driver"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds a new feature to allow matching all "*" MachineDeploymentClasses.
1. Match all if MachineDeploymentClass.Names is a "*".
```yaml
matchResources:
  machineDeploymentClass:
    names : [*]
```
2. Match some if explicitly mentioned.
```yaml
matchResources:
  machineDeploymentClass:
    names: [something, something, something]
```
3. Match some if glob matched.
```yaml
matchResources:
  machineDeploymentClass:
    names: [something-*]
```

3. Match none if no machineDeploymentClass  is set (should produce a webhook failure)
```yaml
matchResources:
  machineDeploymentClass: {}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5648 
