### PR TITLE
[release-1.2] 🌱 Update versions doc adding Kubernetes 1.25

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -63,17 +63,18 @@ These diagrams show the relationships between components in a Cluster API releas
 
 #### Core Provider (`cluster-api-controller`)
 
-|                   | CAPI v0.3 (v1alpha3) | CAPI v0.4 (v1alpha4) | CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
-|-------------------|----------------------|----------------------|---------------------|--------------------------|
-| Kubernetes v1.16  | ✓                    |                      |                     |                          |
-| Kubernetes v1.17  | ✓                    |                      |                     |                          |
-| Kubernetes v1.18  | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
-| Kubernetes v1.19  | ✓                    | ✓                    | ✓                   | ✓ (only workload v1.2)   |
-| Kubernetes v1.20  | ✓                    | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.21  | ✓                    | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.22  | ✓ (only workload)    | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.23* |                      | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.24  |                      |                      |                     | ✓                        |
+|                   | v0.3 (v1alpha3)      | v0.4 (v1alpha4)   | v1.0 (v1beta1)    | v1.1 (v1beta1)    | v1.2 (v1beta1)    |
+|-------------------|----------------------|-------------------|-------------------|-------------------|-------------------|
+| Kubernetes v1.16  | ✓                    |                   |                   |                   |                   |
+| Kubernetes v1.17  | ✓                    |                   |                   |                   |                   |
+| Kubernetes v1.18  | ✓                    | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.19  | ✓                    | ✓                 | ✓                 | ✓                 | ✓ (only workload) |
+| Kubernetes v1.20  | ✓                    | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.21  | ✓                    | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.22  | ✓ (only workload)    | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.23* |                      | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.24  |                      |                   |                   | ✓                 | ✓                 |
+| Kubernetes v1.25  |                      |                   |                   |                   | ✓                 |
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
    Previous Kubernetes **minor** versions are not affected.
@@ -83,39 +84,43 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 
 #### Kubeadm Bootstrap Provider (`kubeadm-bootstrap-controller`)
 
-|                                                                   | CAPI v0.3 (v1alpha3) | CAPI v0.4 (v1alpha4) | CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
-|-------------------------------------------------------------------|----------------------|----------------------|---------------------|--------------------------|
-| Kubernetes v1.16 + kubeadm/v1beta2                                | ✓                    |                      |                     |                          |
-| Kubernetes v1.17 + kubeadm/v1beta2                                | ✓                    |                      |                     |                          |
-| Kubernetes v1.18 + kubeadm/v1beta2                                | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
-| Kubernetes v1.19 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓ (only workload v1.2)   |
-| Kubernetes v1.20 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.21 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) | ✓ (only workload)    | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.23 + kubeadm/v1beta3                                |                      | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.24 + kubeadm/v1beta3                                |                      |                      |                     | ✓                        |
+|                                                                   | v0.3 (v1alpha3)   | v0.4 (v1alpha4)   | v1.0 (v1beta1)    | v1.1 (v1beta1)    | v1.2 (v1beta1)    |
+|-------------------------------------------------------------------|-------------------|-------------------|-------------------|-------------------|-------------------|
+| Kubernetes v1.16 + kubeadm/v1beta2                                | ✓                 |                   |                   |                   |                   |
+| Kubernetes v1.17 + kubeadm/v1beta2                                | ✓                 |                   |                   |                   |                   |
+| Kubernetes v1.18 + kubeadm/v1beta2                                | ✓                 | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.19 + kubeadm/v1beta2                                | ✓                 | ✓                 | ✓                 | ✓                 | ✓ (only workload) |
+| Kubernetes v1.20 + kubeadm/v1beta2                                | ✓                 | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.21 + kubeadm/v1beta2                                | ✓                 | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) | ✓ (only workload) | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.23 + kubeadm/v1beta3                                |                   | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.24 + kubeadm/v1beta3                                |                   |                   |                   | ✓                 | ✓                 |
+| Kubernetes v1.25 + kubeadm/v1beta3                                |                   |                   |                   |                   | ✓                 |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
-|                            | CAPI v0.3 (v1alpha3) | CAPI v0.4 (v1alpha4) | CAPI v1.0 (v1beta1) | CAPI v1.1+v1.2 (v1beta1) |
-|----------------------------|----------------------|----------------------|---------------------|--------------------------|
-| Kubernetes v1.16 + etcd/v3 | ✓                    |                      |                     |                          |
-| Kubernetes v1.17 + etcd/v3 | ✓                    |                      |                     |                          |
-| Kubernetes v1.18 + etcd/v3 | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload)        |
-| Kubernetes v1.19 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓ (only workload v1.2)   |
-| Kubernetes v1.20 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.21 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.22 + etcd/v3 | ✓* (only workload)   | ✓                    | ✓                   | ✓                        |
-| Kubernetes v1.23 + etcd/v3 |                      | ✓*                   | ✓*                  | ✓                        |
-| Kubernetes v1.24 + etcd/v3 |                      |                      |                     | ✓                        |
+|                            |  v0.3 (v1alpha3)   |  v0.4 (v1alpha4)  |  v1.0 (v1beta1)   | v1.1 (v1beta1)    |  v1.2 (v1beta1)   |
+|----------------------------|--------------------|-------------------|-------------------|-------------------|-------------------|
+| Kubernetes v1.16 + etcd/v3 | ✓                  |                   |                   |                   |                   |
+| Kubernetes v1.17 + etcd/v3 | ✓                  |                   |                   |                   |                   |
+| Kubernetes v1.18 + etcd/v3 | ✓                  | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.19 + etcd/v3 | ✓                  | ✓                 | ✓                 | ✓                 | ✓ (only workload) |
+| Kubernetes v1.20 + etcd/v3 | ✓                  | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.21 + etcd/v3 | ✓                  | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.22 + etcd/v3 | ✓* (only workload) | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.23 + etcd/v3 |                    | ✓*                | ✓*                | ✓                 | ✓                 |
+| Kubernetes v1.24 + etcd/v3 |                    |                   |                   | ✓                 | ✓                 |
+| Kubernetes v1.25 + etcd/v3 |                    |                   |                   |                   | ✓                 |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 
 The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 
 \*  Newer versions of CoreDNS may not be compatible as an upgrade target for clusters managed with Cluster API. Kubernetes versions marked on the table are supported as an upgrade target only if CoreDNS is not upgraded to the latest version supported by the respective Kubernetes version. The versions supported are represented in the below table.
+
+##### CoreDNS
 
 | CAPI Version    | Max CoreDNS Version for Upgrade |
 |-----------------|---------------------------------|


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Cherry-pick of #7194 (+ synced the versions.md in general a bit)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
