### PR TITLE
✨ clusterctl: add command groups

### DIFF
--- a/cmd/clusterctl/cmd/alpha.go
+++ b/cmd/clusterctl/cmd/alpha.go
@@ -21,9 +21,10 @@ import (
 )
 
 var alphaCmd = &cobra.Command{
-	Use:   "alpha",
-	Short: "Commands for features in alpha",
-	Long:  `These commands correspond to alpha features in clusterctl.`,
+	Use:     "alpha",
+	GroupID: groupOther,
+	Short:   "Commands for features in alpha",
+	Long:    `These commands correspond to alpha features in clusterctl.`,
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/backup.go
+++ b/cmd/clusterctl/cmd/backup.go
@@ -33,8 +33,9 @@ type backupOptions struct {
 var buo = &backupOptions{}
 
 var backupCmd = &cobra.Command{
-	Use:   "backup",
-	Short: "Backup Cluster API objects and all dependencies from a management cluster",
+	Use:     "backup",
+	GroupID: groupManagement,
+	Short:   "Backup Cluster API objects and all dependencies from a management cluster",
 	Long: LongDesc(`
 		Backup Cluster API objects and all dependencies from a management cluster.`),
 

--- a/cmd/clusterctl/cmd/completion.go
+++ b/cmd/clusterctl/cmd/completion.go
@@ -80,6 +80,7 @@ var (
 
 	completionCmd = &cobra.Command{
 		Use:     "completion [bash|zsh]",
+		GroupID: groupOther,
 		Short:   "Output shell completion code for the specified shell (bash or zsh)",
 		Long:    LongDesc(completionLong),
 		Example: completionExample,

--- a/cmd/clusterctl/cmd/config.go
+++ b/cmd/clusterctl/cmd/config.go
@@ -21,9 +21,10 @@ import (
 )
 
 var configCmd = &cobra.Command{
-	Use:   "config",
-	Short: "Display clusterctl configuration",
-	Long:  `Display clusterctl configuration.`,
+	Use:     "config",
+	GroupID: groupOther,
+	Short:   "Display clusterctl configuration",
+	Long:    `Display clusterctl configuration.`,
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/delete.go
+++ b/cmd/clusterctl/cmd/delete.go
@@ -40,8 +40,9 @@ type deleteOptions struct {
 var dd = &deleteOptions{}
 
 var deleteCmd = &cobra.Command{
-	Use:   "delete [providers]",
-	Short: "Delete one or more providers from the management cluster",
+	Use:     "delete [providers]",
+	GroupID: groupManagement,
+	Short:   "Delete one or more providers from the management cluster",
 	Long: LongDesc(`
 		Delete one or more providers from the management cluster.`),
 

--- a/cmd/clusterctl/cmd/describe.go
+++ b/cmd/clusterctl/cmd/describe.go
@@ -21,9 +21,10 @@ import (
 )
 
 var describeCmd = &cobra.Command{
-	Use:   "describe",
-	Short: "Describe workload clusters",
-	Long:  `Describe the status of workload clusters.`,
+	Use:     "describe",
+	GroupID: groupDebug,
+	Short:   "Describe workload clusters",
+	Long:    `Describe the status of workload clusters.`,
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/generate.go
+++ b/cmd/clusterctl/cmd/generate.go
@@ -21,9 +21,10 @@ import (
 )
 
 var generateCmd = &cobra.Command{
-	Use:   "generate",
-	Short: "Generate yaml using clusterctl yaml processor",
-	Long:  `Generate yaml using clusterctl yaml processor.`,
+	Use:     "generate",
+	GroupID: groupManagement,
+	Short:   "Generate yaml using clusterctl yaml processor",
+	Long:    `Generate yaml using clusterctl yaml processor.`,
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/get.go
+++ b/cmd/clusterctl/cmd/get.go
@@ -21,9 +21,10 @@ import (
 )
 
 var getCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get info from a management or workload cluster",
-	Long:  `Get info from a management or workload cluster`,
+	Use:     "get",
+	GroupID: groupManagement,
+	Short:   "Get info from a management or workload cluster",
+	Long:    `Get info from a management or workload cluster`,
 }
 
 func init() {

--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -44,8 +44,9 @@ type initOptions struct {
 var initOpts = &initOptions{}
 
 var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize a management cluster",
+	Use:     "init",
+	GroupID: groupManagement,
+	Short:   "Initialize a management cluster",
 	Long: LongDesc(`
 		Initialize a management cluster.
 

--- a/cmd/clusterctl/cmd/move.go
+++ b/cmd/clusterctl/cmd/move.go
@@ -37,8 +37,9 @@ type moveOptions struct {
 var mo = &moveOptions{}
 
 var moveCmd = &cobra.Command{
-	Use:   "move",
-	Short: "Move Cluster API objects and all dependencies between management clusters",
+	Use:     "move",
+	GroupID: groupManagement,
+	Short:   "Move Cluster API objects and all dependencies between management clusters",
 	Long: LongDesc(`
 		Move Cluster API objects and all dependencies between management clusters.
 

--- a/cmd/clusterctl/cmd/restore.go
+++ b/cmd/clusterctl/cmd/restore.go
@@ -32,8 +32,9 @@ type restoreOptions struct {
 var ro = &restoreOptions{}
 
 var restoreCmd = &cobra.Command{
-	Use:   "restore",
-	Short: "Restore Cluster API objects from file by glob. Object files are searched in config directory",
+	Use:     "restore",
+	GroupID: groupManagement,
+	Short:   "Restore Cluster API objects from file by glob. Object files are searched in config directory",
 	Long: LongDesc(`
 		Restore Cluster API objects from file by glob. Object files are searched in the default config directory
 		or in the provided directory.`),

--- a/cmd/clusterctl/cmd/root.go
+++ b/cmd/clusterctl/cmd/root.go
@@ -37,6 +37,12 @@ type stackTracer interface {
 	StackTrace() errors.StackTrace
 }
 
+const (
+	groupDebug      = "group-debug"
+	groupManagement = "group-management"
+	groupOther      = "group-other"
+)
+
 var (
 	cfgFile   string
 	verbosity *int
@@ -117,6 +123,23 @@ func init() {
 	RootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
 		"Path to clusterctl configuration (default is `$HOME/.cluster-api/clusterctl.yaml`) or to a remote location (i.e. https://example.com/clusterctl.yaml)")
+
+	RootCmd.AddGroup(
+		&cobra.Group{
+			ID:    groupManagement,
+			Title: "Cluster Management Commands:",
+		},
+		&cobra.Group{
+			ID:    groupDebug,
+			Title: "Troubleshooting and Debugging Commands:",
+		},
+		&cobra.Group{
+			ID:    groupOther,
+			Title: "Other Commands:",
+		})
+
+	RootCmd.SetHelpCommandGroupID(groupOther)
+	RootCmd.SetCompletionCommandGroupID(groupOther)
 
 	cobra.OnInitialize(initConfig, registerCompletionFuncForCommonFlags)
 }

--- a/cmd/clusterctl/cmd/upgrade.go
+++ b/cmd/clusterctl/cmd/upgrade.go
@@ -25,9 +25,10 @@ import (
 )
 
 var upgradeCmd = &cobra.Command{
-	Use:   "upgrade",
-	Short: "Upgrade core and provider components in a management cluster",
-	Args:  cobra.NoArgs,
+	Use:     "upgrade",
+	GroupID: groupManagement,
+	Short:   "Upgrade core and provider components in a management cluster",
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	},

--- a/cmd/clusterctl/cmd/version.go
+++ b/cmd/clusterctl/cmd/version.go
@@ -39,9 +39,10 @@ type versionOptions struct {
 var vo = &versionOptions{}
 
 var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print clusterctl version",
-	Args:  cobra.NoArgs,
+	Use:     "version",
+	GroupID: groupOther,
+	Short:   "Print clusterctl version",
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runVersion()
 	},


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the clusterctl command overview by grouping the commands. I opted to create two groups: "Management commands" and "Other commands". **I welcome any feedback regarding the names.**

This feature would also allow the flattening of the command structure in the future. For example the alpha commands could be placed under a "Alpha commands" group and displayed immediately under the help command. 

New clusterctl output:
```
Cluster Management Commands:
  delete      Delete one or more providers from the management cluster
  generate    Generate yaml using clusterctl yaml processor
  get         Get info from a management or workload cluster
  init        Initialize a management cluster
  move        Move Cluster API objects and all dependencies between management clusters
  upgrade     Upgrade core and provider components in a management cluster

Troubleshooting and Debugging Commands:
  describe    Describe workload clusters

Other Commands:
  alpha       Commands for features in alpha
  completion  Output shell completion code for the specified shell (bash or zsh)
  config      Display clusterctl configuration
  help        Help about any command
  version     Print clusterctl version
```

Old clusterctl output:
```
Available Commands:
  alpha       Commands for features in alpha.
  backup      Backup Cluster API objects and all dependencies from a management cluster.
  completion  Output shell completion code for the specified shell (bash or zsh)
  config      Display clusterctl configuration.
  delete      Delete one or more providers from the management cluster.
  describe    Describe workload clusters.
  generate    Generate yaml using clusterctl yaml processor.
  get         Get info from a management or a workload cluster
  help        Help about any command
  init        Initialize a management cluster.
  move        Move Cluster API objects and all dependencies between management clusters.
  restore     Restore Cluster API objects from file by glob. Object files are searched in config directory
  upgrade     Upgrade core and provider components in a management cluster.
  version     Print clusterctl version.
```
