### PR TITLE
📖  Add vcluster to CAPI book Quick Start

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -206,7 +206,7 @@ Additional documentation about experimental features can be found in [Experiment
 Depending on the infrastructure provider you are planning to use, some additional prerequisites should be satisfied
 before getting started with Cluster API. See below for the expected settings for common providers.
 
-{{#tabs name:"tab-installation-infrastructure" tabs:"AWS,Azure,CloudStack,DigitalOcean,Docker,Equinix Metal,GCP,Hetzner,IBM Cloud,Metal3,Nutanix,Kubevirt,OCI,OpenStack,VCD,vSphere"}}
+{{#tabs name:"tab-installation-infrastructure" tabs:"AWS,Azure,CloudStack,DigitalOcean,Docker,Equinix Metal,GCP,Hetzner,IBM Cloud,Metal3,Nutanix,Kubevirt,OCI,OpenStack,VCD,vcluster,vSphere"}}
 {{#tab AWS}}
 
 Download the latest binary of `clusterawsadm` from the [AWS provider releases].
@@ -476,6 +476,15 @@ clusterctl init --infrastructure vcd
 ```
 
 {{#/tab }}
+{{#tab vcluster}}
+
+```bash
+clusterctl init --infrastructure vcluster
+```
+
+Please follow the Cluster API Provider for [vcluster Quick Start Guide](https://github.com/loft-sh/cluster-api-provider-vcluster/blob/main/docs/quick-start.md)
+
+{{#/tab }}
 {{#tab vSphere}}
 
 ```bash
@@ -562,7 +571,7 @@ before configuring a cluster with Cluster API. Instructions are provided for com
 Otherwise, you can look at the `clusterctl generate cluster` [command][clusterctl generate cluster] documentation for details about how to
 discover the list of variables required by a cluster templates.
 
-{{#tabs name:"tab-configuration-infrastructure" tabs:"AWS,Azure,CloudStack,DigitalOcean,Docker,Equinix Metal,GCP,IBM Cloud,Metal3,Nutanix,Kubevirt,OpenStack,vSphere"}}
+{{#tabs name:"tab-configuration-infrastructure" tabs:"AWS,Azure,CloudStack,DigitalOcean,Docker,Equinix Metal,GCP,IBM Cloud,Metal3,Nutanix,Kubevirt,OpenStack,VCD,vcluster,vSphere"}}
 {{#tab AWS}}
 
 ```bash
@@ -855,8 +864,20 @@ see [CAPVCD](https://github.com/vmware/cluster-api-provider-cloud-director)
 To see all required VCD environment variables execute:
 ```bash
 clusterctl generate cluster --infrastructure vcd --list-variables capi-quickstart
-``
+```
 
+
+{{#/tab }}
+{{#tab vcluster}}
+
+```bash
+export CLUSTER_NAME=kind
+export CLUSTER_NAMESPACE=vcluster
+export KUBERNETES_VERSION=1.23.4
+export HELM_VALUES="service:\n  type: NodePort"
+```
+
+Please see the [vcluster installation instructions](https://github.com/loft-sh/cluster-api-provider-vcluster#installation-instructions) for more details.
 
 {{#/tab }}
 {{#tab vSphere}}
@@ -897,18 +918,7 @@ For more information about prerequisites, credentials management, or permissions
 
 For the purpose of this tutorial, we'll name our cluster capi-quickstart.
 
-{{#tabs name:"tab-clusterctl-config-cluster" tabs:"Azure|AWS|CloudStack|DigitalOcean|Equinix Metal|GCP|Metal3|Nutanix|Kubevirt|OpenStack|vSphere,Docker"}}
-{{#tab Azure|AWS|CloudStack|DigitalOcean|Equinix Metal|GCP|Metal3|OpenStack|vSphere}}
-
-```bash
-clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.24.0 \
-  --control-plane-machine-count=3 \
-  --worker-machine-count=3 \
-  > capi-quickstart.yaml
-```
-
-{{#/tab }}
+{{#tabs name:"tab-clusterctl-config-cluster" tabs:"Docker, vcluster, others..."}}
 {{#tab Docker}}
 
 <aside class="note warning">
@@ -921,6 +931,33 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
+  --kubernetes-version v1.24.0 \
+  --control-plane-machine-count=3 \
+  --worker-machine-count=3 \
+  > capi-quickstart.yaml
+```
+
+{{#/tab }}
+{{#tab vcluster}}
+
+```bash
+export CLUSTER_NAME=kind
+export CLUSTER_NAMESPACE=vcluster
+export KUBERNETES_VERSION=1.23.4
+export HELM_VALUES="service:\n  type: NodePort"
+
+kubectl create namespace ${CLUSTER_NAMESPACE}
+clusterctl generate cluster ${CLUSTER_NAME} \
+    --infrastructure vcluster \
+    --kubernetes-version ${KUBERNETES_VERSION} \
+    --target-namespace ${CLUSTER_NAMESPACE} | kubectl apply -f -
+```
+
+{{#/tab }}
+{{#tab others...}}
+
+```bash
+clusterctl generate cluster capi-quickstart \
   --kubernetes-version v1.24.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
@@ -1010,12 +1047,14 @@ If you're using Docker Desktop on macOS, or Docker Desktop (Docker Engine works 
 
 Calico is used here as an example.
 
-{{#tabs name:"tab-deploy-cni" tabs:"AWS|CloudStack|DigitalOcean|Docker|Equinix Metal|GCP|Metal3|Nutanix|Kubevirt|OpenStack|vSphere,Azure"}}
-{{#tab AWS|CloudStack|DigitalOcean|Docker|Equinix Metal|GCP|Metal3|OpenStack|vSphere}}
+{{#tabs name:"tab-deploy-cni" tabs:"Azure,vcluster,others..."}}
+{{#tab Azure}}
+
+Azure [does not currently support Calico networking](https://docs.projectcalico.org/reference/public-cloud/azure). As a workaround, it is recommended that Azure clusters use the Calico spec below that uses VXLAN.
 
 ```bash
 kubectl --kubeconfig=./capi-quickstart.kubeconfig \
-  apply -f https://docs.projectcalico.org/v3.21/manifests/calico.yaml
+  apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico.yaml
 ```
 
 After a short while, our nodes should be running and in `Ready` state,
@@ -1026,13 +1065,16 @@ kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
 ```
 
 {{#/tab }}
-{{#tab Azure}}
+{{#tab vcluster}}
 
-Azure [does not currently support Calico networking](https://docs.projectcalico.org/reference/public-cloud/azure). As a workaround, it is recommended that Azure clusters use the Calico spec below that uses VXLAN.
+Calico not required for vcluster.
+
+{{#/tab }}
+{{#tab others...}}
 
 ```bash
 kubectl --kubeconfig=./capi-quickstart.kubeconfig \
-  apply -f https://raw.githubusercontent.com/kubernetes-sigs/cluster-api-provider-azure/main/templates/addons/calico.yaml
+  apply -f https://docs.projectcalico.org/v3.21/manifests/calico.yaml
 ```
 
 After a short while, our nodes should be running and in `Ready` state,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a link to the vcluster provider Quick Start in the CAPI Quick Start. 

