### PR TITLE
🌱 tilt: fix promtail values.yaml tow work with loki

### DIFF
--- a/hack/observability/promtail/values.yaml
+++ b/hack/observability/promtail/values.yaml
@@ -2,18 +2,19 @@
 
 config:
   # publish data to loki
-  lokiAddress: http://loki:3100/loki/api/v1/push
+  clients:
+    - url: http://loki:3100/loki/api/v1/push
 
   snippets:
     pipelineStages:
-    # Parse cluster and machine to make them available as labels.
-    - cri: { }
-    - json:
-        expressions:
+      # Parse cluster and machine to make them available as labels.
+      - cri: {}
+      - json:
+          expressions:
+            controller:
+            cluster: join('/',[Cluster.namespace,Cluster.name])
+            machine: join('/',[Machine.namespace,Machine.name])
+      - labels:
           controller:
-          cluster: join('/',[Cluster.namespace,Cluster.name])
-          machine: join('/',[Machine.namespace,Machine.name])
-    - labels:
-        controller:
-        cluster:
-        machine:
+          cluster:
+          machine:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR fixes the configuration of the new charts to promtail to work with loki.

Note: Developers might need to clean their copies of local helm charts to make sure the configuration is working with the compatible version of observability tools.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
