### PR TITLE
🌱  Add .gitattributes file to hide generated diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Hide generated crd yamls by default in the Github diff UX
+**/config/crd/bases/*.yaml linguist-generated=true
+cmd/clusterctl/config/manifest/clusterctl-api.yaml linguist-generated=true


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add a `.gitattributes` file to hide generated CRD yamls in PRs. Our generated go code is already automatically hidden by [github linguist](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github). 

The `.gitattributes` file lets us customize it's config - I'm sure there will be more potential additions to this in future.