### PR TITLE
✨ Taint nodes with PreferNoSchedule during rollouts

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -217,6 +217,14 @@ const (
 	MachineSetPreflightCheckControlPlaneIsStable MachineSetPreflightCheck = "ControlPlaneIsStable"
 )
 
+// NodeOutdatedRevisionTaint can be added to Nodes at rolling updates in general triggered by updating MachineDeployment
+// This taint is used to prevent unnecessary pod churn, i.e., as the first node is drained, pods previously running on
+// that node are scheduled onto nodes who have yet to be replaced, but will be torn down soon.
+var NodeOutdatedRevisionTaint = corev1.Taint{
+	Key:    "node.cluster.x-k8s.io/outdated-revision",
+	Effect: corev1.TaintEffectPreferNoSchedule,
+}
+
 // NodeUninitializedTaint can be added to Nodes at creation by the bootstrap provider, e.g. the
 // KubeadmBootstrap provider will add the taint.
 // This taint is used to prevent workloads to be scheduled on Nodes before the node is initialized by Cluster API.

--- a/internal/util/taints/taints.go
+++ b/internal/util/taints/taints.go
@@ -46,3 +46,13 @@ func HasTaint(taints []corev1.Taint, targetTaint corev1.Taint) bool {
 	}
 	return false
 }
+
+// EnsureNodeTaint makes sure the node has the Taint.
+// It returns true if the taints are modified, false otherwise.
+func EnsureNodeTaint(node *corev1.Node, taint corev1.Taint) bool {
+	if !HasTaint(node.Spec.Taints, taint) {
+		node.Spec.Taints = append(node.Spec.Taints, taint)
+		return true
+	}
+	return false
+}

--- a/test/e2e/data/test-extension/deployment.yaml
+++ b/test/e2e/data/test-extension/deployment.yaml
@@ -1,0 +1,138 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-manager
+  namespace: test-extension-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-extension-manager-role
+subjects:
+- kind: ServiceAccount
+  name: test-extension-manager
+  namespace: test-extension-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-webhook-service
+  namespace: test-extension-system
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    app: test-extension-manager
+    cluster.x-k8s.io/provider: runtime-extension-test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-manager
+  namespace: test-extension-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-extension-manager
+      cluster.x-k8s.io/provider: runtime-extension-test
+  template:
+    metadata:
+      labels:
+        app: test-extension-manager
+        cluster.x-k8s.io/provider: runtime-extension-test
+    spec:
+      containers:
+      - command:
+        - /manager
+        image: gcr.io/k8s-staging-cluster-api/test-extension-amd64:dev
+        imagePullPolicy: IfNotPresent
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: test-extension-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: test-extension-webhook-service-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-serving-cert
+  namespace: test-extension-system
+spec:
+  dnsNames:
+  - test-extension-webhook-service.test-extension-system.svc
+  - test-extension-webhook-service.test-extension-system.svc.cluster.local
+  - localhost
+  issuerRef:
+    kind: Issuer
+    name: test-extension-selfsigned-issuer
+  secretName: test-extension-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: runtime-extension-test
+  name: test-extension-selfsigned-issuer
+  namespace: test-extension-system
+spec:
+  selfSigned: {}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

If the MachineSet or MachineDeployment has many replicas, and each node has many pods, changes to an existing MachineDeployment or MachineSet infrastructure template can result in unnecessary pod churn. As the first node is drained, pods previously running on that node may be scheduled onto nodes who have yet to be replaced, but will be torn down soon. This can happen over and over again. 

To avoid the above problem, this PR changes the machine controller to add `PreferNoSchedule` taint to nodes in old MachineDeployment. As mentioned in https://github.com/kubernetes-sigs/cluster-api/issues/7043#issuecomment-1230083125, tainting should be triggered by MachineDeployment controller. In the MachineDeployment controller, the old MachineSets are given an annotation, then the annotation is propagated from MachineSet to Machines, and finally Machine with the annotation sets taint to Node.

This behavior may be related to #493

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7043 
