### PR TITLE
⚠️ Removing deprecated healthcheck condition

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -136,12 +136,6 @@ const (
 	// In the event that the health check fails it will be set to False.
 	MachineHealthCheckSucceededCondition ConditionType = "HealthCheckSucceeded"
 
-	// MachineHealthCheckSuccededCondition is set on machines that have passed a healthcheck by the MachineHealthCheck controller.
-	// In the event that the health check fails it will be set to False.
-	//
-	// Deprecated: This const is going to be removed in a next release. Use MachineHealthCheckSucceededCondition instead.
-	MachineHealthCheckSuccededCondition ConditionType = "HealthCheckSucceeded"
-
 	// MachineHasFailureReason is the reason used when a machine has either a FailureReason or a FailureMessage set on its status.
 	MachineHasFailureReason = "MachineHasFailure"
 

--- a/docs/book/src/developer/providers/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/v1.3-to-v1.4.md
@@ -21,6 +21,7 @@ maintainers of providers and consumers of our Go API.
 ### Removals
 
 - `clusterctl backup` has been removed.
+- `MachineHealthCheckSuccededCondition` condition type has been removed.
 
 ### API Changes
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Cleanup of the deprecated `MachineHealthCheckSuccededCondition` condition in the v1beta1 API.
Should use the MachineHealthCheckSucceededCondition `variable intead.`

There's no changes in the documentation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Subtask of #7713
