### PR TITLE
✨Make control plane port configurable in CAPD

### DIFF
--- a/test/e2e/data/infrastructure-docker/v1beta1/main/cluster-template-ipv6/cluster-ipv6.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/cluster-template-ipv6/cluster-ipv6.yaml
@@ -9,3 +9,12 @@ spec:
       cidrBlocks: ['${DOCKER_SERVICE_IPV6_CIDRS}']
     pods:
       cidrBlocks: ['${DOCKER_POD_IPV6_CIDRS}']
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerCluster
+metadata:
+  name: '${CLUSTER_NAME}'
+spec:
+  controlPlaneEndpoint:
+    port: 7777
+    host: ""

--- a/test/infrastructure/docker/api/v1beta1/dockercluster_types.go
+++ b/test/infrastructure/docker/api/v1beta1/dockercluster_types.go
@@ -91,6 +91,7 @@ type APIEndpoint struct {
 	Host string `json:"host"`
 
 	// Port is the port on which the API server is serving.
+	// Defaults to 6443 if not set.
 	Port int `json:"port"`
 }
 

--- a/test/infrastructure/docker/api/v1beta1/dockercluster_webhook.go
+++ b/test/infrastructure/docker/api/v1beta1/dockercluster_webhook.go
@@ -61,7 +61,11 @@ func (c *DockerCluster) ValidateDelete() error {
 	return nil
 }
 
-func defaultDockerClusterSpec(_ *DockerClusterSpec) {}
+func defaultDockerClusterSpec(s *DockerClusterSpec) {
+	if s.ControlPlaneEndpoint.Port == 0 {
+		s.ControlPlaneEndpoint.Port = 6443
+	}
+}
 
 func validateDockerClusterSpec(_ DockerClusterSpec) field.ErrorList {
 	return nil

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -349,6 +349,7 @@ spec:
                     type: string
                   port:
                     description: Port is the port on which the API server is serving.
+                      Defaults to 6443 if not set.
                     type: integer
                 required:
                 - host

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
@@ -179,7 +179,7 @@ spec:
                             type: string
                           port:
                             description: Port is the port on which the API server
-                              is serving.
+                              is serving. Defaults to 6443 if not set.
                             type: integer
                         required:
                         - host

--- a/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
+++ b/test/infrastructure/docker/internal/controllers/dockercluster_controller.go
@@ -153,9 +153,10 @@ func (r *DockerClusterReconciler) reconcileNormal(ctx context.Context, dockerClu
 		return ctrl.Result{}, errors.Wrap(err, "failed to get ip for the load balancer")
 	}
 
-	dockerCluster.Spec.ControlPlaneEndpoint = infrav1.APIEndpoint{
-		Host: lbIP,
-		Port: 6443,
+	if dockerCluster.Spec.ControlPlaneEndpoint.Host == "" {
+		// Surface the control plane endpoint
+		// Note: the control plane port is already set by the user or defaulted by the dockerCluster webhook.
+		dockerCluster.Spec.ControlPlaneEndpoint.Host = lbIP
 	}
 
 	// Mark the dockerCluster ready

--- a/test/infrastructure/docker/internal/docker/kind_manager_test.go
+++ b/test/infrastructure/docker/internal/docker/kind_manager_test.go
@@ -135,4 +135,6 @@ func TestCreateExternalLoadBalancerNode(t *testing.T) {
 	g.Expect(runConfig).ToNot(BeNil())
 	g.Expect(runConfig.Labels).To(HaveLen(2))
 	g.Expect(runConfig.Labels["io.x-k8s.kind.role"]).To(Equal(constants.ExternalLoadBalancerNodeRoleValue))
+	g.Expect(runConfig.PortMappings).To(HaveLen(1))
+	g.Expect(runConfig.PortMappings[0].ContainerPort).To(Equal(int32(ControlPlanePort)))
 }

--- a/test/infrastructure/docker/internal/docker/loadbalancer.go
+++ b/test/infrastructure/docker/internal/docker/loadbalancer.go
@@ -38,11 +38,12 @@ type lbCreator interface {
 
 // LoadBalancer manages the load balancer for a specific docker cluster.
 type LoadBalancer struct {
-	name      string
-	image     string
-	container *types.Node
-	ipFamily  clusterv1.ClusterIPFamily
-	lbCreator lbCreator
+	name             string
+	image            string
+	container        *types.Node
+	ipFamily         clusterv1.ClusterIPFamily
+	lbCreator        lbCreator
+	controlPlanePort int
 }
 
 // NewLoadBalancer returns a new helper for managing a docker loadbalancer with a given name.
@@ -71,11 +72,12 @@ func NewLoadBalancer(ctx context.Context, cluster *clusterv1.Cluster, dockerClus
 	image := getLoadBalancerImage(dockerCluster)
 
 	return &LoadBalancer{
-		name:      cluster.Name,
-		image:     image,
-		container: container,
-		ipFamily:  ipFamily,
-		lbCreator: &Manager{},
+		name:             cluster.Name,
+		image:            image,
+		container:        container,
+		ipFamily:         ipFamily,
+		lbCreator:        &Manager{},
+		controlPlanePort: dockerCluster.Spec.ControlPlaneEndpoint.Port,
 	}, nil
 }
 
@@ -166,7 +168,7 @@ func (s *LoadBalancer) UpdateConfiguration(ctx context.Context) error {
 	}
 
 	loadBalancerConfig, err := loadbalancer.Config(&loadbalancer.ConfigData{
-		ControlPlanePort: 6443,
+		ControlPlanePort: s.controlPlanePort,
 		BackendServers:   backendServers,
 		IPv6:             s.ipFamily == clusterv1.IPv6IPFamily,
 	})


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently, CAPD exposes the host and port of the control plane endpoint but doesn't leverage them. 
I made 6443 a default port to keep the behavior consistent.

cc @richardcase @belgaied2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
