### PR TITLE
🐛 Fix machinepool instance id bug

### DIFF
--- a/exp/internal/controllers/machinepool_controller_noderef.go
+++ b/exp/internal/controllers/machinepool_controller_noderef.go
@@ -156,7 +156,7 @@ func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client
 			continue
 		}
 
-		nodeRefsMap[nodeProviderID.ID()] = node
+		nodeRefsMap[nodeProviderID.String()] = node
 	}
 	for _, providerID := range providerIDList {
 		pid, err := noderefutil.NewProviderID(providerID)
@@ -164,7 +164,7 @@ func (r *MachinePoolReconciler) deleteRetiredNodes(ctx context.Context, c client
 			log.V(2).Info("Failed to parse ProviderID, skipping", "err", err, "providerID", providerID)
 			continue
 		}
-		delete(nodeRefsMap, pid.ID())
+		delete(nodeRefsMap, pid.String())
 	}
 	for _, node := range nodeRefsMap {
 		if err := c.Delete(ctx, node); err != nil {
@@ -192,7 +192,7 @@ func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, c client.
 				continue
 			}
 
-			nodeRefsMap[nodeProviderID.ID()] = node
+			nodeRefsMap[nodeProviderID.String()] = node
 		}
 
 		if nodeList.Continue == "" {
@@ -207,7 +207,7 @@ func (r *MachinePoolReconciler) getNodeReferences(ctx context.Context, c client.
 			log.V(2).Info("Failed to parse ProviderID, skipping", "err", err, "providerID", providerID)
 			continue
 		}
-		if node, ok := nodeRefsMap[pid.ID()]; ok {
+		if node, ok := nodeRefsMap[pid.String()]; ok {
 			available++
 			if nodeIsReady(&node) {
 				ready++

--- a/exp/internal/controllers/machinepool_controller_noderef_test.go
+++ b/exp/internal/controllers/machinepool_controller_noderef_test.go
@@ -66,6 +66,22 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 				ProviderID: "azure://westus2/id-node-4",
 			},
 		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "azure-nodepool1-0",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "azure://westus2/id-nodepool1/0",
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "azure-nodepool2-0",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "azure://westus2/id-nodepool2/0",
+			},
+		},
 	}
 
 	client := fake.NewClientBuilder().WithObjects(nodeList...).Build()
@@ -135,6 +151,25 @@ func TestMachinePoolGetNodeReference(t *testing.T) {
 				references: []corev1.ObjectReference{},
 				available:  0,
 				ready:      0,
+			},
+		},
+		{
+			name:           "valid provider id with non-unique instance id, valid azure node",
+			providerIDList: []string{"azure://westus2/id-nodepool1/0"},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{
+					{Name: "azure-nodepool1-0"},
+				},
+			},
+		},
+		{
+			name:           "valid provider ids with same instance ids, valid azure nodes",
+			providerIDList: []string{"azure://westus2/id-nodepool1/0", "azure://westus2/id-nodepool2/0"},
+			expected: &getNodeReferencesResult{
+				references: []corev1.ObjectReference{
+					{Name: "azure-nodepool1-0"},
+					{Name: "azure-nodepool2-0"},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: 

Using `ProviderID.ID()` is not good enough for all providers as some providers like Azure VMSS don't assign a unique instance id to each VM in a scale set and it causes a bug when multiple MachinePools are present where IDs collide and noderefs end up in the wrong MachinePool Status. Using the full provider ID string ensures uniqueness and guarantees that nodes will be matched to the correct MachinePool

More details in this [slack thread](https://kubernetes.slack.com/archives/CEX9HENG7/p1658498393187099).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/4526
