### PR TITLE
🌱 Add oscr to cluster-api-docs-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -100,4 +100,5 @@ aliases:
 
   cluster-api-docs-reviewers:
     - killianmuldoon
+    - oscr
   cluster-api-docs-maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**:

PR to add myself as reviewer for docs. Just to help out with some of the simpler, more straight forward doc prs.