### PR TITLE
📖 grammar: remove extra space before comma and punctuation

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -473,7 +473,7 @@ func (o *objectMover) fromDirectory(graph *objectGraph, toProxy Proxy) error {
 	}
 
 	// Resume reconciling the Clusters after being restored from a directory.
-	// By default, when moved to a directory , Clusters are paused, so they must be unpaused to be used again.
+	// By default, when moved to a directory, Clusters are paused, so they must be unpaused to be used again.
 	log.V(1).Info("Resuming the target cluster")
 	return setClusterPause(toProxy, clusters, false, o.dryRun)
 }

--- a/docs/book/src/clusterctl/commands/delete.md
+++ b/docs/book/src/clusterctl/commands/delete.md
@@ -33,7 +33,7 @@ the aws provider, it deletes all the `AWSCluster`, `AWSMachine` etc.
 
 </aside>
 
-If you want to delete all the providers in a single operation , you can use the `--all` flag.
+If you want to delete all the providers in a single operation, you can use the `--all` flag.
 
 ```bash
 clusterctl delete --all

--- a/docs/book/src/tasks/experimental-features/runtime-sdk/implement-extensions.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/implement-extensions.md
@@ -212,7 +212,7 @@ synchronously.
 ### Availability
 
 Runtime Extension failure could result in errors in handling the workload clusters lifecycle, and so the implementation
-should be robust, have proper error handling, avoid panics, etc.. . Failure policies can be set up to mitigate the
+should be robust, have proper error handling, avoid panics, etc. Failure policies can be set up to mitigate the
 negative impact of a Runtime Extension on the Cluster API Runtime, but this option can’t be used in all cases
 (see [Error Management](#error-management)).
 

--- a/hack/tools/runtime-openapi-gen/vendored_openapi.go
+++ b/hack/tools/runtime-openapi-gen/vendored_openapi.go
@@ -168,7 +168,7 @@ func schema_pkg_apis_meta_v1_ObjectMeta(ref common.ReferenceCallback) common.Ope
 					},
 					"resourceVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+							Description: "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

Reading the clusterctl documentation I noticed an extra space before a comma. So I searched for more occurrences and fixed them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
