### PR TITLE
🐛 Fix kube-proxy upgrade with docker.io image

### DIFF
--- a/util/container/image.go
+++ b/util/container/image.go
@@ -123,7 +123,7 @@ func ModifyImageTag(imageName, tagName string) (string, error) {
 		return "", errors.Wrap(err, "failed to update image tag")
 	}
 
-	return reference.FamiliarString(reference.TagNameOnly(namedTagged)), nil
+	return reference.TagNameOnly(namedTagged).String(), nil
 }
 
 // ImageTagIsValid ensures that a given image tag is compliant with the OCI spec.

--- a/util/container/image_test.go
+++ b/util/container/image_test.go
@@ -120,6 +120,22 @@ func TestParseImageName(t *testing.T) {
 			tag:       "",
 			wantError: true,
 		},
+		{
+			name:      "input with a docker.io/ image name",
+			input:     "docker.io/dev/kube-proxy:v1.99.99",
+			repo:      "docker.io/dev",
+			imageName: "kube-proxy",
+			tag:       "v1.99.99",
+			wantError: false,
+		},
+		{
+			name:      "input with a docker.io/ image name that is not canonical",
+			input:     "dev/kube-proxy:v1.99.99",
+			repo:      "dev",
+			imageName: "kube-proxy",
+			tag:       "v1.99.99",
+			wantError: true,
+		},
 	}
 	for _, tc := range testCases {
 		g := NewWithT(t)
@@ -216,5 +232,12 @@ func TestModifyImageTag(t *testing.T) {
 		res, err := ModifyImageTag(image, testTag)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(res).To(Equal("example.com/image:v1.17.4_build1"))
+	})
+	t.Run("should ensure image is a docker compatible tag with docker.io", func(t *testing.T) {
+		testTag := "v1.17.4+build1"
+		image := "docker.io/dev/image:1.17.3"
+		res, err := ModifyImageTag(image, testTag)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(res).To(Equal("docker.io/dev/image:v1.17.4_build1"))
 	})
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
I was upgrading the control-plane on a Kubernetes cluster overriding `clusterConfiguration.imageRepository: docker.io/foo` and ran into an error where the `kube-proxy` DS was never updated.
```
E0811 03:44:47.681926       1 controller.go:387] controller/kubeadmcontrolplane "msg"="failed to update kube-proxy daemonset" "error"="failed to parse image name: couldn't parse image name: repository name must be canonical" "cluster"="dkoshkin-upgrade" "name"="dkoshkin-upgrade-control-plane" "namespace"="default" "reconciler group"="controlplane.cluster.x-k8s.io" "reconciler kind"="KubeadmControlPlane"
```
You can also see these error messages in the logs for new clusters if using a `imageRepository: doker.io` `imageRepository`, but its real subtle since it doesn't surface in any statuses.

--- 

This happens because the call `reference.FamiliarString` in `ModifyImageTag` strips `docker.io/` and then is used in `reference.ParseNamed(image)` in the `ImageFromString` function, which expects a canoncial name with `docker.io`.

The first commit 0fd85f3454ed01b749c09a638272edd0c9dadff8 adds a failing unit test and a couple other tests for `ImageFromString()` func.

The second commit f239ed0ce1ed54f8caefd3ef1689f8dd9da3578d removes the culprit `reference.FamiliarString` call. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
