### PR TITLE
:bug: Don't retry health check when Unauthorized is returned

### DIFF
--- a/controllers/remote/cluster_cache_tracker.go
+++ b/controllers/remote/cluster_cache_tracker.go
@@ -482,6 +482,12 @@ func (t *ClusterCacheTracker) healthCheckCluster(ctx context.Context, in *health
 		// If no error occurs, reset the unhealthy counter.
 		_, err := restClient.Get().AbsPath(in.path).Timeout(in.requestTimeout).DoRaw(ctx)
 		if err != nil {
+			if apierrors.IsUnauthorized(err) {
+				// Unauthorized means that the underlying kubeconfig is not authorizing properly anymore, which
+				// usually is the result of automatic kubeconfig refreshes, meaning that we have to throw away the
+				// clusterAccessor and rely on the creation of a new one (with a refreshed kubeconfig)
+				return false, err
+			}
 			unhealthyCount++
 		} else {
 			unhealthyCount = 0


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This fixes unnecessary delays in self-repair when the underlying provider (e.g. the AWS provider) performs periodic kubeconfig refreshes. Without this, the health check is retried 10 times with a 10s interval, meaning that the controller is unable to act for at least 100 seconds, even though it could repair itself immediately.
