### PR TITLE
🌱 ClusterClass & test/framework: consider replicas for control plane readiness

### DIFF
--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -207,6 +207,7 @@ func (c *ControlPlaneContract) IsUpgrading(obj *unstructured.Unstructured) (bool
 // - spec.replicas != status.replicas.
 // - spec.replicas != status.updatedReplicas.
 // - spec.replicas != status.readyReplicas.
+// - status.unavailableReplicas > 0.
 func (c *ControlPlaneContract) IsScaling(obj *unstructured.Unstructured) (bool, error) {
 	desiredReplicas, err := c.Replicas().Get(obj)
 	if err != nil {
@@ -247,7 +248,7 @@ func (c *ControlPlaneContract) IsScaling(obj *unstructured.Unstructured) (bool, 
 	}
 
 	unavailableReplicas, err := c.UnavailableReplicas().Get(obj)
-	if err != nil && !errors.Is(err, errNotFound) {
+	if err != nil {
 		if !errors.Is(err, errNotFound) {
 			return false, errors.Wrap(err, "failed to get control plane status unavailableReplicas")
 		}

--- a/internal/contract/controlplane.go
+++ b/internal/contract/controlplane.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/cluster-api/util/version"
 )
@@ -245,9 +246,29 @@ func (c *ControlPlaneContract) IsScaling(obj *unstructured.Unstructured) (bool, 
 		return false, errors.Wrap(err, "failed to get control plane status readyReplicas")
 	}
 
+	unavailableReplicas, err := c.UnavailableReplicas().Get(obj)
+	if err != nil && !errors.Is(err, errNotFound) {
+		if !errors.Is(err, errNotFound) {
+			return false, errors.Wrap(err, "failed to get control plane status unavailableReplicas")
+		}
+		// If unavailableReplicas is not set on the control plane we assume it is 0.
+		// We have to do this as the following happens after clusterctl move with KCP:
+		// * clusterctl move creates the KCP object without status
+		// * the KCP controller won't patch the field to 0 if it doesn't exist
+		//   * This is because the patchHelper marshals before/after object to JSON to calculate a diff
+		//     and as the unavailableReplicas field is not a pointer, not set and 0 are both rendered as 0.
+		//     If before/after of the field is the same (i.e. 0), there is no diff and thus also no patch to set it to 0.
+		unavailableReplicas = pointer.Int64(0)
+	}
+
+	// Control plane is still scaling if:
+	// * .spec.replicas, .status.replicas, .status.updatedReplicas,
+	//   .status.readyReplicas are not equal and
+	// * unavailableReplicas > 0
 	if *statusReplicas != *desiredReplicas ||
 		*updatedReplicas != *desiredReplicas ||
-		*readyReplicas != *desiredReplicas {
+		*readyReplicas != *desiredReplicas ||
+		*unavailableReplicas > 0 {
 		return true, nil
 	}
 	return false, nil

--- a/internal/contract/controlplane_test.go
+++ b/internal/contract/controlplane_test.go
@@ -353,9 +353,10 @@ func TestControlPlaneIsScaling(t *testing.T) {
 					"replicas": int64(2),
 				},
 				"status": map[string]interface{}{
-					"replicas":        int64(2),
-					"updatedReplicas": int64(2),
-					"readyReplicas":   int64(2),
+					"replicas":            int64(2),
+					"updatedReplicas":     int64(2),
+					"readyReplicas":       int64(2),
+					"unavailableReplicas": int64(0),
 				},
 			}},
 			wantScaling: false,
@@ -370,53 +371,117 @@ func TestControlPlaneIsScaling(t *testing.T) {
 			wantScaling: true,
 		},
 		{
-			name: "should return true if status.replicas is not set on control plane",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
-				"spec": map[string]interface{}{
-					"replicas": int64(2),
-				},
-				"status": map[string]interface{}{},
-			}},
-			wantScaling: true,
-		},
-		{
-			name: "should return true if spec and status replicas do not match",
+			name: "should return true if status replicas is not set on control plane",
 			obj: &unstructured.Unstructured{Object: map[string]interface{}{
 				"spec": map[string]interface{}{
 					"replicas": int64(2),
 				},
 				"status": map[string]interface{}{
-					"replicas":        int64(1),
-					"updatedReplicas": int64(2),
-					"readyReplicas":   int64(2),
+					"updatedReplicas":     int64(2),
+					"readyReplicas":       int64(2),
+					"unavailableReplicas": int64(0),
 				},
 			}},
 			wantScaling: true,
 		},
 		{
-			name: "should return true if spec and status updatedReplicas do not match",
+			name: "should return true if spec replicas and status replicas do not match",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+				"status": map[string]interface{}{
+					"replicas":            int64(1),
+					"updatedReplicas":     int64(2),
+					"readyReplicas":       int64(2),
+					"unavailableReplicas": int64(0),
+				},
+			}},
+			wantScaling: true,
+		},
+		{
+			name: "should return true if status updatedReplicas is not set on control plane",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+				"status": map[string]interface{}{
+					"replicas":            int64(2),
+					"readyReplicas":       int64(2),
+					"unavailableReplicas": int64(0),
+				},
+			}},
+			wantScaling: true,
+		},
+		{
+			name: "should return true if spec replicas and status updatedReplicas do not match",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+				"status": map[string]interface{}{
+					"replicas":            int64(2),
+					"updatedReplicas":     int64(1),
+					"readyReplicas":       int64(2),
+					"unavailableReplicas": int64(0),
+				},
+			}},
+			wantScaling: true,
+		},
+		{
+			name: "should return true if status readyReplicas is not set on control plane",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+				"status": map[string]interface{}{
+					"replicas":            int64(2),
+					"updatedReplicas":     int64(2),
+					"unavailableReplicas": int64(0),
+				},
+			}},
+			wantScaling: true,
+		},
+		{
+			name: "should return true if spec replicas and status readyReplicas do not match",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": int64(2),
+				},
+				"status": map[string]interface{}{
+					"replicas":            int64(2),
+					"updatedReplicas":     int64(2),
+					"readyReplicas":       int64(1),
+					"unavailableReplicas": int64(0),
+				},
+			}},
+			wantScaling: true,
+		},
+		{
+			name: "should return false if status unavailableReplicas is not set on control plane",
 			obj: &unstructured.Unstructured{Object: map[string]interface{}{
 				"spec": map[string]interface{}{
 					"replicas": int64(2),
 				},
 				"status": map[string]interface{}{
 					"replicas":        int64(2),
-					"updatedReplicas": int64(1),
+					"updatedReplicas": int64(2),
 					"readyReplicas":   int64(2),
 				},
 			}},
-			wantScaling: true,
+			wantScaling: false,
 		},
 		{
-			name: "should return true if spec and status readyReplicas do not match",
+			name: "should return true if status unavailableReplicas is > 0",
 			obj: &unstructured.Unstructured{Object: map[string]interface{}{
 				"spec": map[string]interface{}{
 					"replicas": int64(2),
 				},
 				"status": map[string]interface{}{
-					"replicas":        int64(2),
-					"updatedReplicas": int64(2),
-					"readyReplicas":   int64(1),
+					"replicas":            int64(2),
+					"updatedReplicas":     int64(2),
+					"readyReplicas":       int64(2),
+					"unavailableReplicas": int64(1),
 				},
 			}},
 			wantScaling: true,

--- a/internal/controllers/topology/cluster/desired_state_test.go
+++ b/internal/controllers/topology/cluster/desired_state_test.go
@@ -611,7 +611,7 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 		defer utilfeature.SetFeatureGateDuringTest(t, feature.Gates, feature.RuntimeSDK, true)()
 
 		// Note: the version used by the machine deployments does
-		// not affect how we determining the control plane version.
+		// not affect how we're determining the control plane version.
 		// We only want to know if the machine deployments are stable.
 		//
 		// A machine deployment is considered stable if all the following are true:
@@ -706,10 +706,11 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 						"spec.replicas": int64(2),
 					}).
 					WithStatusFields(map[string]interface{}{
-						"status.version":         "v1.2.2",
-						"status.replicas":        int64(2),
-						"status.updatedReplicas": int64(2),
-						"status.readyReplicas":   int64(2),
+						"status.version":             "v1.2.2",
+						"status.replicas":            int64(2),
+						"status.updatedReplicas":     int64(2),
+						"status.readyReplicas":       int64(2),
+						"status.unavailableReplicas": int64(0),
 					}).
 					Build(),
 				expectedVersion: "v1.2.3",
@@ -739,10 +740,11 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 						"spec.replicas": int64(2),
 					}).
 					WithStatusFields(map[string]interface{}{
-						"status.version":         "v1.2.2",
-						"status.replicas":        int64(1),
-						"status.updatedReplicas": int64(1),
-						"status.readyReplicas":   int64(1),
+						"status.version":             "v1.2.2",
+						"status.replicas":            int64(1),
+						"status.updatedReplicas":     int64(1),
+						"status.readyReplicas":       int64(1),
+						"status.unavailableReplicas": int64(0),
 					}).
 					Build(),
 				expectedVersion: "v1.2.2",
@@ -756,10 +758,11 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 						"spec.replicas": int64(2),
 					}).
 					WithStatusFields(map[string]interface{}{
-						"status.version":         "v1.2.2",
-						"status.replicas":        int64(2),
-						"status.updatedReplicas": int64(2),
-						"status.readyReplicas":   int64(2),
+						"status.version":             "v1.2.2",
+						"status.replicas":            int64(2),
+						"status.updatedReplicas":     int64(2),
+						"status.readyReplicas":       int64(2),
+						"status.unavailableReplicas": int64(0),
 					}).
 					Build(),
 				machineDeploymentsState: scope.MachineDeploymentsStateMap{
@@ -778,10 +781,11 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 						"spec.replicas": int64(2),
 					}).
 					WithStatusFields(map[string]interface{}{
-						"status.version":         "v1.2.2",
-						"status.replicas":        int64(2),
-						"status.updatedReplicas": int64(2),
-						"status.readyReplicas":   int64(2),
+						"status.version":             "v1.2.2",
+						"status.replicas":            int64(2),
+						"status.updatedReplicas":     int64(2),
+						"status.readyReplicas":       int64(2),
+						"status.unavailableReplicas": int64(0),
 					}).
 					Build(),
 				machineDeploymentsState: scope.MachineDeploymentsStateMap{
@@ -800,10 +804,11 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 						"spec.replicas": int64(2),
 					}).
 					WithStatusFields(map[string]interface{}{
-						"status.version":         "v1.2.2",
-						"status.replicas":        int64(2),
-						"status.updatedReplicas": int64(2),
-						"status.readyReplicas":   int64(2),
+						"status.version":             "v1.2.2",
+						"status.replicas":            int64(2),
+						"status.updatedReplicas":     int64(2),
+						"status.readyReplicas":       int64(2),
+						"status.unavailableReplicas": int64(0),
 					}).
 					Build(),
 				machineDeploymentsState: scope.MachineDeploymentsStateMap{
@@ -822,10 +827,11 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 						"spec.replicas": int64(2),
 					}).
 					WithStatusFields(map[string]interface{}{
-						"status.version":         "v1.2.2",
-						"status.replicas":        int64(2),
-						"status.updatedReplicas": int64(2),
-						"status.readyReplicas":   int64(2),
+						"status.version":             "v1.2.2",
+						"status.replicas":            int64(2),
+						"status.updatedReplicas":     int64(2),
+						"status.readyReplicas":       int64(2),
+						"status.unavailableReplicas": int64(0),
 					}).
 					Build(),
 				machineDeploymentsState: scope.MachineDeploymentsStateMap{
@@ -1211,10 +1217,11 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 				"spec.replicas": int64(2),
 			}).
 			WithStatusFields(map[string]interface{}{
-				"status.version":         "v1.2.2",
-				"status.replicas":        int64(2),
-				"status.updatedReplicas": int64(2),
-				"status.readyReplicas":   int64(2),
+				"status.version":             "v1.2.2",
+				"status.replicas":            int64(2),
+				"status.updatedReplicas":     int64(2),
+				"status.readyReplicas":       int64(2),
+				"status.unavailableReplicas": int64(0),
 			}).
 			Build()
 
@@ -1697,10 +1704,11 @@ func TestComputeMachineDeploymentVersion(t *testing.T) {
 			"spec.replicas": int64(2),
 		}).
 		WithStatusFields(map[string]interface{}{
-			"status.version":         "v1.2.2",
-			"status.replicas":        int64(2),
-			"status.updatedReplicas": int64(2),
-			"status.readyReplicas":   int64(2),
+			"status.version":             "v1.2.2",
+			"status.replicas":            int64(2),
+			"status.updatedReplicas":     int64(2),
+			"status.readyReplicas":       int64(2),
+			"status.unavailableReplicas": int64(0),
 		}).
 		Build()
 	controlPlaneStable123 := builder.ControlPlane("test1", "cp1").
@@ -1709,10 +1717,11 @@ func TestComputeMachineDeploymentVersion(t *testing.T) {
 			"spec.replicas": int64(2),
 		}).
 		WithStatusFields(map[string]interface{}{
-			"status.version":         "v1.2.3",
-			"status.replicas":        int64(2),
-			"status.updatedReplicas": int64(2),
-			"status.readyReplicas":   int64(2),
+			"status.version":             "v1.2.3",
+			"status.replicas":            int64(2),
+			"status.updatedReplicas":     int64(2),
+			"status.readyReplicas":       int64(2),
+			"status.unavailableReplicas": int64(0),
 		}).
 		Build()
 	controlPlaneUpgrading := builder.ControlPlane("test1", "cp1").
@@ -1729,10 +1738,11 @@ func TestComputeMachineDeploymentVersion(t *testing.T) {
 			"spec.replicas": int64(2),
 		}).
 		WithStatusFields(map[string]interface{}{
-			"status.version":         "v1.2.3",
-			"status.replicas":        int64(1),
-			"status.updatedReplicas": int64(1),
-			"status.readyReplicas":   int64(1),
+			"status.version":             "v1.2.3",
+			"status.replicas":            int64(1),
+			"status.updatedReplicas":     int64(1),
+			"status.readyReplicas":       int64(1),
+			"status.unavailableReplicas": int64(0),
 		}).
 		Build()
 	controlPlaneDesired := builder.ControlPlane("test1", "cp1").

--- a/internal/controllers/topology/cluster/reconcile_state_test.go
+++ b/internal/controllers/topology/cluster/reconcile_state_test.go
@@ -498,10 +498,11 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 			"spec.replicas": int64(2),
 		}).
 		WithStatusFields(map[string]interface{}{
-			"status.version":         topologyVersion,
-			"status.replicas":        int64(2),
-			"status.updatedReplicas": int64(2),
-			"status.readyReplicas":   int64(2),
+			"status.version":             topologyVersion,
+			"status.replicas":            int64(2),
+			"status.updatedReplicas":     int64(2),
+			"status.readyReplicas":       int64(2),
+			"status.unavailableReplicas": int64(0),
 		}).
 		Build()
 	controlPlaneStableAtLowerVersion := builder.ControlPlane("test1", "cp1").
@@ -510,10 +511,11 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 			"spec.replicas": int64(2),
 		}).
 		WithStatusFields(map[string]interface{}{
-			"status.version":         lowerVersion,
-			"status.replicas":        int64(2),
-			"status.updatedReplicas": int64(2),
-			"status.readyReplicas":   int64(2),
+			"status.version":             lowerVersion,
+			"status.replicas":            int64(2),
+			"status.updatedReplicas":     int64(2),
+			"status.readyReplicas":       int64(2),
+			"status.unavailableReplicas": int64(0),
 		}).
 		Build()
 	controlPlaneUpgrading := builder.ControlPlane("test1", "cp1").
@@ -522,10 +524,11 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 			"spec.replicas": int64(2),
 		}).
 		WithStatusFields(map[string]interface{}{
-			"status.version":         lowerVersion,
-			"status.replicas":        int64(2),
-			"status.updatedReplicas": int64(2),
-			"status.readyReplicas":   int64(2),
+			"status.version":             lowerVersion,
+			"status.replicas":            int64(2),
+			"status.updatedReplicas":     int64(2),
+			"status.readyReplicas":       int64(2),
+			"status.unavailableReplicas": int64(0),
 		}).
 		Build()
 	controlPlaneScaling := builder.ControlPlane("test1", "cp1").
@@ -534,10 +537,11 @@ func TestReconcile_callAfterClusterUpgrade(t *testing.T) {
 			"spec.replicas": int64(2),
 		}).
 		WithStatusFields(map[string]interface{}{
-			"status.version":         topologyVersion,
-			"status.replicas":        int64(1),
-			"status.updatedReplicas": int64(1),
-			"status.readyReplicas":   int64(1),
+			"status.version":             topologyVersion,
+			"status.replicas":            int64(1),
+			"status.updatedReplicas":     int64(1),
+			"status.readyReplicas":       int64(1),
+			"status.unavailableReplicas": int64(0),
 		}).
 		Build()
 

--- a/test/e2e/clusterctl_upgrade.go
+++ b/test/e2e/clusterctl_upgrade.go
@@ -436,6 +436,7 @@ func ClusterctlUpgradeSpec(ctx context.Context, inputGetter func() ClusterctlUpg
 		}
 
 		// After the upgrade check that there were no unexpected rollouts.
+		log.Logf("Verify there are no unexpected rollouts")
 		Consistently(func() bool {
 			postUpgradeMachineList := &unstructured.UnstructuredList{}
 			postUpgradeMachineList.SetGroupVersionKind(clusterv1.GroupVersion.WithKind("MachineList"))


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This is a follow-up to #7833. While triaging further we found out that:
* the topology controller was not waiting until KCP was entirely stable before triggering a rollout of the control plane
* the test framework wasn't waiting until KCP was entirely stable
  * in the upgrade test this means the upgrade is triggered while KCP is still not stable from the create

Thx @fabriziopandini for collaborating on debugging this stuff! :)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Follow-up to: #7833