### PR TITLE
⚠️ ClusterClass: validate unknown fields in variable values

### DIFF
--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -319,6 +319,12 @@ type JSONSchemaProps struct {
 	// +optional
 	ExclusiveMinimum bool `json:"exclusiveMinimum,omitempty"`
 
+	// XPreserveUnknownFields allows setting fields in a variable object
+	// which are not defined in the variable schema. This affects fields recursively,
+	// except if nested properties or additionalProperties are specified in the schema.
+	// +optional
+	XPreserveUnknownFields bool `json:"x-kubernetes-preserve-unknown-fields,omitempty"`
+
 	// Enum is the list of valid values of the variable.
 	// NOTE: Can be set for all types.
 	// +optional

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -1181,6 +1181,13 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_JSONSchemaProps(ref common.Referen
 							Format:      "",
 						},
 					},
+					"x-kubernetes-preserve-unknown-fields": {
+						SchemaProps: spec.SchemaProps{
+							Description: "XPreserveUnknownFields allows setting fields in a variable object which are not defined in the variable schema. This affects fields recursively, except if nested properties or additionalProperties are specified in the schema.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"enum": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Enum is the list of valid values of the variable. NOTE: Can be set for all types.",

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -964,6 +964,13 @@ spec:
                               description: 'UniqueItems specifies if items in an array
                                 must be unique. NOTE: Can only be set if type is array.'
                               type: boolean
+                            x-kubernetes-preserve-unknown-fields:
+                              description: XPreserveUnknownFields allows setting fields
+                                in a variable object which are not defined in the
+                                variable schema. This affects fields recursively,
+                                except if nested properties or additionalProperties
+                                are specified in the schema.
+                              type: boolean
                           required:
                           - type
                           type: object

--- a/internal/topology/variables/schema.go
+++ b/internal/topology/variables/schema.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
@@ -46,6 +47,13 @@ func convertToAPIExtensionsJSONSchemaProps(schema *clusterv1.JSONSchemaProps, fl
 		Pattern:          schema.Pattern,
 		ExclusiveMaximum: schema.ExclusiveMaximum,
 		ExclusiveMinimum: schema.ExclusiveMinimum,
+	}
+
+	// Only set XPreserveUnknownFields to true if it's true.
+	// apiextensions.JSONSchemaProps only allows setting XPreserveUnknownFields
+	// to true or undefined, false is forbidden.
+	if schema.XPreserveUnknownFields {
+		props.XPreserveUnknownFields = pointer.Bool(true)
 	}
 
 	if schema.Default != nil && schema.Default.Raw != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR improves the validation of variable values. The validating webhook will now return validation errors if nested fields in variable objects are not defined in the schema.

If users encounter those validation errors they have the following options:
* update the variable schema in the ClusterClass to either add the missing fields or x-kubernetes-preserve-unknown-fields
* update the variable in the Cluster to drop the unknown fields


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6135
