### PR TITLE
✨e2e: Support use customize kubectl

### DIFF
--- a/test/framework/exec/kubectl.go
+++ b/test/framework/exec/kubectl.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 )
 
 // KubectlApply shells out to kubectl apply.
@@ -29,7 +30,7 @@ func KubectlApply(ctx context.Context, kubeconfigPath string, resources []byte, 
 	aargs := append([]string{"apply", "--kubeconfig", kubeconfigPath, "-f", "-"}, args...)
 	rbytes := bytes.NewReader(resources)
 	applyCmd := NewCommand(
-		WithCommand("kubectl"),
+		WithCommand(kubectlPath()),
 		WithArgs(aargs...),
 		WithStdin(rbytes),
 	)
@@ -46,7 +47,7 @@ func KubectlApply(ctx context.Context, kubeconfigPath string, resources []byte, 
 func KubectlWait(ctx context.Context, kubeconfigPath string, args ...string) error {
 	wargs := append([]string{"wait", "--kubeconfig", kubeconfigPath}, args...)
 	wait := NewCommand(
-		WithCommand("kubectl"),
+		WithCommand(kubectlPath()),
 		WithArgs(wargs...),
 	)
 	_, stderr, err := wait.Run(ctx)
@@ -55,4 +56,11 @@ func KubectlWait(ctx context.Context, kubeconfigPath string, args ...string) err
 		return err
 	}
 	return nil
+}
+
+func kubectlPath() string {
+	if kubectlPath, ok := os.LookupEnv("CAPI_KUBECTL_PATH"); ok {
+		return kubectlPath
+	}
+	return "kubectl"
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

now e2e test framework only support use kubectl of system, sometimes user need a different version of kubectl, this PR enable it by customize kubectl path with `CAPI_KUBECTL_PATH` env var.
