### PR TITLE
🌱 cc `@cluster-api-release-team` when auto-opening the PR to promote images from staging to prod

### DIFF
--- a/hack/get-project-maintainers.sh
+++ b/hack/get-project-maintainers.sh
@@ -27,4 +27,4 @@ cd "${REPO_ROOT}" && make ${YQ_BIN} >/dev/null
 
 KEYS=()
 while IFS='' read -r line; do KEYS+=("$line"); done < <(${YQ_PATH} e '.aliases["cluster-api-maintainers"][]' OWNERS_ALIASES)
-echo "${KEYS[@]/#/@}"
+echo "${KEYS[@]/#/@} @cluster-api-release-team"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds the @cluster-api-release-team to the list of people/teams CC'd on the PR to promote images from staging to production registry.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


/cc @CecileRobertMichon 
/hold until https://github.com/kubernetes/org/pull/3802 is merged