### PR TITLE
🌱 E2e: Unhold CI packages before installing

### DIFF
--- a/test/framework/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
+++ b/test/framework/kubernetesversions/data/debian_injection_script.envsubst.sh.tpl
@@ -88,7 +88,9 @@ if [[ "$${KUBERNETES_VERSION}" != "" ]]; then
     PACKAGE_VERSION="$(apt-cache madison kubelet | grep "$${VERSION_REGEX}-" | head -n1 | cut -d '|' -f 2 | tr -d '[:space:]')"
     for CI_PACKAGE in "$${PACKAGES_TO_TEST[@]}"; do
       echo "* installing package: $${CI_PACKAGE} $${PACKAGE_VERSION}"
+      apt-mark unhold "$${CI_PACKAGE}"
       apt-get install -y "$${CI_PACKAGE}=$${PACKAGE_VERSION}"
+      apt-mark hold "$${CI_PACKAGE}"
     done
   else
     CI_URL="https://dl.k8s.io/ci/$${KUBERNETES_VERSION}/bin/linux/amd64"


### PR DESCRIPTION
**What this PR does / why we need it**:

It is [common to mark kubeadm and related packages as held](https://v1-25.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/#call-kubeadm-upgrade) at a specific version to avoid accidental upgrades. The script for injecting CI artifacts does not take this into account, which means that if the base image used already has some version of a package installed and held, the script will fail to install the asked for version. To avoid this, we unhold before installing the packages and then hold again, as customary. Holding after installation also avoids any unintended upgrades later.

An alternative could be to add the flag `--allow-change-held-packages` to the install command, but I think unholding is a nicer way to do it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-openstack/issues/1429
