### PR TITLE
🐛 clusterctl: support Windows paths in overridesFolder

### DIFF
--- a/cmd/clusterctl/client/repository/overrides.go
+++ b/cmd/clusterctl/client/repository/overrides.go
@@ -18,8 +18,10 @@ package repository
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/drone/envsubst/v2"
@@ -78,6 +80,19 @@ func (o *overrides) Path() string {
 			logf.Log.Info(fmt.Sprintf("⚠️overridesFolder %q could not be evaluated: %v", basepath, err))
 		} else {
 			basepath = evaluatedBasePath
+		}
+
+		if runtime.GOOS == "windows" {
+			parsedBasePath, err := url.Parse(basepath)
+			if err != nil {
+				logf.Log.Info(fmt.Sprintf("⚠️overridesFolder %q could not be parsed: %v", basepath, err))
+			} else {
+				// in case of windows, we should take care of removing the additional / which is required by the URI standard
+				// for windows local paths. see https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/ for more details.
+				// Encoded file paths are not required in Windows 10 versions <1803 and are unsupported in Windows 10 >=1803
+				// https://support.microsoft.com/en-us/help/4467268/url-encoded-unc-paths-not-url-decoded-in-windows-10-version-1803-later
+				basepath = filepath.FromSlash(strings.TrimPrefix(parsedBasePath.Path, "/"))
+			}
 		}
 	}
 

--- a/cmd/clusterctl/client/repository/repository_local.go
+++ b/cmd/clusterctl/client/repository/repository_local.go
@@ -148,8 +148,7 @@ func newLocalRepository(providerConfig config.Provider, configVariablesClient co
 		// for windows local paths. see https://blogs.msdn.microsoft.com/ie/2006/12/06/file-uris-in-windows/ for more details.
 		// Encoded file paths are not required in Windows 10 versions <1803 and are unsupported in Windows 10 >=1803
 		// https://support.microsoft.com/en-us/help/4467268/url-encoded-unc-paths-not-url-decoded-in-windows-10-version-1803-later
-		path = strings.TrimPrefix(path, "/")
-		path = filepath.FromSlash(path)
+		path = filepath.FromSlash(strings.TrimPrefix(path, "/"))
 	}
 	if !filepath.IsAbs(path) {
 		return nil, errors.Errorf("invalid path: path %q must be an absolute path", providerConfig.URL())


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
We have ~ the same code in `newLocalRepository` apparently just never noticed that it's missing for `overridesFolder`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
