### PR TITLE
🐛 Fix Architecture metadata in Dockerfiles for distroless base image references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
 
+# Build architecture
+ARG ARCH
+
 # Ignore Hadolint rule "Always tag the version of an image explicitly."
 # It's an invalid finding since the image is explicitly set in the Makefile.
 # https://github.com/hadolint/hadolint/wiki/DL3006
@@ -60,7 +63,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o manager ${package}
 
 # Production image
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/cmd/clusterctl/Dockerfile
+++ b/cmd/clusterctl/Dockerfile
@@ -18,6 +18,9 @@
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
 
+# Build architecture
+ARG ARCH
+
 # Ignore Hadolint rule "Always tag the version of an image explicitly."
 # It's an invalid finding since the image is explicitly set in the Makefile.
 # https://github.com/hadolint/hadolint/wiki/DL3006
@@ -60,7 +63,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o clusterctl ${package}
 
 # Production image
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/clusterctl .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/test/extension/Dockerfile
+++ b/test/extension/Dockerfile
@@ -18,6 +18,9 @@
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
 
+# Build architecture
+ARG ARCH
+
 # Ignore Hadolint rule "Always tag the version of an image explicitly."
 # It's an invalid finding since the image is explicitly set in the Makefile.
 # https://github.com/hadolint/hadolint/wiki/DL3006
@@ -63,7 +66,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o /workspace/extension ${package}
 
 # Production image
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/extension .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -17,6 +17,9 @@
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
 
+# Build architecture
+ARG ARCH
+
 # Ignore Hadolint rule "Always tag the version of an image explicitly."
 # It's an invalid finding since the image is explicitly set in the Makefile.
 # https://github.com/hadolint/hadolint/wiki/DL3006
@@ -57,6 +60,9 @@ COPY . .
 # Essentially, change directories into CAPD
 WORKDIR /workspace/test/infrastructure/docker
 
+# Build
+ARG ARCH
+
 # Build the CAPD manager using the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
@@ -67,7 +73,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Ignore Hadolint rule "Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag."
 # https://github.com/hadolint/hadolint/wiki/DL3007
 # hadolint ignore=DL3007
-FROM gcr.io/distroless/static:latest
+FROM --platform=${ARCH} gcr.io/distroless/static:latest
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
**What this PR does / why we need it**:

References the correct architecture for the distroless base image. Before this commit, docker would have chosen the platform of the docker host.

Current main:
```sh
$ uname -m
arm64
$ ARCH=ppc64le REGISTRY=test make docker-build-core
$ docker inspect docker.io/test/cluster-api-controller-ppc64le:dev | grep Architecture
        "Architecture": "arm64",
```

WIth this commit:
```sh
$ uname -m
arm64
$ ARCH=ppc64le REGISTRY=test make docker-build-core
$ docker inspect docker.io/test/cluster-api-controller-ppc64le:dev | grep Architecture
        "Architecture": "ppc64le",
```

Note: I had to move the `ARG ARCH` above the first `FROM`, otherwise it is not set/empty in `FROM` lines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7055
