### PR TITLE
✨ Add environment variable to enable tracing for hack/ shell scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ export KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT ?= 60s
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
 
+# Enables shell script tracing. Enable by running: TRACE=1 make <target>
+TRACE ?= 0
+
 #
 # Directories.
 #
@@ -556,7 +559,7 @@ lint-fix: $(GOLANGCI_LINT) ## Lint the codebase and run auto-fixers if supported
 
 .PHONY: tiltfile-fix
 tiltfile-fix: ## Format the Tiltfile
-	./hack/verify-starlark.sh fix
+	TRACE=$(TRACE) ./hack/verify-starlark.sh fix
 
 APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
 
@@ -593,23 +596,23 @@ verify-conversions: $(CONVERSION_VERIFIER)  ## Verifies expected API conversion 
 
 .PHONY: verify-doctoc
 verify-doctoc:
-	./hack/verify-doctoc.sh
+	TRACE=$(TRACE) ./hack/verify-doctoc.sh
 
 .PHONY: verify-capi-book-summary
 verify-capi-book-summary:
-	./hack/verify-capi-book-summary.sh
+	TRACE=$(TRACE) ./hack/verify-capi-book-summary.sh
 
 .PHONY: verify-boilerplate
 verify-boilerplate: ## Verify boilerplate text exists in each file
-	./hack/verify-boilerplate.sh
+	TRACE=$(TRACE) ./hack/verify-boilerplate.sh
 
 .PHONY: verify-shellcheck
 verify-shellcheck: ## Verify shell files
-	./hack/verify-shellcheck.sh
+	TRACE=$(TRACE) ./hack/verify-shellcheck.sh
 
 .PHONY: verify-tiltfile
 verify-tiltfile: ## Verify Tiltfile format
-	./hack/verify-starlark.sh
+	TRACE=$(TRACE) ./hack/verify-starlark.sh
 
 ## --------------------------------------
 ## Binaries

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 # Ensure the go tool exists and is a viable version.
 verify_go_version() {
   if [[ -z "$(command -v go)" ]]; then

--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -18,6 +18,10 @@
 
 set -e
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 usage() {
   this=$1
   cat <<EOF
@@ -42,12 +46,11 @@ parse_args() {
   # over-ridden by flag below
 
   BINDIR=${BINDIR:-./bin}
-  while getopts "b:dh?x" arg; do
+  while getopts "b:dh?" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;
       d) log_set_priority 10 ;;
       h | \?) usage "$0" ;;
-      x) set -x ;;
     esac
   done
   shift $((OPTIND - 1))

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -18,7 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-set -x
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
 
 GOPATH_BIN="$(go env GOPATH)/bin"
 MINIMUM_KIND_VERSION=v0.16.0

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 GOPATH_BIN="$(go env GOPATH)/bin/"
 MINIMUM_KUBECTL_VERSION=v1.19.0
 goarch="$(go env GOARCH)"

--- a/hack/get-project-maintainers.sh
+++ b/hack/get-project-maintainers.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 YQ_BIN=yq

--- a/hack/kind-install-for-capd.sh
+++ b/hack/kind-install-for-capd.sh
@@ -26,6 +26,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 KIND_CLUSTER_NAME=${CAPI_KIND_CLUSTER_NAME:-"capi-test"}
 
 if [[ "$(kind get clusters)" =~ .*"${KIND_CLUSTER_NAME}".* ]]; then

--- a/hack/pin-dependency.sh
+++ b/hack/pin-dependency.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 # Usage:

--- a/hack/setup-envtest-with-kind.sh
+++ b/hack/setup-envtest-with-kind.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 os="unknown"
 if [[ "${OSTYPE}" == "linux"* ]]; then
   os="linux"

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 boilerDir="${KUBE_ROOT}/hack/boilerplate"

--- a/hack/verify-capi-book-summary.sh
+++ b/hack/verify-capi-book-summary.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 RESULT=0
 SUMMARY=$(cat ./docs/book/src/SUMMARY.md)
 

--- a/hack/verify-doctoc.sh
+++ b/hack/verify-doctoc.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 command -v doctoc || echo "doctoc is not available on your system, skipping verification" && exit 0
 
 doctoc_files="README.md \

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -17,6 +17,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 VERSION="v0.8.0"
 
 OS="unknown"

--- a/hack/verify-starlark.sh
+++ b/hack/verify-starlark.sh
@@ -17,6 +17,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 ROOT_PATH="$(cd "${SCRIPT_DIR}"/.. && pwd)"
 

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -17,6 +17,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
 version::get_version_vars() {
     # shellcheck disable=SC1083
     GIT_COMMIT="$(git rev-parse HEAD^{commit})"


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr adds an environment variable to toggle shell script tracing. This is something I often turn by hand but never considered to automate until I read: https://sharats.me/posts/shell-script-best-practices/ I also added it to the Makefile allowing it to be simply toggled using make.

### Use cases demonstrated
Case: variable set but disabled 
```
$ TRACE=0 make verify-shellcheck
TRACE=0 ./hack/verify-shellcheck.sh
Running shellcheck...
Cleaning up...
```

Case: no variable set
```
$ make verify-shellcheck
TRACE=0 ./hack/verify-shellcheck.sh
Running shellcheck...
Cleaning up...
```

Case: variable set and enabled
```
$ TRACE=1 make verify-shellcheck
+ version::ldflags
+ version::get_version_vars
++ git rev-parse 'HEAD^{commit}'
+ GIT_COMMIT=1bf70d5c24004977844b9da7570853c32e29c6b3
++ git status --porcelain
(...)
+ GIT_TREE_STATE=dirty
+ [[ -n '' ]]
++ git describe --abbrev=14 --match 'v[0-9]*'
+ GIT_VERSION=v1.2.0-beta.0-702-g1bf70d5c240049
++ echo v1.2.0-beta.0-702-g1bf70d5c240049
++ sed 's/[^-]//g'
+ DASHES_IN_VERSION=---
+ [[ --- == \-\-\- ]]
++ echo v1.2.0-beta.0-702-g1bf70d5c240049
++ sed 's/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\-\2/'
+ GIT_VERSION=v1.2.0-beta.0.702-1bf70d5c240049
+ [[ dirty == \d\i\r\t\y ]]
+ GIT_VERSION+=-dirty
(... output shortened) 
```

Case: running shell script directly
```
$ TRACE=1 ./hack/verify-shellcheck.sh 
+ VERSION=v0.8.0
+ OS=unknown
+ [[ linux-gnu == \l\i\n\u\x* ]]
+ OS=linux
++ dirname ./hack/verify-shellcheck.sh
```