### PR TITLE
🌱 Bump shellcheck version (0.8.0 -> 0.9.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,8 @@ GO_APIDIFF_PKG := github.com/joelanford/go-apidiff
 HADOLINT_VER := v2.10.0
 HADOLINT_FAILURE_THRESHOLD = warning
 
+SHELLCHECK_VER := v0.9.0
+
 KPROMO_VER := v3.4.5
 KPROMO_BIN := kpromo
 KPROMO :=  $(abspath $(TOOLS_BIN_DIR)/$(KPROMO_BIN)-$(KPROMO_VER))
@@ -616,7 +618,7 @@ verify-boilerplate: ## Verify boilerplate text exists in each file
 
 .PHONY: verify-shellcheck
 verify-shellcheck: ## Verify shell files
-	TRACE=$(TRACE) ./hack/verify-shellcheck.sh
+	TRACE=$(TRACE) ./hack/verify-shellcheck.sh $(SHELLCHECK_VER)
 
 .PHONY: verify-tiltfile
 verify-tiltfile: ## Verify Tiltfile format

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -21,7 +21,12 @@ if [[ "${TRACE-0}" == "1" ]]; then
     set -o xtrace
 fi
 
-VERSION="v0.8.0"
+if [ $# -ne 1 ]; then
+  echo 1>&2 "$0: usage: ./verify-shellcheck.sh <version>"
+  exit 2
+fi
+
+VERSION=${1}
 
 OS="unknown"
 if [[ "${OSTYPE}" == "linux"* ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

* Updates shellcheck version to latest and greatest (0.8.0 -> 0.9.0)
* Moves the version from the verify-shellcheck script to the Makefile
