### PR TITLE
🌱 remove image tag pinning for kube-state-metrics

### DIFF
--- a/hack/observability/kube-state-metrics/chart/values.yaml
+++ b/hack/observability/kube-state-metrics/chart/values.yaml
@@ -1,7 +1,3 @@
-image:
-  tag: v2.6.0
-  pullPolicy: IfNotPresent
-
 # Add the CR configuration from the config map.
 volumeMounts:
  - mountPath: /etc/config


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Drops hardcoded kube-state-metrics version tag.

New helm chart release which includes kube-state-metrics v2.6.0 was created via https://github.com/prometheus-community/helm-charts/pull/2422

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7143
