### PR TITLE
:book: Add klog.Background PR to migration guide

### DIFF
--- a/docs/book/src/developer/providers/v1.1-to-v1.2.md
+++ b/docs/book/src/developer/providers/v1.1-to-v1.2.md
@@ -183,7 +183,7 @@ NOTES:
       ```
       </details>
 
-      This change has been introduced in CAPI in the following PRs: [#6072](https://github.com/kubernetes-sigs/cluster-api/pull/6072), [#6190](https://github.com/kubernetes-sigs/cluster-api/pull/6190).</br>
+      This change has been introduced in CAPI in the following PRs: [#6072](https://github.com/kubernetes-sigs/cluster-api/pull/6072), [#6190](https://github.com/kubernetes-sigs/cluster-api/pull/6190), [#6602](https://github.com/kubernetes-sigs/cluster-api/pull/6602).</br>
       **Note**: This change is not mandatory for providers, but highly recommended.
 
 - Following E2E framework functions are now checking that machines are created in the expected failure domain (if defined);


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add up to date information on the klog functions used to set up the logger in the 1.1-1.2 migration guide. This was brought up as a point of confusion for migration.