### PR TITLE
📖 Fix Runtime SDK implement extension sample to reflect updated k8s.io/component-base changes

### DIFF
--- a/docs/book/src/developer/tilt.md
+++ b/docs/book/src/developer/tilt.md
@@ -365,7 +365,7 @@ A provider must supply a `tilt-provider.yaml` file describing how to build it. H
 ```yaml
 name: aws
 config:
-  image: "gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller",
+  image: "gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller"
   live_reload_deps: ["main.go", "go.mod", "go.sum", "api", "cmd", "controllers", "pkg"]
   label: CAPA
 ```

--- a/docs/book/src/tasks/experimental-features/runtime-sdk/implement-extensions.md
+++ b/docs/book/src/tasks/experimental-features/runtime-sdk/implement-extensions.md
@@ -46,8 +46,8 @@ import (
 	"github.com/spf13/pflag"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
+	logsv1 "k8s.io/component-base/logs/api/v1"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	runtimecatalog "sigs.k8s.io/cluster-api/exp/runtime/catalog"
@@ -75,7 +75,7 @@ func init() {
 func InitFlags(fs *pflag.FlagSet) {
 	// Initialize logs flags using Kubernetes component-base machinery.
 	logs.AddFlags(fs, logs.SkipLoggingConfigurationFlags())
-	logOptions.AddFlags(fs)
+	logsv1.AddFlags(logOptions, fs)
 
 	// Add test-extension specific flags
 	fs.StringVar(&profilerAddress, "profiler-address", "",
@@ -99,7 +99,7 @@ func main() {
 	pflag.Parse()
 
 	// Validates logs flags using Kubernetes component-base machinery and applies them
-	if err := logOptions.ValidateAndApply(nil); err != nil {
+	if err := logsv1.ValidateAndApply(logOptions, nil); err != nil {
 		setupLog.Error(err, "unable to start extension")
 		os.Exit(1)
 	}
@@ -128,17 +128,17 @@ func main() {
 
 	// Register extension handlers.
 	if err := webhookServer.AddExtensionHandler(server.ExtensionHandler{
-		Hook:           runtimehooksv1.BeforeClusterCreate,
-		Name:           "before-cluster-create",
-		HandlerFunc:    DoBeforeClusterCreate,
+		Hook:        runtimehooksv1.BeforeClusterCreate,
+		Name:        "before-cluster-create",
+		HandlerFunc: DoBeforeClusterCreate,
 	}); err != nil {
 		setupLog.Error(err, "error adding handler")
 		os.Exit(1)
 	}
 	if err := webhookServer.AddExtensionHandler(server.ExtensionHandler{
-		Hook:           runtimehooksv1.BeforeClusterUpgrade,
-		Name:           "before-cluster-upgrade",
-		HandlerFunc:    DoBeforeClusterUpgrade,
+		Hook:        runtimehooksv1.BeforeClusterUpgrade,
+		Name:        "before-cluster-upgrade",
+		HandlerFunc: DoBeforeClusterUpgrade,
 	}); err != nil {
 		setupLog.Error(err, "error adding handler")
 		os.Exit(1)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the sample to comply with the latest cluster-api dependencies.

Cherry-picks fixes of https://github.com/kubernetes-sigs/cluster-api/pull/7211 to the sample.

The dependency to cluster-api resolves to the transitive version of `k8s.io/component-base` (maybe also via controller-runtime) which is not compatible anymore to the documented sample since `v0.25.0`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
