### PR TITLE
✨ golangci-lint enable most recommended revive checks and fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -152,6 +152,38 @@ linters-settings:
     allow-unused: false
     allow-leading-space: false
     require-specific: true
+  revive:
+    rules:
+      # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      #- name: if-return  # TODO This is a recommended rule with many findings which may require it's own pr.
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      #- name: unused-parameter  # TODO This is a recommended rule with many findings which may require it's own pr.
+      - name: unreachable-code
+      - name: redefines-builtin-id
+      #
+      # Rules in addition to the recommended configuration above.
+      #
+      - name: bool-literal-in-expr
+      - name: constant-logical-expr
   gosec:
     excludes:
     - G307 # Deferring unsafe method "Close" on type "\*os.File"

--- a/exp/addons/internal/controllers/clusterresourceset_controller_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller_test.go
@@ -188,7 +188,7 @@ metadata:
 				return false
 			}
 
-			if binding.Spec.Bindings[0].Resources[0].Applied != true || binding.Spec.Bindings[0].Resources[1].Applied != true {
+			if !binding.Spec.Bindings[0].Resources[0].Applied || !binding.Spec.Bindings[0].Resources[1].Applied {
 				return false
 			}
 

--- a/internal/controllers/machine/machine_controller_test.go
+++ b/internal/controllers/machine/machine_controller_test.go
@@ -282,7 +282,7 @@ func TestMachine_Reconcile(t *testing.T) {
 		if err := env.Get(ctx, key, machine); err != nil {
 			return false
 		}
-		if conditions.Has(machine, clusterv1.InfrastructureReadyCondition) != true {
+		if !conditions.Has(machine, clusterv1.InfrastructureReadyCondition) {
 			return false
 		}
 		readyCondition := conditions.Get(machine, clusterv1.ReadyCondition)

--- a/util/patch/patch_test.go
+++ b/util/patch/patch_test.go
@@ -627,7 +627,7 @@ func TestPatchHelper(t *testing.T) {
 					return false
 				}
 
-				return objAfter.Spec.Paused == true &&
+				return objAfter.Spec.Paused &&
 					reflect.DeepEqual(obj.Spec.InfrastructureRef, objAfter.Spec.InfrastructureRef)
 			}, timeout).Should(BeTrue())
 		})

--- a/util/version/version.go
+++ b/util/version/version.go
@@ -104,9 +104,8 @@ func newBuildIdentifiers(ids []string) buildIdentifiers {
 func (v buildIdentifiers) compare(o buildIdentifiers) int {
 	i := 0
 	for ; i < len(v) && i < len(o); i++ {
-		if comp := v[i].compare(o[i]); comp == 0 {
-			continue
-		} else {
+		comp := v[i].compare(o[i])
+		if comp != 0 {
 			return comp
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

We are currently using the default revive linter checks. However if you explicitly enable an additional rule the default rules are disabled. So by explicitly setting the revive rules we can add additional interesting checks.

I selected to add most of the [recommended rules](https://github.com/mgechev/revive#recommended-configuration) instead of the [default rules](https://github.com/mgechev/revive/blob/master/defaults.toml). I commented out some of the recommended checks because of the large amount of findings. I also added a section for additional checks that we might be interested in.

The code changes are to resolve the following findings by the new revive checks:
```
util/version/version.go:109:10: superfluous-else: if block ends with a continue statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
                } else {
                        return comp
                }
util/patch/patch_test.go:630:12: bool-literal-in-expr: omit Boolean literal in expression (revive)
                                return objAfter.Spec.Paused == true &&
                                       ^
internal/controllers/machine/machine_controller_test.go:285:6: bool-literal-in-expr: omit Boolean literal in expression (revive)
                if conditions.Has(machine, clusterv1.InfrastructureReadyCondition) != true {
                   ^
exp/addons/internal/controllers/clusterresourceset_controller_test.go:191:7: bool-literal-in-expr: omit Boolean literal in expression (revive)
                        if binding.Spec.Bindings[0].Resources[0].Applied != true || binding.Spec.Bindings[0].Resources[1].Applied != true {
                           ^
```