### PR TITLE
[release-1.2] 🐛 fix hadolint finding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o manager ${package}
 
 # Production image
-FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot-${ARCH}
 WORKDIR /
 COPY --from=builder /workspace/manager .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/cmd/clusterctl/Dockerfile
+++ b/cmd/clusterctl/Dockerfile
@@ -59,7 +59,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o clusterctl ${package}
 
 # Production image
-FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot-${ARCH}
 WORKDIR /
 COPY --from=builder /workspace/clusterctl .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/test/extension/Dockerfile
+++ b/test/extension/Dockerfile
@@ -62,7 +62,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -o /workspace/extension ${package}
 
 # Production image
-FROM --platform=${ARCH} gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot-${ARCH}
 WORKDIR /
 COPY --from=builder /workspace/extension .
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -trimpath -a -o /workspace/manager main.go
 
 # NOTE: CAPD can't use non-root because docker requires access to the docker socket
-FROM --platform=${ARCH} gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:latest-${ARCH}
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Manual cherry-pick of #7078.

Skipping the Makefile changes because they depend on the `lint-dockerfiles` target which does not exist on the release-1.2 branch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
