### PR TITLE
🌱 Loki: increase Loki ingestion limits for log-push

### DIFF
--- a/hack/observability/loki/values.yaml
+++ b/hack/observability/loki/values.yaml
@@ -1,1 +1,10 @@
 # Placeholder for loki chart configuration, see https://github.com/grafana/helm-charts/tree/main/charts/loki
+
+# Set high ingestion limits so log-push can push logs without hitting the rate limits:
+# Push response: status: "429 Too Many Requests", body: "Ingestion rate limit exceeded for user fake (limit:
+# 4194304 bytes/sec) while attempting to ingest '1000' lines totaling '755293' bytes, reduce log volume or
+# contact your Loki administrator to see if the limit can be increased"
+config:
+  limits_config:
+    ingestion_rate_mb: 1024
+    ingestion_burst_size_mb: 1024


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR increases the ingestion limits. When using log-push I noticed that most logs didn't get into Loki because of these errors:
> Push response: status: "429 Too Many Requests", body: "Ingestion rate limit exceeded for user fake (limit:
> 4194304 bytes/sec) while attempting to ingest '1000' lines totaling '755293' bytes, reduce log volume or
> contact your Loki administrator to see if the limit can be increased

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
