### PR TITLE
🌱 Set golangci-lint path-prefix when linting test and hack/tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,8 +542,8 @@ generate-diagrams: ## Generate diagrams for *.plantuml files
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Lint the codebase
 	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
-	cd $(TEST_DIR); $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
-	cd $(TOOLS_DIR); $(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_EXTRA_ARGS)
+	cd $(TEST_DIR); $(GOLANGCI_LINT) run --path-prefix $(TEST_DIR) -v $(GOLANGCI_LINT_EXTRA_ARGS)
+	cd $(TOOLS_DIR); $(GOLANGCI_LINT) run --path-prefix $(TOOLS_DIR) -v $(GOLANGCI_LINT_EXTRA_ARGS)
 	./scripts/ci-lint-dockerfiles.sh $(HADOLINT_VER) $(HADOLINT_FAILURE_THRESHOLD)
 
 .PHONY: lint-dockerfiles


### PR DESCRIPTION
**What this PR does / why we need it**:

When running golangci-lint in for example test directory, findings are returned with paths based on where golangci-lint was run. For example when running in `test` you get:

```
framework/clusterctl/logger/logger.go:38:23: unused-parameter: parameter 'info' seems to be unused, consider removing or renaming it as _ (revive)
func (l *logger) Init(info logr.RuntimeInfo) {
                      ^
framework/clusterctl/logger/logger.go:41:26: unused-parameter: parameter 'level' seems to be unused, consider removing or renaming it as _ (revive)
func (l *logger) Enabled(level int) bool {
                         ^
```

Note that the `test` directory is missing from the path `framework/clusterctl/logger/logger.go` 

However by setting setting path-prefix we get the full path. Like this:

```
test/framework/clusterctl/logger/logger.go:38:23: unused-parameter: parameter 'info' seems to be unused, consider removing or renaming it as _ (revive)
func (l *logger) Init(info logr.RuntimeInfo) {
                      ^
test/framework/clusterctl/logger/logger.go:41:26: unused-parameter: parameter 'level' seems to be unused, consider removing or renaming it as _ (revive)
func (l *logger) Enabled(level int) bool {
                         ^
```

This change makes it more clear where the finding is, and more importantly it allows editors such as IntelliJ to directly open the finding.