### PR TITLE
🌱 clusterctl: Add --validate option to init

### DIFF
--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -69,6 +69,10 @@ type InitOptions struct {
 	// SkipTemplateProcess allows for skipping the call to the template processor, including also variable replacement in the component YAML.
 	// NOTE this works only if the rawYaml is a valid yaml by itself, like e.g when using envsubst/the simple processor.
 	skipTemplateProcess bool
+
+	// IgnoreValidationErrors allows for skipping the validation of provider installs.
+	// NOTE this should only be used for development
+	IgnoreValidationErrors bool
 }
 
 // Init initializes a management cluster by adding the requested list of providers.
@@ -108,7 +112,10 @@ func (c *clusterctlClient) Init(options InitOptions) ([]Components, error) {
 	// - There should be only one instance of the same provider.
 	// - All the providers must support the same API Version of Cluster API (contract)
 	if err := installer.Validate(); err != nil {
-		return nil, err
+		if !options.IgnoreValidationErrors {
+			return nil, err
+		}
+		log.Error(err, "Ignoring validation errors")
 	}
 
 	// Before installing the providers, ensure the cert-manager Webhook is in place.

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -34,6 +34,7 @@ type initOptions struct {
 	infrastructureProviders []string
 	targetNamespace         string
 	listImages              bool
+	validate                bool
 	waitProviders           bool
 	waitProviderTimeout     int
 }
@@ -108,6 +109,8 @@ func init() {
 		"Wait for providers to be installed.")
 	initCmd.Flags().IntVar(&initOpts.waitProviderTimeout, "wait-provider-timeout", 5*60,
 		"Wait timeout per provider installation in seconds. This value is ignored if --wait-providers is false")
+	initCmd.Flags().BoolVar(&initOpts.validate, "validate", true,
+		"If true, clusterctl will validate that the deployments will succeed on the management cluster.")
 
 	// TODO: Move this to a sub-command or similar, it shouldn't really be a flag.
 	initCmd.Flags().BoolVar(&initOpts.listImages, "list-images", false,
@@ -132,6 +135,7 @@ func runInit() error {
 		LogUsageInstructions:    true,
 		WaitProviders:           initOpts.waitProviders,
 		WaitProviderTimeout:     time.Duration(initOpts.waitProviderTimeout) * time.Second,
+		IgnoreValidationErrors:  !initOpts.validate,
 	}
 
 	if initOpts.listImages {


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Can be used during clusterctl init to ignore validation errors, most frequently during development of tools that consume clusterctl as a library.

Concretely, it's helping me out during debugging.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
