### PR TITLE
[release-1.2] 🌱 Add explicit length check for cluster and md names

### DIFF
--- a/internal/webhooks/cluster.go
+++ b/internal/webhooks/cluster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -148,6 +149,19 @@ func (webhook *Cluster) ValidateDelete(_ context.Context, obj runtime.Object) er
 
 func (webhook *Cluster) validate(ctx context.Context, oldCluster, newCluster *clusterv1.Cluster) error {
 	var allErrs field.ErrorList
+	// The Cluster name is used as a label value. This check ensures that names which are not valid label values are rejected.
+	if errs := validation.IsValidLabelValue(newCluster.Name); len(errs) != 0 {
+		for _, err := range errs {
+			allErrs = append(
+				allErrs,
+				field.Invalid(
+					field.NewPath("metadata", "name"),
+					newCluster.Name,
+					fmt.Sprintf("must be a valid label value %s", err),
+				),
+			)
+		}
+	}
 	specPath := field.NewPath("spec")
 	if newCluster.Spec.InfrastructureRef != nil && newCluster.Spec.InfrastructureRef.Namespace != newCluster.Namespace {
 		allErrs = append(

--- a/internal/webhooks/cluster_test.go
+++ b/internal/webhooks/cluster_test.go
@@ -409,6 +409,36 @@ func TestClusterValidation(t *testing.T) {
 					WithTopology(&clusterv1.Topology{}).
 					Build(),
 			},
+			{
+				name:      "pass with name of under 63 characters",
+				expectErr: false,
+				in:        builder.Cluster("fooNamespace", "short-name").Build(),
+			},
+			{
+				name:      "pass with _, -, . characters in name",
+				in:        builder.Cluster("fooNamespace", "thisNameContains.A_Non-Alphanumeric").Build(),
+				expectErr: false,
+			},
+			{
+				name:      "fails if cluster name is longer than 63 characters",
+				in:        builder.Cluster("fooNamespace", "thisNameIsReallyMuchLongerThanTheMaximumLengthOfSixtyThreeCharacters").Build(),
+				expectErr: true,
+			},
+			{
+				name:      "error when name starts with NonAlphanumeric character",
+				in:        builder.Cluster("fooNamespace", "-thisNameStartsWithANonAlphanumeric").Build(),
+				expectErr: true,
+			},
+			{
+				name:      "error when name ends with NonAlphanumeric character",
+				in:        builder.Cluster("fooNamespace", "thisNameEndsWithANonAlphanumeric.").Build(),
+				expectErr: true,
+			},
+			{
+				name:      "error when name contains invalid NonAlphanumeric character",
+				in:        builder.Cluster("fooNamespace", "thisNameContainsInvalid!@NonAlphanumerics").Build(),
+				expectErr: true,
+			},
 		}
 	)
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

This is a manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/7712