### PR TITLE
[release-1.2] 🐛 releaselink: fix goproxy to also return versions for major > 1

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -266,7 +266,7 @@ Download the latest binary of `clusterawsadm` from the [AWS provider releases].
 
 Download the latest release; on linux, type:
 ```
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-linux-amd64" version:"1.x"}} -o clusterawsadm
+curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-linux-amd64" version:">=1.0.0"}} -o clusterawsadm
 ```
 
 Make it executable
@@ -288,12 +288,12 @@ clusterawsadm version
 
 Download the latest release; on macOs, type:
 ```
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-darwin-amd64" version:"1.x"}} -o clusterawsadm
+curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-darwin-amd64" version:">=1.0.0"}} -o clusterawsadm
 ```
 
 Or if your Mac has an M1 CPU (”Apple Silicon”):
 ```
-curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-darwin-arm64" version:"1.x"}} -o clusterawsadm
+curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api-provider-aws" asset:"clusterawsadm-darwin-arm64" version:">=1.0.0"}} -o clusterawsadm
 ```
 
 Make it executable

--- a/hack/tools/mdbook/releaselink/releaselink.go
+++ b/hack/tools/mdbook/releaselink/releaselink.go
@@ -20,20 +20,18 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
-	"io"
 	"log"
-	"net/http"
-	"net/url"
 	"os"
-	"path"
 	"reflect"
-	"sort"
 	"strings"
 
 	"github.com/blang/semver"
 	"golang.org/x/tools/go/vcs"
 	"sigs.k8s.io/kubebuilder/docs/book/utils/plugin"
+
+	"sigs.k8s.io/cluster-api/internal/goproxy"
 )
 
 // ReleaseLink responds to {{#releaselink <args>}} input. It asks for a `gomodule` parameter
@@ -57,35 +55,25 @@ func (l ReleaseLink) Process(input *plugin.Input) error {
 		versionRange := semver.MustParseRange(tags.Get("version"))
 		includePrereleases := tags.Get("prereleases") == "true"
 
+		scheme, host, err := goproxy.GetSchemeAndHost(os.Getenv("GOPROXY"))
+		if err != nil {
+			return "", err
+		}
+		if scheme == "" || host == "" {
+			return "", fmt.Errorf("releaselink does not support disabling the go proxy: GOPROXY=%q", os.Getenv("GOPROXY"))
+		}
+
+		goproxyClient := goproxy.NewClient(scheme, host)
+
 		repo, err := vcs.RepoRootForImportPath(gomodule, false)
 		if err != nil {
 			return "", err
 		}
 
-		rawURL := url.URL{
-			Scheme: "https",
-			Host:   "proxy.golang.org",
-			Path:   path.Join(gomodule, "@v", "/list"),
-		}
-
-		resp, err := http.Get(rawURL.String()) //nolint:noctx // NB: as we're just implementing an external interface we won't be able to get a context here.
+		parsedTags, err := goproxyClient.GetVersions(context.Background(), gomodule)
 		if err != nil {
 			return "", err
 		}
-		defer resp.Body.Close()
-
-		out, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return "", err
-		}
-
-		parsedTags := semver.Versions{}
-		for _, line := range strings.Split(string(out), "\n") {
-			if strings.HasPrefix(line, "v") {
-				parsedTags = append(parsedTags, semver.MustParse(strings.TrimPrefix(line, "v")))
-			}
-		}
-		sort.Sort(parsedTags)
 
 		var picked semver.Version
 		for i, tag := range parsedTags {

--- a/internal/goproxy/doc.go
+++ b/internal/goproxy/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package goproxy implements a goproxy client.
+package goproxy

--- a/internal/goproxy/goproxy.go
+++ b/internal/goproxy/goproxy.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	defaultGoProxyHost = "proxy.golang.org"
+)
+
+var (
+	retryableOperationInterval = 10 * time.Second
+	retryableOperationTimeout  = 1 * time.Minute
+)
+
+// Client is a client to query versions from a goproxy instance.
+type Client struct {
+	scheme string
+	host   string
+}
+
+// NewClient returns a new goproxyClient instance.
+func NewClient(scheme, host string) *Client {
+	return &Client{
+		scheme: scheme,
+		host:   host,
+	}
+}
+
+// GetVersions returns the a sorted list of semantical versions which exist for a go module.
+func (g *Client) GetVersions(ctx context.Context, gomodulePath string) (semver.Versions, error) {
+	parsedVersions := semver.Versions{}
+
+	majorVersionNumber := 1
+	var majorVersion string
+	for {
+		if majorVersionNumber > 1 {
+			majorVersion = fmt.Sprintf("v%d", majorVersionNumber)
+		}
+		rawURL := url.URL{
+			Scheme: g.scheme,
+			Host:   g.host,
+			Path:   path.Join(gomodulePath, majorVersion, "@v", "/list"),
+		}
+		majorVersionNumber++
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL.String(), http.NoBody)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get versions: failed to create request")
+		}
+
+		var rawResponse []byte
+		var responseStatusCode int
+		var retryError error
+		_ = wait.PollImmediateWithContext(ctx, retryableOperationInterval, retryableOperationTimeout, func(ctx context.Context) (bool, error) {
+			retryError = nil
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				retryError = errors.Wrapf(err, "failed to get versions: failed to do request")
+				return false, nil
+			}
+			defer resp.Body.Close()
+
+			responseStatusCode = resp.StatusCode
+
+			// Status codes OK and NotFound are expected results:
+			// * OK indicates that we got a list of versions to read.
+			// * NotFound indicates that there are no versions for this module / modules major version.
+			if responseStatusCode != http.StatusOK && responseStatusCode != http.StatusNotFound {
+				retryError = errors.Errorf("failed to get versions: response status code %d", resp.StatusCode)
+				return false, nil
+			}
+
+			// only read the response for http.StatusOK
+			if responseStatusCode == http.StatusOK {
+				rawResponse, err = io.ReadAll(resp.Body)
+				if err != nil {
+					retryError = errors.Wrap(err, "failed to get versions: error reading goproxy response body")
+					return false, nil
+				}
+			}
+			return true, nil
+		})
+		if retryError != nil {
+			return nil, retryError
+		}
+
+		// Don't try to read the versions if status was not found.
+		if responseStatusCode == http.StatusNotFound {
+			break
+		}
+
+		for _, s := range strings.Split(string(rawResponse), "\n") {
+			if s == "" {
+				continue
+			}
+			parsedVersion, err := semver.ParseTolerant(s)
+			if err != nil {
+				// Discard releases with tags that are not a valid semantic versions (the user can point explicitly to such releases).
+				continue
+			}
+			parsedVersions = append(parsedVersions, parsedVersion)
+		}
+	}
+
+	if len(parsedVersions) == 0 {
+		return nil, fmt.Errorf("no versions found for go module %q", gomodulePath)
+	}
+
+	sort.Sort(parsedVersions)
+
+	return parsedVersions, nil
+}
+
+// GetSchemeAndHost detects and returns the scheme and host for goproxy requests.
+// It returns empty strings if goproxy is disabled via `off` or `direct` values.
+func GetSchemeAndHost(goproxy string) (string, string, error) {
+	// Fallback to default
+	if goproxy == "" {
+		return "https", defaultGoProxyHost, nil
+	}
+
+	var goproxyHost, goproxyScheme string
+	// xref https://github.com/golang/go/blob/master/src/cmd/go/internal/modfetch/proxy.go
+	for goproxy != "" {
+		var rawURL string
+		if i := strings.IndexAny(goproxy, ",|"); i >= 0 {
+			rawURL = goproxy[:i]
+			goproxy = goproxy[i+1:]
+		} else {
+			rawURL = goproxy
+			goproxy = ""
+		}
+
+		rawURL = strings.TrimSpace(rawURL)
+		if rawURL == "" {
+			continue
+		}
+		if rawURL == "off" || rawURL == "direct" {
+			// Return nothing to fallback to github repository client without an error.
+			return "", "", nil
+		}
+
+		// Single-word tokens are reserved for built-in behaviors, and anything
+		// containing the string ":/" or matching an absolute file path must be a
+		// complete URL. For all other paths, implicitly add "https://".
+		if strings.ContainsAny(rawURL, ".:/") && !strings.Contains(rawURL, ":/") && !filepath.IsAbs(rawURL) && !path.IsAbs(rawURL) {
+			rawURL = "https://" + rawURL
+		}
+
+		parsedURL, err := url.Parse(rawURL)
+		if err != nil {
+			return "", "", errors.Wrapf(err, "parse GOPROXY url %q", rawURL)
+		}
+		goproxyHost = parsedURL.Host
+		goproxyScheme = parsedURL.Scheme
+		// A host was found so no need to continue.
+		break
+	}
+
+	return goproxyScheme, goproxyHost, nil
+}

--- a/internal/goproxy/goproxy_test.go
+++ b/internal/goproxy/goproxy_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package goproxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/blang/semver"
+	. "github.com/onsi/gomega"
+)
+
+func TestClient_GetVersions(t *testing.T) {
+	retryableOperationInterval = 200 * time.Millisecond
+	retryableOperationTimeout = 1 * time.Second
+
+	clientGoproxy, muxGoproxy, teardownGoproxy := NewFakeGoproxy()
+	defer teardownGoproxy()
+
+	// setup an handler for returning 2 fake releases
+	muxGoproxy.HandleFunc("/github.com/o/r1/@v/list", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, "v1.1.0\n")
+		fmt.Fprint(w, "v0.2.0\n")
+	})
+
+	// setup an handler for returning 2 fake releases for v1
+	muxGoproxy.HandleFunc("/github.com/o/r2/@v/list", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, "v1.1.0\n")
+		fmt.Fprint(w, "v0.2.0\n")
+	})
+	// setup an handler for returning 2 fake releases for v2
+	muxGoproxy.HandleFunc("/github.com/o/r2/v2/@v/list", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, "v2.0.1\n")
+		fmt.Fprint(w, "v2.0.0\n")
+	})
+
+	tests := []struct {
+		name         string
+		gomodulePath string
+		want         semver.Versions
+		wantErr      bool
+	}{
+		{
+			"No versions",
+			"github.com/o/doesntexist",
+			nil,
+			true,
+		},
+		{
+			"Two versions < v2",
+			"github.com/o/r1",
+			semver.Versions{
+				semver.MustParse("0.2.0"),
+				semver.MustParse("1.1.0"),
+			},
+			false,
+		},
+		{
+			"Multiple versiosn including > v1",
+			"github.com/o/r2",
+			semver.Versions{
+				semver.MustParse("0.2.0"),
+				semver.MustParse("1.1.0"),
+				semver.MustParse("2.0.0"),
+				semver.MustParse("2.0.1"),
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			g := NewWithT(t)
+
+			got, err := clientGoproxy.GetVersions(ctx, tt.gomodulePath)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(got).To(BeEquivalentTo(tt.want))
+		})
+	}
+}
+
+func Test_GetGoproxyHost(t *testing.T) {
+	retryableOperationInterval = 200 * time.Millisecond
+	retryableOperationTimeout = 1 * time.Second
+
+	tests := []struct {
+		name       string
+		envvar     string
+		wantScheme string
+		wantHost   string
+		wantErr    bool
+	}{
+		{
+			name:       "defaulting",
+			envvar:     "",
+			wantScheme: "https",
+			wantHost:   "proxy.golang.org",
+			wantErr:    false,
+		},
+		{
+			name:       "direct falls back to empty strings",
+			envvar:     "direct",
+			wantScheme: "",
+			wantHost:   "",
+			wantErr:    false,
+		},
+		{
+			name:       "off falls back to empty strings",
+			envvar:     "off",
+			wantScheme: "",
+			wantHost:   "",
+			wantErr:    false,
+		},
+		{
+			name:       "other goproxy",
+			envvar:     "foo.bar.de",
+			wantScheme: "https",
+			wantHost:   "foo.bar.de",
+			wantErr:    false,
+		},
+		{
+			name:       "other goproxy comma separated, return first",
+			envvar:     "foo.bar,foobar.barfoo",
+			wantScheme: "https",
+			wantHost:   "foo.bar",
+			wantErr:    false,
+		},
+		{
+			name:       "other goproxy including https scheme",
+			envvar:     "https://foo.bar",
+			wantScheme: "https",
+			wantHost:   "foo.bar",
+			wantErr:    false,
+		},
+		{
+			name:       "other goproxy including http scheme",
+			envvar:     "http://foo.bar",
+			wantScheme: "http",
+			wantHost:   "foo.bar",
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			gotScheme, gotHost, err := GetSchemeAndHost(tt.envvar)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(gotScheme).To(Equal(tt.wantScheme))
+			g.Expect(gotHost).To(Equal(tt.wantHost))
+		})
+	}
+}
+
+// NewFakeGoproxy sets up a test HTTP server along with a github.Client that is
+// configured to talk to that test server. Tests should register handlers on
+// mux which provide mock responses for the API method being tested.
+func NewFakeGoproxy() (client *Client, mux *http.ServeMux, teardown func()) {
+	// mux is the HTTP request multiplexer used with the test server.
+	mux = http.NewServeMux()
+
+	apiHandler := http.NewServeMux()
+	apiHandler.Handle("/", mux)
+
+	// server is a test HTTP server used to provide mock API responses.
+	server := httptest.NewServer(apiHandler)
+
+	// client is the GitHub client being tested and is configured to use test server.
+	url, _ := url.Parse(server.URL + "/")
+	return NewClient(url.Scheme, url.Host), mux, server.Close
+}
+
+func testMethod(t *testing.T, r *http.Request, want string) {
+	t.Helper()
+
+	if got := r.Method; got != want {
+		t.Errorf("Request method: %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

* Fixes goproxy for `releaselink` to also list versions > v1

Cherry-picks #7709 for releaselink only

cc @fabriziopandini 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
