### PR TITLE
:bug: Set nofile ulimit for loadbalancer container

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-units v0.4.0
 	github.com/flatcar/ignition v0.36.2
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.2.0
@@ -49,7 +50,6 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
-	github.com/docker/go-units v0.4.0 // indirect
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect

--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -384,6 +384,7 @@ func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContaine
 		Tmpfs:         runConfig.Tmpfs,
 		PortBindings:  nat.PortMap{},
 		RestartPolicy: dockercontainer.RestartPolicy{Name: "unless-stopped"},
+		Resources:     runConfig.Resources,
 	}
 	networkConfig := network.NetworkingConfig{}
 

--- a/test/infrastructure/container/interface.go
+++ b/test/infrastructure/container/interface.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 
+	dockercontainer "github.com/docker/docker/api/types/container"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -95,6 +97,8 @@ type RunContainerInput struct {
 	PortMappings []PortMapping
 	// IPFamily is the IP version to use.
 	IPFamily clusterv1.ClusterIPFamily
+	// Resource limits and settings for the container.
+	Resources dockercontainer.Resources
 }
 
 // ExecContainerInput contains values for running exec on a container.


### PR DESCRIPTION
Hardcode a nofile ulimit when running the load balancer container. I set the limit to a quite high number, but I don't think it's required to be that high for CAPD clusters.

This change is intended to solve: https://github.com/docker-library/haproxy/issues/194 which impacts CAPD on Fedora, and possibly other linux distros. In future the addition of Resource setting to the run container config structs could be used to set other kinds of limits e.g. Memory, CPU.
