### PR TITLE
:book: Add "KCP" to glossary

### DIFF
--- a/docs/book/src/reference/glossary.md
+++ b/docs/book/src/reference/glossary.md
@@ -172,6 +172,10 @@ A cluster that passes the Kubernetes conformance tests.
 
 Refers to the [main Kubernetes git repository](https://github.com/kubernetes/kubernetes) or the main Kubernetes project.
 
+### KCP
+
+Kubeadm Control plane Provider
+
 # L
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the definition of `KCP` to the glossary page.

reference: https://github.com/kubernetes-sigs/cluster-api/blob/main/CONTRIBUTING.md#contributors-ladder

