### PR TITLE
📖  Remove 'is is' typo in book

### DIFF
--- a/docs/book/src/developer/logging.md
+++ b/docs/book/src/developer/logging.md
@@ -163,7 +163,7 @@ extra_args:
     - "--v=5"
     - "--logging-format=json"
 ```
-The above options can be combined with other settings from our [Tilt](tilt.md) setup. Once Tilt is is up and running with these settings users will be able to browse logs using the Grafana Explore UI. 
+The above options can be combined with other settings from our [Tilt](tilt.md) setup. Once Tilt is up and running with these settings users will be able to browse logs using the Grafana Explore UI. 
 
 This will normally be available on `localhost:3001`. To explore logs from Loki, open the Explore interface for the DataSource 'Loki'. [This link](http://localhost:3001/explore?datasource%22:%22Loki%22) should work as a shortcut with the default Tilt settings.
 


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Remove instances of 'is is' from across the codebase.


Fixes #https://github.com/kubernetes-sigs/cluster-api/pull/7084#issuecomment-1219363682