### PR TITLE
🌱 Fix spelling in log message (cluter -> cluster)

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -321,9 +321,9 @@ func (o *objectMover) move(graph *objectGraph, toProxy Proxy) error {
 		return err
 	}
 
-	log.V(1).Info("Pausing the source cluster classes")
+	log.V(1).Info("Pausing the source ClusterClasses")
 	if err := setClusterClassPause(o.fromProxy, clusterClasses, true, o.dryRun); err != nil {
-		return errors.Wrap(err, "error pausing cluster classes")
+		return errors.Wrap(err, "error pausing ClusterClasses")
 	}
 
 	// Ensure all the expected target namespaces are in place before creating objects.
@@ -355,10 +355,10 @@ func (o *objectMover) move(graph *objectGraph, toProxy Proxy) error {
 		}
 	}
 
-	// Resume the cluster classes in the target management cluster, so the controllers start reconciling it.
-	log.V(1).Info("Resuming the target cluter classes")
+	// Resume the ClusterClasses in the target management cluster, so the controllers start reconciling it.
+	log.V(1).Info("Resuming the target ClusterClasses")
 	if err := setClusterClassPause(toProxy, clusterClasses, false, o.dryRun); err != nil {
-		return errors.Wrap(err, "error resuming cluster classes")
+		return errors.Wrap(err, "error resuming ClusterClasses")
 	}
 
 	// Reset the pause field on the Cluster object in the target management cluster, so the controllers start reconciling it.
@@ -381,9 +381,9 @@ func (o *objectMover) backup(graph *objectGraph, directory string) error {
 		return err
 	}
 
-	log.V(1).Info("Pausing the source cluster classes")
+	log.V(1).Info("Pausing the source ClusterClasses")
 	if err := setClusterClassPause(o.fromProxy, clusterClasses, true, o.dryRun); err != nil {
-		return errors.Wrap(err, "error pausing cluster classes")
+		return errors.Wrap(err, "error pausing ClusterClasses")
 	}
 
 	// Define the move sequence by processing the ownerReference chain, so we ensure that a Kubernetes object is moved only after its owners.
@@ -401,10 +401,10 @@ func (o *objectMover) backup(graph *objectGraph, directory string) error {
 		}
 	}
 
-	// Resume the cluster classes in the target management cluster, so the controllers start reconciling it.
-	log.V(1).Info("Resuming the target cluter classes")
+	// Resume the ClusterClasses in the target management cluster, so the controllers start reconciling it.
+	log.V(1).Info("Resuming the target ClusterClasses")
 	if err := setClusterClassPause(o.fromProxy, clusterClasses, false, o.dryRun); err != nil {
-		return errors.Wrap(err, "error resuming cluster classes")
+		return errors.Wrap(err, "error resuming ClusterClasses")
 	}
 
 	// Reset the pause field on the Cluster object in the target management cluster, so the controllers start reconciling it.
@@ -443,9 +443,9 @@ func (o *objectMover) restore(graph *objectGraph, toProxy Proxy) error {
 
 	// Resume reconciling the ClusterClasses after being restored from a backup.
 	// By default, during backup, ClusterClasses are paused so they must be unpaused to be used again
-	log.V(1).Info("Resuming the target cluter classes")
+	log.V(1).Info("Resuming the target ClusterClasses")
 	if err := setClusterClassPause(toProxy, clusterClasses, false, o.dryRun); err != nil {
-		return errors.Wrap(err, "error resuming cluster classes")
+		return errors.Wrap(err, "error resuming ClusterClasses")
 	}
 
 	// Resume reconciling the Clusters after being restored from a backup.

--- a/cmd/clusterctl/client/clusterclass.go
+++ b/cmd/clusterctl/client/clusterclass.go
@@ -59,7 +59,7 @@ func addClusterClassIfMissing(template Template, clusterClassClient repository.C
 	return mergedTemplate, nil
 }
 
-// clusterClassNamesFromTemplate returns the list of cluster classes referenced
+// clusterClassNamesFromTemplate returns the list of ClusterClasses referenced
 // by custers defined in the template. If not clusters are defined in the template
 // or if no cluster uses a cluster class it returns an empty list.
 func clusterClassNamesFromTemplate(template Template) ([]string, error) {
@@ -85,7 +85,7 @@ func clusterClassNamesFromTemplate(template Template) ([]string, error) {
 	return classes, nil
 }
 
-// fetchMissingClusterClassTemplates returns a list of templates for cluster classes that do not yet exist
+// fetchMissingClusterClassTemplates returns a list of templates for ClusterClasses that do not yet exist
 // in the cluster. If the cluster is not initialized, all the ClusterClasses are added.
 func fetchMissingClusterClassTemplates(clusterClassClient repository.ClusterClassClient, clusterClient cluster.Client, classes []string, targetNamespace string, listVariablesOnly bool) (Template, error) {
 	// first check if the cluster is initialized.
@@ -114,7 +114,7 @@ func fetchMissingClusterClassTemplates(clusterClassClient repository.ClusterClas
 	}
 
 	// Get the templates for all ClusterClasses and associated objects if the target
-	// CluterClass does not exits in the cluster.
+	// ClusterClass does not exits in the cluster.
 	templates := []repository.Template{}
 	for _, class := range classes {
 		if clusterInitialized {

--- a/cmd/clusterctl/client/repository/client.go
+++ b/cmd/clusterctl/client/repository/client.go
@@ -48,7 +48,7 @@ type Client interface {
 	// Please note that templates are expected to exist for the infrastructure providers only.
 	Templates(version string) TemplateClient
 
-	// ClusterClasses provide access to YAML file for the cluster classes available
+	// ClusterClasses provide access to YAML file for the ClusterClasses available
 	// for the provider.
 	ClusterClasses(version string) ClusterClassClient
 

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func InitFlags(fs *pflag.FlagSet) {
 		"Number of clusters to process simultaneously")
 
 	fs.IntVar(&clusterClassConcurrency, "clusterclass-concurrency", 10,
-		"Number of cluster classes to process simultaneously")
+		"Number of ClusterClasses to process simultaneously")
 
 	fs.IntVar(&clusterConcurrency, "cluster-concurrency", 10,
 		"Number of clusters to process simultaneously")


### PR DESCRIPTION
**What this PR does / why we need it**:

Found a spelling mistake in the logs and making a separate pr so it can be cherry-picked into older releases.
