### PR TITLE
📖 add /docs to / redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,6 +26,11 @@
     status = 301
     force = true
 
+[[redirects]]
+    from = "/docs/*"
+    to = "/:splat"
+    status = 301
+
 [[headers]]
     for = "/tasks/experimental-features/runtime-sdk/runtime-sdk-openapi.yaml"
     [headers.values]


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Adds a redirect from `/docs/something/else` to `/something/else` to the book. This allows links that are valid within the repository to also work in the book.

Example: https://github.com/kubernetes-sigs/cluster-api/pull/7110#discussion_r958366116

/cc @CecileRobertMichon 
