### PR TITLE
Keep v1.Node after deleteing Machine.

### DIFF
--- a/api/v1beta1/machine_types.go
+++ b/api/v1beta1/machine_types.go
@@ -59,6 +59,9 @@ const (
 	// This annotation can be set on BootstrapConfig or Machine objects. The value set on the Machine object takes precedence.
 	// This annotation can only be used on Control Plane Machines.
 	MachineCertificatesExpiryDateAnnotation = "machine.cluster.x-k8s.io/certificates-expiry"
+
+	// MachineDetachedAnnotation is the annotation set on machines if keep v1.Node after deleting machine.
+	MachineDetachedAnnotation = "machine.cluster.x-k8s.io/detached"
 )
 
 // ANCHOR: MachineSpec

--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -507,6 +507,15 @@ func (r *Reconciler) isDeleteNodeAllowed(ctx context.Context, cluster *clusterv1
 		return errClusterIsBeingDeleted
 	}
 
+	// If the machine is detached, considered as no nodeRef.
+	if machine.Annotations != nil {
+		if _, found := machine.Annotations[clusterv1.MachineDetachedAnnotation]; found {
+			log.Info("The machine is detached, it's not allowed to delete.",
+				"machine", machine)
+			return errNilNodeRef
+		}
+	}
+
 	// Cannot delete something that doesn't exist.
 	if machine.Status.NodeRef == nil {
 		return errNilNodeRef


### PR DESCRIPTION
Signed-off-by: Klaus Ma <klausm@nvidia.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Enable cluster-api to keep v1.Node after deleting Machine for migration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7378
