### PR TITLE
:seedling: Update Deprecated comments to correctly trigger staticcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -179,6 +179,10 @@ issues:
   # changes in PRs and avoid nitpicking.
   exclude-use-default: false
   exclude-rules:
+  # Specific exclude rules for deprecated fields that are still part of the codebase. These should be removed as the referenced deprecated item is removed from the project.
+  - linters:
+      - staticcheck
+    text: "SA1019: (bootstrapv1.ClusterStatus|clusterv1.ClusterTopologyManagedFieldsAnnotation|scope.Config.Spec.UseExperimentalRetryJoin|DockerMachine.Spec.Bootstrapped|machineStatus.Bootstrapped) is deprecated"
   - linters:
     - revive
     text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"

--- a/api/v1alpha4/common_types.go
+++ b/api/v1alpha4/common_types.go
@@ -27,6 +27,7 @@ const (
 	ClusterLabelName = "cluster.x-k8s.io/cluster-name"
 
 	// ClusterTopologyLabelName is the label set on all the object which are managed as part of a ClusterTopology.
+	//
 	// Deprecated: use ClusterTopologyOwnedLabel instead.
 	ClusterTopologyLabelName = "cluster.x-k8s.io/topology"
 
@@ -117,11 +118,13 @@ var (
 
 const (
 	// MachineNodeNameIndex is used by the Machine Controller to index Machines by Node name, and add a watch on Nodes.
+	//
 	// Deprecated: Use api/v1alpha4/index.MachineNodeNameField instead.
 	MachineNodeNameIndex = "status.nodeRef.name"
 
 	// MachineProviderIDIndex is used to index Machines by ProviderID. It's useful to find Machines
 	// in a management cluster from Nodes in a workload cluster.
+	//
 	// Deprecated: Use api/v1alpha4/index.MachineProviderIDField instead.
 	MachineProviderIDIndex = "spec.providerID"
 )

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -40,7 +40,9 @@ const (
 	// to easily discover which fields have been set by templates + patches/variables at a given reconcile;
 	// instead, it is not necessary to store managed paths for typed objets (e.g. Cluster, MachineDeployments)
 	// given that the topology controller explicitly sets a well-known, immutable list of fields at every reconcile.
+	//
 	// Deprecated: Topology controller is now using server side apply and this annotation will be removed in a future release.
+	// When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml.
 	ClusterTopologyManagedFieldsAnnotation = "topology.cluster.x-k8s.io/managed-field-paths"
 
 	// ClusterTopologyMachineDeploymentLabelName is the label set on the generated  MachineDeployment objects

--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -138,6 +138,7 @@ const (
 
 	// MachineHealthCheckSuccededCondition is set on machines that have passed a healthcheck by the MachineHealthCheck controller.
 	// In the event that the health check fails it will be set to False.
+	//
 	// Deprecated: This const is going to be removed in a next release. Use MachineHealthCheckSucceededCondition instead.
 	MachineHealthCheckSuccededCondition ConditionType = "HealthCheckSucceeded"
 

--- a/bootstrap/kubeadm/api/v1alpha4/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1alpha4/kubeadm_types.go
@@ -180,6 +180,7 @@ type ImageMeta struct {
 
 // ClusterStatus contains the cluster status. The ClusterStatus will be stored in the kubeadm-config
 // ConfigMap in the cluster, and then updated by kubeadm when additional control plane instance joins or leaves the cluster.
+//
 // Deprecated: ClusterStatus has been removed from kubeadm v1beta3 API; This type is preserved only to support
 // conversion to older versions of the kubeadm API.
 type ClusterStatus struct {

--- a/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadm_types.go
@@ -192,6 +192,7 @@ type ImageMeta struct {
 
 // ClusterStatus contains the cluster status. The ClusterStatus will be stored in the kubeadm-config
 // ConfigMap in the cluster, and then updated by kubeadm when additional control plane instance joins or leaves the cluster.
+//
 // Deprecated: ClusterStatus has been removed from kubeadm v1beta3 API; This type is preserved only to support
 // conversion to older versions of the kubeadm API.
 type ClusterStatus struct {

--- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
@@ -97,7 +97,9 @@ type KubeadmConfigSpec struct {
 	//
 	// For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
 	// +optional
+	//
 	// Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+	// When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
 	UseExperimentalRetryJoin bool `json:"useExperimentalRetryJoin,omitempty"`
 
 	// Ignition contains Ignition specific configuration.

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -2929,8 +2929,9 @@ spec:
                   is to add retries to kubeadm proper and use that functionality.
                   \n This will add about 40KB to userdata \n For more information,
                   refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
-                  Deprecated: This experimental fix is no longer needed and this field
-                  will be removed in a future release."
+                  \n Deprecated: This experimental fix is no longer needed and this
+                  field will be removed in a future release. When removing also remove
+                  from staticcheck exclude-rules for SA1019 in golangci.yml"
                 type: boolean
               users:
                 description: Users specifies extra users to add

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -2980,8 +2980,10 @@ spec:
                           The long term goal is to add retries to kubeadm proper and
                           use that functionality. \n This will add about 40KB to userdata
                           \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
-                          Deprecated: This experimental fix is no longer needed and
-                          this field will be removed in a future release."
+                          \n Deprecated: This experimental fix is no longer needed
+                          and this field will be removed in a future release. When
+                          removing also remove from staticcheck exclude-rules for
+                          SA1019 in golangci.yml"
                         type: boolean
                       users:
                         description: Users specifies extra users to add

--- a/cmd/clusterctl/api/v1alpha3/provider_type.go
+++ b/cmd/clusterctl/api/v1alpha3/provider_type.go
@@ -49,6 +49,7 @@ type Provider struct {
 
 	// WatchedNamespace indicates the namespace where the provider controller is watching.
 	// If empty the provider controller is watching for objects in all namespaces.
+	//
 	// Deprecated: in clusterctl v1alpha4 all the providers watch all the namespaces; this field will be removed in a future version of this API
 	// +optional
 	WatchedNamespace string `json:"watchedNamespace,omitempty"`

--- a/cmd/clusterctl/client/client.go
+++ b/cmd/clusterctl/client/client.go
@@ -55,10 +55,12 @@ type Client interface {
 	Move(options MoveOptions) error
 
 	// Backup saves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target management cluster.
+	//
 	// Deprecated: This will be dropped in a future release. Please use Move.
 	Backup(options BackupOptions) error
 
 	// Restore restores all the Cluster API objects existing in a configured directory based on a glob to a target management cluster.
+	//
 	// Deprecated: This will be dropped in a future release. Please use Move.
 	Restore(options RestoreOptions) error
 

--- a/cmd/clusterctl/client/cluster/cert_manager.go
+++ b/cmd/clusterctl/client/cluster/cert_manager.go
@@ -43,8 +43,9 @@ const (
 
 	certManagerNamespace = "cert-manager"
 
-	// Deprecated: Use clusterctlv1.CertManagerVersionAnnotation instead.
 	// This is maintained only for supporting upgrades from cluster created with clusterctl v1alpha3.
+	//
+	// Deprecated: Use clusterctlv1.CertManagerVersionAnnotation instead.
 	// TODO: Remove once upgrades from v1alpha3 are no longer supported.
 	certManagerVersionAnnotation = "certmanager.clusterctl.cluster.x-k8s.io/version"
 )

--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -53,10 +53,12 @@ type ObjectMover interface {
 	FromDirectory(toCluster Client, directory string) error
 
 	// Backup saves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target directory.
+	//
 	// Deprecated: This will be dropped in a future release. Please use ToDirectory.
 	Backup(namespace string, directory string) error
 
 	// Restore restores all the Cluster API objects existing in a configured directory to a target management cluster.
+	//
 	// Deprecated: This will be dropped in a future release. Please use FromDirectory.
 	Restore(toCluster Client, directory string) error
 }

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -49,6 +49,7 @@ type MoveOptions struct {
 }
 
 // BackupOptions holds options supported by backup.
+//
 // Deprecated: This will be dropped in a future release. Please use MoveOptions.
 type BackupOptions struct {
 	// FromKubeconfig defines the kubeconfig to use for accessing the source management cluster. If empty,
@@ -64,6 +65,7 @@ type BackupOptions struct {
 }
 
 // RestoreOptions holds options supported by restore.
+//
 // Deprecated: This will be dropped in a future release. Please use MoveOptions.
 type RestoreOptions struct {
 	// FromKubeconfig defines the kubeconfig to use for accessing the target management cluster. If empty,
@@ -158,7 +160,9 @@ func (c *clusterctlClient) toDirectory(options MoveOptions) error {
 	return fromCluster.ObjectMover().ToDirectory(options.Namespace, options.ToDirectory)
 }
 
-// Deprecated: This will be dropped in a future release. Please use Move.
+// Backup saves all the Cluster API objects existing in a namespace (or from all the namespaces if empty) to a target directory.
+//
+// Deprecated: This will be dropped in a future release. Please use ToDirectory.
 func (c *clusterctlClient) Backup(options BackupOptions) error {
 	return c.Move(MoveOptions{
 		FromKubeconfig: options.FromKubeconfig,
@@ -167,7 +171,9 @@ func (c *clusterctlClient) Backup(options BackupOptions) error {
 	})
 }
 
-// Deprecated: This will be dropped in a future release. Please use Move.
+// Restore restores all the Cluster API objects existing in a configured directory to a target management cluster.
+//
+// Deprecated: This will be dropped in a future release. Please use FromDirectory.
 func (c *clusterctlClient) Restore(options RestoreOptions) error {
 	return c.Move(MoveOptions{
 		ToKubeconfig:  options.ToKubeconfig,

--- a/cmd/clusterctl/config/crd/bases/clusterctl.cluster.x-k8s.io_providers.yaml
+++ b/cmd/clusterctl/config/crd/bases/clusterctl.cluster.x-k8s.io_providers.yaml
@@ -59,11 +59,11 @@ spec:
             description: Version indicates the component version.
             type: string
           watchedNamespace:
-            description: 'WatchedNamespace indicates the namespace where the provider
+            description: "WatchedNamespace indicates the namespace where the provider
               controller is watching. If empty the provider controller is watching
-              for objects in all namespaces. Deprecated: in clusterctl v1alpha4 all
-              the providers watch all the namespaces; this field will be removed in
-              a future version of this API'
+              for objects in all namespaces. \n Deprecated: in clusterctl v1alpha4
+              all the providers watch all the namespaces; this field will be removed
+              in a future version of this API"
             type: string
         type: object
     served: true

--- a/cmd/clusterctl/config/manifest/clusterctl-api.yaml
+++ b/cmd/clusterctl/config/manifest/clusterctl-api.yaml
@@ -58,11 +58,11 @@ spec:
             description: Version indicates the component version.
             type: string
           watchedNamespace:
-            description: 'WatchedNamespace indicates the namespace where the provider
+            description: "WatchedNamespace indicates the namespace where the provider
               controller is watching. If empty the provider controller is watching
-              for objects in all namespaces. Deprecated: in clusterctl v1alpha4 all
-              the providers watch all the namespaces; this field will be removed in
-              a future version of this API'
+              for objects in all namespaces. \n Deprecated: in clusterctl v1alpha4
+              all the providers watch all the namespaces; this field will be removed
+              in a future version of this API"
             type: string
         type: object
     served: true

--- a/controllers/external/util.go
+++ b/controllers/external/util.go
@@ -60,6 +60,7 @@ func Delete(ctx context.Context, c client.Writer, ref *corev1.ObjectReference) e
 }
 
 // CloneTemplateInput is the input to CloneTemplate.
+//
 // Deprecated: use CreateFromTemplateInput instead. This type will be removed in a future release.
 type CloneTemplateInput struct {
 	// Client is the controller runtime client.
@@ -88,6 +89,7 @@ type CloneTemplateInput struct {
 }
 
 // CloneTemplate uses the client and the reference to create a new object from the template.
+//
 // Deprecated: use CreateFromTemplate instead. This function will be removed in a future release.
 func CloneTemplate(ctx context.Context, in *CloneTemplateInput) (*corev1.ObjectReference, error) {
 	from, err := Get(ctx, in.Client, in.TemplateRef, in.Namespace)

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -3415,8 +3415,9 @@ spec:
                       The long term goal is to add retries to kubeadm proper and use
                       that functionality. \n This will add about 40KB to userdata
                       \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
-                      Deprecated: This experimental fix is no longer needed and this
-                      field will be removed in a future release."
+                      \n Deprecated: This experimental fix is no longer needed and
+                      this field will be removed in a future release. When removing
+                      also remove from staticcheck exclude-rules for SA1019 in golangci.yml"
                     type: boolean
                   users:
                     description: Users specifies extra users to add

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -2230,8 +2230,10 @@ spec:
                               to add retries to kubeadm proper and use that functionality.
                               \n This will add about 40KB to userdata \n For more
                               information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
-                              Deprecated: This experimental fix is no longer needed
-                              and this field will be removed in a future release."
+                              \n Deprecated: This experimental fix is no longer needed
+                              and this field will be removed in a future release.
+                              When removing also remove from staticcheck exclude-rules
+                              for SA1019 in golangci.yml"
                             type: boolean
                           users:
                             description: Users specifies extra users to add

--- a/test/infrastructure/docker/api/v1beta1/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1beta1/dockermachine_types.go
@@ -51,7 +51,9 @@ type DockerMachineSpec struct {
 
 	// Bootstrapped is true when the kubeadm bootstrapping has been run
 	// against this machine
+	//
 	// Deprecated: This field will be removed in the next apiVersion.
+	// When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml.
 	// +optional
 	Bootstrapped bool `json:"bootstrapped,omitempty"`
 }

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
@@ -527,9 +527,10 @@ spec:
                         type: object
                       type: array
                     bootstrapped:
-                      description: 'Bootstrapped is true when the kubeadm bootstrapping
-                        has been run against this machine Deprecated: This field will
-                        be removed in the next apiVersion.'
+                      description: "Bootstrapped is true when the kubeadm bootstrapping
+                        has been run against this machine \n Deprecated: This field
+                        will be removed in the next apiVersion. When removing also
+                        remove from staticcheck exclude-rules for SA1019 in golangci.yml"
                       type: boolean
                     instanceName:
                       description: InstanceName is the identification of the Machine

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -346,9 +346,10 @@ spec:
             description: DockerMachineSpec defines the desired state of DockerMachine.
             properties:
               bootstrapped:
-                description: 'Bootstrapped is true when the kubeadm bootstrapping
-                  has been run against this machine Deprecated: This field will be
-                  removed in the next apiVersion.'
+                description: "Bootstrapped is true when the kubeadm bootstrapping
+                  has been run against this machine \n Deprecated: This field will
+                  be removed in the next apiVersion. When removing also remove from
+                  staticcheck exclude-rules for SA1019 in golangci.yml."
                 type: boolean
               customImage:
                 description: CustomImage allows customizing the container image that

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
@@ -241,9 +241,10 @@ spec:
                       of the machine.
                     properties:
                       bootstrapped:
-                        description: 'Bootstrapped is true when the kubeadm bootstrapping
-                          has been run against this machine Deprecated: This field
-                          will be removed in the next apiVersion.'
+                        description: "Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine \n Deprecated: This field
+                          will be removed in the next apiVersion. When removing also
+                          remove from staticcheck exclude-rules for SA1019 in golangci.yml."
                         type: boolean
                       customImage:
                         description: CustomImage allows customizing the container

--- a/test/infrastructure/docker/exp/api/v1beta1/dockermachinepool_types.go
+++ b/test/infrastructure/docker/exp/api/v1beta1/dockermachinepool_types.go
@@ -107,7 +107,9 @@ type DockerMachinePoolInstanceStatus struct {
 
 	// Bootstrapped is true when the kubeadm bootstrapping has been run
 	// against this machine
+	//
 	// Deprecated: This field will be removed in the next apiVersion.
+	// When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
 	// +optional
 	Bootstrapped bool `json:"bootstrapped,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update the "Deprecated" comments in CAPI to make them visible to the staticcheck linter.

[staticcheck requires a new paragraph to properly identify a field/function/method/struct as deprecated](https://github.com/golang/go/wiki/Deprecated#examples): 

> To signal that an identifier should not be used, add a paragraph to its doc comment that begins with Deprecated: followed by some information about the deprecation, and a recommendation on what to use instead, if applicable.


