### PR TITLE
📖  Fix typos in word Cluster and through

### DIFF
--- a/cmd/clusterctl/client/clusterclass.go
+++ b/cmd/clusterctl/client/clusterclass.go
@@ -60,12 +60,12 @@ func addClusterClassIfMissing(template Template, clusterClassClient repository.C
 }
 
 // clusterClassNamesFromTemplate returns the list of ClusterClasses referenced
-// by custers defined in the template. If not clusters are defined in the template
+// by clusters defined in the template. If not clusters are defined in the template
 // or if no cluster uses a cluster class it returns an empty list.
 func clusterClassNamesFromTemplate(template Template) ([]string, error) {
 	classes := []string{}
 
-	// loop thorugh all the objects and if the object is a cluster
+	// loop through all the objects and if the object is a cluster
 	// check and see if cluster.spec.topology.class is defined.
 	// If defined, add value to the result.
 	for i := range template.Objs() {

--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -47,7 +47,7 @@ The default value is 0, meaning that the volume can be detached without any time
   * the default test timeout has been [changed to 1h](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#timeout-behavior)
   * the `--junit-report` argument [replaces JUnit custom reporter](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#improved-reporting-infrastructure) code
   * see the ["Update tests to Ginkgo v2" PR](https://github.com/kubernetes-sigs/cluster-api/pull/6906) for a reference example
-- Custer API introduced new [logging guidelines](../../developer/logging.md). All reconcilers in the core repository were updated
+- Cluster API introduced new [logging guidelines](../../developer/logging.md). All reconcilers in the core repository were updated
   to [log the entire object hierarchy](../../developer/logging.md#keyvalue-pairs). It would be great if providers would be adjusted 
   as well to make it possible to cross-reference log entries across providers (please see CAPD for an infra provider reference implementation). 
 - The `CreateLogFile` function and `CreateLogFileInput` struct in the E2E test framework for clusterctl has been renamed to `OpenLogFile` and `OpenLogFileInput` because the function will now append to the logfile instead of truncating the content.

--- a/docs/proposals/20210526-cluster-class-and-managed-topologies.md
+++ b/docs/proposals/20210526-cluster-class-and-managed-topologies.md
@@ -154,7 +154,7 @@ for all fields of all templates referenced in a ClusterClass.
 
 #### Story 5 - Ability to define ClusterClass customizations
 As a ClusterClass author (e.g. an infrastructure provider author), I want to be able to write a ClusterClass which covers a wide range of use cases. To make this possible, 
-I want to make the CusterClass customizable, i.e. depending on configuration provided during Cluster creation, the managed topology should have a different shape.
+I want to make the ClusterClass customizable, i.e. depending on configuration provided during Cluster creation, the managed topology should have a different shape.
 
 **Note**: Without this feature all Clusters of the same ClusterClass would be the same apart from the properties that are already configure via the topology,
 like Kubernetes version, labels and annotations. This would limit the number of variants a single ClusterClass could address, i.e. separate ClusterClasses would be 


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Fix a few typos across the code in the word Cluster and the word through.
Fixes #
