### PR TITLE
🌱 Cluster topology: fix comment about MD replicas defaulting

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -171,7 +171,7 @@ type MachineDeploymentTopology struct {
 	FailureDomain *string `json:"failureDomain,omitempty"`
 
 	// Replicas is the number of worker nodes belonging to this set.
-	// If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero)
+	// If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to 1)
 	// and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
 	// of this value.
 	// +optional

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -1794,7 +1794,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentTopology(ref comm
 					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Replicas is the number of worker nodes belonging to this set. If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero) and it's assumed that an external entity (like cluster autoscaler) is responsible for the management of this value.",
+							Description: "Replicas is the number of worker nodes belonging to this set. If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to 1) and it's assumed that an external entity (like cluster autoscaler) is responsible for the management of this value.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1251,8 +1251,8 @@ spec:
                               description: Replicas is the number of worker nodes
                                 belonging to this set. If the value is nil, the MachineDeployment
                                 is created without the number of Replicas (defaulting
-                                to zero) and it's assumed that an external entity
-                                (like cluster autoscaler) is responsible for the management
+                                to 1) and it's assumed that an external entity (like
+                                cluster autoscaler) is responsible for the management
                                 of this value.
                               format: int32
                               type: integer

--- a/docs/proposals/20210526-cluster-class-and-managed-topologies.md
+++ b/docs/proposals/20210526-cluster-class-and-managed-topologies.md
@@ -607,7 +607,7 @@ Note: Builtin variables are defined in [Builtin variables](#builtin-variables) b
       Name string `json:"name"`
 
       // The number of worker nodes belonging to this set.
-      // If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero)
+      // If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to 1)
       // and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
       // of this value.
       // +optional

--- a/docs/proposals/images/runtime-hooks/runtime-hooks-openapi.yaml
+++ b/docs/proposals/images/runtime-hooks/runtime-hooks-openapi.yaml
@@ -525,7 +525,7 @@ components:
         replicas:
           description: Replicas is the number of worker nodes belonging to this set.
             If the value is nil, the MachineDeployment is created without the number
-            of Replicas (defaulting to zero) and it's assumed that an external entity
+            of Replicas (defaulting to 1) and it's assumed that an external entity
             (like cluster autoscaler) is responsible for the management of this value.
           format: int32
           type: integer


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR updates the godoc comment of the MD replicas field in Cluster.spec.topology to reflect hat we are actually defautling to 1 and not 0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
