### PR TITLE
✨ Update golangci-lint 1.50. Enable new linter dupword

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,5 +25,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.49.0
+          version: v1.50.0
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   - containedctx
   - depguard
   - dogsled
+  - dupword
   - durationcheck
   - errcheck
   - errchkjson

--- a/cmd/clusterctl/client/yamlprocessor/simple_processor_test.go
+++ b/cmd/clusterctl/client/yamlprocessor/simple_processor_test.go
@@ -186,7 +186,7 @@ func TestSimpleProcessor_Process(t *testing.T) {
 				configVariablesClient: test.NewFakeVariableClient().
 					WithVar("BAR", "bar"),
 			},
-			want:    []byte("foo bar, bar, bar"),
+			want:    []byte("foo bar, bar, bar"), //nolint:dupword
 			wantErr: false,
 		},
 		{
@@ -196,7 +196,7 @@ func TestSimpleProcessor_Process(t *testing.T) {
 				configVariablesClient: test.NewFakeVariableClient().
 					WithVar("BAR", "bar"),
 			},
-			want:    []byte(`\\ foo bar, bar, bar`),
+			want:    []byte(`\\ foo bar, bar, bar`), //nolint:dupword
 			wantErr: false,
 		},
 		{

--- a/internal/contract/types_test.go
+++ b/internal/contract/types_test.go
@@ -60,7 +60,7 @@ func TestPath_IsParenOf(t *testing.T) {
 			want:  false,
 		},
 		{
-			name:  "False for not overlapping path path",
+			name:  "False for not overlapping path",
 			p:     Path{"foo", "bar"},
 			other: Path{"baz"},
 			want:  false,
@@ -102,7 +102,7 @@ func TestPath_Equal(t *testing.T) {
 			want:  false,
 		},
 		{
-			name:  "False for not overlapping path path",
+			name:  "False for not overlapping path",
 			p:     Path{"foo", "bar"},
 			other: Path{"baz"},
 			want:  false,
@@ -144,7 +144,7 @@ func TestPath_Overlaps(t *testing.T) {
 			want:  true,
 		},
 		{
-			name:  "False for not overlapping path path",
+			name:  "False for not overlapping path",
 			p:     Path{"foo", "bar"},
 			other: Path{"baz"},
 			want:  false,


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates golangci-lint to v1.50.0. Enable new linter `dupword`. Not that many findings by dupword right now but I have made at least two prs cleaning up dupwords before. So it's likely good to have :) 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
