### PR TITLE
:bug: Outdated failure Reason&Message will not been cleanup when external object recovery

### DIFF
--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -138,6 +138,7 @@ func (r *MachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	defer func() {
+		r.reconcileFailure(mp)
 		r.reconcilePhase(mp)
 		// TODO(jpang): add support for metrics.
 

--- a/exp/internal/controllers/machinepool_controller_phases.go
+++ b/exp/internal/controllers/machinepool_controller_phases.go
@@ -46,6 +46,17 @@ var (
 	externalReadyWait = 30 * time.Second
 )
 
+func (r *MachinePoolReconciler) reconcileFailure(mp *expv1.MachinePool) {
+	switch {
+	case !mp.Status.BootstrapReady:
+		return
+	case !mp.Status.InfrastructureReady:
+		return
+	}
+	mp.Status.FailureReason = nil
+	mp.Status.FailureMessage = nil
+}
+
 func (r *MachinePoolReconciler) reconcilePhase(mp *expv1.MachinePool) {
 	// Set the phase to "pending" if nil.
 	if mp.Status.Phase == "" {

--- a/internal/controllers/cluster/cluster_controller.go
+++ b/internal/controllers/cluster/cluster_controller.go
@@ -126,6 +126,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	}
 
 	defer func() {
+		r.reconcileFailure(ctx, cluster)
 		// Always reconcile the Status.Phase field.
 		r.reconcilePhase(ctx, cluster)
 

--- a/internal/controllers/cluster/cluster_controller_phases.go
+++ b/internal/controllers/cluster/cluster_controller_phases.go
@@ -41,6 +41,17 @@ import (
 	"sigs.k8s.io/cluster-api/util/secret"
 )
 
+func (r *Reconciler) reconcileFailure(_ context.Context, cluster *clusterv1.Cluster) {
+	switch {
+	case !cluster.Status.ControlPlaneReady:
+		return
+	case !cluster.Status.InfrastructureReady:
+		return
+	}
+	cluster.Status.FailureReason = nil
+	cluster.Status.FailureMessage = nil
+}
+
 func (r *Reconciler) reconcilePhase(_ context.Context, cluster *clusterv1.Cluster) {
 	if cluster.Status.Phase == "" {
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhasePending)

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -174,6 +174,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	}
 
 	defer func() {
+		r.reconcileFailure(ctx, m)
 		r.reconcilePhase(ctx, m)
 
 		// Always attempt to patch the object and status after each reconciliation.


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, once the external object (e.g. bootstrapConfig, infrastructure) experiencing breakdowns, the failureReason and failureMessage are passed to the current object via reconcileExternal, even if the external object recovers later, the failureReason and failureMessage of the current object will not be cleaned up, and thus the phase of the current object is always in failed 

So, this PR adds a reconcile step that determines whether failureReason and failureMessage are retained based on the ready state of the external object

In addition, some testing methods have been updated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
