### PR TITLE
🌱 Fix an error message of the failure domain field in the Machine controller

### DIFF
--- a/internal/controllers/machine/machine_controller_phases.go
+++ b/internal/controllers/machine/machine_controller_phases.go
@@ -313,7 +313,7 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, cluster *clust
 	switch {
 	case err == util.ErrUnstructuredFieldNotFound: // no-op
 	case err != nil:
-		return ctrl.Result{}, errors.Wrapf(err, "failed to failure domain from infrastructure provider for Machine %q in namespace %q", m.Name, m.Namespace)
+		return ctrl.Result{}, errors.Wrapf(err, "failed to retrieve failure domain from infrastructure provider for Machine %q in namespace %q", m.Name, m.Namespace)
 	default:
 		m.Spec.FailureDomain = pointer.String(failureDomain)
 	}


### PR DESCRIPTION
This is really nitpicking, but I added a missing verb to an error message of the failure domain field in the Machine controller.
