### PR TITLE
🐛  Fix nil pointer in patch Apply

### DIFF
--- a/util/conditions/patch.go
+++ b/util/conditions/patch.go
@@ -134,6 +134,9 @@ func (p Patch) Apply(latest Setter, options ...ApplyOption) error {
 
 	applyOpt := &applyOptions{}
 	for _, o := range options {
+		if util.IsNil(o) {
+			return errors.New("error patching conditions: ApplyOption was nil")
+		}
 		o(applyOpt)
 	}
 

--- a/util/conditions/patch_test.go
+++ b/util/conditions/patch_test.go
@@ -283,6 +283,14 @@ func TestApply(t *testing.T) {
 			want:    conditionList(fooFalse), // after condition should be kept in case of error
 			wantErr: false,
 		},
+		{
+			name:    "Error when nil passed as an ApplyOption",
+			before:  getterWithConditions(fooTrue),
+			after:   getterWithConditions(fooFalse),
+			latest:  setterWithConditions(),
+			options: []ApplyOption{nil},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fix a nil pointer discovered through fuzzing. This condition is unlikely or impossible to occur in CAPI code, but is possible for consumers of the code.

Part of the broader issue discussed in https://github.com/kubernetes-sigs/cluster-api/pull/6334#issuecomment-1084602280