### PR TITLE
 🐛 Fix nodeDrainTimeout for ControlPlane on Topology managed clusters

### DIFF
--- a/internal/contract/controlplane_test.go
+++ b/internal/contract/controlplane_test.go
@@ -153,7 +153,7 @@ func TestControlPlane(t *testing.T) {
 		g := NewWithT(t)
 
 		duration := metav1.Duration{Duration: 2*time.Minute + 5*time.Second}
-
+		expectedDurationString := "2m5s"
 		g.Expect(ControlPlane().MachineTemplate().NodeDrainTimeout().Path()).To(Equal(Path{"spec", "machineTemplate", "nodeDrainTimeout"}))
 
 		err := ControlPlane().MachineTemplate().NodeDrainTimeout().Set(obj, duration)
@@ -163,6 +163,12 @@ func TestControlPlane(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
 		g.Expect(*got).To(Equal(duration))
+
+		// Check that the literal string value of the duration is correctly formatted.
+		durationString, found, err := unstructured.NestedString(obj.UnstructuredContent(), "spec", "machineTemplate", "nodeDrainTimeout")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(durationString).To(Equal(expectedDurationString))
 	})
 }
 

--- a/internal/contract/types.go
+++ b/internal/contract/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package contract
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -151,7 +152,7 @@ func (i *Duration) Get(obj *unstructured.Unstructured) (*metav1.Duration, error)
 	}
 
 	d := &metav1.Duration{}
-	if err := d.UnmarshalJSON([]byte(durationString)); err != nil {
+	if err := d.UnmarshalJSON([]byte(strconv.Quote(durationString))); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal duration %s from object", "."+strings.Join(i.path, "."))
 	}
 
@@ -160,12 +161,7 @@ func (i *Duration) Get(obj *unstructured.Unstructured) (*metav1.Duration, error)
 
 // Set sets the metav1.Duration value in the path.
 func (i *Duration) Set(obj *unstructured.Unstructured, value metav1.Duration) error {
-	durationString, err := value.MarshalJSON()
-	if err != nil {
-		return errors.Wrapf(err, "failed to marshal duration %s", value.Duration.String())
-	}
-
-	if err := unstructured.SetNestedField(obj.UnstructuredContent(), string(durationString), i.path...); err != nil {
+	if err := unstructured.SetNestedField(obj.UnstructuredContent(), value.Duration.String(), i.path...); err != nil {
 		return errors.Wrapf(err, "failed to set path %s of object %v", "."+strings.Join(i.path, "."), obj.GroupVersionKind())
 	}
 	return nil

--- a/internal/controllers/topology/cluster/desired_state_test.go
+++ b/internal/controllers/topology/cluster/desired_state_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cluster
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -315,7 +314,7 @@ func TestComputeControlPlane(t *testing.T) {
 
 		assertNestedField(g, obj, version, contract.ControlPlane().Version().Path()...)
 		assertNestedField(g, obj, int64(replicas), contract.ControlPlane().Replicas().Path()...)
-		assertNestedField(g, obj, fmt.Sprintf("%q", duration), contract.ControlPlane().MachineTemplate().NodeDrainTimeout().Path()...)
+		assertNestedField(g, obj, duration.String(), contract.ControlPlane().MachineTemplate().NodeDrainTimeout().Path()...)
 		assertNestedFieldUnset(g, obj, contract.ControlPlane().MachineTemplate().InfrastructureRef().Path()...)
 
 		// Ensure no ownership is added to generated ControlPlane.

--- a/test/e2e/data/infrastructure-docker/v1beta1/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/bases/cluster-with-topology.yaml
@@ -17,11 +17,13 @@ spec:
     version: "${KUBERNETES_VERSION}"
     controlPlane:
       metadata: {}
+      nodeDrainTimeout: "30s"
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     workers:
       machineDeployments:
       - class: "default-worker"
         name: "md-0"
+        nodeDrainTimeout: "30s"
         replicas: ${WORKER_MACHINE_COUNT}
         failureDomain: fd4
     variables:


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

This changes adds setting nodeDrainTimout field to the ControlPlane and MachineDeploymentTopology in our ClusterClass quick start test and adds a fix which unquotes the string before setting it in the patch.

On reviewing #https://github.com/kubernetes-sigs/cluster-api/pull/7031 it looks like we're not able to reconcile NodeDrainTimeout (added in https://github.com/kubernetes-sigs/cluster-api/issues/6278) on the control plane in a topology managed cluster. 

