### PR TITLE
[release-1.2] 🌱 clusterctl: support envsubst in clusterctl config 

### DIFF
--- a/cmd/clusterctl/client/config/cert_manager_client.go
+++ b/cmd/clusterctl/client/config/cert_manager_client.go
@@ -17,8 +17,10 @@ limitations under the License.
 package config
 
 import (
+	"os"
 	"time"
 
+	"github.com/drone/envsubst/v2"
 	"github.com/pkg/errors"
 )
 
@@ -77,6 +79,12 @@ func (p *certManagerClient) Get() (CertManager, error) {
 	if userCertManager.URL != "" {
 		url = userCertManager.URL
 	}
+
+	url, err := envsubst.Eval(url, os.Getenv)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to evaluate url: %q", url)
+	}
+
 	if userCertManager.Version != "" {
 		version = userCertManager.Version
 	}

--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -18,9 +18,11 @@ package config
 
 import (
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 
+	"github.com/drone/envsubst/v2"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 
@@ -283,6 +285,12 @@ func (p *providersClient) List() ([]Provider, error) {
 	}
 
 	for _, u := range userDefinedProviders {
+		var err error
+		u.URL, err = envsubst.Eval(u.URL, os.Getenv)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to evaluate url: %q", u.URL)
+		}
+
 		provider := NewProvider(u.Name, u.URL, u.Type)
 		if err := validateProvider(provider); err != nil {
 			return nil, errors.Wrapf(err, "error validating configuration for the %s with name %s. Please fix the providers value in clusterctl configuration file", provider.Type(), provider.Name())

--- a/docs/book/src/clusterctl/configuration.md
+++ b/docs/book/src/clusterctl/configuration.md
@@ -41,6 +41,8 @@ providers:
 
 See [provider contract](provider-contract.md) for instructions about how to set up a provider repository.
 
+**Note**: It is possible to use the `${HOME}` and `${CLUSTERCTL_REPOSITORY_PATH}` environment variables in `url`.
+
 ## Variables
 
 When installing a provider `clusterctl` reads a YAML file that is published in the provider repository. While executing
@@ -72,6 +74,8 @@ wants to use a different repository, it is possible to use the following configu
 cert-manager:
   url: "/Users/foo/.cluster-api/dev-repository/cert-manager/latest/cert-manager.yaml"
 ```
+
+**Note**: It is possible to use the `${HOME}` and `${CLUSTERCTL_REPOSITORY_PATH}` environment variables in `url`.
 
 Similarly, it is possible to override the default version installed by clusterctl by configuring:
 
@@ -167,6 +171,7 @@ run,
 ```bash
 clusterctl init --infrastructure aws:v0.5.0 -v5
 ```
+
 ```bash
 ...
 Using Override="infrastructure-components.yaml" Provider="infrastructure-aws" Version="v0.5.0"
@@ -180,6 +185,8 @@ directory in the clusterctl config file as
 ```yaml
 overridesFolder: /Users/foobar/workspace/dev-releases
 ```
+
+**Note**: It is possible to use the `${HOME}` and `${CLUSTERCTL_REPOSITORY_PATH}` environment variables in `overridesFolder`.
 
 ## Image overrides
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Manual cherry-pick of #7343

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
