### PR TITLE
:seedling: Make KCP diskSetup field mutable

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -126,6 +126,7 @@ const (
 	scheduler            = "scheduler"
 	ntp                  = "ntp"
 	ignition             = "ignition"
+	diskSetup            = "diskSetup"
 )
 
 const minimumCertificatesExpiryDays = 7
@@ -156,6 +157,7 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, users},
 		{spec, kubeadmConfigSpec, ntp, "*"},
 		{spec, kubeadmConfigSpec, ignition, "*"},
+		{spec, kubeadmConfigSpec, diskSetup, "*"},
 		{spec, "machineTemplate", "metadata", "*"},
 		{spec, "machineTemplate", "infrastructureRef", "apiVersion"},
 		{spec, "machineTemplate", "infrastructureRef", "name"},

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -648,6 +648,16 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 		Directory: "/tmp/patches",
 	}
 
+	updateDiskSetup := before.DeepCopy()
+	updateDiskSetup.Spec.KubeadmConfigSpec.DiskSetup = &bootstrapv1.DiskSetup{
+		Filesystems: []bootstrapv1.Filesystem{
+			{
+				Device:     "/dev/sda",
+				Filesystem: "ext4",
+			},
+		},
+	}
+
 	tests := []struct {
 		name                  string
 		enableIgnitionFeature bool
@@ -971,6 +981,12 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: false,
 			before:    before,
 			kcp:       updateJoinConfigurationPatches,
+		},
+		{
+			name:      "should allow changes to diskSetup",
+			expectErr: false,
+			before:    before,
+			kcp:       updateDiskSetup,
 		},
 		{
 			name:      "should return error when rolloutBefore.certificatesExpiryDays is invalid",


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Makes KCP diskSetup field mutable. 
Needed if you want to to alter the disk layout for new control-plane nodes.

