### PR TITLE
✨ Reduce github api requests in clusterctl by querying go modules

### DIFF
--- a/cmd/clusterctl/client/config/cert_manager.go
+++ b/cmd/clusterctl/client/config/cert_manager.go
@@ -19,7 +19,7 @@ package config
 // CertManager defines cert-manager configuration.
 type CertManager interface {
 	// URL returns the name of the cert-manager repository.
-	// If empty, "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml" will be used.
+	// If empty, "https://github.com/cert-manager/cert-manager/releases/{DefaultVersion}/cert-manager.yaml" will be used.
 	URL() string
 
 	// Version returns the cert-manager version to install.

--- a/cmd/clusterctl/client/config/cert_manager_client.go
+++ b/cmd/clusterctl/client/config/cert_manager_client.go
@@ -32,9 +32,9 @@ const (
 	CertManagerDefaultVersion = "v1.10.0"
 
 	// CertManagerDefaultURL defines the default cert-manager repository url to be used by clusterctl.
-	// NOTE: At runtime /latest will be replaced with the CertManagerDefaultVersion or with the
+	// NOTE: At runtime CertManagerDefaultVersion may be replaced with the
 	// version defined by the user in the clusterctl configuration file.
-	CertManagerDefaultURL = "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"
+	CertManagerDefaultURL = "https://github.com/cert-manager/cert-manager/releases/" + CertManagerDefaultVersion + "/cert-manager.yaml"
 
 	// CertManagerDefaultTimeout defines the default cert-manager timeout to be used by clusterctl.
 	CertManagerDefaultTimeout = 10 * time.Minute

--- a/cmd/clusterctl/client/repository/goproxy.go
+++ b/cmd/clusterctl/client/repository/goproxy.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repository
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	defaultGoProxyHost = "proxy.golang.org"
+)
+
+type goproxyClient struct {
+	scheme string
+	host   string
+}
+
+func newGoproxyClient(scheme, host string) *goproxyClient {
+	return &goproxyClient{
+		scheme: scheme,
+		host:   host,
+	}
+}
+
+func (g *goproxyClient) getVersions(ctx context.Context, base, owner, repository string) ([]string, error) {
+	// A goproxy is also able to handle the github repository path instead of the actual go module name.
+	gomodulePath := path.Join(base, owner, repository)
+
+	rawURL := url.URL{
+		Scheme: g.scheme,
+		Host:   g.host,
+		Path:   path.Join(gomodulePath, "@v", "/list"),
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL.String(), http.NoBody)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get versions: failed to create request")
+	}
+
+	var rawResponse []byte
+	var retryError error
+	_ = wait.PollImmediateWithContext(ctx, retryableOperationInterval, retryableOperationTimeout, func(ctx context.Context) (bool, error) {
+		retryError = nil
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			retryError = errors.Wrapf(err, "failed to get versions: failed to do request")
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			retryError = errors.Errorf("failed to get versions: response status code %d", resp.StatusCode)
+			return false, nil
+		}
+
+		rawResponse, err = io.ReadAll(resp.Body)
+		if err != nil {
+			retryError = errors.Wrap(err, "failed to get versions: error reading goproxy response body")
+			return false, nil
+		}
+		return true, nil
+	})
+	if retryError != nil {
+		return nil, retryError
+	}
+
+	parsedVersions := semver.Versions{}
+	for _, s := range strings.Split(string(rawResponse), "\n") {
+		if s == "" {
+			continue
+		}
+		parsedVersion, err := semver.ParseTolerant(s)
+		if err != nil {
+			// Discard releases with tags that are not a valid semantic versions (the user can point explicitly to such releases).
+			continue
+		}
+		parsedVersions = append(parsedVersions, parsedVersion)
+	}
+
+	sort.Sort(parsedVersions)
+
+	versions := []string{}
+	for _, v := range parsedVersions {
+		versions = append(versions, "v"+v.String())
+	}
+
+	return versions, nil
+}
+
+// getGoproxyHost detects and returns the scheme and host for goproxy requests.
+// It returns empty strings if goproxy is disabled via `off` or `direct` values.
+func getGoproxyHost(goproxy string) (string, string, error) {
+	// Fallback to default
+	if goproxy == "" {
+		return "https", defaultGoProxyHost, nil
+	}
+
+	var goproxyHost, goproxyScheme string
+	// xref https://github.com/golang/go/blob/master/src/cmd/go/internal/modfetch/proxy.go
+	for goproxy != "" {
+		var rawURL string
+		if i := strings.IndexAny(goproxy, ",|"); i >= 0 {
+			rawURL = goproxy[:i]
+			goproxy = goproxy[i+1:]
+		} else {
+			rawURL = goproxy
+			goproxy = ""
+		}
+
+		rawURL = strings.TrimSpace(rawURL)
+		if rawURL == "" {
+			continue
+		}
+		if rawURL == "off" || rawURL == "direct" {
+			// Return nothing to fallback to github repository client without an error.
+			return "", "", nil
+		}
+
+		// Single-word tokens are reserved for built-in behaviors, and anything
+		// containing the string ":/" or matching an absolute file path must be a
+		// complete URL. For all other paths, implicitly add "https://".
+		if strings.ContainsAny(rawURL, ".:/") && !strings.Contains(rawURL, ":/") && !filepath.IsAbs(rawURL) && !path.IsAbs(rawURL) {
+			rawURL = "https://" + rawURL
+		}
+
+		parsedURL, err := url.Parse(rawURL)
+		if err != nil {
+			return "", "", errors.Wrapf(err, "parse GOPROXY url %q", rawURL)
+		}
+		goproxyHost = parsedURL.Host
+		goproxyScheme = parsedURL.Scheme
+		// A host was found so no need to continue.
+		break
+	}
+
+	return goproxyScheme, goproxyHost, nil
+}

--- a/cmd/clusterctl/client/repository/goproxy_test.go
+++ b/cmd/clusterctl/client/repository/goproxy_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repository
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_getGoproxyHost(t *testing.T) {
+	retryableOperationInterval = 200 * time.Millisecond
+	retryableOperationTimeout = 1 * time.Second
+
+	tests := []struct {
+		name       string
+		envvar     string
+		wantScheme string
+		wantHost   string
+		wantErr    bool
+	}{
+		{
+			name:       "defaulting",
+			envvar:     "",
+			wantScheme: "https",
+			wantHost:   "proxy.golang.org",
+			wantErr:    false,
+		},
+		{
+			name:       "direct falls back to empty strings",
+			envvar:     "direct",
+			wantScheme: "",
+			wantHost:   "",
+			wantErr:    false,
+		},
+		{
+			name:       "off falls back to empty strings",
+			envvar:     "off",
+			wantScheme: "",
+			wantHost:   "",
+			wantErr:    false,
+		},
+		{
+			name:       "other goproxy",
+			envvar:     "foo.bar.de",
+			wantScheme: "https",
+			wantHost:   "foo.bar.de",
+			wantErr:    false,
+		},
+		{
+			name:       "other goproxy comma separated, return first",
+			envvar:     "foo.bar,foobar.barfoo",
+			wantScheme: "https",
+			wantHost:   "foo.bar",
+			wantErr:    false,
+		},
+		{
+			name:       "other goproxy including https scheme",
+			envvar:     "https://foo.bar",
+			wantScheme: "https",
+			wantHost:   "foo.bar",
+			wantErr:    false,
+		},
+		{
+			name:       "other goproxy including http scheme",
+			envvar:     "http://foo.bar",
+			wantScheme: "http",
+			wantHost:   "foo.bar",
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotScheme, gotHost, err := getGoproxyHost(tt.envvar)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getGoproxyHost() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotScheme != tt.wantScheme {
+				t.Errorf("getGoproxyHost() = %v, wantScheme %v", gotScheme, tt.wantScheme)
+			}
+			if gotHost != tt.wantHost {
+				t.Errorf("getGoproxyHost() = %v, wantHost %v", gotHost, tt.wantHost)
+			}
+		})
+	}
+}

--- a/cmd/clusterctl/client/repository/repository_github.go
+++ b/cmd/clusterctl/client/repository/repository_github.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -34,6 +35,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
+	logf "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 )
 
 const (
@@ -68,6 +70,7 @@ type gitHubRepository struct {
 	rootPath                 string
 	componentsPath           string
 	injectClient             *github.Client
+	injectGoproxyClient      *goproxyClient
 }
 
 var _ Repository = &gitHubRepository{}
@@ -80,6 +83,12 @@ func injectGithubClient(c *github.Client) githubRepositoryOption {
 	}
 }
 
+func injectGoproxyClient(c *goproxyClient) githubRepositoryOption {
+	return func(g *gitHubRepository) {
+		g.injectGoproxyClient = c
+	}
+}
+
 // DefaultVersion returns defaultVersion field of gitHubRepository struct.
 func (g *gitHubRepository) DefaultVersion() string {
 	return g.defaultVersion
@@ -87,10 +96,36 @@ func (g *gitHubRepository) DefaultVersion() string {
 
 // GetVersions returns the list of versions that are available in a provider repository.
 func (g *gitHubRepository) GetVersions() ([]string, error) {
-	versions, err := g.getVersions()
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get repository versions")
+	log := logf.Log
+
+	cacheID := fmt.Sprintf("%s/%s", g.owner, g.repository)
+	if versions, ok := cacheVersions[cacheID]; ok {
+		return versions, nil
 	}
+
+	goProxyClient, err := g.getGoproxyClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "get versions client")
+	}
+
+	var versions []string
+	if goProxyClient != nil {
+		versions, err = goProxyClient.getVersions(context.TODO(), githubDomain, g.owner, g.repository)
+		// Log the error before fallback to github repository client happens.
+		if err != nil {
+			log.V(5).Info("error using Goproxy client to list versions for repository, falling back to github client", "owner", g.owner, "repository", g.repository, "error", err)
+		}
+	}
+
+	// Fallback to github repository client if goProxyClient is nil or an error occurred.
+	if goProxyClient == nil || err != nil {
+		versions, err = g.getVersions()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get repository versions")
+		}
+	}
+
+	cacheVersions[cacheID] = versions
 	return versions, nil
 }
 
@@ -201,6 +236,24 @@ func (g *gitHubRepository) getClient() *github.Client {
 	return github.NewClient(g.authenticatingHTTPClient)
 }
 
+// getGoproxyClient returns a go proxy client.
+// It returns nil, nil if the environment variable is set to `direct` or `off`
+// to skip goproxy requests.
+func (g *gitHubRepository) getGoproxyClient() (*goproxyClient, error) {
+	if g.injectGoproxyClient != nil {
+		return g.injectGoproxyClient, nil
+	}
+	scheme, host, err := getGoproxyHost(os.Getenv("GOPROXY"))
+	if err != nil {
+		return nil, err
+	}
+	// Don't return a client if scheme and host is set to empty string.
+	if scheme == "" && host == "" {
+		return nil, nil
+	}
+	return newGoproxyClient(scheme, host), nil
+}
+
 // setClientToken sets authenticatingHTTPClient field of gitHubRepository struct.
 func (g *gitHubRepository) setClientToken(token string) {
 	ts := oauth2.StaticTokenSource(
@@ -211,11 +264,6 @@ func (g *gitHubRepository) setClientToken(token string) {
 
 // getVersions returns all the release versions for a github repository.
 func (g *gitHubRepository) getVersions() ([]string, error) {
-	cacheID := fmt.Sprintf("%s/%s", g.owner, g.repository)
-	if versions, ok := cacheVersions[cacheID]; ok {
-		return versions, nil
-	}
-
 	client := g.getClient()
 
 	// get all the releases
@@ -253,7 +301,6 @@ func (g *gitHubRepository) getVersions() ([]string, error) {
 		versions = append(versions, tagName)
 	}
 
-	cacheVersions[cacheID] = versions
 	return versions, nil
 }
 

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -112,6 +112,12 @@ To access provider specific information, such as the components YAML to be used 
 `clusterctl init` accesses the **provider repositories**, that are well-known places where the release assets for
 a provider are published.
 
+Per default `clusterctl` will use a go proxy to detect the available versions to prevent additional
+API calls to the GitHub API. It is possible to configure the go proxy url using the `GOPROXY` variable as
+for go itself (defaults to `https://proxy.golang.org`).
+To immediately fallback to the GitHub client and not use a go proxy, the environment variable could get set to
+`GOPROXY=off` or `GOPROXY=direct`.
+
 See [clusterctl configuration](../configuration.md) for more info about provider repository configurations.
 
 <aside class="note">

--- a/docs/book/src/clusterctl/overview.md
+++ b/docs/book/src/clusterctl/overview.md
@@ -28,6 +28,12 @@ While using providers hosted on GitHub, clusterctl is calling GitHub API which a
 
 To avoid rate limiting for the public repos set the `GITHUB_TOKEN` environment variable. To generate a token [follow this](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) documentation. The token only needs `repo` scope for clusterctl.
 
+Per default `clusterctl` will use a go proxy to detect the available versions to prevent additional
+API calls to the GitHub API. It is possible to configure the go proxy url using the `GOPROXY` variable as
+for go itself (defaults to `https://proxy.golang.org`).
+To immediately fallback to the GitHub client and not use a go proxy, the environment variable could get set to
+`GOPROXY=off` or `GOPROXY=direct`.
+
 # Installing clusterctl
 Instructions are available in the [Quick Start](../user/quick-start.md#install-clusterctl).
 

--- a/docs/book/src/clusterctl/provider-contract.md
+++ b/docs/book/src/clusterctl/provider-contract.md
@@ -49,6 +49,12 @@ A GitHub release can be used as a provider repository if:
 See the [GitHub docs](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) for more information
 about how to create a release.
 
+Per default `clusterctl` will use a go proxy to detect the available versions to prevent additional
+API calls to the GitHub API. It is possible to configure the go proxy url using the `GOPROXY` variable as
+for go itself (defaults to `https://proxy.golang.org`).
+To immediately fallback to the GitHub client and not use a go proxy, the environment variable could get set to
+`GOPROXY=off` or `GOPROXY=direct`.
+
 #### Creating a provider repository on GitLab
 
 You can use a GitLab generic packages for provider artifacts.


### PR DESCRIPTION
**What this PR does / why we need it**:

Reduce github api requests in clusterctl

* Removes additional cert-manager latest version detection because it always gets overwritten afterwards anyway.
* Uses goproxy instead of github api for listing repository versions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #3982
