### PR TITLE
📖 Adds webhook TLS config info to the migration doc

### DIFF
--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -66,3 +66,7 @@ The default value is 0, meaning that the volume can be detached without any time
   The variable `SkipUpgrade` could be set to revert to the old behaviour by making use of the `KUBERNETES_VERSION` variable and skipping the kubernetes upgrade.
 - cert-manager upgraded from v1.9.1 to v1.10.0.
 - Machine `providerID` is now being strictly checked for equality when compared against Kubernetes node `providerID` data. This is the expected criteria for correlating a Cluster API machine to its corresponding Kubernetes node, but historically this comparison was not strict, and instead compared only against the `ID` substring part of the full `providerID` string. Because different providers construct `providerID` strings differently, the `ID` substring is not uniformly defined and implemented across providers, and thus the existing `providerID` equality can not guarantee the correct Machine-Node correlation. It is very unlikely that this new behavior will break existing providers, but FYI: if strict `providerID` equality will degrade expected behaviors, you may need to update your provider implementation prior to adopting Cluster API v1.3.
+- The default minimum TLS version in use by the webhook servers is 1.2.
+
+### Suggested changes for providers
+- Provider can expose the configuration of the TLS Options for the webhook server; it is recommended to use utility functions under the `util/flags` package to ensure consistency across CAPI and other providers.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the webhook TLS configuration info and utility function usage suggestion to the migration docs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes n/a

Checkout [this comment](https://github.com/kubernetes-sigs/cluster-api/pull/7483#issuecomment-1304090680) for background on this PR
