### PR TITLE
🌱 Fix verify-shellcheck script and fix findings

### DIFF
--- a/hack/ensure-golangci-lint.sh
+++ b/hack/ensure-golangci-lint.sh
@@ -167,6 +167,8 @@ echoerr() {
   echo "$@" 1>&2
 }
 log_prefix() {
+  # Invoked indirectly
+  # shellcheck disable=SC2317
   echo "$0"
 }
 _logp=6
@@ -230,7 +232,7 @@ uname_arch() {
     armv6*) arch="armv6" ;;
     armv7*) arch="armv7" ;;
   esac
-  echo ${arch}
+  echo "${arch}"
 }
 uname_os_check() {
   os=$(uname_os)

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -73,7 +73,7 @@ fi
 
 echo "Running shellcheck..."
 cd "${ROOT_PATH}" || exit
-IGNORE_FILES=$(find . -name "*.sh" | grep "tilt_modules")
+IGNORE_FILES=$(find . -name "*.sh" | { grep "tilt_modules" || true; })
 echo "Ignoring shellcheck on ${IGNORE_FILES}"
 FILES=$(find . -name "*.sh" -not -path "./tilt_modules/*")
 while read -r file; do


### PR DESCRIPTION
**What this PR does / why we need it**:

The verify-shellcheck script exited after grep didn't find any matches. This fix enables the script to continue. 

Also fixes the findings that causes the pr #7749 to fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
