### PR TITLE
🌱 e2e: cleanup controller log and metric output path

### DIFF
--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -107,7 +107,7 @@ func InitManagementClusterAndWatchControllerLogs(ctx context.Context, input Init
 			GetLister:  client,
 			ClientSet:  input.ClusterProxy.GetClientSet(),
 			Deployment: deployment,
-			LogPath:    filepath.Join(input.LogFolder, "controllers"),
+			LogPath:    filepath.Join(input.LogFolder, "logs", deployment.GetNamespace()),
 		})
 
 		if !input.DisableMetricsCollection {
@@ -115,7 +115,7 @@ func InitManagementClusterAndWatchControllerLogs(ctx context.Context, input Init
 				GetLister:   client,
 				ClientSet:   input.ClusterProxy.GetClientSet(),
 				Deployment:  deployment,
-				MetricsPath: filepath.Join(input.LogFolder, "controllers"),
+				MetricsPath: filepath.Join(input.LogFolder, "metrics", deployment.GetNamespace()),
 			})
 		}
 	}
@@ -163,14 +163,14 @@ func UpgradeManagementClusterAndWait(ctx context.Context, input UpgradeManagemen
 			GetLister:  client,
 			ClientSet:  input.ClusterProxy.GetClientSet(),
 			Deployment: deployment,
-			LogPath:    filepath.Join(input.LogFolder, "controllers"),
+			LogPath:    filepath.Join(input.LogFolder, "logs", deployment.GetNamespace()),
 		})
 
 		framework.WatchPodMetrics(ctx, framework.WatchPodMetricsInput{
 			GetLister:   client,
 			ClientSet:   input.ClusterProxy.GetClientSet(),
 			Deployment:  deployment,
-			MetricsPath: filepath.Join(input.LogFolder, "controllers"),
+			MetricsPath: filepath.Join(input.LogFolder, "metrics", deployment.GetNamespace()),
 		})
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Cleans up the folder used for controller logs to be in a more generic structure.
Especially with future e2e tests which e.g. include more runtime SDK parts this leads to a more intuitive directory structure
to find artifacts for logging or metrics.

Artifacts structure for logs and metrics prior to this PR:

```txt
artifacts/clusters/<cluster-name>/logs/<namespace>/<deployment>/<pod>/
|- manager.log
|- manager-log-metadata.json
|- metrics.txt
```

Example:
```txt
artifacts/clusters/bootstrap/controllers/capd-controller-manager/capd-controller-manager-f8666db7f-hh8jz/
|- manager.log
|- manager-log-metadata.json
|- metrics.txt
`

Artifacts structure with this PR:

```txt
artifacts/clusters/<cluster-name>/
|- logs/<namespace>/<deployment>/<pod>/
  |- manager.log
  |- manager-log-metadata.json
|- metrics/<namespace>/<deployment>/<pod>/
  |- metrics.txt
```

Example:

```txt
artifacts/clusters/bootstrap/
|- logs/capd-system/capd-controller-manager/capd-controller-manager-f8666db7f-hh8jz/
  |- manager.log
  |- manager-log-metadata.json
|- metrics/capd-system/capd-controller-manager/capd-controller-manager-f8666db7f-hh8jz/
  |- metrics.txt
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6900
