### PR TITLE
🌱 KCP should avoid to reconcile certificates too early

### DIFF
--- a/controlplane/kubeadm/internal/controllers/controller.go
+++ b/controlplane/kubeadm/internal/controllers/controller.go
@@ -621,6 +621,11 @@ func (r *KubeadmControlPlaneReconciler) reconcileCertificateExpiries(ctx context
 		return ctrl.Result{}, nil
 	}
 
+	// Return if KCP is not yet initialized (no API server to contact for checking certificate expiration).
+	if !controlPlane.KCP.Status.Initialized {
+		return ctrl.Result{}, nil
+	}
+
 	// Ignore machines which are being deleted.
 	machines := controlPlane.Machines.Filter(collections.Not(collections.HasDeletionTimestamp))
 

--- a/controlplane/kubeadm/internal/controllers/controller_test.go
+++ b/controlplane/kubeadm/internal/controllers/controller_test.go
@@ -918,7 +918,9 @@ func TestReconcileCertificateExpiries(t *testing.T) {
 	detectedExpiry := time.Now().Add(25 * 24 * time.Hour)
 
 	cluster := newCluster(&types.NamespacedName{Name: "foo", Namespace: metav1.NamespaceDefault})
-	kcp := &controlplanev1.KubeadmControlPlane{}
+	kcp := &controlplanev1.KubeadmControlPlane{
+		Status: controlplanev1.KubeadmControlPlaneStatus{Initialized: true},
+	}
 	machineWithoutExpiryAnnotation := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "machineWithoutExpiryAnnotation",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR prevents KCP to reconcile certificate expiration if the control plane is not yet initialized, thus getting rid of some noisy errors in the logs.