### PR TITLE
🐛 Remove extra slash in hack/ensure-kind script

### DIFF
--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 set -x
 
-GOPATH_BIN="$(go env GOPATH)/bin/"
+GOPATH_BIN="$(go env GOPATH)/bin"
 MINIMUM_KIND_VERSION=v0.16.0
 goarch="$(go env GOARCH)"
 goos="$(go env GOOS)"


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Remove extra slash in hack/ensure-kind script where `chmod +x "${GOPATH_BIN}/kind"` resolves to `<some-path>/go/bin//kind`. I don't think it causes a bug but it's probably unintended.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
