### PR TITLE
✨ Add generic addon deployment config to tilt

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -45,6 +45,8 @@ import (
 	"sigs.k8s.io/cluster-api/util/conditions"
 )
 
+var hookResponsesConfigMapName = "test-extension-hookresponses"
+
 // clusterUpgradeWithRuntimeSDKSpecInput is the input for clusterUpgradeWithRuntimeSDKSpec.
 type clusterUpgradeWithRuntimeSDKSpecInput struct {
 	E2EConfig             *clusterctl.E2EConfig
@@ -123,7 +125,6 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 		// Set up a Namespace where to host objects for this spec and create a watcher for the Namespace events.
 		namespace, cancelWatches = setupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
 		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
-
 		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
 	})
 
@@ -132,10 +133,10 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 		testExtensionDeploymentTemplate, err := os.ReadFile(testExtensionPath) //nolint:gosec
 		Expect(err).ToNot(HaveOccurred(), "Failed to read the extension deployment manifest file")
 
-		// Set the SERVICE_NAMESPACE, which is used in the cert-manager Certificate CR.
+		// Set the TEST_EXTENSION_SERVICE_NAMESPACE, which is used in the cert-manager Certificate CR.
 		// We have to dynamically set the namespace here, because it depends on the test run and thus
 		// cannot be set when rendering the test extension YAML with kustomize.
-		testExtensionDeployment := strings.ReplaceAll(string(testExtensionDeploymentTemplate), "${SERVICE_NAMESPACE}", namespace.Name)
+		testExtensionDeployment := strings.ReplaceAll(string(testExtensionDeploymentTemplate), "${TEST_EXTENSION_SERVICE_NAMESPACE}", namespace.Name)
 
 		Expect(testExtensionDeployment).ToNot(BeEmpty(), "Test Extension deployment manifest file should not be empty")
 		Expect(input.BootstrapClusterProxy.Apply(ctx, []byte(testExtensionDeployment), "--namespace", namespace.Name)).To(Succeed())
@@ -147,7 +148,7 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 			To(Succeed(), "Failed to create the extension config")
 
 		Expect(input.BootstrapClusterProxy.GetClient().Create(ctx,
-			responsesConfigMap(clusterName, namespace))).
+			responsesConfigMap(namespace))).
 			To(Succeed(), "Failed to create the responses configMap")
 
 		By("Wait for test extension deployment to be availabel")
@@ -251,7 +252,7 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 
 		By("Checking all lifecycle hooks have been called")
 		// Assert that each hook has been called and returned "Success" during the test.
-		Expect(checkLifecycleHookResponses(ctx, input.BootstrapClusterProxy.GetClient(), namespace.Name, clusterName, map[string]string{
+		Expect(checkLifecycleHookResponses(ctx, input.BootstrapClusterProxy.GetClient(), namespace.Name, map[string]string{
 			"BeforeClusterCreate":          "Status: Success, RetryAfterSeconds: 0",
 			"BeforeClusterUpgrade":         "Status: Success, RetryAfterSeconds: 0",
 			"BeforeClusterDelete":          "Status: Success, RetryAfterSeconds: 0",
@@ -310,10 +311,10 @@ func extensionConfig(specName string, namespace *corev1.Namespace) *runtimev1.Ex
 }
 
 // responsesConfigMap generates a ConfigMap with preloaded responses for the test extension.
-func responsesConfigMap(name string, namespace *corev1.Namespace) *corev1.ConfigMap {
+func responsesConfigMap(namespace *corev1.Namespace) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-hookresponses", name),
+			Name:      hookResponsesConfigMapName,
 			Namespace: namespace.Name,
 		},
 		// Set the initial preloadedResponses for each of the tested hooks.
@@ -333,12 +334,12 @@ func responsesConfigMap(name string, namespace *corev1.Namespace) *corev1.Config
 
 // Check that each hook in hooks has been called at least once by checking if its actualResponseStatus is in the hook response configmap.
 // If the provided hooks have both keys and values check that the values match those in the hook response configmap.
-func checkLifecycleHookResponses(ctx context.Context, c client.Client, namespace string, clusterName string, expectedHookResponses map[string]string) error {
-	responseData := getLifecycleHookResponsesFromConfigMap(ctx, c, namespace, clusterName)
+func checkLifecycleHookResponses(ctx context.Context, c client.Client, namespace string, expectedHookResponses map[string]string) error {
+	responseData := getLifecycleHookResponsesFromConfigMap(ctx, c, namespace)
 	for hookName, expectedResponse := range expectedHookResponses {
 		actualResponse, ok := responseData[hookName+"-actualResponseStatus"]
 		if !ok {
-			return errors.Errorf("hook %s call not recorded in configMap %s", hookName, klog.KRef(namespace, clusterName+"-hookresponses"))
+			return errors.Errorf("hook %s call not recorded in configMap %s/%s", hookName, namespace, hookResponsesConfigMapName)
 		}
 		if expectedResponse != "" && expectedResponse != actualResponse {
 			return errors.Errorf("hook %s was expected to be %s in configMap got %s", hookName, expectedResponse, actualResponse)
@@ -348,21 +349,20 @@ func checkLifecycleHookResponses(ctx context.Context, c client.Client, namespace
 }
 
 // Check that each hook in expectedHooks has been called at least once by checking if its actualResponseStatus is in the hook response configmap.
-func checkLifecycleHooksCalledAtLeastOnce(ctx context.Context, c client.Client, namespace string, clusterName string, expectedHooks []string) error {
-	responseData := getLifecycleHookResponsesFromConfigMap(ctx, c, namespace, clusterName)
+func checkLifecycleHooksCalledAtLeastOnce(ctx context.Context, c client.Client, namespace string, expectedHooks []string) error {
+	responseData := getLifecycleHookResponsesFromConfigMap(ctx, c, namespace)
 	for _, hookName := range expectedHooks {
 		if _, ok := responseData[hookName+"-actualResponseStatus"]; !ok {
-			return errors.Errorf("hook %s call not recorded in configMap %s", hookName, klog.KRef(namespace, clusterName+"-hookresponses"))
+			return errors.Errorf("hook %s call not recorded in configMap %s/%s", hookName, namespace, hookResponsesConfigMapName)
 		}
 	}
 	return nil
 }
 
-func getLifecycleHookResponsesFromConfigMap(ctx context.Context, c client.Client, namespace string, clusterName string) map[string]string {
+func getLifecycleHookResponsesFromConfigMap(ctx context.Context, c client.Client, namespace string) map[string]string {
 	configMap := &corev1.ConfigMap{}
-	configMapName := clusterName + "-hookresponses"
 	Eventually(func() error {
-		return c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: configMapName}, configMap)
+		return c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: hookResponsesConfigMapName}, configMap)
 	}).Should(Succeed(), "Failed to get the hook response configmap")
 	return configMap.Data
 }
@@ -449,7 +449,7 @@ func runtimeHookTestHandler(ctx context.Context, c client.Client, namespace, clu
 
 	// Check that the LifecycleHook has been called at least once and - when required - that the TopologyReconciled condition is a Failure.
 	Eventually(func() error {
-		if err := checkLifecycleHooksCalledAtLeastOnce(ctx, c, namespace, clusterName, []string{hookName}); err != nil {
+		if err := checkLifecycleHooksCalledAtLeastOnce(ctx, c, namespace, []string{hookName}); err != nil {
 			return err
 		}
 
@@ -474,7 +474,7 @@ func runtimeHookTestHandler(ctx context.Context, c client.Client, namespace, clu
 	// Patch the ConfigMap to set the hook response to "Success".
 	Byf("Setting %s response to Status:Success to unblock the reconciliation", hookName)
 
-	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: clusterName + "-hookresponses", Namespace: namespace}}
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: hookResponsesConfigMapName, Namespace: namespace}}
 	Eventually(func() error {
 		return c.Get(ctx, util.ObjectKey(configMap), configMap)
 	}).Should(Succeed(), "Failed to get ConfigMap %s", klog.KObj(configMap))

--- a/test/extension/config/certmanager/certificate.yaml
+++ b/test/extension/config/certmanager/certificate.yaml
@@ -12,11 +12,11 @@ kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
 spec:
-  # $(SERVICE_NAME) will be substituted by kustomize
-  # $(SERVICE_NAMESPACE) will be substituted on deployment
+  # $(TEST_EXTENSION_SERVICE_NAMESPACE) will be substituted by kustomize
+  # $(TEST_EXTENSION_SERVICE_NAMESPACE) will be substituted on deployment
   dnsNames:
-  - $(SERVICE_NAME).${SERVICE_NAMESPACE}.svc
-  - $(SERVICE_NAME).${SERVICE_NAMESPACE}.svc.cluster.local
+  - $(SERVICE_NAME).${TEST_EXTENSION_SERVICE_NAMESPACE}.svc
+  - $(SERVICE_NAME).${TEST_EXTENSION_SERVICE_NAMESPACE}.svc.cluster.local
   # for local testing.
   - localhost
   issuerRef:

--- a/test/extension/config/default/rolebinding.yaml
+++ b/test/extension/config/default/rolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: test-extension
-    namespace: ${SERVICE_NAMESPACE}
+    namespace: ${TEST_EXTENSION_SERVICE_NAMESPACE}

--- a/test/extension/config/tilt/extensionconfig.yaml
+++ b/test/extension/config/tilt/extensionconfig.yaml
@@ -1,0 +1,18 @@
+apiVersion: runtime.cluster.x-k8s.io/v1alpha1
+kind: ExtensionConfig
+metadata:
+  annotations:
+    runtime.cluster.x-k8s.io/inject-ca-from-secret: default/webhook-service-cert
+  name: test-extension
+spec:
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: default
+      port: 443
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - default

--- a/test/extension/config/tilt/hookresponses-configmap.yaml
+++ b/test/extension/config/tilt/hookresponses-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-extension-hookresponses
+  namespace: default
+data:
+  AfterClusterUpgrade-preloadedResponse: '{"Status": "Success"}'
+  AfterControlPlaneInitialized-preloadedResponse: '{"Status": "Success"}'
+  AfterControlPlaneUpgrade-preloadedResponse: '{"Status": "Success", "RetryAfterSeconds":
+    5}'
+  BeforeClusterCreate-preloadedResponse: '{"Status": "Success", "RetryAfterSeconds":
+    5}'
+  BeforeClusterDelete-preloadedResponse: '{"Status": "Success", "RetryAfterSeconds":
+    5}'
+  BeforeClusterUpgrade-preloadedResponse: '{"Status": "Success", "RetryAfterSeconds":
+    5}'

--- a/test/extension/handlers/lifecycle/handlers.go
+++ b/test/extension/handlers/lifecycle/handlers.go
@@ -44,12 +44,12 @@ func (h *Handler) DoBeforeClusterCreate(ctx context.Context, request *runtimehoo
 	log.Info("BeforeClusterCreate is called")
 	cluster := request.Cluster
 
-	if err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.BeforeClusterCreate, response); err != nil {
+	if err := h.readResponseFromConfigMap(ctx, cluster.Namespace, runtimehooksv1.BeforeClusterCreate, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
-	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.BeforeClusterCreate, response); err != nil {
+	if err := h.recordCallInConfigMap(ctx, cluster.Namespace, runtimehooksv1.BeforeClusterCreate, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -61,13 +61,13 @@ func (h *Handler) DoBeforeClusterUpgrade(ctx context.Context, request *runtimeho
 	log.Info("BeforeClusterUpgrade is called")
 	cluster := request.Cluster
 
-	if err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.BeforeClusterUpgrade, response); err != nil {
+	if err := h.readResponseFromConfigMap(ctx, cluster.Namespace, runtimehooksv1.BeforeClusterUpgrade, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
 
-	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.BeforeClusterUpgrade, response); err != nil {
+	if err := h.recordCallInConfigMap(ctx, cluster.Namespace, runtimehooksv1.BeforeClusterUpgrade, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -79,13 +79,13 @@ func (h *Handler) DoAfterControlPlaneInitialized(ctx context.Context, request *r
 	log.Info("AfterControlPlaneInitialized is called")
 	cluster := request.Cluster
 
-	if err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterControlPlaneInitialized, response); err != nil {
+	if err := h.readResponseFromConfigMap(ctx, cluster.Namespace, runtimehooksv1.AfterControlPlaneInitialized, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
 
-	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterControlPlaneInitialized, response); err != nil {
+	if err := h.recordCallInConfigMap(ctx, cluster.Namespace, runtimehooksv1.AfterControlPlaneInitialized, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -97,13 +97,13 @@ func (h *Handler) DoAfterControlPlaneUpgrade(ctx context.Context, request *runti
 	log.Info("AfterControlPlaneUpgrade is called")
 	cluster := request.Cluster
 
-	if err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterControlPlaneUpgrade, response); err != nil {
+	if err := h.readResponseFromConfigMap(ctx, cluster.Namespace, runtimehooksv1.AfterControlPlaneUpgrade, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
 
-	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterControlPlaneUpgrade, response); err != nil {
+	if err := h.recordCallInConfigMap(ctx, cluster.Namespace, runtimehooksv1.AfterControlPlaneUpgrade, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -115,13 +115,13 @@ func (h *Handler) DoAfterClusterUpgrade(ctx context.Context, request *runtimehoo
 	log.Info("AfterClusterUpgrade is called")
 	cluster := request.Cluster
 
-	if err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterClusterUpgrade, response); err != nil {
+	if err := h.readResponseFromConfigMap(ctx, cluster.Namespace, runtimehooksv1.AfterClusterUpgrade, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
 
-	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.AfterClusterUpgrade, response); err != nil {
+	if err := h.recordCallInConfigMap(ctx, cluster.Namespace, runtimehooksv1.AfterClusterUpgrade, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
@@ -133,21 +133,21 @@ func (h *Handler) DoBeforeClusterDelete(ctx context.Context, request *runtimehoo
 	log.Info("BeforeClusterDelete is called")
 	cluster := request.Cluster
 
-	if err := h.readResponseFromConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.BeforeClusterDelete, response); err != nil {
+	if err := h.readResponseFromConfigMap(ctx, cluster.Namespace, runtimehooksv1.BeforeClusterDelete, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 		return
 	}
-	if err := h.recordCallInConfigMap(ctx, cluster.Name, cluster.Namespace, runtimehooksv1.BeforeClusterDelete, response); err != nil {
+	if err := h.recordCallInConfigMap(ctx, cluster.Namespace, runtimehooksv1.BeforeClusterDelete, response); err != nil {
 		response.Status = runtimehooksv1.ResponseStatusFailure
 		response.Message = err.Error()
 	}
 }
 
-func (h *Handler) readResponseFromConfigMap(ctx context.Context, name, namespace string, hook runtimecatalog.Hook, response runtimehooksv1.ResponseObject) error {
+func (h *Handler) readResponseFromConfigMap(ctx context.Context, namespace string, hook runtimecatalog.Hook, response runtimehooksv1.ResponseObject) error {
 	hookName := runtimecatalog.HookName(hook)
 	configMap := &corev1.ConfigMap{}
-	configMapName := name + "-hookresponses"
+	configMapName := "test-extension-hookresponses"
 	if err := h.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: configMapName}, configMap); err != nil {
 		return errors.Wrapf(err, "failed to read the ConfigMap %s", klog.KRef(namespace, configMapName))
 	}
@@ -161,10 +161,10 @@ func (h *Handler) readResponseFromConfigMap(ctx context.Context, name, namespace
 	return nil
 }
 
-func (h *Handler) recordCallInConfigMap(ctx context.Context, name, namespace string, hook runtimecatalog.Hook, response runtimehooksv1.ResponseObject) error {
+func (h *Handler) recordCallInConfigMap(ctx context.Context, namespace string, hook runtimecatalog.Hook, response runtimehooksv1.ResponseObject) error {
 	hookName := runtimecatalog.HookName(hook)
 	configMap := &corev1.ConfigMap{}
-	configMapName := name + "-hookresponses"
+	configMapName := "test-extension-hookresponses"
 	if err := h.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: configMapName}, configMap); err != nil {
 		return errors.Wrapf(err, "failed to read the ConfigMap %s", klog.KRef(namespace, configMapName))
 	}


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add a generic deployment mechanism for addons to the tilt file and tilt prepare. This mechanism allows  Runtime SDK extensions to be developed alongside the core controllers using the Tilt development flow. It can also be used to develop arbitrary deployments and addons built using the same workflow in tilt as providers use today.

May be related to #6647 
/area runtime-sdk
Fixes #6864 
