### PR TITLE
🐛 Fix APIVersion in OwnerReferences to ClusterResourceSets

### DIFF
--- a/exp/addons/internal/controllers/clusterresourceset_helpers.go
+++ b/exp/addons/internal/controllers/clusterresourceset_helpers.go
@@ -150,7 +150,7 @@ func ensureOwnerRefs(clusterResourceSetBinding *addonsv1.ClusterResourceSetBindi
 	})
 	ownerRefs = util.EnsureOwnerRef(ownerRefs,
 		metav1.OwnerReference{
-			APIVersion: clusterResourceSet.GroupVersionKind().String(),
+			APIVersion: clusterResourceSet.GroupVersionKind().GroupVersion().String(),
 			Kind:       clusterResourceSet.GroupVersionKind().Kind,
 			Name:       clusterResourceSet.Name,
 			UID:        clusterResourceSet.UID,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Issue got introduced in https://github.com/kubernetes-sigs/cluster-api/pull/6989 .

The introduced change creates an OwnerReference at the `ClusterResourceSetBinding` which looks like as follows:
```
    - apiVersion: addons.cluster.x-k8s.io/v1beta1, Kind=ClusterResourceSet
      kind: ClusterResourceSet
      name: self-hosted-64pplg-crs-0
      uid: 630b7f3c-babd-409e-837a-d6a849729b9d
```

This fix adjusts it to be:

```
    - apiVersion: addons.cluster.x-k8s.io/v1beta1
      kind: ClusterResourceSet
      name: self-hosted-64pplg-crs-0
      uid: 630b7f3c-babd-409e-837a-d6a849729b9d
```

Without the fix, `clusterctl move` is broken because it tries to get an `ClusterResourceSet` of `APIVersion` `addons.cluster.x-k8s.io/v1beta1, Kind=ClusterResourceSet` which does not exist on the client and thus results in the following error:

```
error reading "addons.cluster.x-k8s.io/v1beta1, Kind=ClusterResourceSet, Kind=ClusterResourceSet" /: no matches for kind "ClusterResourceSet" in version "addons.cluster.x-k8s.io/v1beta1, Kind=ClusterResourceSet"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
