### PR TITLE
:book: Update cert manager version in migration doc

### DIFF
--- a/docs/book/src/developer/providers/v1.2-to-v1.3.md
+++ b/docs/book/src/developer/providers/v1.2-to-v1.3.md
@@ -68,7 +68,7 @@ The default value is 0, meaning that the volume can be detached without any time
   * `ETCD_VERSION_UPGRADE_TO`
   * `COREDNS_VERSION_UPGRADE_TO`
   The variable `SkipUpgrade` could be set to revert to the old behaviour by making use of the `KUBERNETES_VERSION` variable and skipping the kubernetes upgrade.
-- cert-manager upgraded from v1.9.1 to v1.10.0.
+- cert-manager upgraded from v1.9.1 to v1.10.1.
 - Machine `providerID` is now being strictly checked for equality when compared against Kubernetes node `providerID` data. This is the expected criteria for correlating a Cluster API machine to its corresponding Kubernetes node, but historically this comparison was not strict, and instead compared only against the `ID` substring part of the full `providerID` string. Because different providers construct `providerID` strings differently, the `ID` substring is not uniformly defined and implemented across providers, and thus the existing `providerID` equality can not guarantee the correct Machine-Node correlation. It is very unlikely that this new behavior will break existing providers, but FYI: if strict `providerID` equality will degrade expected behaviors, you may need to update your provider implementation prior to adopting Cluster API v1.3.
 - The default minimum TLS version in use by the webhook servers is 1.2.
 - OwnerReferences are now more strictly enforced for objects managed by Cluster API. Machines, Bootstrap configs, Infrastructure Machines and Secrets created by CAPI components [now have strictly enforced controller owner references](https://github.com/kubernetes-sigs/cluster-api/issues/7575). This is not expected to require changes for providers.


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Update cert manager version in the migration doc. Related to version bump in #7705 
