### PR TITLE
[release-1.1] :bug: Remove registry defaulting from e2e tests

### DIFF
--- a/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1beta1/clusterclass-quick-start.yaml
@@ -38,7 +38,7 @@ spec:
     schema:
       openAPIV3Schema:
         type: string
-        default: "k8s.gcr.io"
+        default: ""
         example: "k8s.gcr.io"
         description: "imageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default."
   - name: etcdImageTag

--- a/test/framework/daemonset_helpers.go
+++ b/test/framework/daemonset_helpers.go
@@ -44,7 +44,11 @@ func WaitForKubeProxyUpgrade(ctx context.Context, input WaitForKubeProxyUpgradeI
 		if err := input.Getter.Get(ctx, client.ObjectKey{Name: "kube-proxy", Namespace: metav1.NamespaceSystem}, ds); err != nil {
 			return false, err
 		}
-		if ds.Spec.Template.Spec.Containers[0].Image == "k8s.gcr.io/kube-proxy:"+containerutil.SemverToOCIImageTag(input.KubernetesVersion) {
+		image, err := containerutil.ImageFromString(ds.Spec.Template.Spec.Containers[0].Image)
+		if err != nil {
+			return false, err
+		}
+		if image.Name == "kube-proxy" && image.Tag == containerutil.SemverToOCIImageTag(input.KubernetesVersion) {
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Remove setting of the registry in the 1.1 CAPI e2e tests. 

Fixes #7768 
