### PR TITLE
🐛 Add OwnerRef to clusterResourceSetBinding on each reconcile

### DIFF
--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/cluster-api/util"
 )
 
 // ANCHOR: ResourceBinding
@@ -100,6 +102,11 @@ func (c *ClusterResourceSetBinding) DeleteBinding(clusterResourceSet *ClusterRes
 			break
 		}
 	}
+	clusterResourceSet.OwnerReferences = util.RemoveOwnerRef(c.OwnerReferences, metav1.OwnerReference{
+		APIVersion: clusterResourceSet.APIVersion,
+		Kind:       clusterResourceSet.Kind,
+		Name:       clusterResourceSet.Name,
+	})
 }
 
 // +kubebuilder:object:root=true

--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -264,6 +264,8 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 		}
 	}()
 
+	// Ensure that the owner references are set on the ClusterResourceSetBinding.
+	clusterResourceSetBinding.OwnerReferences = ensureOwnerRefs(clusterResourceSetBinding, clusterResourceSet, cluster)
 	errList := []error{}
 	resourceSetBinding := clusterResourceSetBinding.GetOrCreateBinding(clusterResourceSet)
 

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -518,8 +518,8 @@ metadata:
 			if err != nil {
 				return false
 			}
-			return len(binding.Spec.Bindings) == 2
-		}, timeout).Should(BeTrue())
+			return len(binding.Spec.Bindings) == 2 && len(binding.OwnerReferences) == 3
+		}, timeout).Should(BeTrue(), "Expected 2 ClusterResourceSets and 3 OwnerReferences")
 
 		t.Log("Verifying deleted CRS is deleted from ClusterResourceSetBinding")
 		// Delete one of the CRS instances and wait until it is removed from the binding list.
@@ -534,8 +534,8 @@ metadata:
 			if err != nil {
 				return false
 			}
-			return len(binding.Spec.Bindings) == 1
-		}, timeout).Should(BeTrue())
+			return len(binding.Spec.Bindings) == 1 && len(binding.OwnerReferences) == 2
+		}, timeout).Should(BeTrue(), "ClusterResourceSetBinding should have 1 ClusterResourceSet and 2 OwnerReferences")
 
 		t.Log("Verifying ClusterResourceSetBinding is deleted after deleting all matching CRS objects")
 		// Delete one of the CRS instances and wait until it is removed from the binding list.


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fix an issue where OwnerReferences were only added to a ClusterResourceSetBinding on Create. This fix will ensure the references are set each time the ClusterResourceSet the Binding is created from from is reconciled.

Fixes #6007 
