### PR TITLE
🌱 New Filter NeedsRollout to determine if a machine needs rollout.

### DIFF
--- a/controlplane/kubeadm/internal/control_plane.go
+++ b/controlplane/kubeadm/internal/control_plane.go
@@ -256,13 +256,8 @@ func (c *ControlPlane) MachinesNeedingRollout() collections.Machines {
 	machines := c.Machines.Filter(collections.Not(collections.HasDeletionTimestamp))
 
 	// Return machines if they are scheduled for rollout or if with an outdated configuration.
-	return machines.AnyFilter(
-		// Machines whose certificates are about to expire.
-		collections.ShouldRolloutBefore(&c.reconciliationTime, c.KCP.Spec.RolloutBefore),
-		// Machines that are scheduled for rollout (KCP.Spec.RolloutAfter set, the RolloutAfter deadline is expired, and the machine was created before the deadline).
-		collections.ShouldRolloutAfter(&c.reconciliationTime, c.KCP.Spec.RolloutAfter),
-		// Machines that do not match with KCP config.
-		collections.Not(MatchesMachineSpec(c.infraResources, c.kubeadmConfigs, c.KCP)),
+	return machines.Filter(
+		NeedsRollout(&c.reconciliationTime, c.KCP.Spec.RolloutAfter, c.KCP.Spec.RolloutBefore, c.infraResources, c.kubeadmConfigs, c.KCP),
 	)
 }
 
@@ -270,12 +265,7 @@ func (c *ControlPlane) MachinesNeedingRollout() collections.Machines {
 // plane's configuration and therefore do not require rollout.
 func (c *ControlPlane) UpToDateMachines() collections.Machines {
 	return c.Machines.Filter(
-		// Machines that shouldn't be rollout out if their certificates are not about to expire.
-		collections.Not(collections.ShouldRolloutBefore(&c.reconciliationTime, c.KCP.Spec.RolloutBefore)),
-		// Machines that shouldn't be rolled out after the deadline has expired.
-		collections.Not(collections.ShouldRolloutAfter(&c.reconciliationTime, c.KCP.Spec.RolloutAfter)),
-		// Machines that match with KCP config.
-		MatchesMachineSpec(c.infraResources, c.kubeadmConfigs, c.KCP),
+		collections.Not(NeedsRollout(&c.reconciliationTime, c.KCP.Spec.RolloutAfter, c.KCP.Spec.RolloutBefore, c.infraResources, c.kubeadmConfigs, c.KCP)),
 	)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: 
The [MachinesNeedingRollout](https://github.com/kubernetes-sigs/cluster-api/blob/main/controlplane/kubeadm/internal/control_plane.go#L254) and the [UpToDateMachines](https://github.com/kubernetes-sigs/cluster-api/blob/main/controlplane/kubeadm/internal/control_plane.go#L271) functions in `controlplane/kubeadm/internal/` use multiple filters in combination to determine if the machine needs rollout.

[NeedsRollout](https://github.com/dharmicksai/cluster-api/blob/NeedsRollout/controlplane/kubeadm/internal/filters.go#L47) filter contains the list of filters that are used to determine if a machine needs rollout. Now the NeedsRollout filter is used as a single filter in both functions to determine if a machine needs rollout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7215
