### PR TITLE
:sparkles: Add topology field for MinReadySeconds

### DIFF
--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -69,6 +69,7 @@ func (src *Cluster) ConvertTo(dstRaw conversion.Hub) error {
 				dst.Spec.Topology.Workers.MachineDeployments[i].NodeDrainTimeout = restored.Spec.Topology.Workers.MachineDeployments[i].NodeDrainTimeout
 				dst.Spec.Topology.Workers.MachineDeployments[i].NodeVolumeDetachTimeout = restored.Spec.Topology.Workers.MachineDeployments[i].NodeVolumeDetachTimeout
 				dst.Spec.Topology.Workers.MachineDeployments[i].NodeDeletionTimeout = restored.Spec.Topology.Workers.MachineDeployments[i].NodeDeletionTimeout
+				dst.Spec.Topology.Workers.MachineDeployments[i].MinReadySeconds = restored.Spec.Topology.Workers.MachineDeployments[i].MinReadySeconds
 				dst.Spec.Topology.Workers.MachineDeployments[i].MachineHealthCheck = restored.Spec.Topology.Workers.MachineDeployments[i].MachineHealthCheck
 			}
 		}

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -1248,6 +1248,7 @@ func autoConvert_v1beta1_MachineDeploymentTopology_To_v1alpha4_MachineDeployment
 	// WARNING: in.NodeDrainTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.NodeVolumeDetachTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.NodeDeletionTimeout requires manual conversion: does not exist in peer-type
+	// WARNING: in.MinReadySeconds requires manual conversion: does not exist in peer-type
 	// WARNING: in.Variables requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -199,6 +199,13 @@ type MachineDeploymentTopology struct {
 	// +optional
 	NodeDeletionTimeout *metav1.Duration `json:"nodeDeletionTimeout,omitempty"`
 
+	// Minimum number of seconds for which a newly created machine should
+	// be ready.
+	// Defaults to 0 (machine will be considered available as soon as it
+	// is ready)
+	// +optional
+	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
+
 	// Variables can be used to customize the MachineDeployment through patches.
 	// +optional
 	Variables *MachineDeploymentVariables `json:"variables,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -992,6 +992,11 @@ func (in *MachineDeploymentTopology) DeepCopyInto(out *MachineDeploymentTopology
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.MinReadySeconds != nil {
+		in, out := &in.MinReadySeconds, &out.MinReadySeconds
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Variables != nil {
 		in, out := &in.Variables, &out.Variables
 		*out = new(MachineDeploymentVariables)

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -1708,6 +1708,13 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentTopology(ref comm
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"minReadySeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"variables": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Variables can be used to customize the MachineDeployment through patches.",

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1211,6 +1211,12 @@ spec:
                                     controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
                                   type: object
                               type: object
+                            minReadySeconds:
+                              description: Minimum number of seconds for which a newly
+                                created machine should be ready. Defaults to 0 (machine
+                                will be considered available as soon as it is ready)
+                              format: int32
+                              type: integer
                             name:
                               description: Name is the unique identifier for this
                                 MachineDeploymentTopology. The value is used with

--- a/internal/controllers/topology/cluster/desired_state.go
+++ b/internal/controllers/topology/cluster/desired_state.go
@@ -601,7 +601,8 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, desiredControlP
 			Namespace: s.Current.Cluster.Namespace,
 		},
 		Spec: clusterv1.MachineDeploymentSpec{
-			ClusterName: s.Current.Cluster.Name,
+			ClusterName:     s.Current.Cluster.Name,
+			MinReadySeconds: machineDeploymentTopology.MinReadySeconds,
 			Template: clusterv1.MachineTemplateSpec{
 				ObjectMeta: clusterv1.ObjectMeta{
 					Labels:      mergeMap(machineDeploymentTopology.Metadata.Labels, machineDeploymentBlueprint.Metadata.Labels),

--- a/internal/controllers/topology/cluster/desired_state_test.go
+++ b/internal/controllers/topology/cluster/desired_state_test.go
@@ -1328,6 +1328,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 	nodeDrainTimeout := metav1.Duration{Duration: 10 * time.Second}
 	nodeVolumeDetachTimeout := metav1.Duration{Duration: 10 * time.Second}
 	nodeDeletionTimeout := metav1.Duration{Duration: 10 * time.Second}
+	minReadySeconds := int32(5)
 	mdTopology := clusterv1.MachineDeploymentTopology{
 		Metadata: clusterv1.ObjectMeta{
 			Labels: map[string]string{"foo": "baz"},
@@ -1339,6 +1340,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 		NodeDrainTimeout:        &nodeDrainTimeout,
 		NodeVolumeDetachTimeout: &nodeVolumeDetachTimeout,
 		NodeDeletionTimeout:     &nodeDeletionTimeout,
+		MinReadySeconds:         &minReadySeconds,
 	}
 
 	t.Run("Generates the machine deployment and the referenced templates", func(t *testing.T) {
@@ -1365,6 +1367,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 
 		actualMd := actual.Object
 		g.Expect(*actualMd.Spec.Replicas).To(Equal(replicas))
+		g.Expect(*actualMd.Spec.MinReadySeconds).To(Equal(minReadySeconds))
 		g.Expect(*actualMd.Spec.Template.Spec.FailureDomain).To(Equal(failureDomain))
 		g.Expect(*actualMd.Spec.Template.Spec.NodeDrainTimeout).To(Equal(nodeDrainTimeout))
 		g.Expect(*actualMd.Spec.Template.Spec.NodeDeletionTimeout).To(Equal(nodeDeletionTimeout))

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/bases/cluster-with-topology.yaml
@@ -26,6 +26,7 @@ spec:
         name: "md-0"
         nodeDeletionTimeout: "30s"
         nodeVolumeDetachTimeout: "5m"
+        minReadySeconds: 5
         replicas: ${WORKER_MACHINE_COUNT}
         failureDomain: fd4
     variables:


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
