### PR TITLE
✨ Add `clusterctl init list-images` command

### DIFF
--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -78,12 +78,7 @@ var initCmd = &cobra.Command{
 		clusterctl init --infrastructure=aws,vsphere
 
 		# Initialize a management cluster with a custom target namespace for the provider resources.
-		clusterctl init --infrastructure aws --target-namespace foo
-
-		# Lists the container images required for initializing the management cluster.
-		#
-		# Note: This command is a dry-run; it won't perform any action other than printing to screen.
-		clusterctl init --infrastructure aws --list-images`),
+		clusterctl init --infrastructure aws --target-namespace foo`),
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runInit()
@@ -91,17 +86,17 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
-	initCmd.Flags().StringVar(&initOpts.kubeconfig, "kubeconfig", "",
+	initCmd.PersistentFlags().StringVar(&initOpts.kubeconfig, "kubeconfig", "",
 		"Path to the kubeconfig for the management cluster. If unspecified, default discovery rules apply.")
-	initCmd.Flags().StringVar(&initOpts.kubeconfigContext, "kubeconfig-context", "",
+	initCmd.PersistentFlags().StringVar(&initOpts.kubeconfigContext, "kubeconfig-context", "",
 		"Context to be used within the kubeconfig file. If empty, current context will be used.")
-	initCmd.Flags().StringVar(&initOpts.coreProvider, "core", "",
+	initCmd.PersistentFlags().StringVar(&initOpts.coreProvider, "core", "",
 		"Core provider version (e.g. cluster-api:v1.1.5) to add to the management cluster. If unspecified, Cluster API's latest release is used.")
-	initCmd.Flags().StringSliceVarP(&initOpts.infrastructureProviders, "infrastructure", "i", nil,
+	initCmd.PersistentFlags().StringSliceVarP(&initOpts.infrastructureProviders, "infrastructure", "i", nil,
 		"Infrastructure providers and versions (e.g. aws:v0.5.0) to add to the management cluster.")
-	initCmd.Flags().StringSliceVarP(&initOpts.bootstrapProviders, "bootstrap", "b", nil,
+	initCmd.PersistentFlags().StringSliceVarP(&initOpts.bootstrapProviders, "bootstrap", "b", nil,
 		"Bootstrap providers and versions (e.g. kubeadm:v1.1.5) to add to the management cluster. If unspecified, Kubeadm bootstrap provider's latest release is used.")
-	initCmd.Flags().StringSliceVarP(&initOpts.controlPlaneProviders, "control-plane", "c", nil,
+	initCmd.PersistentFlags().StringSliceVarP(&initOpts.controlPlaneProviders, "control-plane", "c", nil,
 		"Control plane providers and versions (e.g. kubeadm:v1.1.5) to add to the management cluster. If unspecified, the Kubeadm control plane provider's latest release is used.")
 	initCmd.Flags().StringVarP(&initOpts.targetNamespace, "target-namespace", "n", "",
 		"The target namespace where the providers should be deployed. If unspecified, the provider components' default namespace is used.")
@@ -112,10 +107,11 @@ func init() {
 	initCmd.Flags().BoolVar(&initOpts.validate, "validate", true,
 		"If true, clusterctl will validate that the deployments will succeed on the management cluster.")
 
-	// TODO: Move this to a sub-command or similar, it shouldn't really be a flag.
 	initCmd.Flags().BoolVar(&initOpts.listImages, "list-images", false,
 		"Lists the container images required for initializing the management cluster (without actually installing the providers)")
+	_ = initCmd.Flags().MarkDeprecated("list-images", "use 'clusterctl init list-images' instead.")
 
+	initCmd.AddCommand(initListImagesCmd)
 	RootCmd.AddCommand(initCmd)
 }
 

--- a/cmd/clusterctl/cmd/init_list_images.go
+++ b/cmd/clusterctl/cmd/init_list_images.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+)
+
+var initListImagesCmd = &cobra.Command{
+	Use:   "list-images",
+	Short: "Lists the container images required for initializing the management cluster",
+	Long: LongDesc(`
+		Lists the container images required for initializing the management cluster.
+
+		See https://cluster-api.sigs.k8s.io for more details.`),
+
+	Example: Examples(`
+		# Lists the container images required for initializing the management cluster.
+		#
+		# Note: This command is a dry-run; it won't perform any action other than printing to screen.
+		clusterctl init list-images --infrastructure aws
+
+		# List infrastructure, bootstrap, control-plane and core images
+		clusterctl init list-images --infrastructure vcd --bootstrap kubeadm --control-plane nested --core cluster-api:v1.2.0
+	`),
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runInitListImages()
+	},
+}
+
+func runInitListImages() error {
+	c, err := client.New(cfgFile)
+	if err != nil {
+		return err
+	}
+
+	options := client.InitOptions{
+		Kubeconfig:              client.Kubeconfig{Path: initOpts.kubeconfig, Context: initOpts.kubeconfigContext},
+		CoreProvider:            initOpts.coreProvider,
+		BootstrapProviders:      initOpts.bootstrapProviders,
+		ControlPlaneProviders:   initOpts.controlPlaneProviders,
+		InfrastructureProviders: initOpts.infrastructureProviders,
+		LogUsageInstructions:    false,
+	}
+
+	images, err := c.InitImages(options)
+	if err != nil {
+		return err
+	}
+
+	for _, i := range images {
+		fmt.Println(i)
+	}
+	return nil
+}

--- a/docs/book/src/clusterctl/commands/additional-commands.md
+++ b/docs/book/src/clusterctl/commands/additional-commands.md
@@ -22,3 +22,7 @@ or in the provided directory.
 # clusterctl version
 
 Print clusterctl version.
+
+# clusterctl init list-images
+
+Lists the container images required for initializing the management cluster.

--- a/docs/book/src/clusterctl/commands/commands.md
+++ b/docs/book/src/clusterctl/commands/commands.md
@@ -1,22 +1,23 @@
 # clusterctl commands
 
-| Command                                                                      | Description                                                                                                |
-|------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
-| [`clusterctl alpha rollout`](alpha-rollout.md)                               | Manages the rollout of Cluster API resources. For example: MachineDeployments.                             |
-| [`clusterctl alpha topology plan`](alpha-topology-plan.md)                   | Describes the changes to a cluster topology for a given input.                                             |
-| [`clusterctl backup`](additional-commands.md#clusterctl-backup)              | Backup Cluster API objects and all their dependencies from a management cluster.                           |
-| [`clusterctl completion`](completion.md)                                     | Output shell completion code for the specified shell (bash or zsh).                                        |
-| [`clusterctl config`](additional-commands.md#clusterctl-config-repositories) | Display clusterctl configuration.                                                                          |
-| [`clusterctl delete`](delete.md)                                             | Delete one or more providers from the management cluster.                                                  |
-| [`clusterctl describe cluster`](describe-cluster.md)                         | Describe workload clusters.                                                                                |
-| [`clusterctl generate cluster`](generate-cluster.md)                         | Generate templates for creating workload clusters.                                                         |
-| [`clusterctl generate provider`](generate-provider.md)                       | Generate templates for provider components.                                                                |
-| [`clusterctl generate yaml`](generate-yaml.md)                               | Process yaml using clusterctl's yaml processor.                                                            |
-| [`clusterctl get kubeconfig`](get-kubeconfig.md)                             | Gets the kubeconfig file for accessing a workload cluster.                                                 |
-| [`clusterctl help`](additional-commands.md#clusterctl-help)                  | Help about any command.                                                                                    |
-| [`clusterctl init`](init.md)                                                 | Initialize a management cluster.                                                                           |
-| [`clusterctl move`](move.md)                                                 | Move Cluster API objects and all their dependencies between management clusters.                           |
-| [`clusterctl restore`](additional-commands.md#clusterctl-restore)            | Restore Cluster API objects from file by glob.                                                             |
-| [`clusterctl upgrade plan`](upgrade.md#upgrade-plan)                         | Provide a list of recommended target versions for upgrading Cluster API providers in a management cluster. |
-| [`clusterctl upgrade apply`](upgrade.md#upgrade-apply)                       | Apply new versions of Cluster API core and providers in a management cluster.                              |
-| [`clusterctl version`](additional-commands.md#clusterctl-version)            | Print clusterctl version.                                                                                  |
+| Command                                                                              | Description                                                                                                |
+|--------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| [`clusterctl alpha rollout`](alpha-rollout.md)                                       | Manages the rollout of Cluster API resources. For example: MachineDeployments.                             |
+| [`clusterctl alpha topology plan`](alpha-topology-plan.md)                           | Describes the changes to a cluster topology for a given input.                                             |
+| [`clusterctl backup`](additional-commands.md#clusterctl-backup)                      | Backup Cluster API objects and all their dependencies from a management cluster.                           |
+| [`clusterctl completion`](completion.md)                                             | Output shell completion code for the specified shell (bash or zsh).                                        |
+| [`clusterctl config`](additional-commands.md#clusterctl-config-repositories)         | Display clusterctl configuration.                                                                          |
+| [`clusterctl delete`](delete.md)                                                     | Delete one or more providers from the management cluster.                                                  |
+| [`clusterctl describe cluster`](describe-cluster.md)                                 | Describe workload clusters.                                                                                |
+| [`clusterctl generate cluster`](generate-cluster.md)                                 | Generate templates for creating workload clusters.                                                         |
+| [`clusterctl generate provider`](generate-provider.md)                               | Generate templates for provider components.                                                                |
+| [`clusterctl generate yaml`](generate-yaml.md)                                       | Process yaml using clusterctl's yaml processor.                                                            |
+| [`clusterctl get kubeconfig`](get-kubeconfig.md)                                     | Gets the kubeconfig file for accessing a workload cluster.                                                 |
+| [`clusterctl help`](additional-commands.md#clusterctl-help)                          | Help about any command.                                                                                    |
+| [`clusterctl init`](init.md)                                                         | Initialize a management cluster.                                                                           |
+| [`clusterctl init list-images`](additional-commands.md#clusterctl-init-list-images)  | Lists the container images required for initializing the management cluster.                               |
+| [`clusterctl move`](move.md)                                                         | Move Cluster API objects and all their dependencies between management clusters.                           |
+| [`clusterctl restore`](additional-commands.md#clusterctl-restore)                    | Restore Cluster API objects from file by glob.                                                             |
+| [`clusterctl upgrade plan`](upgrade.md#upgrade-plan)                                 | Provide a list of recommended target versions for upgrading Cluster API providers in a management cluster. |
+| [`clusterctl upgrade apply`](upgrade.md#upgrade-apply)                               | Apply new versions of Cluster API core and providers in a management cluster.                              |
+| [`clusterctl version`](additional-commands.md#clusterctl-version)                    | Print clusterctl version.                                                                                  |

--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -19,6 +19,7 @@ in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controlle
 ### Deprecation
 
 - `sigs.k8s.io/cluster-api/controllers/external.CloneTemplate` has been deprecated and will be removed in a future release. Please use `sigs.k8s.io/cluster-api/controllers/external.CreateFromTemplate` instead.
+- `clusterctl init --list-images` has been deprecated and will be removed in a future release. Please use `clusterctl init list-images` instead.
 
 ### Removals
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In clusterctl / init the there is a [todo](https://github.com/kubernetes-sigs/cluster-api/blob/1ec0cd6174f1b860dc466db587241ea7edea0b9f/cmd/clusterctl/cmd/init.go#L112) to convert `clusterctl init --list-images` to a sub-command.

Instead of redeclaring the flags needed by `list-images` I updated some flags in `init` from `initCmd.Flags()` -> `initCmd.PersistentFlags()` to inherit them. Is this an acceptable approach? (Maybe common flags like kube context etc should really be in root?).

The documentation is sparse and more placeholder. Will be replaced later if the general approach is ok.

```shell
$ ./bin/clusterctl init list-images -h
Lists the container images required for initializing the management cluster.

See https://cluster-api.sigs.k8s.io for more details.

Usage:
  clusterctl init list-images [flags]

Examples:
  # Lists the container images required for initializing the management cluster.
  #
  # Note: This command is a dry-run; it won't perform any action other than printing to screen.
  clusterctl init list-images --infrastructure aws
  
  # List infrastructure, bootstrap, control-plane and core images
  clusterctl init list-images --infrastructure vcd --bootstrap kubeadm --control-plane nested --core cluster-api:v1.2.0

Flags:
  -h, --help   help for list-images

Global Flags:
  -b, --bootstrap strings                           Bootstrap providers and versions (e.g. kubeadm:v1.1.5) to add to the management cluster. If unspecified, Kubeadm bootstrap provider's latest release is used.
      --config $HOME/.cluster-api/clusterctl.yaml   Path to clusterctl configuration (default is $HOME/.cluster-api/clusterctl.yaml) or to a remote location (i.e. https://example.com/clusterctl.yaml)
  -c, --control-plane strings                       Control plane providers and versions (e.g. kubeadm:v1.1.5) to add to the management cluster. If unspecified, the Kubeadm control plane provider's latest release is used.
      --core string                                 Core provider version (e.g. cluster-api:v1.1.5) to add to the management cluster. If unspecified, Cluster API's latest release is used.
  -i, --infrastructure strings                      Infrastructure providers and versions (e.g. aws:v0.5.0) to add to the management cluster.
      --kubeconfig string                           Path to the kubeconfig for the management cluster. If unspecified, default discovery rules apply.
      --kubeconfig-context string                   Context to be used within the kubeconfig file. If empty, current context will be used.
  -v, --v int                                       Set the log level verbosity. This overrides the CLUSTERCTL_LOG_LEVEL environment variable.
```

Example usage
```
$ ./bin/clusterctl init list-images --infrastructure vcd --bootstrap kubeadm --control-plane nested --core cluster-api:v1.2.0
gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
k8s.gcr.io/cluster-api/cluster-api-controller:v1.2.0
projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:0.5.1
us.gcr.io/k8s-artifacts-prod/cluster-api-nested/nested-controlplane-controller:v0.1.0
```