### PR TITLE
:bug: Add CleanupAndWait call for flaky ClusterClass test

### DIFF
--- a/internal/webhooks/test/clusterclass_test.go
+++ b/internal/webhooks/test/clusterclass_test.go
@@ -446,7 +446,7 @@ func TestClusterClassWebhook_Delete_MultipleExistingClusters(t *testing.T) {
 	defer func() {
 		// Delete each of the clusters.
 		for _, c := range clusters {
-			g.Expect(env.Delete(ctx, c)).To(Succeed())
+			g.Expect(env.CleanupAndWait(ctx, c)).To(Succeed())
 		}
 
 		// Delete the ClusterClasses in the API server.


### PR DESCRIPTION
Add a `DeleteAndWait` function to our test package which allows waiting until an object is deleting before moving on.

Fixes flake in https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/7587/pull-cluster-api-test-main/1595021734782701568
