### PR TITLE
🌱 tilt: remove securityContext for live_update

### DIFF
--- a/hack/tools/tilt-prepare/main.go
+++ b/hack/tools/tilt-prepare/main.go
@@ -775,6 +775,12 @@ func prepareWorkload(name, prefix, binaryName, containerName string, objs []unst
 			cmd := []string{"sh", "/start.sh", "/" + binaryName}
 			args := append(container.Args, []string(ts.ExtraArgs[name])...)
 
+			// remove securityContext for tilt live_update, see https://github.com/tilt-dev/tilt/issues/3060
+			container.SecurityContext = nil
+			// ensure it's also removed from the pod template matching this container
+			// setting this outside the loop would means altering every deployments
+			d.Spec.Template.Spec.SecurityContext = nil
+
 			// alter deployment for working nicely with delve debugger;
 			// most specifically, configuring delve, starting the manager with profiling enabled, dropping liveness and
 			// readiness probes and disabling leader election.


### PR DESCRIPTION


<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

As of now, tilt live_update feature requires the pod to run as root, see https://github.com/tilt-dev/tilt/issues/3060

This PR removes any securityContext in manager manifests during tilt-prepare.
it allows every providers to add securityContext in manifests (like in https://github.com/kubernetes-sigs/cluster-api/pull/7831)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
