### PR TITLE
✨ Add missing status_replicas_ready metric for MachineDeployments at kube-state-metrics

### DIFF
--- a/hack/observability/kube-state-metrics/crd-config.yaml
+++ b/hack/observability/kube-state-metrics/crd-config.yaml
@@ -458,6 +458,15 @@ spec:
           - availableReplicas
           nilIsZero: true
         type: Gauge
+    - name: status_replicas_ready
+      help: The number of ready replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
     - name: status_replicas_unavailable
       help: The number of unavailable replicas per machinedeployment.
       each:

--- a/hack/observability/kube-state-metrics/metrics/machinedeployment.yaml
+++ b/hack/observability/kube-state-metrics/metrics/machinedeployment.yaml
@@ -87,6 +87,15 @@
           - availableReplicas
           nilIsZero: true
         type: Gauge
+    - name: status_replicas_ready
+      help: The number of ready replicas per machinedeployment.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
     - name: status_replicas_unavailable
       help: The number of unavailable replicas per machinedeployment.
       each:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Adds missing `capi_machinedeployment_status_replicas_ready` metric to the config for kube-state-metrics.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
part of #6458
