### PR TITLE
:seedling: Update cert-manager to v1.11.0

### DIFF
--- a/cmd/clusterctl/client/config/cert_manager_client.go
+++ b/cmd/clusterctl/client/config/cert_manager_client.go
@@ -29,7 +29,7 @@ const (
 	CertManagerConfigKey = "cert-manager"
 
 	// CertManagerDefaultVersion defines the default cert-manager version to be used by clusterctl.
-	CertManagerDefaultVersion = "v1.10.1"
+	CertManagerDefaultVersion = "v1.11.0"
 
 	// CertManagerDefaultURL defines the default cert-manager repository url to be used by clusterctl.
 	// NOTE: At runtime CertManagerDefaultVersion may be replaced with the

--- a/docs/book/src/clusterctl/commands/init.md
+++ b/docs/book/src/clusterctl/commands/init.md
@@ -190,7 +190,7 @@ If this happens, there are no guarantees about the proper functioning of `cluste
 Cluster API providers require a cert-manager version supporting the `cert-manager.io/v1` API to be installed in the cluster.
 
 While doing init, clusterctl checks if there is a version of cert-manager already installed. If not, clusterctl will
-install a default version (currently cert-manager v1.10.1). See [clusterctl configuration](../configuration.md) for
+install a default version (currently cert-manager v1.11.0). See [clusterctl configuration](../configuration.md) for
 available options to customize this operation.
 
 <aside class="note warning">

--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -81,7 +81,7 @@ The generated binary can be found at ./hack/tools/bin/envsubst
 You'll need to deploy [cert-manager] components on your [management cluster][mcluster], using `kubectl`
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
 ```
 
 Ensure the cert-manager webhook service is ready before creating the Cluster API components.

--- a/docs/book/src/user/quick-start.md
+++ b/docs/book/src/user/quick-start.md
@@ -734,7 +734,7 @@ The output of `clusterctl init` is similar to this:
 
 ```bash
 Fetching providers
-Installing cert-manager Version="v1.10.1"
+Installing cert-manager Version="v1.11.0"
 Waiting for cert-manager to be available...
 Installing Provider="cluster-api" Version="v1.0.0" TargetNamespace="capi-system"
 Installing Provider="bootstrap-kubeadm" Version="v1.0.0" TargetNamespace="capi-kubeadm-bootstrap-system"

--- a/docs/book/src/user/troubleshooting.md
+++ b/docs/book/src/user/troubleshooting.md
@@ -161,7 +161,7 @@ clusterctl init --infrastructure docker
 ```
 ```bash
 Fetching providers
-Installing cert-manager Version="v1.10.1"
+Installing cert-manager Version="v1.11.0"
 Error: action failed after 10 attempts: failed to get cert-manager object /, Kind=, /: Object 'Kind' is missing in 'unstructured object has no kind'
 ```
 
@@ -173,7 +173,7 @@ cert-manager:
   url: "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"
 ```
 
-Alternatively a Cert Manager yaml file can be placed in the [clusterctl overrides layer](../clusterctl/configuration.md#overrides-layer) which is by default in `$HOME/.cluster-api/overrides`. A Cert Manager yaml file can be placed at `$(HOME)/.cluster-api/overrides/cert-manager/v1.10.1/cert-manager.yaml`
+Alternatively a Cert Manager yaml file can be placed in the [clusterctl overrides layer](../clusterctl/configuration.md#overrides-layer) which is by default in `$HOME/.cluster-api/overrides`. A Cert Manager yaml file can be placed at `$(HOME)/.cluster-api/overrides/cert-manager/v1.11.0/cert-manager.yaml`
 
 More information on the clusterctl config file can be found at [its page in the book](../clusterctl/configuration.md#clusterctl-configuration-file)
 

--- a/scripts/ci-e2e-lib.sh
+++ b/scripts/ci-e2e-lib.sh
@@ -201,9 +201,9 @@ EOL
 # the actual test run less sensible to the network speed.
 kind:prepullAdditionalImages () {
   # Pulling cert manager images so we can pre-load in kind nodes
-  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.10.1"
-  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.10.1"
-  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.10.1"
+  kind::prepullImage "quay.io/jetstack/cert-manager-cainjector:v1.11.0"
+  kind::prepullImage "quay.io/jetstack/cert-manager-webhook:v1.11.0"
+  kind::prepullImage "quay.io/jetstack/cert-manager-controller:v1.11.0"
 }
 
 # kind:prepullImage pre-pull a docker image if no already present locally.

--- a/test/e2e/config/docker.yaml
+++ b/test/e2e/config/docker.yaml
@@ -19,11 +19,11 @@ images:
   loadBehavior: tryLoad
 - name: gcr.io/k8s-staging-cluster-api/test-extension-{ARCH}:dev
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-cainjector:v1.10.1
+- name: quay.io/jetstack/cert-manager-cainjector:v1.11.0
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-webhook:v1.10.1
+- name: quay.io/jetstack/cert-manager-webhook:v1.11.0
   loadBehavior: tryLoad
-- name: quay.io/jetstack/cert-manager-controller:v1.10.1
+- name: quay.io/jetstack/cert-manager-controller:v1.11.0
   loadBehavior: tryLoad
 
 providers:


### PR DESCRIPTION
Signed-off-by: brcox <brcox@redhat.com>

**What this PR does / why we need it**:
Resolves https://github.com/kubernetes-sigs/cluster-api/issues/7892

**Which issue(s) this PR fixes**:
Resolves https://github.com/kubernetes-sigs/cluster-api/issues/7892
