### PR TITLE
🐛 Fix potential nilpointer error in machine remediation

### DIFF
--- a/controlplane/kubeadm/internal/controllers/fakes_test.go
+++ b/controlplane/kubeadm/internal/controllers/fakes_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/blang/semver"
+	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -69,7 +70,10 @@ type fakeWorkloadCluster struct {
 	EtcdMembersResult []string
 }
 
-func (f fakeWorkloadCluster) ForwardEtcdLeadership(_ context.Context, _ *clusterv1.Machine, _ *clusterv1.Machine) error {
+func (f fakeWorkloadCluster) ForwardEtcdLeadership(_ context.Context, _ *clusterv1.Machine, leaderCandidate *clusterv1.Machine) error {
+	if leaderCandidate == nil {
+		return errors.New("leaderCandidate is nil")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fix a possible nil pointer when etcd healthy quorum is available, but no healthy machine is available to become etcd leader. Add a condition to the machine to be remediated surfacing the issue.

Fixes: #7000 
