### PR TITLE
✨ golangci-lint: set go version in run configuration instead of for eac…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,14 @@
+run:
+  timeout: 10m
+  go: "1.19"
+  build-tags:
+    - tools
+    - e2e
+  skip-files:
+    - "zz_generated.*\\.go$"
+    - "vendored_openapi\\.go$"
+  allow-parallel-runners: true
+
 linters:
   disable-all: true
   enable:
@@ -141,10 +152,6 @@ linters-settings:
     allow-unused: false
     allow-leading-space: false
     require-specific: true
-  staticcheck:
-    go: "1.19"
-  stylecheck:
-    go: "1.19"
   gosec:
     excludes:
     - G307 # Deferring unsafe method "Close" on type "\*os.File"
@@ -170,8 +177,7 @@ linters-settings:
     - wrapperFunc
     - rangeValCopy
     - hugeParam
-  unused:
-    go: "1.19"
+
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0
@@ -254,13 +260,3 @@ issues:
     - gocritic
     text: "deferInLoop: Possible resource leak, 'defer' is called in the 'for' loop"
     path: _test\.go
-
-run:
-  timeout: 10m
-  build-tags:
-  - tools
-  - e2e
-  skip-files:
-  - "zz_generated.*\\.go$"
-  - "vendored_openapi\\.go$"
-  allow-parallel-runners: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr removes configuration that has been deprecated in golangci-lint.

Instead of setting go version per linter, it should now be set globally in the run configuration. 
https://golangci-lint.run/usage/linters/#staticcheck
https://golangci-lint.run/usage/configuration/#run-configuration

It seems like golangci-lint can read the go version from go.mod file. However in order to be explicit I set the global version to 1.19.