### PR TITLE
🌱 test/e2e: Extend ClusterClass changes test to cover InfrastructureMachineTemplate rotation

### DIFF
--- a/test/e2e/clusterclass_changes.go
+++ b/test/e2e/clusterclass_changes.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -71,6 +72,15 @@ type ClusterClassChangesSpecInput struct {
 	//   "spec.template.spec.path.to.field": <value>,
 	// }
 	ModifyMachineDeploymentBootstrapConfigTemplateFields map[string]interface{}
+
+	// ModifyMachineDeploymentInfrastructureMachineTemplateFields are the fields which will be set on the
+	// InfrastructureMachineTemplate of all MachineDeploymentClasses of the ClusterClass after the initial Cluster creation.
+	// The test verifies that these fields are rolled out to the MachineDeployments.
+	// NOTE: The fields are configured in the following format:
+	// map[string]interface{}{
+	//   "spec.template.spec.path.to.field": <value>,
+	// }
+	ModifyMachineDeploymentInfrastructureMachineTemplateFields map[string]interface{}
 }
 
 // ClusterClassChangesSpec implements a test that verifies that ClusterClass changes are rolled out successfully.
@@ -80,6 +90,9 @@ type ClusterClassChangesSpecInput struct {
 //     and wait until the change has been rolled out to the ControlPlane of the Cluster.
 //   - Modify the BootstrapTemplate of all MachineDeploymentClasses of the ClusterClass by setting
 //     ModifyMachineDeploymentBootstrapConfigTemplateFields and wait until the change has been rolled out
+//     to the MachineDeployments of the Cluster.
+//   - Modify the InfrastructureMachineTemplate of all MachineDeploymentClasses of the ClusterClass by setting
+//     ModifyMachineDeploymentInfrastructureMachineTemplateFields and wait until the change has been rolled out
 //     to the MachineDeployments of the Cluster.
 //   - Rebase the Cluster to a copy of the ClusterClass which has an additional worker label set. Then wait
 //     until the change has been rolled out to the MachineDeployments of the Cluster and verify the ControlPlane
@@ -110,7 +123,6 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
 		Expect(input.E2EConfig.Variables).To(HaveValidVersion(input.E2EConfig.GetVariable(KubernetesVersion)))
 		Expect(input.ModifyControlPlaneFields).ToNot(BeEmpty(), "Invalid argument. input.ModifyControlPlaneFields can't be empty when calling %s spec", specName)
-		Expect(input.ModifyMachineDeploymentBootstrapConfigTemplateFields).ToNot(BeEmpty(), "Invalid argument. input.ModifyMachineDeploymentBootstrapConfigTemplateFields can't be empty when calling %s spec", specName)
 
 		// Set up a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = setupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
@@ -154,7 +166,8 @@ func ClusterClassChangesSpec(ctx context.Context, inputGetter func() ClusterClas
 			ClusterClass:                        clusterResources.ClusterClass,
 			Cluster:                             clusterResources.Cluster,
 			ModifyBootstrapConfigTemplateFields: input.ModifyMachineDeploymentBootstrapConfigTemplateFields,
-			WaitForMachineDeployments:           input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+			ModifyInfrastructureMachineTemplateFields: input.ModifyMachineDeploymentInfrastructureMachineTemplateFields,
+			WaitForMachineDeployments:                 input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 		})
 
 		By("Rebasing the Cluster to a ClusterClass with a modified label for MachineDeployments and wait for changes to be applied to the MachineDeployment objects")
@@ -243,11 +256,12 @@ func modifyControlPlaneViaClusterClassAndWait(ctx context.Context, input modifyC
 
 // modifyMachineDeploymentViaClusterClassAndWaitInput is the input type for modifyMachineDeploymentViaClusterClassAndWait.
 type modifyMachineDeploymentViaClusterClassAndWaitInput struct {
-	ClusterProxy                        framework.ClusterProxy
-	ClusterClass                        *clusterv1.ClusterClass
-	Cluster                             *clusterv1.Cluster
-	ModifyBootstrapConfigTemplateFields map[string]interface{}
-	WaitForMachineDeployments           []interface{}
+	ClusterProxy                              framework.ClusterProxy
+	ClusterClass                              *clusterv1.ClusterClass
+	Cluster                                   *clusterv1.Cluster
+	ModifyBootstrapConfigTemplateFields       map[string]interface{}
+	ModifyInfrastructureMachineTemplateFields map[string]interface{}
+	WaitForMachineDeployments                 []interface{}
 }
 
 // modifyMachineDeploymentViaClusterClassAndWait modifies the BootstrapConfigTemplate of MachineDeploymentClasses of a ClusterClass
@@ -273,7 +287,6 @@ func modifyMachineDeploymentViaClusterClassAndWait(ctx context.Context, input mo
 		bootstrapConfigTemplateRef := mdClass.Template.Bootstrap.Ref
 		bootstrapConfigTemplate, err := external.Get(ctx, mgmtClient, bootstrapConfigTemplateRef, input.Cluster.Namespace)
 		Expect(err).ToNot(HaveOccurred())
-
 		// Create a new BootstrapConfigTemplate object with a new name and ModifyBootstrapConfigTemplateFields set.
 		newBootstrapConfigTemplate := bootstrapConfigTemplate.DeepCopy()
 		newBootstrapConfigTemplateName := fmt.Sprintf("%s-%s", bootstrapConfigTemplateRef.Name, util.RandomString(6))
@@ -284,10 +297,25 @@ func modifyMachineDeploymentViaClusterClassAndWait(ctx context.Context, input mo
 		}
 		Expect(mgmtClient.Create(ctx, newBootstrapConfigTemplate)).To(Succeed())
 
+		// Retrieve InfrastructureMachineTemplate object.
+		infrastructureMachineTemplateRef := mdClass.Template.Infrastructure.Ref
+		infrastructureMachineTemplate, err := external.Get(ctx, mgmtClient, infrastructureMachineTemplateRef, input.Cluster.Namespace)
+		Expect(err).ToNot(HaveOccurred())
+		// Create a new InfrastructureMachineTemplate object with a new name and ModifyInfrastructureMachineTemplateFields set.
+		newInfrastructureMachineTemplate := infrastructureMachineTemplate.DeepCopy()
+		newInfrastructureMachineTemplateName := fmt.Sprintf("%s-%s", infrastructureMachineTemplateRef.Name, util.RandomString(6))
+		newInfrastructureMachineTemplate.SetName(newInfrastructureMachineTemplateName)
+		newInfrastructureMachineTemplate.SetResourceVersion("")
+		for fieldPath, value := range input.ModifyInfrastructureMachineTemplateFields {
+			Expect(unstructured.SetNestedField(newInfrastructureMachineTemplate.Object, value, strings.Split(fieldPath, ".")...)).To(Succeed())
+		}
+		Expect(mgmtClient.Create(ctx, newInfrastructureMachineTemplate)).To(Succeed())
+
 		// Patch the BootstrapConfigTemplate ref of the MachineDeploymentClass to reference the new BootstrapConfigTemplate.
 		patchHelper, err := patch.NewHelper(input.ClusterClass, mgmtClient)
 		Expect(err).ToNot(HaveOccurred())
 		bootstrapConfigTemplateRef.Name = newBootstrapConfigTemplateName
+		infrastructureMachineTemplateRef.Name = newInfrastructureMachineTemplateName
 		Expect(patchHelper.Patch(ctx, input.ClusterClass)).To(Succeed())
 
 		log.Logf("Waiting for MachineDeployment rollout for MachineDeploymentClass %q to complete.", mdClass.Class)
@@ -322,7 +350,23 @@ func modifyMachineDeploymentViaClusterClassAndWait(ctx context.Context, input mo
 					if err != nil || !ok {
 						return errors.Errorf("failed to get field %q", fieldPath)
 					}
-					if currentValue != expectedValue {
+					if !reflect.DeepEqual(currentValue, expectedValue) {
+						return errors.Errorf("field %q should be equal to %q, but is %q", fieldPath, expectedValue, currentValue)
+					}
+				}
+
+				// Get the corresponding InfrastructureMachineTemplate.
+				infrastructureMachineTemplateRef := md.Spec.Template.Spec.InfrastructureRef
+				infrastructureMachineTemplate, err := external.Get(ctx, mgmtClient, &infrastructureMachineTemplateRef, input.Cluster.Namespace)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Verify that ModifyInfrastructureMachineTemplateFields have been set.
+				for fieldPath, expectedValue := range input.ModifyInfrastructureMachineTemplateFields {
+					currentValue, ok, err := unstructured.NestedFieldNoCopy(infrastructureMachineTemplate.Object, strings.Split(fieldPath, ".")...)
+					if err != nil || !ok {
+						return errors.Errorf("failed to get field %q", fieldPath)
+					}
+					if !reflect.DeepEqual(currentValue, expectedValue) {
 						return errors.Errorf("field %q should be equal to %q, but is %q", fieldPath, expectedValue, currentValue)
 					}
 				}

--- a/test/e2e/clusterclass_changes_test.go
+++ b/test/e2e/clusterclass_changes_test.go
@@ -44,6 +44,21 @@ var _ = Describe("When testing ClusterClass changes [ClusterClass]", func() {
 			ModifyMachineDeploymentBootstrapConfigTemplateFields: map[string]interface{}{
 				"spec.template.spec.verbosity": int64(4),
 			},
+			// ModifyMachineDeploymentInfrastructureMachineTemplateFields are the fields which will be set on the
+			// InfrastructureMachineTemplate of all MachineDeploymentClasses of the ClusterClass after the initial Cluster creation.
+			// The test verifies that these fields are rolled out to the MachineDeployments.
+			ModifyMachineDeploymentInfrastructureMachineTemplateFields: map[string]interface{}{
+				"spec.template.spec.extraMounts": []interface{}{
+					map[string]interface{}{
+						"containerPath": "/var/run/docker.sock",
+						"hostPath":      "/var/run/docker.sock",
+					},
+					map[string]interface{}{
+						"containerPath": "/tmp",
+						"hostPath":      "/tmp",
+					},
+				},
+			},
 		}
 	})
 })


### PR DESCRIPTION

Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR extends the ClusterClass changes e2e test to cover InfrastructureMachineTemplate rotation. This makes it easy to test if the webhook change for ClusterClass SSA has been implemented correctly.

xref: https://cluster-api.sigs.k8s.io/developer/providers/v1.1-to-v1.2.html#required-api-changes-for-providers (2nd point)

I would like to cherry-pick this in to release-1.2 to make it directly available to providers adopting CAPI v1.2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
