### PR TITLE
🐛 Add template flavor for topology-changes test

### DIFF
--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -100,6 +100,7 @@ cluster-templates-v1beta1: $(KUSTOMIZE) ## Generate cluster templates for v1beta
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/cluster-template-kcp-scale-in --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/cluster-template-kcp-scale-in.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/cluster-template-ipv6 --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/cluster-template-ipv6.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/cluster-template-topology --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/cluster-template-topology.yaml
+	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/cluster-template-topology-changes --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/cluster-template-topology-changes.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/cluster-template-ignition --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/cluster-template-ignition.yaml
 
 test-extension-deployment: $(KUSTOMIZE) ## Generate deployment for test extension

--- a/test/e2e/clusterclass_changes_test.go
+++ b/test/e2e/clusterclass_changes_test.go
@@ -31,7 +31,7 @@ var _ = Describe("When testing ClusterClass changes [ClusterClass]", func() {
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
-			Flavor:                "topology",
+			Flavor:                "topology-changes",
 			// ModifyControlPlaneFields are the ControlPlane fields which will be set on the
 			// ControlPlaneTemplate of the ClusterClass after the initial Cluster creation.
 			// The test verifies that these fields are rolled out to the ControlPlane.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -195,6 +195,7 @@ providers:
     - sourcePath: "../data/infrastructure-docker/v1beta1/cluster-template-kcp-scale-in.yaml"
     - sourcePath: "../data/infrastructure-docker/v1beta1/cluster-template-ipv6.yaml"
     - sourcePath: "../data/infrastructure-docker/v1beta1/cluster-template-topology.yaml"
+    - sourcePath: "../data/infrastructure-docker/v1beta1/cluster-template-topology-changes.yaml"
     - sourcePath: "../data/infrastructure-docker/v1beta1/cluster-template-ignition.yaml"
     - sourcePath: "../data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml"
     - sourcePath: "../data/infrastructure-docker/v1beta1/clusterclass-quick-start-runtimesdk.yaml"

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-topology-changes/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-topology-changes/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+  - ../bases/cluster-with-topology.yaml
+  - ../bases/crs.yaml
+
+patches:
+  - path: ./node-drain-timeout.yaml
+    target:
+      group: cluster.x-k8s.io
+      version: v1beta1
+      kind: Cluster

--- a/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-topology-changes/node-drain-timeout.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/cluster-template-topology-changes/node-drain-timeout.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/topology/controlPlane/nodeDrainTimeout


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fix a failing e2e test caused by changes made in #7047 which overwrite the changes made in this test.

Add a new template to our e2e test package specifically for the broken test which patches the template to remove the overwriting value i.e. nodeDrainTimeout set in Cluster `.spec.topology.controlPlane`

/kind bug
/area testing