### PR TITLE
⚠️ Use Kubernetes 1.26 in Quick Start docs and CAPD.

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes_bump.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes_bump.md
@@ -17,8 +17,8 @@ Prerequisites:
 
 ### Supporting managing and running on the new Kubernetes version
 
-This section contains tasks to update our book, e2e testing and CI to use and test the new Kubernetes version 
-as well as changes to Cluster API that we might have to make to support the new Kubernetes version. All of these 
+This section contains tasks to update our book, e2e testing and CI to use and test the new Kubernetes version
+as well as changes to Cluster API that we might have to make to support the new Kubernetes version. All of these
 changes should be cherry-picked to all release series that will support the new Kubernetes version.
 
 * [ ] Modify quickstart and CAPD to use the new Kubernetes release:
@@ -28,8 +28,9 @@ changes should be cherry-picked to all release series that will support the new 
   * Ensure the latest available kind version is used (including the latest images for this kind release)
   * Verify the quickstart manually
   * Prior art: #7156
+  * bump `InitWithKubernetesVersion` in `clusterctl_upgrade_test.go`
 * [ ] Job configurations:
-  * For all releases which will support the new Kubernetes version: 
+  * For all releases which will support the new Kubernetes version:
     * Update `INIT_WITH_KUBERNETES_VERSION`.
     * Add new periodic upgrade jobs .
     * Adjust presubmit jobs so that we have the latest upgrade jobs available on PRs.
@@ -39,12 +40,12 @@ changes should be cherry-picked to all release series that will support the new 
   * Update job documentation in `jobs.md`
   * Prior art: #7194 #7196
 * [ ] Issues specific to the Kubernetes minor release:
-  * Sometimes there are adjustments that we have to make in Cluster API to be able to support 
+  * Sometimes there are adjustments that we have to make in Cluster API to be able to support
     a new Kubernetes minor version. Please add these issues here when they are identified.
 
 ### Using new Kubernetes dependencies
 
-This section contains tasks to update Cluster API to use the latest Kubernetes Go dependencies and related topics 
+This section contains tasks to update Cluster API to use the latest Kubernetes Go dependencies and related topics
 like using the right Go version and build images. These changes are only made on the main branch. We don't
 need them in older releases as they are not necessary to manage workload clusters of the new Kubernetes version or
 run the Cluster API controllers on the new Kubernetes version.
@@ -64,5 +65,5 @@ run the Cluster API controllers on the new Kubernetes version.
   * **Note**: This PR should be cherry-picked as well. It is part of this section as it depends on kubebuilder/controller-runtime
     releases and is not strictly necessary for [Supporting managing and running on the new Kubernetes version](#supporting-managing-and-running-on-the-new-kubernetes-version).
   * Prior art: #7193
-* [ ] Bump conversion-gen via `CONVERSION_GEN_VER` in `Makefile` 
+* [ ] Bump conversion-gen via `CONVERSION_GEN_VER` in `Makefile`
   * Prior art: #7118

--- a/Tiltfile
+++ b/Tiltfile
@@ -3,8 +3,8 @@
 envsubst_cmd = "./hack/tools/bin/envsubst"
 clusterctl_cmd = "./bin/clusterctl"
 kubectl_cmd = "kubectl"
-kubernetes_version = "v1.25.3"
 default_build_engine = "docker"
+kubernetes_version = "v1.26.0"
 
 if str(local("command -v " + kubectl_cmd + " || true", quiet = True)) == "":
     fail("Required command '" + kubectl_cmd + "' not found in PATH")

--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -185,7 +185,7 @@ kustomize_substitutions:
 {{#/tabs }}
 
 **deploy_observability** ([string], default=[]): If set, installs on the dev cluster one of more observability
-tools. 
+tools.
 Important! This feature requires the `helm` command to be available in the user's path.
 
 Supported values are:
@@ -315,7 +315,7 @@ Custom values for variable substitutions can be set using `kustomize_substitutio
 ```yaml
 kustomize_substitutions:
   NAMESPACE: default
-  KUBERNETES_VERSION: v1.25.3
+  KUBERNETES_VERSION: v1.26.0
   CONTROL_PLANE_MACHINE_COUNT: 1
   WORKER_MACHINE_COUNT: 3
 ```

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -675,7 +675,7 @@ export OSC_REGION=<you-region>
 # Create namespace
 kubectl create namespace cluster-api-provider-outscale-system
 # Create secret
-kubectl create secret generic cluster-api-provider-outscale --from-literal=access_key=${OSC_ACCESS_KEY} --from-literal=secret_key=${OSC_SECRET_KEY} --from-literal=region=${OSC_REGION}  -n cluster-api-provider-outscale-system 
+kubectl create secret generic cluster-api-provider-outscale --from-literal=access_key=${OSC_ACCESS_KEY} --from-literal=secret_key=${OSC_SECRET_KEY} --from-literal=region=${OSC_REGION}  -n cluster-api-provider-outscale-system
 # Initialize the management cluster
 clusterctl init --infrastructure outscale
 ```
@@ -1004,7 +1004,7 @@ Please visit the [IBM Cloud provider] for more information.
 export KKZONE=""
 # The ssh name of the all instance Linux user. (e.g. root, ubuntu)
 export USER_NAME=<your-linux-user>
-# The ssh password of the all instance Linux user. 
+# The ssh password of the all instance Linux user.
 export PASSWORD=<your-linux-user-password>
 # The ssh IP address of the all instance. (e.g. "[{address: 192.168.100.3}, {address: 192.168.100.4}]")
 export INSTANCES=<your-linux-ip-address>
@@ -1214,7 +1214,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.25.3 \
+  --kubernetes-version v1.26.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1226,7 +1226,7 @@ clusterctl generate cluster capi-quickstart --flavor development \
 ```bash
 export CLUSTER_NAME=kind
 export CLUSTER_NAMESPACE=vcluster
-export KUBERNETES_VERSION=1.25.0
+export KUBERNETES_VERSION=1.26.0
 export HELM_VALUES="service:\n  type: NodePort"
 
 kubectl create namespace ${CLUSTER_NAMESPACE}
@@ -1257,7 +1257,7 @@ clusterctl generate cluster capi-quickstart \
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.25.3 \
+  --kubernetes-version v1.26.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1317,7 +1317,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                    CLUSTER           INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE    VERSION
-capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.25.3
+capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.26.0
 ```
 
 <aside class="note warning">
@@ -1519,12 +1519,12 @@ kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
 ```
 ```bash
 NAME                                          STATUS   ROLES           AGE   VERSION
-capi-quickstart-g2trk-9xrjv                   Ready    control-plane   12m   v1.25.3
-capi-quickstart-g2trk-bmm9v                   Ready    control-plane   11m   v1.25.3
-capi-quickstart-g2trk-hvs9q                   Ready    control-plane   13m   v1.25.3
-capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          12m   v1.25.3
-capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          12m   v1.25.3
-capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          12m   v1.25.3
+capi-quickstart-g2trk-9xrjv                   Ready    control-plane   12m   v1.26.0
+capi-quickstart-g2trk-bmm9v                   Ready    control-plane   11m   v1.26.0
+capi-quickstart-g2trk-hvs9q                   Ready    control-plane   13m   v1.26.0
+capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          12m   v1.26.0
+capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          12m   v1.26.0
+capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          12m   v1.26.0
 ```
 
 {{#/tab }}

--- a/test/e2e/clusterctl_upgrade_test.go
+++ b/test/e2e/clusterctl_upgrade_test.go
@@ -68,7 +68,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.2=>current)", func() {
 			SkipCleanup:               skipCleanup,
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.7/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
-			InitWithKubernetesVersion: "v1.25.3",
+			InitWithKubernetesVersion: "v1.26.0",
 		}
 	})
 })
@@ -83,7 +83,7 @@ var _ = Describe("When testing clusterctl upgrades (v1.3=>current)", func() {
 			SkipCleanup:               skipCleanup,
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
-			InitWithKubernetesVersion: "v1.25.3",
+			InitWithKubernetesVersion: "v1.26.0",
 		}
 	})
 })
@@ -98,7 +98,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.2=>cur
 			SkipCleanup:               skipCleanup,
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.2.7/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
-			InitWithKubernetesVersion: "v1.25.3",
+			InitWithKubernetesVersion: "v1.26.0",
 			WorkloadFlavor:            "topology",
 		}
 	})
@@ -114,7 +114,7 @@ var _ = Describe("When testing clusterctl upgrades using ClusterClass (v1.3=>cur
 			SkipCleanup:               skipCleanup,
 			InitWithBinary:            "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.3.0/clusterctl-{OS}-{ARCH}",
 			InitWithProvidersContract: "v1beta1",
-			InitWithKubernetesVersion: "v1.25.3",
+			InitWithKubernetesVersion: "v1.26.0",
 			WorkloadFlavor:            "topology",
 		}
 	})

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -254,11 +254,11 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.25.3"
-  KUBERNETES_VERSION: "v1.25.3"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.24.7"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.25.3"
-  ETCD_VERSION_UPGRADE_TO: "3.5.4-0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.26.0"
+  KUBERNETES_VERSION: "v1.26.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.25.3"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.26.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.6-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.9.3"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "IPv4"

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.25.3"
+	DefaultNodeImageVersion = "v1.26.0"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -33,7 +33,7 @@ ENV GOPROXY=$goproxy
 # Gets additional CAPD dependencies
 WORKDIR /tmp
 
-RUN curl -LO "https://dl.k8s.io/release/v1.25.3/bin/linux/${ARCH}/kubectl" && \
+RUN curl -LO "https://dl.k8s.io/release/v1.26.0/bin/linux/${ARCH}/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl
 

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.25.3
+  version: v1.26.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.25.3
+      version: v1.26.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.25.3
+  version: v1.26.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -90,7 +90,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.25.3
+      version: v1.26.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.25.3
+  version: v1.26.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.25.3
+      version: v1.26.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.25.3
+  version: v1.26.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -83,7 +83,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.25.3
+      version: v1.26.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -50,7 +50,7 @@ import (
 
 const (
 	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.25.3"
+	defaultImageTag  = "v1.26.0"
 )
 
 type nodeCreator interface {


### PR DESCRIPTION
Signed-off-by: Aniruddha Basak <codewithaniruddha@gmail.com>

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Updates the Quick Start guide to use Kubernetes 1.26.
Part of #7671

cc @kubernetes-sigs/cluster-api-release-team