### PR TITLE
🌱 hack/observability: pin charts

### DIFF
--- a/hack/observability/grafana/kustomization.yaml
+++ b/hack/observability/grafana/kustomization.yaml
@@ -7,3 +7,4 @@ helmCharts:
     releaseName: grafana
     namespace: observability
     valuesFile: values.yaml
+    version: 6.35.0

--- a/hack/observability/kube-state-metrics/chart/kustomization.yaml
+++ b/hack/observability/kube-state-metrics/chart/kustomization.yaml
@@ -4,3 +4,4 @@ helmCharts:
     namespace: observability
     releaseName: kube-state-metrics
     valuesFile: values.yaml
+    version: 4.18.0

--- a/hack/observability/loki/kustomization.yaml
+++ b/hack/observability/loki/kustomization.yaml
@@ -7,3 +7,4 @@ helmCharts:
     releaseName: loki
     namespace: observability
     valuesFile: values.yaml
+    version: 2.16.0

--- a/hack/observability/prometheus/kustomization.yaml
+++ b/hack/observability/prometheus/kustomization.yaml
@@ -7,3 +7,4 @@ helmCharts:
     releaseName: prometheus
     namespace: observability
     valuesFile: values.yaml
+    version: 15.12.0

--- a/hack/observability/promtail/kustomization.yaml
+++ b/hack/observability/promtail/kustomization.yaml
@@ -7,3 +7,4 @@ helmCharts:
     releaseName: promtail
     namespace: observability
     valuesFile: values.yaml
+    version: 6.3.0

--- a/hack/observability/visualizer/kustomization.yaml
+++ b/hack/observability/visualizer/kustomization.yaml
@@ -7,3 +7,4 @@ helmCharts:
     releaseName: visualizer
     namespace: observability
     valuesFile: values.yaml
+    version: 1.0.0


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Talked to Fabrizio, with the latest issues we have with the Loki bump (we need fixes in the Loki chart to adopt it) we would propose to pin the Helm charts. This makes it also more predictable when we invest effort into bumping charts and in the meantime it will "just work"

For future bumps I would suggest to just do a basic test that the logs of our controllers show up in Grafana

P.S. @ykakarap you were right! :)
P.S. 2: Verified locally and works for me


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
