### PR TITLE
🌱 Update versions doc adding Kubernetes 1.25

### DIFF
--- a/docs/book/src/developer/providers/version-migration.md
+++ b/docs/book/src/developer/providers/version-migration.md
@@ -7,3 +7,4 @@ maintainers of other providers and consumers of the Go API in upgrading from one
 - [v0.4 to v1.0](v0.4-to-v1.0.md)
 - [v1.0 to v1.1](v1.0-to-v1.1.md)
 - [v1.1 to v1.2](v1.1-to-v1.2.md)
+- [v1.2 to v1.3](v1.2-to-v1.3.md)

--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -63,17 +63,18 @@ These diagrams show the relationships between components in a Cluster API releas
 
 #### Core Provider (`cluster-api-controller`)
 
-|                   | v0.3 (v1alpha3)      | v0.4 (v1alpha4) 			| v1.0 (v1beta1)      | v1.1 (v1beta1)     | v1.2 (v1beta1)       | v1.3 (v1beta1)      |
-|-------------------|----------------------|----------------------|---------------------|--------------------|----------------------|---------------------|
-| Kubernetes v1.16  | ✓                    |                      |                     |                     |                     |                     |
-| Kubernetes v1.17  | ✓                    |                   	  |                     |                     |                     |                     |
-| Kubernetes v1.18  | ✓                    | ✓ (only workload)    | ✓ (only workload)  	| ✓ (only workload)   | ✓ (only workload)   | ✓ (only workload)  |
-| Kubernetes v1.19  | ✓                    | ✓                    | ✓                   | ✓                   | ✓ (only workload)   | ✓ (only workload)  |
-| Kubernetes v1.20  | ✓                    | ✓                    | ✓                   | ✓                   | ✓                   | ✓                  |
-| Kubernetes v1.21  | ✓                    | ✓                    | ✓                   | ✓                   | ✓                   | ✓                  |
-| Kubernetes v1.22  | ✓ (only workload)    | ✓                    | ✓                   | ✓                   | ✓                   | ✓                  |
-| Kubernetes v1.23* |                      | ✓                    | ✓                   | ✓                   | ✓                   | ✓                  |
-| Kubernetes v1.24  |                      |                      |                     | ✓                   | ✓                   | ✓                  |
+|                   | v0.3 (v1alpha3)      | v0.4 (v1alpha4) 			| v1.0 (v1beta1)      | v1.1 (v1beta1)    | v1.2 (v1beta1)       | v1.3 (v1beta1)      |
+|-------------------|----------------------|----------------------|---------------------|-------------------|----------------------|---------------------|
+| Kubernetes v1.16  | ✓                    |                      |                     |                   |                     |                     |
+| Kubernetes v1.17  | ✓                    |                   	  |                     |                   |                     |                     |
+| Kubernetes v1.18  | ✓                    | ✓ (only workload)    | ✓ (only workload)  	| ✓ (only workload) | ✓ (only workload)   | ✓ (only workload)  |
+| Kubernetes v1.19  | ✓                    | ✓                    | ✓                   | ✓                 | ✓ (only workload)   | ✓ (only workload)  |
+| Kubernetes v1.20  | ✓                    | ✓                    | ✓                   | ✓                 | ✓                   | ✓                  |
+| Kubernetes v1.21  | ✓                    | ✓                    | ✓                   | ✓                 | ✓                   | ✓                  |
+| Kubernetes v1.22  | ✓ (only workload)    | ✓                    | ✓                   | ✓                 | ✓                   | ✓                  |
+| Kubernetes v1.23* |                      | ✓                    | ✓                   | ✓                 | ✓                   | ✓                  |
+| Kubernetes v1.24  |                      |                      |                     | ✓                 | ✓                   | ✓                  |
+| Kubernetes v1.25  |                      |                      |                     |                   | ✓                   | ✓                  |
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
 	 Previous Kubernetes **minor** versions are not affected.
@@ -84,33 +85,35 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 
 #### Kubeadm Bootstrap Provider (`kubeadm-bootstrap-controller`)
 
-|                                                                   | v0.3 (v1alpha3)      | v0.4 (v1alpha4)      | v1.0 (v1beta1)      | v1.1 (v1beta1)       | v1.2 (v1beta1)        | v1.3 (v1beta1)    |
-|-------------------------------------------------------------------|----------------------|----------------------|---------------------|----------------------|----------------------|--------------------|
-| Kubernetes v1.16 + kubeadm/v1beta2                                | ✓                    |                      |                     |                      |                      |                    |
-| Kubernetes v1.17 + kubeadm/v1beta2                                | ✓                    |                      |                     |                      |                      |                    |
-| Kubernetes v1.18 + kubeadm/v1beta2                                | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)    | ✓ (only workload)    | ✓ (only workload)  |
-| Kubernetes v1.19 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                    | ✓ (only workload)    | ✓ (only workload)  |
-| Kubernetes v1.20 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                    | ✓                    | ✓                  |
-| Kubernetes v1.21 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                    | ✓                    | ✓                  |
-| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) | ✓ (only workload)    | ✓                    | ✓                   | ✓                    | ✓                    | ✓                  |
-| Kubernetes v1.23 + kubeadm/v1beta3                                |                      | ✓                    | ✓                   | ✓                    | ✓                    | ✓                  |
-| Kubernetes v1.24 + kubeadm/v1beta3                                |                      |                      |                     | ✓                    | ✓                    | ✓                  |
+|                                                                   | v0.3 (v1alpha3)      | v0.4 (v1alpha4)      | v1.0 (v1beta1)      | v1.1 (v1beta1)    | v1.2 (v1beta1)        | v1.3 (v1beta1)    |
+|-------------------------------------------------------------------|----------------------|----------------------|---------------------|-------------------|----------------------|--------------------|
+| Kubernetes v1.16 + kubeadm/v1beta2                                | ✓                    |                      |                     |                   |                      |                    |
+| Kubernetes v1.17 + kubeadm/v1beta2                                | ✓                    |                      |                     |                   |                      |                    |
+| Kubernetes v1.18 + kubeadm/v1beta2                                | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload) | ✓ (only workload)    | ✓ (only workload)  |
+| Kubernetes v1.19 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                 | ✓ (only workload)    | ✓ (only workload)  |
+| Kubernetes v1.20 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                 | ✓                    | ✓                  |
+| Kubernetes v1.21 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                 | ✓                    | ✓                  |
+| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) | ✓ (only workload)    | ✓                    | ✓                   | ✓                 | ✓                    | ✓                  |
+| Kubernetes v1.23 + kubeadm/v1beta3                                |                      | ✓                    | ✓                   | ✓                 | ✓                    | ✓                  |
+| Kubernetes v1.24 + kubeadm/v1beta3                                |                      |                      |                     | ✓                 | ✓                    | ✓                  |
+| Kubernetes v1.25 + kubeadm/v1beta3                                |                      |                      |                     |                   | ✓                    | ✓                  |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
-|                            |  v0.3 (v1alpha3)     |  v0.4 (v1alpha4)     |  v1.0 (v1beta1)     |  v1.1 (v1beta1)    |  v1.2 (v1beta1)     |  v1.3 (v1beta1)     |
-|----------------------------|----------------------|----------------------|---------------------|--------------------|---------------------|---------------------|
-| Kubernetes v1.16 + etcd/v3 | ✓                    |                      |                     |                    |                     |                     |
-| Kubernetes v1.17 + etcd/v3 | ✓                    |                      |                     |                    |                     |                     |
-| Kubernetes v1.18 + etcd/v3 | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)  | ✓ (only workload)   | ✓ (only workload)   |
-| Kubernetes v1.19 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                  | ✓ (only workload)   | ✓ (only workload)   |
-| Kubernetes v1.20 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                  | ✓                   | ✓                   |
-| Kubernetes v1.21 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                  | ✓                   | ✓                   |
-| Kubernetes v1.22 + etcd/v3 | ✓* (only workload)   | ✓                    | ✓                   | ✓                  | ✓                   | ✓                   |
-| Kubernetes v1.23 + etcd/v3 |                      | ✓*                   | ✓*                  | ✓                  | ✓                   | ✓                   |
-| Kubernetes v1.24 + etcd/v3 |                      |                      |                     | ✓                  | ✓                   | ✓                   |
+|                            |  v0.3 (v1alpha3)     |  v0.4 (v1alpha4)     |  v1.0 (v1beta1)     | v1.1 (v1beta1)    |  v1.2 (v1beta1)     |  v1.3 (v1beta1)     |
+|----------------------------|----------------------|----------------------|---------------------|-------------------|---------------------|---------------------|
+| Kubernetes v1.16 + etcd/v3 | ✓                    |                      |                     |                   |                     |                     |
+| Kubernetes v1.17 + etcd/v3 | ✓                    |                      |                     |                   |                     |                     |
+| Kubernetes v1.18 + etcd/v3 | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload) | ✓ (only workload)   | ✓ (only workload)   |
+| Kubernetes v1.19 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                 | ✓ (only workload)   | ✓ (only workload)   |
+| Kubernetes v1.20 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                 | ✓                   | ✓                   |
+| Kubernetes v1.21 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                 | ✓                   | ✓                   |
+| Kubernetes v1.22 + etcd/v3 | ✓* (only workload)   | ✓                    | ✓                   | ✓                 | ✓                   | ✓                   |
+| Kubernetes v1.23 + etcd/v3 |                      | ✓*                   | ✓*                  | ✓                 | ✓                   | ✓                   |
+| Kubernetes v1.24 + etcd/v3 |                      |                      |                     | ✓                 | ✓                   | ✓                   |
+| Kubernetes v1.25 + etcd/v3 |                      |                      |                     |                   | ✓                   | ✓                   |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Kubernetes 1.25 to the versions.md doc

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #6661
