### PR TITLE
📖 docs: add instructions for tilt with local registry

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -55,6 +55,9 @@ If you prefer JSON, you can create a `tilt-settings.json` file instead. YAML wil
 
 </aside>
 
+### Using a local image registry
+You can use with a local registry on your machine. Such a registry can be created by running `make kind-cluster`. You can then configure `default_registry: localhost:5000` in your `tilt-settings.json` file.
+
 #### tilt-settings fields
 
 **allowed_contexts** (Array, default=[]): A list of kubeconfig contexts Tilt is allowed to use. See the Tilt documentation on


### PR DESCRIPTION
**What this PR does / why we need it**:

Added instructions how to use tilt with local registry. By avoiding network pushes the iterations can be much faster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
