### PR TITLE
⚠️ Drop ClusterTopologyManagedFieldsAnnotation field from v1beta1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -222,7 +222,7 @@ issues:
   # Specific exclude rules for deprecated fields that are still part of the codebase. These should be removed as the referenced deprecated item is removed from the project.
   - linters:
       - staticcheck
-    text: "SA1019: (bootstrapv1.ClusterStatus|clusterv1.ClusterTopologyManagedFieldsAnnotation|scope.Config.Spec.UseExperimentalRetryJoin|DockerMachine.Spec.Bootstrapped|machineStatus.Bootstrapped) is deprecated"
+    text: "SA1019: (bootstrapv1.ClusterStatus|scope.Config.Spec.UseExperimentalRetryJoin|DockerMachine.Spec.Bootstrapped|machineStatus.Bootstrapped) is deprecated"
   - linters:
     - revive
     text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -29,22 +29,6 @@ const (
 	// ClusterTopologyOwnedLabel is the label set on all the object which are managed as part of a ClusterTopology.
 	ClusterTopologyOwnedLabel = "topology.cluster.x-k8s.io/owned"
 
-	// ClusterTopologyManagedFieldsAnnotation is the annotation used to store the list of paths managed
-	// by the topology controller; changes to those paths will be considered authoritative.
-	// NOTE: Managed field depends on the last reconciliation of a managed object; this list can
-	// change during the lifecycle of an object, depending on how the corresponding template + patch/variable
-	// changes over time.
-	// NOTE: The topology controller is only concerned about managed paths in the spec; given that
-	// we are dropping spec. from the result to reduce verbosity of the generated annotation.
-	// NOTE: Managed paths are relevant only for unstructured objects where it is not possible
-	// to easily discover which fields have been set by templates + patches/variables at a given reconcile;
-	// instead, it is not necessary to store managed paths for typed objets (e.g. Cluster, MachineDeployments)
-	// given that the topology controller explicitly sets a well-known, immutable list of fields at every reconcile.
-	//
-	// Deprecated: Topology controller is now using server side apply and this annotation will be removed in a future release.
-	// When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml.
-	ClusterTopologyManagedFieldsAnnotation = "topology.cluster.x-k8s.io/managed-field-paths"
-
 	// ClusterTopologyMachineDeploymentNameLabel is the label set on the generated  MachineDeployment objects
 	// to track the name of the MachineDeployment topology it represents.
 	ClusterTopologyMachineDeploymentNameLabel = "topology.cluster.x-k8s.io/deployment-name"

--- a/docs/book/src/developer/providers/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/v1.3-to-v1.4.md
@@ -21,11 +21,12 @@ maintainers of providers and consumers of our Go API.
 ### Removals
 
 - `clusterctl backup` has been removed.
-- `MachineHealthCheckSuccededCondition` condition type has been removed.
-- `CloneTemplate` and `CloneTemplateInput` has been removed.
-- The option `--list-images` from `init` subcommand has been removed.
+- `api/v1beta1.MachineHealthCheckSuccededCondition` condition type has been removed.
+- `controller/external/util.CloneTemplate` and `controllers/external/util.CloneTemplateInput` has been removed.
+- The option `--list-images` from `clusterctl init` subcommand has been removed.
 - `exp/runtime/server.NewServer` has been removed.
 - `--disable-no-echo` option from `clusterctl describe cluster` subcommand has been removed
+- `api/v1beta1.ClusterTopologyManagedFieldsAnnotation` field has been removed.
 
 ### API Changes
 

--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper_test.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper_test.go
@@ -487,57 +487,6 @@ func TestServerSideApply(t *testing.T) {
 	})
 }
 
-func TestServerSideApply_CleanupLegacyManagedFields(t *testing.T) {
-	g := NewWithT(t)
-	// Create a namespace for running the test
-	ns, err := env.CreateNamespace(ctx, "ssa")
-	g.Expect(err).ToNot(HaveOccurred())
-
-	// Build the test object to work with.
-	obj := builder.TestInfrastructureCluster(ns.Name, "obj1").WithSpecFields(map[string]interface{}{
-		"spec.foo": "",
-	}).Build()
-	obj.SetAnnotations(map[string]string{clusterv1.ClusterTopologyManagedFieldsAnnotation: "foo"})
-
-	t.Run("Server side apply cleanups legacy managed fields", func(t *testing.T) {
-		g := NewWithT(t)
-
-		// Create the object simulating reconcile with legacy managed fields
-		g.Expect(env.CreateAndWait(ctx, obj.DeepCopy(), client.FieldOwner("manager")))
-
-		// Gets the object and create SSA patch helper triggering cleanup.
-		original := builder.TestInfrastructureCluster("", "").Build()
-		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(obj), original)).To(Succeed())
-
-		modified := obj.DeepCopy()
-		_, err := NewServerSidePatchHelper(ctx, original, modified, env.GetClient())
-		g.Expect(err).ToNot(HaveOccurred())
-
-		// Get created object after cleanup
-		got := builder.TestInfrastructureCluster("", "").Build()
-		g.Expect(env.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(obj), got)).To(Succeed())
-
-		// Check annotation has been removed
-		g.Expect(got.GetAnnotations()).ToNot(HaveKey(clusterv1.ClusterTopologyManagedFieldsAnnotation))
-
-		// Check managed fields has been fixed
-		gotManagedFields := got.GetManagedFields()
-		gotLegacyManager, gotSSAManager := false, false
-		for i := range gotManagedFields {
-			if gotManagedFields[i].Manager == "manager" &&
-				gotManagedFields[i].Operation == metav1.ManagedFieldsOperationUpdate {
-				gotLegacyManager = true
-			}
-			if gotManagedFields[i].Manager == TopologyManagerName &&
-				gotManagedFields[i].Operation == metav1.ManagedFieldsOperationApply {
-				gotSSAManager = true
-			}
-		}
-		g.Expect(gotLegacyManager).To(BeFalse())
-		g.Expect(gotSSAManager).To(BeTrue())
-	})
-}
-
 // getTopologyManagedFields returns metadata.managedFields entry tracking
 // server side apply operations for the topology controller.
 func getTopologyManagedFields(original client.Object) map[string]interface{} {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Removing the deprecated `ClusterTopologyManagedFieldsAnnotation` from v1beta1 API

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #7713
