### PR TITLE
✨ Add failure domain annotation to node

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -65,6 +65,9 @@ const (
 	// MachineAnnotation is the annotation set on nodes identifying the machine the node belongs to.
 	MachineAnnotation = "cluster.x-k8s.io/machine"
 
+	// FailureDomainAnnotation is the annotation set on nodes identifying the failure domain the node belongs to.
+	FailureDomainAnnotation = "cluster.x-k8s.io/failure-domain"
+
 	// OwnerKindAnnotation is the annotation set on nodes identifying the owner kind.
 	OwnerKindAnnotation = "cluster.x-k8s.io/owner-kind"
 

--- a/internal/controllers/machine/machine_controller_noderef.go
+++ b/internal/controllers/machine/machine_controller_noderef.go
@@ -109,6 +109,10 @@ func (r *Reconciler) reconcileNode(ctx context.Context, cluster *clusterv1.Clust
 		desired[clusterv1.OwnerKindAnnotation] = owner.Kind
 		desired[clusterv1.OwnerNameAnnotation] = owner.Name
 	}
+	if machine.Spec.FailureDomain != nil {
+		desired[clusterv1.FailureDomainAnnotation] = *machine.Spec.FailureDomain
+	}
+
 	if annotations.AddAnnotations(node, desired) {
 		if err := patchHelper.Patch(ctx, node); err != nil {
 			log.V(2).Info("Failed patch node to set annotations", "err", err, "node name", node.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
I want to have failure domain annotation in a node to specify pod topology spread constraint. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None