### PR TITLE
✨ Make Makefile less verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -761,11 +761,11 @@ IMAGE_REVIEWERS ?= $(shell ./hack/get-project-maintainers.sh)
 
 .PHONY: $(RELEASE_DIR)
 $(RELEASE_DIR):
-	mkdir -p $(RELEASE_DIR)/
+	@mkdir -p $(RELEASE_DIR)/
 
 .PHONY: $(RELEASE_NOTES_DIR)
 $(RELEASE_NOTES_DIR):
-	mkdir -p $(RELEASE_NOTES_DIR)/
+	@mkdir -p $(RELEASE_NOTES_DIR)/
 
 .PHONY: release
 release: clean-release ## Build and push container images using the latest git tag for the commit
@@ -810,23 +810,23 @@ manifest-modification-dev: # Set the manifest images to the staging bucket.
 
 .PHONY: release-manifests
 release-manifests: $(RELEASE_DIR) $(KUSTOMIZE) $(RUNTIME_OPENAPI_GEN) ## Build the manifests to publish with a release
-	# Build core-components.
+	@# Build core-components.
 	$(KUSTOMIZE) build config/default > $(RELEASE_DIR)/core-components.yaml
-	# Build bootstrap-components.
+	@# Build bootstrap-components.
 	$(KUSTOMIZE) build bootstrap/kubeadm/config/default > $(RELEASE_DIR)/bootstrap-components.yaml
-	# Build control-plane-components.
+	@# Build control-plane-components.
 	$(KUSTOMIZE) build controlplane/kubeadm/config/default > $(RELEASE_DIR)/control-plane-components.yaml
 
-	## Build cluster-api-components (aggregate of all of the above).
+	@## Build cluster-api-components (aggregate of all of the above).
 	cat $(RELEASE_DIR)/core-components.yaml > $(RELEASE_DIR)/cluster-api-components.yaml
-	echo "---" >> $(RELEASE_DIR)/cluster-api-components.yaml
+	@echo "---" >> $(RELEASE_DIR)/cluster-api-components.yaml
 	cat $(RELEASE_DIR)/bootstrap-components.yaml >> $(RELEASE_DIR)/cluster-api-components.yaml
-	echo "---" >> $(RELEASE_DIR)/cluster-api-components.yaml
+	@echo "---" >> $(RELEASE_DIR)/cluster-api-components.yaml
 	cat $(RELEASE_DIR)/control-plane-components.yaml >> $(RELEASE_DIR)/cluster-api-components.yaml
-	# Add metadata to the release artifacts
+	@# Add metadata to the release artifacts
 	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
 
-	# Generate OpenAPI specification.
+	@# Generate OpenAPI specification.
 	$(RUNTIME_OPENAPI_GEN) --version $(RELEASE_TAG) --output-file $(RELEASE_DIR)/runtime-sdk-openapi.yaml
 
 .PHONY: release-manifests-dev
@@ -1108,7 +1108,7 @@ $(OPENAPI_GEN): # Build openapi-gen from tools folder.
 ## We are forcing a rebuilt of runtime-openapi-gen via PHONY so that we're always using an up-to-date version.
 .PHONY: $(RUNTIME_OPENAPI_GEN)
 $(RUNTIME_OPENAPI_GEN): $(TOOLS_DIR)/go.mod # Build openapi-gen from tools folder.
-	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/$(RUNTIME_OPENAPI_GEN_BIN) sigs.k8s.io/cluster-api/hack/tools/runtime-openapi-gen
+	@cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/$(RUNTIME_OPENAPI_GEN_BIN) sigs.k8s.io/cluster-api/hack/tools/runtime-openapi-gen
 
 $(GOTESTSUM): # Build gotestsum from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) $(GOTESTSUM_PKG) $(GOTESTSUM_BIN) $(GOTESTSUM_VER)


### PR DESCRIPTION
**What this PR does / why we need it**:

From a developer point of view I would like to suggest making the Makefiles a little less verbose. IMO there are a lot of details printed which makes it harder to grasp what is happening. Compare the following two outputs:

Current main branch:
```bash
make release-manifests
mkdir -p out/
cd hack/tools; go build -tags=tools -o bin/runtime-openapi-gen sigs.k8s.io/cluster-api/hack/tools/runtime-openapi-gen
# Build core-components.
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/kustomize-v4.5.2 build config/default > out/core-components.yaml
# Build bootstrap-components.
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/kustomize-v4.5.2 build bootstrap/kubeadm/config/default > out/bootstrap-components.yaml
# Build control-plane-components.
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/kustomize-v4.5.2 build controlplane/kubeadm/config/default > out/control-plane-components.yaml
## Build cluster-api-components (aggregate of all of the above).
cat out/core-components.yaml > out/cluster-api-components.yaml
echo "---" >> out/cluster-api-components.yaml
cat out/bootstrap-components.yaml >> out/cluster-api-components.yaml
echo "---" >> out/cluster-api-components.yaml
cat out/control-plane-components.yaml >> out/cluster-api-components.yaml
# Add metadata to the release artifacts
cp metadata.yaml out/metadata.yaml
# Generate OpenAPI specification.
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/runtime-openapi-gen --version v1.2.0-beta.0 --output-file out/runtime-sdk-openapi.yaml
```

This pr, where I left only the essential steps unmuted:
```bash
make release-manifests
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/kustomize-v4.5.2 build config/default > out/core-components.yaml
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/kustomize-v4.5.2 build bootstrap/kubeadm/config/default > out/bootstrap-components.yaml
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/kustomize-v4.5.2 build controlplane/kubeadm/config/default > out/control-plane-components.yaml
cat out/core-components.yaml > out/cluster-api-components.yaml
cat out/bootstrap-components.yaml >> out/cluster-api-components.yaml
cat out/control-plane-components.yaml >> out/cluster-api-components.yaml
cp metadata.yaml out/metadata.yaml
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/runtime-openapi-gen --version v1.2.0-beta.0 --output-file out/runtime-sdk-openapi.yaml
```

Note: if anyone needs all the information it's possible to get it using for example `--trace`:
```bash
make --trace release-manifests
Makefile:764: target 'out' does not exist
mkdir -p out/
Makefile:1111: update target '/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/runtime-openapi-gen' due to: hack/tools/go.mod
cd hack/tools; go build -tags=tools -o bin/runtime-openapi-gen sigs.k8s.io/cluster-api/hack/tools/runtime-openapi-gen
Makefile:813: update target 'release-manifests' due to: out /home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/kustomize-v4.5.2 /home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/runtime-openapi-gen
# Build core-components.
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/kustomize-v4.5.2 build config/default > out/core-components.yaml
# Build bootstrap-components.
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/kustomize-v4.5.2 build bootstrap/kubeadm/config/default > out/bootstrap-components.yaml
# Build control-plane-components.
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/kustomize-v4.5.2 build controlplane/kubeadm/config/default > out/control-plane-components.yaml
## Build cluster-api-components (aggregate of all of the above).
cat out/core-components.yaml > out/cluster-api-components.yaml
echo "---" >> out/cluster-api-components.yaml
cat out/bootstrap-components.yaml >> out/cluster-api-components.yaml
echo "---" >> out/cluster-api-components.yaml
cat out/control-plane-components.yaml >> out/cluster-api-components.yaml
# Add metadata to the release artifacts
cp metadata.yaml out/metadata.yaml
# Generate OpenAPI specification.
/home/oscar/go/src/k8s.io/kubernetes-sig/cluster-api/hack/tools/bin/runtime-openapi-gen --version v1.2.0-beta.0 --output-file out/runtime-sdk-openapi.yaml
```

If there is support for such a change, I can expand this pr with more targets. 