### PR TITLE
🐛 Ensure MD finalizer applied on reconcile

### DIFF
--- a/internal/controllers/topology/cluster/structuredmerge/options.go
+++ b/internal/controllers/topology/cluster/structuredmerge/options.go
@@ -33,10 +33,11 @@ var (
 		{"metadata", "namespace"},
 		// uid is optional for a server side apply intent but sets the expectation of an object getting created or a specific one updated.
 		{"metadata", "uid"},
-		// the topology controller controls/has an opinion for labels, annotation, ownerReferences and spec only.
+		// the topology controller controls/has an opinion for labels, annotation, ownerReferences, finalizers and spec only.
 		{"metadata", "labels"},
 		{"metadata", "annotations"},
 		{"metadata", "ownerReferences"},
+		{"metadata", "finalizers"},
 		{"spec"},
 	}
 


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Ensure that the MachineDeploymentTopologyFinalizer is added by the Topology controller on each Reconcile where the MachineDeployment is not currently being deleted.

Fixes #7530 
