### PR TITLE
🐛 Fix to enable Cluster Autoscaler with Replicas field set in a Classy Cluster

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -136,6 +136,12 @@ const (
 	// instead of being a source of truth for eventual consistency.
 	// This annotation can be used to inform MachinePool status during in-progress scaling scenarios.
 	ReplicasManagedByAnnotation = "cluster.x-k8s.io/replicas-managed-by"
+
+	// ClusterAutoscaler Annotations are applied under the NodePool metadata. These annotations will be percolated to
+	// the correspoding MachineDeployment.These annotations provide the range within which a particular
+	// MachineDeployment can be scaled out/in.
+	ClusterAutoscalerMinAnnotation = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size"
+	ClusterAutoscalerMaxAnnotation = "cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size"
 )
 
 const (


### PR DESCRIPTION

**What this PR does / why we need it**:
For classy cluster if replica field set for each NodePool, the cluster topology reconciler overwrites the replicas count as set by the cluster autoscaler.  This limits enabling cluster autoscaler as a Day-1 op on a classy cluster. With this fix the topology reconciler will skip updating the replica field if the autoscaler annotations are present under the NodePool.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7293
