### PR TITLE
🐛 Update ClusterResourceSetBinding owner references

### DIFF
--- a/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1beta1/clusterresourcesetbinding_types.go
@@ -102,7 +102,7 @@ func (c *ClusterResourceSetBinding) DeleteBinding(clusterResourceSet *ClusterRes
 			break
 		}
 	}
-	clusterResourceSet.OwnerReferences = util.RemoveOwnerRef(c.OwnerReferences, metav1.OwnerReference{
+	c.OwnerReferences = util.RemoveOwnerRef(c.OwnerReferences, metav1.OwnerReference{
 		APIVersion: clusterResourceSet.APIVersion,
 		Kind:       clusterResourceSet.Kind,
 		Name:       clusterResourceSet.Name,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The ClusterResourceSet owner references were being updated due to a typo. This update was ineffectual, because the ClusterResourceSet object is not patched after the references are updated.

However, due to a separate bug (https://github.com/kubernetes-sigs/cluster-api/pull/7309) in RemoveOwnerRef, the ClusterResourceSetBinding owner references _were_ being updated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
