### PR TITLE
✨ Propagate labels and annotations from ClusterClass and Cluster topology to KCP and MD

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -101,7 +101,7 @@ type Topology struct {
 
 // ControlPlaneTopology specifies the parameters for the control plane nodes in the cluster.
 type ControlPlaneTopology struct {
-	// Metadata is the metadata applied to the machines of the ControlPlane.
+	// Metadata is the metadata applied to ControlPlane and the machines of the ControlPlane.
 	// At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
 	//
 	// This field is supported if and only if the control plane provider template
@@ -133,7 +133,7 @@ type WorkersTopology struct {
 // MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology.
 // This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
 type MachineDeploymentTopology struct {
-	// Metadata is the metadata applied to the machines of the MachineDeployment.
+	// Metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment.
 	// At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
 	// +optional
 	Metadata ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -819,7 +819,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ControlPlaneTopology(ref common.Re
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.\n\nThis field is supported if and only if the control plane provider template referenced in the ClusterClass is Machine based.",
+							Description: "Metadata is the metadata applied to ControlPlane and the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.\n\nThis field is supported if and only if the control plane provider template referenced in the ClusterClass is Machine based.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("sigs.k8s.io/cluster-api/api/v1beta1.ObjectMeta"),
 						},
@@ -1630,7 +1630,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentTopology(ref comm
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.",
+							Description: "Metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("sigs.k8s.io/cluster-api/api/v1beta1.ObjectMeta"),
 						},

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -838,10 +838,10 @@ spec:
                     description: ControlPlane describes the cluster control plane.
                     properties:
                       metadata:
-                        description: "Metadata is the metadata applied to the machines
-                          of the ControlPlane. At runtime this metadata is merged
-                          with the corresponding metadata from the ClusterClass. \n
-                          This field is supported if and only if the control plane
+                        description: "Metadata is the metadata applied to ControlPlane
+                          and the machines of the ControlPlane. At runtime this metadata
+                          is merged with the corresponding metadata from the ClusterClass.
+                          \n This field is supported if and only if the control plane
                           provider template referenced in the ClusterClass is Machine
                           based."
                         properties:
@@ -942,9 +942,9 @@ spec:
                               type: string
                             metadata:
                               description: Metadata is the metadata applied to the
-                                machines of the MachineDeployment. At runtime this
-                                metadata is merged with the corresponding metadata
-                                from the ClusterClass.
+                                MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding
+                                metadata from the ClusterClass.
                               properties:
                                 annotations:
                                   additionalProperties:

--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -203,6 +203,13 @@ func (c *ControlPlaneContract) IsScaling(obj *unstructured.Unstructured) (bool, 
 	return false, nil
 }
 
+// Metadata provides access to the metadata of a ControlPlane object.
+func (c *ControlPlaneContract) Metadata() *Metadata {
+	return &Metadata{
+		path: Path{"metadata"},
+	}
+}
+
 // ControlPlaneMachineTemplate provides a helper struct for working with MachineTemplate in ClusterClass.
 type ControlPlaneMachineTemplate struct{}
 

--- a/internal/controllers/topology/cluster/desired_state.go
+++ b/internal/controllers/topology/cluster/desired_state.go
@@ -176,11 +176,21 @@ func (r *Reconciler) computeControlPlane(ctx context.Context, s *scope.Scope, in
 	cluster := s.Current.Cluster
 	currentRef := cluster.Spec.ControlPlaneRef
 
+	// Compute the labels and annotations to be applied to KubeadmControlPlane and Machines.
+	// We merge the labels and annotations from topology and ClusterClass.
+	topologyMetadata := s.Blueprint.Topology.ControlPlane.Metadata
+	clusterClassMetadata := s.Blueprint.ClusterClass.Spec.ControlPlane.Metadata
+
+	machineLabels := mergeMap(topologyMetadata.Labels, clusterClassMetadata.Labels)
+	machineAnnotations := mergeMap(topologyMetadata.Annotations, clusterClassMetadata.Annotations)
+
 	controlPlane, err := templateToObject(templateToInput{
 		template:              template,
 		templateClonedFromRef: templateClonedFromRef,
 		cluster:               cluster,
 		namePrefix:            fmt.Sprintf("%s-", cluster.Name),
+		labels:                machineLabels,
+		annotations:           machineAnnotations,
 		currentObjectRef:      currentRef,
 		// Note: It is not possible to add an ownerRef to Cluster at this stage, otherwise the provisioning
 		// of the ControlPlane starts no matter of the object being actually referenced by the Cluster itself.
@@ -205,13 +215,7 @@ func (r *Reconciler) computeControlPlane(ctx context.Context, s *scope.Scope, in
 			return nil, errors.Wrap(err, "failed to spec.machineTemplate.infrastructureRef in the ControlPlane object")
 		}
 
-		// Compute the labels and annotations to be applied to ControlPlane machines.
-		// We merge the labels and annotations from topology and ClusterClass.
-		// We also add the cluster-name and the topology owned labels, so they are propagated down to Machines.
-		topologyMetadata := s.Blueprint.Topology.ControlPlane.Metadata
-		clusterClassMetadata := s.Blueprint.ClusterClass.Spec.ControlPlane.Metadata
-
-		machineLabels := mergeMap(topologyMetadata.Labels, clusterClassMetadata.Labels)
+		// Add the cluster-name and the topology owned labels, so they are propagated down to Machines.
 		if machineLabels == nil {
 			machineLabels = map[string]string{}
 		}
@@ -220,7 +224,7 @@ func (r *Reconciler) computeControlPlane(ctx context.Context, s *scope.Scope, in
 		if err := contract.ControlPlane().MachineTemplate().Metadata().Set(controlPlane,
 			&clusterv1.ObjectMeta{
 				Labels:      machineLabels,
-				Annotations: mergeMap(topologyMetadata.Annotations, clusterClassMetadata.Annotations),
+				Annotations: machineAnnotations,
 			}); err != nil {
 			return nil, errors.Wrap(err, "failed to set spec.machineTemplate.metadata in the ControlPlane object")
 		}
@@ -512,6 +516,10 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, desiredControlP
 		return nil, errors.Wrapf(err, "failed to compute version for %s", machineDeploymentTopology.Name)
 	}
 
+	// Compute labels for MachineDeployment and Machines
+	machineLabels := mergeMap(machineDeploymentTopology.Metadata.Labels, machineDeploymentBlueprint.Metadata.Labels)
+	machineAnnotations := mergeMap(machineDeploymentTopology.Metadata.Annotations, machineDeploymentBlueprint.Metadata.Annotations)
+
 	// Compute the MachineDeployment object.
 	gv := clusterv1.GroupVersion
 	desiredMachineDeploymentObj := &clusterv1.MachineDeployment{
@@ -527,8 +535,8 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, desiredControlP
 			ClusterName: s.Current.Cluster.Name,
 			Template: clusterv1.MachineTemplateSpec{
 				ObjectMeta: clusterv1.ObjectMeta{
-					Labels:      mergeMap(machineDeploymentTopology.Metadata.Labels, machineDeploymentBlueprint.Metadata.Labels),
-					Annotations: mergeMap(machineDeploymentTopology.Metadata.Annotations, machineDeploymentBlueprint.Metadata.Annotations),
+					Labels:      machineLabels,
+					Annotations: machineAnnotations,
 				},
 				Spec: clusterv1.MachineSpec{
 					ClusterName:       s.Current.Cluster.Name,
@@ -562,7 +570,10 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, desiredControlP
 	labels[clusterv1.ClusterLabelName] = s.Current.Cluster.Name
 	labels[clusterv1.ClusterTopologyOwnedLabel] = ""
 	labels[clusterv1.ClusterTopologyMachineDeploymentLabelName] = machineDeploymentTopology.Name
-	desiredMachineDeploymentObj.SetLabels(labels)
+	desiredMachineDeploymentObj.SetLabels(mergeMap(labels, machineLabels))
+
+	// Apply Annotations
+	desiredMachineDeploymentObj.SetAnnotations(machineAnnotations)
 
 	// Set the selector with the subset of labels identifying controlled machines.
 	// NOTE: this prevents the web hook to add cluster.x-k8s.io/deployment-name label, that is
@@ -710,6 +721,8 @@ type templateToInput struct {
 	cluster               *clusterv1.Cluster
 	namePrefix            string
 	currentObjectRef      *corev1.ObjectReference
+	labels                map[string]string
+	annotations           map[string]string
 	// OwnerRef is an optional OwnerReference to attach to the cloned object.
 	ownerRef *metav1.OwnerReference
 }
@@ -724,6 +737,8 @@ func templateToObject(in templateToInput) (*unstructured.Unstructured, error) {
 	labels[clusterv1.ClusterLabelName] = in.cluster.Name
 	labels[clusterv1.ClusterTopologyOwnedLabel] = ""
 
+	templateLabels := mergeMap(labels, in.labels)
+
 	// Generate the object from the template.
 	// NOTE: OwnerRef can't be set at this stage; other controllers are going to add OwnerReferences when
 	// the object is actually created.
@@ -731,7 +746,8 @@ func templateToObject(in templateToInput) (*unstructured.Unstructured, error) {
 		Template:    in.template,
 		TemplateRef: in.templateClonedFromRef,
 		Namespace:   in.cluster.Namespace,
-		Labels:      labels,
+		Labels:      templateLabels,
+		Annotations: in.annotations,
 		ClusterName: in.cluster.Name,
 		OwnerRef:    in.ownerRef,
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
It is possible to specify labels and annotations in cluster topology spec, but they are propagated only to `Machines` created by `MachineDeployment` and `KubeadmControlPlane`.  This prevents users from setting annotations for `cluster-autoscaler` in Cluster topology spec.

This PR would allow to propagate labels and annotations from ClusterClass and Cluster topology spec not only to `Machines`, but also to `KubeadmControlPlane` and `MachineDeployments`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7006
