### PR TITLE
🌱 `make promote-images` should also work if the user uses a SSH style URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -819,7 +819,10 @@ PREVIOUS_TAG ?= $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | sort
 RELEASE_ALIAS_TAG := $(PULL_BASE_REF)
 RELEASE_DIR := out
 RELEASE_NOTES_DIR := _releasenotes
-USER_FORK ?= $(shell git config --get remote.origin.url | cut -d/ -f4)
+USER_FORK ?= $(shell git config --get remote.origin.url | cut -d/ -f4) # only works on https://github.com/<username>/cluster-api.git style URLs
+ifeq ($(USER_FORK),)
+USER_FORK := $(shell git config --get remote.origin.url | cut -d: -f2 | cut -d/ -f1) # for git@github.com:<username>/cluster-api.git style URLs
+endif
 IMAGE_REVIEWERS ?= $(shell ./hack/get-project-maintainers.sh)
 
 .PHONY: $(RELEASE_DIR)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR fixes `make promote-images` so that it can also be used if the origin URL is ssh style (`git@github.com:<user-name>/cluster-api.git`). 
Currently this only works if the user uses a `https://` style URL and the user will have to manually set `export USER_FORK=<username>` to bypass this problem otherwise.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
