### PR TITLE
✨ Integrate kube-state-metrics and CR config into tilt.

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -352,6 +352,10 @@ def deploy_observability():
         k8s_yaml(read_file("./.tiltbuild/yaml/prometheus.observability.yaml"), allow_duplicates = True)
         k8s_resource(workload = "prometheus-server", new_name = "prometheus", port_forwards = "9090", extra_pod_selectors = [{"app": "prometheus"}], labels = ["observability"])
 
+    if "kube-state-metrics" in settings.get("deploy_observability", []):
+        k8s_yaml(read_file("./.tiltbuild/yaml/kube-state-metrics.observability.yaml"), allow_duplicates = True)
+        k8s_resource(workload = "kube-state-metrics", new_name = "kube-state-metrics", extra_pod_selectors = [{"app": "kube-state-metrics"}], labels = ["observability"])
+
     if "visualizer" in settings.get("deploy_observability", []):
         k8s_yaml(read_file("./.tiltbuild/yaml/visualizer.observability.yaml"), allow_duplicates = True)
         k8s_resource(

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -173,8 +173,19 @@ kustomize_substitutions:
 {{#/tabs }}
 
 **deploy_observability** ([string], default=[]): If set, installs on the dev cluster one of more observability
-tools. Supported values are `grafana`, `loki`, `visualizer`, `promtail` and/or `prometheus` (Note: the UI for `grafana`, `prometheus`, and `visualizer` will be accessible via a link in the tilt console).
+tools. 
 Important! This feature requires the `helm` command to be available in the user's path.
+
+Supported values are:
+
+  * `grafana`*: To create dashboards and query `loki` as well as `prometheus`.
+  * `kube-state-metrics`: For exposing metrics for kubernetes and CAPI resources to `prometheus`.
+  * `loki`: To receive and store logs.
+  * `prometheus`*: For collecting metrics from Kubernetes.
+  * `promtail`: For providing pod logs to `loki`.
+  * `visualizer`*: Visualize Cluster API resources for each cluster, provide quick access to the specs and status of any resource.
+
+\*: Note: the UI will be accessible via a link in the tilt console
 
 **debug** (Map{string: Map} default{}): A map of named configurations for the provider. The key is the name of the provider.
 

--- a/hack/observability/kube-state-metrics/chart/kustomization.yaml
+++ b/hack/observability/kube-state-metrics/chart/kustomization.yaml
@@ -1,0 +1,6 @@
+helmCharts:
+  - name: kube-state-metrics
+    repo: https://prometheus-community.github.io/helm-charts
+    namespace: observability
+    releaseName: kube-state-metrics
+    valuesFile: values.yaml

--- a/hack/observability/kube-state-metrics/chart/values.yaml
+++ b/hack/observability/kube-state-metrics/chart/values.yaml
@@ -1,0 +1,77 @@
+image:
+  tag: v2.6.0
+  pullPolicy: IfNotPresent
+
+# Add the CR configuration from the config map.
+volumeMounts:
+ - mountPath: /etc/config
+   name: config-volume
+
+volumes:
+ - configMap:
+     name: kube-state-metrics-crd-config
+   name: config-volume
+
+extraArgs:
+- "--custom-resource-state-config-file=/etc/config/crd-config.yaml"
+
+rbac:
+  extraRules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    resources:
+    - clusters
+    - machinedeployments
+    - machinesets
+    - machines
+    - machinehealthchecks
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    resources:
+    - kubeadmcontrolplanes
+    verbs:
+    - get
+    - list
+    - watch
+
+collectors:
+  # CAPI CRs
+  - clusters
+  - machinedeployments
+  - machinesets
+  - machines
+  - machinehealthchecks
+  - kubeadmcontrolplanes
+  # We need to define all default collectors too, otherwise the helm chart does not include this resources in rbac
+  - certificatesigningrequests
+  - configmaps
+  - cronjobs
+  - daemonsets
+  - deployments
+  - endpoints
+  - horizontalpodautoscalers
+  - ingresses
+  - jobs
+  - limitranges
+  - mutatingwebhookconfigurations
+  - namespaces
+  - networkpolicies
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  - poddisruptionbudgets
+  - pods
+  - replicasets
+  - replicationcontrollers
+  - resourcequotas
+  - secrets
+  - services
+  - statefulsets
+  - storageclasses
+  - validatingwebhookconfigurations
+  - volumeattachments
+  # - verticalpodautoscalers # not a default resource, see also: https://github.com/kubernetes/kube-state-metrics#enabling-verticalpodautoscalers

--- a/hack/observability/kube-state-metrics/crd-config.yaml
+++ b/hack/observability/kube-state-metrics/crd-config.yaml
@@ -1,0 +1,746 @@
+# This file was auto-generated via: make generate-metrics-config
+kind: CustomResourceStateMetrics
+spec:
+  resources:
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: Cluster
+      version: v1beta1
+    labelsFromPath:
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_cluster
+    metrics:
+    - name: info
+      help: Information about a cluster.
+      each:
+        info:
+          labelsFromPath:
+            topology_version:
+            - spec
+            - topology
+            - version
+            topology_class:
+            - spec
+            - topology
+            - class
+            control_plane_endpoint_host:
+            - spec
+            - controlPlaneEndpoint
+            - host
+            control_plane_endpoint_port:
+            - spec
+            - controlPlaneEndpoint
+            - port
+        type: Info
+    - name: spec_paused
+      help: Whether the cluster is paused and any of its resources will not be processed by the controllers.
+      each:
+        gauge:
+          nilIsZero: true
+          path:
+          - spec
+          - paused
+        type: Gauge
+    - name: status_phase
+      help: The clusters current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - Pending
+          - Provisioning
+          - Provisioned
+          - Deleting
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the cluster is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a cluster.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+  - groupVersionKind:
+      group: controlplane.cluster.x-k8s.io
+      kind: KubeadmControlPlane
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - metadata
+      - ownerReferences
+      - '[kind=Cluster]'
+      - name
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_kubeadmcontrolplane
+    metrics:
+    - name: info
+      help: Information about a kubeadmcontrolplane.
+      each:
+        info:
+          labelsFromPath:
+            version:
+            - spec
+            - version
+        type: Info
+    - name: status_replicas
+      help: The number of replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_ready
+      help: The number of ready replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_unavailable
+      help: The number of unavailable replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - unavailableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_updated
+      help: The number of updated replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - updatedReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: spec_replicas
+      help: The number of desired machines for a kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+        type: Gauge
+    - name: spec_strategy_rollingupdate_max_surge
+      help: Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - spec
+          - rolloutStrategy
+          - rollingUpdate
+          - maxSurge
+        type: Gauge
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the kubeadmcontrolplane is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a kubeadmcontrolplane.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: Machine
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machine
+    metrics:
+    - name: info
+      help: Information about a machine.
+      each:
+        info:
+          labelsFromPath:
+            failure_domain:
+            - spec
+            - failureDomain
+            internal_ip:
+            - status
+            - addresses
+            - "[type=InternalIP]"
+            - address
+            provider_id:
+            - spec
+            - providerID
+            version:
+            - spec
+            - version
+            containerRuntimeVersion:
+            - status
+            - nodeInfo
+            - containerRuntimeVersion
+        type: Info
+    - name: status_noderef
+      help: Information about the node reference of a machine.
+      each:
+        info:
+          labelsFromPath:
+            node_name:
+            - status
+            - nodeRef
+            - name
+            node_uid:
+            - status
+            - nodeRef
+            - uid
+        type: Info
+    - name: status_phase
+      help: The machines current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - Pending
+          - Provisioning
+          - Provisioned
+          - Running
+          - Deleting
+          - Deleted
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the machine is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a machine.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachineDeployment
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machinedeployment
+    metrics:
+    - name: spec_paused
+      help: Whether the machinedeployment is paused and any of its resources will not be processed by the controllers.
+      each:
+        gauge:
+          nilIsZero: true
+          path:
+          - spec
+          - paused
+        type: Gauge
+    - name: spec_replicas
+      help: The number of desired machines for a machinedeployment.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+        type: Gauge
+    - name: spec_strategy_rollingupdate_max_surge
+      help: Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a machinedeployment.
+      each:
+        gauge:
+          path:
+          - spec
+          - strategy
+          - rollingUpdate
+          - maxSurge
+        type: Gauge
+    - name: spec_strategy_rollingupdate_max_unavailable
+      help: Maximum number of unavailable replicas during a rolling update of a machinedeployment.
+      each:
+        gauge:
+          path:
+          - spec
+          - strategy
+          - rollingUpdate
+          - maxUnavailable
+        type: Gauge
+    - name: status_phase
+      help: The machinedeployments current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - ScalingUp
+          - ScalingDown
+          - Running
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet
+    - name: status_replicas
+      help: The number of replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_available
+      help: The number of available replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - availableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_unavailable
+      help: The number of unavailable replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - unavailableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_updated
+      help: The number of updated replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - updatedReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the machinedeployment is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a machinedeployment.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachineHealthCheck
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machinehealthcheck
+    metrics:
+    - name: status_current_healthy
+      help: Current number of healthy machines.
+      each:
+        gauge:
+          path:
+          - status
+          - currentHealthy
+        type: Gauge
+    - name: status_expected_machines
+      help: Total number of pods counted by this machinehealthcheck.
+      each:
+        gauge:
+          path:
+          - status
+          - expectedMachines
+        type: Gauge
+    - name: status_remediations_allowed
+      help: Number of machine remediations that are currently allowed.
+      each:
+        gauge:
+          path:
+          - status
+          - remediationsAllowed
+        type: Gauge
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the machinehealthcheck is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a machinehealthcheck.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachineSet
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machineset
+    metrics:
+    - name: spec_replicas
+      help: The number of desired machines for a machineset.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_available_replicas
+      help: The number of available replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - availableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_fully_labeled_replicas
+      help: The number of fully labeled replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - fullyLabeledReplicas
+        type: Gauge
+    - name: status_ready_replicas
+      help: The number of ready replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas
+      help: The number of replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the machineset is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a machineset.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info

--- a/hack/observability/kube-state-metrics/kustomization.yaml
+++ b/hack/observability/kube-state-metrics/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+  - ../namespace.yaml
+  # The kube-state-metrics helm chart will reference a configmap with name `kube-state-metrics-crd-config`.
+  # The configMapGenerator below will create the configmap and append a hash suffix calculated from its
+  # content to the name. Kustomize will append the suffix hash to all references in the helm chart, but
+  # only when the helm chart content is referenced in "resources".
+  # This would not work if the helm chart is configured in this file via the "helmCharts" option.
+  - ./chart
+
+namespace: observability
+
+configMapGenerator:
+- name: kube-state-metrics-crd-config
+  files:
+  - crd-config.yaml

--- a/hack/observability/kube-state-metrics/metrics/README.md
+++ b/hack/observability/kube-state-metrics/metrics/README.md
@@ -1,0 +1,7 @@
+# Metrics
+
+**Disclamer**: This is a temporary workaround. The long-term goal is to generate metric configuration from API type markers.
+
+The make target `generate-metrics-config` is used to generate a single file which contains the Cluster API specific custom resource configuration for kube-state-metrics.
+
+To regenerate the file `../crd-config.yaml`, execute the `make generate-metrics-config` command.

--- a/hack/observability/kube-state-metrics/metrics/cluster.yaml
+++ b/hack/observability/kube-state-metrics/metrics/cluster.yaml
@@ -1,0 +1,63 @@
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: Cluster
+      version: v1beta1
+    labelsFromPath:
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_cluster
+    metrics:
+    - name: info
+      help: Information about a cluster.
+      each:
+        info:
+          labelsFromPath:
+            topology_version:
+            - spec
+            - topology
+            - version
+            topology_class:
+            - spec
+            - topology
+            - class
+            control_plane_endpoint_host:
+            - spec
+            - controlPlaneEndpoint
+            - host
+            control_plane_endpoint_port:
+            - spec
+            - controlPlaneEndpoint
+            - port
+        type: Info
+    - name: spec_paused
+      help: Whether the cluster is paused and any of its resources will not be processed by the controllers.
+      each:
+        gauge:
+          nilIsZero: true
+          path:
+          - spec
+          - paused
+        type: Gauge
+    - name: status_phase
+      help: The clusters current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - Pending
+          - Provisioning
+          - Provisioned
+          - Deleting
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet

--- a/hack/observability/kube-state-metrics/metrics/common_metrics.yaml
+++ b/hack/observability/kube-state-metrics/metrics/common_metrics.yaml
@@ -1,0 +1,37 @@
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the ${RESOURCE} is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a ${RESOURCE}.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet

--- a/hack/observability/kube-state-metrics/metrics/header.yaml
+++ b/hack/observability/kube-state-metrics/metrics/header.yaml
@@ -1,0 +1,3 @@
+kind: CustomResourceStateMetrics
+spec:
+  resources:

--- a/hack/observability/kube-state-metrics/metrics/kubeadmcontrolplane.yaml
+++ b/hack/observability/kube-state-metrics/metrics/kubeadmcontrolplane.yaml
@@ -1,0 +1,84 @@
+  - groupVersionKind:
+      group: controlplane.cluster.x-k8s.io
+      kind: KubeadmControlPlane
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - metadata
+      - ownerReferences
+      - '[kind=Cluster]'
+      - name
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_kubeadmcontrolplane
+    metrics:
+    - name: info
+      help: Information about a kubeadmcontrolplane.
+      each:
+        info:
+          labelsFromPath:
+            version:
+            - spec
+            - version
+        type: Info
+    - name: status_replicas
+      help: The number of replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_ready
+      help: The number of ready replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_unavailable
+      help: The number of unavailable replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - unavailableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_updated
+      help: The number of updated replicas per kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - status
+          - updatedReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: spec_replicas
+      help: The number of desired machines for a kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+        type: Gauge
+    - name: spec_strategy_rollingupdate_max_surge
+      help: Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a kubeadmcontrolplane.
+      each:
+        gauge:
+          path:
+          - spec
+          - rolloutStrategy
+          - rollingUpdate
+          - maxSurge
+        type: Gauge

--- a/hack/observability/kube-state-metrics/metrics/machine.yaml
+++ b/hack/observability/kube-state-metrics/metrics/machine.yaml
@@ -1,0 +1,75 @@
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: Machine
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machine
+    metrics:
+    - name: info
+      help: Information about a machine.
+      each:
+        info:
+          labelsFromPath:
+            failure_domain:
+            - spec
+            - failureDomain
+            internal_ip:
+            - status
+            - addresses
+            - "[type=InternalIP]"
+            - address
+            provider_id:
+            - spec
+            - providerID
+            version:
+            - spec
+            - version
+            containerRuntimeVersion:
+            - status
+            - nodeInfo
+            - containerRuntimeVersion
+        type: Info
+    - name: status_noderef
+      help: Information about the node reference of a machine.
+      each:
+        info:
+          labelsFromPath:
+            node_name:
+            - status
+            - nodeRef
+            - name
+            node_uid:
+            - status
+            - nodeRef
+            - uid
+        type: Info
+    - name: status_phase
+      help: The machines current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - Pending
+          - Provisioning
+          - Provisioned
+          - Running
+          - Deleting
+          - Deleted
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet

--- a/hack/observability/kube-state-metrics/metrics/machinedeployment.yaml
+++ b/hack/observability/kube-state-metrics/metrics/machinedeployment.yaml
@@ -1,0 +1,107 @@
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachineDeployment
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machinedeployment
+    metrics:
+    - name: spec_paused
+      help: Whether the machinedeployment is paused and any of its resources will not be processed by the controllers.
+      each:
+        gauge:
+          nilIsZero: true
+          path:
+          - spec
+          - paused
+        type: Gauge
+    - name: spec_replicas
+      help: The number of desired machines for a machinedeployment.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+        type: Gauge
+    - name: spec_strategy_rollingupdate_max_surge
+      help: Maximum number of replicas that can be scheduled above the desired number of replicas during a rolling update of a machinedeployment.
+      each:
+        gauge:
+          path:
+          - spec
+          - strategy
+          - rollingUpdate
+          - maxSurge
+        type: Gauge
+    - name: spec_strategy_rollingupdate_max_unavailable
+      help: Maximum number of unavailable replicas during a rolling update of a machinedeployment.
+      each:
+        gauge:
+          path:
+          - spec
+          - strategy
+          - rollingUpdate
+          - maxUnavailable
+        type: Gauge
+    - name: status_phase
+      help: The machinedeployments current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - ScalingUp
+          - ScalingDown
+          - Running
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet
+    - name: status_replicas
+      help: The number of replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_available
+      help: The number of available replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - availableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_unavailable
+      help: The number of unavailable replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - unavailableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_updated
+      help: The number of updated replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - updatedReplicas
+          nilIsZero: true
+        type: Gauge

--- a/hack/observability/kube-state-metrics/metrics/machinehealthcheck.yaml
+++ b/hack/observability/kube-state-metrics/metrics/machinehealthcheck.yaml
@@ -1,0 +1,43 @@
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachineHealthCheck
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machinehealthcheck
+    metrics:
+    - name: status_current_healthy
+      help: Current number of healthy machines.
+      each:
+        gauge:
+          path:
+          - status
+          - currentHealthy
+        type: Gauge
+    - name: status_expected_machines
+      help: Total number of pods counted by this machinehealthcheck.
+      each:
+        gauge:
+          path:
+          - status
+          - expectedMachines
+        type: Gauge
+    - name: status_remediations_allowed
+      help: Number of machine remediations that are currently allowed.
+      each:
+        gauge:
+          path:
+          - status
+          - remediationsAllowed
+        type: Gauge

--- a/hack/observability/kube-state-metrics/metrics/machineset.yaml
+++ b/hack/observability/kube-state-metrics/metrics/machineset.yaml
@@ -1,0 +1,63 @@
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachineSet
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machineset
+    metrics:
+    - name: spec_replicas
+      help: The number of desired machines for a machineset.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_available_replicas
+      help: The number of available replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - availableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_fully_labeled_replicas
+      help: The number of fully labeled replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - fullyLabeledReplicas
+        type: Gauge
+    - name: status_ready_replicas
+      help: The number of ready replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas
+      help: The number of replicas per machineset.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge

--- a/hack/observability/kube-state-metrics/metrics/owner_metric.yaml
+++ b/hack/observability/kube-state-metrics/metrics/owner_metric.yaml
@@ -1,0 +1,17 @@
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

* Adds `kube-state-metrics` to `hack/observability` which uses the `kube-state-metrics` helm chart and adds configuration for CAPI CRs
* Integrates into tilt

Currently not added metrics:
- `*_labels`

TODOs:

- [x] Use new kube-state-metrics release as soon as it got published
- [x] ~~Split CR configuration to multiple files if https://github.com/kubernetes/kube-state-metrics/pull/1810 gets merged~~
    - won't implement for now. Split could be done in future when KSM provides a CR for configuration purposes.
- [x] Verify if all expected metrics are configured (except `_labels`)
- [x] update proposal for `*_spec_paused` and `*_annotation_paused` metrics
- [x] Provide docs
- [ ] review kcp and md `*_status_replicas_*` metrics and unify

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #6458 
