### PR TITLE
:sparkles: Add Cluster topology field for MachineDeployment Strategy

### DIFF
--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -70,6 +70,7 @@ func (src *Cluster) ConvertTo(dstRaw conversion.Hub) error {
 				dst.Spec.Topology.Workers.MachineDeployments[i].NodeVolumeDetachTimeout = restored.Spec.Topology.Workers.MachineDeployments[i].NodeVolumeDetachTimeout
 				dst.Spec.Topology.Workers.MachineDeployments[i].NodeDeletionTimeout = restored.Spec.Topology.Workers.MachineDeployments[i].NodeDeletionTimeout
 				dst.Spec.Topology.Workers.MachineDeployments[i].MinReadySeconds = restored.Spec.Topology.Workers.MachineDeployments[i].MinReadySeconds
+				dst.Spec.Topology.Workers.MachineDeployments[i].Strategy = restored.Spec.Topology.Workers.MachineDeployments[i].Strategy
 				dst.Spec.Topology.Workers.MachineDeployments[i].MachineHealthCheck = restored.Spec.Topology.Workers.MachineDeployments[i].MachineHealthCheck
 			}
 		}

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -1245,6 +1245,7 @@ func autoConvert_v1beta1_MachineDeploymentTopology_To_v1alpha4_MachineDeployment
 	// WARNING: in.NodeVolumeDetachTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.NodeDeletionTimeout requires manual conversion: does not exist in peer-type
 	// WARNING: in.MinReadySeconds requires manual conversion: does not exist in peer-type
+	// WARNING: in.Strategy requires manual conversion: does not exist in peer-type
 	// WARNING: in.Variables requires manual conversion: does not exist in peer-type
 	return nil
 }

--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -206,6 +206,11 @@ type MachineDeploymentTopology struct {
 	// +optional
 	MinReadySeconds *int32 `json:"minReadySeconds,omitempty"`
 
+	// The deployment strategy to use to replace existing machines with
+	// new ones.
+	// +optional
+	Strategy *MachineDeploymentStrategy `json:"strategy,omitempty"`
+
 	// Variables can be used to customize the MachineDeployment through patches.
 	// +optional
 	Variables *MachineDeploymentVariables `json:"variables,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1020,6 +1020,11 @@ func (in *MachineDeploymentTopology) DeepCopyInto(out *MachineDeploymentTopology
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Strategy != nil {
+		in, out := &in.Strategy, &out.Strategy
+		*out = new(MachineDeploymentStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Variables != nil {
 		in, out := &in.Variables, &out.Variables
 		*out = new(MachineDeploymentVariables)

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -1751,6 +1751,12 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentTopology(ref comm
 							Format:      "int32",
 						},
 					},
+					"strategy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The deployment strategy to use to replace existing machines with new ones.",
+							Ref:         ref("sigs.k8s.io/cluster-api/api/v1beta1.MachineDeploymentStrategy"),
+						},
+					},
 					"variables": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Variables can be used to customize the MachineDeployment through patches.",
@@ -1762,7 +1768,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentTopology(ref comm
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "sigs.k8s.io/cluster-api/api/v1beta1.MachineDeploymentVariables", "sigs.k8s.io/cluster-api/api/v1beta1.MachineHealthCheckTopology", "sigs.k8s.io/cluster-api/api/v1beta1.ObjectMeta"},
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Duration", "sigs.k8s.io/cluster-api/api/v1beta1.MachineDeploymentStrategy", "sigs.k8s.io/cluster-api/api/v1beta1.MachineDeploymentVariables", "sigs.k8s.io/cluster-api/api/v1beta1.MachineHealthCheckTopology", "sigs.k8s.io/cluster-api/api/v1beta1.ObjectMeta"},
 	}
 }
 

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1256,6 +1256,75 @@ spec:
                                 of this value.
                               format: int32
                               type: integer
+                            strategy:
+                              description: The deployment strategy to use to replace
+                                existing machines with new ones.
+                              properties:
+                                rollingUpdate:
+                                  description: Rolling update config params. Present
+                                    only if MachineDeploymentStrategyType = RollingUpdate.
+                                  properties:
+                                    deletePolicy:
+                                      description: DeletePolicy defines the policy
+                                        used by the MachineDeployment to identify
+                                        nodes to delete when downscaling. Valid values
+                                        are "Random, "Newest", "Oldest" When no value
+                                        is supplied, the default DeletePolicy of MachineSet
+                                        is used
+                                      enum:
+                                      - Random
+                                      - Newest
+                                      - Oldest
+                                      type: string
+                                    maxSurge:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: 'The maximum number of machines
+                                        that can be scheduled above the desired number
+                                        of machines. Value can be an absolute number
+                                        (ex: 5) or a percentage of desired machines
+                                        (ex: 10%). This can not be 0 if MaxUnavailable
+                                        is 0. Absolute number is calculated from percentage
+                                        by rounding up. Defaults to 1. Example: when
+                                        this is set to 30%, the new MachineSet can
+                                        be scaled up immediately when the rolling
+                                        update starts, such that the total number
+                                        of old and new machines do not exceed 130%
+                                        of desired machines. Once old machines have
+                                        been killed, new MachineSet can be scaled
+                                        up further, ensuring that total number of
+                                        machines running at any time during the update
+                                        is at most 130% of desired machines.'
+                                      x-kubernetes-int-or-string: true
+                                    maxUnavailable:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: 'The maximum number of machines
+                                        that can be unavailable during the update.
+                                        Value can be an absolute number (ex: 5) or
+                                        a percentage of desired machines (ex: 10%).
+                                        Absolute number is calculated from percentage
+                                        by rounding down. This can not be 0 if MaxSurge
+                                        is 0. Defaults to 0. Example: when this is
+                                        set to 30%, the old MachineSet can be scaled
+                                        down to 70% of desired machines immediately
+                                        when the rolling update starts. Once new machines
+                                        are ready, old MachineSet can be scaled down
+                                        further, followed by scaling up the new MachineSet,
+                                        ensuring that the total number of machines
+                                        available at all times during the update is
+                                        at least 70% of desired machines.'
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                type:
+                                  description: Type of deployment. Default is RollingUpdate.
+                                  enum:
+                                  - RollingUpdate
+                                  - OnDelete
+                                  type: string
+                              type: object
                             variables:
                               description: Variables can be used to customize the
                                 MachineDeployment through patches.

--- a/internal/controllers/topology/cluster/desired_state.go
+++ b/internal/controllers/topology/cluster/desired_state.go
@@ -603,6 +603,7 @@ func computeMachineDeployment(_ context.Context, s *scope.Scope, desiredControlP
 		Spec: clusterv1.MachineDeploymentSpec{
 			ClusterName:     s.Current.Cluster.Name,
 			MinReadySeconds: machineDeploymentTopology.MinReadySeconds,
+			Strategy:        machineDeploymentTopology.Strategy,
 			Template: clusterv1.MachineTemplateSpec{
 				ObjectMeta: clusterv1.ObjectMeta{
 					Labels:      mergeMap(machineDeploymentTopology.Metadata.Labels, machineDeploymentBlueprint.Metadata.Labels),

--- a/internal/controllers/topology/cluster/desired_state_test.go
+++ b/internal/controllers/topology/cluster/desired_state_test.go
@@ -1329,6 +1329,9 @@ func TestComputeMachineDeployment(t *testing.T) {
 	nodeVolumeDetachTimeout := metav1.Duration{Duration: 10 * time.Second}
 	nodeDeletionTimeout := metav1.Duration{Duration: 10 * time.Second}
 	minReadySeconds := int32(5)
+	strategy := clusterv1.MachineDeploymentStrategy{
+		Type: clusterv1.OnDeleteMachineDeploymentStrategyType,
+	}
 	mdTopology := clusterv1.MachineDeploymentTopology{
 		Metadata: clusterv1.ObjectMeta{
 			Labels: map[string]string{"foo": "baz"},
@@ -1341,6 +1344,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 		NodeVolumeDetachTimeout: &nodeVolumeDetachTimeout,
 		NodeDeletionTimeout:     &nodeDeletionTimeout,
 		MinReadySeconds:         &minReadySeconds,
+		Strategy:                &strategy,
 	}
 
 	t.Run("Generates the machine deployment and the referenced templates", func(t *testing.T) {
@@ -1368,6 +1372,7 @@ func TestComputeMachineDeployment(t *testing.T) {
 		actualMd := actual.Object
 		g.Expect(*actualMd.Spec.Replicas).To(Equal(replicas))
 		g.Expect(*actualMd.Spec.MinReadySeconds).To(Equal(minReadySeconds))
+		g.Expect(*actualMd.Spec.Strategy).To(Equal(strategy))
 		g.Expect(*actualMd.Spec.Template.Spec.FailureDomain).To(Equal(failureDomain))
 		g.Expect(*actualMd.Spec.Template.Spec.NodeDrainTimeout).To(Equal(nodeDrainTimeout))
 		g.Expect(*actualMd.Spec.Template.Spec.NodeDeletionTimeout).To(Equal(nodeDeletionTimeout))

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/bases/cluster-with-topology.yaml
@@ -29,6 +29,10 @@ spec:
         minReadySeconds: 5
         replicas: ${WORKER_MACHINE_COUNT}
         failureDomain: fd4
+        strategy:
+          rollingUpdate:
+            maxSurge: "20%"
+            maxUnavailable: 0
     variables:
       # We set an empty value to use the default tag kubeadm init is using.
     - name: etcdImageTag


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #