### PR TITLE
:bug: Fix/clusterctl describe color

### DIFF
--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -103,7 +103,7 @@ var describeClusterClusterCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runDescribeCluster(args[0])
+		return runDescribeCluster(cmd, args[0])
 	},
 }
 
@@ -136,7 +136,7 @@ func init() {
 		"Disable grouping machines when ready condition has the same Status, Severity and Reason.")
 	_ = describeClusterClusterCmd.Flags().MarkDeprecated("disable-grouping",
 		"use --grouping instead.")
-	describeClusterClusterCmd.Flags().BoolVarP(&dc.color, "color", "c", false, "Enable color output, even when stdout is not a tty.")
+	describeClusterClusterCmd.Flags().BoolVarP(&dc.color, "color", "c", false, "Enable or disable color output; if not set color is enabled by default only if using tty. The flag is overridden by the NO_COLOR env variable if set.")
 
 	// completions
 	describeClusterClusterCmd.ValidArgsFunction = resourceNameCompletionFunc(
@@ -150,7 +150,7 @@ func init() {
 	describeCmd.AddCommand(describeClusterClusterCmd)
 }
 
-func runDescribeCluster(name string) error {
+func runDescribeCluster(cmd *cobra.Command, name string) error {
 	c, err := client.New(cfgFile)
 	if err != nil {
 		return err
@@ -172,8 +172,8 @@ func runDescribeCluster(name string) error {
 		return err
 	}
 
-	if dc.color {
-		color.NoColor = false
+	if cmd.Flags().Changed("color") {
+		color.NoColor = !dc.color
 	}
 
 	printObjectTree(tree)


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Change the behaviour of the color flag in `clusterctl describe cluster`.

Previous behaviour: If true turn color on. If false no-op.
New behaviour: If true turn color on. If false turn color off. If unset no-op.

Related to #7381 
/area clusterctl
