### PR TITLE
✨ add NodeVolumeDetachTimeout support for Cluster Topology

### DIFF
--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -47,6 +47,10 @@ func (src *Cluster) ConvertTo(dstRaw conversion.Hub) error {
 			dst.Spec.Topology.ControlPlane.NodeDrainTimeout = restored.Spec.Topology.ControlPlane.NodeDrainTimeout
 		}
 
+		if restored.Spec.Topology.ControlPlane.NodeVolumeDetachTimeout != nil {
+			dst.Spec.Topology.ControlPlane.NodeVolumeDetachTimeout = restored.Spec.Topology.ControlPlane.NodeVolumeDetachTimeout
+		}
+
 		if restored.Spec.Topology.ControlPlane.NodeDeletionTimeout != nil {
 			dst.Spec.Topology.ControlPlane.NodeDeletionTimeout = restored.Spec.Topology.ControlPlane.NodeDeletionTimeout
 		}
@@ -59,6 +63,7 @@ func (src *Cluster) ConvertTo(dstRaw conversion.Hub) error {
 				dst.Spec.Topology.Workers.MachineDeployments[i].FailureDomain = restored.Spec.Topology.Workers.MachineDeployments[i].FailureDomain
 				dst.Spec.Topology.Workers.MachineDeployments[i].Variables = restored.Spec.Topology.Workers.MachineDeployments[i].Variables
 				dst.Spec.Topology.Workers.MachineDeployments[i].NodeDrainTimeout = restored.Spec.Topology.Workers.MachineDeployments[i].NodeDrainTimeout
+				dst.Spec.Topology.Workers.MachineDeployments[i].NodeVolumeDetachTimeout = restored.Spec.Topology.Workers.MachineDeployments[i].NodeVolumeDetachTimeout
 				dst.Spec.Topology.Workers.MachineDeployments[i].NodeDeletionTimeout = restored.Spec.Topology.Workers.MachineDeployments[i].NodeDeletionTimeout
 			}
 		}

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -889,6 +889,7 @@ func autoConvert_v1beta1_ControlPlaneTopology_To_v1alpha4_ControlPlaneTopology(i
 	}
 	out.Replicas = (*int32)(unsafe.Pointer(in.Replicas))
 	// WARNING: in.NodeDrainTimeout requires manual conversion: does not exist in peer-type
+	// WARNING: in.NodeVolumeDetachTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.NodeDeletionTimeout requires manual conversion: does not exist in peer-type
 	return nil
 }
@@ -1243,6 +1244,7 @@ func autoConvert_v1beta1_MachineDeploymentTopology_To_v1alpha4_MachineDeployment
 	// WARNING: in.FailureDomain requires manual conversion: does not exist in peer-type
 	out.Replicas = (*int32)(unsafe.Pointer(in.Replicas))
 	// WARNING: in.NodeDrainTimeout requires manual conversion: does not exist in peer-type
+	// WARNING: in.NodeVolumeDetachTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.NodeDeletionTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.Variables requires manual conversion: does not exist in peer-type
 	return nil

--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -122,6 +122,11 @@ type ControlPlaneTopology struct {
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 
+	// NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+	// to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+	// +optional
+	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
+
 	// NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
 	// hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
 	// Defaults to 10 seconds.
@@ -172,6 +177,11 @@ type MachineDeploymentTopology struct {
 	// NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
+
+	// NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+	// to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+	// +optional
+	NodeVolumeDetachTimeout *metav1.Duration `json:"nodeVolumeDetachTimeout,omitempty"`
 
 	// NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
 	// hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -466,6 +466,11 @@ func (in *ControlPlaneTopology) DeepCopyInto(out *ControlPlaneTopology) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.NodeVolumeDetachTimeout != nil {
+		in, out := &in.NodeVolumeDetachTimeout, &out.NodeVolumeDetachTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.NodeDeletionTimeout != nil {
 		in, out := &in.NodeDeletionTimeout, &out.NodeDeletionTimeout
 		*out = new(metav1.Duration)
@@ -964,6 +969,11 @@ func (in *MachineDeploymentTopology) DeepCopyInto(out *MachineDeploymentTopology
 	}
 	if in.NodeDrainTimeout != nil {
 		in, out := &in.NodeDrainTimeout, &out.NodeDrainTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.NodeVolumeDetachTimeout != nil {
+		in, out := &in.NodeVolumeDetachTimeout, &out.NodeVolumeDetachTimeout
 		*out = new(metav1.Duration)
 		**out = **in
 	}

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -837,6 +837,12 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ControlPlaneTopology(ref common.Re
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"nodeVolumeDetachTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 					"nodeDeletionTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely. Defaults to 10 seconds.",
@@ -1674,6 +1680,12 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentTopology(ref comm
 					"nodeDrainTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
+					"nodeVolumeDetachTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -876,6 +876,12 @@ spec:
                           any time limitations. NOTE: NodeDrainTimeout is different
                           from `kubectl drain --timeout`'
                         type: string
+                      nodeVolumeDetachTimeout:
+                        description: NodeVolumeDetachTimeout is the total amount of
+                          time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the
+                          volumes can be detached without any time limitations.
+                        type: string
                       replicas:
                         description: Replicas is the number of control plane nodes.
                           If the value is nil, the ControlPlane object is created
@@ -992,6 +998,13 @@ spec:
                                 can be drained without any time limitations. NOTE:
                                 NodeDrainTimeout is different from `kubectl drain
                                 --timeout`'
+                              type: string
+                            nodeVolumeDetachTimeout:
+                              description: NodeVolumeDetachTimeout is the total amount
+                                of time that the controller will spend on waiting
+                                for all volumes to be detached. The default value
+                                is 0, meaning that the volumes can be detached without
+                                any time limitations.
                               type: string
                             replicas:
                               description: Replicas is the number of worker nodes

--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -227,6 +227,13 @@ func (c *ControlPlaneMachineTemplate) NodeDrainTimeout() *Duration {
 	}
 }
 
+// NodeVolumeDetachTimeout provides access to the nodeVolumeDetachTimeout of a MachineTemplate.
+func (c *ControlPlaneMachineTemplate) NodeVolumeDetachTimeout() *Duration {
+	return &Duration{
+		path: Path{"spec", "machineTemplate", "nodeVolumeDetachTimeout"},
+	}
+}
+
 // NodeDeletionTimeout provides access to the nodeDeletionTimeout of a MachineTemplate.
 func (c *ControlPlaneMachineTemplate) NodeDeletionTimeout() *Duration {
 	return &Duration{

--- a/internal/contract/controlplane_test.go
+++ b/internal/contract/controlplane_test.go
@@ -171,6 +171,28 @@ func TestControlPlane(t *testing.T) {
 		g.Expect(durationString).To(Equal(expectedDurationString))
 	})
 
+	t.Run("Manages spec.machineTemplate.nodeVolumeDetachTimeout", func(t *testing.T) {
+		g := NewWithT(t)
+
+		duration := metav1.Duration{Duration: 2*time.Minute + 10*time.Second}
+		expectedDurationString := "2m10s"
+		g.Expect(ControlPlane().MachineTemplate().NodeVolumeDetachTimeout().Path()).To(Equal(Path{"spec", "machineTemplate", "nodeVolumeDetachTimeout"}))
+
+		err := ControlPlane().MachineTemplate().NodeVolumeDetachTimeout().Set(obj, duration)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		got, err := ControlPlane().MachineTemplate().NodeVolumeDetachTimeout().Get(obj)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(got).ToNot(BeNil())
+		g.Expect(*got).To(Equal(duration))
+
+		// Check that the literal string value of the duration is correctly formatted.
+		durationString, found, err := unstructured.NestedString(obj.UnstructuredContent(), "spec", "machineTemplate", "nodeVolumeDetachTimeout")
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(durationString).To(Equal(expectedDurationString))
+	})
+
 	t.Run("Manages spec.machineTemplate.nodeDeletionTimeout", func(t *testing.T) {
 		g := NewWithT(t)
 

--- a/internal/controllers/topology/cluster/desired_state.go
+++ b/internal/controllers/topology/cluster/desired_state.go
@@ -242,6 +242,13 @@ func (r *Reconciler) computeControlPlane(ctx context.Context, s *scope.Scope, in
 		}
 	}
 
+	// If it is required to manage the NodeVolumeDetachTimeout for the control plane, set the corresponding field.
+	if s.Blueprint.Topology.ControlPlane.NodeVolumeDetachTimeout != nil {
+		if err := contract.ControlPlane().MachineTemplate().NodeVolumeDetachTimeout().Set(controlPlane, *s.Blueprint.Topology.ControlPlane.NodeVolumeDetachTimeout); err != nil {
+			return nil, errors.Wrap(err, "failed to set spec.machineTemplate.nodeVolumeDetachTimeout in the ControlPlane object")
+		}
+	}
+
 	// If it is required to manage the NodeDeletionTimeout for the control plane, set the corresponding field.
 	if s.Blueprint.Topology.ControlPlane.NodeDeletionTimeout != nil {
 		if err := contract.ControlPlane().MachineTemplate().NodeDeletionTimeout().Set(controlPlane, *s.Blueprint.Topology.ControlPlane.NodeDeletionTimeout); err != nil {
@@ -538,13 +545,14 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, desiredControlP
 					Annotations: mergeMap(machineDeploymentTopology.Metadata.Annotations, machineDeploymentBlueprint.Metadata.Annotations),
 				},
 				Spec: clusterv1.MachineSpec{
-					ClusterName:         s.Current.Cluster.Name,
-					Version:             pointer.String(version),
-					Bootstrap:           clusterv1.Bootstrap{ConfigRef: contract.ObjToRef(desiredMachineDeployment.BootstrapTemplate)},
-					InfrastructureRef:   *contract.ObjToRef(desiredMachineDeployment.InfrastructureMachineTemplate),
-					FailureDomain:       machineDeploymentTopology.FailureDomain,
-					NodeDrainTimeout:    machineDeploymentTopology.NodeDrainTimeout,
-					NodeDeletionTimeout: machineDeploymentTopology.NodeDeletionTimeout,
+					ClusterName:             s.Current.Cluster.Name,
+					Version:                 pointer.String(version),
+					Bootstrap:               clusterv1.Bootstrap{ConfigRef: contract.ObjToRef(desiredMachineDeployment.BootstrapTemplate)},
+					InfrastructureRef:       *contract.ObjToRef(desiredMachineDeployment.InfrastructureMachineTemplate),
+					FailureDomain:           machineDeploymentTopology.FailureDomain,
+					NodeDrainTimeout:        machineDeploymentTopology.NodeDrainTimeout,
+					NodeVolumeDetachTimeout: machineDeploymentTopology.NodeVolumeDetachTimeout,
+					NodeDeletionTimeout:     machineDeploymentTopology.NodeDeletionTimeout,
 				},
 			},
 		},

--- a/internal/controllers/topology/cluster/desired_state_test.go
+++ b/internal/controllers/topology/cluster/desired_state_test.go
@@ -263,6 +263,7 @@ func TestComputeControlPlane(t *testing.T) {
 	replicas := int32(3)
 	duration := 10 * time.Second
 	nodeDrainTimeout := metav1.Duration{Duration: duration}
+	nodeVolumeDetachTimeout := metav1.Duration{Duration: duration}
 	nodeDeletionTimeout := metav1.Duration{Duration: duration}
 	cluster := &clusterv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -277,9 +278,10 @@ func TestComputeControlPlane(t *testing.T) {
 						Labels:      map[string]string{"l2": ""},
 						Annotations: map[string]string{"a2": ""},
 					},
-					Replicas:            &replicas,
-					NodeDrainTimeout:    &nodeDrainTimeout,
-					NodeDeletionTimeout: &nodeDeletionTimeout,
+					Replicas:                &replicas,
+					NodeDrainTimeout:        &nodeDrainTimeout,
+					NodeVolumeDetachTimeout: &nodeVolumeDetachTimeout,
+					NodeDeletionTimeout:     &nodeDeletionTimeout,
 				},
 			},
 		},
@@ -317,6 +319,7 @@ func TestComputeControlPlane(t *testing.T) {
 		assertNestedField(g, obj, version, contract.ControlPlane().Version().Path()...)
 		assertNestedField(g, obj, int64(replicas), contract.ControlPlane().Replicas().Path()...)
 		assertNestedField(g, obj, duration.String(), contract.ControlPlane().MachineTemplate().NodeDrainTimeout().Path()...)
+		assertNestedField(g, obj, duration.String(), contract.ControlPlane().MachineTemplate().NodeVolumeDetachTimeout().Path()...)
 		assertNestedField(g, obj, duration.String(), contract.ControlPlane().MachineTemplate().NodeDeletionTimeout().Path()...)
 		assertNestedFieldUnset(g, obj, contract.ControlPlane().MachineTemplate().InfrastructureRef().Path()...)
 
@@ -1321,17 +1324,19 @@ func TestComputeMachineDeployment(t *testing.T) {
 	replicas := int32(5)
 	failureDomain := "always-up-region"
 	nodeDrainTimeout := metav1.Duration{Duration: 10 * time.Second}
+	nodeVolumeDetachTimeout := metav1.Duration{Duration: 10 * time.Second}
 	nodeDeletionTimeout := metav1.Duration{Duration: 10 * time.Second}
 	mdTopology := clusterv1.MachineDeploymentTopology{
 		Metadata: clusterv1.ObjectMeta{
 			Labels: map[string]string{"foo": "baz"},
 		},
-		Class:               "linux-worker",
-		Name:                "big-pool-of-machines",
-		Replicas:            &replicas,
-		FailureDomain:       &failureDomain,
-		NodeDrainTimeout:    &nodeDrainTimeout,
-		NodeDeletionTimeout: &nodeDeletionTimeout,
+		Class:                   "linux-worker",
+		Name:                    "big-pool-of-machines",
+		Replicas:                &replicas,
+		FailureDomain:           &failureDomain,
+		NodeDrainTimeout:        &nodeDrainTimeout,
+		NodeVolumeDetachTimeout: &nodeVolumeDetachTimeout,
+		NodeDeletionTimeout:     &nodeDeletionTimeout,
 	}
 
 	t.Run("Generates the machine deployment and the referenced templates", func(t *testing.T) {

--- a/internal/controllers/topology/cluster/patches/engine.go
+++ b/internal/controllers/topology/cluster/patches/engine.go
@@ -371,6 +371,7 @@ func updateDesiredState(ctx context.Context, req *runtimehooksv1.GeneratePatches
 		contract.ControlPlane().MachineTemplate().Metadata().Path(),
 		contract.ControlPlane().MachineTemplate().InfrastructureRef().Path(),
 		contract.ControlPlane().MachineTemplate().NodeDrainTimeout().Path(),
+		contract.ControlPlane().MachineTemplate().NodeVolumeDetachTimeout().Path(),
 		contract.ControlPlane().MachineTemplate().NodeDeletionTimeout().Path(),
 		contract.ControlPlane().Replicas().Path(),
 		contract.ControlPlane().Version().Path(),

--- a/test/e2e/data/infrastructure-docker/v1beta1/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/bases/cluster-with-topology.yaml
@@ -18,12 +18,14 @@ spec:
     controlPlane:
       metadata: {}
       nodeDeletionTimeout: "30s"
+      nodeVolumeDetachTimeout: "5m"
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
     workers:
       machineDeployments:
       - class: "default-worker"
         name: "md-0"
         nodeDeletionTimeout: "30s"
+        nodeVolumeDetachTimeout: "5m"
         replicas: ${WORKER_MACHINE_COUNT}
         failureDomain: fd4
     variables:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR add NodeVolumeDetachTimeout support for Cluster Topology.

NodeVolumeDetachTimeout is introduced in https://github.com/kubernetes-sigs/cluster-api/pull/6413.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7233

/hold until https://github.com/kubernetes-sigs/cluster-api/pull/6413 is merged.
