### PR TITLE
🌱  Update kindnetd to the latest release version

### DIFF
--- a/test/e2e/data/cni/kindnet/kindnet.yaml
+++ b/test/e2e/data/cni/kindnet/kindnet.yaml
@@ -6,20 +6,19 @@ metadata:
   name: kindnet
 rules:
   - apiGroups:
-      - policy
-    resources:
-      - podsecuritypolicies
-    verbs:
-      - use
-    resourceNames:
-      - kindnet
-  - apiGroups:
       - ""
     resources:
       - nodes
     verbs:
       - list
       - watch
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -67,7 +66,7 @@ spec:
       serviceAccountName: kindnet
       containers:
         - name: kindnet-cni
-          image: kindest/kindnetd:0.5.4
+          image: kindest/kindnetd:v20220726-ed811e41
           env:
             - name: HOST_IP
               valueFrom:
@@ -100,9 +99,14 @@ spec:
             capabilities:
               add: ["NET_RAW", "NET_ADMIN"]
       volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt/cni/bin
+            type: DirectoryOrCreate
         - name: cni-cfg
           hostPath:
             path: /etc/cni/net.d
+            type: DirectoryOrCreate
         - name: xtables-lock
           hostPath:
             path: /run/xtables.lock


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update kindnetd to the [latest release tag](https://hub.docker.com/r/kindest/kindnetd/tags) - v20220726-ed811e41. This change ensures that references to `PodSecurityPolicies`, which are being removed in Kubernetes 1.25, are no longer in the CAPI repo. 

/kind cleanup
