### PR TITLE
✨ Enable linters: asasalint, bidichk, durationcheck, errchkjson. Fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,16 @@
 linters:
   disable-all: true
   enable:
+  - asasalint
   - asciicheck
+  - bidichk
   - bodyclose
   - containedctx
   - depguard
   - dogsled
+  - durationcheck
   - errcheck
+  - errchkjson
   - exportloopref
   - gci
   - goconst

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -18,7 +18,7 @@
 FROM maven:3-jdk-8
 
 RUN apt-get update && apt-get install -y --no-install-recommends graphviz=2.42.2-5 fonts-symbola=2.60-1.1 fonts-wqy-zenhei=0.9.45-8 && rm -rf /var/lib/apt/lists/*
-RUN wget -O /plantuml.jar https://github.com/plantuml/plantuml/releases/download/v1.2022.6/plantuml-1.2022.6.jar
+RUN wget -nv -O /plantuml.jar https://github.com/plantuml/plantuml/releases/download/v1.2022.6/plantuml-1.2022.6.jar
 
 # By default, java writes a 'hsperfdata_<username>' directory in the work dir.
 # This directory is not needed; to ensure it is not written, we set `-XX:-UsePerfData`

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -33,7 +33,7 @@ ENV GOPROXY=$goproxy
 # Gets additional CAPD dependencies
 WORKDIR /tmp
 
-RUN curl -LO https://dl.k8s.io/release/v1.25.0/bin/linux/${ARCH}/kubectl && \
+RUN curl -LO "https://dl.k8s.io/release/v1.25.0/bin/linux/${ARCH}/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl
 

--- a/util/conditions/matcher.go
+++ b/util/conditions/matcher.go
@@ -42,7 +42,7 @@ func (m matchConditions) Match(actual interface{}) (success bool, err error) {
 		elems = append(elems, MatchCondition(condition))
 	}
 
-	return gomega.ConsistOf(elems).Match(actual)
+	return gomega.ConsistOf(elems...).Match(actual)
 }
 
 func (m matchConditions) FailureMessage(actual interface{}) (message string) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables some of the "bug" finding linters in golangci-lint that are currently disabled. 

*  asasalint
* bidichk
* durationcheck
* errchkjson

https://golangci-lint.run/usage/linters/

Also fixes some findings (including Hadolint findings).

There are some bug linters that find alot more. But I will add these 1 by 1 since they require more work to review. 
