### PR TITLE
:book: fixing clusterctl.exe installation directions for curl.exe

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -165,14 +165,14 @@ clusterctl version
 Go to the working directory where you want clusterctl downloaded.
 
 Download the latest release; on Windows, type:
-```bash
-curl {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-windows-amd64.exe" version:"1.2.x"}} -o clusterctl.exe
+```powershell
+curl.exe -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-windows-amd64.exe" version:"1.2.x"}} -o clusterctl.exe
 ```
 Append or prepend the path of that directory to the `PATH` environment variable.
 
 Test to ensure the version you installed is up-to-date:
-```bash
-clusterctl version
+```powershell
+clusterctl.exe version
 ```
 
 {{#/tab }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes clusterctl.exe installation on Windows, first it was missing the -L for the redirect and was returning empty content for the http request. but... curl is sometimes an alias in PowerShell for `Invoke-WebRequest` so the best and most cross compatible way for cmd and powershell I ever found was to just call `curl.exe` explicitly which always ends up being the curl everyone expects.

This is what happens using the docs as they exist today in powershell
```
~ > curl https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/clusterctl-windows-amd64.exe -o clusterctl.exe
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
~ > get-content .\clusterctl.exe
~ > clusterctl
ResourceUnavailable: Program 'clusterctl.exe' failed to run: An error occurred trying to start process 'C:\Users\luthe\bin\clusterctl.exe' with working directory 'C:\Users\luthe'. The specified executable is not a valid application for this OS platform.At line:1 char:1
+ clusterctl
+ ~~~~~~~~~~.
```

This is what happens after this patch

```
~ > curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.0/clusterctl-windows-amd64.exe -o clusterctl.exe
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 61.6M  100 61.6M    0     0  26.6M      0  0:00:02  0:00:02 --:--:-- 33.8M
~ > .\clusterctl.exe version
clusterctl version: &version.Info{Major:"1", Minor:"2", GitVersion:"v1.2.0", GitCommit:"aebeed871c780cfc71bc292dd59eed381da0771f", GitTreeState:"clean", BuildDate:"2022-07-18T14:52:17Z", GoVersion:"go1.18.3", Compiler:"gc", Platform:"windows/amd64"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
