### PR TITLE
🌱 improves the existing capi metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,7 +524,7 @@ generate-metrics-config: $(ENVSUBST_BIN) ## Generate ./hack/observability/kube-s
 	METRICS_DIR="${OBSERVABILITY_DIR}/kube-state-metrics/metrics"; \
 	echo "# This file was auto-generated via: make generate-metrics-config" > "$${OUTPUT_FILE}"; \
 	cat "$${METRICS_DIR}/header.yaml" >> "$${OUTPUT_FILE}"; \
-	for resource in cluster kubeadmcontrolplane machine machinedeployment machinehealthcheck machineset; do \
+	for resource in cluster kubeadmcontrolplane machine machinedeployment machinehealthcheck machineset machinepool; do \
 		cat "$${METRICS_DIR}/$${resource}.yaml"; \
 		RESOURCE="$${resource}" ${ENVSUBST_BIN} < "$${METRICS_DIR}/common_metrics.yaml"; \
 		if [[ "$${resource}" != "cluster" ]]; then \

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -146,7 +146,7 @@ const (
 
 // MachineAddress contains information for the node's address.
 type MachineAddress struct {
-	// Machine address type, one of Hostname, ExternalIP or InternalIP.
+	// Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.
 	Type MachineAddressType `json:"type"`
 
 	// The machine address.

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -1329,7 +1329,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineAddress(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Machine address type, one of Hostname, ExternalIP or InternalIP.",
+							Description: "Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -951,8 +951,8 @@ spec:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address

--- a/hack/observability/kube-state-metrics/crd-config.yaml
+++ b/hack/observability/kube-state-metrics/crd-config.yaml
@@ -39,6 +39,22 @@ spec:
             - spec
             - controlPlaneEndpoint
             - port
+            control_plane_reference_kind:
+            - spec
+            - controlPlaneRef
+            - kind
+            control_plane_reference_name:
+            - spec
+            - controlPlaneRef
+            - name
+            infrastructure_reference_kind:
+            - spec
+            - infrastructureRef
+            - kind
+            infrastructure_reference_name:
+            - spec
+            - infrastructureRef
+            - name
         type: Info
     - name: spec_paused
       help: Whether the cluster is paused and any of its resources will not be processed by the controllers.
@@ -264,24 +280,48 @@ spec:
       each:
         info:
           labelsFromPath:
+            container_runtime_version:
+            - status
+            - nodeInfo
+            - containerRuntimeVersion
             failure_domain:
             - spec
             - failureDomain
-            internal_ip:
+            kernel_version:
             - status
-            - addresses
-            - "[type=InternalIP]"
-            - address
+            - nodeInfo
+            - kernelVersion
+            kubelet_version:
+            - status
+            - nodeInfo
+            - kubeletVersion
+            kube_proxy_version:
+            - status
+            - nodeInfo
+            - kubeProxyVersion
+            os_image:
+            - status
+            - nodeInfo
+            - osImage
             provider_id:
             - spec
             - providerID
             version:
             - spec
             - version
-            containerRuntimeVersion:
-            - status
-            - nodeInfo
-            - containerRuntimeVersion
+        type: Info
+    - name: addresses
+      help: Address information about a machine.
+      each:
+        info:
+          path:
+          - status
+          - addresses
+          labelsFromPath:
+            type:
+            - type
+            address:
+            - address
         type: Info
     - name: status_noderef
       help: Information about the node reference of a machine.
@@ -720,6 +760,179 @@ spec:
         type: Info
     - name: status_condition
       help: The condition of a machineset.
+      each:
+        stateSet:
+          labelName: status
+          labelsFromPath:
+            type:
+            - type
+          list:
+          - 'True'
+          - 'False'
+          - Unknown
+          path:
+          - status
+          - conditions
+          valueFrom:
+          - status
+        type: StateSet
+    - name: owner
+      help: Owner references.
+      each:
+        info:
+          labelsFromPath:
+            owner_is_controller:
+            - controller
+            owner_kind:
+            - kind
+            owner_name:
+            - name
+            owner_uid:
+            - uid
+          path:
+          - metadata
+          - ownerReferences
+        type: Info
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachinePool
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machinepool
+    metrics:
+    - name: spec_replicas
+      help: The number of desired machines for a machinepool.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+        type: Gauge
+    - name: status_replicas
+      help: The number of replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_ready
+      help: The number of ready replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_available
+      help: The number of available replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - availableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_unavailable
+      help: The number of unavailable replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - unavailableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: info
+      each:
+        type: Info
+        info:
+          labelsFromPath:
+            infrastructure_reference_name:
+            - spec
+            - template
+            - spec
+            - infrastructureRef
+            - name
+            infrastructure_reference_kind:
+            - spec
+            - template
+            - spec
+            - infrastructureRef
+            - kind
+            bootstrap_configuration_reference_name:
+            - spec
+            - template
+            - spec
+            - bootstrap
+            - configRef
+            - name
+            bootstrap_configuration_reference_kind:
+            - spec
+            - template
+            - spec
+            - bootstrap
+            - configRef
+            - kind
+            failure_domain:
+            - spec
+            - template
+            - spec
+            - failureDomain
+            version:
+            - spec
+            - template
+            - spec
+            - version
+    - name: status_phase
+      help: The machinepools current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - ScalingUp
+          - ScalingDown
+          - Running
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet
+    - name: created
+      help: Unix creation timestamp.
+      each:
+        gauge:
+          path:
+          - metadata
+          - creationTimestamp
+        type: Gauge
+    - name: annotation_paused
+      help: Whether the machinepool is paused and any of its resources will not be processed by the controllers.
+      each:
+        info:
+          path:
+          - metadata
+          - annotations
+          - cluster.x-k8s.io/paused
+          labelsFromPath:
+            paused_value: []
+        type: Info
+    - name: status_condition
+      help: The condition of a machinepool.
       each:
         stateSet:
           labelName: status

--- a/hack/observability/kube-state-metrics/metrics/cluster.yaml
+++ b/hack/observability/kube-state-metrics/metrics/cluster.yaml
@@ -35,6 +35,22 @@
             - spec
             - controlPlaneEndpoint
             - port
+            control_plane_reference_kind:
+            - spec
+            - controlPlaneRef
+            - kind
+            control_plane_reference_name:
+            - spec
+            - controlPlaneRef
+            - name
+            infrastructure_reference_kind:
+            - spec
+            - infrastructureRef
+            - kind
+            infrastructure_reference_name:
+            - spec
+            - infrastructureRef
+            - name
         type: Info
     - name: spec_paused
       help: Whether the cluster is paused and any of its resources will not be processed by the controllers.

--- a/hack/observability/kube-state-metrics/metrics/machine.yaml
+++ b/hack/observability/kube-state-metrics/metrics/machine.yaml
@@ -22,24 +22,48 @@
       each:
         info:
           labelsFromPath:
+            container_runtime_version:
+            - status
+            - nodeInfo
+            - containerRuntimeVersion
             failure_domain:
             - spec
             - failureDomain
-            internal_ip:
+            kernel_version:
             - status
-            - addresses
-            - "[type=InternalIP]"
-            - address
+            - nodeInfo
+            - kernelVersion
+            kubelet_version:
+            - status
+            - nodeInfo
+            - kubeletVersion
+            kube_proxy_version:
+            - status
+            - nodeInfo
+            - kubeProxyVersion
+            os_image:
+            - status
+            - nodeInfo
+            - osImage
             provider_id:
             - spec
             - providerID
             version:
             - spec
             - version
-            containerRuntimeVersion:
-            - status
-            - nodeInfo
-            - containerRuntimeVersion
+        type: Info
+    - name: addresses
+      help: Address information about a machine.
+      each:
+        info:
+          path:
+          - status
+          - addresses
+          labelsFromPath:
+            type:
+            - type
+            address:
+            - address
         type: Info
     - name: status_noderef
       help: Information about the node reference of a machine.

--- a/hack/observability/kube-state-metrics/metrics/machinepool.yaml
+++ b/hack/observability/kube-state-metrics/metrics/machinepool.yaml
@@ -1,0 +1,119 @@
+  - groupVersionKind:
+      group: cluster.x-k8s.io
+      kind: MachinePool
+      version: v1beta1
+    labelsFromPath:
+      cluster_name:
+      - spec
+      - clusterName
+      name:
+      - metadata
+      - name
+      namespace:
+      - metadata
+      - namespace
+      uid:
+      - metadata
+      - uid
+    metricNamePrefix: capi_machinepool
+    metrics:
+    - name: spec_replicas
+      help: The number of desired machines for a machinepool.
+      each:
+        gauge:
+          path:
+          - spec
+          - replicas
+        type: Gauge
+    - name: status_replicas
+      help: The number of replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - replicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_ready
+      help: The number of ready replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - readyReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_available
+      help: The number of available replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - availableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: status_replicas_unavailable
+      help: The number of unavailable replicas per machinepool.
+      each:
+        gauge:
+          path:
+          - status
+          - unavailableReplicas
+          nilIsZero: true
+        type: Gauge
+    - name: info
+      each:
+        type: Info
+        info:
+          labelsFromPath:
+            infrastructure_reference_name:
+            - spec
+            - template
+            - spec
+            - infrastructureRef
+            - name
+            infrastructure_reference_kind:
+            - spec
+            - template
+            - spec
+            - infrastructureRef
+            - kind
+            bootstrap_configuration_reference_name:
+            - spec
+            - template
+            - spec
+            - bootstrap
+            - configRef
+            - name
+            bootstrap_configuration_reference_kind:
+            - spec
+            - template
+            - spec
+            - bootstrap
+            - configRef
+            - kind
+            failure_domain:
+            - spec
+            - template
+            - spec
+            - failureDomain
+            version:
+            - spec
+            - template
+            - spec
+            - version
+    - name: status_phase
+      help: The machinepools current phase.
+      each:
+        stateSet:
+          labelName: phase
+          list:
+          - ScalingUp
+          - ScalingDown
+          - Running
+          - Failed
+          - Unknown
+          path:
+          - status
+          - phase
+        type: StateSet

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
@@ -518,8 +518,8 @@ spec:
                             description: The machine address.
                             type: string
                           type:
-                            description: Machine address type, one of Hostname, ExternalIP
-                              or InternalIP.
+                            description: Machine address type, one of Hostname, ExternalIP,
+                              InternalIP, ExternalDNS or InternalDNS.
                             type: string
                         required:
                         - address

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -402,8 +402,8 @@ spec:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR is intentionally split into three commits to make the review more easier for now:

1. add control plane and infra ref labels to cluster
    add the following labels from the cluster cr spec to the cluster_info
    metric:
    * `control_plane_reference_kind`
    * `control_plane_reference_name`
    * `infrastructure_reference_kind`
    * `infrastructure_reference_name`
1. introduce new capi_machine_addresses metric
    to represent the different kind of addresses in an own metric.
    
    `containerRuntimeVersion` label got also renamed to
    `container_runtime_version`
1. add initial capi_machinepool metrics


Regarding 2.
With the discussion in [this slack thread in #kube-state-metrics](https://kubernetes.slack.com/archives/CJJ529RUY/p1673349221630899) i will change the metric implementation again.

Signed-off-by: Mario Constanti <mario@constanti.de>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
