### PR TITLE
🐛 add lint-dockerfiles to verify and fix hadolint finding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o manager ${package}
 
 # Production image
-FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot-${ARCH}
 WORKDIR /
 COPY --from=builder /workspace/manager .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/Makefile
+++ b/Makefile
@@ -472,7 +472,7 @@ apidiff: $(GO_APIDIFF) ## Check for API differences
 ALL_VERIFY_CHECKS = doctoc boilerplate shellcheck tiltfile modules gen conversions capi-book-summary
 
 .PHONY: verify
-verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS)) ## Run all verify-* targets
+verify: $(addprefix verify-,$(ALL_VERIFY_CHECKS)) lint-dockerfiles ## Run all verify-* targets
 
 .PHONY: verify-modules
 verify-modules: generate-modules  ## Verify go modules are up to date

--- a/cmd/clusterctl/Dockerfile
+++ b/cmd/clusterctl/Dockerfile
@@ -63,7 +63,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o clusterctl ${package}
 
 # Production image
-FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot-${ARCH}
 WORKDIR /
 COPY --from=builder /workspace/clusterctl .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/test/extension/Dockerfile
+++ b/test/extension/Dockerfile
@@ -66,7 +66,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o /workspace/extension ${package}
 
 # Production image
-FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot-${ARCH}
 WORKDIR /
 COPY --from=builder /workspace/extension .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -73,7 +73,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Ignore Hadolint rule "Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag."
 # https://github.com/hadolint/hadolint/wiki/DL3007
 # hadolint ignore=DL3007
-FROM --platform=${ARCH} gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:latest-${ARCH}
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

* Adds the `lint-dockerfiles` target to the verify target so it gets run by the verify job.
* Fixes the hadolint finding [DL3029](https://github.com/hadolint/hadolint/wiki/DL3029), introduced in #7070.

Alternative to using the `ARCH` argument in the tag would have been to ignore the hadolint finding (which was invalid in our case) or rename the `ARCH` argument to `BUILDPLATFORM`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #7070
