### PR TITLE
⚠️ Removing deprecated --list-images flag on init command

### DIFF
--- a/cmd/clusterctl/cmd/init.go
+++ b/cmd/clusterctl/cmd/init.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -35,7 +34,6 @@ type initOptions struct {
 	ipamProviders             []string
 	runtimeExtensionProviders []string
 	targetNamespace           string
-	listImages                bool
 	validate                  bool
 	waitProviders             bool
 	waitProviderTimeout       int
@@ -114,10 +112,6 @@ func init() {
 	initCmd.Flags().BoolVar(&initOpts.validate, "validate", true,
 		"If true, clusterctl will validate that the deployments will succeed on the management cluster.")
 
-	initCmd.Flags().BoolVar(&initOpts.listImages, "list-images", false,
-		"Lists the container images required for initializing the management cluster (without actually installing the providers)")
-	_ = initCmd.Flags().MarkDeprecated("list-images", "use 'clusterctl init list-images' instead.")
-
 	initCmd.AddCommand(initListImagesCmd)
 	RootCmd.AddCommand(initCmd)
 }
@@ -141,18 +135,6 @@ func runInit() error {
 		WaitProviders:             initOpts.waitProviders,
 		WaitProviderTimeout:       time.Duration(initOpts.waitProviderTimeout) * time.Second,
 		IgnoreValidationErrors:    !initOpts.validate,
-	}
-
-	if initOpts.listImages {
-		images, err := c.InitImages(options)
-		if err != nil {
-			return err
-		}
-
-		for _, i := range images {
-			fmt.Println(i)
-		}
-		return nil
 	}
 
 	if _, err := c.Init(options); err != nil {

--- a/docs/book/src/developer/providers/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/v1.3-to-v1.4.md
@@ -23,6 +23,7 @@ maintainers of providers and consumers of our Go API.
 - `clusterctl backup` has been removed.
 - `MachineHealthCheckSuccededCondition` condition type has been removed.
 - `CloneTemplate` and `CloneTemplateInput` has been removed.
+- The option `--list-images` from `init` subcommand has been removed.
 
 ### API Changes
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Removing the deprecated `--list-images` from init command

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #7713
