### PR TITLE
📖 book: add download links for all clusterctl architectures to quick start

### DIFF
--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -154,10 +154,23 @@ The clusterctl CLI tool handles the lifecycle of a Cluster API management cluste
 {{#tab Linux}}
 
 #### Install clusterctl binary with curl on Linux
-Download the latest release; on Linux, type:
+If you are unsure you can determine your computers architecture by running `uname -a`
+
+Download for AMD64:
 ```bash
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-amd64" version:"1.3.x"}} -o clusterctl
 ```
+
+Download for ARM64:
+```bash
+curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-arm64" version:"1.3.x"}} -o clusterctl
+```
+
+Download for PPC64LE:
+```bash
+curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-linux-ppc64le" version:"1.3.x"}} -o clusterctl
+```
+
 Install clusterctl:
 ```bash
 sudo install -o root -g root -m 0755 clusterctl /usr/local/bin/clusterctl
@@ -171,12 +184,14 @@ clusterctl version
 {{#tab macOS}}
 
 #### Install clusterctl binary with curl on macOS
-Download the latest release; on macOS, type:
+If you are unsure you can determine your computers architecture by running `uname -a`
+
+Download for AMD64:
 ```bash
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-amd64" version:"1.3.x"}} -o clusterctl
 ```
 
-Or if your Mac has an M1 CPU ("Apple Silicon"):
+Download for M1 CPU ("Apple Silicon") / ARM64:
 ```bash
 curl -L {{#releaselink gomodule:"sigs.k8s.io/cluster-api" asset:"clusterctl-darwin-arm64" version:"1.3.x"}} -o clusterctl
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds all architectures ([listed in Makefile](https://github.com/kubernetes-sigs/cluster-api/blob/97573c15810fc2ae279d7d44e788139307dc9432/Makefile#L911-L917)) to the Quick Start docs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
