### PR TITLE
🐛 `clusterctl init --list-images` should not need an initialized cluster

### DIFF
--- a/cmd/clusterctl/client/init.go
+++ b/cmd/clusterctl/client/init.go
@@ -73,6 +73,10 @@ type InitOptions struct {
 	// IgnoreValidationErrors allows for skipping the validation of provider installs.
 	// NOTE this should only be used for development
 	IgnoreValidationErrors bool
+
+	// allowMissingProviderCRD is used to allow for a missing provider CRD when listing images.
+	// It is set to false to enforce that provider CRD is available when performing the standard init operation.
+	allowMissingProviderCRD bool
 }
 
 // Init initializes a management cluster by adding the requested list of providers.
@@ -173,6 +177,8 @@ func (c *clusterctlClient) InitImages(options InitOptions) ([]string, error) {
 	// skip variable parsing when listing images
 	options.skipTemplateProcess = true
 
+	options.allowMissingProviderCRD = true
+
 	// create an installer service, add the requested providers to the install queue and then perform validation
 	// of the target state of the management cluster before starting the installation.
 	installer, err := c.setupInstaller(clusterClient, options)
@@ -197,16 +203,22 @@ func (c *clusterctlClient) InitImages(options InitOptions) ([]string, error) {
 func (c *clusterctlClient) setupInstaller(cluster cluster.Client, options InitOptions) (cluster.ProviderInstaller, error) {
 	installer := cluster.ProviderInstaller()
 
-	providerList, err := cluster.ProviderInventory().List()
-	if err != nil {
-		return nil, err
-	}
+	providerList := &clusterctlv1.ProviderList{}
 
 	addOptions := addToInstallerOptions{
 		installer:           installer,
 		targetNamespace:     options.TargetNamespace,
 		skipTemplateProcess: options.skipTemplateProcess,
 		providerList:        providerList,
+	}
+
+	if !options.allowMissingProviderCRD {
+		providerList, err := cluster.ProviderInventory().List()
+		if err != nil {
+			return nil, err
+		}
+
+		addOptions.providerList = providerList
 	}
 
 	if options.CoreProvider != "" {


### PR DESCRIPTION
- Add ProviderCRDInstalled field in InitOptions
- In setupInstaller check if ProviderCRDInstalled is installed or not
  - If yes return normal error
  - If not return empty provider list

Signed-off-by: Aniruddha Basak <codewithaniruddha@gmail.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6986
