### PR TITLE
:seedling: Cleanup special handling for tilt_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,6 @@ vendor
 tilt.d
 tilt-settings.json
 tilt-settings.yaml
-tilt_modules
 .tiltbuild
 
 # User-supplied clusterctl hacks settings

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -150,7 +150,7 @@ def file_passes(filename, refs, regexs):
 def file_extension(filename):
     return os.path.splitext(filename)[1].split(".")[-1].lower()
 
-skipped_dirs = ['tilt_modules', '_gopath', '_output', '.git', 'cluster/env.sh',
+skipped_dirs = ['_gopath', '_output', '.git', 'cluster/env.sh',
                 "vendor", "test/e2e/generated/bindata.go", "hack/boilerplate/test",
                 "staging/src/k8s.io/kubectl/pkg/generated/bindata.go"]
 

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -73,9 +73,7 @@ fi
 
 echo "Running shellcheck..."
 cd "${ROOT_PATH}" || exit
-IGNORE_FILES=$(find . -name "*.sh" | { grep "tilt_modules" || true; })
-echo "Ignoring shellcheck on ${IGNORE_FILES}"
-FILES=$(find . -name "*.sh" -not -path "./tilt_modules/*")
+FILES=$(find . -name "*.sh")
 while read -r file; do
     "$SHELLCHECK" -x "$file" >> "${OUT}" 2>&1
 done <<< "$FILES"


### PR DESCRIPTION
Signed-off-by: Chirayu Kapoor <dev.csociety@gmail.com>

**What this PR does / why we need it**:
Clean up special handling for the tilt_modules folder as there is no more tilt_modules folder in the project.

**Which issue(s) this PR fixes**
Fixes https://github.com/kubernetes-sigs/cluster-api/issues/7773
