### PR TITLE
✨ adjust self-hosted e2e test to also upgrade the cluster

### DIFF
--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -54,3 +54,9 @@ The default value is 0, meaning that the volume can be detached without any time
 - The `Move` function in E2E test framework for clusterctl has been modified to:
   * print the `clusterctl move` command including the arguments similar to `Init`.
   * log the output to the a `clusterctl-move.log` file at the subdirectory `logs/<namespace>`.
+- The self-hosted upgrade test now also upgrades the self-hosted clusters kubernetes version by default. For that it requires the following variables to be set:
+  * `KUBERNETES_VERSION_UPGRADE_FROM`
+  * `KUBERNETES_VERSION_UPGRADE_TO`
+  * `ETCD_VERSION_UPGRADE_TO`
+  * `COREDNS_VERSION_UPGRADE_TO`
+  The variable `SkipUpgrade` could be set to revert to the old behaviour by making use of the `KUBERNETES_VERSION` variable and skipping the kubernetes upgrade.

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/bases/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/bases/cluster-with-kcp.yaml
@@ -59,6 +59,8 @@ spec:
       extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+      # The DOCKER_PRELOAD_IMAGES variable gets set in self-hosted E2E tests to the list of images of the E2E configuration.
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 # KubeadmControlPlane referenced by the Cluster object with
 # - the label kcp-adoption.step2, because it should be created in the second step of the kcp-adoption test.

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/bases/cluster-with-topology.yaml
@@ -35,3 +35,6 @@ spec:
       # We set an empty value to use the default tag kubeadm init is using.
     - name: coreDNSImageTag
       value: ""
+    - name: preLoadImages
+      # The DOCKER_PRELOAD_IMAGES variable gets set in self-hosted E2E tests to the list of images of the E2E configuration.
+      value: ${DOCKER_PRELOAD_IMAGES:-[]}

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/bases/md.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/bases/md.yaml
@@ -11,6 +11,8 @@ spec:
       extraMounts:
         - containerPath: "/var/run/docker.sock"
           hostPath: "/var/run/docker.sock"
+      # The DOCKER_PRELOAD_IMAGES variable gets set in self-hosted E2E tests to the list of images of the E2E configuration.
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 # KubeadmConfigTemplate referenced by the MachineDeployment
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/bases/mp.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/bases/mp.yaml
@@ -32,6 +32,10 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachinePool
 metadata:
   name: "${CLUSTER_NAME}-dmp-0"
+spec:
+  template:
+      # The DOCKER_PRELOAD_IMAGES variable gets set in self-hosted E2E tests to the list of images of the E2E configuration.
+      preLoadImages: ${DOCKER_PRELOAD_IMAGES:-[]}
 ---
 # KubeadmConfigTemplate referenced by the MachinePool
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/clusterclass-quick-start.yaml
@@ -75,6 +75,15 @@ spec:
         default: ""
         example: "0"
         description: "kubeadmControlPlaneMaxSurge is the maximum number of control planes that can be scheduled above or under the desired number of control plane machines."
+  - name: preLoadImages
+    required: false
+    schema:
+      openAPIV3Schema:
+        default: []
+        type: array
+        items:
+          type: string
+        description: "preLoadImages sets the images for the docker machines to preload."
   patches:
   - name: lbImageRepository
     definitions:
@@ -183,6 +192,25 @@ spec:
         valueFrom:
           template: |
             kindest/node:{{ .builtin.controlPlane.version | replace "+" "_" }}
+  - name: preloadImages
+    description: |
+      Sets the container images to preload to the node that is used for running dockerMachines.
+      This is especially required for self-hosted e2e tests to ensure the required controller images to be available
+      and reduce load to public registries.
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        matchResources:
+          controlPlane: true
+          machineDeploymentClass:
+            names:
+            - default-worker
+      jsonPatches:
+      - op: add
+        path: "/spec/template/spec/preLoadImages"
+        valueFrom:
+          variable: preLoadImages
   - name: kubeadmControlPlaneMaxSurge
     description: "Sets the maxSurge value used for rolloutStrategy in the KubeadmControlPlane."
     enabledIf: '{{ ne .kubeadmControlPlaneMaxSurge "" }}'

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -21,6 +21,7 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("When testing Cluster API working on self-hosted clusters", func() {
@@ -38,12 +39,29 @@ var _ = Describe("When testing Cluster API working on self-hosted clusters", fun
 var _ = Describe("When testing Cluster API working on self-hosted clusters using ClusterClass [ClusterClass]", func() {
 	SelfHostedSpec(ctx, func() SelfHostedSpecInput {
 		return SelfHostedSpecInput{
-			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			ArtifactFolder:        artifactFolder,
-			SkipCleanup:           skipCleanup,
-			Flavor:                "topology",
+			E2EConfig:                e2eConfig,
+			ClusterctlConfigPath:     clusterctlConfigPath,
+			BootstrapClusterProxy:    bootstrapClusterProxy,
+			ArtifactFolder:           artifactFolder,
+			SkipCleanup:              skipCleanup,
+			Flavor:                   "topology",
+			ControlPlaneMachineCount: pointer.Int64Ptr(1),
+			WorkerMachineCount:       pointer.Int64Ptr(1),
+		}
+	})
+})
+
+var _ = Describe("When testing Cluster API working on self-hosted clusters using ClusterClass with a HA control plane [ClusterClass]", func() {
+	SelfHostedSpec(ctx, func() SelfHostedSpecInput {
+		return SelfHostedSpecInput{
+			E2EConfig:                e2eConfig,
+			ClusterctlConfigPath:     clusterctlConfigPath,
+			BootstrapClusterProxy:    bootstrapClusterProxy,
+			ArtifactFolder:           artifactFolder,
+			SkipCleanup:              skipCleanup,
+			Flavor:                   "topology",
+			ControlPlaneMachineCount: pointer.Int64Ptr(3),
+			WorkerMachineCount:       pointer.Int64Ptr(1),
 		}
 	})
 })

--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -46,7 +46,11 @@ import (
 
 const (
 	retryableOperationInterval = 3 * time.Second
-	retryableOperationTimeout  = 1 * time.Minute
+	// retryableOperationTimeout requires a higher value especially for self-hosted upgrades.
+	// Short unavailability of the Kube APIServer due to joining etcd members paired with unreachable conversion webhooks due to
+	// failed leader election and thus controller restarts lead to longer taking retries.
+	// The timeout occurs when listing machines in `GetControlPlaneMachinesByCluster`.
+	retryableOperationTimeout = 3 * time.Minute
 )
 
 // ClusterProxy defines the behavior of a type that acts as an intermediary with an existing Kubernetes cluster.

--- a/test/framework/clusterctl/client.go
+++ b/test/framework/clusterctl/client.go
@@ -201,6 +201,7 @@ type ConfigClusterInput struct {
 	ControlPlaneMachineCount *int64
 	WorkerMachineCount       *int64
 	Flavor                   string
+	ClusterctlVariables      map[string]string
 }
 
 // ConfigCluster gets a workload cluster based on a template.
@@ -228,6 +229,16 @@ func ConfigCluster(ctx context.Context, input ConfigClusterInput) []byte {
 		ControlPlaneMachineCount: input.ControlPlaneMachineCount,
 		WorkerMachineCount:       input.WorkerMachineCount,
 		TargetNamespace:          input.Namespace,
+	}
+
+	if len(input.ClusterctlVariables) > 0 {
+		outputPath := filepath.Join(filepath.Dir(input.ClusterctlConfigPath), fmt.Sprintf("clusterctl-upgrade-config-%s.yaml", input.ClusterName))
+		copyAndAmendClusterctlConfig(ctx, copyAndAmendClusterctlConfigInput{
+			ClusterctlConfigPath: input.ClusterctlConfigPath,
+			OutputPath:           outputPath,
+			Variables:            input.ClusterctlVariables,
+		})
+		input.ClusterctlConfigPath = outputPath
 	}
 
 	clusterctlClient, log := getClusterctlClientWithLogger(input.ClusterctlConfigPath, fmt.Sprintf("%s-cluster-template.yaml", input.ClusterName), input.LogFolder)

--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -271,7 +271,8 @@ func ApplyClusterTemplateAndWait(ctx context.Context, input ApplyClusterTemplate
 		WorkerMachineCount:       input.ConfigCluster.WorkerMachineCount,
 		InfrastructureProvider:   input.ConfigCluster.InfrastructureProvider,
 		// setup clusterctl logs folder
-		LogFolder: input.ConfigCluster.LogFolder,
+		LogFolder:           input.ConfigCluster.LogFolder,
+		ClusterctlVariables: input.ConfigCluster.ClusterctlVariables,
 	})
 	Expect(workloadClusterTemplate).ToNot(BeNil(), "Failed to get the cluster template")
 

--- a/test/framework/convenience.go
+++ b/test/framework/convenience.go
@@ -29,6 +29,7 @@ import (
 	clusterv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
@@ -56,6 +57,9 @@ func TryAddDefaultSchemes(scheme *runtime.Scheme) {
 	// Add the CAPI experiments scheme.
 	_ = expv1.AddToScheme(scheme)
 	_ = addonsv1.AddToScheme(scheme)
+
+	// Add the CAPI clusterctl scheme.
+	_ = clusterctlv1.AddToScheme(scheme)
 
 	// Add the core CAPI v1alpha3 scheme.
 	_ = clusterv1alpha3.AddToScheme(scheme)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

* Adds an cluster upgrade to self-hosted test as additional step
* Allows to configure the number of nodes for testing ha and non-ha self-hosted clusters

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3728
