### PR TITLE
📖  Sync cluster-api-state-metrics proposal to match implementation state.

### DIFF
--- a/docs/proposals/20220411-cluster-api-state-metrics.md
+++ b/docs/proposals/20220411-cluster-api-state-metrics.md
@@ -10,7 +10,7 @@ reviewers:
   - "@apricote"
   - "@fabriziopandini"
 creation-date: 2022-03-03
-last-updated: 2022-03-15
+last-updated: 2022-09-07
 status: experimental
 ---
 
@@ -34,12 +34,12 @@ status: experimental
       - [Scrapable Information](#scrapable-information)
       - [Relationship to kube-state-metrics](#relationship-to-kube-state-metrics)
       - [How does kube-state-metrics work](#how-does-kube-state-metrics-work)
-      - [Reuse kube-state-metrics packages](#reuse-kube-state-metrics-packages)
-      - [Package structure for cluster-api-state-metrics](#package-structure-for-cluster-api-state-metrics)
+    - [Use kube-state-metrics custom resource configuration](#use-kube-state-metrics-custom-resource-configuration)
     - [Security Model](#security-model)
     - [Risks and Mitigations](#risks-and-mitigations)
   - [Alternatives](#alternatives)
-    - [Directly use kube-state-metrics](#directly-use-kube-state-metrics)
+    - [Reuse kube-state-metrics packages](#reuse-kube-state-metrics-packages)
+      - [Package structure for cluster-api-state-metrics](#package-structure-for-cluster-api-state-metrics)
     - [Expose metrics by the controllers](#expose-metrics-by-the-controllers)
   - [Upgrade Strategy](#upgrade-strategy)
   - [Additional Details](#additional-details)
@@ -63,23 +63,25 @@ Refer to the [Cluster API Book Glossary].
 
 ## Summary
 
-This proposal outlines a new experimental component for exposing metrics specific to CAPI's CRs.
+This proposal outlines adding kube-state-metrics as a new component for exposing metrics specific to CAPI's CRs.
 
-This component is derived from  [mercedes-benz/cluster-api-state-metrics] and all the merits for its inception goes to the team that created it: [@chrischdi](https://github.com/chrischdi), [@seanschneeweiss](https://github.com/seanschneeweiss), [@tobiasgiese](https://github.com/tobiasgiese).
+This solution is derived from [mercedes-benz/cluster-api-state-metrics] and all the merits for its inception goes to the team that created it: [@chrischdi](https://github.com/chrischdi), [@seanschneeweiss](https://github.com/seanschneeweiss), [@tobiasgiese](https://github.com/tobiasgiese).
 
 A special thank goes to [Mercedes-Benz] who allowed the donation of this project to CNCF and to the Cluster API community.
+
+Also it builds up on the custom resource feature of [kube-state-metrics] which was introduced in v2.5.0 and improved in v2.6.0.
 
 ## Motivation
 
 As of now CAPI controllers only expose metrics that are provided by controller-runtime, which in turn are specific to the controllers internal behavior and thus do not provide any information about the state of the clusters provisioned by CAPI.
 
-This proposal introduces a new component that can generate a new set of metrics that will help end users to monitor the state of the Cluster API resources in their [OpenMetrics] compatible monitoring system of choice.
+This proposal introduces a kube-state-metrics and Custom Resource configuration to generate a new set of metrics that will help end users to monitor the state of the Cluster API resources in their [OpenMetrics] compatible monitoring system of choice.
 
 ### Goals
 
 - Define metrics to monitor the state of the Cluster API resources, thus solving parts of the [metrics umbrella issue #1477]
-- Implementing a new component, which exposes the above metrics by following the [OpenMetrics] standard
-- Make metrics part of the CAPI developer workflow by making them accessible via Tilt and possible also as a E2E test artifacts
+- Adding Custom Resource configuration for kube-state-metrics, which then exposes the below metrics by following the [OpenMetrics] standard
+- Make metrics part of the CAPI developer workflow by making them accessible via Tilt
 - Implement metrics for core CAPI CRs
 
 ### Non-Goals
@@ -93,12 +95,18 @@ This proposal introduces a new component that can generate a new set of metrics 
   - a KubeadmControlPlane is not healthy.
   - 70% of my worker Machines are not healthy.
   - 70% of my Machines are blocked on deletion.
+- Auto-generation of the metric definition from markers at the type definitions.
+- Introduction of generic `*_labels` metrics which work in the same way as `kube_*_labels` metrics.
+  - This needs implementation on kube-state-metrics side to also include using the configuration from the existing flags.
+  - For now, a custom user-specified `Info` metric could get configured to create a customized `*_labels` metric which exposes explicitly listed labels.
 
 ## Proposal
 
-This proposal introduces a CAPI specific kube-state-metrics named `cluster-api-state-metrics` to expose metrics for CAPI specific CRs.
+This proposal introduces a CAPI specific configuration for kube-state-metrics to expose metrics for CAPI specific CRs.
 
-The implementation will be deployed as a separate component by using the provided yaml files. In future it may be integrated into the core provider manifest to deploy it automatically using `clusterctl`.
+The configuration could be deployed using the kube-state-metrics helm chart and should leverage the custom-resource configuration file.
+
+In future the configuration for kube-state-metrics may be added to the release artifacts of CAPI.
 
 ### User Stories
 
@@ -108,7 +116,7 @@ As a service provider/cluster operator, I want to have metrics for the Cluster A
 
 #### Story 2
 
-As an application developer, I would like to deploy cluster-api-state-metrics together with the prometheus stack via Tilt. This allows further analysis by using the metrics like measuring the duration of several provisioning phases.
+As an application developer, I would like to deploy kube-state-metrics including the CAPI configuration together with the prometheus stack via Tilt. This allows further analysis by using the metrics like measuring the duration of several provisioning phases.
 
 ### Implementation Details/Notes/Constraints
 
@@ -116,7 +124,7 @@ As an application developer, I would like to deploy cluster-api-state-metrics to
 
 Following Cluster API CRDs currently exist.
 The *In-scope* column marks CRDs for which metrics should be exposed.
-In future iterations other CRs may be added or the cluster-api-state-metrics could be extended to support provider specific CRDs too.
+In future iterations other CRs or configuration for provider specific CRDs could be added.
 
 | Name                      | API Group/Version                       | In-scope |
 |---------------------------|-----------------------------------------|----------|
@@ -174,9 +182,30 @@ It caches the current state of the metrics using an internal cache and updates t
 
 On requests to `/metrics` the cached data gets concatenated to a single string and returned as a response.
 
-#### Reuse kube-state-metrics packages
+### Use kube-state-metrics custom resource configuration
 
-Cluster-api-state-metrics should re-use as many packages provided by kube-state-metrics as possible. This allows re-use of flags, configuration and extended functionality like sharding or tls configuration without additional implementation.
+kube-state-metrics v2.5.0 introduced an experimental feature to create metrics for CRDs.
+The feature for v2.5.0 did not fulfill all requirements for the metrics of this proposal.
+Because of that improvements got contributed to kube-state-metrics to improve the feature and support more use-cases, including the metrics of this proposal.
+
+For the implementation of this proposal a proper configuration file for kube-state-metrics should be provided and kube-state-metrics should be used to expose the metrics.
+
+### Security Model
+
+- RBAC definitions should be generated for markers at the type definitions in future.
+- RBAC definitions should only grant `get`, `list` and `watch` permissions to CRs relevant for the application.
+
+### Risks and Mitigations
+
+This initial implementation provides a baseline on which incremental changes can be introduced in the future. Instead of encompassing all possible use cases under a single proposal, this proposal mitigates the risk of waiting too long to consider all required use cases regarding this topic.
+
+## Alternatives
+
+### Reuse kube-state-metrics packages
+
+Cluster-api-state-metrics could re-use packages provided by kube-state-metrics to implement the metrics. This allows re-use of flags, configuration and extended functionality like sharding or tls configuration without additional implementation.
+
+When first writing the proposal, this was the favoured option because at that state, kube-state-metrics did not support configuration for custom resource metrics. As of today this is not the case anymore.
 
 An [extension mechanism](https://github.com/kubernetes/kube-state-metrics/pull/1644) was introduced to the kube-state-metrics packages which allows using its basic mechanism but defining custom metrics for Custom Resources.
 The `k8s.io/kube-state-metrics/v2/pkg/customresource.RegistryFactory`[[2]] interface was [introduced](https://github.com/kubernetes/kube-state-metrics/pull/1644) to allow defining custom metrics for Custom Resources while leveraging kube-state-metrics logic.
@@ -197,34 +226,9 @@ These `customresource.RegistryFactory` implementations get used in a `main.go` w
   - imports and uses `k8s.io/kube-state-metrics/v2/pkg/options.NewOptions()`[[3]] to define the same cli flags and options as kube-state-metrics, except the enabled metrics.
   - imports and uses `k8s.io/kube-state-metrics/v2/pkg/app.RunKubeStateMetrics(...)`[[3]] to start the metrics server using the given options and the custom registry factory from `store.Factories()`.
 
-### Security Model
-
-- RBAC definitions should be generated via kubebuilder annotations.
-- RBAC definitions should only grant `get`, `list` and `watch` permissions to CRs relevant for the application.
-
-### Risks and Mitigations
-
-This initial implementation provides a baseline on which incremental changes can be introduced in the future. Instead of encompassing all possible use cases under a single proposal, this proposal mitigates the risk of waiting too long to consider all required use cases regarding this topic.
-
-## Alternatives
-
-### Directly use kube-state-metrics
-
-> [kube-state-metrics] is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
-
-On a first thought, using kube-state-metrics would be a great fit to retrieve the desired metrics. However, kube-state-metrics does not plan to implement metrics for CRs of CRDs:
-
-> There is no meaningful extension kube-state-metrics can do other than potentially providing a library to reuse the mechanisms built in this repository. [[4]]
-
-The linked issue also states that:
-
-> operators should expose metrics about the objects they expose themselves. [[4]]
-
-Because of that kube-state-metrics itself does not fit this use-case.
-
 ### Expose metrics by the controllers
 
-To solve this in the spirit of the kube-state-metrics maintainers it may make sense to implement the metrics directly within the CAPI controllers.
+It may make sense to implement the metrics directly within the CAPI controllers.
 This might be a working solution but would impose following disadvantages:
 
 - Requires changes in at least 3 controllers:
@@ -238,7 +242,9 @@ Nevertheless, including metrics directly in the controllers may be valid for fut
 
 ## Upgrade Strategy
 
-Cluster-api-state-metrics could follow the API versions of the CAPI controllers. By using a seperate go package using its own `go.mod` file we can prevent adding transitive dependencies to the core module. A `replace` directive inside the `go.mod` can ensure that always the same version will be used for the `sigs.k8s.io/cluster-api` dependency.
+After being introduced and validated to be valuable, the configuration file for kube-state-metrics could be provided as release artifact.
+A user could also update its kube-state-metrics configuration after upgrading Cluster API to expose the latest compatible metrics.
+The conversion webhooks provided by the controllers for the Custom Resources allow to still expose metrics during the version shift, even when the default APIVersion gets changed by the Cluster API upgrade.
 
 ## Additional Details
 
@@ -250,13 +256,16 @@ Common labels:
 
 - `cluster=<cluster-name>`
 
-| metric name                     | value                                       | type  | additional labels/tags                         | xref                    |
-|---------------------------------|---------------------------------------------|-------|------------------------------------------------|-------------------------|
-| `capi_cluster_labels`           | `1`                                         | Gauge | `.metadata.labels`                             | common                  |
-| `capi_cluster_created`          | `.metadata.creationTimestamp`               | Gauge |                                                | common                  |
-| `capi_cluster_paused`           | `.spec.paused` or `annotations.HasPaused()` | Gauge |                                                |                         |
-| `capi_cluster_status_condition` | `.status.conditions==<condition>`           | Gauge | `condition=<condition>` `status=<true\|false>` |                         |
-| `capi_cluster_status_phase`     | `.status.phase==<phase>`                    | Gauge | `phase=<phase>`                                | [Pod], [cluster phases] |
+| metric name                        | value                             | type  | additional labels/tags                                                                                                                                                                                               | xref                    |
+|------------------------------------|-----------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
+| `capi_cluster_created`             | `.metadata.creationTimestamp`     | Gauge |                                                                                                                                                                                                                      | common                  |
+| `capi_cluster_annotation_paused` * | `1`                               | Gauge | `paused_value=<paused annotation value>`                                                                                                                                                                             |                         |
+| `capi_cluster_info`                | `1`                               | Gauge |                                                                                                                                                                                                                      |                         |
+| `capi_cluster_spec_paused`         | `.spec.paused`                    | Gauge | `topology_version=.spec.topology.version`<br>`topology_class=.spec.topology.class`<br>`control_plane_endpoint_host=.spec.controlPlaneEndpoint.host`<br>`control_plane_endpoint_port=.spec.controlPlaneEndpoint.port` |                         |
+| `capi_cluster_status_condition`    | `.status.conditions==<condition>` | Gauge | `condition=<condition>` `status=<true\|false>`                                                                                                                                                                       |                         |
+| `capi_cluster_status_phase`        | `.status.phase==<phase>`          | Gauge | `phase=<phase>`                                                                                                                                                                                                      | [Pod], [cluster phases] |
+
+*: A metric will only be exposed if the annotation existst. If so it will always have a value of `1` and expose a label which contains its value. Prometheus would drop labels having an empty value, which is why an empty value would be equal to a not set annotation otherwise.
 
 #### KubeadmControlPlane CR
 
@@ -266,9 +275,8 @@ Common labels:
 
 | metric name                                                      | value                                          | type  | additional labels/tags                              | xref         |
 |------------------------------------------------------------------|------------------------------------------------|-------|-----------------------------------------------------|--------------|
-| `capi_kubeadmcontrolplane_labels`                                | `1`                                            | Gauge | `.metadata.labels`                                  | common       |
 | `capi_kubeadmcontrolplane_created`                               | `.metadata.creationTimestamp`                  | Gauge |                                                     | common       |
-| `capi_kubeadmcontrolplane_paused`                                | `annotations.HasPaused()`                      | Gauge |                                                     |              |
+| `capi_kubeadmcontrolplane_annotation_paused` *                   | `1`                                            | Gauge | `paused_value=<paused annotation value>`            |              |
 | `capi_kubeadmcontrolplane_status_condition`                      | `.status.conditions==<condition>`              | Gauge | `condition=<condition>` `status=<true\|false>`      |              |
 | `capi_kubeadmcontrolplane_status_replicas`                       | `.status.replicas`                             | Gauge |                                                     | [Deployment] |
 | `capi_kubeadmcontrolplane_status_replicas_ready`                 | `.status.readyReplicas`                        | Gauge |                                                     | [Deployment] |
@@ -279,6 +287,8 @@ Common labels:
 | `capi_kubeadmcontrolplane_info`                                  | `1`                                            | Gauge | `version=.spec.version`                             | [Pod]        |
 | `capi_kubeadmcontrolplane_owner`                                 | `1`                                            | Gauge | `owner_kind=<owner kind>` `owner_name=<owner name>` | [ReplicaSet] |
 
+*: A metric will only be exposed if the annotation existst. If so it will always have a value of `1` and expose a label which contains its value. Prometheus would drop labels having an empty value, which is why an empty value would be equal to a not set annotation otherwise.
+
 #### MachineDeployment CR
 
 Common labels:
@@ -287,12 +297,13 @@ Common labels:
 
 | metric name                                                          | value                                         | type  | additional labels/tags                              | xref                              |
 |----------------------------------------------------------------------|-----------------------------------------------|-------|-----------------------------------------------------|-----------------------------------|
-| `capi_machinedeployment_labels`                                      | `1`                                           | Gauge | `.metadata.labels`                                  | common                            |
 | `capi_machinedeployment_created`                                     | `.metadata.creationTimestamp`                 | Gauge |                                                     | common                            |
-| `capi_machinedeployment_paused`                                      | `.Spec.Paused` or `annotations.HasPaused()`   | Gauge |                                                     |                                   |
+| `capi_machinedeployment_annotation_paused` *                         | `1`                                           | Gauge | `paused_value=<paused annotation value>`            |                                   |
+| `capi_machinedeployment_spec_paused`                                 | `.Spec.Paused`                                | Gauge |                                                     |                                   |
 | `capi_machinedeployment_status_condition`                            | `.status.conditions==<condition>`             | Gauge | `condition=<condition>` `status=<true\|false>`      |                                   |
 | `capi_machinedeployment_status_replicas`                             | `.status.replicas`                            | Gauge |                                                     | [Deployment]                      |
 | `capi_machinedeployment_status_replicas_available`                   | `.status.availableReplicas`                   | Gauge |                                                     | [Deployment]                      |
+| `capi_machinedeployment_status_replicas_ready`                       | `.status.readyReplicas`                       | Gauge |                                                     | [Deployment]                      |
 | `capi_machinedeployment_status_replicas_unavailable`                 | `.status.unavailableReplicas`                 | Gauge |                                                     | [Deployment]                      |
 | `capi_machinedeployment_status_replicas_updated`                     | `.status.updatedReplicas`                     | Gauge |                                                     | [Deployment]                      |
 | `capi_machinedeployment_spec_replicas`                               | `.spec.replicas`                              | Gauge |                                                     | [Deployment]                      |
@@ -300,6 +311,8 @@ Common labels:
 | `capi_machinedeployment_spec_strategy_rollingupdate_max_surge`       | `.spec.strategy.rollingUpdate.maxSurge`       | Gauge |                                                     | [Deployment]                      |
 | `capi_machinedeployment_status_phase`                                | `.status.phase==<phase>`                      | Gauge | `phase=<phase>`                                     | [Pod], [machinedeployment phases] |
 | `capi_machinedeployment_owner`                                       | `1`                                           | Gauge | `owner_kind=<owner kind>` `owner_name=<owner name>` | [ReplicaSet]                      |
+
+*: A metric will only be exposed if the annotation existst. If so it will always have a value of `1` and expose a label which contains its value. Prometheus would drop labels having an empty value, which is why an empty value would be equal to a not set annotation otherwise.
 
 #### MachineSet CR
 
@@ -309,9 +322,8 @@ Common labels:
 
 | metric name                                     | value                             | type  | additional labels/tags                              | xref         |
 |-------------------------------------------------|-----------------------------------|-------|-----------------------------------------------------|--------------|
-| `capi_machineset_labels`                        | `1`                               | Gauge | `.metadata.labels`                                  | common       |
 | `capi_machineset_created`                       | `.metadata.creationTimestamp`     | Gauge |                                                     | common       |
-| `capi_machineset_paused`                        | `annotations.HasPaused()`         | Gauge |                                                     |              |
+| `capi_machineset_annotation_paused` *           | `1`                               | Gauge | `paused_value=<paused annotation value>`            |              |
 | `capi_machineset_status_available_replicas`     | `.status.availableReplicas`       | Gauge |                                                     | [ReplicaSet] |
 | `capi_machineset_status_condition`              | `.status.conditions==<condition>` | Gauge | `condition=<condition>` `status=<true\|false>`      |              |
 | `capi_machineset_status_replicas`               | `.status.replicas`                | Gauge |                                                     | [ReplicaSet] |
@@ -320,22 +332,25 @@ Common labels:
 | `capi_machineset_spec_replicas`                 | `.spec.replicas`                  | Gauge |                                                     | [ReplicaSet] |
 | `capi_machineset_owner`                         | `1`                               | Gauge | `owner_kind=<owner kind>` `owner_name=<owner name>` | [ReplicaSet] |
 
+*: A metric will only be exposed if the annotation existst. If so it will always have a value of `1` and expose a label which contains its value. Prometheus would drop labels having an empty value, which is why an empty value would be equal to a not set annotation otherwise.
+
 #### Machine CR
 
 Common labels:
 
 - `machine=<machine-name>`
 
-| metric name                     | value                             | type  | additional labels/tags                                                                                                                       | xref                    |
-|---------------------------------|-----------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
-| `capi_machine_labels`           | `1`                               | Gauge | `.metadata.labels`                                                                                                                           | common                  |
-| `capi_machine_created`          | `.metadata.creationTimestamp`     | Gauge |                                                                                                                                              | common                  |
-| `capi_machine_paused`           | `annotations.HasPaused()`         | Gauge |                                                                                                                                              |                         |
-| `capi_machine_status_condition` | `.status.conditions==<condition>` | Gauge | `condition=<condition>`<br>`status=<true\|false>`                                                                                            |                         |
-| `capi_machine_status_phase`     | `.status.phase==<phase>`          | Gauge | `phase=<phase>`                                                                                                                              | [Pod], [machine phases] |
-| `capi_machine_owner`            | `1`                               | Gauge | `owner_kind=<owner kind>`<br>`owner_name=<owner name>`                                                                                       | [ReplicaSet]            |
-| `capi_machine_info`             | `1`                               | Gauge | `internal_ip=<.status.addresses>`<br>`version=<.spec.version>`<br>`provider_id=<.spec.providerID>`<br>`failure_domain=<.spec.failureDomain>` | [Pod]                   |
-| `capi_machine_status_noderef`   | `1`                               | Gauge | `node=<.status.nodeRef.name>`                                                                                                                |                         |
+| metric name                        | value                             | type  | additional labels/tags                                                                                                                       | xref                    |
+|------------------------------------|-----------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
+| `capi_machine_created`             | `.metadata.creationTimestamp`     | Gauge |                                                                                                                                              | common                  |
+| `capi_machine_annotation_paused` * | `1`                               | Gauge | `paused_value=<paused annotation value>`                                                                                                     |                         |
+| `capi_machine_status_condition`    | `.status.conditions==<condition>` | Gauge | `condition=<condition>`<br>`status=<true\|false>`                                                                                            |                         |
+| `capi_machine_status_phase`        | `.status.phase==<phase>`          | Gauge | `phase=<phase>`                                                                                                                              | [Pod], [machine phases] |
+| `capi_machine_owner`               | `1`                               | Gauge | `owner_kind=<owner kind>`<br>`owner_name=<owner name>`                                                                                       | [ReplicaSet]            |
+| `capi_machine_info`                | `1`                               | Gauge | `internal_ip=<.status.addresses>`<br>`version=<.spec.version>`<br>`provider_id=<.spec.providerID>`<br>`failure_domain=<.spec.failureDomain>` | [Pod]                   |
+| `capi_machine_status_noderef`      | `1`                               | Gauge | `node=<.status.nodeRef.name>`                                                                                                                |                         |
+
+*: A metric will only be exposed if the annotation existst. If so it will always have a value of `1` and expose a label which contains its value. Prometheus would drop labels having an empty value, which is why an empty value would be equal to a not set annotation otherwise.
 
 #### MachineHealthCheck CR
 
@@ -343,22 +358,25 @@ Common labels:
 
 - `machinehealthcheck=<machinehealthcheck-name>`
 
-| metric name                                           | value                             | type  | additional labels/tags                            | xref   |
-|-------------------------------------------------------|-----------------------------------|-------|---------------------------------------------------|--------|
-| `capi_machinehealthcheck_labels`                      | `1`                               | Gauge | `.metadata.labels`                                | common |
-| `capi_machinehealthcheck_created`                     | `.metadata.creationTimestamp`     | Gauge |                                                   | common |
-| `capi_machinehealthcheck_paused`                      | `annotations.HasPaused()`         | Gauge |                                                   |        |
-| `capi_machinehealthcheck_status_condition`            | `.status.conditions==<condition>` | Gauge | `condition=<condition>`<br>`status=<true\|false>` |        |
-| `capi_machinehealthcheck_status_expected_machines`    | `.status.expectedMachines`        | Gauge |                                                   |        |
-| `capi_machinehealthcheck_status_current_healthy`      | `.status.currentHealthy`          | Gauge |                                                   |        |
-| `capi_machinehealthcheck_status_remediations_allowed` | `.status.remediationsAllowed`     | Gauge |                                                   |        |
+| metric name                                           | value                             | type  | additional labels/tags                                 | xref         |
+|-------------------------------------------------------|-----------------------------------|-------|--------------------------------------------------------|--------------|
+| `capi_machinehealthcheck_created`                     | `.metadata.creationTimestamp`     | Gauge |                                                        | common       |
+| `capi_machinehealthcheck_annotation_paused` *         | `1`                               | Gauge | `paused_value=<paused annotation value>`               |              |
+| `capi_machinehealthcheck_owner`                       | `1`                               | Gauge | `owner_kind=<owner kind>`<br>`owner_name=<owner name>` | [ReplicaSet] |
+| `capi_machinehealthcheck_status_condition`            | `.status.conditions==<condition>` | Gauge | `condition=<condition>`<br>`status=<true\|false>`      |              |
+| `capi_machinehealthcheck_status_expected_machines`    | `.status.expectedMachines`        | Gauge |                                                        |              |
+| `capi_machinehealthcheck_status_current_healthy`      | `.status.currentHealthy`          | Gauge |                                                        |              |
+| `capi_machinehealthcheck_status_remediations_allowed` | `.status.remediationsAllowed`     | Gauge |                                                        |              |
+
+*: A metric will only be exposed if the annotation existst. If so it will always have a value of `1` and expose a label which contains its value. Prometheus would drop labels having an empty value, which is why an empty value would be equal to a not set annotation otherwise.
 
 ### Gaduation Criteria
 
-The initial plan is to add cluster-api-state-metrics as an experimental feature under `exp/` and allow it to be enabled via `tilt`.
+The initial plan is to add kube-state-metrics as to the `./hack/observability` directory and allow it to be enabled via `tilt`.
 
 ## Implementation History
 
+- [x] 09/07/2022: Updated proposal to match current implementation state, removed `_labels` metrics due to lack of functionality in kube-state-metrics
 - [x] 03/02/2022: Proposed idea in an issue or [community meeting]
 - [x] 03/15/2022: Compile a Google Doc following the CAEP template
 - [x] 03/16/2022: Present proposal at a [community meeting]


### PR DESCRIPTION
**What this PR does / why we need it**:

Syncs the cluster-api-state-metrics proposal to match implementation state.
Implementation was mostly done in #7095

This also removes the `_labels` metric references. There are kube-state-metrics specific flags regarding these metric which won't affect custom resource configuration (allow/deny-list). Exposing all metrics would lead increase the cardinality without being worth it. Use-case specific configuration should be added by the user if required.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #6458
