### PR TITLE
:book: docs/tilt: fix duplicate key in tilt-provider.yaml

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -354,7 +354,6 @@ A provider must supply a `tilt-provider.yaml` file describing how to build it. H
 name: aws
 config:
   image: "gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller",
-  label: CAPA
   live_reload_deps: ["main.go", "go.mod", "go.sum", "api", "cmd", "controllers", "pkg"]
   label: CAPA
 ```


### PR DESCRIPTION
Signed-off-by: Benjamin Gentil <benjamin.gentil@infomaniak.com>

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: this fixes a duplicate key in the `tilt-provider.yaml` example

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
