### PR TITLE
Change test-extension pull policy to IfNotPresent

### DIFF
--- a/test/extension/config/default/manager_pull_policy.yaml
+++ b/test/extension/config/default/manager_pull_policy.yaml
@@ -7,4 +7,7 @@ spec:
     spec:
       containers:
       - name: manager
-        imagePullPolicy: Always
+        # No image is currently published for the test extension.
+        # To run locally either pre-load the image onto the control-plane nodes or change the manager_image_patch.yaml
+        # image ref to a registry with an up-to-date test-extension image.
+        imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update the pull policy of the test extension image to IfNotPresent to allow for pre-loading of the image onto control plane machines by default.
