### PR TITLE
🌱 add PreWaitForCluster hook and CNIPath to e2e clusterctl upgrade test

### DIFF
--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -68,12 +68,16 @@ type ClusterctlUpgradeSpecInput struct {
 	// provider contract to use to initialise the secondary management cluster, e.g. `v1alpha3`
 	InitWithProvidersContract string
 	SkipCleanup               bool
-	ControlPlaneWaiters       clusterctl.ControlPlaneWaiters
-	PreInit                   func(managementClusterProxy framework.ClusterProxy)
-	PreUpgrade                func(managementClusterProxy framework.ClusterProxy)
-	PostUpgrade               func(managementClusterProxy framework.ClusterProxy)
-	MgmtFlavor                string
-	WorkloadFlavor            string
+	// PreWaitForCluster is a function that can be used as a hook to apply extra resources (that cannot be part of the template) in the generated namespace hosting the cluster
+	// This function is called after applying the cluster template and before waiting for the cluster resources.
+	PreWaitForCluster   func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace string, workloadClusterName string)
+	ControlPlaneWaiters clusterctl.ControlPlaneWaiters
+	PreInit             func(managementClusterProxy framework.ClusterProxy)
+	PreUpgrade          func(managementClusterProxy framework.ClusterProxy)
+	PostUpgrade         func(managementClusterProxy framework.ClusterProxy)
+	MgmtFlavor          string
+	CNIManifestPath     string
+	WorkloadFlavor      string
 }
 
 // ClusterctlUpgradeSpec implements a test that verifies clusterctl upgrade of a management cluster.
@@ -167,6 +171,12 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 				ControlPlaneMachineCount: pointer.Int64Ptr(1),
 				WorkerMachineCount:       pointer.Int64Ptr(1),
 			},
+			PreWaitForCluster: func() {
+				if input.PreWaitForCluster != nil {
+					input.PreWaitForCluster(input.BootstrapClusterProxy, managementClusterNamespace.Name, managementClusterName)
+				}
+			},
+			CNIManifestPath:              input.CNIManifestPath,
 			ControlPlaneWaiters:          input.ControlPlaneWaiters,
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
 			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
@@ -275,6 +285,11 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 
 		log.Logf("Applying the cluster template yaml to the cluster")
 		Expect(managementClusterProxy.Apply(ctx, workloadClusterTemplate)).To(Succeed())
+
+		if input.PreWaitForCluster != nil {
+			By("Running PreWaitForCluster steps against the management cluster")
+			input.PreWaitForCluster(managementClusterProxy, testNamespace.Name, workLoadClusterName)
+		}
 
 		By("Waiting for the machines to exists")
 		Eventually(func() (int64, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherrypick of https://github.com/kubernetes-sigs/cluster-api/pull/6636
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
