### PR TITLE
📖 Add CAPM3 to glossary

### DIFF
--- a/docs/book/src/reference/glossary.md
+++ b/docs/book/src/reference/glossary.md
@@ -56,6 +56,9 @@ Cluster API Provider Hetzner
 ### CAPIBM
 Cluster API Provider IBM Cloud
 
+### CAPM3
+Cluster API Provider Metal3
+
 ### CAPN
 Cluster API Provider Nested
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Cluster API Provider Metal3 to the [glossary](https://cluster-api.sigs.k8s.io/reference/glossary.html#c) in the book
