### PR TITLE
:seedling: Improved the usage to reflect the required arguments in `generate cluster`, `describe cluster` and `get kubeconfig`

### DIFF
--- a/cmd/clusterctl/cmd/describe_cluster.go
+++ b/cmd/clusterctl/cmd/describe_cluster.go
@@ -71,7 +71,7 @@ type describeClusterOptions struct {
 var dc = &describeClusterOptions{}
 
 var describeClusterClusterCmd = &cobra.Command{
-	Use:   "cluster",
+	Use:   "cluster NAME",
 	Short: "Describe workload clusters",
 	Long: LongDesc(`
 		Provide an "at glance" view of a Cluster API cluster designed to help the user in quickly

--- a/cmd/clusterctl/cmd/generate_cluster.go
+++ b/cmd/clusterctl/cmd/generate_cluster.go
@@ -47,7 +47,7 @@ type generateClusterOptions struct {
 var gc = &generateClusterOptions{}
 
 var generateClusterClusterCmd = &cobra.Command{
-	Use:   "cluster",
+	Use:   "cluster NAME",
 	Short: "Generate templates for creating workload clusters",
 	Long: LongDesc(`
 		Generate templates for creating workload clusters.

--- a/cmd/clusterctl/cmd/get_kubeconfig.go
+++ b/cmd/clusterctl/cmd/get_kubeconfig.go
@@ -35,7 +35,7 @@ type getKubeconfigOptions struct {
 var gk = &getKubeconfigOptions{}
 
 var getKubeconfigCmd = &cobra.Command{
-	Use:   "kubeconfig",
+	Use:   "kubeconfig NAME",
 	Short: "Gets the kubeconfig file for accessing a workload cluster",
 	Long: LongDesc(`
 		Gets the kubeconfig file for accessing a workload cluster`),


### PR DESCRIPTION
Signed-off-by: Chirayu Kapoor <dev.csociety@gmail.com>

**What this PR does / why we need it**:

For example when running `clusterctl generate cluster --help`, usage is described as:
```
Usage:
  clusterctl generate cluster [flags]
```

However, if you attempt to run the given example you will get an error.
```
clusterctl generate cluster
Error: accepts 1 arg(s), received 0
```

Since the command has a required argument, updated the usage to reflect the required arguments. For example:
```
Usage:
  clusterctl generate cluster NAME [flags]
```

Similar improvement has been applied in the usage text of `generate cluster`, `describe cluster` and `get kubeconfig` 

**Which issue(s) this PR fixes**:
Fixes #6867