### PR TITLE
🌱  Remove references to third_party directory

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -274,6 +274,4 @@ run:
   skip-files:
   - "zz_generated.*\\.go$"
   - "vendored_openapi\\.go$"
-  skip-dirs:
-  - third_party
   allow-parallel-runners: true

--- a/Tiltfile
+++ b/Tiltfile
@@ -55,7 +55,6 @@ providers = {
             "exp",
             "feature",
             "internal",
-            "third_party",
             "util",
             "webhooks",
         ],

--- a/docs/book/src/developer/repository-layout.md
+++ b/docs/book/src/developer/repository-layout.md
@@ -21,7 +21,6 @@ cluster-api
 └───logos
 └───scripts
 └───test
-└───third_party
 └───util
 └───version
 └───webhooks
@@ -115,10 +114,6 @@ This folder has scripts used for building, testing and developer workflow.
 [~/scripts](https://github.com/kubernetes-sigs/cluster-api/tree/main/scripts)
 
 This folder consists of CI scripts related to setup, build and e2e tests. These are mostly called by CI jobs.
-
-[~/third_party](https://github.com/kubernetes-sigs/cluster-api/tree/main/third_party)
-
-This folder is used to copy code from other projects in-tree.
 
 ### Util, Feature and Errors
 

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -150,7 +150,7 @@ def file_passes(filename, refs, regexs):
 def file_extension(filename):
     return os.path.splitext(filename)[1].split(".")[-1].lower()
 
-skipped_dirs = ['third_party', 'tilt_modules', '_gopath', '_output', '.git', 'cluster/env.sh',
+skipped_dirs = ['tilt_modules', '_gopath', '_output', '.git', 'cluster/env.sh',
                 "vendor", "test/e2e/generated/bindata.go", "hack/boilerplate/test",
                 "staging/src/k8s.io/kubectl/pkg/generated/bindata.go"]
 

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -64,9 +64,9 @@ fi
 
 echo "Running shellcheck..."
 cd "${ROOT_PATH}" || exit
-IGNORE_FILES=$(find . -name "*.sh" | grep "third_party\|tilt_modules")
+IGNORE_FILES=$(find . -name "*.sh" | grep "tilt_modules")
 echo "Ignoring shellcheck on ${IGNORE_FILES}"
-FILES=$(find . -name "*.sh" -not -path "./tilt_modules/*" -not -path "*third_party*")
+FILES=$(find . -name "*.sh" -not -path "./tilt_modules/*")
 while read -r file; do
     "$SHELLCHECK" -x "$file" >> "${OUT}" 2>&1
 done <<< "$FILES"


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

#7108 removed the `third_party' folder from the repo. This change removes a number of references to that directory from across the book, scripts and config.
