### PR TITLE
📖  Added a single line linux command in quick-start for installing clusterctl 

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -107,13 +107,9 @@ Download the latest release; on linux, type:
 ```bash
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-amd64" version:"1.2.x"}} -o clusterctl
 ```
-Make the clusterctl binary executable.
+Install clusterctl:
 ```bash
-chmod +x ./clusterctl
-```
-Move the binary in to your PATH.
-```bash
-sudo mv ./clusterctl /usr/local/bin/clusterctl
+sudo install -o root -g root -m 0755 clusterctl /usr/local/bin/clusterctl
 ```
 Test to ensure the version you installed is up-to-date:
 ```bash


### PR DESCRIPTION
**What this PR does / why we need it**:
I have added a single-line Linux command (will make the file executable and will move it to the desired location ) . which performed the installation of the clusterctl. After downloading the clusterctl binary file , the User can install it by running this single-line command. Earlier we were doing it by making it executable and then moving it. 

It will be user friendly. 

Install clusterctl
```
sudo install -o root -g root -m 0755 clusterctl /usr/local/bin/clusterctl
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7372 
