### PR TITLE
🌱 [WIP] Watch pods of a deployment to start log streaming for newly running pods

### DIFF
--- a/test/e2e/cluster_upgrade_runtimesdk.go
+++ b/test/e2e/cluster_upgrade_runtimesdk.go
@@ -158,10 +158,10 @@ func clusterUpgradeWithRuntimeSDKSpec(ctx context.Context, inputGetter func() cl
 
 		By("Watch Deployment logs of test extension")
 		framework.WatchDeploymentLogs(ctx, framework.WatchDeploymentLogsInput{
-			GetLister:  input.BootstrapClusterProxy.GetClient(),
-			ClientSet:  input.BootstrapClusterProxy.GetClientSet(),
-			Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-extension", Namespace: namespace.Name}},
-			LogPath:    filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName(), "logs", namespace.Name),
+			GetListerWithWatch: input.BootstrapClusterProxy.GetClient(),
+			ClientSet:          input.BootstrapClusterProxy.GetClientSet(),
+			Deployment:         &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-extension", Namespace: namespace.Name}},
+			LogPath:            filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName(), "logs", namespace.Name),
 		})
 
 		By("Creating a workload cluster")

--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -64,7 +64,7 @@ type ClusterProxy interface {
 	GetScheme() *runtime.Scheme
 
 	// GetClient returns a controller-runtime client to the Kubernetes cluster.
-	GetClient() client.Client
+	GetClient() client.WithWatch
 
 	// GetClientSet returns a client-go client to the Kubernetes cluster.
 	GetClientSet() *kubernetes.Clientset
@@ -173,13 +173,13 @@ func (p *clusterProxy) GetScheme() *runtime.Scheme {
 }
 
 // GetClient returns a controller-runtime client for the cluster.
-func (p *clusterProxy) GetClient() client.Client {
+func (p *clusterProxy) GetClient() client.WithWatch {
 	config := p.GetRESTConfig()
 
-	var c client.Client
+	var c client.WithWatch
 	var newClientErr error
 	err := wait.PollImmediate(retryableOperationInterval, retryableOperationTimeout, func() (bool, error) {
-		c, newClientErr = client.New(config, client.Options{Scheme: p.scheme})
+		c, newClientErr = client.NewWithWatch(config, client.Options{Scheme: p.scheme})
 		if newClientErr != nil {
 			return false, nil //nolint:nilerr
 		}

--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -104,10 +104,10 @@ func InitManagementClusterAndWatchControllerLogs(ctx context.Context, input Init
 
 		// Start streaming logs from all controller providers
 		framework.WatchDeploymentLogs(ctx, framework.WatchDeploymentLogsInput{
-			GetLister:  client,
-			ClientSet:  input.ClusterProxy.GetClientSet(),
-			Deployment: deployment,
-			LogPath:    filepath.Join(input.LogFolder, "logs", deployment.GetNamespace()),
+			GetListerWithWatch: input.ClusterProxy.GetClient(),
+			ClientSet:          input.ClusterProxy.GetClientSet(),
+			Deployment:         deployment,
+			LogPath:            filepath.Join(input.LogFolder, "logs", deployment.GetNamespace()),
 		})
 
 		if !input.DisableMetricsCollection {
@@ -160,10 +160,10 @@ func UpgradeManagementClusterAndWait(ctx context.Context, input UpgradeManagemen
 
 		// Start streaming logs from all controller providers
 		framework.WatchDeploymentLogs(ctx, framework.WatchDeploymentLogsInput{
-			GetLister:  client,
-			ClientSet:  input.ClusterProxy.GetClientSet(),
-			Deployment: deployment,
-			LogPath:    filepath.Join(input.LogFolder, "logs", deployment.GetNamespace()),
+			GetListerWithWatch: input.ClusterProxy.GetClient(),
+			ClientSet:          input.ClusterProxy.GetClientSet(),
+			Deployment:         deployment,
+			LogPath:            filepath.Join(input.LogFolder, "logs", deployment.GetNamespace()),
 		})
 
 		framework.WatchPodMetrics(ctx, framework.WatchPodMetricsInput{

--- a/test/framework/interfaces.go
+++ b/test/framework/interfaces.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -39,6 +40,11 @@ type Lister interface {
 	List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
 }
 
+// Watcher can watch resources.
+type Watcher interface {
+	Watch(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error)
+}
+
 // Deleter can delete resources.
 type Deleter interface {
 	Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
@@ -48,4 +54,11 @@ type Deleter interface {
 type GetLister interface {
 	Getter
 	Lister
+}
+
+// GetListerWithWatch can get, list and watch resources.
+type GetListerWithWatch interface {
+	Getter
+	Lister
+	Watcher
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Uses a watch in a separate go routine for pods to start new go routines to stream logs instead of doing a list once.

Note: I adjusted the `func (p *clusterProxy) GetClient()` func to return a `client.WithWatch` instead of a `client.Client`. We could also expose a separate func for that like e.g. `func (p *clusterProxy) GetClientWithWatch() client.WithWatch`. I think the way it currently is is not a breaking change, because the returned client still fulfills the `client.Client` interface.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4684
