### PR TITLE
🌱 MD reconciler: improve integration test

### DIFF
--- a/internal/controllers/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller_test.go
@@ -92,9 +92,10 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 				Replicas:             pointer.Int32(2),
 				RevisionHistoryLimit: pointer.Int32(0),
 				Selector: metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						clusterv1.ClusterLabelName: testCluster.Name,
-					},
+					// We're using the same labels for spec.selector and spec.template.labels.
+					// The labels are later changed and we will use the initial labels later to
+					// verify that all original MachineSets have been deleted.
+					MatchLabels: labels,
 				},
 				Strategy: &clusterv1.MachineDeploymentStrategy{
 					Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
@@ -340,8 +341,8 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 		// expect old MachineSets with old labels to be deleted
 		//
 		oldLabels := deployment.Spec.Selector.MatchLabels
-		oldLabels[clusterv1.MachineDeploymentLabelName] = deployment.Name
 
+		// Change labels and selector to a new set of labels which doesn't have any overlap with the previous labels.
 		newLabels := map[string]string{
 			"new-key":                  "new-value",
 			clusterv1.ClusterLabelName: testCluster.Name,


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Extracted from #7591 to make clear that the unit test validation was broken before any prod code changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
