### PR TITLE
🌱 logging: adjust reconcilers to log object owners 

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -474,7 +474,7 @@ def deploy_observability():
 
     if "grafana" in settings.get("deploy_observability", []):
         k8s_yaml(read_file("./.tiltbuild/yaml/grafana.observability.yaml"), allow_duplicates = True)
-        k8s_resource(workload = "grafana", port_forwards = "3001:3000", extra_pod_selectors = [{"app": "grafana"}], labels = ["observability"])
+        k8s_resource(workload = "grafana", port_forwards = "3001:3000", extra_pod_selectors = [{"app": "grafana"}], labels = ["observability"], objects = ["grafana:serviceaccount"])
 
     if "prometheus" in settings.get("deploy_observability", []):
         k8s_yaml(read_file("./.tiltbuild/yaml/prometheus.observability.yaml"), allow_duplicates = True)

--- a/bootstrap/kubeadm/config/rbac/role.yaml
+++ b/bootstrap/kubeadm/config/rbac/role.yaml
@@ -42,6 +42,7 @@ rules:
   - machinepools/status
   - machines
   - machines/status
+  - machinesets
   verbs:
   - get
   - list

--- a/docs/book/src/developer/logging.md
+++ b/docs/book/src/developer/logging.md
@@ -181,6 +181,11 @@ Will return logs from the `capi-controller-manager` which are parsed in json. Pa
 Will return logs from the `capi-controller-manager` that are associated with the Cluster `my-cluster`.
 
 ```
+{app="capi-controller-manager"} | json | cluster_name="my-cluster" | v <= 2
+```
+Will return logs from the `capi-controller-manager` that are associated with the Cluster `my-cluster` with log level <= 2.
+
+```
 {app="capi-controller-manager"} | json | cluster_name="my-cluster" reconcileID="6f6ad971-bdb6-4fa3-b803-xxxxxxxxxxxx"
 ```
 

--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -35,3 +35,6 @@ in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controlle
   * the default test timeout has been [changed to 1h](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#timeout-behavior)
   * the `--junit-report` argument [replaces JUnit custom reporter](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#improved-reporting-infrastructure) code
   * see the ["Update tests to Ginkgo v2" PR](https://github.com/kubernetes-sigs/cluster-api/pull/6906) for a reference example
+- Custer API introduced new [logging guidelines](../../developer/logging.md). All reconcilers in the core repository were updated
+  to [log the entire object hierarchy](../../developer/logging.md#keyvalue-pairs). It would be great if providers would be adjusted 
+  as well to make it possible to cross-reference log entries across providers (please see CAPD for an infra provider reference implementation). 

--- a/exp/internal/controllers/machinepool_controller_phases.go
+++ b/exp/internal/controllers/machinepool_controller_phases.go
@@ -134,7 +134,7 @@ func (r *MachinePoolReconciler) reconcileExternal(ctx context.Context, cluster *
 	// Add watcher for external object, if there isn't one already.
 	_, loaded := r.externalWatchers.LoadOrStore(obj.GroupVersionKind().String(), struct{}{})
 	if !loaded && r.controller != nil {
-		log.Info("Adding watcher on external object", "gvk", obj.GroupVersionKind())
+		log.Info("Adding watcher on external object", "groupVersionKind", obj.GroupVersionKind())
 		err := r.controller.Watch(
 			&source.Kind{Type: obj},
 			&handler.EnqueueRequestForOwner{OwnerType: &expv1.MachinePool{}},

--- a/internal/controllers/machine/machine_controller_phases.go
+++ b/internal/controllers/machine/machine_controller_phases.go
@@ -98,7 +98,7 @@ func (r *Reconciler) reconcileExternal(ctx context.Context, cluster *clusterv1.C
 	obj, err := external.Get(ctx, r.Client, ref, m.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(errors.Cause(err)) {
-			log.Info("could not find external ref, requeueing", "refGVK", ref.GroupVersionKind(), "refName", ref.Name, "Machine", klog.KObj(m))
+			log.Info("could not find external ref, requeueing", ref.Kind, klog.KRef(m.Namespace, ref.Name))
 			return external.ReconcileOutput{RequeueAfter: externalReadyWait}, nil
 		}
 		return external.ReconcileOutput{}, err

--- a/test/infrastructure/docker/config/rbac/role.yaml
+++ b/test/infrastructure/docker/config/rbac/role.yaml
@@ -18,6 +18,7 @@ rules:
   resources:
   - clusters
   - machines
+  - machinesets
   verbs:
   - get
   - list

--- a/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
+++ b/test/infrastructure/docker/exp/internal/controllers/dockermachinepool_controller.go
@@ -83,6 +83,7 @@ func (r *DockerMachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	log = log.WithValues("MachinePool", machinePool.Name)
+	ctx = ctrl.LoggerInto(ctx, log)
 
 	// Fetch the Cluster.
 	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, machinePool.ObjectMeta)

--- a/util/log/doc.go
+++ b/util/log/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package log provides log utils.
+package log

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package log provides log utils.
+package log
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+// AddOwners adds the owners of an Object based on OwnerReferences as k/v pairs to the logger in ctx.
+// Note: If an owner is a MachineSet we also add the owners from the MachineSet OwnerReferences.
+func AddOwners(ctx context.Context, c client.Client, obj metav1.Object) (context.Context, logr.Logger, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	owners, err := getOwners(ctx, c, obj)
+	if err != nil {
+		return nil, logr.Logger{}, errors.Wrapf(err, "failed to add object hierarchy to logger")
+	}
+
+	// Add owners as k/v pairs.
+	keysAndValues := []interface{}{}
+	addedKinds := sets.NewString()
+	for _, owner := range owners {
+		// Don't add duplicate kinds.
+		if addedKinds.Has(owner.Kind) {
+			continue
+		}
+
+		keysAndValues = append(keysAndValues, owner.Kind, klog.KRef(owner.Namespace, owner.Name))
+		addedKinds.Insert(owner.Kind)
+	}
+	log = log.WithValues(keysAndValues...)
+
+	ctx = ctrl.LoggerInto(ctx, log)
+	return ctx, log, nil
+}
+
+// owner represents an owner of an object.
+type owner struct {
+	Kind      string
+	Name      string
+	Namespace string
+}
+
+// getOwners returns owners of an Object based on OwnerReferences.
+// Note: If an owner is a MachineSet we also return the owners from the MachineSet OwnerReferences.
+func getOwners(ctx context.Context, c client.Client, obj metav1.Object) ([]owner, error) {
+	owners := []owner{}
+	for _, ownerRef := range obj.GetOwnerReferences() {
+		owners = append(owners, owner{
+			Kind:      ownerRef.Kind,
+			Namespace: obj.GetNamespace(),
+			Name:      ownerRef.Name,
+		})
+
+		// continue if the ownerRef does not point to a MachineSet.
+		if ownerRef.Kind != "MachineSet" {
+			continue
+		}
+
+		// get owners of the MachineSet.
+		var ms clusterv1.MachineSet
+		if err := c.Get(ctx, client.ObjectKey{Namespace: obj.GetNamespace(), Name: ownerRef.Name}, &ms); err != nil {
+			// continue if the MachineSet doesn't exist.
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, errors.Wrapf(err, "failed to get owners: failed to get MachineSet %s", klog.KRef(obj.GetNamespace(), ownerRef.Name))
+		}
+
+		for _, ref := range ms.GetOwnerReferences() {
+			owners = append(owners, owner{
+				Kind:      ref.Kind,
+				Namespace: obj.GetNamespace(),
+				Name:      ref.Name,
+			})
+		}
+	}
+
+	return owners, nil
+}

--- a/util/log/log_test.go
+++ b/util/log/log_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func Test_AddObjectHierarchy(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+
+	md := &clusterv1.MachineSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "MachineDeployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: metav1.NamespaceDefault,
+			Name:      "development-3961-md-0-l4zn6",
+		},
+	}
+	mdOwnerRef := metav1.OwnerReference{
+		APIVersion: md.APIVersion,
+		Kind:       md.Kind,
+		Name:       md.Name,
+	}
+
+	ms := &clusterv1.MachineSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "MachineSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       metav1.NamespaceDefault,
+			Name:            "development-3961-md-0-l4zn6-758c9b7677",
+			OwnerReferences: []metav1.OwnerReference{mdOwnerRef},
+		},
+	}
+	msOwnerRef := metav1.OwnerReference{
+		APIVersion: ms.APIVersion,
+		Kind:       ms.Kind,
+		Name:       ms.Name,
+	}
+
+	tests := []struct {
+		name                  string
+		obj                   metav1.Object
+		objects               []client.Object
+		expectedKeysAndValues []interface{}
+	}{
+		{
+			name: "MachineSet owning Machine is added",
+			// MachineSet does not exist in Kubernetes so only MachineSet is added
+			// and MachineDeployment is not.
+			obj: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{msOwnerRef},
+					Namespace:       metav1.NamespaceDefault,
+				},
+			},
+			expectedKeysAndValues: []interface{}{
+				"MachineSet",
+				klog.ObjectRef{Namespace: ms.Namespace, Name: ms.Name},
+			},
+		},
+		{
+			name: "MachineDeployment and MachineSet owning Machine is added",
+			obj: &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{msOwnerRef},
+					Namespace:       metav1.NamespaceDefault,
+				},
+			},
+			objects: []client.Object{ms},
+			expectedKeysAndValues: []interface{}{
+				"MachineSet",
+				klog.ObjectRef{Namespace: ms.Namespace, Name: ms.Name},
+				"MachineDeployment",
+				klog.ObjectRef{Namespace: md.Namespace, Name: md.Name},
+			},
+		},
+		{
+			name: "MachineDeployment owning MachineSet is added",
+			obj: &clusterv1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{mdOwnerRef},
+					Namespace:       metav1.NamespaceDefault,
+				},
+			},
+			expectedKeysAndValues: []interface{}{
+				"MachineDeployment",
+				klog.ObjectRef{Namespace: md.Namespace, Name: md.Name},
+			},
+		},
+		{
+			name: "KubeadmControlPlane and Machine owning DockerMachine are added",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+					"kind":       "DockerMachine",
+					"metadata": map[string]interface{}{
+						"ownerReferences": []interface{}{
+							map[string]interface{}{
+								"apiVersion": clusterv1.GroupVersion.String(),
+								"kind":       "Machine",
+								"name":       "development-3961-4flkb-gzxnb",
+							},
+							map[string]interface{}{
+								"apiVersion": clusterv1.GroupVersion.String(),
+								"kind":       "KubeadmControlPlane",
+								"name":       "development-3961-4flkb",
+							},
+						},
+						"namespace": metav1.NamespaceDefault,
+					},
+				},
+			},
+			expectedKeysAndValues: []interface{}{
+				"Machine",
+				klog.ObjectRef{Namespace: metav1.NamespaceDefault, Name: "development-3961-4flkb-gzxnb"},
+				"KubeadmControlPlane",
+				klog.ObjectRef{Namespace: metav1.NamespaceDefault, Name: "development-3961-4flkb"},
+			},
+		},
+		{
+			name: "Duplicate Cluster ownerRef should be deduplicated",
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+					"kind":       "DockerCluster",
+					"metadata": map[string]interface{}{
+						"ownerReferences": []interface{}{
+							map[string]interface{}{
+								"apiVersion": clusterv1.GroupVersion.String(),
+								"kind":       "Cluster",
+								"name":       "development-3961",
+							},
+							map[string]interface{}{
+								"apiVersion": clusterv1.GroupVersion.String(),
+								"kind":       "Cluster",
+								"name":       "development-3961",
+							},
+						},
+						"namespace": metav1.NamespaceDefault,
+					},
+				},
+			},
+			expectedKeysAndValues: []interface{}{
+				"Cluster",
+				klog.ObjectRef{Namespace: metav1.NamespaceDefault, Name: "development-3961"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.objects...).
+				Build()
+
+			// Create fake log sink so we can later verify the added k/v pairs.
+			ctx := ctrl.LoggerInto(context.Background(), logr.New(&fakeLogSink{}))
+
+			_, logger, err := AddOwners(ctx, c, tt.obj)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(logger.GetSink().(fakeLogSink).keysAndValues).To(Equal(tt.expectedKeysAndValues))
+		})
+	}
+}
+
+type fakeLogSink struct {
+	// Embedding NullLogSink so we don't have to implement all funcs
+	// of the LogSink interface.
+	log.NullLogSink
+	keysAndValues []interface{}
+}
+
+// WithValues stores keysAndValues so we can later check if the
+// right keysAndValues have been added.
+func (f fakeLogSink) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	f.keysAndValues = keysAndValues
+	return f
+}


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
With this PR we're logging all relevant k/v pairs for all our resources.

This PR also contains 1-2 smaller other logging fixes and an improvement to our Tiltfile so the ServiceAccount of Grafana is **always** deployed before the Grafana deployment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
