### PR TITLE
🌱 Add ok-to-test label to dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
   commit-message:
       prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
@@ -14,3 +16,5 @@ updates:
     - dependency-name: "github.com/coredns/corefile-migration"
   commit-message:
     prefix: ":seedling:"
+  labels:
+    - "ok-to-test"


### PR DESCRIPTION
**What this PR does / why we need it**:

Felt like unnecessary work to give dependabot "ok-to-test" for each pr. Better to just let it build directly.