### PR TITLE
🌱 Update golangci-lint version (1.48.0 -> 1.49.0)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,5 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.48.0
+          version: v1.49.0
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,6 +141,10 @@ linters-settings:
     allow-unused: false
     allow-leading-space: false
     require-specific: true
+  revive:
+    rules:
+      - name: package-comments
+        disabled: true
   staticcheck:
     go: "1.18"
   stylecheck:
@@ -274,6 +278,4 @@ run:
   skip-files:
   - "zz_generated.*\\.go$"
   - "vendored_openapi\\.go$"
-  skip-dirs:
-  - third_party
   allow-parallel-runners: true

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -155,7 +155,7 @@ func main() {
 	if profilerAddress != "" {
 		klog.Infof("Profiler listening for requests at %s", profilerAddress)
 		go func() {
-			klog.Info(http.ListenAndServe(profilerAddress, nil))
+			klog.Info(http.ListenAndServe(profilerAddress, nil)) //#nosec Missing timeout
 		}()
 	}
 

--- a/cmd/clusterctl/client/alpha/rollout_pauser.go
+++ b/cmd/clusterctl/client/alpha/rollout_pauser.go
@@ -36,7 +36,7 @@ func (r *rollout) ObjectPauser(proxy cluster.Proxy, ref corev1.ObjectReference) 
 			return errors.Wrapf(err, "failed to fetch %v/%v", ref.Kind, ref.Name)
 		}
 		if deployment.Spec.Paused {
-			return errors.Errorf("MachineDeploymet is already paused: %v/%v\n", ref.Kind, ref.Name) //nolint:revive // MachineDeployment is intentionally capitalized.
+			return errors.Errorf("MachineDeploymet is already paused: %v/%v\n", ref.Kind, ref.Name) // MachineDeployment is intentionally capitalized.
 		}
 		if err := pauseMachineDeployment(proxy, ref.Name, ref.Namespace); err != nil {
 			return err

--- a/cmd/clusterctl/client/alpha/rollout_resumer.go
+++ b/cmd/clusterctl/client/alpha/rollout_resumer.go
@@ -36,7 +36,7 @@ func (r *rollout) ObjectResumer(proxy cluster.Proxy, ref corev1.ObjectReference)
 			return errors.Wrapf(err, "failed to fetch %v/%v", ref.Kind, ref.Name)
 		}
 		if !deployment.Spec.Paused {
-			return errors.Errorf("MachineDeployment is not currently paused: %v/%v\n", ref.Kind, ref.Name) //nolint:revive // MachineDeployment is intentionally capitalized.
+			return errors.Errorf("MachineDeployment is not currently paused: %v/%v\n", ref.Kind, ref.Name) // MachineDeployment is intentionally capitalized.
 		}
 		if err := resumeMachineDeployment(proxy, ref.Name, ref.Namespace); err != nil {
 			return err

--- a/cmd/clusterctl/internal/test/fake_proxy.go
+++ b/cmd/clusterctl/internal/test/fake_proxy.go
@@ -47,7 +47,7 @@ type FakeProxy struct {
 }
 
 var (
-	FakeScheme = runtime.NewScheme() //nolint:revive
+	FakeScheme = runtime.NewScheme()
 )
 
 func init() {

--- a/controlplane/kubeadm/internal/etcd/fake/client.go
+++ b/controlplane/kubeadm/internal/etcd/fake/client.go
@@ -23,7 +23,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-type FakeEtcdClient struct { //nolint:revive
+type FakeEtcdClient struct {
 	AlarmResponse        *clientv3.AlarmResponse
 	EtcdEndpoints        []string
 	MemberListResponse   *clientv3.MemberListResponse

--- a/controlplane/kubeadm/main.go
+++ b/controlplane/kubeadm/main.go
@@ -158,7 +158,7 @@ func main() {
 	if profilerAddress != "" {
 		klog.Infof("Profiler listening for requests at %s", profilerAddress)
 		go func() {
-			klog.Info(http.ListenAndServe(profilerAddress, nil))
+			klog.Info(http.ListenAndServe(profilerAddress, nil)) //#nosec Missing timeout
 		}()
 	}
 

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func main() {
 	if profilerAddress != "" {
 		klog.Infof("Profiler listening for requests at %s", profilerAddress)
 		go func() {
-			klog.Info(http.ListenAndServe(profilerAddress, nil))
+			klog.Info(http.ListenAndServe(profilerAddress, nil)) //#nosec Missing timeout
 		}()
 	}
 

--- a/test/extension/main.go
+++ b/test/extension/main.go
@@ -91,7 +91,7 @@ func main() {
 	if profilerAddress != "" {
 		klog.Infof("Profiler listening for requests at %s", profilerAddress)
 		go func() {
-			klog.Info(http.ListenAndServe(profilerAddress, nil))
+			klog.Info(http.ListenAndServe(profilerAddress, nil)) //#nosec Missing timeout
 		}()
 	}
 

--- a/test/infrastructure/docker/main.go
+++ b/test/infrastructure/docker/main.go
@@ -128,7 +128,7 @@ func main() {
 	if profilerAddress != "" {
 		klog.Infof("Profiler listening for requests at %s", profilerAddress)
 		go func() {
-			klog.Info(http.ListenAndServe(profilerAddress, nil))
+			klog.Info(http.ListenAndServe(profilerAddress, nil)) //#nosec Missing timeout
 		}()
 	}
 

--- a/util/defaulting/defaulting.go
+++ b/util/defaulting/defaulting.go
@@ -25,7 +25,7 @@ import (
 
 // DefaultingValidator interface is for objects that define both defaulting
 // and validating webhooks.
-type DefaultingValidator interface { //nolint:revive
+type DefaultingValidator interface {
 	admission.Defaulter
 	admission.Validator
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates `golangci-lint` version
* Disables `package-comments` rule since it file specific and gives a lot of positives.
* Added `//#nosec Missing timeout` for a new finding. This might actually be worth fixing.
* Removed some unused `//nolint:revive` which triggered `nolintlint`
* Removed `skip-dirs` since `third_party` folder is removed