### PR TITLE
🐛 Fix the description of ControlPlaneInitializedCondition is misleading

### DIFF
--- a/api/v1alpha4/condition_consts.go
+++ b/api/v1alpha4/condition_consts.go
@@ -59,7 +59,7 @@ const (
 
 const (
 	// ControlPlaneInitializedCondition reports if the cluster's control plane has been initialized such that the
-	// cluster's apiserver is reachable and at least one control plane Machine has a node reference. Once this
+	// cluster's apiserver is reachable or at least one control plane Machine has a node reference. Once this
 	// condition is marked true, its value is never changed. See the ControlPlaneReady condition for an indication of
 	// the current readiness of the cluster's control plane.
 	ControlPlaneInitializedCondition ConditionType = "ControlPlaneInitialized"

--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -59,7 +59,7 @@ const (
 
 const (
 	// ControlPlaneInitializedCondition reports if the cluster's control plane has been initialized such that the
-	// cluster's apiserver is reachable and at least one control plane Machine has a node reference. Once this
+	// cluster's apiserver is reachable or at least one control plane Machine has a node reference. Once this
 	// condition is marked true, its value is never changed. See the ControlPlaneReady condition for an indication of
 	// the current readiness of the cluster's control plane.
 	ControlPlaneInitializedCondition ConditionType = "ControlPlaneInitialized"


### PR DESCRIPTION
…ncileControlPlane

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

cluster ControlPlaneInitializedCondition reports if the cluster's control plane has been initialized such that the cluster's apiserver is reachable and at least one control plane Machine has a node reference, 
but in the scenario where ControlPlaneRef is not nil, we cannot determine whether there is a control plane machine, and we can only judge by the ControlPlaneInitializedCondition of the control plane, so I think it is necessary to modify the description of cluster ControlPlaneInitialized

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4936
