### PR TITLE
🐛 bump kindnetd to v20220927-ce36d7c0 to fix routes on self-hosted upgrades

### DIFF
--- a/test/e2e/data/cni/kindnet/kindnet.yaml
+++ b/test/e2e/data/cni/kindnet/kindnet.yaml
@@ -66,7 +66,7 @@ spec:
       serviceAccountName: kindnet
       containers:
         - name: kindnet-cni
-          image: kindest/kindnetd:v20220726-ed811e41
+          image: kindest/kindnetd:v20220927-ce36d7c0
           env:
             - name: HOST_IP
               valueFrom:


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Bumps the kindnet cni version used in tests to include 
- https://github.com/kubernetes-sigs/kind/pull/2941

This fixes a bug detected during working at #3728 and described in the kind PR https://github.com/kubernetes-sigs/kind/pull/2941 .

Edit: Workload clusters using kindnet are also affected from this bug and for upgrade tests the bug may cause pod-to-pod networking issues due to wrong ip routes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
