### PR TITLE
:bug:  [WIP] Update MachineSet and MachineDeployment ownerRef versions on reconcile

### DIFF
--- a/internal/controllers/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller_test.go
@@ -244,7 +244,7 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 		//
 		secondMachineSet := machineSets.Items[0]
 		t.Log("Scaling the MachineDeployment to 3 replicas")
-		modifyFunc := func(d *clusterv1.MachineDeployment) { d.Spec.Replicas = pointer.Int32(3) }
+		modifyFunc := func(md *clusterv1.MachineDeployment) { md.Spec.Replicas = pointer.Int32(3) }
 		g.Expect(updateMachineDeployment(ctx, env, deployment, modifyFunc)).To(Succeed())
 		g.Eventually(func() int {
 			key := client.ObjectKey{Name: secondMachineSet.Name, Namespace: secondMachineSet.Namespace}
@@ -258,7 +258,7 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 		// Update a MachineDeployment, expect Reconcile to be called and a new MachineSet to appear.
 		//
 		t.Log("Setting a label on the MachineDeployment")
-		modifyFunc = func(d *clusterv1.MachineDeployment) { d.Spec.Template.Labels["updated"] = "true" }
+		modifyFunc = func(md *clusterv1.MachineDeployment) { md.Spec.Template.Labels["updated"] = "true" }
 		g.Expect(updateMachineDeployment(ctx, env, deployment, modifyFunc)).To(Succeed())
 		g.Eventually(func() int {
 			if err := env.List(ctx, machineSets, msListOpts...); err != nil {
@@ -268,8 +268,8 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 		}, timeout).Should(BeEquivalentTo(2))
 
 		t.Log("Updating deletePolicy on the MachineDeployment")
-		modifyFunc = func(d *clusterv1.MachineDeployment) {
-			d.Spec.Strategy.RollingUpdate.DeletePolicy = pointer.String("Newest")
+		modifyFunc = func(md *clusterv1.MachineDeployment) {
+			md.Spec.Strategy.RollingUpdate.DeletePolicy = pointer.String("Newest")
 		}
 		g.Expect(updateMachineDeployment(ctx, env, deployment, modifyFunc)).To(Succeed())
 		g.Eventually(func() string {
@@ -348,9 +348,9 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 		}
 
 		t.Log("Updating MachineDeployment label")
-		modifyFunc = func(d *clusterv1.MachineDeployment) {
-			d.Spec.Selector.MatchLabels = newLabels
-			d.Spec.Template.Labels = newLabels
+		modifyFunc = func(md *clusterv1.MachineDeployment) {
+			md.Spec.Selector.MatchLabels = newLabels
+			md.Spec.Template.Labels = newLabels
 		}
 		g.Expect(updateMachineDeployment(ctx, env, deployment, modifyFunc)).To(Succeed())
 

--- a/internal/controllers/machinedeployment/machinedeployment_rolling.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rolling.go
@@ -30,8 +30,8 @@ import (
 )
 
 // rolloutRolling implements the logic for rolling a new MachineSet.
-func (r *Reconciler) rolloutRolling(ctx context.Context, d *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) error {
-	newMS, oldMSs, err := r.getAllMachineSetsAndSyncRevision(ctx, d, msList, true)
+func (r *Reconciler) rolloutRolling(ctx context.Context, md *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) error {
+	newMS, oldMSs, err := r.getAllMachineSetsAndSyncRevision(ctx, md, msList, true)
 	if err != nil {
 		return err
 	}
@@ -46,25 +46,25 @@ func (r *Reconciler) rolloutRolling(ctx context.Context, d *clusterv1.MachineDep
 	allMSs := append(oldMSs, newMS)
 
 	// Scale up, if we can.
-	if err := r.reconcileNewMachineSet(ctx, allMSs, newMS, d); err != nil {
+	if err := r.reconcileNewMachineSet(ctx, allMSs, newMS, md); err != nil {
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := r.syncDeploymentStatus(allMSs, newMS, md); err != nil {
 		return err
 	}
 
 	// Scale down, if we can.
-	if err := r.reconcileOldMachineSets(ctx, allMSs, oldMSs, newMS, d); err != nil {
+	if err := r.reconcileOldMachineSets(ctx, allMSs, oldMSs, newMS, md); err != nil {
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := r.syncDeploymentStatus(allMSs, newMS, md); err != nil {
 		return err
 	}
 
-	if mdutil.DeploymentComplete(d, &d.Status) {
-		if err := r.cleanupDeployment(ctx, oldMSs, d); err != nil {
+	if mdutil.DeploymentComplete(md, &md.Status) {
+		if err := r.cleanupDeployment(ctx, oldMSs, md); err != nil {
 			return err
 		}
 	}

--- a/internal/controllers/machinedeployment/machinedeployment_rollout_ondelete.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rollout_ondelete.go
@@ -32,8 +32,8 @@ import (
 )
 
 // rolloutOnDelete implements the logic for the OnDelete MachineDeploymentStrategyType.
-func (r *Reconciler) rolloutOnDelete(ctx context.Context, d *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) error {
-	newMS, oldMSs, err := r.getAllMachineSetsAndSyncRevision(ctx, d, msList, true)
+func (r *Reconciler) rolloutOnDelete(ctx context.Context, md *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) error {
+	newMS, oldMSs, err := r.getAllMachineSetsAndSyncRevision(ctx, md, msList, true)
 	if err != nil {
 		return err
 	}
@@ -48,25 +48,25 @@ func (r *Reconciler) rolloutOnDelete(ctx context.Context, d *clusterv1.MachineDe
 	allMSs := append(oldMSs, newMS)
 
 	// Scale up, if we can.
-	if err := r.reconcileNewMachineSetOnDelete(ctx, allMSs, newMS, d); err != nil {
+	if err := r.reconcileNewMachineSetOnDelete(ctx, allMSs, newMS, md); err != nil {
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := r.syncDeploymentStatus(allMSs, newMS, md); err != nil {
 		return err
 	}
 
 	// Scale down, if we can.
-	if err := r.reconcileOldMachineSetsOnDelete(ctx, oldMSs, allMSs, d); err != nil {
+	if err := r.reconcileOldMachineSetsOnDelete(ctx, oldMSs, allMSs, md); err != nil {
 		return err
 	}
 
-	if err := r.syncDeploymentStatus(allMSs, newMS, d); err != nil {
+	if err := r.syncDeploymentStatus(allMSs, newMS, md); err != nil {
 		return err
 	}
 
-	if mdutil.DeploymentComplete(d, &d.Status) {
-		if err := r.cleanupDeployment(ctx, oldMSs, d); err != nil {
+	if mdutil.DeploymentComplete(md, &md.Status) {
+		if err := r.cleanupDeployment(ctx, oldMSs, md); err != nil {
 			return err
 		}
 	}

--- a/internal/controllers/machinedeployment/mdutil/util.go
+++ b/internal/controllers/machinedeployment/mdutil/util.go
@@ -323,12 +323,12 @@ func MaxSurge(deployment clusterv1.MachineDeployment) int32 {
 // GetProportion will estimate the proportion for the provided machine set using 1. the current size
 // of the parent deployment, 2. the replica count that needs be added on the machine sets of the
 // deployment, and 3. the total replicas added in the machine sets of the deployment so far.
-func GetProportion(ms *clusterv1.MachineSet, d clusterv1.MachineDeployment, deploymentReplicasToAdd, deploymentReplicasAdded int32, logger logr.Logger) int32 {
+func GetProportion(ms *clusterv1.MachineSet, md clusterv1.MachineDeployment, deploymentReplicasToAdd, deploymentReplicasAdded int32, logger logr.Logger) int32 {
 	if ms == nil || *(ms.Spec.Replicas) == 0 || deploymentReplicasToAdd == 0 || deploymentReplicasToAdd == deploymentReplicasAdded {
 		return int32(0)
 	}
 
-	msFraction := getMachineSetFraction(*ms, d, logger)
+	msFraction := getMachineSetFraction(*ms, md, logger)
 	allowed := deploymentReplicasToAdd - deploymentReplicasAdded
 
 	if deploymentReplicasToAdd > 0 {
@@ -345,20 +345,20 @@ func GetProportion(ms *clusterv1.MachineSet, d clusterv1.MachineDeployment, depl
 
 // getMachineSetFraction estimates the fraction of replicas a machine set can have in
 // 1. a scaling event during a rollout or 2. when scaling a paused deployment.
-func getMachineSetFraction(ms clusterv1.MachineSet, d clusterv1.MachineDeployment, logger logr.Logger) int32 {
+func getMachineSetFraction(ms clusterv1.MachineSet, md clusterv1.MachineDeployment, logger logr.Logger) int32 {
 	// If we are scaling down to zero then the fraction of this machine set is its whole size (negative)
-	if *(d.Spec.Replicas) == int32(0) {
+	if *(md.Spec.Replicas) == int32(0) {
 		return -*(ms.Spec.Replicas)
 	}
 
-	deploymentReplicas := *(d.Spec.Replicas) + MaxSurge(d)
+	deploymentReplicas := *(md.Spec.Replicas) + MaxSurge(md)
 	annotatedReplicas, ok := getMaxReplicasAnnotation(&ms, logger)
 	if !ok {
 		// If we cannot find the annotation then fallback to the current deployment size. Note that this
 		// will not be an accurate proportion estimation in case other machine sets have different values
 		// which means that the deployment was scaled at some point but we at least will stay in limits
 		// due to the min-max comparisons in getProportion.
-		annotatedReplicas = d.Status.Replicas
+		annotatedReplicas = md.Status.Replicas
 	}
 
 	// We should never proportionally scale up from zero which means ms.spec.replicas and annotatedReplicas

--- a/internal/controllers/machinedeployment/mdutil/util_test.go
+++ b/internal/controllers/machinedeployment/mdutil/util_test.go
@@ -593,32 +593,32 @@ func TestDeploymentComplete(t *testing.T) {
 	tests := []struct {
 		name string
 
-		d *clusterv1.MachineDeployment
+		md *clusterv1.MachineDeployment
 
 		expected bool
 	}{
 		{
 			name: "not complete: min but not all machines become available",
 
-			d:        deployment(5, 5, 5, 4, 1, 0),
+			md:       deployment(5, 5, 5, 4, 1, 0),
 			expected: false,
 		},
 		{
 			name: "not complete: min availability is not honored",
 
-			d:        deployment(5, 5, 5, 3, 1, 0),
+			md:       deployment(5, 5, 5, 3, 1, 0),
 			expected: false,
 		},
 		{
 			name: "complete",
 
-			d:        deployment(5, 5, 5, 5, 0, 0),
+			md:       deployment(5, 5, 5, 5, 0, 0),
 			expected: true,
 		},
 		{
 			name: "not complete: all machines are available but not updated",
 
-			d:        deployment(5, 5, 4, 5, 0, 0),
+			md:       deployment(5, 5, 4, 5, 0, 0),
 			expected: false,
 		},
 		{
@@ -626,13 +626,13 @@ func TestDeploymentComplete(t *testing.T) {
 
 			// old machine set: spec.replicas=1, status.replicas=1, status.availableReplicas=1
 			// new machine set: spec.replicas=1, status.replicas=1, status.availableReplicas=0
-			d:        deployment(1, 2, 1, 1, 0, 1),
+			md:       deployment(1, 2, 1, 1, 0, 1),
 			expected: false,
 		},
 		{
 			name: "not complete: one replica deployment never comes up",
 
-			d:        deployment(1, 1, 1, 0, 1, 1),
+			md:       deployment(1, 1, 1, 0, 1, 1),
 			expected: false,
 		},
 	}
@@ -641,7 +641,7 @@ func TestDeploymentComplete(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			g.Expect(DeploymentComplete(test.d, &test.d.Status)).To(Equal(test.expected))
+			g.Expect(DeploymentComplete(test.md, &test.md.Status)).To(Equal(test.expected))
 		})
 	}
 }

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -737,7 +737,7 @@ func TestAdoptOrphan(t *testing.T) {
 		Client: fake.NewClientBuilder().WithObjects(&m).Build(),
 	}
 	for _, tc := range testCases {
-		g.Expect(r.adoptOrphan(ctx, tc.machineSet.DeepCopy(), tc.machine.DeepCopy())).To(Succeed())
+		g.Expect(r.updateControllerReference(ctx, tc.machineSet.DeepCopy(), tc.machine.DeepCopy())).To(Succeed())
 
 		key := client.ObjectKey{Namespace: tc.machine.Namespace, Name: tc.machine.Name}
 		g.Expect(r.Client.Get(ctx, key, &tc.machine)).To(Succeed())

--- a/util/util.go
+++ b/util/util.go
@@ -437,6 +437,20 @@ func HasOwner(refList []metav1.OwnerReference, apiVersion string, kinds []string
 	return false
 }
 
+// HasOwnerWithSameVersion checks if any of the references in the passed list match the given group from apiVersion and one of the given kinds.
+func HasOwnerWithSameVersion(refList []metav1.OwnerReference, apiVersion string, kinds []string) bool {
+	kindMap := make(map[string]bool)
+	for _, kind := range kinds {
+		kindMap[kind] = true
+	}
+	for _, mr := range refList {
+		if mr.APIVersion == apiVersion && kindMap[mr.Kind] {
+			return true
+		}
+	}
+	return false
+}
+
 // GetGVKMetadata retrieves a CustomResourceDefinition metadata from the API server using partial object metadata.
 //
 // This function is greatly more efficient than GetCRDWithContract and should be preferred in most cases.


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Currently if the apiVersion of an ownerReference doesn't match any version that is served by the Kubernetes apiServer garbage collection of resources based on ownerReferences fails. Ref: https://github.com/kubernetes/kubernetes/issues/96650

When Cluster API stops serving deprecated APIVersions - i.e. v1alpha3 and v1alpha4 when they're removed - we want to ensure garbage collection continues to work as expected. This change ensures that these ownerReferences are kept up to date on each reconcile for a subset of resources.

Specifically this changes ensures updates for the apiVersion in OwnerReferences of:
- Machines owned by MachineSets
- MachineSets owned by MachineDeployments
- MachineDeployments owned by Clusters

Fixes #7224
