### PR TITLE
🐛 test/e2e: fix duplicate mount in CAPD test

### DIFF
--- a/test/e2e/clusterclass_changes_test.go
+++ b/test/e2e/clusterclass_changes_test.go
@@ -54,7 +54,9 @@ var _ = Describe("When testing ClusterClass changes [ClusterClass]", func() {
 						"hostPath":      "/var/run/docker.sock",
 					},
 					map[string]interface{}{
-						"containerPath": "/tmp",
+						// /tmp cannot be used as containerPath as
+						// it already exists.
+						"containerPath": "/test",
 						"hostPath":      "/tmp",
 					},
 				},


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
While debugging test failures I saw that our test config seems to be invalid. 
The configured mount produces the following errors:
```plain
failed to create worker DockerMachine: error creating container \"clusterclass-changes-cmdpbw-md-0-lkq2j-6944fbd987-tnh24\": Error response from daemon: Duplicate mount point: /tmp","errVerbose":"Error response from daemon: Duplicate mount point: /tmp\nerror creating container
```

* [x] to be verified by running e2e tests if that fixes it
  * => Verified error doesn't occur in the logs anymore

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
