### PR TITLE
[release-1.2] ⚠️ Use Kubernetes 1.26 in Quick Start docs and CAPD

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -259,7 +259,6 @@ configs](https://github.com/kubernetes-sigs/cluster-api/tree/main/test/infrastru
 These can be customized for your specific needs.
 
 <aside class="note">
-
 <h1>Use of clusterctl</h1>
 
 When the worker cluster has been created using tilt, `clusterctl` should not be used for management

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -587,7 +587,7 @@ export OSC_REGION=<you-region>
 # Create namespace
 kubectl create namespace cluster-api-provider-outscale-system
 # Create secret
-kubectl create secret generic cluster-api-provider-outscale --from-literal=access_key=${OSC_ACCESS_KEY} --from-literal=secret_key=${OSC_SECRET_KEY} --from-literal=region=${OSC_REGION}  -n cluster-api-provider-outscale-system 
+kubectl create secret generic cluster-api-provider-outscale --from-literal=access_key=${OSC_ACCESS_KEY} --from-literal=secret_key=${OSC_SECRET_KEY} --from-literal=region=${OSC_REGION}  -n cluster-api-provider-outscale-system
 # Initialize the management cluster
 clusterctl init --infrastructure outscale
 ```
@@ -916,7 +916,7 @@ Please visit the [IBM Cloud provider] for more information.
 export KKZONE=""
 # The ssh name of the all instance Linux user. (e.g. root, ubuntu)
 export USER_NAME=<your-linux-user>
-# The ssh password of the all instance Linux user. 
+# The ssh password of the all instance Linux user.
 export PASSWORD=<your-linux-user-password>
 # The ssh IP address of the all instance. (e.g. "[{address: 192.168.100.3}, {address: 192.168.100.4}]")
 export INSTANCES=<your-linux-ip-address>
@@ -1126,7 +1126,7 @@ The Docker provider is not designed for production use and is intended for devel
 
 ```bash
 clusterctl generate cluster capi-quickstart --flavor development \
-  --kubernetes-version v1.25.0 \
+  --kubernetes-version v1.26.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1138,7 +1138,7 @@ clusterctl generate cluster capi-quickstart --flavor development \
 ```bash
 export CLUSTER_NAME=kind
 export CLUSTER_NAMESPACE=vcluster
-export KUBERNETES_VERSION=1.25.0
+export KUBERNETES_VERSION=1.26.0
 export HELM_VALUES="service:\n  type: NodePort"
 
 kubectl create namespace ${CLUSTER_NAMESPACE}
@@ -1169,7 +1169,7 @@ clusterctl generate cluster capi-quickstart \
 
 ```bash
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.25.0 \
+  --kubernetes-version v1.26.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   > capi-quickstart.yaml
@@ -1229,7 +1229,7 @@ You should see an output is similar to this:
 
 ```bash
 NAME                    CLUSTER           INITIALIZED   API SERVER AVAILABLE   REPLICAS   READY   UPDATED   UNAVAILABLE   AGE    VERSION
-capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.25.0
+capi-quickstart-g2trk   capi-quickstart   true                                 3                  3         3             4m7s   v1.26.0
 ```
 
 <aside class="note warning">
@@ -1416,12 +1416,12 @@ kubectl --kubeconfig=./capi-quickstart.kubeconfig get nodes
 ```
 ```bash
 NAME                                          STATUS   ROLES           AGE   VERSION
-capi-quickstart-g2trk-9xrjv                   Ready    control-plane   12m   v1.25.0
-capi-quickstart-g2trk-bmm9v                   Ready    control-plane   11m   v1.25.0
-capi-quickstart-g2trk-hvs9q                   Ready    control-plane   13m   v1.25.0
-capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          12m   v1.25.0
-capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          12m   v1.25.0
-capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          12m   v1.25.0
+capi-quickstart-g2trk-9xrjv                   Ready    control-plane   12m   v1.26.0
+capi-quickstart-g2trk-bmm9v                   Ready    control-plane   11m   v1.26.0
+capi-quickstart-g2trk-hvs9q                   Ready    control-plane   13m   v1.26.0
+capi-quickstart-md-0-55x6t-5649968bd7-8tq9v   Ready    <none>          12m   v1.26.0
+capi-quickstart-md-0-55x6t-5649968bd7-glnjd   Ready    <none>          12m   v1.26.0
+capi-quickstart-md-0-55x6t-5649968bd7-sfzp6   Ready    <none>          12m   v1.26.0
 ```
 
 {{#/tab }}

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -206,11 +206,11 @@ variables:
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION_MANAGEMENT: "v1.25.0"
-  KUBERNETES_VERSION: "v1.25.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "1.24.4"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.25.0"
-  ETCD_VERSION_UPGRADE_TO: "3.5.4-0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.26.0"
+  KUBERNETES_VERSION: "v1.26.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.25.3"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.26.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.6-0"
   COREDNS_VERSION_UPGRADE_TO: "v1.9.3"
   DOCKER_SERVICE_DOMAIN: "cluster.local"
   IP_FAMILY: "IPv4"

--- a/test/framework/bootstrap/kind_provider.go
+++ b/test/framework/bootstrap/kind_provider.go
@@ -37,7 +37,7 @@ const (
 	DefaultNodeImageRepository = "kindest/node"
 
 	// DefaultNodeImageVersion is the default Kubernetes version to be used for creating a kind cluster.
-	DefaultNodeImageVersion = "v1.25.0"
+	DefaultNodeImageVersion = "v1.26.0"
 )
 
 // KindClusterOption is a NewKindClusterProvider option.

--- a/test/infrastructure/docker/Dockerfile
+++ b/test/infrastructure/docker/Dockerfile
@@ -29,7 +29,7 @@ ENV GOPROXY=$goproxy
 # Gets additional CAPD dependencies
 WORKDIR /tmp
 
-RUN curl -LO https://dl.k8s.io/release/v1.25.0/bin/linux/${ARCH}/kubectl && \
+RUN curl -LO "https://dl.k8s.io/release/v1.26.0/bin/linux/${ARCH}/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/bin/kubectl
 

--- a/test/infrastructure/docker/examples/machine-pool.yaml
+++ b/test/infrastructure/docker/examples/machine-pool.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.25.0
+  version: v1.26.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -80,7 +80,7 @@ spec:
   replicas: 2
   template:
     spec:
-      version: v1.25.0
+      version: v1.26.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-ipv6.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.25.0
+  version: v1.26.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -90,7 +90,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.25.0
+      version: v1.26.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster-without-kcp.yaml
@@ -32,7 +32,7 @@ metadata:
   name: controlplane-0
   namespace: default
 spec:
-  version: v1.25.0
+  version: v1.26.0
   clusterName: my-cluster
   bootstrap:
     configRef:
@@ -80,7 +80,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.25.0
+      version: v1.26.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/examples/simple-cluster.yaml
+++ b/test/infrastructure/docker/examples/simple-cluster.yaml
@@ -35,7 +35,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: v1.25.0
+  version: v1.26.0
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -83,7 +83,7 @@ spec:
       cluster.x-k8s.io/cluster-name: my-cluster
   template:
     spec:
-      version: v1.25.0
+      version: v1.26.0
       clusterName: my-cluster
       bootstrap:
         configRef:

--- a/test/infrastructure/docker/internal/docker/machine.go
+++ b/test/infrastructure/docker/internal/docker/machine.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	defaultImageName = "kindest/node"
-	defaultImageTag  = "v1.25.0"
+	defaultImageTag  = "v1.26.0"
 )
 
 type nodeCreator interface {


### PR DESCRIPTION
Signed-off-by: Aniruddha Basak <codewithaniruddha@gmail.com>

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
part of #7671 

cc @kubernetes-sigs/cluster-api-release-team
