### PR TITLE
🌱 CAPD: make Machine bootstrap reentrant

### DIFF
--- a/test/infrastructure/docker/api/v1beta1/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1beta1/dockermachine_types.go
@@ -51,6 +51,7 @@ type DockerMachineSpec struct {
 
 	// Bootstrapped is true when the kubeadm bootstrapping has been run
 	// against this machine
+	// Deprecated: This field will be removed in the next apiVersion.
 	// +optional
 	Bootstrapped bool `json:"bootstrapped,omitempty"`
 }

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
@@ -527,8 +527,9 @@ spec:
                         type: object
                       type: array
                     bootstrapped:
-                      description: Bootstrapped is true when the kubeadm bootstrapping
-                        has been run against this machine
+                      description: 'Bootstrapped is true when the kubeadm bootstrapping
+                        has been run against this machine Deprecated: This field will
+                        be removed in the next apiVersion.'
                       type: boolean
                     instanceName:
                       description: InstanceName is the identification of the Machine

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -346,8 +346,9 @@ spec:
             description: DockerMachineSpec defines the desired state of DockerMachine.
             properties:
               bootstrapped:
-                description: Bootstrapped is true when the kubeadm bootstrapping has
-                  been run against this machine
+                description: 'Bootstrapped is true when the kubeadm bootstrapping
+                  has been run against this machine Deprecated: This field will be
+                  removed in the next apiVersion.'
                 type: boolean
               customImage:
                 description: CustomImage allows customizing the container image that

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
@@ -241,8 +241,9 @@ spec:
                       of the machine.
                     properties:
                       bootstrapped:
-                        description: Bootstrapped is true when the kubeadm bootstrapping
-                          has been run against this machine
+                        description: 'Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine Deprecated: This field
+                          will be removed in the next apiVersion.'
                         type: boolean
                       customImage:
                         description: CustomImage allows customizing the container

--- a/test/infrastructure/docker/exp/api/v1beta1/dockermachinepool_types.go
+++ b/test/infrastructure/docker/exp/api/v1beta1/dockermachinepool_types.go
@@ -107,6 +107,7 @@ type DockerMachinePoolInstanceStatus struct {
 
 	// Bootstrapped is true when the kubeadm bootstrapping has been run
 	// against this machine
+	// Deprecated: This field will be removed in the next apiVersion.
 	// +optional
 	Bootstrapped bool `json:"bootstrapped,omitempty"`
 }

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -355,7 +355,7 @@ func (m *Machine) ExecBootstrap(ctx context.Context, data string, format bootstr
 		}
 		err := cmd.Run(ctx)
 		if err != nil {
-			log.Info("Failed running command", "command", command, "stdout", outStd.String(), "stderr", outErr.String(), "bootstrap data", data)
+			log.Info("Failed running command", "instance", m.Name(), "command", command, "stdout", outStd.String(), "stderr", outErr.String(), "bootstrap data", data)
 			logContainerDebugInfo(ctx, log, m.ContainerName())
 			return errors.Wrap(errors.WithStack(err), "failed to run cloud config")
 		}
@@ -365,7 +365,7 @@ func (m *Machine) ExecBootstrap(ctx context.Context, data string, format bootstr
 }
 
 // CheckForBootstrapSuccess checks if bootstrap was successful by checking for existence of the sentinel file.
-func (m *Machine) CheckForBootstrapSuccess(ctx context.Context) error {
+func (m *Machine) CheckForBootstrapSuccess(ctx context.Context, logResult bool) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	if m.container == nil {
@@ -378,7 +378,9 @@ func (m *Machine) CheckForBootstrapSuccess(ctx context.Context) error {
 	cmd.SetStderr(&outErr)
 	cmd.SetStdout(&outStd)
 	if err := cmd.Run(ctx); err != nil {
-		log.Info("Failed running command", "command", "test -f /run/cluster-api/bootstrap-success.complete", "stdout", outStd.String(), "stderr", outErr.String())
+		if logResult {
+			log.Info("Failed running command", "command", "test -f /run/cluster-api/bootstrap-success.complete", "stdout", outStd.String(), "stderr", outErr.String())
+		}
 		return errors.Wrap(errors.WithStack(err), "failed to run bootstrap check")
 	}
 	return nil


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Makes the machine bootstrap reentrant. Currently we might try to bootstrap a machine again even though it's already successfully bootstrapped.

Found during implementation of #7244

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
