### PR TITLE
[WIP] :seedling: Use manager and builder pkgs of controller-runtime explicitly.

### DIFF
--- a/api/v1beta1/index/cluster.go
+++ b/api/v1beta1/index/cluster.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -34,7 +34,7 @@ const (
 
 // ByClusterClassName adds the cluster class name  index to the
 // managers cache.
-func ByClusterClassName(ctx context.Context, mgr ctrl.Manager) error {
+func ByClusterClassName(ctx context.Context, mgr manager.Manager) error {
 	if err := mgr.GetCache().IndexField(ctx, &clusterv1.Cluster{},
 		ClusterClassNameField,
 		clusterByClassName,

--- a/api/v1beta1/index/index.go
+++ b/api/v1beta1/index/index.go
@@ -20,13 +20,13 @@ package index
 import (
 	"context"
 
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"sigs.k8s.io/cluster-api/feature"
 )
 
 // AddDefaultIndexes registers the default list of indexes.
-func AddDefaultIndexes(ctx context.Context, mgr ctrl.Manager) error {
+func AddDefaultIndexes(ctx context.Context, mgr manager.Manager) error {
 	if err := ByMachineNode(ctx, mgr); err != nil {
 		return err
 	}

--- a/api/v1beta1/index/machine.go
+++ b/api/v1beta1/index/machine.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/utils/pointer"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/noderefutil"
@@ -40,7 +40,7 @@ const (
 
 // ByMachineNode adds the machine node name index to the
 // managers cache.
-func ByMachineNode(ctx context.Context, mgr ctrl.Manager) error {
+func ByMachineNode(ctx context.Context, mgr manager.Manager) error {
 	if err := mgr.GetCache().IndexField(ctx, &clusterv1.Machine{},
 		MachineNodeNameField,
 		machineByNodeName,
@@ -64,7 +64,7 @@ func machineByNodeName(o client.Object) []string {
 
 // ByMachineProviderID adds the machine providerID index to the
 // managers cache.
-func ByMachineProviderID(ctx context.Context, mgr ctrl.Manager) error {
+func ByMachineProviderID(ctx context.Context, mgr manager.Manager) error {
 	if err := mgr.GetCache().IndexField(ctx, &clusterv1.Machine{},
 		MachineProviderIDField,
 		machineByProviderID,

--- a/api/v1beta1/machine_webhook.go
+++ b/api/v1beta1/machine_webhook.go
@@ -25,7 +25,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"sigs.k8s.io/cluster-api/util/version"
@@ -33,8 +34,8 @@ import (
 
 const defaultNodeDeletionTimeout = 10 * time.Second
 
-func (m *Machine) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
+func (m *Machine) SetupWebhookWithManager(mgr manager.Manager) error {
+	return builder.WebhookManagedBy(mgr).
 		For(m).
 		Complete()
 }

--- a/api/v1beta1/machinedeployment_webhook.go
+++ b/api/v1beta1/machinedeployment_webhook.go
@@ -27,14 +27,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/pointer"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"sigs.k8s.io/cluster-api/util/version"
 )
 
-func (m *MachineDeployment) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
+func (m *MachineDeployment) SetupWebhookWithManager(mgr manager.Manager) error {
+	return builder.WebhookManagedBy(mgr).
 		For(m).
 		Complete()
 }

--- a/api/v1beta1/machinehealthcheck_webhook.go
+++ b/api/v1beta1/machinehealthcheck_webhook.go
@@ -25,7 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
@@ -50,8 +51,8 @@ func SetMinNodeStartupTimeout(d metav1.Duration) {
 	minNodeStartupTimeout = d
 }
 
-func (m *MachineHealthCheck) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
+func (m *MachineHealthCheck) SetupWebhookWithManager(mgr manager.Manager) error {
+	return builder.WebhookManagedBy(mgr).
 		For(m).
 		Complete()
 }

--- a/api/v1beta1/machineset_webhook.go
+++ b/api/v1beta1/machineset_webhook.go
@@ -25,14 +25,15 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"sigs.k8s.io/cluster-api/util/version"
 )
 
-func (m *MachineSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
+func (m *MachineSet) SetupWebhookWithManager(mgr manager.Manager) error {
+	return builder.WebhookManagedBy(mgr).
 		For(m).
 		Complete()
 }

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_webhook.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_webhook.go
@@ -22,7 +22,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"sigs.k8s.io/cluster-api/feature"
@@ -38,8 +39,8 @@ var (
 	pathConflictMsg                                  = "path property must be unique among all files"
 )
 
-func (c *KubeadmConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
+func (c *KubeadmConfig) SetupWebhookWithManager(mgr manager.Manager) error {
+	return builder.WebhookManagedBy(mgr).
 		For(c).
 		Complete()
 }

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfigtemplate_webhook.go
@@ -20,12 +20,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-func (r *KubeadmConfigTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
+func (r *KubeadmConfigTemplate) SetupWebhookWithManager(mgr manager.Manager) error {
+	return builder.WebhookManagedBy(mgr).
 		For(r).
 		Complete()
 }

--- a/exp/addons/api/v1beta1/clusterresourceset_webhook.go
+++ b/exp/addons/api/v1beta1/clusterresourceset_webhook.go
@@ -24,14 +24,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"sigs.k8s.io/cluster-api/feature"
 )
 
-func (m *ClusterResourceSet) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewWebhookManagedBy(mgr).
+func (m *ClusterResourceSet) SetupWebhookWithManager(mgr manager.Manager) error {
+	return builder.WebhookManagedBy(mgr).
 		For(m).
 		Complete()
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Use manager and builder pkgs of controller-runtime explicitly. Otherwise, controller-runtime will implicitly set the `kubeconfig` flag to the global command line FlagSet when using the alias types defined in alias.go. See:
https://github.com/kubernetes-sigs/controller-runtime/blob/15b6689c55745514d6bade4c55efb3333c0da4d9/alias.go#L80

The usage of the alias potentially collides with user code that imports the api packages of Cluster API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7176

<sub>Johannes Frey <[johannes.frey@mercedes-benz.com](mailto:johannes.frey@mercedes-benz.com)>, Mercedes-Benz Tech Innovation GmbH ([Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))</sub>