### PR TITLE
🐛 Load kustomize_substitution values into environment variables in Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -426,6 +426,9 @@ def deploy_templates(filename, provider, substitutions):
     if not os.path.exists(filename):
         fail(filename + " not found")
 
+    for name, value in substitutions.items():
+        os.environ[name] = value
+
     os.environ["NAMESPACE"] = substitutions.get("NAMESPACE", "default")
     os.environ["KUBERNETES_VERSION"] = substitutions.get("KUBERNETES_VERSION", "v1.24.0")
     os.environ["CONTROL_PLANE_MACHINE_COUNT"] = substitutions.get("CONTROL_PLANE_MACHINE_COUNT", "1")


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Follow up to #6254 which fixes an issue where the `kustomize_substitution` values are not actually being loaded into the environment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
