### PR TITLE
🌱 KCP: remove unused code

### DIFF
--- a/controlplane/kubeadm/internal/control_plane_test.go
+++ b/controlplane/kubeadm/internal/control_plane_test.go
@@ -20,13 +20,9 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -62,34 +58,6 @@ func TestControlPlane(t *testing.T) {
 		t.Run("With some machines in non defined failure domains", func(t *testing.T) {
 			controlPlane.Machines.Insert(machine("machine-5", withFailureDomain("unknown")))
 			g.Expect(*controlPlane.FailureDomainWithMostMachines(controlPlane.Machines)).To(Equal("unknown"))
-		})
-	})
-
-	t.Run("Generating components", func(t *testing.T) {
-		controlPlane := &ControlPlane{
-			KCP: &controlplanev1.KubeadmControlPlane{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cp",
-					UID:  types.UID("test-uid"),
-				},
-			},
-			Cluster: &clusterv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-cluster",
-				},
-			},
-		}
-
-		t.Run("Should generate KubeadmConfig without a controller reference", func(t *testing.T) {
-			spec := &bootstrapv1.KubeadmConfigSpec{}
-			kubeadmConfig := controlPlane.GenerateKubeadmConfig(spec)
-			g.Expect(kubeadmConfig.Labels["cluster.x-k8s.io/cluster-name"]).To(Equal("test-cluster"))
-			g.Expect(kubeadmConfig.OwnerReferences[0].Controller).To(BeNil())
-		})
-
-		t.Run("Should generate a new machine with a controller reference", func(t *testing.T) {
-			machine := controlPlane.NewMachine(&corev1.ObjectReference{Namespace: "foobar"}, &corev1.ObjectReference{Namespace: "foobar"}, pointer.String("failureDomain"))
-			g.Expect(machine.OwnerReferences[0].Controller).ToNot(BeNil())
 		})
 	})
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Just found a bit of code in KCP that apparently nobody really uses :)

Happy to keep some or all of the funcs if we think there's a good reason for it

Follow-up:
* [x] Open an issue to see if we can find unused funcs (or funcs only used by test code) via linters => https://github.com/kubernetes-sigs/cluster-api/issues/7599

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
