### PR TITLE
✨ Update github.com/joelanford/go-apidiff version (0.4.0 -> 0.5.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ ENVSUBST_BIN := envsubst
 ENVSUBST := $(abspath $(TOOLS_BIN_DIR)/$(ENVSUBST_BIN)-$(ENVSUBST_VER))
 ENVSUBST_PKG := github.com/drone/envsubst/v2/cmd/envsubst
 
-GO_APIDIFF_VER := v0.4.0
+GO_APIDIFF_VER := v0.5.0
 GO_APIDIFF_BIN := go-apidiff
 GO_APIDIFF := $(abspath $(TOOLS_BIN_DIR)/$(GO_APIDIFF_BIN)-$(GO_APIDIFF_VER))
 GO_APIDIFF_PKG := github.com/joelanford/go-apidiff

--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -18,6 +18,7 @@ in Cluster API are kept in sync with the versions used by `sigs.k8s.io/controlle
 - k8s.io/*: v0.24.x => v0.25.x (derived from controller-runtime)
 - github.com/onsi/ginkgo: v1.x => v2.x (derived from controller-runtime)
 - k8s.io/kubectl: v0.24.x => 0.25.x
+- github.com/joelanford/go-apidiff: 0.4.0 => 0.5.0
 
 ## Changes by Kind
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A simple dependency bump to keep it up to date. Updates go-apidiff version from 0.4.0 -> 0.5.0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
