### PR TITLE
🌱 [WIP] Replace internal log usages with klog

### DIFF
--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -36,7 +36,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
-	tlog "sigs.k8s.io/cluster-api/internal/log"
+	"k8s.io/klog/v2"
 	runtimeclient "sigs.k8s.io/cluster-api/internal/runtime/client"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -162,7 +162,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func patchExtensionConfig(ctx context.Context, client client.Client, original, modified *runtimev1.ExtensionConfig, options ...patch.Option) error {
 	patchHelper, err := patch.NewHelper(original, client)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create patch helper for %s", tlog.KObj{Obj: modified})
+		return errors.Wrapf(err, "failed to create patch helper for %s", klog.KObj(modified))
 	}
 
 	options = append(options, patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
@@ -170,7 +170,7 @@ func patchExtensionConfig(ctx context.Context, client client.Client, original, m
 	}})
 	err = patchHelper.Patch(ctx, modified, options...)
 	if err != nil {
-		return errors.Wrapf(err, "failed to patch %s", tlog.KObj{Obj: modified})
+		return errors.Wrapf(err, "failed to patch %s", klog.KObj(modified))
 	}
 	return nil
 }
@@ -181,7 +181,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, extensionConfig *runti
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Unregistering ExtensionConfig information from registry")
 	if err := r.RuntimeClient.Unregister(extensionConfig); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to unregister %s", tlog.KObj{Obj: extensionConfig})
+		return ctrl.Result{}, errors.Wrapf(err, "failed to unregister %s", klog.KObj(extensionConfig))
 	}
 	return ctrl.Result{}, nil
 }
@@ -217,7 +217,7 @@ func discoverExtensionConfig(ctx context.Context, runtimeClient runtimeclient.Cl
 	if err != nil {
 		modifiedExtensionConfig := extensionConfig.DeepCopy()
 		conditions.MarkFalse(modifiedExtensionConfig, runtimev1.RuntimeExtensionDiscoveredCondition, runtimev1.DiscoveryFailedReason, clusterv1.ConditionSeverityError, "error in discovery: %v", err)
-		return modifiedExtensionConfig, errors.Wrapf(err, "failed to discover %s", tlog.KObj{Obj: extensionConfig})
+		return modifiedExtensionConfig, errors.Wrapf(err, "failed to discover %s", klog.KObj(extensionConfig))
 	}
 
 	conditions.MarkTrue(discoveredExtension, runtimev1.RuntimeExtensionDiscoveredCondition)

--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -33,6 +33,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	tlog "sigs.k8s.io/cluster-api/internal/log"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -157,7 +158,7 @@ func (r *Reconciler) reconcileExternal(ctx context.Context, clusterClass *cluste
 	log := ctrl.LoggerFrom(ctx)
 
 	if err := utilconversion.UpdateReferenceAPIContract(ctx, r.Client, r.APIReader, ref); err != nil {
-		return errors.Wrapf(err, "failed to update reference API contract of %s", tlog.KRef{Ref: ref})
+		return errors.Wrapf(err, "failed to update reference API contract of %s", klog.KRef(ref.Namespace, ref.Name))
 	}
 
 	// If we dont need to set the ownerReference then return early.

--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -32,7 +32,6 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
-	tlog "sigs.k8s.io/cluster-api/internal/log"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
@@ -102,7 +101,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		if err := patchHelper.Patch(ctx, clusterClass); err != nil {
 			reterr = kerrors.NewAggregate([]error{
 				reterr,
-				errors.Wrapf(err, "failed to patch %s", tlog.KObj{Obj: clusterClass})},
+				errors.Wrapf(err, "failed to patch %s", klog.KObj(clusterClass))},
 			)
 		}
 	}()
@@ -183,17 +182,17 @@ func (r *Reconciler) reconcileExternal(ctx context.Context, clusterClass *cluste
 	// Initialize the patch helper.
 	patchHelper, err := patch.NewHelper(obj, r.Client)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create patch helper for %s", tlog.KObj{Obj: obj})
+		return errors.Wrapf(err, "failed to create patch helper for %s", klog.KObj(obj))
 	}
 
 	// Set external object ControllerReference to the ClusterClass.
 	if err := controllerutil.SetOwnerReference(clusterClass, obj, r.Client.Scheme()); err != nil {
-		return errors.Wrapf(err, "failed to set cluster class owner reference for %s", tlog.KObj{Obj: obj})
+		return errors.Wrapf(err, "failed to set cluster class owner reference for %s", klog.KObj(obj))
 	}
 
 	// Patch the external object.
 	if err := patchHelper.Patch(ctx, obj); err != nil {
-		return errors.Wrapf(err, "failed to patch object %s", tlog.KObj{Obj: obj})
+		return errors.Wrapf(err, "failed to patch object %s", klog.KObj(obj))
 	}
 
 	return nil

--- a/internal/controllers/clusterclass/clusterclass_controller_test.go
+++ b/internal/controllers/clusterclass/clusterclass_controller_test.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	tlog "sigs.k8s.io/cluster-api/internal/log"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/internal/test/builder"
 )
 
@@ -242,7 +242,7 @@ func assertHasOwnerReference(obj client.Object, ownerRef metav1.OwnerReference) 
 		}
 	}
 	if !found {
-		return fmt.Errorf("object %s does not have OwnerReference %s", tlog.KObj{Obj: obj}, &ownerRef)
+		return fmt.Errorf("object %s does not have OwnerReference %s", klog.KObj(obj), &ownerRef)
 	}
 	return nil
 }

--- a/internal/controllers/topology/cluster/blueprint.go
+++ b/internal/controllers/topology/cluster/blueprint.go
@@ -24,7 +24,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/scope"
-	tlog "sigs.k8s.io/cluster-api/internal/log"
+	"k8s.io/klog/v2"
 )
 
 // getBlueprint gets a ClusterBlueprint with the ClusterClass and the referenced templates to be used for a managed Cluster topology.
@@ -47,21 +47,21 @@ func (r *Reconciler) getBlueprint(ctx context.Context, cluster *clusterv1.Cluste
 	// Get ClusterClass.spec.infrastructure.
 	blueprint.InfrastructureClusterTemplate, err = r.getReference(ctx, blueprint.ClusterClass.Spec.Infrastructure.Ref)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get infrastructure cluster template for %s", tlog.KObj{Obj: blueprint.ClusterClass})
+		return nil, errors.Wrapf(err, "failed to get infrastructure cluster template for %s", klog.KObj(blueprint.ClusterClass))
 	}
 
 	// Get ClusterClass.spec.controlPlane.
 	blueprint.ControlPlane = &scope.ControlPlaneBlueprint{}
 	blueprint.ControlPlane.Template, err = r.getReference(ctx, blueprint.ClusterClass.Spec.ControlPlane.Ref)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get control plane template for %s", tlog.KObj{Obj: blueprint.ClusterClass})
+		return nil, errors.Wrapf(err, "failed to get control plane template for %s", klog.KObj(blueprint.ClusterClass))
 	}
 
 	// If the clusterClass mandates the controlPlane has infrastructureMachines, read it.
 	if blueprint.HasControlPlaneInfrastructureMachine() {
 		blueprint.ControlPlane.InfrastructureMachineTemplate, err = r.getReference(ctx, blueprint.ClusterClass.Spec.ControlPlane.MachineInfrastructure.Ref)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get control plane's machine template for %s", tlog.KObj{Obj: blueprint.ClusterClass})
+			return nil, errors.Wrapf(err, "failed to get control plane's machine template for %s", klog.KObj(blueprint.ClusterClass))
 		}
 	}
 
@@ -83,13 +83,13 @@ func (r *Reconciler) getBlueprint(ctx context.Context, cluster *clusterv1.Cluste
 		// Get the infrastructure machine template.
 		machineDeploymentBlueprint.InfrastructureMachineTemplate, err = r.getReference(ctx, machineDeploymentClass.Template.Infrastructure.Ref)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get infrastructure machine template for %s, MachineDeployment class %q", tlog.KObj{Obj: blueprint.ClusterClass}, machineDeploymentClass.Class)
+			return nil, errors.Wrapf(err, "failed to get infrastructure machine template for %s, MachineDeployment class %q", klog.KObj(blueprint.ClusterClass), machineDeploymentClass.Class)
 		}
 
 		// Get the bootstrap machine template.
 		machineDeploymentBlueprint.BootstrapTemplate, err = r.getReference(ctx, machineDeploymentClass.Template.Bootstrap.Ref)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get bootstrap machine template for %s, MachineDeployment class %q", tlog.KObj{Obj: blueprint.ClusterClass}, machineDeploymentClass.Class)
+			return nil, errors.Wrapf(err, "failed to get bootstrap machine template for %s, MachineDeployment class %q", klog.KObj(blueprint.ClusterClass), machineDeploymentClass.Class)
 		}
 
 		// If the machineDeploymentClass defines a MachineHealthCheck add it to the blueprint.

--- a/internal/controllers/topology/cluster/current_state.go
+++ b/internal/controllers/topology/cluster/current_state.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/cluster-api/internal/contract"
 	"sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/scope"
 	tlog "sigs.k8s.io/cluster-api/internal/log"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/util/labels"
 )
 
@@ -75,7 +76,7 @@ func (r *Reconciler) getCurrentState(ctx context.Context, s *scope.Scope) (*scop
 func (r *Reconciler) getCurrentInfrastructureClusterState(ctx context.Context, cluster *clusterv1.Cluster) (*unstructured.Unstructured, error) {
 	infra, err := r.getReference(ctx, cluster.Spec.InfrastructureRef)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read %s", tlog.KRef{Ref: cluster.Spec.InfrastructureRef})
+		return nil, errors.Wrapf(err, "failed to read %s", klog.KRef(cluster.Spec.InfrastructureRef.Namespace, cluster.Spec.InfrastructureRef.Name))
 	}
 	// check that the referenced object has the ClusterTopologyOwnedLabel label.
 	// Nb. This is to make sure that a managed topology cluster does not have a reference to an object that is not
@@ -96,7 +97,7 @@ func (r *Reconciler) getCurrentControlPlaneState(ctx context.Context, cluster *c
 	// Get the control plane object.
 	res.Object, err = r.getReference(ctx, cluster.Spec.ControlPlaneRef)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read %s", tlog.KRef{Ref: cluster.Spec.ControlPlaneRef})
+		return nil, errors.Wrapf(err, "failed to read %s", klog.KRef(cluster.Spec.ControlPlaneRef.Namespace, cluster.Spec.ControlPlaneRef.Name))
 	}
 	// check that the referenced object has the ClusterTopologyOwnedLabel label.
 	// Nb. This is to make sure that a managed topology cluster does not have a reference to an object that is not

--- a/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
+++ b/internal/controllers/topology/machinedeployment/machinedeployment_controller.go
@@ -29,7 +29,6 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/controllers/topology/machineset"
-	tlog "sigs.k8s.io/cluster-api/internal/log"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -139,11 +138,11 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, md *clusterv1.MachineD
 	// Delete unused templates.
 	ref := md.Spec.Template.Spec.Bootstrap.ConfigRef
 	if err := machineset.DeleteTemplateIfUnused(ctx, r.Client, templatesInUse, ref); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to delete bootstrap template for %s", tlog.KObj{Obj: md})
+		return ctrl.Result{}, errors.Wrapf(err, "failed to delete bootstrap template for %s", klog.KObj(md))
 	}
 	ref = &md.Spec.Template.Spec.InfrastructureRef
 	if err := machineset.DeleteTemplateIfUnused(ctx, r.Client, templatesInUse, ref); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to delete infrastructure template for %s", tlog.KObj{Obj: md})
+		return ctrl.Result{}, errors.Wrapf(err, "failed to delete infrastructure template for %s", klog.KObj(md))
 	}
 
 	// If the MachineDeployment has a MachineHealthCheck delete it.
@@ -154,12 +153,12 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, md *clusterv1.MachineD
 	// Remove the finalizer so the MachineDeployment can be garbage collected by Kubernetes.
 	patchHelper, err := patch.NewHelper(md, r.Client)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to create patch helper for %s", tlog.KObj{Obj: md})
+		return ctrl.Result{}, errors.Wrapf(err, "failed to create patch helper for %s", klog.KObj(md))
 	}
 
 	controllerutil.RemoveFinalizer(md, clusterv1.MachineDeploymentTopologyFinalizer)
 	if err := patchHelper.Patch(ctx, md); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to patch %s", tlog.KObj{Obj: md})
+		return ctrl.Result{}, errors.Wrapf(err, "failed to patch %s", klog.KObj(md))
 	}
 	return ctrl.Result{}, nil
 }
@@ -176,7 +175,7 @@ func (r *Reconciler) deleteMachineHealthCheckForMachineDeployment(ctx context.Co
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return errors.Wrapf(err, "failed to delete %s", tlog.KObj{Obj: mhc})
+		return errors.Wrapf(err, "failed to delete %s", klog.KObj(mhc))
 	}
 	return nil
 }

--- a/internal/controllers/topology/machineset/machineset_controller.go
+++ b/internal/controllers/topology/machineset/machineset_controller.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	tlog "sigs.k8s.io/cluster-api/internal/log"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	clog "sigs.k8s.io/cluster-api/util/log"
@@ -164,21 +163,21 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, ms *clusterv1.MachineS
 	// Delete unused templates.
 	ref := ms.Spec.Template.Spec.Bootstrap.ConfigRef
 	if err := DeleteTemplateIfUnused(ctx, r.Client, templatesInUse, ref); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to delete bootstrap template for %s", tlog.KObj{Obj: ms})
+		return ctrl.Result{}, errors.Wrapf(err, "failed to delete bootstrap template for %s", klog.KObj(ms))
 	}
 	ref = &ms.Spec.Template.Spec.InfrastructureRef
 	if err := DeleteTemplateIfUnused(ctx, r.Client, templatesInUse, ref); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to delete infrastructure template for %s", tlog.KObj{Obj: ms})
+		return ctrl.Result{}, errors.Wrapf(err, "failed to delete infrastructure template for %s", klog.KObj(ms))
 	}
 
 	// Remove the finalizer so the MachineSet can be garbage collected by Kubernetes.
 	patchHelper, err := patch.NewHelper(ms, r.Client)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to create patch helper for %s", tlog.KObj{Obj: ms})
+		return ctrl.Result{}, errors.Wrapf(err, "failed to create patch helper for %s", klog.KObj(ms))
 	}
 	controllerutil.RemoveFinalizer(ms, clusterv1.MachineSetTopologyFinalizer)
 	if err := patchHelper.Patch(ctx, ms); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to patch %s", tlog.KObj{Obj: ms})
+		return ctrl.Result{}, errors.Wrapf(err, "failed to patch %s", klog.KObj(ms))
 	}
 
 	return ctrl.Result{}, nil
@@ -193,7 +192,7 @@ func getMachineDeploymentName(ms *clusterv1.MachineSet) (*types.NamespacedName, 
 		gv, err := schema.ParseGroupVersion(ref.APIVersion)
 		if err != nil {
 			return nil, errors.Errorf("could not calculate MachineDeployment name for %s: invalid apiVersion %q: %v",
-				tlog.KObj{Obj: ms}, ref.APIVersion, err)
+				klog.KObj(ms), ref.APIVersion, err)
 		}
 		if gv.Group == clusterv1.GroupVersion.Group {
 			return &client.ObjectKey{Namespace: ms.Namespace, Name: ref.Name}, nil
@@ -203,5 +202,5 @@ func getMachineDeploymentName(ms *clusterv1.MachineSet) (*types.NamespacedName, 
 	// Note: Once we set an owner reference to a MachineDeployment in a MachineSet it stays there
 	// and is not deleted when the MachineDeployment is deleted. So we assume there's something wrong,
 	// if we couldn't find a MachineDeployment owner reference.
-	return nil, errors.Errorf("could not calculate MachineDeployment name for %s", tlog.KObj{Obj: ms})
+	return nil, errors.Errorf("could not calculate MachineDeployment name for %s", klog.KObj(ms))
 }

--- a/internal/controllers/topology/machineset/util.go
+++ b/internal/controllers/topology/machineset/util.go
@@ -63,7 +63,7 @@ func CalculateTemplatesInUse(md *clusterv1.MachineDeployment, msList []*clusterv
 		bootstrapRef := ms.Spec.Template.Spec.Bootstrap.ConfigRef
 		infrastructureRef := &ms.Spec.Template.Spec.InfrastructureRef
 		if err := addTemplateRef(templatesInUse, bootstrapRef, infrastructureRef); err != nil {
-			return nil, errors.Wrapf(err, "failed to add templates of %s to templatesInUse", tlog.KObj{Obj: ms})
+			return nil, errors.Wrapf(err, "failed to add templates of %s to templatesInUse", klog.KObj(ms))
 		}
 	}
 
@@ -77,7 +77,7 @@ func CalculateTemplatesInUse(md *clusterv1.MachineDeployment, msList []*clusterv
 	bootstrapRef := md.Spec.Template.Spec.Bootstrap.ConfigRef
 	infrastructureRef := &md.Spec.Template.Spec.InfrastructureRef
 	if err := addTemplateRef(templatesInUse, bootstrapRef, infrastructureRef); err != nil {
-		return nil, errors.Wrapf(err, "failed to add templates of %s to templatesInUse", tlog.KObj{Obj: md})
+		return nil, errors.Wrapf(err, "failed to add templates of %s to templatesInUse", klog.KObj(md))
 	}
 	return templatesInUse, nil
 }

--- a/internal/controllers/topology/machineset/util.go
+++ b/internal/controllers/topology/machineset/util.go
@@ -30,6 +30,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/external"
 	tlog "sigs.k8s.io/cluster-api/internal/log"
+	"k8s.io/klog/v2"
 )
 
 // GetMachineSetsForDeployment returns a list of MachineSets associated with a MachineDeployment.
@@ -97,13 +98,13 @@ func DeleteTemplateIfUnused(ctx context.Context, c client.Client, templatesInUse
 
 	// If the template is still in use, do nothing.
 	if templatesInUse[refID] {
-		log.V(3).Infof("Not deleting %s, because it's still in use", tlog.KRef{Ref: ref})
+		log.V(3).Infof("Not deleting %s, because it's still in use", klog.KRef(ref.Namespace, ref.Name))
 		return nil
 	}
 
-	log.Infof("Deleting %s", tlog.KRef{Ref: ref})
+	log.Infof("Deleting %s", klog.KRef(ref.Namespace, ref.Name))
 	if err := external.Delete(ctx, c, ref); err != nil && !apierrors.IsNotFound(err) {
-		return errors.Wrapf(err, "failed to delete %s", tlog.KRef{Ref: ref})
+		return errors.Wrapf(err, "failed to delete %s", klog.KRef(ref.Namespace, ref.Name))
 	}
 	return nil
 }

--- a/internal/hooks/tracking.go
+++ b/internal/hooks/tracking.go
@@ -27,7 +27,7 @@ import (
 
 	runtimev1 "sigs.k8s.io/cluster-api/exp/runtime/api/v1alpha1"
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
-	tlog "sigs.k8s.io/cluster-api/internal/log"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
@@ -41,7 +41,7 @@ func MarkAsPending(ctx context.Context, c client.Client, obj client.Object, hook
 
 	patchHelper, err := patch.NewHelper(obj, c)
 	if err != nil {
-		return errors.Wrapf(err, "failed to mark %q hook(s) as pending: failed to create patch helper for %s", strings.Join(hookNames, ","), tlog.KObj{Obj: obj})
+		return errors.Wrapf(err, "failed to mark %q hook(s) as pending: failed to create patch helper for %s", strings.Join(hookNames, ","), klog.KObj(obj))
 	}
 
 	// Read the annotation of the objects and add the hook to the comma separated list
@@ -53,7 +53,7 @@ func MarkAsPending(ctx context.Context, c client.Client, obj client.Object, hook
 	obj.SetAnnotations(annotations)
 
 	if err := patchHelper.Patch(ctx, obj); err != nil {
-		return errors.Wrapf(err, "failed to mark %q hook(s) as pending: failed to patch %s", strings.Join(hookNames, ","), tlog.KObj{Obj: obj})
+		return errors.Wrapf(err, "failed to mark %q hook(s) as pending: failed to patch %s", strings.Join(hookNames, ","), klog.KObj(obj))
 	}
 
 	return nil
@@ -80,7 +80,7 @@ func MarkAsDone(ctx context.Context, c client.Client, obj client.Object, hooks .
 
 	patchHelper, err := patch.NewHelper(obj, c)
 	if err != nil {
-		return errors.Wrapf(err, "failed to mark %q hook(s) as done: failed to create patch helper for %s", strings.Join(hookNames, ","), tlog.KObj{Obj: obj})
+		return errors.Wrapf(err, "failed to mark %q hook(s) as done: failed to create patch helper for %s", strings.Join(hookNames, ","), klog.KObj(obj))
 	}
 
 	// Read the annotation of the objects and add the hook to the comma separated list
@@ -95,7 +95,7 @@ func MarkAsDone(ctx context.Context, c client.Client, obj client.Object, hooks .
 	obj.SetAnnotations(annotations)
 
 	if err := patchHelper.Patch(ctx, obj); err != nil {
-		return errors.Wrapf(err, "failed to mark %q hook(s) as done: failed to patch %s", strings.Join(hookNames, ","), tlog.KObj{Obj: obj})
+		return errors.Wrapf(err, "failed to mark %q hook(s) as done: failed to patch %s", strings.Join(hookNames, ","), klog.KObj(obj))
 	}
 
 	return nil
@@ -117,7 +117,7 @@ func IsOkToDelete(obj client.Object) bool {
 func MarkAsOkToDelete(ctx context.Context, c client.Client, obj client.Object) error {
 	patchHelper, err := patch.NewHelper(obj, c)
 	if err != nil {
-		return errors.Wrapf(err, "failed to mark %s as ok to delete: failed to create patch helper", tlog.KObj{Obj: obj})
+		return errors.Wrapf(err, "failed to mark %s as ok to delete: failed to create patch helper", klog.KObj(obj))
 	}
 
 	annotations := obj.GetAnnotations()
@@ -128,7 +128,7 @@ func MarkAsOkToDelete(ctx context.Context, c client.Client, obj client.Object) e
 	obj.SetAnnotations(annotations)
 
 	if err := patchHelper.Patch(ctx, obj); err != nil {
-		return errors.Wrapf(err, "failed to mark %s as ok to delete: failed to patch", tlog.KObj{Obj: obj})
+		return errors.Wrapf(err, "failed to mark %s as ok to delete: failed to patch", klog.KObj(obj))
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the first step to replace all usages of internal loggers `tlog.KRef` and `tlog.KObj` with `klog.KRef` and `klog.KObj` respectively.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref: https://github.com/kubernetes-sigs/cluster-api/issues/7029
