### PR TITLE
:book: Add Docker specific get kubeconfig to quickstart

### DIFF
--- a/docs/book/src/clusterctl/developers.md
+++ b/docs/book/src/clusterctl/developers.md
@@ -181,18 +181,27 @@ For example, assuming that on [docker hub][kind-docker-hub] there is no
 image for version `vX.Y.Z`, therefore creating a CAPD workload cluster with
 `--kubernetes-version=vX.Y.Z` will fail. See [issue 3795] for more details.
 
-### Get the kubeconfig for the workload cluster
+### Get the kubeconfig for the workload cluster when using Docker Desktop
 
-The command for getting the kubeconfig file for connecting to a workload cluster is the following:
+For Docker Desktop on macOS, Linux or Windows use kind to retrieve the kubeconfig.
+
+```bash
+kind get kubeconfig --name capi-quickstart > capi-quickstart.kubeconfig
+````
+
+Docker Engine for Linux works with the default clusterctl approach.
+```bash
+clusterctl get kubeconfig capi-quickstart > capi-quickstart.kubeconfig
+```
+
+### Fix kubeconfig when using Docker Desktop and clusterctl
+When retrieving the kubeconfig using `clusterctl` with Docker Desktop on macOS or Windows or Docker Desktop (Docker Engine works fine) on Linux, you'll need to take a few extra steps to get the kubeconfig for a workload cluster created with the Docker provider.
 
 ```bash
 clusterctl get kubeconfig capi-quickstart > capi-quickstart.kubeconfig
 ```
 
-### Fix kubeconfig when using Docker Desktop
-
-When using Docker Desktop on macOS or Docker Desktop (Docker Engine works fine) on Linux, you'll need to take a few extra steps to get the kubeconfig for a workload cluster created with the Docker provider.
-
+To fix the kubeconfig run:
 ```bash
 # Point the kubeconfig to the exposed port of the load balancer, rather than the inaccessible container IP.
 sed -i -e "s/server:.*/server: https:\/\/$(docker port capi-quickstart-lb 6443/tcp | sed "s/0.0.0.0/127.0.0.1/")/g" ./capi-quickstart.kubeconfig

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -1091,19 +1091,34 @@ The control plane won't be `Ready` until we install a CNI in the next step.
 
 </aside>
 
-After the first control plane node is up and running, we can retrieve the [workload cluster] Kubeconfig:
+After the first control plane node is up and running, we can retrieve the [workload cluster] Kubeconfig.
+
+{{#tabs name:"tab-get-kubeconfig" tabs:"Default,Docker"}}
+
+{{#/tab }}
+{{#tab Default}}
 
 ```bash
 clusterctl get kubeconfig capi-quickstart > capi-quickstart.kubeconfig
 ```
 
+{{#/tab }}
+
+{{#tab Docker}}
+For Docker Desktop on macOS, Linux or Windows use kind to retrieve the kubeconfig. Docker Engine for Linux works with the default clusterctl approach.
+
+```bash
+kind get kubeconfig --name capi-quickstart > capi-quickstart.kubeconfig
+```
+
 <aside class="note warning">
 
-<h1>Warning</h1>
-
-If you're using Docker Desktop on macOS, or Docker Desktop (Docker Engine works fine) on Linux, you'll need to take a few extra steps to get the kubeconfig for a workload cluster created with the Docker provider. See [Additional Notes for the Docker provider](../clusterctl/developers.md#additional-notes-for-the-docker-provider).
+Note: To use the default clusterctl method to retrieve kubeconfig for a workload cluster created with the Docker provider when using Docker Desktop see [Additional Notes for the Docker provider](../clusterctl/developers.md#additional-notes-for-the-docker-provider).
 
 </aside>
+
+{{#/tab }}
+{{#/tabs }}
 
 ### Deploy a CNI solution
 


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update the quick start to point Docker provider users to `kind` when retrieving the kubeconfig for their workload cluster. This will avoid users, especially on Windows and MacOS, from having to use the sed script (or Windows alternative) to update the config retrieved by clusterctl.

Related to https://github.com/kubernetes-sigs/cluster-api/issues/5263
