### PR TITLE
🌱  Log full object name and creation error for topology template reconcile

### DIFF
--- a/internal/controllers/topology/cluster/reconcile_state.go
+++ b/internal/controllers/topology/cluster/reconcile_state.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -506,10 +508,10 @@ func (r *Reconciler) createMachineDeployment(ctx context.Context, cluster *clust
 	log.Infof(fmt.Sprintf("Creating %s", tlog.KObj{Obj: md.Object}))
 	helper, err := r.patchHelperFactory(ctx, nil, md.Object)
 	if err != nil {
-		return createErrorWithoutObjectName(err, md.Object)
+		return createErrorWithoutObjectName(ctx, err, md.Object)
 	}
 	if err := helper.Patch(ctx); err != nil {
-		return createErrorWithoutObjectName(err, md.Object)
+		return createErrorWithoutObjectName(ctx, err, md.Object)
 	}
 	r.recorder.Eventf(cluster, corev1.EventTypeNormal, createEventReason, "Created %q", tlog.KObj{Obj: md.Object})
 
@@ -654,10 +656,10 @@ func (r *Reconciler) reconcileReferencedObject(ctx context.Context, in reconcile
 		log.Infof("Creating %s", tlog.KObj{Obj: in.desired})
 		helper, err := r.patchHelperFactory(ctx, nil, in.desired, structuredmerge.IgnorePaths(in.ignorePaths))
 		if err != nil {
-			return errors.Wrap(createErrorWithoutObjectName(err, in.desired), "failed to create patch helper")
+			return errors.Wrap(createErrorWithoutObjectName(ctx, err, in.desired), "failed to create patch helper")
 		}
 		if err := helper.Patch(ctx); err != nil {
-			return createErrorWithoutObjectName(err, in.desired)
+			return createErrorWithoutObjectName(ctx, err, in.desired)
 		}
 		r.recorder.Eventf(in.cluster, corev1.EventTypeNormal, createEventReason, "Created %q", tlog.KObj{Obj: in.desired})
 		return nil
@@ -731,10 +733,10 @@ func (r *Reconciler) reconcileReferencedTemplate(ctx context.Context, in reconci
 		log.Infof("Creating %s", tlog.KObj{Obj: in.desired})
 		helper, err := r.patchHelperFactory(ctx, nil, in.desired)
 		if err != nil {
-			return errors.Wrap(createErrorWithoutObjectName(err, in.desired), "failed to create patch helper")
+			return errors.Wrap(createErrorWithoutObjectName(ctx, err, in.desired), "failed to create patch helper")
 		}
 		if err := helper.Patch(ctx); err != nil {
-			return createErrorWithoutObjectName(err, in.desired)
+			return createErrorWithoutObjectName(ctx, err, in.desired)
 		}
 		r.recorder.Eventf(in.cluster, corev1.EventTypeNormal, createEventReason, "Created %q", tlog.KObj{Obj: in.desired})
 		return nil
@@ -783,10 +785,10 @@ func (r *Reconciler) reconcileReferencedTemplate(ctx context.Context, in reconci
 	log.Infof("Creating %s", tlog.KObj{Obj: in.desired})
 	helper, err := r.patchHelperFactory(ctx, nil, in.desired)
 	if err != nil {
-		return errors.Wrap(createErrorWithoutObjectName(err, in.desired), "failed to create patch helper")
+		return errors.Wrap(createErrorWithoutObjectName(ctx, err, in.desired), "failed to create patch helper")
 	}
 	if err := helper.Patch(ctx); err != nil {
-		return createErrorWithoutObjectName(err, in.desired)
+		return createErrorWithoutObjectName(ctx, err, in.desired)
 	}
 	r.recorder.Eventf(in.cluster, corev1.EventTypeNormal, createEventReason, "Created %q as a replacement for %q (template rotation)", tlog.KObj{Obj: in.desired}, in.ref.Name)
 
@@ -801,7 +803,13 @@ func (r *Reconciler) reconcileReferencedTemplate(ctx context.Context, in reconci
 // createErrorWithoutObjectName removes the name of the object from the error message. As each new Create call involves an
 // object with a unique generated name each error appears to be a different error. As the errors are being surfaced in a condition
 // on the Cluster, the name is removed here to prevent each creation error from triggering a new reconciliation.
-func createErrorWithoutObjectName(err error, obj client.Object) error {
+func createErrorWithoutObjectName(ctx context.Context, err error, obj client.Object) error {
+	log := ctrl.LoggerFrom(ctx)
+	if obj != nil {
+		log = log.WithValues(obj.GetObjectKind().GroupVersionKind().Kind, klog.KObj(obj))
+	}
+	log.Error(err, "Failed to create object")
+
 	var statusError *apierrors.StatusError
 	if errors.As(err, &statusError) {
 		var msg string

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -2980,7 +2980,7 @@ func Test_createErrorWithoutObjectName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			err := createErrorWithoutObjectName(tt.input, tt.obj)
+			err := createErrorWithoutObjectName(ctx, tt.input, tt.obj)
 			g.Expect(err.Error()).To(Equal(tt.expected.Error()))
 		})
 	}


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add a log with the full object name in before stripping the unique identifier in createErrorWithoutObjectName.

Fixes #7238
