### PR TITLE
:bug: Add deterministic prefix and suffix to label hash

### DIFF
--- a/internal/labels/helpers.go
+++ b/internal/labels/helpers.go
@@ -19,6 +19,7 @@ package labels
 
 import (
 	"encoding/base64"
+	"fmt"
 	"hash/fnv"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -41,7 +42,7 @@ func MustFormatValue(str string) string {
 		// If this changes in a future go version this function will panic.
 		panic(err)
 	}
-	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(hasher.Sum(nil))
+	return fmt.Sprintf("hash_%s_z", base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(hasher.Sum(nil)))
 }
 
 // MustEqualValue returns true if the actualLabelValue equals either the inputLabelValue or the hashed

--- a/internal/labels/helpers_test.go
+++ b/internal/labels/helpers_test.go
@@ -37,7 +37,7 @@ func TestNameLabelValue(t *testing.T) {
 		{
 			name:           "return  for a name with more than 63 characters",
 			machineSetName: "machineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetName",
-			want:           "FR_ghQ",
+			want:           "hash_FR_ghQ_z",
 		},
 	}
 	for _, tt := range tests {
@@ -71,13 +71,13 @@ func TestMustMatchLabelValueForName(t *testing.T) {
 		{
 			name:           "don't match labels when MachineSet name is long",
 			machineSetName: "machineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetName",
-			labelValue:     "Nx4RdE",
+			labelValue:     "hash_Nx4RdE_z",
 			want:           false,
 		},
 		{
 			name:           "match labels when MachineSet name is long",
 			machineSetName: "machineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetNamemachineSetName",
-			labelValue:     "FR_ghQ",
+			labelValue:     "hash_FR_ghQ_z",
 			want:           true,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Add a deterministic suffix and prefix to the label hash to signal it is a hash value and ensure it always follows validity rules.