### PR TITLE
🌱 teste/e2e: tag clusterctl ClusterClass test with [ClusterClass]

### DIFF
--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -73,7 +73,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.2=>current)", func() {
 	})
 })
 
-var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.2=>current)", func() {
+var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.2=>current) [ClusterClass]", func() {
 	ClusterctlUpgradeSpec(ctx, func() ClusterctlUpgradeSpecInput {
 		return ClusterctlUpgradeSpecInput{
 			E2EConfig:                 e2eConfig,


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
The PR that yesterday introduced a new clustectl upgrade ClusterClass e2e test lead to failures in the e2e-mink8s job: https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-mink8s-main

This is because the e2e-mink8s Job is using Kubernetes v1.20 and thus has ClusterTopology/ClusterClass disabled.

Usually this job skips all ClusterClass tests but only when they are tagged correctly. (GINKGO_SKIP: \[Conformance\] \[K8s-Upgrade\]|\[IPv6\]|\[ClusterClass\])

(Open https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api#capi-e2e-main and grep for "[ClusterClass]" to see the other tagged jobs)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7324
