### PR TITLE
🌱 Fix the lint error on main

### DIFF
--- a/cmd/clusterctl/client/cluster/template_test.go
+++ b/cmd/clusterctl/client/cluster/template_test.go
@@ -310,7 +310,7 @@ func Test_templateClient_GetFromURL(t *testing.T) {
 	// redirect stdin
 	saveStdin := os.Stdin
 	defer func() { os.Stdin = saveStdin }()
-	os.Stdin, err = os.Open(path)
+	os.Stdin, err = os.Open(path) //nolint:gosec
 	g.Expect(err).NotTo(HaveOccurred())
 
 	type args struct {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This fixes a lint error on main that could block other PRs.

The lint error on main was introduced in this PR: https://github.com/kubernetes-sigs/cluster-api/pull/7228

The lint job on this PR seems to be stuck in a "awaiting approval" stage and was not run on the original PR. Ref: https://github.com/kubernetes-sigs/cluster-api/actions/runs/3082322705

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
