### PR TITLE
:seedling: Remove logger from ControlPlane internal

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/storage/names"
-	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -37,9 +36,6 @@ import (
 	"sigs.k8s.io/cluster-api/util/failuredomains"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
-
-// Log is the global logger for the internal package.
-var Log = klogr.New()
 
 // ControlPlane holds business logic around control planes.
 // It should never need to connect to a service, that responsibility lies outside of this struct.


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Removes the now unused Logger from the ControlPlane package. This logger was used previous to the changes in #6994 specifically [here](https://github.com/kubernetes-sigs/cluster-api/pull/6150/files#diff-52adeada03991a6272ae7710a3725d8abf89ae5567146d75c61351888d93e3ea)