### PR TITLE
📖 update cert-manager label searching command

### DIFF
--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -101,7 +101,7 @@ You may want to migrate to a user-managed cert-manager further down the line, af
 
 `clusterctl` looks for the label `clusterctl.cluster.x-k8s.io/core=cert-manager` on all api resources in the `cert-manager` namespace. If it finds the label, `clusterctl` will manage the cert-manager deployment. You can list all the resources with that label by running:
 ```bash
-kubectl get all -A --selector=clusterctl.cluster.x-k8s.io/core=cert-manager
+kubectl get mutatingwebhookconfiguration,validatingwebhookconfiguration,clusterrole,clusterrolebinding,crds,all -A --selector=clusterctl.cluster.x-k8s.io/core=cert-manager
 ```
 If you want to manage and install your own cert-manager, you'll need to remove this label from all API resources.
 

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -101,7 +101,7 @@ You may want to migrate to a user-managed cert-manager further down the line, af
 
 `clusterctl` looks for the label `clusterctl.cluster.x-k8s.io/core=cert-manager` on all api resources in the `cert-manager` namespace. If it finds the label, `clusterctl` will manage the cert-manager deployment. You can list all the resources with that label by running:
 ```bash
-kubectl get mutatingwebhookconfiguration,validatingwebhookconfiguration,clusterrole,clusterrolebinding,crds,all -A --selector=clusterctl.cluster.x-k8s.io/core=cert-manager
+kubectl api-resources --verbs=list -o name | xargs -n 1 kubectl get --show-kind --ignore-not-found -A --selector=clusterctl.cluster.x-k8s.io/core=cert-manager
 ```
 If you want to manage and install your own cert-manager, you'll need to remove this label from all API resources.
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
`kubectl get all -A` doesn't actually return all resources, see https://github.com/kubernetes/kubectl/issues/151. This command should now cover all the CAPI mangaed `cert-manager` resources.