### PR TITLE
🌱 Implement single-node cluster self-hosted upgrade test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1209,6 +1209,7 @@ generate-e2e-templates-v1beta1: $(KUSTOMIZE)
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-upgrades-runtimesdk --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-upgrades-runtimesdk.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-kcp-scale-in --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-kcp-scale-in.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-ipv6 --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-ipv6.yaml
+	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-topology-single-node-cluster --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-topology-single-node-cluster.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-topology --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-topology.yaml
 	$(KUSTOMIZE) build $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-ignition --load-restrictor LoadRestrictionsNone > $(DOCKER_TEMPLATES)/v1beta1/main/cluster-template-ignition.yaml
 

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -195,6 +195,7 @@ providers:
     - sourcePath: "../data/infrastructure-docker/v1beta1/main/cluster-template-upgrades-runtimesdk.yaml"
     - sourcePath: "../data/infrastructure-docker/v1beta1/main/cluster-template-kcp-scale-in.yaml"
     - sourcePath: "../data/infrastructure-docker/v1beta1/main/cluster-template-ipv6.yaml"
+    - sourcePath: "../data/infrastructure-docker/v1beta1/main/cluster-template-topology-single-node-cluster.yaml"
     - sourcePath: "../data/infrastructure-docker/v1beta1/main/cluster-template-topology.yaml"
     - sourcePath: "../data/infrastructure-docker/v1beta1/main/cluster-template-ignition.yaml"
     - sourcePath: "../data/infrastructure-docker/v1beta1/main/clusterclass-quick-start.yaml"

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/cluster-template-topology-single-node-cluster/disable-control-plane-taint-variable.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/cluster-template-topology-single-node-cluster/disable-control-plane-taint-variable.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/topology/variables/-
+  value:
+    name: controlPlaneTaint
+    value: false

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/cluster-template-topology-single-node-cluster/kustomization.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/cluster-template-topology-single-node-cluster/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../bases/cluster-with-topology.yaml
+  - ../bases/crs.yaml
+
+patches:
+- path: disable-control-plane-taint-variable.yaml
+  target:
+    group: cluster.x-k8s.io
+    version: v1beta1
+    kind: Cluster
+

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/clusterclass-quick-start.yaml
@@ -84,6 +84,12 @@ spec:
         items:
           type: string
         description: "preLoadImages sets the images for the docker machines to preload."
+  - name: controlPlaneTaint
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: boolean
+        default: true
   patches:
   - name: lbImageRepository
     definitions:
@@ -225,6 +231,21 @@ spec:
         path: /spec/template/spec/rolloutStrategy/rollingUpdate/maxSurge
         valueFrom:
           template: "{{ .kubeadmControlPlaneMaxSurge }}"
+  - name: controlPlaneTaint
+    enabledIf: "{{ not .controlPlaneTaint }}"
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: "/spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/taints"
+        value: []
+      - op: add
+        path: "/spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/taints"
+        value: []
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -65,3 +65,18 @@ var _ = Describe("When testing Cluster API working on self-hosted clusters using
 		}
 	})
 })
+
+var _ = Describe("When testing Cluster API working on single-node self-hosted clusters using ClusterClass [ClusterClass]", func() {
+	SelfHostedSpec(ctx, func() SelfHostedSpecInput {
+		return SelfHostedSpecInput{
+			E2EConfig:                e2eConfig,
+			ClusterctlConfigPath:     clusterctlConfigPath,
+			BootstrapClusterProxy:    bootstrapClusterProxy,
+			ArtifactFolder:           artifactFolder,
+			SkipCleanup:              skipCleanup,
+			Flavor:                   "topology-single-node-cluster",
+			ControlPlaneMachineCount: pointer.Int64Ptr(1),
+			WorkerMachineCount:       pointer.Int64Ptr(0),
+		}
+	})
+})


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Adds an E2E test for Single Node Cluster (1x control-plane, 0x workers) self-hosted scale-out upgrades.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7230
