### PR TITLE
:seedling: support clusterctl generate cluster with templates from stdin

### DIFF
--- a/cmd/clusterctl/client/cluster/template.go
+++ b/cmd/clusterctl/client/cluster/template.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 	"encoding/base64"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -129,6 +130,14 @@ func (t *templateClient) GetFromURL(templateURL, targetNamespace string, skipTem
 }
 
 func (t *templateClient) getURLContent(templateURL string) ([]byte, error) {
+	if templateURL == "-" {
+		b, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read stdin")
+		}
+		return b, nil
+	}
+
 	rURL, err := url.Parse(templateURL)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse %q", templateURL)

--- a/cmd/clusterctl/client/cluster/template_test.go
+++ b/cmd/clusterctl/client/cluster/template_test.go
@@ -307,6 +307,12 @@ func Test_templateClient_GetFromURL(t *testing.T) {
 	path := filepath.Join(tmpDir, "cluster-template.yaml")
 	g.Expect(os.WriteFile(path, []byte(template), 0600)).To(Succeed())
 
+	// redirect stdin
+	saveStdin := os.Stdin
+	defer func() { os.Stdin = saveStdin }()
+	os.Stdin, err = os.Open(path)
+	g.Expect(err).NotTo(HaveOccurred())
+
 	type args struct {
 		templateURL         string
 		targetNamespace     string
@@ -332,6 +338,16 @@ func Test_templateClient_GetFromURL(t *testing.T) {
 			name: "Get from GitHub",
 			args: args{
 				templateURL:         "https://github.com/kubernetes-sigs/cluster-api/blob/main/config/default/cluster-template.yaml",
+				targetNamespace:     "",
+				skipTemplateProcess: false,
+			},
+			want:    template,
+			wantErr: false,
+		},
+		{
+			name: "Get from stdin",
+			args: args{
+				templateURL:         "-",
 				targetNamespace:     "",
 				skipTemplateProcess: false,
 			},

--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -124,7 +124,7 @@ func init() {
 
 	// flags for the url source
 	generateClusterClusterCmd.Flags().StringVar(&gc.url, "from", "",
-		"The URL to read the workload cluster template from. If unspecified, the infrastructure provider repository URL will be used")
+		"The URL to read the workload cluster template from. If unspecified, the infrastructure provider repository URL will be used. If set to '-', the workload cluster template is read from stdin.")
 
 	// flags for the config map source
 	generateClusterClusterCmd.Flags().StringVar(&gc.configMapName, "from-config-map", "",

--- a/docs/book/src/clusterctl/commands/generate-cluster.md
+++ b/docs/book/src/clusterctl/commands/generate-cluster.md
@@ -69,9 +69,10 @@ clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
 Also following flags are available `--from-config-map-namespace` (defaults to current namespace) and `--from-config-map-key`
 (defaults to `template`).
 
-#### GitHub or local file system folder
+#### GitHub, local file system folder or standard input
 
-Use the `--from` flag to read cluster templates stored in a GitHub repository or in a local file system folder; e.g.
+Use the `--from` flag to read cluster templates stored in a GitHub repository, in a local file system folder,
+or from the standard input; e.g.
 
 ```bash
 clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
@@ -83,6 +84,13 @@ or
 ```bash
 clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
    --from ~/my-template.yaml > my-cluster.yaml
+```
+
+or
+
+```bash
+cat ~/my-template.yaml | clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
+    --from - > my-cluster.yaml
 ```
 
 ### Variables


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Support stdin as an input source for the `clusterctl generate cluster` command. See #7227 for reference.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7227
