### PR TITLE
⚠️ Use Kubernetes 1.25 in Quick Start docs and CAPD.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ _releasenotes
 # Used during parts of the build process. Files _should_ get cleaned up automatically.
 # This is also a good location for any temporary manfiests used during development
 tmp
+
+# asdf (not a typo! ;) used to manage multiple versions of tools
+.tool-versions

--- a/Tiltfile
+++ b/Tiltfile
@@ -509,7 +509,7 @@ def cluster_templates():
 
     # Ensure we have default values for a small set of well-known variables
     substitutions["NAMESPACE"] = substitutions.get("NAMESPACE", "default")
-    substitutions["KUBERNETES_VERSION"] = substitutions.get("KUBERNETES_VERSION", "v1.24.0")
+    substitutions["KUBERNETES_VERSION"] = substitutions.get("KUBERNETES_VERSION", "v1.25.0")
     substitutions["CONTROL_PLANE_MACHINE_COUNT"] = substitutions.get("CONTROL_PLANE_MACHINE_COUNT", "1")
     substitutions["WORKER_MACHINE_COUNT"] = substitutions.get("WORKER_MACHINE_COUNT", "3")
 

--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -12,7 +12,7 @@ maintainers of providers and consumers of our Go API.
 **Note**: Only the most relevant dependencies are listed, `k8s.io/` and `ginkgo`/`gomega` dependencies
 in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controller-runtime`.
 
--
+- sigs.k8s.io/kind: v0.14.x => v0.15.x
 
 ## Changes by Kind
 

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -8,7 +8,7 @@ workflow that offers easy deployments and rapid iterative builds.
 ## Prerequisites
 
 1. [Docker](https://docs.docker.com/install/): v19.03 or newer
-1. [kind](https://kind.sigs.k8s.io): v0.9 or newer
+1. [kind](https://kind.sigs.k8s.io): v0.15 or newer
 1. [Tilt](https://docs.tilt.dev/install.html): v0.22.2 or newer
 1. [kustomize](https://github.com/kubernetes-sigs/kustomize): provided via `make kustomize`
 1. [envsubst](https://github.com/drone/envsubst): provided via `make envsubst`
@@ -303,7 +303,7 @@ Custom values for variable substitutions can be set using `kustomize_substitutio
 ```yaml
 kustomize_substitutions:
   NAMESPACE: default
-  KUBERNETES_VERSION: v1.24.0
+  KUBERNETES_VERSION: v1.25.0
   CONTROL_PLANE_MACHINE_COUNT: 1
   WORKER_MACHINE_COUNT: 3
 ```

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -45,7 +45,7 @@ a target [management cluster] on the selected [infrastructure provider].
 
    [kind] is not designed for production use.
 
-   **Minimum [kind] supported version**: v0.14.0
+   **Minimum [kind] supported version**: v0.15.0
 
    **Help with common issues can be found in the [Troubleshooting Guide](./troubleshooting.md).**
 
@@ -948,7 +948,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.24.0 \
+  --kubernetes-version v1.25.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -960,7 +960,7 @@ clusterctl generate cluster capi-quickstart --flavor development \
 ```bash
 export CLUSTER_NAME=kind
 export CLUSTER_NAMESPACE=vcluster
-export KUBERNETES_VERSION=1.23.4
+export KUBERNETES_VERSION=1.25.0
 export HELM_VALUES="service:\n  type: NodePort"
 
 kubectl create namespace ${CLUSTER_NAMESPACE}
@@ -975,7 +975,7 @@ clusterctl generate cluster ${CLUSTER_NAME} \
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.24.0 \
+  --kubernetes-version v1.25.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1034,8 +1034,8 @@ kubectl get kubeadmcontrolplane
 You should see an output is similar to this:
 
 ```bash
-NAME                            INITIALIZED   API SERVER AVAILABLE   VERSION   REPLICAS   READY   UPDATED   UNAVAILABLE
-capi-quickstart-control-plane   true                                 v1.24.0   3                  3         3
+NAME                    CLUSTER           INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE    VERSION
+capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.25.0
 ```
 
 <aside class="note warning">
@@ -1091,7 +1091,7 @@ Calico not required for vcluster.
 
 ```bash
 kubectl --kubeconfig=./capi-quickstart.kubeconfig \
-  apply -f https://docs.projectcalico.org/v3.21/manifests/calico.yaml
+  apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.1/manifests/calico.yaml
 ```
 
 After a short while, our nodes should be running and in `Ready` state,
@@ -1099,6 +1099,15 @@ let's check the status using `kubectl get nodes`:
 
 ```bash
 kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
+```
+```bash
+NAME                                          STATUS   ROLES           AGE   VERSION
+capi-quickstart-g2trk-9xrjv                   Ready    control-plane   12m   v1.25.0
+capi-quickstart-g2trk-bmm9v                   Ready    control-plane   11m   v1.25.0
+capi-quickstart-g2trk-hvs9q                   Ready    control-plane   13m   v1.25.0
+capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          12m   v1.25.0
+capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          12m   v1.25.0
+capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          12m   v1.25.0
 ```
 
 {{#/tab }}

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -21,7 +21,7 @@ set -o pipefail
 set -x
 
 GOPATH_BIN="$(go env GOPATH)/bin/"
-MINIMUM_KIND_VERSION=v0.14.0
+MINIMUM_KIND_VERSION=v0.15.0
 goarch="$(go env GOARCH)"
 goos="$(go env GOOS)"
 

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -205,12 +205,12 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.24.0"
-  KUBERNETES_VERSION: "v1.24.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.23.6"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.24.0"
-  ETCD_VERSION_UPGRADE_TO: "3.5.3-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.8.6"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.25.0"
+  KUBERNETES_VERSION: "v1.25.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "1.24.4"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.25.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.4-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.9.3"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "IPv4"
   DOCKER_SERVICE_CIDRS: "10.128.0.0/12"
@@ -232,7 +232,7 @@ variables:
   # NOTE: We test the latest release with a previous contract.
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-{OS}-{ARCH}"
   INIT_WITH_PROVIDERS_CONTRACT: "v1alpha4"
-  INIT_WITH_KUBERNETES_VERSION: "v1.24.0"
+  INIT_WITH_KUBERNETES_VERSION: "v1.25.0"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.24.0"
+	DefaultNodeImageVersion = "v1.25.0"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -351,6 +352,7 @@ func DeployUnevictablePod(ctx context.Context, input DeployUnevictablePodInput) 
 		},
 	}
 	workloadClient := input.WorkloadClusterProxy.GetClientSet()
+
 	if input.ControlPlane != nil {
 		var serverVersion *version.Info
 		Eventually(func() error {
@@ -383,33 +385,72 @@ func DeployUnevictablePod(ctx context.Context, input DeployUnevictablePodInput) 
 		Deployment: workloadDeployment,
 	})
 
-	budget := &v1beta1.PodDisruptionBudget{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "PodDisruptionBudget",
-			APIVersion: "policy/v1beta1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      input.DeploymentName,
-			Namespace: input.Namespace,
-		},
-		Spec: v1beta1.PodDisruptionBudgetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": "nonstop",
+	// TODO(oscr): Remove when Kubernetes 1.20 support is dropped.
+	serverVersion, err := workloadClient.ServerVersion()
+	Expect(err).ToNot(HaveOccurred(), "Failed to get Kubernetes version for workload")
+
+	// If Kubernetes < 1.21.0 we need to use PDB from v1beta1
+	if utilversion.MustParseGeneric(serverVersion.String()).LessThan(utilversion.MustParseGeneric("v1.21.0")) {
+		budgetV1Beta1 := &v1beta1.PodDisruptionBudget{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PodDisruptionBudget",
+				APIVersion: "policy/v1beta1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      input.DeploymentName,
+				Namespace: input.Namespace,
+			},
+			Spec: v1beta1.PodDisruptionBudgetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "nonstop",
+					},
+				},
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
+					StrVal: "1",
 				},
 			},
-			MaxUnavailable: &intstr.IntOrString{
-				Type:   intstr.Int,
-				IntVal: 1,
-				StrVal: "1",
+		}
+
+		AddPodDisruptionBudgetV1Beta1(ctx, AddPodDisruptionBudgetInputV1Beta1{
+			Namespace: input.Namespace,
+			ClientSet: workloadClient,
+			Budget:    budgetV1Beta1,
+		})
+
+		// If Kubernetes >= 1.21.0 then we need to use PDB from v1
+	} else {
+		budget := &policyv1.PodDisruptionBudget{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PodDisruptionBudget",
+				APIVersion: "policy/v1",
 			},
-		},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      input.DeploymentName,
+				Namespace: input.Namespace,
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "nonstop",
+					},
+				},
+				MaxUnavailable: &intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 1,
+					StrVal: "1",
+				},
+			},
+		}
+
+		AddPodDisruptionBudget(ctx, AddPodDisruptionBudgetInput{
+			Namespace: input.Namespace,
+			ClientSet: workloadClient,
+			Budget:    budget,
+		})
 	}
-	AddPodDisruptionBudget(ctx, AddPodDisruptionBudgetInput{
-		Namespace: input.Namespace,
-		ClientSet: workloadClient,
-		Budget:    budget,
-	})
 
 	WaitForDeploymentsAvailable(ctx, WaitForDeploymentsAvailableInput{
 		Getter:     input.WorkloadClusterProxy.GetClient(),
@@ -435,11 +476,29 @@ func AddDeploymentToWorkloadCluster(ctx context.Context, input AddDeploymentToWo
 
 type AddPodDisruptionBudgetInput struct {
 	ClientSet *kubernetes.Clientset
-	Budget    *v1beta1.PodDisruptionBudget
+	Budget    *policyv1.PodDisruptionBudget
 	Namespace string
 }
 
 func AddPodDisruptionBudget(ctx context.Context, input AddPodDisruptionBudgetInput) {
+	Eventually(func() error {
+		budget, err := input.ClientSet.PolicyV1().PodDisruptionBudgets(input.Namespace).Create(ctx, input.Budget, metav1.CreateOptions{})
+		if budget != nil && err == nil {
+			return nil
+		}
+		return fmt.Errorf("podDisruptionBudget needs to be successfully deployed: %v", err)
+	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "podDisruptionBudget needs to be successfully deployed")
+}
+
+// TODO(oscr): Delete below when Kubernetes 1.20 support is dropped.
+
+type AddPodDisruptionBudgetInputV1Beta1 struct {
+	ClientSet *kubernetes.Clientset
+	Budget    *v1beta1.PodDisruptionBudget
+	Namespace string
+}
+
+func AddPodDisruptionBudgetV1Beta1(ctx context.Context, input AddPodDisruptionBudgetInputV1Beta1) {
 	Eventually(func() error {
 		budget, err := input.ClientSet.PolicyV1beta1().PodDisruptionBudgets(input.Namespace).Create(ctx, input.Budget, metav1.CreateOptions{})
 		if budget != nil && err == nil {

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -33,7 +33,7 @@ ENV GOPROXY=$goproxy
 # Gets additional CAPD dependencies
 WORKDIR /tmp
 
-RUN curl -LO https://dl.k8s.io/release/v1.24.0/bin/linux/${ARCH}/kubectl && \
+RUN curl -LO https://dl.k8s.io/release/v1.25.0/bin/linux/${ARCH}/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl
 

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.24.0
+  version: v1.25.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.24.0
+      version: v1.25.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.24.0
+  version: v1.25.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -90,7 +90,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.24.0
+      version: v1.25.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.24.0
+  version: v1.25.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.24.0
+      version: v1.25.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.24.0
+  version: v1.25.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -83,7 +83,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.24.0
+      version: v1.25.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -50,7 +50,7 @@ import (
 
 const (
 	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.24.0"
+	defaultImageTag  = "v1.25.0"
 )
 
 type nodeCreator interface {


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the Quick Start guide to use Kubernetes 1.25. Now using kind 0.15.0 and Calico 3.24.1. 

Calico was updated due to breakage `error: unable to recognize "https://docs.projectcalico.org/v3.21/manifests/calico.yaml": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1"`.

The updated QS "works on my machine" and all pods in management and worker cluster seem to be running. 

Part of #6661
