### PR TITLE
✨ Adds a verify script that run trivy scanner on container images

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,22 @@
+name: scan-images
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"
+
+# Remove all permissions from GITHUB_TOKEN except metadata.
+permissions: {}
+
+jobs:
+  scan:
+    name: Trivy
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+    - name: Setup go
+      uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # tag=v3.4.0
+      with:
+        go-version: 1.19
+    - name: Run verify container script
+      run: make verify-container-images

--- a/Makefile
+++ b/Makefile
@@ -624,6 +624,10 @@ verify-shellcheck: ## Verify shell files
 verify-tiltfile: ## Verify Tiltfile format
 	TRACE=$(TRACE) ./hack/verify-starlark.sh
 
+.PHONY: verify-container-images
+verify-container-images: ## Verify container images
+	TRACE=$(TRACE) ./hack/verify-container-images.sh
+
 ## --------------------------------------
 ## Binaries
 ## --------------------------------------

--- a/docs/book/src/reference/jobs.md
+++ b/docs/book/src/reference/jobs.md
@@ -43,6 +43,13 @@ GitHub Presubmit Workflows:
 * release (run on tags)
   * Creates a GitHub release with release notes for the tag.
 
+
+GitHub Weekly Workflows:
+* golangci-lint: golangci/golangci-lint-action
+  * Weekly check all Markdown links
+* scan-images:
+  * Scan all images for vulnerabilities. Can be run locally via `make verify-container-images`
+
 ### Postsubmits
 
 Prow Postsubmits:

--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -12,38 +12,39 @@ This document details the responsibilities and tasks for each role in the releas
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [Release Lead](#release-lead)
-  - [Responsibilities](#responsibilities)
-  - [Tasks](#tasks)
-    - [Set a tentative release date for the minor release](#set-a-tentative-release-date-for-the-minor-release)
-    - [Assemble release team](#assemble-release-team)
-    - [Finalize release schedule and team](#finalize-release-schedule-and-team)
-    - [Prepare main branch for development of the new release](#prepare-main-branch-for-development-of-the-new-release)
-    - [Create a new GitHub milestone for the next release](#create-a-new-github-milestone-for-the-next-release)
-    - [[Track] Remove previously deprecated code](#track-remove-previously-deprecated-code)
-    - [[Track] Bump dependencies](#track-bump-dependencies)
-    - [Create a release branch](#create-a-release-branch)
-    - [[Continuously] Maintain the GitHub release milestone](#continuously-maintain-the-github-release-milestone)
-    - [[Repeatedly] Cut a release](#repeatedly-cut-a-release)
-    - [[Optional] [Track] Bump the Cluster API apiVersion](#optional-track-bump-the-cluster-api-apiversion)
-    - [[Optional] [Track] Bump the Kubernetes version](#optional-track-bump-the-kubernetes-version)
-- [Communications/Docs/Release Notes Manager](#communicationsdocsrelease-notes-manager)
-  - [Responsibilities](#responsibilities-1)
-  - [Tasks](#tasks-1)
-    - [Add docs to collect release notes for users and migration notes for provider implementers](#add-docs-to-collect-release-notes-for-users-and-migration-notes-for-provider-implementers)
-    - [Update supported versions](#update-supported-versions)
-    - [Ensure the book for the new release is available](#ensure-the-book-for-the-new-release-is-available)
-    - [Polish release notes](#polish-release-notes)
-    - [Change production branch in Netlify to the new release branch](#change-production-branch-in-netlify-to-the-new-release-branch)
-    - [Update clusterctl links in the quickstart](#update-clusterctl-links-in-the-quickstart)
-    - [Continuously: Communicate key dates to the community](#continuously-communicate-key-dates-to-the-community)
-- [CI Signal/Bug Triage/Automation Manager](#ci-signalbug-triageautomation-manager)
-  - [Responsibilities](#responsibilities-2)
-  - [Tasks](#tasks-2)
-    - [Setup jobs and dashboards for a new release branch](#setup-jobs-and-dashboards-for-a-new-release-branch)
-    - [[Continuously] Monitor CI signal](#continuously-monitor-ci-signal)
-    - [[Continuously] Reduce the amount of flaky tests](#continuously-reduce-the-amount-of-flaky-tests)
-    - [[Continuously] Bug triage](#continuously-bug-triage)
+- [Release Tasks](#release-tasks)
+  - [Release Lead](#release-lead)
+    - [Responsibilities](#responsibilities)
+    - [Tasks](#tasks)
+      - [Set a tentative release date for the minor release](#set-a-tentative-release-date-for-the-minor-release)
+      - [Assemble release team](#assemble-release-team)
+      - [Finalize release schedule and team](#finalize-release-schedule-and-team)
+      - [Prepare main branch for development of the new release](#prepare-main-branch-for-development-of-the-new-release)
+      - [Create a new GitHub milestone for the next release](#create-a-new-github-milestone-for-the-next-release)
+      - [\[Track\] Remove previously deprecated code](#track-remove-previously-deprecated-code)
+      - [\[Track\] Bump dependencies](#track-bump-dependencies)
+      - [Create a release branch](#create-a-release-branch)
+      - [\[Continuously\] Maintain the GitHub release milestone](#continuously-maintain-the-github-release-milestone)
+      - [\[Repeatedly\] Cut a release](#repeatedly-cut-a-release)
+      - [\[Optional\] \[Track\] Bump the Cluster API apiVersion](#optional-track-bump-the-cluster-api-apiversion)
+      - [\[Optional\] \[Track\] Bump the Kubernetes version](#optional-track-bump-the-kubernetes-version)
+  - [Communications/Docs/Release Notes Manager](#communicationsdocsrelease-notes-manager)
+    - [Responsibilities](#responsibilities-1)
+    - [Tasks](#tasks-1)
+      - [Add docs to collect release notes for users and migration notes for provider implementers](#add-docs-to-collect-release-notes-for-users-and-migration-notes-for-provider-implementers)
+      - [Update supported versions](#update-supported-versions)
+      - [Ensure the book for the new release is available](#ensure-the-book-for-the-new-release-is-available)
+      - [Polish release notes](#polish-release-notes)
+      - [Change production branch in Netlify to the new release branch](#change-production-branch-in-netlify-to-the-new-release-branch)
+      - [Update clusterctl links in the quickstart](#update-clusterctl-links-in-the-quickstart)
+      - [Continuously: Communicate key dates to the community](#continuously-communicate-key-dates-to-the-community)
+  - [CI Signal/Bug Triage/Automation Manager](#ci-signalbug-triageautomation-manager)
+    - [Responsibilities](#responsibilities-2)
+    - [Tasks](#tasks-2)
+      - [Setup jobs and dashboards for a new release branch](#setup-jobs-and-dashboards-for-a-new-release-branch)
+      - [\[Continuously\] Monitor CI signal](#continuously-monitor-ci-signal)
+      - [\[Continuously\] Reduce the amount of flaky tests](#continuously-reduce-the-amount-of-flaky-tests)
+      - [\[Continuously\] Bug triage](#continuously-bug-triage)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -155,6 +156,7 @@ This can be done by:
 #### [Repeatedly] Cut a release
 
 1. Ensure CI is stable before cutting the release (e.g. by checking with the CI manager)
+   Note: special attention should be given to image scan results, so we can avoid cutting a release with CVE or document known CVEs in release notes.
 2. Create and push the release tags to the GitHub repository:
    ```bash 
    # Export the tag of the release to be cut, e.g.:
@@ -388,6 +390,8 @@ The goal of this task is to keep our tests running in CI stable.
     1. Create an issue using an appropriate template (failing-test) in the Cluster API repository to surface the CI failure.
     2. Identify if the issue is a known issue, new issue or a regression.
     3. Mark the issue as `release-blocking` if applicable.
+4. Triage periodic GitHub actions failures, with special attention to image scan results;
+   Eventually open issues as described above.
 
 #### [Continuously] Reduce the amount of flaky tests
 

--- a/hack/verify-container-images.sh
+++ b/hack/verify-container-images.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+fi
+
+TRIVY_VERSION=0.34.0
+
+GO_OS="$(go env GOOS)"
+if [[ "${GO_OS}" == "linux" ]]; then
+  TRIVY_OS="Linux"
+elif [[ "${GO_OS}" == "darwin"* ]]; then
+  TRIVY_OS="macOS"
+fi
+
+GO_ARCH="$(go env GOARCH)"
+if [[ "${GO_ARCH}" == "amd" ]]; then
+  TRIVY_ARCH="32bit"
+elif [[ "${GO_ARCH}" == "amd64"* ]]; then
+  TRIVY_ARCH="64bit"
+elif [[ "${GO_ARCH}" == "arm" ]]; then
+  TRIVY_ARCH="ARM"
+elif [[ "${GO_ARCH}" == "arm64" ]]; then
+  TRIVY_ARCH="ARM64"
+fi
+
+TOOL_BIN=hack/tools/bin
+mkdir -p ${TOOL_BIN}
+
+# Downloads trivy scanner
+curl -L -o ${TOOL_BIN}/trivy.tar.gz "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_${TRIVY_OS}-${TRIVY_ARCH}.tar.gz"
+
+tar -xf "${TOOL_BIN}/trivy.tar.gz" -C "${TOOL_BIN}" trivy
+chmod +x ${TOOL_BIN}/trivy
+rm ${TOOL_BIN}/trivy.tar.gz
+
+# Builds all the container images to be scanned and cleans up changes to ./*manager_image_patch.yaml ./*manager_pull_policy.yaml.
+make REGISTRY=gcr.io/k8s-staging-cluster-api PULL_POLICY=IfNotPresent TAG=dev docker-build
+make clean-release-git
+
+# Scan the images
+${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/clusterctl-"${GO_ARCH}":dev && R1=$? || R1=$?
+${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/test-extension-"${GO_ARCH}":dev && R2=$? || R2=$?
+${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller-"${GO_ARCH}":dev && R3=$? || R3=$?
+${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller-"${GO_ARCH}":dev && R4=$? || R4=$?
+${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/cluster-api-controller-"${GO_ARCH}":dev && R5=$? || R5=$?
+${TOOL_BIN}/trivy image -q --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL gcr.io/k8s-staging-cluster-api/capd-manager-"${GO_ARCH}":dev && R6=$? || R6=$?
+
+echo ""
+BRed='\033[1;31m'
+BGreen='\033[1;32m'
+NC='\033[0m' # No
+
+if [ "$R1" -ne "0" ] || [ "$R2"  -ne "0" ] || [ "$R3" -ne "0" ] || [ "$R4" -ne "0"  ] || [ "$R5" -ne "0"  ] || [ "$R6" -ne "0" ]
+then
+  echo -e "${BRed}Check container images failed! There are vulnerability to be fixed${NC}"
+  exit 1
+fi
+
+echo -e "${BGreen}Check container images passed! No vulnerability found${NC}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding a verify script that runs [trivy](https://aquasecurity.github.io/trivy/) scanner on all the container images; the script is very basic for now, and it assumes someone will run it manually.
~~In follow-up iterations, we can think about how to automate this (when to run it, for changes on go.mod files, periodically), if to limit validation only to the image we release on production or not, and how to get a signal from the command output.~~
Also added a GitHub workflow running the same check periodically

For now, it will be great if we can have the release team running it periodically on main / before cutting a patch

@ykakarap @sbueringer @CecileRobertMichon opionis?

