### PR TITLE
📖 docs: switch kubebuilder installation instructions on macOS to homebrew

### DIFF
--- a/docs/book/src/developer/providers/implementers-guide/overview.md
+++ b/docs/book/src/developer/providers/implementers-guide/overview.md
@@ -27,6 +27,9 @@ brew install kubernetes-cli
 
 # Install kustomize
 brew install kustomize
+
+# Install Kubebuilder
+brew install kubebuilder
 ```
 {{#/tab }}
 {{#tab Linux}}
@@ -39,16 +42,14 @@ curl -fLO https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 # Install kustomize
 curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 chmod +x ./kustomize && sudo mv ./kustomize /usr/local/bin/kustomize
-```
 
-{{#/tab }}
-{{#/tabs }}
-
-```bash
 # Install Kubebuilder
 curl -sLo kubebuilder https://go.kubebuilder.io/dl/latest/$(go env GOOS)/$(go env GOARCH)
 chmod +x ./kubebuilder && sudo mv ./kubebuilder /usr/local/bin/kubebuilder
 ```
+
+{{#/tab }}
+{{#/tabs }}
 
 [kubebuilder-book]: https://book.kubebuilder.io/
 [kubectl-install]: http://kubernetes.io/docs/user-guide/prereqs/


### PR DESCRIPTION
**What this PR does / why we need it**:

Homebrew has a recipe for Kubebuilder and it's at the latest version, so developers should use that to automatically receive updates.