### PR TITLE
:seedling:  check for annotations 'false' values for boolean annotations

### DIFF
--- a/cmd/clusterctl/client/alpha/rollout_pauser.go
+++ b/cmd/clusterctl/client/alpha/rollout_pauser.go
@@ -48,7 +48,7 @@ func (r *rollout) ObjectPauser(proxy cluster.Proxy, ref corev1.ObjectReference) 
 		if err != nil || kcp == nil {
 			return errors.Wrapf(err, "failed to fetch %v/%v", ref.Kind, ref.Name)
 		}
-		if annotations.HasPaused(kcp.GetObjectMeta()) {
+		if annotations.HasPausedValue(kcp.GetObjectMeta()) {
 			return errors.Errorf("KubeadmControlPlane is already paused: %v/%v\n", ref.Kind, ref.Name) //nolint:revive // KubeadmControlPlane is intentionally capitalized.
 		}
 		if err := pauseKubeadmControlPlane(proxy, ref.Name, ref.Namespace); err != nil {

--- a/cmd/clusterctl/client/alpha/rollout_pauser_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_pauser_test.go
@@ -166,7 +166,7 @@ func Test_ObjectPauser(t *testing.T) {
 					kcp := &controlplanev1.KubeadmControlPlane{}
 					err = cl.Get(context.TODO(), key, kcp)
 					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(annotations.HasPaused(kcp.GetObjectMeta())).To(Equal(tt.wantPaused))
+					g.Expect(annotations.HasPausedValue(kcp.GetObjectMeta())).To(Equal(tt.wantPaused))
 				}
 			}
 		})

--- a/cmd/clusterctl/client/alpha/rollout_restarter.go
+++ b/cmd/clusterctl/client/alpha/rollout_restarter.go
@@ -48,7 +48,7 @@ func (r *rollout) ObjectRestarter(proxy cluster.Proxy, ref corev1.ObjectReferenc
 		if err != nil || kcp == nil {
 			return errors.Wrapf(err, "failed to fetch %v/%v", ref.Kind, ref.Name)
 		}
-		if annotations.HasPaused(kcp.GetObjectMeta()) {
+		if annotations.HasPausedValue(kcp.GetObjectMeta()) {
 			return errors.Errorf("can't restart paused KubeadmControlPlane (remove annotation 'cluster.x-k8s.io/paused' first): %v/%v", ref.Kind, ref.Name)
 		}
 		if kcp.Spec.RolloutAfter != nil && kcp.Spec.RolloutAfter.After(time.Now()) {

--- a/cmd/clusterctl/client/alpha/rollout_resumer.go
+++ b/cmd/clusterctl/client/alpha/rollout_resumer.go
@@ -49,7 +49,7 @@ func (r *rollout) ObjectResumer(proxy cluster.Proxy, ref corev1.ObjectReference)
 		if err != nil || kcp == nil {
 			return errors.Wrapf(err, "failed to fetch %v/%v", ref.Kind, ref.Name)
 		}
-		if !annotations.HasPaused(kcp.GetObjectMeta()) {
+		if !annotations.HasPausedValue(kcp.GetObjectMeta()) {
 			return errors.Errorf("KubeadmControlPlane is not currently paused: %v/%v\n", ref.Kind, ref.Name) //nolint:revive // KubeadmControlPlane is intentionally capitalized.
 		}
 		if err := resumeKubeadmControlPlane(proxy, ref.Name, ref.Namespace); err != nil {

--- a/cmd/clusterctl/client/alpha/rollout_resumer_test.go
+++ b/cmd/clusterctl/client/alpha/rollout_resumer_test.go
@@ -169,7 +169,7 @@ func Test_ObjectResumer(t *testing.T) {
 					kcp := &controlplanev1.KubeadmControlPlane{}
 					err = cl.Get(context.TODO(), key, kcp)
 					g.Expect(err).ToNot(HaveOccurred())
-					g.Expect(annotations.HasPaused(kcp.GetObjectMeta())).To(Equal(tt.wantPaused))
+					g.Expect(annotations.HasPausedValue(kcp.GetObjectMeta())).To(Equal(tt.wantPaused))
 				}
 			}
 		})

--- a/exp/runtime/internal/controllers/extensionconfig_controller.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller.go
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// Return early if the ExtensionConfig is paused.
-	if annotations.HasPaused(extensionConfig) {
+	if annotations.HasPausedValue(extensionConfig) {
 		log.Info("Reconciliation is paused for this object")
 		return ctrl.Result{}, nil
 	}

--- a/internal/controllers/clusterclass/clusterclass_controller.go
+++ b/internal/controllers/clusterclass/clusterclass_controller.go
@@ -104,7 +104,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	}
 
 	// Return early if the ClusterClass is paused.
-	if annotations.HasPaused(clusterClass) {
+	if annotations.HasPausedValue(clusterClass) {
 		log.Info("Reconciliation is paused for this object")
 		return ctrl.Result{}, nil
 	}
@@ -358,7 +358,7 @@ func (r *Reconciler) reconcileExternal(ctx context.Context, clusterClass *cluste
 	}
 
 	// If referenced object is paused, return early.
-	if annotations.HasPaused(obj) {
+	if annotations.HasPausedValue(obj) {
 		log.V(3).Info("External object referenced is paused", "refGroupVersionKind", ref.GroupVersionKind(), "refName", ref.Name)
 		return nil
 	}

--- a/internal/controllers/machinehealthcheck/machinehealthcheck_targets.go
+++ b/internal/controllers/machinehealthcheck/machinehealthcheck_targets.go
@@ -345,11 +345,11 @@ func minDuration(durations []time.Duration) time.Duration {
 // shouldSkipRemediation checks if the machine should be skipped for remediation.
 // Returns true if it should be skipped along with the reason for skipping.
 func shouldSkipRemediation(m *clusterv1.Machine) (bool, string) {
-	if annotations.HasPaused(m) {
+	if annotations.HasPausedValue(m) {
 		return true, fmt.Sprintf("machine has %q annotation", clusterv1.PausedAnnotation)
 	}
 
-	if annotations.HasSkipRemediation(m) {
+	if annotations.HasSkipRemediationValue(m) {
 		return true, fmt.Sprintf("machine has %q annotation", clusterv1.MachineSkipRemediationAnnotation)
 	}
 

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -35,16 +35,31 @@ func IsPaused(cluster *clusterv1.Cluster, o metav1.Object) bool {
 
 // IsExternallyManaged returns true if the object has the `managed-by` annotation.
 func IsExternallyManaged(o metav1.Object) bool {
-	return hasTruthyAnnotationValue(o, clusterv1.ManagedByAnnotation)
+	return hasAnnotation(o, clusterv1.ManagedByAnnotation)
 }
 
 // HasPaused returns true if the object has the `paused` annotation.
 func HasPaused(o metav1.Object) bool {
-	return hasTruthyAnnotationValue(o, clusterv1.PausedAnnotation)
+	return hasAnnotation(o, clusterv1.PausedAnnotation)
 }
 
 // HasSkipRemediation returns true if the object has the `skip-remediation` annotation.
 func HasSkipRemediation(o metav1.Object) bool {
+	return hasAnnotation(o, clusterv1.MachineSkipRemediationAnnotation)
+}
+
+// IsExternallyManaged returns true if the object has the `managed-by` annotation not set as 'false'.
+func IsExternallyManagedValue(o metav1.Object) bool {
+	return hasTruthyAnnotationValue(o, clusterv1.ManagedByAnnotation)
+}
+
+// HasPaused returns true if the object has the `paused` annotation not set as 'false'.
+func HasPausedValue(o metav1.Object) bool {
+	return hasTruthyAnnotationValue(o, clusterv1.PausedAnnotation)
+}
+
+// HasSkipRemediation returns true if the object has the `skip-remediation` annotation not set as 'false'.
+func HasSkipRemediationValue(o metav1.Object) bool {
 	return hasTruthyAnnotationValue(o, clusterv1.MachineSkipRemediationAnnotation)
 }
 

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -35,17 +35,17 @@ func IsPaused(cluster *clusterv1.Cluster, o metav1.Object) bool {
 
 // IsExternallyManaged returns true if the object has the `managed-by` annotation.
 func IsExternallyManaged(o metav1.Object) bool {
-	return hasAnnotation(o, clusterv1.ManagedByAnnotation)
+	return hasTruthyAnnotationValue(o, clusterv1.ManagedByAnnotation)
 }
 
 // HasPaused returns true if the object has the `paused` annotation.
 func HasPaused(o metav1.Object) bool {
-	return hasAnnotation(o, clusterv1.PausedAnnotation)
+	return hasTruthyAnnotationValue(o, clusterv1.PausedAnnotation)
 }
 
 // HasSkipRemediation returns true if the object has the `skip-remediation` annotation.
 func HasSkipRemediation(o metav1.Object) bool {
-	return hasAnnotation(o, clusterv1.MachineSkipRemediationAnnotation)
+	return hasTruthyAnnotationValue(o, clusterv1.MachineSkipRemediationAnnotation)
 }
 
 // HasWithPrefix returns true if at least one of the annotations has the prefix specified.

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -91,7 +91,7 @@ func AddAnnotations(o metav1.Object, desired map[string]string) bool {
 	}
 	_, ok := annotations[annotation]
 	return ok
-} */
+}. */
 
 // hasTruthyAnnotationValue returns true if the object has an annotation with a value that is not "false".
 func hasTruthyAnnotationValue(o metav1.Object, annotation string) bool {

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -84,14 +84,14 @@ func AddAnnotations(o metav1.Object, desired map[string]string) bool {
 }
 
 // hasAnnotation returns true if the object has the specified annotation.
-func hasAnnotation(o metav1.Object, annotation string) bool {
+/* func hasAnnotation(o metav1.Object, annotation string) bool {
 	annotations := o.GetAnnotations()
 	if annotations == nil {
 		return false
 	}
 	_, ok := annotations[annotation]
 	return ok
-}
+} */
 
 // hasTruthyAnnotationValue returns true if the object has an annotation with a value that is not "false".
 func hasTruthyAnnotationValue(o metav1.Object, annotation string) bool {

--- a/util/annotations/helpers.go
+++ b/util/annotations/helpers.go
@@ -30,35 +30,20 @@ func IsPaused(cluster *clusterv1.Cluster, o metav1.Object) bool {
 	if cluster.Spec.Paused {
 		return true
 	}
-	return HasPaused(o)
+	return HasPausedValue(o)
 }
 
-// IsExternallyManaged returns true if the object has the `managed-by` annotation.
-func IsExternallyManaged(o metav1.Object) bool {
-	return hasAnnotation(o, clusterv1.ManagedByAnnotation)
-}
-
-// HasPaused returns true if the object has the `paused` annotation.
-func HasPaused(o metav1.Object) bool {
-	return hasAnnotation(o, clusterv1.PausedAnnotation)
-}
-
-// HasSkipRemediation returns true if the object has the `skip-remediation` annotation.
-func HasSkipRemediation(o metav1.Object) bool {
-	return hasAnnotation(o, clusterv1.MachineSkipRemediationAnnotation)
-}
-
-// IsExternallyManaged returns true if the object has the `managed-by` annotation not set as 'false'.
+// IsExternallyManagedValue returns true if the object has the `managed-by` annotation not set as 'false'.
 func IsExternallyManagedValue(o metav1.Object) bool {
 	return hasTruthyAnnotationValue(o, clusterv1.ManagedByAnnotation)
 }
 
-// HasPaused returns true if the object has the `paused` annotation not set as 'false'.
+// HasPausedValue returns true if the object has the `paused` annotation not set as 'false'.
 func HasPausedValue(o metav1.Object) bool {
 	return hasTruthyAnnotationValue(o, clusterv1.PausedAnnotation)
 }
 
-// HasSkipRemediation returns true if the object has the `skip-remediation` annotation not set as 'false'.
+// HasSkipRemediationValue returns true if the object has the `skip-remediation` annotation not set as 'false'.
 func HasSkipRemediationValue(o metav1.Object) bool {
 	return hasTruthyAnnotationValue(o, clusterv1.MachineSkipRemediationAnnotation)
 }

--- a/util/annotations/helpers_test.go
+++ b/util/annotations/helpers_test.go
@@ -152,6 +152,147 @@ func TestAddAnnotations(t *testing.T) {
 	}
 }
 
+func TestExternallyManagedAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      metav1.Object
+		expected bool
+	}{
+		{
+			name: "annotation exists with non false value",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"cluster.x-k8s.io/managed-by": "xyz",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			expected: true,
+		},
+		{
+			name: "annotation exists with  false value",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"cluster.x-k8s.io/managed-by": "false",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ret := IsExternallyManaged(tt.obj)
+			if tt.expected {
+				g.Expect(ret).To(BeTrue())
+			} else {
+				g.Expect(ret).To(BeFalse())
+			}
+		})
+	}
+}
+
+func TestPausedAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      metav1.Object
+		expected bool
+	}{
+		{
+			name: "annotation exists with non false value",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"cluster.x-k8s.io/paused": "xyz",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			expected: true,
+		},
+		{
+			name: "annotation exists with  false value",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"cluster.x-k8s.io/paused": "false",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ret := HasPaused(tt.obj)
+			if tt.expected {
+				g.Expect(ret).To(BeTrue())
+			} else {
+				g.Expect(ret).To(BeFalse())
+			}
+		})
+	}
+}
+
+func TestHasSkipAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      metav1.Object
+		expected bool
+	}{
+		{
+			name: "annotation exists with non false value",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"cluster.x-k8s.io/skip-remediation": "xyz",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			expected: true,
+		},
+		{
+			name: "annotation exists with  false value",
+			obj: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"cluster.x-k8s.io/skip-remediation": "false",
+					},
+				},
+				Spec:   corev1.NodeSpec{},
+				Status: corev1.NodeStatus{},
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ret := HasSkipRemediation(tt.obj)
+			if tt.expected {
+				g.Expect(ret).To(BeTrue())
+			} else {
+				g.Expect(ret).To(BeFalse())
+			}
+		})
+	}
+}
+
 func TestHasTruthyAnnotationValue(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/util/annotations/helpers_test.go
+++ b/util/annotations/helpers_test.go
@@ -189,7 +189,7 @@ func TestExternallyManagedAnnotation(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			ret := IsExternallyManaged(tt.obj)
+			ret := IsExternallyManagedValue(tt.obj)
 			if tt.expected {
 				g.Expect(ret).To(BeTrue())
 			} else {
@@ -236,7 +236,7 @@ func TestPausedAnnotation(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			ret := HasPaused(tt.obj)
+			ret := HasPausedValue(tt.obj)
 			if tt.expected {
 				g.Expect(ret).To(BeTrue())
 			} else {
@@ -283,7 +283,7 @@ func TestHasSkipAnnotation(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			ret := HasSkipRemediation(tt.obj)
+			ret := HasSkipRemediationValue(tt.obj)
 			if tt.expected {
 				g.Expect(ret).To(BeTrue())
 			} else {

--- a/util/predicates/generic_predicates.go
+++ b/util/predicates/generic_predicates.go
@@ -187,7 +187,7 @@ func ResourceNotPausedAndHasFilterLabel(logger logr.Logger, labelValue string) p
 func processIfNotPaused(logger logr.Logger, obj client.Object) bool {
 	kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
 	log := logger.WithValues("namespace", obj.GetNamespace(), kind, obj.GetName())
-	if annotations.HasPaused(obj) {
+	if annotations.HasPausedValue(obj) {
 		log.V(4).Info("Resource is paused, will not attempt to map resource")
 		return false
 	}
@@ -235,7 +235,7 @@ func ResourceIsNotExternallyManaged(logger logr.Logger) predicate.Funcs {
 func processIfNotExternallyManaged(logger logr.Logger, obj client.Object) bool {
 	kind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
 	log := logger.WithValues("namespace", obj.GetNamespace(), kind, obj.GetName())
-	if annotations.IsExternallyManaged(obj) {
+	if annotations.IsExternallyManagedValue(obj) {
 		log.V(4).Info("Resource is externally managed, will not attempt to map resource")
 		return false
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -222,7 +222,7 @@ func ClusterToInfrastructureMapFunc(ctx context.Context, gvk schema.GroupVersion
 			return nil
 		}
 
-		if annotations.IsExternallyManaged(providerCluster) {
+		if annotations.IsExternallyManagedValue(providerCluster) {
 			log.V(4).Info(fmt.Sprintf("%T is externally managed, skipping mapping", providerCluster))
 			return nil
 		}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: if boolean annotation has value `false` it is considered as false and required steps are taken in codebase

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7434 
