### PR TITLE
:sparkles: Adds a make target to generate all the release manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -829,6 +829,11 @@ release: clean-release ## Build and push container images using the latest git t
 	git checkout "${RELEASE_TAG}"
 	# Build binaries first.
 	GIT_VERSION=$(RELEASE_TAG) $(MAKE) release-binaries
+	# Set the manifest images to the staging/production bucket and Builds the manifests to publish with a release.
+	$(MAKE) release-manifests-all
+
+.PHONY: release-manifests-all
+release-manifests-all: # Set the manifest images to the staging/production bucket and Builds the manifests to publish with a release.
 	# Set the manifest image to the production bucket.
 	$(MAKE) manifest-modification REGISTRY=$(PROD_REGISTRY)
 	## Build the manifests


### PR DESCRIPTION
Signed-off-by: Chirayu Kapoor <dev.csociety@gmail.com>

**What this PR does / why we need it**:
Adds make target `release-manifests-all` to generate all the release manifests independently of `make release`

This PR helps the users and developers as `make release-binaries` takes considerable time.

**Which issue(s) this PR fixes**
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/6975
