### PR TITLE
[release-1.2] 🐛 Fix Architecture metadata in Dockerfiles for distroless base image references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@
 # Build the manager binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
+
+# Build architecture
+ARG ARCH
+
 FROM ${builder_image} as builder
 WORKDIR /workspace
 
@@ -55,7 +59,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o manager ${package}
 
 # Production image
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/cmd/clusterctl/Dockerfile
+++ b/cmd/clusterctl/Dockerfile
@@ -17,6 +17,10 @@
 # Build the clusterctl binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
+
+# Build architecture
+ARG ARCH
+
 FROM ${builder_image} as builder
 WORKDIR /workspace
 
@@ -55,7 +59,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o clusterctl ${package}
 
 # Production image
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/clusterctl .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/test/extension/Dockerfile
+++ b/test/extension/Dockerfile
@@ -17,6 +17,10 @@
 # Build the extension binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
+
+# Build architecture
+ARG ARCH
+
 FROM ${builder_image} as builder
 WORKDIR /workspace
 
@@ -58,7 +62,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o /workspace/extension ${package}
 
 # Production image
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/extension .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -16,6 +16,10 @@
 
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
 ARG builder_image
+
+# Build architecture
+ARG ARCH
+
 FROM ${builder_image} as builder
 
 # Run this with docker build --build-arg goproxy=$(go env GOPROXY) to override the goproxy
@@ -52,13 +56,16 @@ COPY . .
 # Essentially, change directories into CAPD
 WORKDIR /workspace/test/infrastructure/docker
 
+# Build
+ARG ARCH
+
 # Build the CAPD manager using the compiler cache folder
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -trimpath -a -o /workspace/manager main.go
 
 # NOTE: CAPD can't use non-root because docker requires access to the docker socket
-FROM gcr.io/distroless/static:latest
+FROM --platform=${ARCH} gcr.io/distroless/static:latest
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
Manual cherry-pick of #7070 

**What this PR does / why we need it**:

References the correct architecture for the distroless base image. Before this commit, docker would have chosen the platform of the docker host.

Current main:
```sh
$ uname -m
arm64
$ ARCH=ppc64le REGISTRY=test make docker-build-core
$ docker inspect docker.io/test/cluster-api-controller-ppc64le:dev | grep Architecture
        "Architecture": "arm64",
```

WIth this commit:
```sh
$ uname -m
arm64
$ ARCH=ppc64le REGISTRY=test make docker-build-core
$ docker inspect docker.io/test/cluster-api-controller-ppc64le:dev | grep Architecture
        "Architecture": "ppc64le",
```

Note: I had to move the `ARG ARCH` above the first `FROM`, otherwise it is not set/empty in `FROM` lines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

