### PR TITLE
🐛 Fix to enable bootstrap secret rotation if the secret itself missing

### DIFF
--- a/bootstrap/kubeadm/internal/controllers/token.go
+++ b/bootstrap/kubeadm/internal/controllers/token.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
@@ -101,6 +102,12 @@ func refreshToken(ctx context.Context, c client.Client, token string, ttl time.D
 func shouldRotate(ctx context.Context, c client.Client, token string, ttl time.Duration) (bool, error) {
 	secret, err := getToken(ctx, c, token)
 	if err != nil {
+		// If the secret is deleted before due to unknown reasons, machine pools cannot be scaled up.
+		// Since that, secret should be rotated if missing.
+		// Normally, it is not expected to reach this line.
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When the bootstrap token is expired and the respective secret is already cleaned up, MachinePools cannot be scaled up due to missing token.  In order to mitigate this issue, the secret can be rotated if it is missing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6029
