### PR TITLE
🌱 MHC: Drop Reconciling log, CAPD: log image name during preload

### DIFF
--- a/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_controller.go
@@ -117,7 +117,6 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opt
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Reconciling")
 
 	// Fetch the MachineHealthCheck instance
 	m := &clusterv1.MachineHealthCheck{}

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -297,19 +297,19 @@ func (m *Machine) PreloadLoadImages(ctx context.Context, images []string) error 
 
 		err = containerRuntime.SaveContainerImage(ctx, image, imageTarPath)
 		if err != nil {
-			return errors.Wrap(err, "failed to save image")
+			return errors.Wrapf(err, "failed to save image %q to %q", image, imageTarPath)
 		}
 
 		f, err := os.Open(imageTarPath)
 		if err != nil {
-			return errors.Wrap(err, "failed to open image")
+			return errors.Wrapf(err, "failed to open image %q from %q", image, imageTarPath)
 		}
 		defer f.Close() //nolint:gocritic // No resource leak.
 
 		ps := m.container.Commander.Command("ctr", "--namespace=k8s.io", "images", "import", "-")
 		ps.SetStdin(f)
 		if err := ps.Run(ctx); err != nil {
-			return errors.Wrap(err, "failed to load image")
+			return errors.Wrapf(err, "failed to load image %q", image)
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
