### PR TITLE
✨ Emit Kubernetes Events when Cluster Phase, ControlPlaneReady, or InfrastructureReady change

### DIFF
--- a/internal/controllers/cluster/cluster_controller.go
+++ b/internal/controllers/cluster/cluster_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -331,6 +332,7 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, cluster *clusterv1.Clu
 	}
 
 	controllerutil.RemoveFinalizer(cluster, clusterv1.ClusterFinalizer)
+	r.recorder.Eventf(cluster, corev1.EventTypeNormal, "Deleted", "Cluster %s has been deleted", cluster.Name)
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controllers/cluster/cluster_controller_phases.go
+++ b/internal/controllers/cluster/cluster_controller_phases.go
@@ -42,6 +42,8 @@ import (
 )
 
 func (r *Reconciler) reconcilePhase(_ context.Context, cluster *clusterv1.Cluster) {
+	preReconcilePhase := cluster.Status.GetTypedPhase()
+
 	if cluster.Status.Phase == "" {
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhasePending)
 	}
@@ -60,6 +62,16 @@ func (r *Reconciler) reconcilePhase(_ context.Context, cluster *clusterv1.Cluste
 
 	if !cluster.DeletionTimestamp.IsZero() {
 		cluster.Status.SetTypedPhase(clusterv1.ClusterPhaseDeleting)
+	}
+
+	// Only record the event if the status has changed
+	if preReconcilePhase != cluster.Status.GetTypedPhase() {
+		// Failed clusters should get a Warning event
+		if cluster.Status.GetTypedPhase() == clusterv1.ClusterPhaseFailed {
+			r.recorder.Eventf(cluster, corev1.EventTypeWarning, string(cluster.Status.GetTypedPhase()), "Cluster %s is %s: %s", cluster.Name, string(cluster.Status.GetTypedPhase()), pointer.StringDeref(cluster.Status.FailureMessage, "unknown"))
+		} else {
+			r.recorder.Eventf(cluster, corev1.EventTypeNormal, string(cluster.Status.GetTypedPhase()), "Cluster %s is %s", cluster.Name, string(cluster.Status.GetTypedPhase()))
+		}
 	}
 }
 
@@ -163,11 +175,16 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, cluster *clust
 	}
 
 	// Determine if the infrastructure provider is ready.
+	preReconcileInfrastructureReady := cluster.Status.InfrastructureReady
 	ready, err := external.IsReady(infraConfig)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	cluster.Status.InfrastructureReady = ready
+	// Only record the event if the status has changed
+	if preReconcileInfrastructureReady != cluster.Status.InfrastructureReady {
+		r.recorder.Eventf(cluster, corev1.EventTypeNormal, "InfrastructureReady", "Cluster %s InfrastructureReady is now %t", cluster.Name, cluster.Status.InfrastructureReady)
+	}
 
 	// Report a summary of current status of the infrastructure object defined for this cluster.
 	conditions.SetMirror(cluster, clusterv1.InfrastructureReadyCondition,
@@ -225,12 +242,17 @@ func (r *Reconciler) reconcileControlPlane(ctx context.Context, cluster *cluster
 		return ctrl.Result{}, nil
 	}
 
+	preReconcileControlPlaneReady := cluster.Status.ControlPlaneReady
 	// Determine if the control plane provider is ready.
 	ready, err := external.IsReady(controlPlaneConfig)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	cluster.Status.ControlPlaneReady = ready
+	// Only record the event if the status has changed
+	if preReconcileControlPlaneReady != cluster.Status.ControlPlaneReady {
+		r.recorder.Eventf(cluster, corev1.EventTypeNormal, "ControlPlaneReady", "Cluster %s ControlPlaneReady is now %t", cluster.Name, cluster.Status.ControlPlaneReady)
+	}
 
 	// Report a summary of current status of the control plane object defined for this cluster.
 	conditions.SetMirror(cluster, clusterv1.ControlPlaneReadyCondition,

--- a/internal/controllers/cluster/cluster_controller_phases_test.go
+++ b/internal/controllers/cluster/cluster_controller_phases_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -136,7 +137,8 @@ func TestClusterReconcilePhases(t *testing.T) {
 						Build()
 				}
 				r := &Reconciler{
-					Client: c,
+					Client:   c,
+					recorder: record.NewFakeRecorder(32),
 				}
 
 				res, err := r.reconcileInfrastructure(ctx, tt.cluster)
@@ -215,7 +217,8 @@ func TestClusterReconcilePhases(t *testing.T) {
 						Build()
 				}
 				r := &Reconciler{
-					Client: c,
+					Client:   c,
+					recorder: record.NewFakeRecorder(32),
 				}
 				res, err := r.reconcileKubeconfig(ctx, tt.cluster)
 				if tt.wantErr {
@@ -364,7 +367,8 @@ func TestClusterReconciler_reconcilePhase(t *testing.T) {
 				Build()
 
 			r := &Reconciler{
-				Client: c,
+				Client:   c,
+				recorder: record.NewFakeRecorder(32),
 			}
 			r.reconcilePhase(ctx, tt.cluster)
 			g.Expect(tt.cluster.Status.GetTypedPhase()).To(Equal(tt.wantPhase))
@@ -479,7 +483,8 @@ func TestClusterReconcilePhases_reconcileFailureDomains(t *testing.T) {
 			}
 
 			r := &Reconciler{
-				Client: fake.NewClientBuilder().WithObjects(objs...).Build(),
+				Client:   fake.NewClientBuilder().WithObjects(objs...).Build(),
+				recorder: record.NewFakeRecorder(32),
 			}
 
 			_, err := r.reconcileInfrastructure(ctx, tt.cluster)


### PR DESCRIPTION
**What this PR does / why we need it**:

Emit Kubernetes Events when Cluster `status.Phase`, `status.ControlPlaneReady`, or `status.InfrastructureReady` change and when the Cluster is deleted.

**Which issue(s) this PR fixes**:
relates to #7424 (but does not resolve it)

Output of events:

```
$> kubectl get cluster
NAME      PHASE          AGE   VERSION
tge-aks   Provisioning   13s   

$> kubectl get events --sort-by=.metadata.creationTimestamp
LAST SEEN   TYPE     REASON         OBJECT            MESSAGE
19s         Normal   Provisioning   cluster/tge-aks   Cluster is Provisioning

$> kubectl get events --sort-by=.metadata.creationTimestamp
LAST SEEN   TYPE     REASON                OBJECT            MESSAGE
52s         Normal   Provisioning          cluster/tge-aks   Cluster is Provisioning
22s         Normal   InfrastructureReady   cluster/tge-aks   Cluster InfrastructureReady is now true

$> kubectl get events --sort-by=.metadata.creationTimestamp
LAST SEEN   TYPE     REASON                OBJECT            MESSAGE
4m16s       Normal   Provisioning          cluster/tge-aks   Cluster is Provisioning
3m46s       Normal   InfrastructureReady   cluster/tge-aks   Cluster InfrastructureReady is now true
6s          Normal   ControlPlaneReady     cluster/tge-aks   Cluster ControlPlaneReady is now true

$> kubectl get events --sort-by=.metadata.creationTimestamp
LAST SEEN   TYPE     REASON                  OBJECT               MESSAGE
4m33s       Normal   Provisioning            cluster/tge-aks      Cluster is Provisioning
4m3s        Normal   InfrastructureReady     cluster/tge-aks      Cluster InfrastructureReady is now true
23s         Normal   ControlPlaneReady       cluster/tge-aks      Cluster ControlPlaneReady is now true
13s         Normal   Provisioned             cluster/tge-aks      Cluster is Provisioned

$> kubectl get cluster tge-aks                             
NAME      PHASE         AGE     VERSION
tge-aks   Provisioned   4m49s   

$> kubectl delete cluster tge-aks
cluster.cluster.x-k8s.io "tge-aks" deleted

$> kubectl get events --sort-by=.metadata.creationTimestamp
LAST SEEN   TYPE     REASON                  OBJECT               MESSAGE
11m         Normal   Provisioning            cluster/tge-aks      Cluster is Provisioning
10m         Normal   InfrastructureReady     cluster/tge-aks      Cluster InfrastructureReady is now true
7m          Normal   ControlPlaneReady       cluster/tge-aks      Cluster ControlPlaneReady is now true
6m50s       Normal   Provisioned             cluster/tge-aks      Cluster is Provisioned
6m47s       Normal   SuccessfulSetNodeRefs   machinepool/system   [{Kind: Namespace: Name:aks-system-21404556-vmss000000 UID:1e467b71-25e5-4a17-a6a6-6ff4f0533683 APIVersion: ResourceVersion: FieldPath:}]
6m47s       Normal   SuccessfulSetNodeRefs   machinepool/worker   [{Kind: Namespace: Name:aks-worker-21404556-vmss000000 UID:469773bb-8a74-42b4-93ad-281fdd3589d3 APIVersion: ResourceVersion: FieldPath:}]
15s         Normal   Deleting                cluster/tge-aks      Cluster is Deleting

$> kubectl get events --sort-by=.metadata.creationTimestamp
LAST SEEN   TYPE     REASON                  OBJECT               MESSAGE
17m         Normal   Provisioning            cluster/tge-aks      Cluster is Provisioning
16m         Normal   InfrastructureReady     cluster/tge-aks      Cluster InfrastructureReady is now true
13m         Normal   ControlPlaneReady       cluster/tge-aks      Cluster ControlPlaneReady is now true
12m         Normal   Provisioned             cluster/tge-aks      Cluster is Provisioned
12m         Normal   SuccessfulSetNodeRefs   machinepool/system   [{Kind: Namespace: Name:aks-system-21404556-vmss000000 UID:1e467b71-25e5-4a17-a6a6-6ff4f0533683 APIVersion: ResourceVersion: FieldPath:}]
12m         Normal   SuccessfulSetNodeRefs   machinepool/worker   [{Kind: Namespace: Name:aks-worker-21404556-vmss000000 UID:469773bb-8a74-42b4-93ad-281fdd3589d3 APIVersion: ResourceVersion: FieldPath:}]
6m23s       Normal   Deleting                cluster/tge-aks      Cluster is Deleting
11s         Normal   Deleted                 cluster/tge-aks      Cluster has been deleted
```

Note: In this example, the `SuccessfulSetNodeRefs` events were already being emitted by Cluster API.

I will be doing a follow-up PR for the remaining aspects of https://github.com/kubernetes-sigs/cluster-api/issues/7424 as it will involve more work and potential coordination with the Cluster API Providers.