### PR TITLE
[WIP] :seedling:  add e2e test for ownerRef reconciliation

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/token.go
+++ b/bootstrap/kubeadm/internal/controllers/token.go
@@ -81,7 +81,7 @@ func getToken(ctx context.Context, c client.Client, token string) (*corev1.Secre
 	}
 
 	if secret.Data == nil {
-		return nil, errors.Errorf("Invalid bootstrap secret %q, remove the token from the kubadm config to re-create", secretName)
+		return nil, errors.Errorf("Invalid bootstrap secret %q, remove the token from the kubeadm config to re-create", secretName)
 	}
 	return secret, nil
 }

--- a/bootstrap/kubeadm/internal/controllers/token.go
+++ b/bootstrap/kubeadm/internal/controllers/token.go
@@ -81,7 +81,7 @@ func getToken(ctx context.Context, c client.Client, token string) (*corev1.Secre
 	}
 
 	if secret.Data == nil {
-		return nil, errors.Errorf("Invalid bootstrap secret %q, remove the token from the kubeadm config to re-create", secretName)
+		return nil, errors.Errorf("Invalid bootstrap secret %q, remove the token from the kubadm config to re-create", secretName)
 	}
 	return secret, nil
 }

--- a/cmd/clusterctl/client/cluster/ownergraph.go
+++ b/cmd/clusterctl/client/cluster/ownergraph.go
@@ -1,0 +1,61 @@
+package cluster
+
+import (
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type OwnerGraph map[string]OwnerGraphNode
+
+type OwnerGraphNode struct {
+	Object corev1.ObjectReference
+	Owners []metav1.OwnerReference
+}
+
+func nodeToOwnerRef(n *node, attributes *ownerReferenceAttributes) metav1.OwnerReference {
+	ref := metav1.OwnerReference{
+		Name:       n.identity.Name,
+		APIVersion: n.identity.APIVersion,
+		Kind:       n.identity.Kind,
+		UID:        n.identity.UID,
+	}
+	if attributes != nil {
+		if attributes.BlockOwnerDeletion != nil {
+			ref.BlockOwnerDeletion = attributes.BlockOwnerDeletion
+		}
+		if attributes.Controller != nil {
+			ref.Controller = attributes.Controller
+		}
+	}
+	return ref
+}
+
+func GetOwnerGraph(namespace string) (OwnerGraph, error) {
+	p := newProxy(Kubeconfig{Path: "", Context: ""})
+	invClient := newInventoryClient(p, nil)
+
+	graph := newObjectGraph(p, invClient)
+
+	// Gets all the types defined by the CRDs installed by clusterctl plus the ConfigMap/Secret core types.
+	err := graph.getDiscoveryTypes()
+	if err != nil {
+		return OwnerGraph{}, errors.Wrap(err, "failed to retrieve discovery types")
+	}
+
+	// Discovery the object graph for the selected types:
+	// - Nodes are defined the Kubernetes objects (Clusters, Machines etc.) identified during the discovery process.
+	// - Edges are derived by the OwnerReferences between nodes.
+	if err := graph.Discovery(namespace); err != nil {
+		return OwnerGraph{}, errors.Wrap(err, "failed to discover the object graph")
+	}
+	owners := OwnerGraph{}
+	for _, v := range graph.uidToNode {
+		n := OwnerGraphNode{Object: v.identity, Owners: []metav1.OwnerReference{}}
+		for owner, attributes := range v.owners {
+			n.Owners = append(n.Owners, nodeToOwnerRef(owner, &attributes))
+		}
+		owners[string(v.identity.UID)] = n
+	}
+	return owners, nil
+}

--- a/test/e2e/owner_references.go
+++ b/test/e2e/owner_references.go
@@ -88,7 +88,7 @@ func OwnerReferencesSpec(ctx context.Context, inputGetter func() OwnerReferences
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 		}, clusterResources)
 
-		toUML(namespace.Name, fmt.Sprintf("%s-before.plantuml", namespace.Name))
+		toUML(namespace.Name, filepath.Join(input.ArtifactFolder, fmt.Sprintf("%s-before.plantuml", namespace.Name)))
 		// Check that the references are as expected on cluster creation.
 		framework.AssertOwnerReferences(namespace.Name,
 			framework.CoreTypeOwnerReferenceAssertion,
@@ -104,7 +104,7 @@ func OwnerReferencesSpec(ctx context.Context, inputGetter func() OwnerReferences
 		// Wait after removing references and unpausing to allow reconcilers to replace the ownerReferences.
 		time.Sleep(20 * time.Second)
 
-		toUML(namespace.Name, fmt.Sprintf("%s-after.plantuml", namespace.Name))
+		toUML(namespace.Name, filepath.Join(input.ArtifactFolder, fmt.Sprintf("%s-after.plantuml", namespace.Name)))
 
 		// Check if the ownerReferences are as expected once the cluster reconciles again.
 		framework.AssertOwnerReferences(namespace.Name,

--- a/test/e2e/owner_references.go
+++ b/test/e2e/owner_references.go
@@ -1,0 +1,121 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// OwnerReferencesInputSpec is the input for OwnerReferencesSpec.
+type OwnerReferencesInputSpec struct {
+	E2EConfig             *clusterctl.E2EConfig
+	ClusterctlConfigPath  string
+	BootstrapClusterProxy framework.ClusterProxy
+	ArtifactFolder        string
+	SkipCleanup           bool
+	ControlPlaneWaiters   clusterctl.ControlPlaneWaiters
+
+	// Flavor, if specified is the template flavor used to create the cluster for testing.
+	// If not specified, and the e2econfig variable IPFamily is IPV6, then "ipv6" is used,
+	// otherwise the default flavor is used.
+	Flavor *string
+}
+
+// OwnerReferencesSpec implements a spec that mimics the operation described in the Cluster API owner reference test.
+func OwnerReferencesSpec(ctx context.Context, inputGetter func() OwnerReferencesInputSpec) {
+	var (
+		specName         = "owner-references"
+		input            OwnerReferencesInputSpec
+		namespace        *corev1.Namespace
+		cancelWatches    context.CancelFunc
+		clusterResources *clusterctl.ApplyClusterTemplateAndWaitResult
+	)
+
+	BeforeEach(func() {
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+		input = inputGetter()
+		Expect(input.E2EConfig).ToNot(BeNil(), "Invalid argument. input.E2EConfig can't be nil when calling %s spec", specName)
+		Expect(input.ClusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. input.ClusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(input.BootstrapClusterProxy).ToNot(BeNil(), "Invalid argument. input.BootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(input.ArtifactFolder, 0750)).To(Succeed(), "Invalid argument. input.ArtifactFolder can't be created for %s spec", specName)
+
+		Expect(input.E2EConfig.Variables).To(HaveKey(KubernetesVersion))
+
+		// Setup a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	})
+
+	It("Should create a workload cluster", func() {
+		By("Creating a workload cluster")
+
+		flavor := clusterctl.DefaultFlavor
+		if input.Flavor != nil {
+			flavor = *input.Flavor
+		}
+
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: input.BootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     input.ClusterctlConfigPath,
+				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   flavor,
+				Namespace:                namespace.Name,
+				ClusterName:              fmt.Sprintf("%s-%s", specName, util.RandomString(6)),
+				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
+				ControlPlaneMachineCount: pointer.Int64(1),
+				WorkerMachineCount:       pointer.Int64(1),
+			},
+			ControlPlaneWaiters:          input.ControlPlaneWaiters,
+			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: input.E2EConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, clusterResources)
+
+		// Check that the references are as expected on cluster creation.
+		framework.AssertOwnerReferences(namespace.Name,
+			framework.CoreTypeOwnerReferenceAssertion,
+			framework.ExpOwnerReferenceAssertions,
+			framework.DockerInfraOwnerReferenceAssertions,
+			framework.KubeadmBootstrapOwnerReferenceAssertions,
+			framework.KubeadmControlPlaneOwnerReferenceAssertions,
+			framework.SecretOwnerReferenceAssertions,
+			framework.ConfigMapReferenceAssertions)
+
+		Expect(framework.RemoveOwnerReferences(ctx, input.BootstrapClusterProxy.GetClient(), namespace.Name)).To(Succeed())
+
+		// Wait after removing references and unpausing to allow reconcilers to replace the ownerReferences.
+		time.Sleep(20 * time.Second)
+
+		// Check if the ownerReferences are as expected once the cluster reconciles again.
+		framework.AssertOwnerReferences(namespace.Name,
+			framework.CoreTypeOwnerReferenceAssertion,
+			framework.ExpOwnerReferenceAssertions,
+			framework.DockerInfraOwnerReferenceAssertions,
+			framework.KubeadmBootstrapOwnerReferenceAssertions,
+			framework.KubeadmControlPlaneOwnerReferenceAssertions,
+			framework.SecretOwnerReferenceAssertions,
+			framework.ConfigMapReferenceAssertions)
+
+		By("PASSED!")
+	})
+
+	AfterEach(func() {
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		dumpSpecResourcesAndCleanup(ctx, specName, input.BootstrapClusterProxy, input.ArtifactFolder, namespace, cancelWatches, clusterResources.Cluster, input.E2EConfig.GetIntervals, input.SkipCleanup)
+	})
+}

--- a/test/e2e/owner_references_test.go
+++ b/test/e2e/owner_references_test.go
@@ -1,0 +1,34 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("When following the Cluster API quick-start with ClusterClass check owner references are correctly reconciled [ClusterClass]", func() {
+	OwnerReferencesSpec(ctx, func() OwnerReferencesInputSpec {
+		return OwnerReferencesInputSpec{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+			Flavor:                pointer.String("topology"),
+		}
+	})
+})
+
+var _ = Describe("When following the Cluster API quick-start check owner references are correctly reconciled", func() {
+	OwnerReferencesSpec(ctx, func() OwnerReferencesInputSpec {
+		return OwnerReferencesInputSpec{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+		}
+	})
+})

--- a/test/framework/ownerreference_helpers.go
+++ b/test/framework/ownerreference_helpers.go
@@ -1,0 +1,265 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	clusterctlcluster "sigs.k8s.io/cluster-api/cmd/clusterctl/client/cluster"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
+)
+
+func RemoveOwnerReferences(ctx context.Context, cli client.Client, namespace string) error {
+	graph, err := clusterctlcluster.GetOwnerGraph(namespace)
+	if err != nil {
+		return err
+	}
+	for _, object := range graph {
+		// First pause each Cluster.
+		if object.Object.Kind == clusterKind {
+			c := &clusterv1.Cluster{}
+			err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: object.Object.Name}, c)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				unpausePatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"spec\":{\"paused\":%s}}", "false")))
+				_ = cli.Patch(ctx, c, unpausePatch)
+			}()
+			pausePatch := client.RawPatch(types.MergePatchType, []byte(fmt.Sprintf("{\"spec\":{\"paused\":%s}}", "true")))
+			err = cli.Patch(ctx, c, pausePatch)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, object := range graph {
+		ref := object.Object
+		// Once all Clusters are paused remove the OwnerReference from all objects in the graph.
+		obj := new(unstructured.Unstructured)
+		obj.SetAPIVersion(ref.APIVersion)
+		obj.SetKind(ref.Kind)
+		obj.SetName(ref.Name)
+
+		err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: object.Object.Name}, obj)
+		if err != nil {
+			return err
+		}
+		helper, err := patch.NewHelper(obj, cli)
+		if err != nil {
+			return err
+		}
+		obj.SetOwnerReferences([]metav1.OwnerReference{})
+		err = helper.Patch(ctx, obj)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func AssertOwnerReferences(namespace string, assertFuncs ...map[string]func(reference []metav1.OwnerReference) error) {
+	allAssertFuncs := map[string]func(reference []metav1.OwnerReference) error{}
+	for _, m := range assertFuncs {
+		for k, v := range m {
+			allAssertFuncs[k] = v
+		}
+	}
+	graph, err := clusterctlcluster.GetOwnerGraph(namespace)
+	Expect(err).To(BeNil())
+	allErrs := []error{}
+	for _, v := range graph {
+		if _, ok := allAssertFuncs[v.Object.Kind]; !ok {
+			allErrs = append(allErrs, errors.New(fmt.Sprintf("kind %s does not have an associated ownerRef assertion function", v.Object.Kind)))
+			continue
+		}
+		if err := allAssertFuncs[v.Object.Kind](v.Owners); err != nil {
+			allErrs = append(allErrs, errors.Wrapf(err, "Unexpected ownerReferences for %s/%s", v.Object.Kind, v.Object.Name))
+		}
+	}
+	var errStrings string
+	for _, err := range allErrs {
+		errStrings = fmt.Sprintf("%s\n%s", errStrings, err.Error())
+	}
+	Expect(kerrors.NewAggregate(allErrs)).To(BeNil(), errStrings)
+}
+
+// Kind and GVK for types in the core API package.
+var (
+	clusterClassKind       = "ClusterClass"
+	clusterKind            = "Cluster"
+	machineKind            = "Machine"
+	machineSetKind         = "MachineSet"
+	machineDeploymentKind  = "MachineDeployment"
+	machineHealthCheckKind = "MachineHealthCheck"
+
+	clusterClassGVK      = clusterv1.GroupVersion.WithKind(clusterClassKind)
+	clusterGVK           = clusterv1.GroupVersion.WithKind(clusterKind)
+	machineDeploymentGVK = clusterv1.GroupVersion.WithKind(machineDeploymentKind)
+	machineSetGVK        = clusterv1.GroupVersion.WithKind(machineSetKind)
+	machineGVK           = clusterv1.GroupVersion.WithKind(machineKind)
+)
+
+var CoreTypeOwnerReferenceAssertion = map[string]func([]metav1.OwnerReference) error{
+	clusterClassKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{})
+	},
+	clusterKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{})
+	},
+	machineDeploymentKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterGVK})
+	},
+	machineSetKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{machineDeploymentGVK})
+	},
+	machineKind: func(owners []metav1.OwnerReference) error {
+		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{machineSetGVK}, []schema.GroupVersionKind{kubeadmControlPlaneGVK})
+	},
+	machineHealthCheckKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterGVK})
+	},
+}
+
+// Kind and GVK for types in the exp package.
+var (
+	clusterResourceSetKind        = "ClusterResourceSet"
+	clusterResourceSetBindingKind = "ClusterResourceSetBinding"
+
+	clusterResourceSetGVK = addonsv1.GroupVersion.WithKind(clusterResourceSetKind)
+)
+var ExpOwnerReferenceAssertions = map[string]func([]metav1.OwnerReference) error{
+	clusterResourceSetKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{})
+	},
+	clusterResourceSetBindingKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterGVK, clusterResourceSetGVK})
+	},
+}
+
+var (
+	configMapKind = "ConfigMap"
+	secretKind    = "Secret"
+)
+
+var SecretOwnerReferenceAssertions = map[string]func([]metav1.OwnerReference) error{
+	secretKind: func(owners []metav1.OwnerReference) error {
+		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{kubeadmControlPlaneGVK}, []schema.GroupVersionKind{kubeadmConfigGVK})
+	},
+}
+var ConfigMapReferenceAssertions = map[string]func([]metav1.OwnerReference) error{
+	configMapKind: func(owners []metav1.OwnerReference) error {
+		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterResourceSetGVK}, []schema.GroupVersionKind{})
+	},
+}
+
+// Kind and GVK for types in the Kubeadm ControlPlane package.
+var (
+	kubeadmControlPlaneKind         = "KubeadmControlPlane"
+	kubeadmControlPlaneTemplateKind = "KubeadmControlPlaneTemplate"
+
+	kubeadmControlPlaneGVK = controlplanev1.GroupVersion.WithKind(kubeadmControlPlaneKind)
+)
+var KubeadmControlPlaneOwnerReferenceAssertions = map[string]func([]metav1.OwnerReference) error{
+	kubeadmControlPlaneKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterGVK})
+	},
+	kubeadmControlPlaneTemplateKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterClassGVK})
+	},
+}
+
+// Kind and GVK for types in the Kubeadm Bootstrap package.
+var (
+	kubeadmConfigKind         = "KubeadmConfig"
+	kubeadmConfigTemplateKind = "KubeadmConfigTemplate"
+
+	kubeadmConfigGVK = bootstrapv1.GroupVersion.WithKind(kubeadmConfigKind)
+)
+
+var KubeadmBootstrapOwnerReferenceAssertions = map[string]func([]metav1.OwnerReference) error{
+	kubeadmConfigTemplateKind: func(owners []metav1.OwnerReference) error {
+		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterGVK}, []schema.GroupVersionKind{clusterClassGVK})
+	},
+	kubeadmConfigKind: func(owners []metav1.OwnerReference) error {
+		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{machineGVK, machineSetGVK}, []schema.GroupVersionKind{machineGVK, kubeadmControlPlaneGVK})
+	},
+}
+
+// Kind and GVK for types in the Docker infrastructure package.
+var (
+	dockerMachineKind         = "DockerMachine"
+	dockerMachineTemplateKind = "DockerMachineTemplate"
+	dockerClusterKind         = "DockerCluster"
+	dockerClusterTemplateKind = "DockerClusterTemplate"
+)
+var DockerInfraOwnerReferenceAssertions = map[string]func([]metav1.OwnerReference) error{
+	dockerMachineKind: func(owners []metav1.OwnerReference) error {
+		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{machineGVK, machineSetGVK}, []schema.GroupVersionKind{machineGVK, kubeadmControlPlaneGVK})
+	},
+	dockerMachineTemplateKind: func(owners []metav1.OwnerReference) error {
+		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterGVK}, []schema.GroupVersionKind{clusterClassGVK})
+	},
+	dockerClusterKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterGVK})
+	},
+	dockerClusterTemplateKind: func(owners []metav1.OwnerReference) error {
+		return hasExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterClassGVK})
+	},
+}
+
+func hasExactOwnersByGVK(refList []metav1.OwnerReference, wantGVKs []schema.GroupVersionKind) error {
+	refGVKs := []schema.GroupVersionKind{}
+	for _, ref := range refList {
+		refGVK, err := ownerRefGVK(ref)
+		if err != nil {
+			return err
+		}
+		refGVKs = append(refGVKs, refGVK)
+	}
+	sort.SliceStable(refGVKs, func(i int, j int) bool {
+		return refGVKs[i].String() > refGVKs[j].String()
+	})
+	sort.SliceStable(wantGVKs, func(i int, j int) bool {
+		return wantGVKs[i].String() > wantGVKs[j].String()
+	})
+	if !reflect.DeepEqual(wantGVKs, refGVKs) {
+		return errors.New(fmt.Sprintf("wanted %v, actual %v", wantGVKs, refGVKs))
+	}
+	return nil
+}
+
+func hasOneOfExactOwnersByGVK(refList []metav1.OwnerReference, possibleGVKS ...[]schema.GroupVersionKind) error {
+	var allErrs []error
+	for _, wantGVK := range possibleGVKS {
+		err := hasExactOwnersByGVK(refList, wantGVK)
+		if err != nil {
+			allErrs = append(allErrs, err)
+			continue
+		}
+		return nil
+	}
+	return kerrors.NewAggregate(allErrs)
+}
+
+func ownerRefGVK(ref metav1.OwnerReference) (schema.GroupVersionKind, error) {
+	refGV, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	return schema.GroupVersionKind{Version: refGV.Version, Group: refGV.Group, Kind: ref.Kind}, nil
+}

--- a/test/framework/ownerreference_helpers.go
+++ b/test/framework/ownerreference_helpers.go
@@ -207,7 +207,7 @@ var KubeadmBootstrapOwnerReferenceAssertions = map[string]func([]metav1.OwnerRef
 		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterGVK}, []schema.GroupVersionKind{clusterClassGVK})
 	},
 	kubeadmConfigKind: func(owners []metav1.OwnerReference) error {
-		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{machineGVK, machineSetGVK}, []schema.GroupVersionKind{machineGVK, kubeadmControlPlaneGVK})
+		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{machineGVK}, []schema.GroupVersionKind{machineGVK, kubeadmControlPlaneGVK})
 	},
 }
 
@@ -220,7 +220,7 @@ var (
 )
 var DockerInfraOwnerReferenceAssertions = map[string]func([]metav1.OwnerReference) error{
 	dockerMachineKind: func(owners []metav1.OwnerReference) error {
-		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{machineGVK, machineSetGVK}, []schema.GroupVersionKind{machineGVK, kubeadmControlPlaneGVK})
+		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{machineGVK}, []schema.GroupVersionKind{machineGVK, kubeadmControlPlaneGVK})
 	},
 	dockerMachineTemplateKind: func(owners []metav1.OwnerReference) error {
 		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterGVK}, []schema.GroupVersionKind{clusterClassGVK})


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add a new e2e test and set of helper functions to test that ownerReferences are correctly reconciled by Cluster API.

This test is designed to capture how Cluster API creates ownerReferences with a newly created Topology based Cluster using KCP + KubeadmBooststrap + Docker infrastructure.

It also tests how ownerReferences are reconciled after they've been removed and re-reconciled.
