### PR TITLE
📖 Fix correct ginkgo and gomega verison in release notes

### DIFF
--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -43,7 +43,7 @@ The default value is 0, meaning that the volume can be detached without any time
 
 ### Other
 
-- e2e tests are upgraded to use Ginkgo v2 (v2.1.4) and Gomega v1.20.0. Providers who use the test framework from this release will also need to upgrade, because Ginkgo v2 can't be imported alongside v1. Please see the [Ginkgo upgrade guide](https://onsi.github.io/ginkgo/MIGRATING_TO_V2), and note:
+- e2e tests are upgraded to use Ginkgo v2 (v2.2.0) and Gomega v1.20.1. Providers who use the test framework from this release will also need to upgrade, because Ginkgo v2 can't be imported alongside v1. Please see the [Ginkgo upgrade guide](https://onsi.github.io/ginkgo/MIGRATING_TO_V2), and note:
   * the default test timeout has been [changed to 1h](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#timeout-behavior)
   * the `--junit-report` argument [replaces JUnit custom reporter](https://onsi.github.io/ginkgo/MIGRATING_TO_V2#improved-reporting-infrastructure) code
   * see the ["Update tests to Ginkgo v2" PR](https://github.com/kubernetes-sigs/cluster-api/pull/6906) for a reference example


### PR DESCRIPTION
**What this PR does / why we need it**:

Just noticed the ginkgo/gomega versions has been bumped but the release not doesn't reflect this update.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
