### PR TITLE
🌱 Add failing/flaking test issue templates to the repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/failing-test.md
+++ b/.github/ISSUE_TEMPLATE/failing-test.md
@@ -1,0 +1,26 @@
+---
+name: 🚨 Failing Test
+about: Report continuously failing tests or jobs in Cluster API CI
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- Please only use this template for submitting reports about continuously failing tests or jobs in Cluster API CI -->
+
+**Which jobs are failing:**
+
+**Which tests are failing:**
+
+**Since when has it been failing:**
+
+**Testgrid link:**
+
+**Reason for failure (if possible):**
+
+**Anything else we need to know:**
+
+/kind failing-test
+
+[One or more /area label. See https://github.com/kubernetes-sigs/cluster-api/labels?q=area for the list of labels]

--- a/.github/ISSUE_TEMPLATE/flaking-test.md
+++ b/.github/ISSUE_TEMPLATE/flaking-test.md
@@ -1,0 +1,27 @@
+---
+name: ❄️ Flaking Test
+about: Report flaky tests or jobs in Cluster API CI
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- Please only use this template for submitting reports about flaky tests or jobs (pass or fail with no underlying change in code) in Cluster API CI -->
+
+**Which jobs are flaking:**
+
+**Which tests are flaking:**
+
+**Testgrid link:**
+
+**Reason for failure (if possible):**
+
+**Anything else we need to know:**
+- links to go.k8s.io/triage appreciated
+- links to specific failures in spyglass appreciated
+
+
+/kind flake
+
+[One or more /area label. See https://github.com/kubernetes-sigs/cluster-api/labels?q=area for the list of labels]

--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -383,8 +383,9 @@ The goal of this task is to keep our tests running in CI stable.
 1. Add yourself to the [Cluster API alert mailing list](https://github.com/kubernetes/k8s.io/blob/151899b2de933e58a4dfd1bfc2c133ce5a8bbe22/groups/sig-cluster-lifecycle/groups.yaml#L20-L35)
     <br\>**Note**: An alternative to the alert mailing list is manually monitoring the [testgrid dashboards](https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api)
     (also dashboards of previous releases). Using the alert mailing list has proven to be a lot less effort though.
-2. Triage CI failures reported by mail alerts or found by monitoring the testgrid dashboards:
-    1. Create an issue in the Cluster API repository to surface the CI failure.
+2. Check the existing **failing-test** and **flaking-test** issue templates under `.github/ISSUE_TEMPLATE/` folder of the repo, used to create an issue for failing or flaking tests respectively. Please make sure they are up-to-date and if not, send a PR to update or improve them.
+3. Triage CI failures reported by mail alerts or found by monitoring the testgrid dashboards:
+    1. Create an issue using an appropriate template (failing-test) in the Cluster API repository to surface the CI failure.
     2. Identify if the issue is a known issue, new issue or a regression.
     3. Mark the issue as `release-blocking` if applicable.
 
@@ -398,7 +399,7 @@ To reduce the amount of flakes please periodically:
     * [periodic-cluster-api-e2e-mink8s-main](https://storage.googleapis.com/k8s-triage/index.html?pr=1&job=periodic-cluster-api-e2e-mink8s-main)
     * [periodic-cluster-api-test-main](https://storage.googleapis.com/k8s-triage/index.html?pr=1&job=periodic-cluster-api-test-main)
     * [periodic-cluster-api-test-mink8s-main](https://storage.googleapis.com/k8s-triage/index.html?pr=1&job=periodic-cluster-api-test-mink8s-main)
-3. Open issues for occurring flakes and ideally fix them or find someone who can.
+2. Open issues using an appropriate template (flaking-test) for occurring flakes and ideally fix them or find someone who can.
    **Note**: Given resource limitations in the Prow cluster it might not be possible to fix all flakes.
    Let's just try to pragmatically keep the amount of flakes pretty low.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
While we can still modify existing issue templates when reporting CI related issues, it would be very helpful if we could have issue templates ready while opening `failing/flaking test` issues in the repository (especially handy for relase team CI signal members) similar to the one used in the k8s repo, as  IMO it helps to:

-  gather all the required and additional information needed to tackle the issue regardless of whoever opens it
-  standardize the issues of the same kind in the future   

**Note:**  I am still using the markdown formatted issue templates for new failing/flaking-test templates in this PR but we have a possibility to move all existing templates from markdown format to [GitHub forms for issue templates ](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) which basically YAML representation of the template. 
Example issue template in kubernetes repo to get the idea how it looks like: https://github.com/kubernetes/kubernetes/issues/new?assignees=&labels=kind%2Ffailing-test&template=failing-test.yaml
k/k repo has already switched to the GitHub forms in https://github.com/kubernetes/kubernetes/pull/104468. We can replace all templates with the GitHub forms if agreed and if not we could still stick to the markdown format as well (since the feature itself seems still in beta). 