### PR TITLE
:sparkles: [kcp] Make kcp.skipPhases field mutable

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -115,6 +115,7 @@ const (
 	initConfiguration    = "initConfiguration"
 	joinConfiguration    = "joinConfiguration"
 	nodeRegistration     = "nodeRegistration"
+	skipPhases           = "skipPhases"
 	patches              = "patches"
 	directory            = "directory"
 	preKubeadmCommands   = "preKubeadmCommands"
@@ -148,8 +149,10 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, kubeadmConfigSpec, clusterConfiguration, scheduler, "*"},
 		{spec, kubeadmConfigSpec, initConfiguration, nodeRegistration, "*"},
 		{spec, kubeadmConfigSpec, initConfiguration, patches, directory},
+		{spec, kubeadmConfigSpec, initConfiguration, skipPhases},
 		{spec, kubeadmConfigSpec, joinConfiguration, nodeRegistration, "*"},
 		{spec, kubeadmConfigSpec, joinConfiguration, patches, directory},
+		{spec, kubeadmConfigSpec, joinConfiguration, skipPhases},
 		{spec, kubeadmConfigSpec, preKubeadmCommands},
 		{spec, kubeadmConfigSpec, postKubeadmCommands},
 		{spec, kubeadmConfigSpec, files},

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -651,6 +651,12 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 		Directory: "/tmp/patches",
 	}
 
+	updateInitConfigurationSkipPhases := before.DeepCopy()
+	updateInitConfigurationSkipPhases.Spec.KubeadmConfigSpec.InitConfiguration.SkipPhases = []string{"addon/kube-proxy"}
+
+	updateJoinConfigurationSkipPhases := before.DeepCopy()
+	updateJoinConfigurationSkipPhases.Spec.KubeadmConfigSpec.JoinConfiguration.SkipPhases = []string{"addon/kube-proxy"}
+
 	updateDiskSetup := before.DeepCopy()
 	updateDiskSetup.Spec.KubeadmConfigSpec.DiskSetup = &bootstrapv1.DiskSetup{
 		Filesystems: []bootstrapv1.Filesystem{
@@ -984,6 +990,18 @@ func TestKubeadmControlPlaneValidateUpdate(t *testing.T) {
 			expectErr: false,
 			before:    before,
 			kcp:       updateJoinConfigurationPatches,
+		},
+		{
+			name:      "should allow changes to initConfiguration.skipPhases",
+			expectErr: false,
+			before:    before,
+			kcp:       updateInitConfigurationSkipPhases,
+		},
+		{
+			name:      "should allow changes to joinConfiguration.skipPhases",
+			expectErr: false,
+			before:    before,
+			kcp:       updateJoinConfigurationSkipPhases,
 		},
 		{
 			name:      "should allow changes to diskSetup",


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Makes KCP skipPhases field mutable, needed in cases like disabling kube-proxy deployment on an existing cluster.

Signed-off-by: Jim Ntosas <ntosas@gmail.com>
