### PR TITLE
:book: update quickstart with link to the new Nutanix doc website

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -449,7 +449,7 @@ Please visit the [Metal3 project][Metal3 provider].
 {{#/tab }}
 {{#tab Nutanix}}
 
-Please follow the Cluster API Provider for [Nutanix Getting Started Guide](https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/docs/getting_started.md)
+Please follow the Cluster API Provider for [Nutanix Getting Started Guide](https://opendocs.nutanix.com/capx/latest/getting_started/)
 
 {{#/tab }}
 {{#tab OCI}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Update Nutanix section in the quickstart with the link to the new official documentation website


