### PR TITLE
📖 Document multiple providers support

### DIFF
--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -36,6 +36,7 @@
             - [Implementing Topology Mutation Hook Extensions](./tasks/experimental-features/runtime-sdk/implement-topology-mutation-hook.md)
             - [Deploying Runtime Extensions](./tasks/experimental-features/runtime-sdk/deploy-runtime-extension.md)
         - [Ignition Bootstrap configuration](./tasks/experimental-features/ignition.md)
+    - [Running multiple providers](./tasks/multiple-providers.md)
 - [Security Guidelines](./security/index.md)
     - [Pod Security Standards](./security/pod-security-standards.md)
 - [clusterctl CLI](./clusterctl/overview.md)

--- a/docs/book/src/tasks/multiple-providers.md
+++ b/docs/book/src/tasks/multiple-providers.md
@@ -1,0 +1,14 @@
+# Running multiple providers
+
+Cluster API supports running multiple infrastructure/bootstrap/control plane providers on the same management cluster. It's highly recommeded to rely on
+[clusterctl init](../clusterctl/commands/init.md) command in this case. [clusterctl](../clusterctl/overview.md) will help ensure that all providers support the same
+[API Version of Cluster API](../clusterctl/provider-contract.md#metadata-yaml) (contract).
+
+<aside class="note warning">
+
+<h1>Warning</h1>
+
+Currently, the case of running multiple providers is not covered in Cluster API E2E test suite. It's recommended to set up a custom validation pipeline of
+your specific combination of providers before deploying it on a production environment.
+
+</aside>


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Explicitly highlight in the documentation that CAPI supports running multiple providers on the same management cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/7234
