### PR TITLE
🌱 KCP: use new registry for Kubernetes >= v1.22

### DIFF
--- a/controlplane/kubeadm/internal/workload_cluster.go
+++ b/controlplane/kubeadm/internal/workload_cluster.go
@@ -87,7 +87,7 @@ var (
 
 	// minKubernetesVersionImageRegistryMigration is first kubernetes version where
 	// the default image registry is registry.k8s.io instead of k8s.gcr.io.
-	minKubernetesVersionImageRegistryMigration = semver.MustParse("1.25.0")
+	minKubernetesVersionImageRegistryMigration = semver.MustParse("1.22.0")
 
 	// nextKubernetesVersionImageRegistryMigration is the next minor version after
 	// the default image registry changed to registry.k8s.io.
@@ -624,10 +624,10 @@ func yamlToUnstructured(rawYAML []byte) (*unstructured.Unstructured, error) {
 
 // ImageRepositoryFromClusterConfig returns the image repository to use. It returns:
 // * clusterConfig.ImageRepository if set.
-// * "registry.k8s.io" if v1.25 <= version < v1.26 to migrate to the new registry
+// * "registry.k8s.io" if v1.22 <= version < v1.26 to migrate to the new registry
 // * "" otherwise.
-// Beginning with kubernetes v1.25, the default registry for kubernetes is registry.k8s.io
-// instead of k8s.gcr.io which is why references should get migrated when upgrading to v1.25.
+// Beginning with kubernetes v1.22, the default registry for kubernetes is registry.k8s.io
+// instead of k8s.gcr.io which is why references should get migrated when upgrading to v1.22.
 // The migration follows the behavior of `kubeadm upgrade`.
 func ImageRepositoryFromClusterConfig(clusterConfig *bootstrapv1.ClusterConfiguration, kubernetesVersion semver.Version) string {
 	// If ImageRepository is explicitly specified, return early.
@@ -636,7 +636,7 @@ func ImageRepositoryFromClusterConfig(clusterConfig *bootstrapv1.ClusterConfigur
 		return clusterConfig.ImageRepository
 	}
 
-	// If v1.25 <= version < v1.26 return the default Kubernetes image repository to
+	// If v1.22 <= version < v1.26 return the default Kubernetes image repository to
 	// migrate to the new location and not cause changes else.
 	if kubernetesVersion.GTE(minKubernetesVersionImageRegistryMigration) &&
 		kubernetesVersion.LT(nextKubernetesVersionImageRegistryMigration) {

--- a/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
+++ b/controlplane/kubeadm/internal/workload_cluster_coredns_test.go
@@ -1213,7 +1213,7 @@ func TestGetCoreDNSInfo(t *testing.T) {
 				},
 			},
 			{
-				name: "rename to coredns/coredns when upgrading to coredns=1.8.0 and kubernetesVersion=1.24.0",
+				name: "rename to coredns/coredns when upgrading to coredns=1.8.0 and kubernetesVersion=1.21.0",
 				objs: []client.Object{newCoreDNSInfoDeploymentWithimage(image162), cm},
 				clusterConfig: &bootstrapv1.ClusterConfiguration{
 					DNS: bootstrapv1.DNS{
@@ -1222,7 +1222,7 @@ func TestGetCoreDNSInfo(t *testing.T) {
 						},
 					},
 				},
-				kubernetesVersion: semver.MustParse("1.24.0"),
+				kubernetesVersion: semver.MustParse("1.21.0"),
 				expectedInfo: coreDNSInfo{
 					CurrentMajorMinorPatch: "1.6.2",
 					FromImageTag:           "1.6.2",
@@ -1248,6 +1248,26 @@ func TestGetCoreDNSInfo(t *testing.T) {
 					FromImageTag:           "1.6.2",
 					TargetMajorMinorPatch:  "1.8.0",
 					FromImage:              "registry.k8s.io/coredns:1.6.2",
+					ToImage:                "registry.k8s.io/coredns/coredns:1.8.0",
+					ToImageTag:             "1.8.0",
+				},
+			},
+			{
+				name: "patches ImageRepository to registry.k8s.io if it's set on neither global nor DNS-level and kubernetesVersion >= v1.22 and rename to coredns/coredns",
+				objs: []client.Object{newCoreDNSInfoDeploymentWithimage(image162), cm},
+				clusterConfig: &bootstrapv1.ClusterConfiguration{
+					DNS: bootstrapv1.DNS{
+						ImageMeta: bootstrapv1.ImageMeta{
+							ImageTag: "1.8.0",
+						},
+					},
+				},
+				kubernetesVersion: semver.MustParse("1.22.0"),
+				expectedInfo: coreDNSInfo{
+					CurrentMajorMinorPatch: "1.6.2",
+					FromImageTag:           "1.6.2",
+					TargetMajorMinorPatch:  "1.8.0",
+					FromImage:              image162,
 					ToImage:                "registry.k8s.io/coredns/coredns:1.8.0",
 					ToImageTag:             "1.8.0",
 				},

--- a/test/framework/daemonset_helpers.go
+++ b/test/framework/daemonset_helpers.go
@@ -42,12 +42,12 @@ func WaitForKubeProxyUpgrade(ctx context.Context, input WaitForKubeProxyUpgradeI
 	parsedVersion, err := semver.ParseTolerant(input.KubernetesVersion)
 	Expect(err).ToNot(HaveOccurred())
 
-	// Beginning with kubernetes v1.25, kubernetes images including kube-proxy get published to registry.k8s.io instead of k8s.gcr.io.
-	// This ensures that the imageRepository setting gets patched to registry.k8s.io when upgrading from v1.24 or lower,
-	// but only if there was no imageRespository explicitly set at the KubeadmControlPlanes ClusterConfiguration.
+	// Beginning with kubernetes v1.22, kubernetes images including kube-proxy get published to registry.k8s.io.
+	// This ensures that the imageRepository setting gets patched to registry.k8s.io when upgrading from v1.21 or lower,
+	// but only if there was no imageRepository explicitly set at the KubeadmControlPlanes ClusterConfiguration.
 	// This follows the behavior of `kubeadm upgrade`.
 	wantKubeProxyRegistry := "registry.k8s.io"
-	if parsedVersion.LT(semver.Version{Major: 1, Minor: 25, Patch: 0, Pre: []semver.PRVersion{{VersionStr: "alpha"}}}) {
+	if parsedVersion.LT(semver.Version{Major: 1, Minor: 22, Patch: 0, Pre: []semver.PRVersion{{VersionStr: "alpha"}}}) {
 		wantKubeProxyRegistry = "k8s.gcr.io"
 	}
 	wantKubeProxyImage := wantKubeProxyRegistry + "/kube-proxy:" + containerutil.SemverToOCIImageTag(input.KubernetesVersion)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Before this PR we started using the new registry with Kubernetes 1.25.

Given:
* that the new registry is cheaper for the project and
* there's an upstream effort (kubeadm) to backport the registry change back until v1.22 

let's align and already use the new registry for Kubernetes >= v1.22


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7472
