### PR TITLE
[WIP] :seedling: Move webhooks to internal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,7 @@ generate-manifests-kubeadm-bootstrap: $(CONTROLLER_GEN) ## Generate manifests e.
 	$(CONTROLLER_GEN) \
 		paths=./bootstrap/kubeadm/api/... \
 		paths=./bootstrap/kubeadm/internal/controllers/... \
+		paths=./bootstrap/kubeadm/internal/webhooks/... \
 		crd:crdVersions=v1 \
 		rbac:roleName=manager-role \
 		output:crd:dir=./bootstrap/kubeadm/config/crd/bases \

--- a/api/v1beta1/machine_webhook.go
+++ b/api/v1beta1/machine_webhook.go
@@ -31,21 +31,28 @@ import (
 	"sigs.k8s.io/cluster-api/util/version"
 )
 
+// Deprecated: This file, including all public and private methods, will be removed in a future release.
+// The Machine webhook validation implementation and API can now be found in the webhooks package.
+
 const defaultNodeDeletionTimeout = 10 * time.Second
 
+// SetupWebhookWithManager sets up Machine webhooks.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.Machine.SetupWebhookWithManager instead.
+// Note: We don't have to call this func for the conversion webhook as there is only a single conversion webhook instance
+// for all resources and we already register it through other types.
 func (m *Machine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(m).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1beta1-machine,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machines,versions=v1beta1,name=validation.machine.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-machine,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machines,versions=v1beta1,name=default.machine.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
 var _ webhook.Validator = &Machine{}
 var _ webhook.Defaulter = &Machine{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.Machine.Default instead.
 func (m *Machine) Default() {
 	if m.Labels == nil {
 		m.Labels = make(map[string]string)
@@ -71,11 +78,15 @@ func (m *Machine) Default() {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.Machine.ValidateCreate instead.
 func (m *Machine) ValidateCreate() error {
 	return m.validate(nil)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.Machine.ValidateUpdate instead.
 func (m *Machine) ValidateUpdate(old runtime.Object) error {
 	oldM, ok := old.(*Machine)
 	if !ok {
@@ -85,6 +96,8 @@ func (m *Machine) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.Machine.ValidateDelete instead.
 func (m *Machine) ValidateDelete() error {
 	return nil
 }

--- a/api/v1beta1/machinedeployment_webhook.go
+++ b/api/v1beta1/machinedeployment_webhook.go
@@ -33,19 +33,26 @@ import (
 	"sigs.k8s.io/cluster-api/util/version"
 )
 
+// Deprecated: This file, including all public and private methods, will be removed in a future release.
+// The MachineDeployment webhook validation implementation and API can now be found in the webhooks package.
+
+// SetupWebhookWithManager sets up MachineDeployment webhooks.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineDeployment.SetupWebhookWithManager instead.
+// Note: We don't have to call this func for the conversion webhook as there is only a single conversion webhook instance
+// for all resources and we already register it through other types.
 func (m *MachineDeployment) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(m).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1beta1-machinedeployment,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinedeployments,versions=v1beta1,name=validation.machinedeployment.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-machinedeployment,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinedeployments,versions=v1beta1,name=default.machinedeployment.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
 var _ webhook.Defaulter = &MachineDeployment{}
 var _ webhook.Validator = &MachineDeployment{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineDeployment.Default instead.
 func (m *MachineDeployment) Default() {
 	PopulateDefaultsMachineDeployment(m)
 	// tolerate version strings without a "v" prefix: prepend it if it's not there
@@ -56,11 +63,15 @@ func (m *MachineDeployment) Default() {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineDeployment.ValidateCreate instead.
 func (m *MachineDeployment) ValidateCreate() error {
 	return m.validate(nil)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineDeployment.ValidateUpdate instead.
 func (m *MachineDeployment) ValidateUpdate(old runtime.Object) error {
 	oldMD, ok := old.(*MachineDeployment)
 	if !ok {
@@ -70,6 +81,8 @@ func (m *MachineDeployment) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineDeployment.ValidateDelete instead.
 func (m *MachineDeployment) ValidateDelete() error {
 	return nil
 }

--- a/api/v1beta1/machinehealthcheck_webhook.go
+++ b/api/v1beta1/machinehealthcheck_webhook.go
@@ -29,6 +29,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+// Deprecated: This file, including all public and private methods, will be removed in a future release.
+// The MachineHealthCheck webhook validation implementation and API can now be found in the webhooks package.
+
 var (
 	// DefaultNodeStartupTimeout is the time allowed for a node to start up.
 	// Can be made longer as part of spec if required for particular provider.
@@ -50,19 +53,23 @@ func SetMinNodeStartupTimeout(d metav1.Duration) {
 	minNodeStartupTimeout = d
 }
 
+// SetupWebhookWithManager sets up MachineHealthCheck webhooks.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineHealthCheck.SetupWebhookWithManager instead.
+// Note: We don't have to call this func for the conversion webhook as there is only a single conversion webhook instance
+// for all resources and we already register it through other types.
 func (m *MachineHealthCheck) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(m).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1beta1-machinehealthcheck,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinehealthchecks,versions=v1beta1,name=validation.machinehealthcheck.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-machinehealthcheck,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinehealthchecks,versions=v1beta1,name=default.machinehealthcheck.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
 var _ webhook.Defaulter = &MachineHealthCheck{}
 var _ webhook.Validator = &MachineHealthCheck{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineHealthCheck.Default instead.
 func (m *MachineHealthCheck) Default() {
 	if m.Labels == nil {
 		m.Labels = make(map[string]string)
@@ -84,11 +91,14 @@ func (m *MachineHealthCheck) Default() {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
 func (m *MachineHealthCheck) ValidateCreate() error {
 	return m.validate(nil)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineHealthCheck.ValidateUpdate instead.
 func (m *MachineHealthCheck) ValidateUpdate(old runtime.Object) error {
 	mhc, ok := old.(*MachineHealthCheck)
 	if !ok {
@@ -98,6 +108,8 @@ func (m *MachineHealthCheck) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineHealthCheck.ValidateDelete instead.
 func (m *MachineHealthCheck) ValidateDelete() error {
 	return nil
 }

--- a/api/v1beta1/machineset_webhook.go
+++ b/api/v1beta1/machineset_webhook.go
@@ -31,19 +31,26 @@ import (
 	"sigs.k8s.io/cluster-api/util/version"
 )
 
+// Deprecated: This file, including all public and private methods, will be removed in a future release.
+// The MachineSet webhook validation implementation and API can now be found in the webhooks package.
+
+// SetupWebhookWithManager sets up MachineSeMachineSet.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineSet.SetupWebhookWithManager instead.
+// Note: We don't have to call this func for the conversion webhook as there is only a single conversion webhook instance
+// for all resources and we already register it through other types.
 func (m *MachineSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(m).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1beta1-machineset,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinesets,versions=v1beta1,name=validation.machineset.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-machineset,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinesets,versions=v1beta1,name=default.machineset.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
 var _ webhook.Defaulter = &MachineSet{}
 var _ webhook.Validator = &MachineSet{}
 
 // Default sets default MachineSet field values.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineSet.Default instead.
 func (m *MachineSet) Default() {
 	if m.Labels == nil {
 		m.Labels = make(map[string]string)
@@ -75,11 +82,15 @@ func (m *MachineSet) Default() {
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineSet.ValidateCreate instead.
 func (m *MachineSet) ValidateCreate() error {
 	return m.validate(nil)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineSet.ValidateUpdate instead.
 func (m *MachineSet) ValidateUpdate(old runtime.Object) error {
 	oldMS, ok := old.(*MachineSet)
 	if !ok {
@@ -89,6 +100,8 @@ func (m *MachineSet) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.MachineSet.ValidateDelete instead.
 func (m *MachineSet) ValidateDelete() error {
 	return nil
 }

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
@@ -105,6 +105,13 @@ type KubeadmConfigSpec struct {
 	Ignition *IgnitionSpec `json:"ignition,omitempty"`
 }
 
+// DefaultKubeadmConfigSpec defaults a KubeadmConfigSpec.
+func DefaultKubeadmConfigSpec(r *KubeadmConfigSpec) {
+	if r.Format == "" {
+		r.Format = CloudConfig
+	}
+}
+
 // IgnitionSpec contains Ignition specific configuration.
 type IgnitionSpec struct {
 	// ContainerLinuxConfig contains CLC specific configuration.

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
@@ -24,36 +24,47 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
+// Deprecated: This file, including all public and private methods, will be removed in a future release.
+// The KubeadmConfig webhook validation implementation and API can now be found in the webhooks package.
+
+// SetupWebhookWithManager sets up KubeadmConfigTemplate webhooks.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.KubeadmConfigTemplate.SetupWebhookWithManager instead.
+// Note: We don't have to call this func for the conversion webhook as there is only a single conversion webhook instance
+// for all resources and we already register it through other types.
 func (r *KubeadmConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate,mutating=true,failurePolicy=fail,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,versions=v1beta1,name=default.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
 var _ webhook.Defaulter = &KubeadmConfigTemplate{}
+var _ webhook.Validator = &KubeadmConfigTemplate{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.KubeadmConfigTemplate.Default instead.
 func (r *KubeadmConfigTemplate) Default() {
 	DefaultKubeadmConfigSpec(&r.Spec.Template.Spec)
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,versions=v1beta1,name=validation.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
-var _ webhook.Validator = &KubeadmConfigTemplate{}
-
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.KubeadmConfigTemplate.ValidateCreate instead.
 func (r *KubeadmConfigTemplate) ValidateCreate() error {
 	return r.Spec.validate(r.Name)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.KubeadmConfigTemplate.ValidateUpdate instead.
 func (r *KubeadmConfigTemplate) ValidateUpdate(old runtime.Object) error {
 	return r.Spec.validate(r.Name)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+// Deprecated: This method is going to be removed in a next release.
+// Note: We're not using this method anymore and are using webhooks.KubeadmConfigTemplate.ValidateDelete instead.
 func (r *KubeadmConfigTemplate) ValidateDelete() error {
 	return nil
 }

--- a/bootstrap/kubeadm/internal/webhooks/doc.go
+++ b/bootstrap/kubeadm/internal/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks contains external webhook implementations for some of our API types.
+package webhooks

--- a/bootstrap/kubeadm/internal/webhooks/kubeadmconfig_test.go
+++ b/bootstrap/kubeadm/internal/webhooks/kubeadmconfig_test.go
@@ -1,0 +1,490 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/internal/webhooks/util"
+)
+
+var (
+	ctx        = ctrl.SetupSignalHandler()
+	fakeScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = bootstrapv1.AddToScheme(fakeScheme)
+}
+
+func TestKubeadmConfigDefault(t *testing.T) {
+	defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.KubeadmBootstrapFormatIgnition, true)()
+
+	g := NewWithT(t)
+
+	kubeadmConfig := &bootstrapv1.KubeadmConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+		Spec: bootstrapv1.KubeadmConfigSpec{},
+	}
+	updateDefaultingKubeadmConfig := kubeadmConfig.DeepCopy()
+	updateDefaultingKubeadmConfig.Spec.Verbosity = pointer.Int32Ptr(4)
+	webhook := &KubeadmConfig{}
+
+	t.Run("for KubeadmConfig", util.CustomDefaultValidateTest(ctx, updateDefaultingKubeadmConfig, webhook))
+	g.Expect(webhook.Default(ctx, kubeadmConfig))
+	g.Expect(kubeadmConfig.Spec.Format).To(Equal(bootstrapv1.CloudConfig))
+
+	ignitionKubeadmConfig := &bootstrapv1.KubeadmConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+		Spec: bootstrapv1.KubeadmConfigSpec{
+			Format: bootstrapv1.Ignition,
+		},
+	}
+
+	t.Run("for KubeadmConfig", util.CustomDefaultValidateTest(ctx, ignitionKubeadmConfig, webhook))
+	g.Expect(webhook.Default(ctx, ignitionKubeadmConfig))
+	g.Expect(ignitionKubeadmConfig.Spec.Format).To(Equal(bootstrapv1.Ignition))
+}
+
+func TestKubeadmConfigValidate(t *testing.T) {
+	cases := map[string]struct {
+		in                    *bootstrapv1.KubeadmConfig
+		enableIgnitionFeature bool
+		expectErr             bool
+	}{
+		"valid content": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Files: []bootstrapv1.File{
+						{
+							Content: "foo",
+						},
+					},
+				},
+			},
+		},
+		"valid contentFrom": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Files: []bootstrapv1.File{
+						{
+							ContentFrom: &bootstrapv1.FileSource{
+								Secret: bootstrapv1.SecretFileSource{
+									Name: "foo",
+									Key:  "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"invalid content and contentFrom": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Files: []bootstrapv1.File{
+						{
+							ContentFrom: &bootstrapv1.FileSource{},
+							Content:     "foo",
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"invalid contentFrom without name": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Files: []bootstrapv1.File{
+						{
+							ContentFrom: &bootstrapv1.FileSource{
+								Secret: bootstrapv1.SecretFileSource{
+									Key: "bar",
+								},
+							},
+							Content: "foo",
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"invalid contentFrom without key": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Files: []bootstrapv1.File{
+						{
+							ContentFrom: &bootstrapv1.FileSource{
+								Secret: bootstrapv1.SecretFileSource{
+									Name: "foo",
+								},
+							},
+							Content: "foo",
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"invalid with duplicate file path": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Files: []bootstrapv1.File{
+						{
+							Content: "foo",
+						},
+						{
+							Content: "bar",
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"valid passwd": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Users: []bootstrapv1.User{
+						{
+							Passwd: pointer.StringPtr("foo"),
+						},
+					},
+				},
+			},
+		},
+		"valid passwdFrom": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Users: []bootstrapv1.User{
+						{
+							PasswdFrom: &bootstrapv1.PasswdSource{
+								Secret: bootstrapv1.SecretPasswdSource{
+									Name: "foo",
+									Key:  "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"invalid passwd and passwdFrom": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Users: []bootstrapv1.User{
+						{
+							PasswdFrom: &bootstrapv1.PasswdSource{},
+							Passwd:     pointer.StringPtr("foo"),
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"invalid passwdFrom without name": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Users: []bootstrapv1.User{
+						{
+							PasswdFrom: &bootstrapv1.PasswdSource{
+								Secret: bootstrapv1.SecretPasswdSource{
+									Key: "bar",
+								},
+							},
+							Passwd: pointer.StringPtr("foo"),
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"invalid passwdFrom without key": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: metav1.NamespaceDefault,
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Users: []bootstrapv1.User{
+						{
+							PasswdFrom: &bootstrapv1.PasswdSource{
+								Secret: bootstrapv1.SecretPasswdSource{
+									Name: "foo",
+								},
+							},
+							Passwd: pointer.StringPtr("foo"),
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"Ignition field is set, format is not Ignition": {
+			enableIgnitionFeature: true,
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Ignition: &bootstrapv1.IgnitionSpec{},
+				},
+			},
+			expectErr: true,
+		},
+		"Ignition field is not set, format is Ignition": {
+			enableIgnitionFeature: true,
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format: bootstrapv1.Ignition,
+				},
+			},
+		},
+		"format is Ignition, user is inactive": {
+			enableIgnitionFeature: true,
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format: bootstrapv1.Ignition,
+					Users: []bootstrapv1.User{
+						{
+							Inactive: pointer.BoolPtr(true),
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"format is Ignition, non-GPT partition configured": {
+			enableIgnitionFeature: true,
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format: bootstrapv1.Ignition,
+					DiskSetup: &bootstrapv1.DiskSetup{
+						Partitions: []bootstrapv1.Partition{
+							{
+								TableType: pointer.StringPtr("MS-DOS"),
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"format is Ignition, experimental retry join is set": {
+			enableIgnitionFeature: true,
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format:                   bootstrapv1.Ignition,
+					UseExperimentalRetryJoin: true,
+				},
+			},
+			expectErr: true,
+		},
+		"feature gate disabled, format is Ignition": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format: bootstrapv1.Ignition,
+				},
+			},
+			expectErr: true,
+		},
+		"feature gate disabled, Ignition field is set": {
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format: bootstrapv1.Ignition,
+					Ignition: &bootstrapv1.IgnitionSpec{
+						ContainerLinuxConfig: &bootstrapv1.ContainerLinuxConfig{},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"replaceFS specified with Ignition": {
+			enableIgnitionFeature: true,
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format: bootstrapv1.Ignition,
+					DiskSetup: &bootstrapv1.DiskSetup{
+						Filesystems: []bootstrapv1.Filesystem{
+							{
+								ReplaceFS: pointer.StringPtr("ntfs"),
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"filesystem partition specified with Ignition": {
+			enableIgnitionFeature: true,
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format: bootstrapv1.Ignition,
+					DiskSetup: &bootstrapv1.DiskSetup{
+						Filesystems: []bootstrapv1.Filesystem{
+							{
+								Partition: pointer.StringPtr("1"),
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"file encoding gzip specified with Ignition": {
+			enableIgnitionFeature: true,
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format: bootstrapv1.Ignition,
+					Files: []bootstrapv1.File{
+						{
+							Encoding: bootstrapv1.Gzip,
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		"file encoding gzip+base64 specified with Ignition": {
+			enableIgnitionFeature: true,
+			in: &bootstrapv1.KubeadmConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigSpec{
+					Format: bootstrapv1.Ignition,
+					Files: []bootstrapv1.File{
+						{
+							Encoding: bootstrapv1.GzipBase64,
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tt.enableIgnitionFeature {
+				// NOTE: KubeadmBootstrapFormatIgnition feature flag is disabled by default.
+				// Enabling the feature flag temporarily for this test.
+				defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.KubeadmBootstrapFormatIgnition, true)()
+			}
+			g := NewWithT(t)
+			webhook := &KubeadmConfig{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateCreate(ctx, tt.in)).NotTo(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, tt.in, tt.in)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateCreate(ctx, tt.in)).To(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, tt.in, tt.in)).To(Succeed())
+			}
+		})
+	}
+}

--- a/bootstrap/kubeadm/internal/webhooks/kubeadmconfigtemplate.go
+++ b/bootstrap/kubeadm/internal/webhooks/kubeadmconfigtemplate.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+)
+
+func (webhook *KubeadmConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&bootstrapv1.KubeadmConfigTemplate{}).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate,mutating=true,failurePolicy=fail,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,versions=v1beta1,name=default.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,versions=v1beta1,name=validation.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// KubeadmConfigTemplate implements a validating and defaulting webhook for KubeadmConfigTemplate.
+type KubeadmConfigTemplate struct {
+	Client client.Reader
+}
+
+var _ webhook.CustomDefaulter = &KubeadmConfigTemplate{}
+var _ webhook.CustomValidator = &KubeadmConfigTemplate{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (webhook *KubeadmConfigTemplate) Default(_ context.Context, obj runtime.Object) error {
+	tpl, ok := obj.(*bootstrapv1.KubeadmConfigTemplate)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a KubeadmConfigTemplate but got a %T", obj))
+	}
+	bootstrapv1.DefaultKubeadmConfigSpec(&tpl.Spec.Template.Spec)
+
+	return nil
+}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *KubeadmConfigTemplate) ValidateCreate(_ context.Context, obj runtime.Object) error {
+	tpl, ok := obj.(*bootstrapv1.KubeadmConfigTemplate)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a KubeadmConfigTemplate but got a %T", obj))
+	}
+	return webhook.validate(tpl)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *KubeadmConfigTemplate) ValidateUpdate(_ context.Context, _, newObj runtime.Object) error {
+	tpl, ok := newObj.(*bootstrapv1.KubeadmConfigTemplate)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a KubeadmConfigTemplate but got a %T", newObj))
+	}
+	return webhook.validate(tpl)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *KubeadmConfigTemplate) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	return nil
+}
+
+func (webhook *KubeadmConfigTemplate) validate(tpl *bootstrapv1.KubeadmConfigTemplate) error {
+	var allErrs field.ErrorList
+
+	allErrs = append(allErrs, ValidateKubeadmConfigSpec(&tpl.Spec.Template.Spec, field.NewPath("spec", "template", "spec"))...)
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(bootstrapv1.GroupVersion.WithKind("KubeadmConfigTemplate").GroupKind(), tpl.Name, allErrs)
+}

--- a/bootstrap/kubeadm/internal/webhooks/kubeadmconfigtemplate_test.go
+++ b/bootstrap/kubeadm/internal/webhooks/kubeadmconfigtemplate_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/webhooks/util"
+)
+
+func TestKubeadmConfigTemplateDefault(t *testing.T) {
+	g := NewWithT(t)
+
+	kubeadmConfigTemplate := &bootstrapv1.KubeadmConfigTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+	}
+	updateDefaultingKubeadmConfigTemplate := kubeadmConfigTemplate.DeepCopy()
+	updateDefaultingKubeadmConfigTemplate.Spec.Template.Spec.Verbosity = pointer.Int32Ptr(4)
+	webhook := &KubeadmConfigTemplate{}
+
+	t.Run("for KubeadmConfigTemplate", util.CustomDefaultValidateTest(ctx, updateDefaultingKubeadmConfigTemplate, webhook))
+	g.Expect(webhook.Default(ctx, kubeadmConfigTemplate))
+	g.Expect(kubeadmConfigTemplate.Spec.Template.Spec.Format).To(Equal(bootstrapv1.CloudConfig))
+}
+
+func TestKubeadmConfigTemplateValidation(t *testing.T) {
+	cases := map[string]struct {
+		in *bootstrapv1.KubeadmConfigTemplate
+	}{
+		"valid configuration": {
+			in: &bootstrapv1.KubeadmConfigTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "baz",
+					Namespace: "default",
+				},
+				Spec: bootstrapv1.KubeadmConfigTemplateSpec{
+					Template: bootstrapv1.KubeadmConfigTemplateResource{
+						Spec: bootstrapv1.KubeadmConfigSpec{},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			webhook := &KubeadmConfigTemplate{}
+
+			g.Expect(webhook.ValidateCreate(ctx, tt.in)).To(Succeed())
+			g.Expect(webhook.ValidateUpdate(ctx, tt.in, tt.in)).To(Succeed())
+		})
+	}
+}

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -46,6 +46,7 @@ import (
 	bootstrapv1alpha4 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	kubeadmbootstrapcontrollers "sigs.k8s.io/cluster-api/bootstrap/kubeadm/controllers"
+	bootstrapwebhooks "sigs.k8s.io/cluster-api/bootstrap/kubeadm/webhooks"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
@@ -227,7 +228,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := (&bootstrapv1.KubeadmConfig{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&bootstrapwebhooks.KubeadmConfig{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "KubeadmConfig")
 		os.Exit(1)
 	}

--- a/bootstrap/kubeadm/main.go
+++ b/bootstrap/kubeadm/main.go
@@ -232,7 +232,7 @@ func setupWebhooks(mgr ctrl.Manager) {
 		setupLog.Error(err, "unable to create webhook", "webhook", "KubeadmConfig")
 		os.Exit(1)
 	}
-	if err := (&bootstrapv1.KubeadmConfigTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&bootstrapwebhooks.KubeadmConfigTemplate{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "KubeadmConfigTemplate")
 		os.Exit(1)
 	}

--- a/bootstrap/kubeadm/webhooks/alias.go
+++ b/bootstrap/kubeadm/webhooks/alias.go
@@ -34,3 +34,15 @@ func (v *KubeadmConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Client: v.Client,
 	}).SetupWebhookWithManager(mgr)
 }
+
+// KubeadmConfigTemplate implements a validation and defaulting webhook for KubeadmConfigTemplate.
+type KubeadmConfigTemplate struct {
+	Client client.Reader
+}
+
+// SetupWebhookWithManager sets up KubeadmConfigTemplate webhooks.
+func (v *KubeadmConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.KubeadmConfigTemplate{
+		Client: v.Client,
+	}).SetupWebhookWithManager(mgr)
+}

--- a/bootstrap/kubeadm/webhooks/alias.go
+++ b/bootstrap/kubeadm/webhooks/alias.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/internal/webhooks"
+)
+
+// KubeadmConfig implements a validation and defaulting webhook for KubeadmConfig.
+type KubeadmConfig struct {
+	Client client.Reader
+}
+
+// SetupWebhookWithManager sets up KubeadmConfig webhooks.
+func (v *KubeadmConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.KubeadmConfig{
+		Client: v.Client,
+	}).SetupWebhookWithManager(mgr)
+}

--- a/bootstrap/kubeadm/webhooks/doc.go
+++ b/bootstrap/kubeadm/webhooks/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package webhooks contains external webhook implementations for some of our API types.
+package webhooks

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -12,6 +12,50 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-cluster-x-k8s-io-v1beta1-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-cluster-x-k8s-io-v1beta1-machine
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -100,50 +144,6 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-cluster-x-k8s-io-v1beta1-cluster
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: default.cluster.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - cluster.x-k8s.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusters
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /mutate-cluster-x-k8s-io-v1beta1-clusterclass
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: default.clusterclass.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - cluster.x-k8s.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusterclasses
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
       path: /mutate-runtime-cluster-x-k8s-io-v1alpha1-extensionconfig
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -210,6 +210,52 @@ metadata:
   creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-cluster-x-k8s-io-v1beta1-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusterclasses
+  sideEffects: None
 - admissionReviewVersions:
   - v1
   - v1beta1
@@ -297,52 +343,6 @@ webhooks:
     - UPDATE
     resources:
     - machinesets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-cluster-x-k8s-io-v1beta1-cluster
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validation.cluster.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - cluster.x-k8s.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - clusters
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-cluster-x-k8s-io-v1beta1-clusterclass
-  failurePolicy: Fail
-  matchPolicy: Equivalent
-  name: validation.clusterclass.cluster.x-k8s.io
-  rules:
-  - apiGroups:
-    - cluster.x-k8s.io
-    apiVersions:
-    - v1beta1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - clusterclasses
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -20,6 +20,7 @@ in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controlle
 
 - `sigs.k8s.io/cluster-api/controllers/external.CloneTemplate` has been deprecated and will be removed in a future release. Please use `sigs.k8s.io/cluster-api/controllers/external.CreateFromTemplate` instead.
 - `clusterctl init --list-images` has been deprecated and will be removed in a future release. Please use `clusterctl init list-images` instead.
+- The Machine, MachineSet, MachineDeployment, MachineHealthCheck webhooks as well as the KubeadmConfig and KubeadmConfigTemplate webhooks have been moved to their corresponding `webhooks` package. Thus, the following methods on `Machine`, `MachineSet`, `MachineDeployment`, `MachineHealthCheck`, `KubeadmConfig` and `KubeadmConfigTemplate` in `api/v1beta1` are deprecated: `SetupWebhookWithManager`, `Default`, `ValidateCreate`, `ValidateUpdate` and `ValidateDelete`.
 
 ### Removals
 

--- a/internal/webhooks/machine.go
+++ b/internal/webhooks/machine.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/version"
+)
+
+const defaultNodeDeletionTimeout = 10 * time.Second
+
+// SetupWebhookWithManager sets up Machine webhooks.
+func (webhook *Machine) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&clusterv1.Machine{}).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1beta1-machine,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machines,versions=v1beta1,name=validation.machine.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-machine,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machines,versions=v1beta1,name=default.machine.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// Machine implements a validating and defaulting webhook for Machine.
+type Machine struct {
+	Client client.Reader
+}
+
+var _ webhook.CustomValidator = &Machine{}
+var _ webhook.CustomDefaulter = &Machine{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (webhook *Machine) Default(_ context.Context, obj runtime.Object) error {
+	machine, ok := obj.(*clusterv1.Machine)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Machine but got a %T", obj))
+	}
+	if machine.Labels == nil {
+		machine.Labels = make(map[string]string)
+	}
+	machine.Labels[clusterv1.ClusterLabelName] = machine.Spec.ClusterName
+
+	if machine.Spec.Bootstrap.ConfigRef != nil && machine.Spec.Bootstrap.ConfigRef.Namespace == "" {
+		machine.Spec.Bootstrap.ConfigRef.Namespace = machine.Namespace
+	}
+
+	if machine.Spec.InfrastructureRef.Namespace == "" {
+		machine.Spec.InfrastructureRef.Namespace = machine.Namespace
+	}
+
+	if machine.Spec.Version != nil && !strings.HasPrefix(*machine.Spec.Version, "v") {
+		normalizedVersion := "v" + *machine.Spec.Version
+		machine.Spec.Version = &normalizedVersion
+	}
+
+	if machine.Spec.NodeDeletionTimeout == nil {
+		machine.Spec.NodeDeletionTimeout = &metav1.Duration{Duration: defaultNodeDeletionTimeout}
+	}
+	return nil
+}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *Machine) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	machine, ok := obj.(*clusterv1.Machine)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
+	}
+	return webhook.validate(ctx, nil, machine)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *Machine) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	newMachine, ok := newObj.(*clusterv1.Machine)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Machine but got a %T", newObj))
+	}
+	oldMachine, ok := oldObj.(*clusterv1.Machine)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Machine but got a %T", oldObj))
+	}
+	return webhook.validate(ctx, oldMachine, newMachine)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *Machine) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	return nil
+}
+
+func (webhook *Machine) validate(_ context.Context, oldMachine, newMachine *clusterv1.Machine) error {
+	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
+	if newMachine.Spec.Bootstrap.ConfigRef == nil && newMachine.Spec.Bootstrap.DataSecretName == nil {
+		allErrs = append(
+			allErrs,
+			field.Required(
+				specPath.Child("bootstrap", "data"),
+				"expected either spec.bootstrap.dataSecretName or spec.bootstrap.configRef to be populated",
+			),
+		)
+	}
+
+	if newMachine.Spec.Bootstrap.ConfigRef != nil && newMachine.Spec.Bootstrap.ConfigRef.Namespace != newMachine.Namespace {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				specPath.Child("bootstrap", "configRef", "namespace"),
+				newMachine.Spec.Bootstrap.ConfigRef.Namespace,
+				"must match metadata.namespace",
+			),
+		)
+	}
+
+	if newMachine.Spec.InfrastructureRef.Namespace != newMachine.Namespace {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				specPath.Child("infrastructureRef", "namespace"),
+				newMachine.Spec.InfrastructureRef.Namespace,
+				"must match metadata.namespace",
+			),
+		)
+	}
+
+	if oldMachine != nil {
+		if oldMachine.Spec.ClusterName != newMachine.Spec.ClusterName {
+			allErrs = append(
+				allErrs,
+				field.Forbidden(specPath.Child("clusterName"), "field is immutable"),
+			)
+		}
+	}
+
+	if newMachine.Spec.Version != nil {
+		if !version.KubeSemver.MatchString(*newMachine.Spec.Version) {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("version"), *newMachine.Spec.Version, "must be a valid semantic version"))
+		}
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("Machine").GroupKind(), newMachine.Name, allErrs)
+}

--- a/internal/webhooks/machine_test.go
+++ b/internal/webhooks/machine_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/webhooks/util"
+)
+
+func TestMachineDefault(t *testing.T) {
+	g := NewWithT(t)
+
+	m := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foobar",
+		},
+		Spec: clusterv1.MachineSpec{
+			Bootstrap: clusterv1.Bootstrap{ConfigRef: &corev1.ObjectReference{}},
+			Version:   pointer.StringPtr("1.17.5"),
+		},
+	}
+	webhook := &Machine{}
+
+	t.Run("for Machine", util.CustomDefaultValidateTest(ctx, m, webhook))
+	g.Expect(webhook.Default(ctx, m)).To(Succeed())
+	g.Expect(m.Labels[clusterv1.ClusterLabelName]).To(Equal(m.Spec.ClusterName))
+	g.Expect(m.Spec.Bootstrap.ConfigRef.Namespace).To(Equal(m.Namespace))
+	g.Expect(m.Spec.InfrastructureRef.Namespace).To(Equal(m.Namespace))
+	g.Expect(*m.Spec.Version).To(Equal("v1.17.5"))
+	g.Expect(m.Spec.NodeDeletionTimeout.Duration).To(Equal(defaultNodeDeletionTimeout))
+}
+
+func TestMachineBootstrapValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		bootstrap clusterv1.Bootstrap
+		expectErr bool
+	}{
+		{
+			name:      "should return error if configref and data are nil",
+			bootstrap: clusterv1.Bootstrap{ConfigRef: nil, DataSecretName: nil},
+			expectErr: true,
+		},
+		{
+			name:      "should not return error if dataSecretName is set",
+			bootstrap: clusterv1.Bootstrap{ConfigRef: nil, DataSecretName: pointer.StringPtr("test")},
+			expectErr: false,
+		},
+		{
+			name:      "should not return error if config ref is set",
+			bootstrap: clusterv1.Bootstrap{ConfigRef: &corev1.ObjectReference{}, DataSecretName: nil},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			machine := &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{Bootstrap: tt.bootstrap},
+			}
+			secondMachine := machine.DeepCopy()
+
+			webhook := &Machine{}
+			if tt.expectErr {
+				g.Expect(webhook.ValidateCreate(ctx, machine)).NotTo(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, machine, secondMachine)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateCreate(ctx, machine)).To(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, machine, secondMachine)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestMachineNamespaceValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		expectErr bool
+		bootstrap clusterv1.Bootstrap
+		infraRef  corev1.ObjectReference
+		namespace string
+	}{
+		{
+			name:      "should succeed if all namespaces match",
+			expectErr: false,
+			namespace: "foobar",
+			bootstrap: clusterv1.Bootstrap{ConfigRef: &corev1.ObjectReference{Namespace: "foobar"}},
+			infraRef:  corev1.ObjectReference{Namespace: "foobar"},
+		},
+		{
+			name:      "should return error if namespace and bootstrap namespace don't match",
+			expectErr: true,
+			namespace: "foobar",
+			bootstrap: clusterv1.Bootstrap{ConfigRef: &corev1.ObjectReference{Namespace: "foobar123"}},
+			infraRef:  corev1.ObjectReference{Namespace: "foobar"},
+		},
+		{
+			name:      "should return error if namespace and infrastructure ref namespace don't match",
+			expectErr: true,
+			namespace: "foobar",
+			bootstrap: clusterv1.Bootstrap{ConfigRef: &corev1.ObjectReference{Namespace: "foobar"}},
+			infraRef:  corev1.ObjectReference{Namespace: "foobar123"},
+		},
+		{
+			name:      "should return error if no namespaces match",
+			expectErr: true,
+			namespace: "foobar1",
+			bootstrap: clusterv1.Bootstrap{ConfigRef: &corev1.ObjectReference{Namespace: "foobar2"}},
+			infraRef:  corev1.ObjectReference{Namespace: "foobar3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			machine := &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{Namespace: tt.namespace},
+				Spec:       clusterv1.MachineSpec{Bootstrap: tt.bootstrap, InfrastructureRef: tt.infraRef},
+			}
+
+			webhook := &Machine{}
+
+			g.Expect(webhook.Default(ctx, machine)).To(Succeed())
+
+			secondMachine := machine.DeepCopy()
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateCreate(ctx, machine)).NotTo(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, machine, secondMachine)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateCreate(ctx, machine)).To(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, machine, secondMachine)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestMachineClusterNameImmutable(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldClusterName string
+		newClusterName string
+		expectErr      bool
+	}{
+		{
+			name:           "when the cluster name has not changed",
+			oldClusterName: "foo",
+			newClusterName: "foo",
+			expectErr:      false,
+		},
+		{
+			name:           "when the cluster name has changed",
+			oldClusterName: "foo",
+			newClusterName: "bar",
+			expectErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			newMachine := &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					ClusterName: tt.newClusterName,
+					Bootstrap:   clusterv1.Bootstrap{ConfigRef: &corev1.ObjectReference{}},
+				},
+			}
+			oldMachine := &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					ClusterName: tt.oldClusterName,
+					Bootstrap:   clusterv1.Bootstrap{ConfigRef: &corev1.ObjectReference{}},
+				},
+			}
+
+			webhook := &Machine{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateUpdate(ctx, oldMachine, newMachine)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateUpdate(ctx, oldMachine, newMachine)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestMachineVersionValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		expectErr bool
+	}{
+		{
+			name:      "should succeed when given a valid semantic version with prepended 'v'",
+			version:   "v1.17.2",
+			expectErr: false,
+		},
+		{
+			name:      "should return error when given a valid semantic version without 'v'",
+			version:   "1.17.2",
+			expectErr: true,
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			version:   "1",
+			expectErr: true,
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			version:   "v1",
+			expectErr: true,
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			version:   "wrong_version",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			machine := &clusterv1.Machine{
+				Spec: clusterv1.MachineSpec{
+					Version:   &tt.version,
+					Bootstrap: clusterv1.Bootstrap{ConfigRef: nil, DataSecretName: pointer.StringPtr("test")},
+				},
+			}
+			secondMachine := machine.DeepCopy()
+
+			webhook := &Machine{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateCreate(ctx, machine)).NotTo(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, machine, secondMachine)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateCreate(ctx, machine)).To(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, machine, secondMachine)).To(Succeed())
+			}
+		})
+	}
+}

--- a/internal/webhooks/machinedeployment.go
+++ b/internal/webhooks/machinedeployment.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/version"
+)
+
+func (webhook *MachineDeployment) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&clusterv1.MachineDeployment{}).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1beta1-machinedeployment,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinedeployments,versions=v1beta1,name=validation.machinedeployment.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-machinedeployment,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinedeployments,versions=v1beta1,name=default.machinedeployment.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// MachineDeployment implements a validating and defaulting webhook for MachineDeployment.
+type MachineDeployment struct {
+	Client client.Reader
+}
+
+var _ webhook.CustomDefaulter = &MachineDeployment{}
+var _ webhook.CustomValidator = &MachineDeployment{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (webhook *MachineDeployment) Default(_ context.Context, obj runtime.Object) error {
+	machineDeployment, ok := obj.(*clusterv1.MachineDeployment)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineDeployment but got a %T", obj))
+	}
+	PopulateDefaultsMachineDeployment(machineDeployment)
+	// tolerate version strings without a "v" prefix: prepend it if it's not there
+	if machineDeployment.Spec.Template.Spec.Version != nil && !strings.HasPrefix(*machineDeployment.Spec.Template.Spec.Version, "v") {
+		normalizedVersion := "v" + *machineDeployment.Spec.Template.Spec.Version
+		machineDeployment.Spec.Template.Spec.Version = &normalizedVersion
+	}
+	return nil
+}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *MachineDeployment) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	machineDeployment, ok := obj.(*clusterv1.MachineDeployment)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineDeployment but got a %T", obj))
+	}
+	return webhook.validate(ctx, nil, machineDeployment)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *MachineDeployment) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	newMD, ok := newObj.(*clusterv1.MachineDeployment)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineDeployment but got a %T", newObj))
+	}
+	oldMD, ok := oldObj.(*clusterv1.MachineDeployment)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineDeployment but got a %T", oldObj))
+	}
+	return webhook.validate(ctx, oldMD, newMD)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *MachineDeployment) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	return nil
+}
+
+func (webhook *MachineDeployment) validate(_ context.Context, oldMachineDeployment, newMachineDeployment *clusterv1.MachineDeployment) error {
+	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
+	selector, err := metav1.LabelSelectorAsSelector(&newMachineDeployment.Spec.Selector)
+	if err != nil {
+		allErrs = append(
+			allErrs,
+			field.Invalid(specPath.Child("selector"), newMachineDeployment.Spec.Selector, err.Error()),
+		)
+	} else if !selector.Matches(labels.Set(newMachineDeployment.Spec.Template.Labels)) {
+		allErrs = append(
+			allErrs,
+			field.Forbidden(
+				specPath.Child("template", "metadata", "labels"),
+				fmt.Sprintf("must match spec.selector %q", selector.String()),
+			),
+		)
+	}
+
+	if oldMachineDeployment != nil {
+		if oldMachineDeployment.Spec.ClusterName != newMachineDeployment.Spec.ClusterName {
+			allErrs = append(
+				allErrs,
+				field.Forbidden(
+					specPath.Child("clusterName"),
+					"field is immutable",
+				),
+			)
+		}
+	}
+
+	if newMachineDeployment.Spec.Strategy != nil && newMachineDeployment.Spec.Strategy.RollingUpdate != nil {
+		total := 1
+		if newMachineDeployment.Spec.Replicas != nil {
+			total = int(*newMachineDeployment.Spec.Replicas)
+		}
+
+		if newMachineDeployment.Spec.Strategy.RollingUpdate.MaxSurge != nil {
+			if _, err := intstr.GetScaledValueFromIntOrPercent(newMachineDeployment.Spec.Strategy.RollingUpdate.MaxSurge, total, true); err != nil {
+				allErrs = append(
+					allErrs,
+					field.Invalid(specPath.Child("strategy", "rollingUpdate", "maxSurge"),
+						newMachineDeployment.Spec.Strategy.RollingUpdate.MaxSurge, fmt.Sprintf("must be either an int or a percentage: %v", err.Error())),
+				)
+			}
+		}
+
+		if newMachineDeployment.Spec.Strategy.RollingUpdate.MaxUnavailable != nil {
+			if _, err := intstr.GetScaledValueFromIntOrPercent(newMachineDeployment.Spec.Strategy.RollingUpdate.MaxUnavailable, total, true); err != nil {
+				allErrs = append(
+					allErrs,
+					field.Invalid(specPath.Child("strategy", "rollingUpdate", "maxUnavailable"),
+						newMachineDeployment.Spec.Strategy.RollingUpdate.MaxUnavailable, fmt.Sprintf("must be either an int or a percentage: %v", err.Error())),
+				)
+			}
+		}
+	}
+
+	if newMachineDeployment.Spec.Template.Spec.Version != nil {
+		if !version.KubeSemver.MatchString(*newMachineDeployment.Spec.Template.Spec.Version) {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("template", "spec", "version"), *newMachineDeployment.Spec.Template.Spec.Version, "must be a valid semantic version"))
+		}
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("MachineDeployment").GroupKind(), newMachineDeployment.Name, allErrs)
+}
+
+// PopulateDefaultsMachineDeployment fills in default field values.
+// This is also called during MachineDeployment sync.
+func PopulateDefaultsMachineDeployment(d *clusterv1.MachineDeployment) {
+	if d.Labels == nil {
+		d.Labels = make(map[string]string)
+	}
+	d.Labels[clusterv1.ClusterLabelName] = d.Spec.ClusterName
+
+	if d.Spec.MinReadySeconds == nil {
+		d.Spec.MinReadySeconds = pointer.Int32Ptr(0)
+	}
+
+	if d.Spec.RevisionHistoryLimit == nil {
+		d.Spec.RevisionHistoryLimit = pointer.Int32Ptr(1)
+	}
+
+	if d.Spec.ProgressDeadlineSeconds == nil {
+		d.Spec.ProgressDeadlineSeconds = pointer.Int32Ptr(600)
+	}
+
+	if d.Spec.Selector.MatchLabels == nil {
+		d.Spec.Selector.MatchLabels = make(map[string]string)
+	}
+
+	if d.Spec.Strategy == nil {
+		d.Spec.Strategy = &clusterv1.MachineDeploymentStrategy{}
+	}
+
+	if d.Spec.Strategy.Type == "" {
+		d.Spec.Strategy.Type = clusterv1.RollingUpdateMachineDeploymentStrategyType
+	}
+
+	if d.Spec.Template.Labels == nil {
+		d.Spec.Template.Labels = make(map[string]string)
+	}
+
+	// Default RollingUpdate strategy only if strategy type is RollingUpdate.
+	if d.Spec.Strategy.Type == clusterv1.RollingUpdateMachineDeploymentStrategyType {
+		if d.Spec.Strategy.RollingUpdate == nil {
+			d.Spec.Strategy.RollingUpdate = &clusterv1.MachineRollingUpdateDeployment{}
+		}
+		if d.Spec.Strategy.RollingUpdate.MaxSurge == nil {
+			ios1 := intstr.FromInt(1)
+			d.Spec.Strategy.RollingUpdate.MaxSurge = &ios1
+		}
+		if d.Spec.Strategy.RollingUpdate.MaxUnavailable == nil {
+			ios0 := intstr.FromInt(0)
+			d.Spec.Strategy.RollingUpdate.MaxUnavailable = &ios0
+		}
+	}
+
+	// If no selector has been provided, add label and selector for the
+	// MachineDeployment's name as a default way of providing uniqueness.
+	if len(d.Spec.Selector.MatchLabels) == 0 && len(d.Spec.Selector.MatchExpressions) == 0 {
+		d.Spec.Selector.MatchLabels[clusterv1.MachineDeploymentLabelName] = d.Name
+		d.Spec.Template.Labels[clusterv1.MachineDeploymentLabelName] = d.Name
+	}
+	// Make sure selector and template to be in the same cluster.
+	d.Spec.Selector.MatchLabels[clusterv1.ClusterLabelName] = d.Spec.ClusterName
+	d.Spec.Template.Labels[clusterv1.ClusterLabelName] = d.Spec.ClusterName
+}

--- a/internal/webhooks/machinedeployment_test.go
+++ b/internal/webhooks/machinedeployment_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/webhooks/util"
+)
+
+func TestMachineDeploymentDefault(t *testing.T) {
+	g := NewWithT(t)
+	md := &clusterv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-md",
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Version: pointer.String("1.19.10"),
+				},
+			},
+		},
+	}
+	webhook := &MachineDeployment{}
+
+	t.Run("for MachineDeployment", util.CustomDefaultValidateTest(ctx, md, webhook))
+	g.Expect(webhook.Default(ctx, md)).To(Succeed())
+	g.Expect(md.Labels[clusterv1.ClusterLabelName]).To(Equal(md.Spec.ClusterName))
+	g.Expect(md.Spec.MinReadySeconds).To(Equal(pointer.Int32Ptr(0)))
+	g.Expect(md.Spec.RevisionHistoryLimit).To(Equal(pointer.Int32Ptr(1)))
+	g.Expect(md.Spec.ProgressDeadlineSeconds).To(Equal(pointer.Int32Ptr(600)))
+	g.Expect(md.Spec.Strategy).ToNot(BeNil())
+	g.Expect(md.Spec.Selector.MatchLabels).To(HaveKeyWithValue(clusterv1.MachineDeploymentLabelName, "test-md"))
+	g.Expect(md.Spec.Template.Labels).To(HaveKeyWithValue(clusterv1.MachineDeploymentLabelName, "test-md"))
+	g.Expect(md.Spec.Strategy.Type).To(Equal(clusterv1.RollingUpdateMachineDeploymentStrategyType))
+	g.Expect(md.Spec.Strategy.RollingUpdate).ToNot(BeNil())
+	g.Expect(md.Spec.Strategy.RollingUpdate.MaxSurge.IntValue()).To(Equal(1))
+	g.Expect(md.Spec.Strategy.RollingUpdate.MaxUnavailable.IntValue()).To(Equal(0))
+	g.Expect(*md.Spec.Template.Spec.Version).To(Equal("v1.19.10"))
+}
+
+func TestMachineDeploymentValidation(t *testing.T) {
+	badMaxSurge := intstr.FromString("1")
+	badMaxUnavailable := intstr.FromString("0")
+
+	goodMaxSurgePercentage := intstr.FromString("1%")
+	goodMaxUnavailablePercentage := intstr.FromString("0%")
+
+	goodMaxSurgeInt := intstr.FromInt(1)
+	goodMaxUnavailableInt := intstr.FromInt(0)
+
+	tests := []struct {
+		name      string
+		selectors map[string]string
+		labels    map[string]string
+		strategy  clusterv1.MachineDeploymentStrategy
+		expectErr bool
+	}{
+		{
+			name:      "should return error on mismatch",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "baz"},
+			expectErr: true,
+		},
+		{
+			name:      "should return error on missing labels",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"": ""},
+			expectErr: true,
+		},
+		{
+			name:      "should return error if all selectors don't match",
+			selectors: map[string]string{"foo": "bar", "hello": "world"},
+			labels:    map[string]string{"foo": "bar"},
+			expectErr: true,
+		},
+		{
+			name:      "should not return error on match",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "bar"},
+			expectErr: false,
+		},
+		{
+			name:      "should return error for invalid selector",
+			selectors: map[string]string{"-123-foo": "bar"},
+			labels:    map[string]string{"-123-foo": "bar"},
+			expectErr: true,
+		},
+		{
+			name:      "should return error for invalid maxSurge",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "bar"},
+			strategy: clusterv1.MachineDeploymentStrategy{
+				Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+				RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+					MaxUnavailable: &goodMaxUnavailableInt,
+					MaxSurge:       &badMaxSurge,
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:      "should return error for invalid maxUnavailable",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "bar"},
+			strategy: clusterv1.MachineDeploymentStrategy{
+				Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+				RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+					MaxUnavailable: &badMaxUnavailable,
+					MaxSurge:       &goodMaxSurgeInt,
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:      "should not return error for valid int maxSurge and maxUnavailable",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "bar"},
+			strategy: clusterv1.MachineDeploymentStrategy{
+				Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+				RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+					MaxUnavailable: &goodMaxUnavailableInt,
+					MaxSurge:       &goodMaxSurgeInt,
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:      "should not return error for valid percentage string maxSurge and maxUnavailable",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "bar"},
+			strategy: clusterv1.MachineDeploymentStrategy{
+				Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+				RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+					MaxUnavailable: &goodMaxUnavailablePercentage,
+					MaxSurge:       &goodMaxSurgePercentage,
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			md := &clusterv1.MachineDeployment{
+				Spec: clusterv1.MachineDeploymentSpec{
+					Strategy: &tt.strategy,
+					Selector: metav1.LabelSelector{
+						MatchLabels: tt.selectors,
+					},
+					Template: clusterv1.MachineTemplateSpec{
+						ObjectMeta: clusterv1.ObjectMeta{
+							Labels: tt.labels,
+						},
+					},
+				},
+			}
+			secondMD := md.DeepCopy()
+			webhook := &MachineDeployment{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateCreate(ctx, md)).NotTo(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, md, secondMD)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateCreate(ctx, md)).To(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, md, secondMD)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestMachineDeploymentVersionValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		expectErr bool
+	}{
+		{
+			name:      "should succeed when given a valid semantic version with prepended 'v'",
+			version:   "v1.17.2",
+			expectErr: false,
+		},
+		{
+			name:      "should return error when given a valid semantic version without 'v'",
+			version:   "1.17.2",
+			expectErr: true,
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			version:   "1",
+			expectErr: true,
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			version:   "v1",
+			expectErr: true,
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			version:   "wrong_version",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			md := &clusterv1.MachineDeployment{
+				Spec: clusterv1.MachineDeploymentSpec{
+
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: pointer.String(tt.version),
+						},
+					},
+				},
+			}
+			secondMD := md.DeepCopy()
+			webhook := &MachineDeployment{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateCreate(ctx, md)).NotTo(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, md, secondMD)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateCreate(ctx, md)).To(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, md, secondMD)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestMachineDeploymentWithSpec(t *testing.T) {
+	g := NewWithT(t)
+	md := &clusterv1.MachineDeployment{
+		Spec: clusterv1.MachineDeploymentSpec{
+			ClusterName: "test-cluster",
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					ClusterName: "test-cluster",
+				},
+			},
+		},
+	}
+	webhook := &MachineDeployment{}
+
+	g.Expect(webhook.Default(ctx, md)).To(Succeed())
+	g.Expect(md.Spec.Selector.MatchLabels).To(HaveKeyWithValue(clusterv1.ClusterLabelName, "test-cluster"))
+	g.Expect(md.Spec.Template.Labels).To(HaveKeyWithValue(clusterv1.ClusterLabelName, "test-cluster"))
+}
+
+func TestMachineDeploymentClusterNameImmutable(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldClusterName string
+		newClusterName string
+		expectErr      bool
+	}{
+		{
+			name:           "when the cluster name has not changed",
+			oldClusterName: "foo",
+			newClusterName: "foo",
+			expectErr:      false,
+		},
+		{
+			name:           "when the cluster name has changed",
+			oldClusterName: "foo",
+			newClusterName: "bar",
+			expectErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			newMD := &clusterv1.MachineDeployment{
+				Spec: clusterv1.MachineDeploymentSpec{
+					ClusterName: tt.newClusterName,
+				},
+			}
+
+			oldMD := &clusterv1.MachineDeployment{
+				Spec: clusterv1.MachineDeploymentSpec{
+					ClusterName: tt.oldClusterName,
+				},
+			}
+			webhook := &MachineDeployment{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateUpdate(ctx, oldMD, newMD)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateUpdate(ctx, oldMD, newMD)).To(Succeed())
+			}
+		})
+	}
+}

--- a/internal/webhooks/machinehealthcheck.go
+++ b/internal/webhooks/machinehealthcheck.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+var (
+	// DefaultNodeStartupTimeout is the time allowed for a node to start up.
+	// Can be made longer as part of spec if required for particular provider.
+	// 10 minutes should allow the instance to start and the node to join the
+	// cluster on most providers.
+	DefaultNodeStartupTimeout = metav1.Duration{Duration: 10 * time.Minute}
+	// Minimum time allowed for a node to start up.
+	minNodeStartupTimeout = metav1.Duration{Duration: 30 * time.Second}
+	// We allow users to disable the nodeStartupTimeout by setting the duration to 0.
+	disabledNodeStartupTimeout = clusterv1.ZeroDuration
+)
+
+// SetMinNodeStartupTimeout allows users to optionally set a custom timeout
+// for the validation webhook.
+//
+// This function is mostly used within envtest (integration tests), and should
+// never be used in a production environment.
+func SetMinNodeStartupTimeout(d metav1.Duration) {
+	minNodeStartupTimeout = d
+}
+
+func (webhook *MachineHealthCheck) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&clusterv1.MachineHealthCheck{}).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1beta1-machinehealthcheck,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinehealthchecks,versions=v1beta1,name=validation.machinehealthcheck.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-machinehealthcheck,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinehealthchecks,versions=v1beta1,name=default.machinehealthcheck.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// MachineHealthCheck implements a validating and defaulting webhook for MachineHealthCheck.
+type MachineHealthCheck struct {
+	Client client.Reader
+}
+
+var _ webhook.CustomDefaulter = &MachineHealthCheck{}
+var _ webhook.CustomValidator = &MachineHealthCheck{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (webhook *MachineHealthCheck) Default(_ context.Context, obj runtime.Object) error {
+	mhc, ok := obj.(*clusterv1.MachineHealthCheck)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineHealthCheck but got a %T", obj))
+	}
+	if mhc.Labels == nil {
+		mhc.Labels = make(map[string]string)
+	}
+	mhc.Labels[clusterv1.ClusterLabelName] = mhc.Spec.ClusterName
+
+	if mhc.Spec.MaxUnhealthy == nil {
+		defaultMaxUnhealthy := intstr.FromString("100%")
+		mhc.Spec.MaxUnhealthy = &defaultMaxUnhealthy
+	}
+
+	if mhc.Spec.NodeStartupTimeout == nil {
+		mhc.Spec.NodeStartupTimeout = &DefaultNodeStartupTimeout
+	}
+
+	if mhc.Spec.RemediationTemplate != nil && mhc.Spec.RemediationTemplate.Namespace == "" {
+		mhc.Spec.RemediationTemplate.Namespace = mhc.Namespace
+	}
+	return nil
+}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *MachineHealthCheck) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	mhc, ok := obj.(*clusterv1.MachineHealthCheck)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineHealthCheck but got a %T", obj))
+	}
+	return webhook.validate(ctx, nil, mhc)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (webhook *MachineHealthCheck) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	newMHC, ok := oldObj.(*clusterv1.MachineHealthCheck)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineHealthCheck but got a %T", newObj))
+	}
+	oldMHC, ok := newObj.(*clusterv1.MachineHealthCheck)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineHealthCheck but got a %T", oldObj))
+	}
+	return webhook.validate(ctx, oldMHC, newMHC)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *MachineHealthCheck) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	return nil
+}
+
+func (webhook *MachineHealthCheck) validate(_ context.Context, oldMachineHealthCheck, newMachineHealthCheck *clusterv1.MachineHealthCheck) error {
+	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	// Validate selector parses as Selector
+	selector, err := metav1.LabelSelectorAsSelector(&newMachineHealthCheck.Spec.Selector)
+	if err != nil {
+		allErrs = append(
+			allErrs,
+			field.Invalid(specPath.Child("selector"), newMachineHealthCheck.Spec.Selector, err.Error()),
+		)
+	}
+
+	// Validate that the selector isn't empty.
+	if selector != nil && selector.Empty() {
+		allErrs = append(
+			allErrs,
+			field.Required(specPath.Child("selector"), "selector must not be empty"),
+		)
+	}
+
+	if clusterName, ok := newMachineHealthCheck.Spec.Selector.MatchLabels[clusterv1.ClusterLabelName]; ok && clusterName != newMachineHealthCheck.Spec.ClusterName {
+		allErrs = append(
+			allErrs,
+			field.Invalid(specPath.Child("selector"), newMachineHealthCheck.Spec.Selector, "cannot specify a cluster selector other than the one specified by ClusterName"))
+	}
+
+	if oldMachineHealthCheck != nil {
+		if oldMachineHealthCheck.Spec.ClusterName != newMachineHealthCheck.Spec.ClusterName {
+			allErrs = append(
+				allErrs,
+				field.Forbidden(specPath.Child("clusterName"), "field is immutable"),
+			)
+		}
+	}
+
+	if newMachineHealthCheck.Spec.NodeStartupTimeout != nil &&
+		newMachineHealthCheck.Spec.NodeStartupTimeout.Seconds() != disabledNodeStartupTimeout.Seconds() &&
+		newMachineHealthCheck.Spec.NodeStartupTimeout.Seconds() < minNodeStartupTimeout.Seconds() {
+		allErrs = append(
+			allErrs,
+			field.Invalid(specPath.Child("nodeStartupTimeout"), newMachineHealthCheck.Spec.NodeStartupTimeout.Seconds(), "must be at least 30s"),
+		)
+	}
+
+	if newMachineHealthCheck.Spec.MaxUnhealthy != nil {
+		if _, err := intstr.GetScaledValueFromIntOrPercent(newMachineHealthCheck.Spec.MaxUnhealthy, 0, false); err != nil {
+			allErrs = append(
+				allErrs,
+				field.Invalid(specPath.Child("maxUnhealthy"), newMachineHealthCheck.Spec.MaxUnhealthy, fmt.Sprintf("must be either an int or a percentage: %v", err.Error())),
+			)
+		}
+	}
+
+	if newMachineHealthCheck.Spec.RemediationTemplate != nil && newMachineHealthCheck.Spec.RemediationTemplate.Namespace != newMachineHealthCheck.Namespace {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				specPath.Child("remediationTemplate", "namespace"),
+				newMachineHealthCheck.Spec.RemediationTemplate.Namespace,
+				"must match metadata.namespace",
+			),
+		)
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("MachineHealthCheck").GroupKind(), newMachineHealthCheck.Name, allErrs)
+}

--- a/internal/webhooks/machinehealthcheck_test.go
+++ b/internal/webhooks/machinehealthcheck_test.go
@@ -1,0 +1,355 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/webhooks/util"
+)
+
+func TestMachineHealthCheckDefault(t *testing.T) {
+	g := NewWithT(t)
+	mhc := &clusterv1.MachineHealthCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+		Spec: clusterv1.MachineHealthCheckSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			},
+			RemediationTemplate: &corev1.ObjectReference{},
+		},
+	}
+	webhook := &MachineHealthCheck{}
+
+	t.Run("for MachineHealthCheck", util.CustomDefaultValidateTest(ctx, mhc, webhook))
+	g.Expect(webhook.Default(ctx, mhc)).To(Succeed())
+	g.Expect(mhc.Labels[clusterv1.ClusterLabelName]).To(Equal(mhc.Spec.ClusterName))
+	g.Expect(mhc.Spec.MaxUnhealthy.String()).To(Equal("100%"))
+	g.Expect(mhc.Spec.NodeStartupTimeout).ToNot(BeNil())
+	g.Expect(*mhc.Spec.NodeStartupTimeout).To(Equal(metav1.Duration{Duration: 10 * time.Minute}))
+	g.Expect(mhc.Spec.RemediationTemplate.Namespace).To(Equal(mhc.Namespace))
+}
+
+func TestMachineHealthCheckLabelSelectorAsSelectorValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectors map[string]string
+		expectErr bool
+	}{
+		{
+			name:      "should not return error for valid selector",
+			selectors: map[string]string{"foo": "bar"},
+			expectErr: false,
+		},
+		{
+			name:      "should return error for invalid selector",
+			selectors: map[string]string{"-123-foo": "bar"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			mhc := &clusterv1.MachineHealthCheck{
+				Spec: clusterv1.MachineHealthCheckSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: tt.selectors,
+					},
+				},
+			}
+			secondMHC := mhc.DeepCopy()
+			webhook := &MachineHealthCheck{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateCreate(ctx, mhc)).NotTo(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, mhc, secondMHC)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateCreate(ctx, mhc)).To(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, mhc, secondMHC)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestMachineHealthCheckClusterNameImmutable(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldClusterName string
+		newClusterName string
+		expectErr      bool
+	}{
+		{
+			name:           "when the cluster name has not changed",
+			oldClusterName: "foo",
+			newClusterName: "foo",
+			expectErr:      false,
+		},
+		{
+			name:           "when the cluster name has changed",
+			oldClusterName: "foo",
+			newClusterName: "bar",
+			expectErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			newMHC := &clusterv1.MachineHealthCheck{
+				Spec: clusterv1.MachineHealthCheckSpec{
+					ClusterName: tt.newClusterName,
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "test",
+						},
+					},
+				},
+			}
+			oldMHC := &clusterv1.MachineHealthCheck{
+				Spec: clusterv1.MachineHealthCheckSpec{
+					ClusterName: tt.oldClusterName,
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"test": "test",
+						},
+					},
+				},
+			}
+			webhook := &MachineHealthCheck{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateUpdate(ctx, oldMHC, newMHC)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateUpdate(ctx, oldMHC, newMHC)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestMachineHealthCheckNodeStartupTimeout(t *testing.T) {
+	zero := metav1.Duration{Duration: 0}
+	twentyNineSeconds := metav1.Duration{Duration: 29 * time.Second}
+	thirtySeconds := metav1.Duration{Duration: 30 * time.Second}
+	oneMinute := metav1.Duration{Duration: 1 * time.Minute}
+	minusOneMinute := metav1.Duration{Duration: -1 * time.Minute}
+
+	tests := []struct {
+		name      string
+		timeout   *metav1.Duration
+		expectErr bool
+	}{
+		{
+			name:      "when the nodeStartupTimeout is not given",
+			timeout:   nil,
+			expectErr: false,
+		},
+		{
+			name:      "when the nodeStartupTimeout is greater than 30s",
+			timeout:   &oneMinute,
+			expectErr: false,
+		},
+		{
+			name:      "when the nodeStartupTimeout is 30s",
+			timeout:   &thirtySeconds,
+			expectErr: false,
+		},
+		{
+			name:      "when the nodeStartupTimeout is 29s",
+			timeout:   &twentyNineSeconds,
+			expectErr: true,
+		},
+		{
+			name:      "when the nodeStartupTimeout is less than 0",
+			timeout:   &minusOneMinute,
+			expectErr: true,
+		},
+		{
+			name:      "when the nodeStartupTimeout is 0 (disabled)",
+			timeout:   &zero,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		g := NewWithT(t)
+
+		mhc := &clusterv1.MachineHealthCheck{
+			Spec: clusterv1.MachineHealthCheckSpec{
+				NodeStartupTimeout: tt.timeout,
+				Selector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"test": "test",
+					},
+				},
+			},
+		}
+		secondMHC := mhc.DeepCopy()
+		webhook := &MachineHealthCheck{}
+
+		if tt.expectErr {
+			g.Expect(webhook.ValidateCreate(ctx, mhc)).NotTo(Succeed())
+			g.Expect(webhook.ValidateUpdate(ctx, mhc, secondMHC)).NotTo(Succeed())
+		} else {
+			g.Expect(webhook.ValidateCreate(ctx, mhc)).To(Succeed())
+			g.Expect(webhook.ValidateUpdate(ctx, mhc, secondMHC)).To(Succeed())
+		}
+	}
+}
+
+func TestMachineHealthCheckMaxUnhealthy(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     intstr.IntOrString
+		expectErr bool
+	}{
+		{
+			name:      "when the value is an integer",
+			value:     intstr.Parse("10"),
+			expectErr: false,
+		},
+		{
+			name:      "when the value is a percentage",
+			value:     intstr.Parse("10%"),
+			expectErr: false,
+		},
+		{
+			name:      "when the value is a random string",
+			value:     intstr.Parse("abcdef"),
+			expectErr: true,
+		},
+		{
+			name:      "when the value stringified integer",
+			value:     intstr.FromString("10"),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		g := NewWithT(t)
+
+		maxUnhealthy := tt.value
+		mhc := &clusterv1.MachineHealthCheck{
+			Spec: clusterv1.MachineHealthCheckSpec{
+				MaxUnhealthy: &maxUnhealthy,
+				Selector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"test": "test",
+					},
+				},
+			},
+		}
+		secondMHC := mhc.DeepCopy()
+		webhook := &MachineHealthCheck{}
+
+		if tt.expectErr {
+			g.Expect(webhook.ValidateCreate(ctx, mhc)).NotTo(Succeed())
+			g.Expect(webhook.ValidateUpdate(ctx, mhc, secondMHC)).NotTo(Succeed())
+		} else {
+			g.Expect(webhook.ValidateCreate(ctx, mhc)).To(Succeed())
+			g.Expect(webhook.ValidateUpdate(ctx, mhc, secondMHC)).To(Succeed())
+		}
+	}
+}
+
+func TestMachineHealthCheckSelectorValidation(t *testing.T) {
+	g := NewWithT(t)
+	mhc := &clusterv1.MachineHealthCheck{}
+	webhook := &MachineHealthCheck{}
+
+	err := webhook.validate(ctx, nil, mhc)
+	g.Expect(err).ToNot(BeNil())
+	g.Expect(err.Error()).To(ContainSubstring("selector must not be empty"))
+}
+
+func TestMachineHealthCheckClusterNameSelectorValidation(t *testing.T) {
+	g := NewWithT(t)
+	mhc := &clusterv1.MachineHealthCheck{
+		Spec: clusterv1.MachineHealthCheckSpec{
+			ClusterName: "foo",
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					clusterv1.ClusterLabelName: "bar",
+					"baz":                      "qux",
+				},
+			},
+		},
+	}
+	webhook := &MachineHealthCheck{}
+
+	err := webhook.validate(ctx, nil, mhc)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("cannot specify a cluster selector other than the one specified by ClusterName"))
+
+	mhc.Spec.Selector.MatchLabels[clusterv1.ClusterLabelName] = "foo"
+	g.Expect(webhook.validate(ctx, nil, mhc)).To(Succeed())
+	delete(mhc.Spec.Selector.MatchLabels, clusterv1.ClusterLabelName)
+	g.Expect(webhook.validate(ctx, nil, mhc)).To(Succeed())
+}
+
+func TestMachineHealthCheckRemediationTemplateNamespaceValidation(t *testing.T) {
+	valid := &clusterv1.MachineHealthCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+		},
+		Spec: clusterv1.MachineHealthCheckSpec{
+			Selector:            metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			RemediationTemplate: &corev1.ObjectReference{Namespace: "foo"},
+		},
+	}
+	invalid := valid.DeepCopy()
+	invalid.Spec.RemediationTemplate.Namespace = "bar"
+
+	tests := []struct {
+		name      string
+		expectErr bool
+		c         *clusterv1.MachineHealthCheck
+	}{
+		{
+			name:      "should return error when MachineHealthCheck namespace and RemediationTemplate ref namespace mismatch",
+			expectErr: true,
+			c:         invalid,
+		},
+		{
+			name:      "should succeed when namespaces match",
+			expectErr: false,
+			c:         valid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			webhook := &MachineHealthCheck{}
+
+			if tt.expectErr {
+				g.Expect(webhook.validate(ctx, tt.c, tt.c)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.validate(ctx, tt.c, tt.c)).To(Succeed())
+			}
+		})
+	}
+}

--- a/internal/webhooks/machineset.go
+++ b/internal/webhooks/machineset.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/version"
+)
+
+func (webhook *MachineSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&clusterv1.MachineSet{}).
+		WithDefaulter(webhook).
+		WithValidator(webhook).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-cluster-x-k8s-io-v1beta1-machineset,mutating=false,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinesets,versions=v1beta1,name=validation.machineset.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-machineset,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=machinesets,versions=v1beta1,name=default.machineset.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// MachineSet implements a validating and defaulting webhook for MachineSet.
+type MachineSet struct {
+	Client client.Reader
+}
+
+var _ webhook.CustomDefaulter = &MachineSet{}
+var _ webhook.CustomValidator = &MachineSet{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type.
+func (webhook *MachineSet) Default(_ context.Context, obj runtime.Object) error {
+	machineSet, ok := obj.(*clusterv1.MachineSet)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineSet but got a %T", obj))
+	}
+	if machineSet.Labels == nil {
+		machineSet.Labels = make(map[string]string)
+	}
+	machineSet.Labels[clusterv1.ClusterLabelName] = machineSet.Spec.ClusterName
+
+	if machineSet.Spec.DeletePolicy == "" {
+		randomPolicy := string(clusterv1.RandomMachineSetDeletePolicy)
+		machineSet.Spec.DeletePolicy = randomPolicy
+	}
+
+	if machineSet.Spec.Selector.MatchLabels == nil {
+		machineSet.Spec.Selector.MatchLabels = make(map[string]string)
+	}
+
+	if machineSet.Spec.Template.Labels == nil {
+		machineSet.Spec.Template.Labels = make(map[string]string)
+	}
+
+	if len(machineSet.Spec.Selector.MatchLabels) == 0 && len(machineSet.Spec.Selector.MatchExpressions) == 0 {
+		machineSet.Spec.Selector.MatchLabels[clusterv1.MachineSetLabelName] = machineSet.Name
+		machineSet.Spec.Template.Labels[clusterv1.MachineSetLabelName] = machineSet.Name
+	}
+
+	if machineSet.Spec.Template.Spec.Version != nil && !strings.HasPrefix(*machineSet.Spec.Template.Spec.Version, "v") {
+		normalizedVersion := "v" + *machineSet.Spec.Template.Spec.Version
+		machineSet.Spec.Template.Spec.Version = &normalizedVersion
+	}
+	return nil
+}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *MachineSet) ValidateCreate(ctx context.Context, obj runtime.Object) error {
+	machineSet, ok := obj.(*clusterv1.MachineSet)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineSet but got a %T", obj))
+	}
+	return webhook.validate(ctx, nil, machineSet)
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *MachineSet) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error {
+	newMS, ok := newObj.(*clusterv1.MachineSet)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineSet but got a %T", newObj))
+	}
+	oldMS, ok := oldObj.(*clusterv1.MachineSet)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a MachineSet but got a %T", oldObj))
+	}
+	return webhook.validate(ctx, oldMS, newMS)
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type.
+func (webhook *MachineSet) ValidateDelete(_ context.Context, _ runtime.Object) error {
+	return nil
+}
+
+func (webhook *MachineSet) validate(_ context.Context, oldMachineSet, newMachineSet *clusterv1.MachineSet) error {
+	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
+	selector, err := metav1.LabelSelectorAsSelector(&newMachineSet.Spec.Selector)
+	if err != nil {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				specPath.Child("selector"),
+				newMachineSet.Spec.Selector,
+				err.Error(),
+			),
+		)
+	} else if !selector.Matches(labels.Set(newMachineSet.Spec.Template.Labels)) {
+		allErrs = append(
+			allErrs,
+			field.Invalid(
+				specPath.Child("template", "metadata", "labels"),
+				newMachineSet.Spec.Template.ObjectMeta.Labels,
+				fmt.Sprintf("must match spec.selector %q", selector.String()),
+			),
+		)
+	}
+
+	if oldMachineSet != nil {
+		if oldMachineSet.Spec.ClusterName != newMachineSet.Spec.ClusterName {
+			allErrs = append(
+				allErrs,
+				field.Forbidden(
+					specPath.Child("clusterName"),
+					"field is immutable",
+				),
+			)
+		}
+	}
+
+	if newMachineSet.Spec.Template.Spec.Version != nil {
+		if !version.KubeSemver.MatchString(*newMachineSet.Spec.Template.Spec.Version) {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					specPath.Child("template", "spec", "version"),
+					*newMachineSet.Spec.Template.Spec.Version,
+					"must be a valid semantic version",
+				),
+			)
+		}
+	}
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(clusterv1.GroupVersion.WithKind("MachineSet").GroupKind(), newMachineSet.Name, allErrs)
+}

--- a/internal/webhooks/machineset_test.go
+++ b/internal/webhooks/machineset_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/webhooks/util"
+)
+
+func TestMachineSetDefault(t *testing.T) {
+	g := NewWithT(t)
+	ms := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ms",
+		},
+		Spec: clusterv1.MachineSetSpec{
+			Template: clusterv1.MachineTemplateSpec{
+				Spec: clusterv1.MachineSpec{
+					Version: pointer.String("1.19.10"),
+				},
+			},
+		},
+	}
+	webhook := &MachineSet{}
+
+	t.Run("for MachineSet", util.CustomDefaultValidateTest(ctx, ms, webhook))
+	g.Expect(webhook.Default(ctx, ms)).To(Succeed())
+	g.Expect(ms.Labels[clusterv1.ClusterLabelName]).To(Equal(ms.Spec.ClusterName))
+	g.Expect(ms.Spec.DeletePolicy).To(Equal(string(clusterv1.RandomMachineSetDeletePolicy)))
+	g.Expect(ms.Spec.Selector.MatchLabels).To(HaveKeyWithValue(clusterv1.MachineSetLabelName, "test-ms"))
+	g.Expect(ms.Spec.Template.Labels).To(HaveKeyWithValue(clusterv1.MachineSetLabelName, "test-ms"))
+	g.Expect(*ms.Spec.Template.Spec.Version).To(Equal("v1.19.10"))
+}
+
+func TestMachineSetLabelSelectorMatchValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectors map[string]string
+		labels    map[string]string
+		expectErr bool
+	}{
+		{
+			name:      "should return error on mismatch",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "baz"},
+			expectErr: true,
+		},
+		{
+			name:      "should return error on missing labels",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"": ""},
+			expectErr: true,
+		},
+		{
+			name:      "should return error if all selectors don't match",
+			selectors: map[string]string{"foo": "bar", "hello": "world"},
+			labels:    map[string]string{"foo": "bar"},
+			expectErr: true,
+		},
+		{
+			name:      "should not return error on match",
+			selectors: map[string]string{"foo": "bar"},
+			labels:    map[string]string{"foo": "bar"},
+			expectErr: false,
+		},
+		{
+			name:      "should return error for invalid selector",
+			selectors: map[string]string{"-123-foo": "bar"},
+			labels:    map[string]string{"-123-foo": "bar"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ms := &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: tt.selectors,
+					},
+					Template: clusterv1.MachineTemplateSpec{
+						ObjectMeta: clusterv1.ObjectMeta{
+							Labels: tt.labels,
+						},
+					},
+				},
+			}
+			secondMS := ms.DeepCopy()
+			webhook := &MachineSet{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateCreate(ctx, ms)).NotTo(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, secondMS, ms)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateCreate(ctx, ms)).To(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, secondMS, ms)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestMachineSetClusterNameImmutable(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldClusterName string
+		newClusterName string
+		expectErr      bool
+	}{
+		{
+			name:           "when the cluster name has not changed",
+			oldClusterName: "foo",
+			newClusterName: "foo",
+			expectErr:      false,
+		},
+		{
+			name:           "when the cluster name has changed",
+			oldClusterName: "foo",
+			newClusterName: "bar",
+			expectErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ms := &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					ClusterName: tt.newClusterName,
+				},
+			}
+			secondMS := &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					ClusterName: tt.oldClusterName,
+				},
+			}
+			webhook := &MachineSet{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateUpdate(ctx, ms, secondMS)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateUpdate(ctx, ms, secondMS)).To(Succeed())
+			}
+		})
+	}
+}
+
+func TestMachineSetVersionValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		expectErr bool
+	}{
+		{
+			name:      "should succeed when given a valid semantic version with prepended 'v'",
+			version:   "v1.19.2",
+			expectErr: false,
+		},
+		{
+			name:      "should return error when given a valid semantic version without 'v'",
+			version:   "1.19.2",
+			expectErr: true,
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			version:   "1",
+			expectErr: true,
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			version:   "v1",
+			expectErr: true,
+		},
+		{
+			name:      "should return error when given an invalid semantic version",
+			version:   "wrong_version",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			ms := &clusterv1.MachineSet{
+				Spec: clusterv1.MachineSetSpec{
+					Template: clusterv1.MachineTemplateSpec{
+						Spec: clusterv1.MachineSpec{
+							Version: pointer.String(tt.version),
+						},
+					},
+				},
+			}
+			secondMS := ms.DeepCopy()
+			webhook := &MachineSet{}
+
+			if tt.expectErr {
+				g.Expect(webhook.ValidateCreate(ctx, ms)).NotTo(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, ms, secondMS)).NotTo(Succeed())
+			} else {
+				g.Expect(webhook.ValidateCreate(ctx, ms)).To(Succeed())
+				g.Expect(webhook.ValidateUpdate(ctx, ms, secondMS)).To(Succeed())
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -488,7 +488,7 @@ func setupWebhooks(mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 
-	if err := (&clusterv1.Machine{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.Machine{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Machine")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -498,7 +498,7 @@ func setupWebhooks(mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 
-	if err := (&clusterv1.MachineDeployment{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.MachineDeployment{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "MachineDeployment")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -493,7 +493,7 @@ func setupWebhooks(mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 
-	if err := (&clusterv1.MachineSet{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.MachineSet{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "MachineSet")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -517,7 +517,7 @@ func setupWebhooks(mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 
-	if err := (&clusterv1.MachineHealthCheck{}).SetupWebhookWithManager(mgr); err != nil {
+	if err := (&webhooks.MachineHealthCheck{Client: mgr.GetClient()}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "MachineHealthCheck")
 		os.Exit(1)
 	}

--- a/webhooks/alias.go
+++ b/webhooks/alias.go
@@ -82,3 +82,15 @@ func (webhook *MachineSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Client: webhook.Client,
 	}).SetupWebhookWithManager(mgr)
 }
+
+// MachineHealthCheck implements a validation and defaulting webhook for MachineHealthCheck.
+type MachineHealthCheck struct {
+	Client client.Reader
+}
+
+// SetupWebhookWithManager sets up MachineHealthCheck webhooks.
+func (webhook *MachineHealthCheck) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.MachineHealthCheck{
+		Client: webhook.Client,
+	}).SetupWebhookWithManager(mgr)
+}

--- a/webhooks/alias.go
+++ b/webhooks/alias.go
@@ -70,3 +70,15 @@ func (webhook *MachineDeployment) SetupWebhookWithManager(mgr ctrl.Manager) erro
 		Client: webhook.Client,
 	}).SetupWebhookWithManager(mgr)
 }
+
+// MachineSet implements a validation and defaulting webhook for MachineSet.
+type MachineSet struct {
+	Client client.Reader
+}
+
+// SetupWebhookWithManager sets up MachineSet webhooks.
+func (webhook *MachineSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.MachineSet{
+		Client: webhook.Client,
+	}).SetupWebhookWithManager(mgr)
+}

--- a/webhooks/alias.go
+++ b/webhooks/alias.go
@@ -58,3 +58,15 @@ func (webhook *Machine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Client: webhook.Client,
 	}).SetupWebhookWithManager(mgr)
 }
+
+// MachineDeployment implements a validation and defaulting webhook for MachineDeployment.
+type MachineDeployment struct {
+	Client client.Reader
+}
+
+// SetupWebhookWithManager sets up MachineDeployment webhooks.
+func (webhook *MachineDeployment) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.MachineDeployment{
+		Client: webhook.Client,
+	}).SetupWebhookWithManager(mgr)
+}

--- a/webhooks/alias.go
+++ b/webhooks/alias.go
@@ -46,3 +46,15 @@ func (webhook *ClusterClass) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Client: webhook.Client,
 	}).SetupWebhookWithManager(mgr)
 }
+
+// Machine implements a validation and defaulting webhook for Machine.
+type Machine struct {
+	Client client.Reader
+}
+
+// SetupWebhookWithManager sets up Machine webhooks.
+func (webhook *Machine) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return (&webhooks.Machine{
+		Client: webhook.Client,
+	}).SetupWebhookWithManager(mgr)
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Follow up of https://github.com/kubernetes-sigs/cluster-api/issues/5599.

Move webhooks to internal and create alias.go for exposing Machine, MachineSet, MachineDeployment, MachineHealthCheck, KubeadmConfig and KubeadmConfigTemplate for now. I also added a deprecation comment to the types in the betav1 package and to the book, as seen in e.g. `cluster_webhook.go` before they were removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7176

<sub>Johannes Frey <[johannes.frey@mercedes-benz.com](mailto:johannes.frey@mercedes-benz.com)>, Mercedes-Benz Tech Innovation GmbH ([Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))</sub>