### PR TITLE
🌱 setup Trivy scanning for supported release branches

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,11 +9,16 @@ permissions: {}
 
 jobs:
   scan:
+    strategy:
+      matrix:
+        branch: [ main, release-1.3, release-1.2 ]
     name: Trivy
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3.1.0
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3.3.0
+      with:
+        ref: ${{ matrix.branch }}
     - name: Setup go
       uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # tag=v3.4.0
       with:

--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -111,7 +111,8 @@ This comes down to changing occurrences of the old version to the new version, e
    5. Modify the test specs in `test/e2e/clusterctl_upgrade_test.go` (according to the versions we want to test described above).
       Please note that `InitWithKubernetesVersion` should be the highest mgmt cluster version supported by the respective Cluster API version. 
 2. Update `create-local-repository.py` and `tools/tilt-prepare/main.go`: `v1.3.99` => `v1.4.99`.
-3. Make sure all tests are green (also run `pull-cluster-api-e2e-full-main` and `pull-cluster-api-e2e-workload-upgrade-1-23-latest-main`).
+3. Update `.github/workflows/scan.yml` to setup Trivy scanning for the currently supported branches.
+4. Make sure all tests are green (also run `pull-cluster-api-e2e-full-main` and `pull-cluster-api-e2e-workload-upgrade-1-23-latest-main`).
 
 Prior art: https://github.com/kubernetes-sigs/cluster-api/pull/6834/files
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds Trivy scanning job to all supported release branches.

By default `on: schedule` jobs only run on the default branch. Copying this workflow to release branches does not trigger the job on the release branches.

Additional notes:
With this we can drop the scan.yaml files from the release branches to avoid confusion as they currently do not do anything. 
`scan.yaml` was added in in the following PRs:
- https://github.com/kubernetes-sigs/cluster-api/pull/7820
- https://github.com/kubernetes-sigs/cluster-api/pull/7821

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
