### PR TITLE
[release-1.2] 🌱 Bump actions/cache from 3.0.4 to 3.2.1

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -31,7 +31,7 @@ jobs:
         path: './src/sigs.k8s.io/cluster-api'
     - name: Set env
       run:  echo "GOPATH=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
-    - uses: actions/cache@v3.0.4
+    - uses: actions/cache@c1a5de879eb890d062a85ee0252d6036480b1fe2 # tag=v3.2.1
       name: Restore go cache
       with:
         path: |


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubernetes-sigs/cluster-api/pull/7805

Bumps [actions/cache](https://github.com/actions/cache) from 3.0.11 to 3.2.1.
