### PR TITLE
📖 docs: add Cluster API 1.4 and Kubernetes 1.26 to supported versions page

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -63,18 +63,20 @@ These diagrams show the relationships between components in a Cluster API releas
 
 #### Core Provider (`cluster-api-controller`)
 
-|                   | v0.3 (v1alpha3)      | v0.4 (v1alpha4) 			| v1.0 (v1beta1)      | v1.1 (v1beta1)    | v1.2 (v1beta1)       | v1.3 (v1beta1)      |
-|-------------------|----------------------|----------------------|---------------------|-------------------|----------------------|---------------------|
-| Kubernetes v1.16  | ✓                    |                      |                     |                   |                     |                     |
-| Kubernetes v1.17  | ✓                    |                   	  |                     |                   |                     |                     |
-| Kubernetes v1.18  | ✓                    | ✓ (only workload)    | ✓ (only workload)  	| ✓ (only workload) | ✓ (only workload)   | ✓ (only workload)  |
-| Kubernetes v1.19  | ✓                    | ✓                    | ✓                   | ✓                 | ✓ (only workload)   | ✓ (only workload)  |
-| Kubernetes v1.20  | ✓                    | ✓                    | ✓                   | ✓                 | ✓                   | ✓                  |
-| Kubernetes v1.21  | ✓                    | ✓                    | ✓                   | ✓                 | ✓                   | ✓                  |
-| Kubernetes v1.22  | ✓ (only workload)    | ✓                    | ✓                   | ✓                 | ✓                   | ✓                  |
-| Kubernetes v1.23* |                      | ✓                    | ✓                   | ✓                 | ✓                   | ✓                  |
-| Kubernetes v1.24  |                      |                      |                     | ✓                 | ✓                   | ✓                  |
-| Kubernetes v1.25  |                      |                      |                     |                   | ✓                   | ✓                  |
+|                   | v0.3 (v1alpha3)      | v0.4 (v1alpha4)   | v1.0 (v1beta1)    | v1.1 (v1beta1)    | v1.2 (v1beta1)    | v1.3 (v1beta1)    | v1.4 (v1beta1)    |
+|-------------------|----------------------|-------------------|-------------------|-------------------|-------------------|-------------------|-------------------|
+| Kubernetes v1.16  | ✓                    |                   |                   |                   |                   |                   |                   |
+| Kubernetes v1.17  | ✓                    |                   |                   |                   |                   |                   |                   |
+| Kubernetes v1.18  | ✓                    | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.19  | ✓                    | ✓                 | ✓                 | ✓                 | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.20  | ✓                    | ✓                 | ✓                 | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.21  | ✓                    | ✓                 | ✓                 | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.22  | ✓ (only workload)    | ✓                 | ✓                 | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.23* |                      | ✓                 | ✓                 | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.24  |                      |                   |                   | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.25  |                      |                   |                   |                   | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.26  |                      |                   |                   |                   |                   |                   |                   |
+
 
 \* There is an issue with CRDs in Kubernetes v1.23.{0-2}. ClusterClass with patches is affected by that (for more details please see [this issue](https://github.com/kubernetes-sigs/cluster-api/issues/5990)). Therefore we recommend to use Kubernetes v1.23.3+ with ClusterClass.
 	 Previous Kubernetes **minor** versions are not affected.
@@ -85,35 +87,37 @@ The Core Provider also talks to API server of every Workload Cluster. Therefore,
 
 #### Kubeadm Bootstrap Provider (`kubeadm-bootstrap-controller`)
 
-|                                                                   | v0.3 (v1alpha3)      | v0.4 (v1alpha4)      | v1.0 (v1beta1)      | v1.1 (v1beta1)    | v1.2 (v1beta1)        | v1.3 (v1beta1)    |
-|-------------------------------------------------------------------|----------------------|----------------------|---------------------|-------------------|----------------------|--------------------|
-| Kubernetes v1.16 + kubeadm/v1beta2                                | ✓                    |                      |                     |                   |                      |                    |
-| Kubernetes v1.17 + kubeadm/v1beta2                                | ✓                    |                      |                     |                   |                      |                    |
-| Kubernetes v1.18 + kubeadm/v1beta2                                | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload) | ✓ (only workload)    | ✓ (only workload)  |
-| Kubernetes v1.19 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                 | ✓ (only workload)    | ✓ (only workload)  |
-| Kubernetes v1.20 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                 | ✓                    | ✓                  |
-| Kubernetes v1.21 + kubeadm/v1beta2                                | ✓                    | ✓                    | ✓                   | ✓                 | ✓                    | ✓                  |
-| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+) | ✓ (only workload)    | ✓                    | ✓                   | ✓                 | ✓                    | ✓                  |
-| Kubernetes v1.23 + kubeadm/v1beta3                                |                      | ✓                    | ✓                   | ✓                 | ✓                    | ✓                  |
-| Kubernetes v1.24 + kubeadm/v1beta3                                |                      |                      |                     | ✓                 | ✓                    | ✓                  |
-| Kubernetes v1.25 + kubeadm/v1beta3                                |                      |                      |                     |                   | ✓                    | ✓                  |
+|                                                                    | v0.3 (v1alpha3)      | v0.4 (v1alpha4)      | v1.0 (v1beta1)      | v1.1 (v1beta1)    | v1.2 (v1beta1)    | v1.3 (v1beta1)    | v1.4 (v1beta1)    |
+|--------------------------------------------------------------------|----------------------|----------------------|---------------------|-------------------|-------------------|-------------------|-------------------|
+| Kubernetes v1.16 + kubeadm/v1beta2                                 | ✓                    |                      |                     |                   |                   |                   |                   |
+| Kubernetes v1.17 + kubeadm/v1beta2                                 | ✓                    |                      |                     |                   |                   |                   |                   |
+| Kubernetes v1.18 + kubeadm/v1beta2                                 | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.19 + kubeadm/v1beta2                                 | ✓                    | ✓                    | ✓                   | ✓                 | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.20 + kubeadm/v1beta2                                 | ✓                    | ✓                    | ✓                   | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.21 + kubeadm/v1beta2                                 | ✓                    | ✓                    | ✓                   | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.22 + kubeadm/v1beta2 (v0.3) kubeadm/v1beta3 (v0.4+)  | ✓ (only workload)    | ✓                    | ✓                   | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.23 + kubeadm/v1beta3                                 |                      | ✓                    | ✓                   | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.24 + kubeadm/v1beta3                                 |                      |                      |                     | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.25 + kubeadm/v1beta3                                 |                      |                      |                     |                   | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.26 + kubeadm/v1beta3                                 |                      |                      |                     |                   |                   |                   |                   |
 
 The Kubeadm Bootstrap Provider generates kubeadm configuration using the API version recommended for the target Kubernetes version.
 
 #### Kubeadm Control Plane Provider (`kubeadm-control-plane-controller`)
 
-|                            |  v0.3 (v1alpha3)     |  v0.4 (v1alpha4)     |  v1.0 (v1beta1)     | v1.1 (v1beta1)    |  v1.2 (v1beta1)     |  v1.3 (v1beta1)     |
-|----------------------------|----------------------|----------------------|---------------------|-------------------|---------------------|---------------------|
-| Kubernetes v1.16 + etcd/v3 | ✓                    |                      |                     |                   |                     |                     |
-| Kubernetes v1.17 + etcd/v3 | ✓                    |                      |                     |                   |                     |                     |
-| Kubernetes v1.18 + etcd/v3 | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload) | ✓ (only workload)   | ✓ (only workload)   |
-| Kubernetes v1.19 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                 | ✓ (only workload)   | ✓ (only workload)   |
-| Kubernetes v1.20 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                 | ✓                   | ✓                   |
-| Kubernetes v1.21 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                 | ✓                   | ✓                   |
-| Kubernetes v1.22 + etcd/v3 | ✓* (only workload)   | ✓                    | ✓                   | ✓                 | ✓                   | ✓                   |
-| Kubernetes v1.23 + etcd/v3 |                      | ✓*                   | ✓*                  | ✓                 | ✓                   | ✓                   |
-| Kubernetes v1.24 + etcd/v3 |                      |                      |                     | ✓                 | ✓                   | ✓                   |
-| Kubernetes v1.25 + etcd/v3 |                      |                      |                     |                   | ✓                   | ✓                   |
+|                            |  v0.3 (v1alpha3)     |  v0.4 (v1alpha4)     |  v1.0 (v1beta1)     | v1.1 (v1beta1)    | v1.2 (v1beta1)    | v1.3 (v1beta1)    | v1.4 (v1beta1)    |
+|----------------------------|----------------------|----------------------|---------------------|-------------------|-------------------|-------------------|-------------------|
+| Kubernetes v1.16 + etcd/v3 | ✓                    |                      |                     |                   |                   |                   |                   |
+| Kubernetes v1.17 + etcd/v3 | ✓                    |                      |                     |                   |                   |                   |                   |
+| Kubernetes v1.18 + etcd/v3 | ✓                    | ✓ (only workload)    | ✓ (only workload)   | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.19 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                 | ✓ (only workload) | ✓ (only workload) | ✓ (only workload) |
+| Kubernetes v1.20 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.21 + etcd/v3 | ✓                    | ✓                    | ✓                   | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.22 + etcd/v3 | ✓* (only workload)   | ✓                    | ✓                   | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.23 + etcd/v3 |                      | ✓*                   | ✓*                  | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.24 + etcd/v3 |                      |                      |                     | ✓                 | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.25 + etcd/v3 |                      |                      |                     |                   | ✓                 | ✓                 | ✓                 |
+| Kubernetes v1.26 + etcd/v3 |                      |                      |                     |                   |                   |                   |                   |
 
 The Kubeadm Control Plane Provider talks to the API server and etcd members of every Workload Cluster whose control plane it owns. It uses the etcd v3 API.
 
@@ -131,11 +135,17 @@ The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 | v1.1 (v1beta1)  | v1.9.3                          |
 | v1.2 (v1beta1)  | v1.9.3 (v1.10.0 with >= v1.2.7) |
 | v1.3 (v1beta1)  | v1.10.0                         |
+| v1.4 (v1beta1)  | v1.10.0                         |
 
 #### Kubernetes version specific notes
 
-**1.24**:
+**1.26**:
+* No specific notes
 
+**1.25**:
+* No specific notes
+
+**1.24**:
 * Kubeadm Bootstrap Provider:
 		* `kubeadm` now sets both the `node-role.kubernetes.io/control-plane` and `node-role.kubernetes.io/master` taints on control plane nodes.
 		* `kubeadm` now only sets the `node-role.kubernetes.io/control-plane` label on control plane nodes (the `node-role.kubernetes.io/master` label is not set anymore).
@@ -144,8 +154,7 @@ The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 
 #### clusterctl
 
-It is strongly recommended to always use the latest version of [clusterctl](../clusterctl/overview.md), in order to
-get all the fixes/latest changes.
+It is strongly recommended to always use the latest version of [clusterctl](../clusterctl/overview.md), in order to get all the fixes/latest changes.
 
 In case of upgrades, clusterctl should be upgraded first and then used to upgrade all the other components.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Cluster API 1.4 and Kubernetes 1.26 ([released 8DEC](https://www.kubernetes.dev/resources/release/)) to the supported versions page.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partof #7672 
