### PR TITLE
🐛 [release-1.1] Explicitly use registry.k8s.io as registry for e2e tests.

### DIFF
--- a/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
@@ -207,6 +207,7 @@ spec:
         nodeDrainTimeout: 1s
       kubeadmConfigSpec:
         clusterConfiguration:
+          imageRepository: registry.k8s.io
           controllerManager:
             extraArgs: { enable-hostpath-provisioner: 'true' }
           apiServer:


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

kubeadm's handling of the Kubernetes registry changed in a recent release breaking our e2e tests. This should fix the tests for release-1.1

Fixes: #7768 
