### PR TITLE
✨ Add Node managed labels support

### DIFF
--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -62,6 +62,13 @@ const (
 	// This annotation can be set on BootstrapConfig or Machine objects. The value set on the Machine object takes precedence.
 	// This annotation can only be used on Control Plane Machines.
 	MachineCertificatesExpiryDateAnnotation = "machine.cluster.x-k8s.io/certificates-expiry"
+
+	// NodeRoleLabelPrefix is one of the CAPI managed Node label prefixes.
+	NodeRoleLabelPrefix = "node-role.kubernetes.io"
+	// NodeRestrictionLabelDomain is one of the CAPI managed Node label domains.
+	NodeRestrictionLabelDomain = "node-restriction.kubernetes.io"
+	// ManagedNodeLabelDomain is one of the CAPI managed Node label domains.
+	ManagedNodeLabelDomain = "node.cluster.x-k8s.io"
 )
 
 // ANCHOR: MachineSpec

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -91,6 +91,7 @@ type Reconciler struct {
 	// nodeDeletionRetryTimeout determines how long the controller will retry deleting a node
 	// during a single reconciliation.
 	nodeDeletionRetryTimeout time.Duration
+	disableNodeLabelSync     bool
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {

--- a/internal/controllers/machine/machine_controller_noderef_test.go
+++ b/internal/controllers/machine/machine_controller_noderef_test.go
@@ -227,3 +227,29 @@ func TestSummarizeNodeConditions(t *testing.T) {
 		})
 	}
 }
+
+func TestGetManagedLabels(t *testing.T) {
+	// Create managedLabels map from known managed prefixes.
+	managedLabels := map[string]string{}
+	managedLabels[clusterv1.ManagedNodeLabelDomain] = ""
+	managedLabels["custom-prefix."+clusterv1.NodeRestrictionLabelDomain] = ""
+	managedLabels["custom-prefix."+clusterv1.NodeRestrictionLabelDomain+"/anything"] = ""
+	managedLabels[clusterv1.NodeRoleLabelPrefix+"/anything"] = ""
+
+	// Append arbitrary labels.
+	allLabels := map[string]string{
+		"foo":                               "",
+		"bar":                               "",
+		"company.xyz/node.cluster.x-k8s.io": "not-managed",
+		"gpu-node.cluster.x-k8s.io":         "not-managed",
+		"company.xyz/node-restriction.kubernetes.io": "not-managed",
+		"gpu-node-restriction.kubernetes.io":         "not-managed",
+	}
+	for k, v := range managedLabels {
+		allLabels[k] = v
+	}
+
+	g := NewWithT(t)
+	got := getManagedLabels(allLabels)
+	g.Expect(got).To(BeEquivalentTo(managedLabels))
+}

--- a/internal/controllers/machine/machine_controller_phases_test.go
+++ b/internal/controllers/machine/machine_controller_phases_test.go
@@ -117,6 +117,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		infraConfig := defaultInfra.DeepCopy()
 
 		r := &Reconciler{
+			disableNodeLabelSync: true,
 			Client: fake.NewClientBuilder().
 				WithScheme(scheme.Scheme).
 				WithObjects(defaultCluster,
@@ -155,6 +156,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		infraConfig := defaultInfra.DeepCopy()
 
 		r := &Reconciler{
+			disableNodeLabelSync: true,
 			Client: fake.NewClientBuilder().
 				WithScheme(scheme.Scheme).
 				WithObjects(defaultCluster,
@@ -198,6 +200,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		machine.Status.LastUpdated = &lastUpdated
 
 		r := &Reconciler{
+			disableNodeLabelSync: true,
 			Client: fake.NewClientBuilder().
 				WithScheme(scheme.Scheme).
 				WithObjects(defaultCluster,
@@ -268,8 +271,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "machine-test-node",
-				Namespace: metav1.NamespaceDefault,
+				Name: "machine-test-node",
 			},
 			Spec: corev1.NodeSpec{ProviderID: "test://id-1"},
 		}
@@ -285,8 +287,9 @@ func TestReconcileMachinePhases(t *testing.T) {
 				defaultKubeconfigSecret,
 			).Build()
 		r := &Reconciler{
-			Client:  cl,
-			Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			disableNodeLabelSync: true,
+			Client:               cl,
+			Tracker:              remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machine)
@@ -334,8 +337,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "machine-test-node",
-				Namespace: metav1.NamespaceDefault,
+				Name: "machine-test-node",
 			},
 			Spec: corev1.NodeSpec{ProviderID: "test://id-1"},
 		}
@@ -351,8 +353,9 @@ func TestReconcileMachinePhases(t *testing.T) {
 				defaultKubeconfigSecret,
 			).Build()
 		r := &Reconciler{
-			Client:  cl,
-			Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			disableNodeLabelSync: true,
+			Client:               cl,
+			Tracker:              remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machine)
@@ -410,8 +413,7 @@ func TestReconcileMachinePhases(t *testing.T) {
 		machine.Status.LastUpdated = &lastUpdated
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "machine-test-node",
-				Namespace: metav1.NamespaceDefault,
+				Name: "machine-test-node",
 			},
 			Spec: corev1.NodeSpec{ProviderID: "test://id-1"},
 		}
@@ -427,8 +429,9 @@ func TestReconcileMachinePhases(t *testing.T) {
 				defaultKubeconfigSecret,
 			).Build()
 		r := &Reconciler{
-			Client:  cl,
-			Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			disableNodeLabelSync: true,
+			Client:               cl,
+			Tracker:              remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machine)
@@ -487,8 +490,9 @@ func TestReconcileMachinePhases(t *testing.T) {
 			).Build()
 
 		r := &Reconciler{
-			Client:  cl,
-			Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			disableNodeLabelSync: true,
+			Client:               cl,
+			Tracker:              remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machine)
@@ -568,9 +572,10 @@ func TestReconcileMachinePhases(t *testing.T) {
 				infraConfig,
 			).Build()
 		r := &Reconciler{
-			Client:   cl,
-			Tracker:  remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
-			recorder: record.NewFakeRecorder(32),
+			disableNodeLabelSync: true,
+			Client:               cl,
+			Tracker:              remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), cl, scheme.Scheme, client.ObjectKey{Name: defaultCluster.Name, Namespace: defaultCluster.Namespace}),
+			recorder:             record.NewFakeRecorder(32),
 		}
 
 		res, err := r.reconcileDelete(ctx, defaultCluster, machine)
@@ -867,6 +872,7 @@ func TestReconcileBootstrap(t *testing.T) {
 
 			bootstrapConfig := &unstructured.Unstructured{Object: tc.bootstrapConfig}
 			r := &Reconciler{
+				disableNodeLabelSync: true,
 				Client: fake.NewClientBuilder().
 					WithObjects(tc.machine,
 						builder.GenericBootstrapConfigCRD.DeepCopy(),
@@ -1077,6 +1083,7 @@ func TestReconcileInfrastructure(t *testing.T) {
 
 			infraConfig := &unstructured.Unstructured{Object: tc.infraConfig}
 			r := &Reconciler{
+				disableNodeLabelSync: true,
 				Client: fake.NewClientBuilder().
 					WithObjects(tc.machine,
 						builder.GenericBootstrapConfigCRD.DeepCopy(),
@@ -1318,6 +1325,7 @@ func TestReconcileCertificateExpiry(t *testing.T) {
 			g := NewWithT(t)
 
 			r := &Reconciler{
+				disableNodeLabelSync: true,
 				Client: fake.NewClientBuilder().
 					WithObjects(
 						tc.machine,

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -615,8 +615,7 @@ func TestReconcileRequest(t *testing.T) {
 
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: metav1.NamespaceDefault,
+			Name: "test",
 		},
 		Spec: corev1.NodeSpec{ProviderID: "test://id-1"},
 	}
@@ -726,8 +725,9 @@ func TestReconcileRequest(t *testing.T) {
 			).Build()
 
 			r := &Reconciler{
-				Client:  clientFake,
-				Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
+				disableNodeLabelSync: true,
+				Client:               clientFake,
+				Tracker:              remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			}
 
 			result, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(&tc.machine)})
@@ -830,8 +830,7 @@ func TestMachineConditions(t *testing.T) {
 
 	node := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: metav1.NamespaceDefault,
+			Name: "test",
 		},
 		Spec: corev1.NodeSpec{ProviderID: "test://id-1"},
 	}
@@ -971,8 +970,9 @@ func TestMachineConditions(t *testing.T) {
 			).Build()
 
 			r := &Reconciler{
-				Client:  clientFake,
-				Tracker: remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
+				disableNodeLabelSync: true,
+				Client:               clientFake,
+				Tracker:              remote.NewTestClusterCacheTracker(logr.New(log.NullLogSink{}), clientFake, scheme.Scheme, client.ObjectKey{Name: testCluster.Name, Namespace: testCluster.Namespace}),
 			}
 
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: util.ObjectKey(&machine)})


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Implements part of https://github.com/kubernetes-sigs/cluster-api/pull/6255. Propagate managed labels from Machines to Nodes.

/hold

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
