### PR TITLE
🌱  Update golangci-lint to 1.49.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,5 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.48.0
+          version: v1.49.0
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ linters:
   - asciicheck
   - bodyclose
   - containedctx
-  - deadcode
   - depguard
   - dogsled
   - errcheck
@@ -19,7 +18,6 @@ linters:
   - gosec
   - gosimple
   - govet
-  - ifshort
   - importas
   - ineffassign
   - misspell
@@ -32,14 +30,12 @@ linters:
   - revive
   - rowserrcheck
   - staticcheck
-  - structcheck
   - stylecheck
   - thelper
   - typecheck
   - unconvert
   - unparam
   - unused
-  - varcheck
   - whitespace
 
 linters-settings:
@@ -51,9 +47,6 @@ linters-settings:
     exclude:
     - '^ \+.*'
     - '^ ANCHOR.*'
-  ifshort:
-    # Maximum length of variable declaration measured in number of characters, after which linter won't suggest using short syntax.
-    max-decl-chars: 50
   gci:
     local-prefixes: "sigs.k8s.io/cluster-api"
   importas:
@@ -215,13 +208,7 @@ issues:
   - linters:
     - gocritic
     text: "appendAssign: append result not assigned to the same slice"
-  # ifshort flags variables that are only used in the if-statement even though there is
-  # already a SimpleStmt being used in the if-statement in question.
-  - linters:
-    - ifshort
-    text: "variable .* is only used in the if-statement"
-    path: controllers/mdutil/util.go
-  # Disable linters for conversion
+ # Disable linters for conversion
   - linters:
     - staticcheck
     text: "SA1019: in.(.+) is deprecated"
@@ -251,15 +238,6 @@ issues:
     - typecheck
     text: import (".+") is a program, not an importable package
     path: ^tools\.go$
-  # TODO(sbueringer) Ignore ifshort false positive: https://github.com/esimonov/ifshort/issues/23
-  - linters:
-    - ifshort
-    text:  "variable 'isDeleteNodeAllowed' is only used in the if-statement.*"
-    path: ^internal/controllers/machine/machine_controller\.go$
-  - linters:
-    - ifshort
-    text: "variable 'kcpMachinesWithErrors' is only used in the if-statement.*"
-    path: ^controlplane/kubeadm/internal/workload_cluster_conditions\.go$
   # We don't care about defer in for loops in test files.
   - linters:
     - gocritic

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for the Kubeadm Bootstrap provider.
 package main
 
 import (
@@ -151,11 +152,13 @@ func main() {
 
 	// klog.Background will automatically use the right logger.
 	ctrl.SetLogger(klog.Background())
-
 	if profilerAddress != "" {
-		klog.Infof("Profiler listening for requests at %s", profilerAddress)
+		setupLog.Info(fmt.Sprintf("Profiler listening for requests at %s", profilerAddress))
 		go func() {
-			klog.Info(http.ListenAndServe(profilerAddress, nil))
+			srv := http.Server{Addr: profilerAddress, ReadHeaderTimeout: 2 * time.Second}
+			if err := srv.ListenAndServe(); err != nil {
+				setupLog.Error(err, "problem running profiler server")
+			}
 		}()
 	}
 

--- a/cmd/clusterctl/main.go
+++ b/cmd/clusterctl/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for clusterctl.
 package main
 
 import (

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for the Kubeadm Control Plane provider.
 package main
 
 import (
@@ -156,9 +157,12 @@ func main() {
 	ctrl.SetLogger(klog.Background())
 
 	if profilerAddress != "" {
-		klog.Infof("Profiler listening for requests at %s", profilerAddress)
+		setupLog.Info(fmt.Sprintf("Profiler listening for requests at %s", profilerAddress))
 		go func() {
-			klog.Info(http.ListenAndServe(profilerAddress, nil))
+			srv := http.Server{Addr: profilerAddress, ReadHeaderTimeout: 2 * time.Second}
+			if err := srv.ListenAndServe(); err != nil {
+				setupLog.Error(err, "problem running profiler server")
+			}
 		}()
 	}
 

--- a/exp/runtime/server/server.go
+++ b/exp/runtime/server/server.go
@@ -175,8 +175,8 @@ func (s *Server) validateHandler(handler ExtensionHandler) error {
 	}
 
 	// Get hook and handler request and response types.
-	hookRequestType := hookFuncType.In(0)  //nolint:ifshort
-	hookResponseType := hookFuncType.In(1) //nolint:ifshort
+	hookRequestType := hookFuncType.In(0)
+	hookResponseType := hookFuncType.In(1)
 	handlerContextType := handlerFuncType.In(0)
 	handlerRequestType := handlerFuncType.In(1)
 	handlerResponseType := handlerFuncType.In(2)

--- a/hack/tools/conversion-verifier/doc.go
+++ b/hack/tools/conversion-verifier/doc.go
@@ -22,4 +22,6 @@ limitations under the License.
 //     the type MUST have a Hub() method.
 //   - For each type with multiple versions, that has a Hub() and storage version,
 //     the type MUST have ConvertFrom() and ConvertTo() methods.
+
+// main is the main package for the conversion-verifier.
 package main

--- a/hack/tools/log-push/main.go
+++ b/hack/tools/log-push/main.go
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for Log Push.
 package main
 
 import (

--- a/hack/tools/mdbook/embed/embed.go
+++ b/hack/tools/mdbook/embed/embed.go
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for mdbook-embed.
 package main
 
 import (

--- a/hack/tools/mdbook/releaselink/releaselink.go
+++ b/hack/tools/mdbook/releaselink/releaselink.go
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for mdbook-releaselink.
 package main
 
 import (

--- a/hack/tools/mdbook/tabulate/tabulate.go
+++ b/hack/tools/mdbook/tabulate/tabulate.go
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for mdbook-tabulate.
 package main
 
 import (

--- a/hack/tools/release/notes.go
+++ b/hack/tools/release/notes.go
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for the release notes generator.
 package main
 
 import (

--- a/hack/tools/runtime-openapi-gen/main.go
+++ b/hack/tools/runtime-openapi-gen/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for openapi-gen.
 package main
 
 import (

--- a/hack/tools/tilt-prepare/main.go
+++ b/hack/tools/tilt-prepare/main.go
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for Tilt Prepare.
 package main
 
 import (

--- a/internal/controllers/machine/machine_controller_phases.go
+++ b/internal/controllers/machine/machine_controller_phases.go
@@ -48,7 +48,7 @@ var (
 )
 
 func (r *Reconciler) reconcilePhase(_ context.Context, m *clusterv1.Machine) {
-	originalPhase := m.Status.Phase //nolint:ifshort // Cannot be inlined because m.Status.Phase might be changed before it is used in the if.
+	originalPhase := m.Status.Phase
 
 	// Set the phase to "pending" if nil.
 	if m.Status.Phase == "" {

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for the Cluster API Core Provider.
 package main
 
 import (
@@ -216,9 +217,12 @@ func main() {
 	ctrl.SetLogger(klog.Background())
 
 	if profilerAddress != "" {
-		klog.Infof("Profiler listening for requests at %s", profilerAddress)
+		setupLog.Info(fmt.Sprintf("Profiler listening for requests at %s", profilerAddress))
 		go func() {
-			klog.Info(http.ListenAndServe(profilerAddress, nil))
+			srv := http.Server{Addr: profilerAddress, ReadHeaderTimeout: 2 * time.Second}
+			if err := srv.ListenAndServe(); err != nil {
+				setupLog.Error(err, "problem running profiler server")
+			}
 		}()
 	}
 

--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -14,12 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for the Test Extension.
 package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -89,9 +92,12 @@ func main() {
 	ctrl.SetLogger(klog.Background())
 
 	if profilerAddress != "" {
-		klog.Infof("Profiler listening for requests at %s", profilerAddress)
+		setupLog.Info(fmt.Sprintf("Profiler listening for requests at %s", profilerAddress))
 		go func() {
-			klog.Info(http.ListenAndServe(profilerAddress, nil))
+			srv := http.Server{Addr: profilerAddress, ReadHeaderTimeout: 2 * time.Second}
+			if err := srv.ListenAndServe(); err != nil {
+				setupLog.Error(err, "problem running profiler server")
+			}
 		}()
 	}
 

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// main is the main package for the Docker Infrastructure Provider.
 package main
 
 import (
 	"context"
 	"flag"
+	"fmt"
 	"math/rand"
 	"net/http"
 	"os"
@@ -126,9 +128,12 @@ func main() {
 	ctrl.SetLogger(klog.Background())
 
 	if profilerAddress != "" {
-		klog.Infof("Profiler listening for requests at %s", profilerAddress)
+		setupLog.Info(fmt.Sprintf("Profiler listening for requests at %s", profilerAddress))
 		go func() {
-			klog.Info(http.ListenAndServe(profilerAddress, nil))
+			srv := http.Server{Addr: profilerAddress, ReadHeaderTimeout: 2 * time.Second}
+			if err := srv.ListenAndServe(); err != nil {
+				setupLog.Error(err, "problem running profiler server")
+			}
 		}()
 	}
 


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update golangci-lint to version 1.49. This update re-enables the revive rules that were disabled in v1.48.0