### PR TITLE
🌱 Upgrade golang version (1.18.3 -> 1.19.0)

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.18'
+          go-version: '^1.19'
       - name: generate release artifacts
         run: |
           make release

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,9 +135,9 @@ linters-settings:
     allow-leading-space: false
     require-specific: true
   staticcheck:
-    go: "1.18"
+    go: "1.19"
   stylecheck:
-    go: "1.18"
+    go: "1.19"
   gosec:
     excludes:
     - G307 # Deferring unsafe method "Close" on type "\*os.File"
@@ -160,7 +160,7 @@ linters-settings:
     - whyNoLint
     - wrapperFunc
   unused:
-    go: "1.18"
+    go: "1.19"
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SHELL:=/usr/bin/env bash
 #
 # Go.
 #
-GO_VERSION ?= 1.18.3
+GO_VERSION ?= 1.19.0
 GO_CONTAINER_IMAGE ?= docker.io/library/golang:$(GO_VERSION)
 
 # Use GOPROXY environment variable if set

--- a/Tiltfile
+++ b/Tiltfile
@@ -189,7 +189,7 @@ def load_addon_tiltfiles():
 
 tilt_helper_dockerfile_header = """
 # Tilt image
-FROM golang:1.18.3 as tilt-helper
+FROM golang:1.19.0 as tilt-helper
 # Support live reloading with Tilt
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 RUN wget --output-document /restart.sh --quiet https://raw.githubusercontent.com/windmilleng/rerun-process-wrapper/master/restart.sh  && \

--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -1,10 +1,11 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
+# See https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/gcb-docker-gcloud
 timeout: 2700s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220830-45cbff55bc'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +14,7 @@ steps:
     - DOCKER_BUILDKIT=1
     args:
     - release-staging-nightly
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220830-45cbff55bc'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,11 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
+# See https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/gcb-docker-gcloud
 timeout: 2700s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'N1_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220830-45cbff55bc'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
@@ -13,7 +14,7 @@ steps:
     - DOCKER_BUILDKIT=1
     args:
     - release-staging
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220609-2e4c91eb7e'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220830-45cbff55bc'
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -5,7 +5,7 @@ maintainers of providers and consumers of our Go API.
 
 ## Minimum Go version
 
-* The Go version used by Cluster API is still Go 1.18.x
+* The Go version used by Cluster API is Go 1.19.x
 
 ## Dependencies
 

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -31,7 +31,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.18.3
+  minimum_go_version=go1.19
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     publish = "docs/book/book"
 
 [build.environment]
-    GO_VERSION = "1.18"
+    GO_VERSION = "1.19"
 
 # Standard Netlify redirects
 [[redirects]]


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade golang version 1.18.3 -> 1.19.0 as required by v1.25.0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #6661