### PR TITLE
🌱 Enable more gocritic diagnostic and performance linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -150,7 +150,9 @@ linters-settings:
     - G108 # Profiling endpoint is automatically exposed on /debug/pprof
   gocritic:
     enabled-tags:
+      - diagnostic
       - experimental
+      - performance
     disabled-checks:
     - appendAssign
     - dupImport # https://github.com/go-critic/go-critic/issues/845
@@ -165,6 +167,8 @@ linters-settings:
     - unnecessaryDefer
     - whyNoLint
     - wrapperFunc
+    - rangeValCopy
+    - hugeParam
   unused:
     go: "1.19"
 issues:

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -154,8 +154,9 @@ func (r *MachinePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// Patch ObservedGeneration only if the reconciliation completed successfully
 		patchOpts := []patch.Option{}
 		if reterr == nil {
-			patchOpts = append(patchOpts, patch.WithStatusObservedGeneration{})
-			patchOpts = append(patchOpts,
+			patchOpts = append(
+				patchOpts,
+				patch.WithStatusObservedGeneration{},
 				patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
 					clusterv1.ReadyCondition,
 					clusterv1.BootstrapReadyCondition,

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -212,12 +212,16 @@ func TestReconcileShim(t *testing.T) {
 		// Add the shim as a temporary owner for the InfrastructureCluster and ControlPlane.
 		// Add the cluster as a final owner for the InfrastructureCluster and ControlPlane (reconciled).
 		ownerRefs := s.Current.InfrastructureCluster.GetOwnerReferences()
-		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1Shim))
-		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1))
+		ownerRefs = append(
+			ownerRefs,
+			*ownerReferenceTo(cluster1Shim),
+			*ownerReferenceTo(cluster1))
 		s.Current.InfrastructureCluster.SetOwnerReferences(ownerRefs)
 		ownerRefs = s.Current.ControlPlane.Object.GetOwnerReferences()
-		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1Shim))
-		ownerRefs = append(ownerRefs, *ownerReferenceTo(cluster1))
+		ownerRefs = append(
+			ownerRefs,
+			*ownerReferenceTo(cluster1Shim),
+			*ownerReferenceTo(cluster1))
 		s.Current.ControlPlane.Object.SetOwnerReferences(ownerRefs)
 
 		// Pre-create a shim

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -148,8 +148,10 @@ func (k *KindClusterProvider) createKindCluster() {
 	if k.nodeImage != "" {
 		nodeImage = k.nodeImage
 	}
-	kindCreateOptions = append(kindCreateOptions, kind.CreateWithNodeImage(nodeImage))
-	kindCreateOptions = append(kindCreateOptions, kind.CreateWithRetain(true))
+	kindCreateOptions = append(
+		kindCreateOptions,
+		kind.CreateWithNodeImage(nodeImage),
+		kind.CreateWithRetain(true))
 
 	provider := kind.NewProvider(kind.ProviderWithLogger(cmd.NewLogger()))
 	err := provider.Create(k.name, kindCreateOptions...)

--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -161,10 +161,12 @@ func Run(ctx context.Context, input RunInput) error {
 	}
 
 	// Formulate our command arguments
-	args := []string{}
+	var args []string
 	args = append(args, ginkgoArgs...)
-	args = append(args, "/usr/local/bin/e2e.test")
-	args = append(args, "--")
+	args = append(
+		args,
+		"/usr/local/bin/e2e.test",
+		"--")
 	args = append(args, e2eArgs...)
 	args = append(args, config.toFlags()...)
 

--- a/test/infrastructure/docker/exp/internal/docker/nodepool.go
+++ b/test/infrastructure/docker/exp/internal/docker/nodepool.go
@@ -366,7 +366,7 @@ func getBootstrapData(ctx context.Context, c client.Client, machinePool *expv1.M
 	}
 
 	format := s.Data["format"]
-	if string(format) == "" {
+	if len(format) == 0 {
 		format = []byte(bootstrapv1.CloudConfig)
 	}
 

--- a/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockermachine_controller.go
@@ -452,7 +452,7 @@ func (r *DockerMachineReconciler) getBootstrapData(ctx context.Context, machine 
 	}
 
 	format := s.Data["format"]
-	if string(format) == "" {
+	if len(format) == 0 {
 		format = []byte(bootstrapv1.CloudConfig)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables additional linters in the gocritic metalinter and fixes findings. 

The groups `diagnostic` and `performance`. The performance rules `rangeValCopy` and `hugeParam` are disabled due to large amount of findings. The fixes are performance types `appendCombine` and `stringXbytes`.

Reference:
https://github.com/go-critic/go-critic/blob/master/docs/overview.md
