### PR TITLE
:book: Fix outdated enabling PodSecurityStandard env variable in CAPI quickstart

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -819,7 +819,7 @@ export SERVICE_DOMAIN="k8s.test"
 
 It is also possible but **not recommended** to disable the per-default enabled [Pod Security Standard](../security/pod-security-standards.md):
 ```bash
-export ENABLE_POD_SECURITY_STANDARD="false"
+export POD_SECURITY_STANDARD_ENABLED="false"
 ```
 
 {{#/tab }}


### PR DESCRIPTION
**What this PR does / why we need it**:

I found out `POD_SECURITY_STANDARD_ENABLED` in CAPI quickstart for CAPD was wrong/outdated. 
I changed it to `ENABLE_POD_SECURITY_STANDARD` which now enables/disables the PodSecurityStandard variable in the manifest generated by `clusterctl` correctly.