### PR TITLE
:bug: Improve MHC validation for topology-managed MHC

### DIFF
--- a/api/v1beta1/machinehealthcheck_webhook.go
+++ b/api/v1beta1/machinehealthcheck_webhook.go
@@ -136,37 +136,52 @@ func (m *MachineHealthCheck) validate(old *MachineHealthCheck) error {
 		)
 	}
 
+	allErrs = append(allErrs, m.ValidateCommonFields(specPath)...)
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(GroupVersion.WithKind("MachineHealthCheck").GroupKind(), m.Name, allErrs)
+}
+
+// ValidateCommonFields validates UnhealthyConditions NodeStartupTimeout, MaxUnhealthy, and RemediationTemplate of the MHC.
+// These are the fields in common with other types which define MachineHealthChecks such as MachineHealthCheckClass and MachineHealthCheckTopology.
+func (m *MachineHealthCheck) ValidateCommonFields(fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
 	if m.Spec.NodeStartupTimeout != nil &&
 		m.Spec.NodeStartupTimeout.Seconds() != disabledNodeStartupTimeout.Seconds() &&
 		m.Spec.NodeStartupTimeout.Seconds() < minNodeStartupTimeout.Seconds() {
 		allErrs = append(
 			allErrs,
-			field.Invalid(specPath.Child("nodeStartupTimeout"), m.Spec.NodeStartupTimeout.Seconds(), "must be at least 30s"),
+			field.Invalid(fldPath.Child("nodeStartupTimeout"), m.Spec.NodeStartupTimeout.String(), "must be at least 30s"),
 		)
 	}
-
 	if m.Spec.MaxUnhealthy != nil {
 		if _, err := intstr.GetScaledValueFromIntOrPercent(m.Spec.MaxUnhealthy, 0, false); err != nil {
 			allErrs = append(
 				allErrs,
-				field.Invalid(specPath.Child("maxUnhealthy"), m.Spec.MaxUnhealthy, fmt.Sprintf("must be either an int or a percentage: %v", err.Error())),
+				field.Invalid(fldPath.Child("maxUnhealthy"), m.Spec.MaxUnhealthy, fmt.Sprintf("must be either an int or a percentage: %v", err.Error())),
 			)
 		}
 	}
-
 	if m.Spec.RemediationTemplate != nil && m.Spec.RemediationTemplate.Namespace != m.Namespace {
 		allErrs = append(
 			allErrs,
 			field.Invalid(
-				specPath.Child("remediationTemplate", "namespace"),
+				fldPath.Child("remediationTemplate", "namespace"),
 				m.Spec.RemediationTemplate.Namespace,
 				"must match metadata.namespace",
 			),
 		)
 	}
 
-	if len(allErrs) == 0 {
-		return nil
+	if len(m.Spec.UnhealthyConditions) == 0 {
+		allErrs = append(allErrs, field.Forbidden(
+			fldPath.Child("unhealthyConditions"),
+			"must have at least one entry",
+		))
 	}
-	return apierrors.NewInvalid(GroupVersion.WithKind("MachineHealthCheck").GroupKind(), m.Name, allErrs)
+
+	return allErrs
 }

--- a/internal/webhooks/clusterclass_test.go
+++ b/internal/webhooks/clusterclass_test.go
@@ -643,7 +643,7 @@ func TestClusterClassValidation(t *testing.T) {
 						},
 					},
 					NodeStartupTimeout: &metav1.Duration{
-						Duration: time.Duration(1)}}).
+						Duration: time.Duration(6000000000000)}}).
 				Build(),
 		},
 		{
@@ -657,7 +657,7 @@ func TestClusterClassValidation(t *testing.T) {
 				// No ControlPlaneMachineInfrastructure makes this an invalid creation request.
 				WithControlPlaneMachineHealthCheck(&clusterv1.MachineHealthCheckClass{
 					NodeStartupTimeout: &metav1.Duration{
-						Duration: time.Duration(1)}}).
+						Duration: time.Duration(6000000000000)}}).
 				Build(),
 			expectErr: true,
 		},
@@ -674,7 +674,7 @@ func TestClusterClassValidation(t *testing.T) {
 						Build()).
 				WithControlPlaneMachineHealthCheck(&clusterv1.MachineHealthCheckClass{
 					NodeStartupTimeout: &metav1.Duration{
-						Duration: time.Duration(1)}}).
+						Duration: time.Duration(6000000000000)}}).
 				Build(),
 			expectErr: true,
 		},
@@ -701,9 +701,38 @@ func TestClusterClassValidation(t *testing.T) {
 								},
 							},
 							NodeStartupTimeout: &metav1.Duration{
-								Duration: time.Duration(1)}}).
+								Duration: time.Duration(6000000000000)}}).
 						Build()).
 				Build(),
+		},
+		{
+			name: "create fail if MachineDeployment MachineHealthCheck NodeStartUpTimeout is too short",
+			in: builder.ClusterClass(metav1.NamespaceDefault, "class1").
+				WithInfrastructureClusterTemplate(
+					builder.InfrastructureClusterTemplate(metav1.NamespaceDefault, "infra1").Build()).
+				WithControlPlaneTemplate(
+					builder.ControlPlaneTemplate(metav1.NamespaceDefault, "cp1").
+						Build()).
+				WithWorkerMachineDeploymentClasses(
+					*builder.MachineDeploymentClass("aa").
+						WithInfrastructureTemplate(
+							builder.InfrastructureMachineTemplate(metav1.NamespaceDefault, "infra1").Build()).
+						WithBootstrapTemplate(
+							builder.BootstrapTemplate(metav1.NamespaceDefault, "bootstrap1").Build()).
+						WithMachineHealthCheckClass(&clusterv1.MachineHealthCheckClass{
+							UnhealthyConditions: []clusterv1.UnhealthyCondition{
+								{
+									Type:    corev1.NodeReady,
+									Status:  corev1.ConditionUnknown,
+									Timeout: metav1.Duration{Duration: 5 * time.Minute},
+								},
+							},
+							NodeStartupTimeout: &metav1.Duration{
+								// nodeStartupTimeout is too short here - 600ns.
+								Duration: time.Duration(600)}}).
+						Build()).
+				Build(),
+			expectErr: true,
 		},
 		{
 			name: "create fail if MachineDeployment MachineHealthCheck does not define UnhealthyConditions",
@@ -721,7 +750,7 @@ func TestClusterClassValidation(t *testing.T) {
 							builder.BootstrapTemplate(metav1.NamespaceDefault, "bootstrap1").Build()).
 						WithMachineHealthCheckClass(&clusterv1.MachineHealthCheckClass{
 							NodeStartupTimeout: &metav1.Duration{
-								Duration: time.Duration(1)}}).
+								Duration: time.Duration(6000000000000)}}).
 						Build()).
 				Build(),
 			expectErr: true,


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add validation for nodeStartupTimeout on cluster creation. Merge MHC validation into a single function in the MHC api definition which can then be used for common validation no matter if the MHC is defined in the Cluster topology, the ClusterClass or an individuation MHC object.
