### PR TITLE
🐛 Fix RemoveOwnerRef so that it does not mutate its input

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -326,7 +326,8 @@ func ReplaceOwnerRef(ownerReferences []metav1.OwnerReference, source metav1.Obje
 // RemoveOwnerRef returns the slice of owner references after removing the supplied owner ref.
 func RemoveOwnerRef(ownerReferences []metav1.OwnerReference, inputRef metav1.OwnerReference) []metav1.OwnerReference {
 	if index := indexOwnerRef(ownerReferences, inputRef); index != -1 {
-		return append(ownerReferences[:index], ownerReferences[index+1:]...)
+		copyOwnerReferences := append([]metav1.OwnerReference{}, ownerReferences...)
+		return append(copyOwnerReferences[:index], copyOwnerReferences[index+1:]...)
 	}
 	return ownerReferences
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -41,7 +41,7 @@ import (
 func TestMachineToInfrastructureMapFunc(t *testing.T) {
 	g := NewWithT(t)
 
-	var testcases = []struct {
+	testcases := []struct {
 		name    string
 		input   schema.GroupVersionKind
 		request client.Object
@@ -110,7 +110,7 @@ func TestMachineToInfrastructureMapFunc(t *testing.T) {
 }
 
 func TestClusterToInfrastructureMapFunc(t *testing.T) {
-	var testcases = []struct {
+	testcases := []struct {
 		name           string
 		input          schema.GroupVersionKind
 		request        *clusterv1.Cluster
@@ -874,10 +874,15 @@ func TestRemoveOwnerRef(t *testing.T) {
 			},
 		},
 	}
+
+	originalOwnerRefs := append([]metav1.OwnerReference{}, ownerRefs...)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			newOwnerRefs := RemoveOwnerRef(ownerRefs, tt.toBeRemoved)
-			g.Expect(HasOwnerRef(newOwnerRefs, tt.toBeRemoved)).NotTo(BeTrue())
+			result := RemoveOwnerRef(ownerRefs, tt.toBeRemoved)
+			// RemoveOwnerRef should remove the owner ref, if it is found.
+			g.Expect(HasOwnerRef(result, tt.toBeRemoved)).NotTo(BeTrue())
+			// RemoveOwnerRef should not mutate its input.
+			g.Expect(ownerRefs).To(Equal(originalOwnerRefs), "RemoveOwnerRef mutated its input")
 		})
 	}
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The `RemoveOwnerRef` function mutates its input. As far as I understand, it is designed to not mutate its input. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
