### PR TITLE
🐛 test/e2e: fix CoreDNS readiness validation, misc improvements

### DIFF
--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -84,6 +84,7 @@ k8s::resolveVersion() {
 
   resolveVersion=$version
   if [[ "$version" =~ ^v ]]; then
+    echo "+ $variableName=\"$version\" already a version, no need to resolve"
     return
   fi
 

--- a/test/e2e/data/kubetest/conformance.yaml
+++ b/test/e2e/data/kubetest/conformance.yaml
@@ -6,3 +6,6 @@ ginkgo.slowSpecThreshold: 120.0
 ginkgo.flakeAttempts: 3
 ginkgo.trace: true
 ginkgo.v: true
+# Use 5m instead of the default 10m to fail faster
+# if kube-system Pods are not coming up.
+system-pods-startup-timeout: 5m

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -357,7 +357,7 @@ func (m *Machine) ExecBootstrap(ctx context.Context, data string, format bootstr
 		if err != nil {
 			log.Info("Failed running command", "instance", m.Name(), "command", command, "stdout", outStd.String(), "stderr", outErr.String(), "bootstrap data", data)
 			logContainerDebugInfo(ctx, log, m.ContainerName())
-			return errors.Wrap(errors.WithStack(err), "failed to run cloud config")
+			return errors.Wrapf(err, "failed to run cloud config: stdout: %s stderr: %s", outStd.String(), outErr.String())
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Some misc improvements + fixes the CoreDNS validation. Previously we only checked if either the image is correct or the pods are ready, now both must be true.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
