### PR TITLE
🐛  Add patch to kubeadmConfigSpec instead of replacing whole array in CAPD manifest

### DIFF
--- a/test/e2e/data/infrastructure-docker/v1beta1/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/clusterclass-quick-start.yaml
@@ -268,29 +268,29 @@ spec:
           readOnly: true
           pathType: "File"
       - op: add
-        path: "/spec/template/spec/kubeadmConfigSpec/files"
+        path: "/spec/template/spec/kubeadmConfigSpec/files/-"
         valueFrom:
           template: |
-            - content: |
-                apiVersion: apiserver.config.k8s.io/v1
-                kind: AdmissionConfiguration
-                plugins:
-                - name: PodSecurity
-                  configuration:
-                    apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25" .builtin.controlPlane.version }}beta1{{ end }}
-                    kind: PodSecurityConfiguration
-                    defaults:
-                      enforce: "baseline"
-                      enforce-version: "latest"
-                      audit: "baseline"
-                      audit-version: "latest"
-                      warn: "baseline"
-                      warn-version: "latest"
-                    exemptions:
-                      usernames: []
-                      runtimeClasses: []
-                      namespaces: [kube-system]
-              path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+            content: |
+              apiVersion: apiserver.config.k8s.io/v1
+              kind: AdmissionConfiguration
+              plugins:
+              - name: PodSecurity
+                configuration:
+                  apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25" .builtin.controlPlane.version }}beta1{{ end }}
+                  kind: PodSecurityConfiguration
+                  defaults:
+                    enforce: "baseline"
+                    enforce-version: "latest"
+                    audit: "baseline"
+                    audit-version: "latest"
+                    warn: "baseline"
+                    warn-version: "latest"
+                  exemptions:
+                    usernames: []
+                    runtimeClasses: []
+                    namespaces: [kube-system]
+            path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
     enabledIf: '{{ semverCompare ">= v1.24" .builtin.controlPlane.version }}'
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/v1beta1/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/main/clusterclass-quick-start.yaml
@@ -348,6 +348,7 @@ spec:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+        files: []
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -210,29 +210,29 @@ spec:
           readOnly: true
           pathType: "File"
       - op: add
-        path: "/spec/template/spec/kubeadmConfigSpec/files"
+        path: "/spec/template/spec/kubeadmConfigSpec/files/-"
         valueFrom:
           template: |
-            - content: |
-                apiVersion: apiserver.config.k8s.io/v1
-                kind: AdmissionConfiguration
-                plugins:
-                - name: PodSecurity
-                  configuration:
-                    apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25" .builtin.controlPlane.version }}beta1{{ end }}
-                    kind: PodSecurityConfiguration
-                    defaults:
-                      enforce: "{{ .podSecurityStandard.enforce }}"
-                      enforce-version: "latest"
-                      audit: "{{ .podSecurityStandard.audit }}"
-                      audit-version: "latest"
-                      warn: "{{ .podSecurityStandard.warn }}"
-                      warn-version: "latest"
-                    exemptions:
-                      usernames: []
-                      runtimeClasses: []
-                      namespaces: [kube-system]
-              path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+            content: |
+              apiVersion: apiserver.config.k8s.io/v1
+              kind: AdmissionConfiguration
+              plugins:
+              - name: PodSecurity
+                configuration:
+                  apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25" .builtin.controlPlane.version }}beta1{{ end }}
+                  kind: PodSecurityConfiguration
+                  defaults:
+                    enforce: "{{ .podSecurityStandard.enforce }}"
+                    enforce-version: "latest"
+                    audit: "{{ .podSecurityStandard.audit }}"
+                    audit-version: "latest"
+                    warn: "{{ .podSecurityStandard.warn }}"
+                    warn-version: "latest"
+                  exemptions:
+                    usernames: []
+                    runtimeClasses: []
+                    namespaces: [kube-system]
+            path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
     enabledIf: "{{ .podSecurityStandard.enabled }}"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
+++ b/test/infrastructure/docker/templates/clusterclass-quick-start.yaml
@@ -269,6 +269,7 @@ spec:
             criSocket: unix:///var/run/containerd/containerd.sock
             kubeletExtraArgs:
               eviction-hard: 'nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%'
+        files: []
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies the JSON patch for `/spec/template/spec/kubeadmConfigSpec/files` in the generated CAPD quickstart manifest.

It essentially modifies the patching behavior to add the patch to the array of patches instead of replacing the whole array.

This solves an issue where the user needs to modify the given `ClusterClass` when it supplies its own file(s) to `KubeadmControlPlaneTemplate` and has `PodSecurityStandard` enabled (default is true). If the user doesn't modify the `ClusterClass`, it won't see the resulting `KubeadmControlPlane` object populated with its file(s), as the JSON patch in `ClusterClass` will override anything specified in the same patch path.

It is possible to specify patches in the `ClusterClass` as well, but if we want to allow users to provide their own patches in `KubeadmControlPlaneTemplate` without having to modify the given `ClusterClass`, it would be better to have the patching in `ClusterClass` set to addition instead of replacement.

There might be other patches where this would require an analogous change, if necessary let me know where so I can change them as well.

**References**
- https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/book/src/tasks/experimental-features/cluster-class/write-clusterclass.md#json-patches-tips--tricks
- https://kubernetes.slack.com/archives/C8TSNPY4T/p1668684229051719?thread_ts=1668525942.617209&cid=C8TSNPY4T
