### PR TITLE
🌱 Tilt must show templates for enabled providers only

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -446,6 +446,9 @@ def cluster_templates():
     })
 
     for provider, provider_dirs in template_dirs.items():
+        if provider not in get_providers():
+            continue
+
         p = providers.get(provider)
         label = p.get("label", provider)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
this prevents tilt to show templates and cluster classes for providers not currently enabled