### PR TITLE
🌱 Fix empty control-plane taints example

### DIFF
--- a/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
@@ -228,7 +228,7 @@ type NodeRegistrationOptions struct {
 
 	// Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
 	// it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
-	// empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.
+	// empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
 	// +optional
 	Taints []corev1.Taint `json:"taints,omitempty"`
 

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -2617,7 +2617,7 @@ spec:
                           nil, in the `kubeadm init` process it will be defaulted
                           to []v1.Taint{''node-role.kubernetes.io/master=""''}. If
                           you don''t want to taint your control-plane node, set this
-                          field to an empty slice, i.e. `taints: {}` in the YAML file.
+                          field to an empty slice, i.e. `taints: []` in the YAML file.
                           This field is solely used for Node registration.'
                         items:
                           description: The node this Taint is attached to has the
@@ -2828,7 +2828,7 @@ spec:
                           nil, in the `kubeadm init` process it will be defaulted
                           to []v1.Taint{''node-role.kubernetes.io/master=""''}. If
                           you don''t want to taint your control-plane node, set this
-                          field to an empty slice, i.e. `taints: {}` in the YAML file.
+                          field to an empty slice, i.e. `taints: []` in the YAML file.
                           This field is solely used for Node registration.'
                         items:
                           description: The node this Taint is attached to has the

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -2646,7 +2646,7 @@ spec:
                                   it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}.
                                   If you don''t want to taint your control-plane node,
                                   set this field to an empty slice, i.e. `taints:
-                                  {}` in the YAML file. This field is solely used
+                                  []` in the YAML file. This field is solely used
                                   for Node registration.'
                                 items:
                                   description: The node this Taint is attached to
@@ -2872,7 +2872,7 @@ spec:
                                   it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}.
                                   If you don''t want to taint your control-plane node,
                                   set this field to an empty slice, i.e. `taints:
-                                  {}` in the YAML file. This field is solely used
+                                  []` in the YAML file. This field is solely used
                                   for Node registration.'
                                 items:
                                   description: The node this Taint is attached to

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -3089,7 +3089,7 @@ spec:
                               i.e. nil, in the `kubeadm init` process it will be defaulted
                               to []v1.Taint{''node-role.kubernetes.io/master=""''}.
                               If you don''t want to taint your control-plane node,
-                              set this field to an empty slice, i.e. `taints: {}`
+                              set this field to an empty slice, i.e. `taints: []`
                               in the YAML file. This field is solely used for Node
                               registration.'
                             items:
@@ -3309,7 +3309,7 @@ spec:
                               i.e. nil, in the `kubeadm init` process it will be defaulted
                               to []v1.Taint{''node-role.kubernetes.io/master=""''}.
                               If you don''t want to taint your control-plane node,
-                              set this field to an empty slice, i.e. `taints: {}`
+                              set this field to an empty slice, i.e. `taints: []`
                               in the YAML file. This field is solely used for Node
                               registration.'
                             items:

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -1882,7 +1882,7 @@ spec:
                                       init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}.
                                       If you don''t want to taint your control-plane
                                       node, set this field to an empty slice, i.e.
-                                      `taints: {}` in the YAML file. This field is
+                                      `taints: []` in the YAML file. This field is
                                       solely used for Node registration.'
                                     items:
                                       description: The node this Taint is attached
@@ -2118,7 +2118,7 @@ spec:
                                       init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}.
                                       If you don''t want to taint your control-plane
                                       node, set this field to an empty slice, i.e.
-                                      `taints: {}` in the YAML file. This field is
+                                      `taints: []` in the YAML file. This field is
                                       solely used for Node registration.'
                                     items:
                                       description: The node this Taint is attached


### PR DESCRIPTION
**What this PR does / why we need it**:

The docs to remove the default control plane taints instruct the user to set the value to _an empty slice, i.e. `taints: {}` in the YAML file_ , but an empty slice is equal to an empty yaml array: `taints: []`.

**Which issue(s) this PR fixes**:
Fixes #
