### PR TITLE
🌱 CAPD: only ignore necessary kubeadm preflight errors

### DIFF
--- a/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudinit
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -53,21 +54,27 @@ func (a *runCmd) Commands() ([]provisioning.Cmd, error) {
 	return cmds, nil
 }
 
+// ignorePreflightErrors are preflight errors that fail in CAPD and thus we have to ignore them.
+const ignorePreflightErrors = "SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables"
+
 func hackKubeadmIgnoreErrors(c provisioning.Cmd) provisioning.Cmd {
 	// case kubeadm commands are defined as a string
 	if c.Cmd == "/bin/sh" && len(c.Args) >= 2 {
 		if c.Args[0] == "-c" {
-			c.Args[1] = strings.Replace(c.Args[1], "kubeadm init", "kubeadm init --ignore-preflight-errors=all", 1)
-			c.Args[1] = strings.Replace(c.Args[1], "kubeadm join", "kubeadm join --ignore-preflight-errors=all", 1)
+			c.Args[1] = strings.Replace(c.Args[1], "kubeadm init", fmt.Sprintf("kubeadm init --ignore-preflight-errors=%s", ignorePreflightErrors), 1)
+			c.Args[1] = strings.Replace(c.Args[1], "kubeadm join", fmt.Sprintf("kubeadm join --ignore-preflight-errors=%s", ignorePreflightErrors), 1)
 		}
 	}
 
 	// case kubeadm commands are defined as a list
 	if c.Cmd == "kubeadm" && len(c.Args) >= 1 {
 		if c.Args[0] == "init" || c.Args[0] == "join" {
-			c.Args = append(c.Args, "")                 // make space
-			copy(c.Args[2:], c.Args[1:])                // shift elements
-			c.Args[1] = "--ignore-preflight-errors=all" // insert the additional arg
+			// make space
+			c.Args = append(c.Args, "")
+			// shift elements
+			copy(c.Args[2:], c.Args[1:])
+			// insert the additional arg
+			c.Args[1] = fmt.Sprintf("--ignore-preflight-errors=%s", ignorePreflightErrors)
 		}
 	}
 

--- a/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd_test.go
+++ b/test/infrastructure/docker/internal/provisioning/cloudinit/runcmd_test.go
@@ -70,7 +70,7 @@ func TestRunCmdRun(t *testing.T) {
 				},
 			},
 			expectedCmds: []provisioning.Cmd{
-				{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm init --ignore-preflight-errors=all --config /run/kubeadm/kubeadm.yaml"}},
+				{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm init --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --config /run/kubeadm/kubeadm.yaml"}},
 			},
 		},
 	}
@@ -100,11 +100,11 @@ runcmd:
 
 	r.Cmds[0] = hackKubeadmIgnoreErrors(r.Cmds[0])
 
-	expected0 := provisioning.Cmd{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm init --ignore-preflight-errors=all --config=/run/kubeadm/kubeadm.yaml"}}
+	expected0 := provisioning.Cmd{Cmd: "/bin/sh", Args: []string{"-c", "kubeadm init --ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables --config=/run/kubeadm/kubeadm.yaml"}}
 	g.Expect(r.Cmds[0]).To(Equal(expected0))
 
 	r.Cmds[1] = hackKubeadmIgnoreErrors(r.Cmds[1])
 
-	expected1 := provisioning.Cmd{Cmd: "kubeadm", Args: []string{"join", "--ignore-preflight-errors=all", "--config=/run/kubeadm/kubeadm-controlplane-join-config.yaml"}}
+	expected1 := provisioning.Cmd{Cmd: "kubeadm", Args: []string{"join", "--ignore-preflight-errors=SystemVerification,Swap,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables", "--config=/run/kubeadm/kubeadm-controlplane-join-config.yaml"}}
 	g.Expect(r.Cmds[1]).To(Equal(expected1))
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
With this PR CAPD only ignores SystemVerification and Swap preflight errors. The goal is to detect other preflight errors which affect other infra providers (e.g. ImagePull).

This should bring the test results of CAPD a bit closer to the ones of other infra providers.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to #7833 
