### PR TITLE
✨ Managed Cluster should set labels and annotations on ControlPlane and MDs

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -101,11 +101,10 @@ type Topology struct {
 
 // ControlPlaneTopology specifies the parameters for the control plane nodes in the cluster.
 type ControlPlaneTopology struct {
-	// Metadata is the metadata applied to the machines of the ControlPlane.
+	// Metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane
+	// if the ControlPlaneTemplate referenced by the ClusterClass is machine based. If not, it
+	// is applied only to the ControlPlane.
 	// At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
-	//
-	// This field is supported if and only if the control plane provider template
-	// referenced in the ClusterClass is Machine based.
 	// +optional
 	Metadata ObjectMeta `json:"metadata,omitempty"`
 
@@ -149,7 +148,7 @@ type WorkersTopology struct {
 // MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology.
 // This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
 type MachineDeploymentTopology struct {
-	// Metadata is the metadata applied to the machines of the MachineDeployment.
+	// Metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment.
 	// At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
 	// +optional
 	Metadata ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -75,7 +75,9 @@ type ClusterClassSpec struct {
 
 // ControlPlaneClass defines the class for the control plane.
 type ControlPlaneClass struct {
-	// Metadata is the metadata applied to the machines of the ControlPlane.
+	// Metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane
+	// if the ControlPlaneTemplate referenced is machine based. If not, it is applied only to the
+	// ControlPlane.
 	// At runtime this metadata is merged with the corresponding metadata from the topology.
 	//
 	// This field is supported if and only if the control plane provider template
@@ -188,7 +190,7 @@ type MachineDeploymentClass struct {
 // MachineDeploymentClassTemplate defines how a MachineDeployment generated from a MachineDeploymentClass
 // should look like.
 type MachineDeploymentClassTemplate struct {
-	// Metadata is the metadata applied to the machines of the MachineDeployment.
+	// Metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment.
 	// At runtime this metadata is merged with the corresponding metadata from the topology.
 	// +optional
 	Metadata ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -815,7 +815,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ControlPlaneClass(ref common.Refer
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the topology.\n\nThis field is supported if and only if the control plane provider template referenced is Machine based.",
+							Description: "Metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane if the ControlPlaneTemplate referenced is machine based. If not, it is applied only to the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the topology.\n\nThis field is supported if and only if the control plane provider template referenced is Machine based.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("sigs.k8s.io/cluster-api/api/v1beta1.ObjectMeta"),
 						},
@@ -874,7 +874,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ControlPlaneTopology(ref common.Re
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.\n\nThis field is supported if and only if the control plane provider template referenced in the ClusterClass is Machine based.",
+							Description: "Metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane if the ControlPlaneTemplate referenced by the ClusterClass is machine based. If not, it is applied only to the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("sigs.k8s.io/cluster-api/api/v1beta1.ObjectMeta"),
 						},
@@ -1481,7 +1481,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentClassTemplate(ref
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the topology.",
+							Description: "Metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the topology.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("sigs.k8s.io/cluster-api/api/v1beta1.ObjectMeta"),
 						},
@@ -1764,7 +1764,7 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_MachineDeploymentTopology(ref comm
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.",
+							Description: "Metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("sigs.k8s.io/cluster-api/api/v1beta1.ObjectMeta"),
 						},

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -560,11 +560,13 @@ spec:
                     - ref
                     type: object
                   metadata:
-                    description: "Metadata is the metadata applied to the machines
-                      of the ControlPlane. At runtime this metadata is merged with
-                      the corresponding metadata from the topology. \n This field
-                      is supported if and only if the control plane provider template
-                      referenced is Machine based."
+                    description: "Metadata is the metadata applied to the ControlPlane
+                      and the Machines of the ControlPlane if the ControlPlaneTemplate
+                      referenced is machine based. If not, it is applied only to the
+                      ControlPlane. At runtime this metadata is merged with the corresponding
+                      metadata from the topology. \n This field is supported if and
+                      only if the control plane provider template referenced is Machine
+                      based."
                     properties:
                       annotations:
                         additionalProperties:
@@ -1357,9 +1359,9 @@ spec:
                               type: object
                             metadata:
                               description: Metadata is the metadata applied to the
-                                machines of the MachineDeployment. At runtime this
-                                metadata is merged with the corresponding metadata
-                                from the topology.
+                                MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding
+                                metadata from the topology.
                               properties:
                                 annotations:
                                   additionalProperties:

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -951,12 +951,12 @@ spec:
                             type: string
                         type: object
                       metadata:
-                        description: "Metadata is the metadata applied to the machines
-                          of the ControlPlane. At runtime this metadata is merged
-                          with the corresponding metadata from the ClusterClass. \n
-                          This field is supported if and only if the control plane
-                          provider template referenced in the ClusterClass is Machine
-                          based."
+                        description: Metadata is the metadata applied to the ControlPlane
+                          and the Machines of the ControlPlane if the ControlPlaneTemplate
+                          referenced by the ClusterClass is machine based. If not,
+                          it is applied only to the ControlPlane. At runtime this
+                          metadata is merged with the corresponding metadata from
+                          the ClusterClass.
                         properties:
                           annotations:
                             additionalProperties:
@@ -1189,9 +1189,9 @@ spec:
                               type: object
                             metadata:
                               description: Metadata is the metadata applied to the
-                                machines of the MachineDeployment. At runtime this
-                                metadata is merged with the corresponding metadata
-                                from the ClusterClass.
+                                MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding
+                                metadata from the ClusterClass.
                               properties:
                                 annotations:
                                   additionalProperties:

--- a/internal/controllers/topology/cluster/desired_state_test.go
+++ b/internal/controllers/topology/cluster/desired_state_test.go
@@ -317,6 +317,8 @@ func TestComputeControlPlane(t *testing.T) {
 			template:    blueprint.ControlPlane.Template,
 			currentRef:  nil,
 			obj:         obj,
+			labels:      mergeMap(blueprint.Topology.ControlPlane.Metadata.Labels, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Labels),
+			annotations: mergeMap(blueprint.Topology.ControlPlane.Metadata.Annotations, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Annotations),
 		})
 
 		assertNestedField(g, obj, version, contract.ControlPlane().Version().Path()...)
@@ -406,6 +408,8 @@ func TestComputeControlPlane(t *testing.T) {
 			template:    blueprint.ControlPlane.Template,
 			currentRef:  nil,
 			obj:         obj,
+			labels:      mergeMap(blueprint.Topology.ControlPlane.Metadata.Labels, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Labels),
+			annotations: mergeMap(blueprint.Topology.ControlPlane.Metadata.Annotations, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Annotations),
 		})
 
 		assertNestedField(g, obj, version, contract.ControlPlane().Version().Path()...)
@@ -449,6 +453,8 @@ func TestComputeControlPlane(t *testing.T) {
 			template:    blueprint.ControlPlane.Template,
 			currentRef:  nil,
 			obj:         obj,
+			labels:      mergeMap(blueprint.Topology.ControlPlane.Metadata.Labels, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Labels),
+			annotations: mergeMap(blueprint.Topology.ControlPlane.Metadata.Annotations, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Annotations),
 		})
 		gotMetadata, err := contract.ControlPlane().MachineTemplate().Metadata().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
@@ -501,6 +507,8 @@ func TestComputeControlPlane(t *testing.T) {
 			template:    blueprint.ControlPlane.Template,
 			currentRef:  scope.Current.Cluster.Spec.ControlPlaneRef,
 			obj:         obj,
+			labels:      mergeMap(blueprint.Topology.ControlPlane.Metadata.Labels, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Labels),
+			annotations: mergeMap(blueprint.Topology.ControlPlane.Metadata.Annotations, blueprint.ClusterClass.Spec.ControlPlane.Metadata.Annotations),
 		})
 	})
 	t.Run("Should choose the correct version for control plane", func(t *testing.T) {
@@ -1449,6 +1457,9 @@ func TestComputeMachineDeployment(t *testing.T) {
 
 		g.Expect(actualMd.Labels).To(HaveKeyWithValue(clusterv1.ClusterTopologyMachineDeploymentNameLabel, "big-pool-of-machines"))
 		g.Expect(actualMd.Labels).To(HaveKey(clusterv1.ClusterTopologyOwnedLabel))
+		for k, v := range mergeMap(mdTopology.Metadata.Labels, md1.Template.Metadata.Labels) {
+			g.Expect(actualMd.Labels).To(HaveKeyWithValue(k, v))
+		}
 
 		g.Expect(actualMd.Spec.Selector.MatchLabels).To(HaveKey(clusterv1.ClusterTopologyOwnedLabel))
 		g.Expect(actualMd.Spec.Selector.MatchLabels).To(HaveKeyWithValue(clusterv1.ClusterTopologyMachineDeploymentNameLabel, "big-pool-of-machines"))
@@ -1529,6 +1540,9 @@ func TestComputeMachineDeployment(t *testing.T) {
 
 		g.Expect(actualMd.Labels).To(HaveKeyWithValue(clusterv1.ClusterTopologyMachineDeploymentNameLabel, "big-pool-of-machines"))
 		g.Expect(actualMd.Labels).To(HaveKey(clusterv1.ClusterTopologyOwnedLabel))
+		for k, v := range mergeMap(mdTopology.Metadata.Labels, md1.Template.Metadata.Labels) {
+			g.Expect(actualMd.Labels).To(HaveKeyWithValue(k, v))
+		}
 
 		g.Expect(actualMd.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue("foo", "baz"))
 		g.Expect(actualMd.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue("fizz", "buzz"))

--- a/test/e2e/data/infrastructure-docker/main/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/main/bases/cluster-with-topology.yaml
@@ -16,7 +16,11 @@ spec:
     class: "quick-start"
     version: "${KUBERNETES_VERSION}"
     controlPlane:
-      metadata: {}
+      metadata:
+        labels:
+          label-from-cluster-topology: "value-from-cluster-topology"
+        annotations:
+          annotation-from-cluster-topology: "value-from-cluster-topology"
       nodeDeletionTimeout: "30s"
       nodeVolumeDetachTimeout: "5m"
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
@@ -24,6 +28,11 @@ spec:
       machineDeployments:
       - class: "default-worker"
         name: "md-0"
+        metadata:
+          labels:
+            label-from-cluster-topology: "value-from-cluster-topology"
+          annotations:
+            annotation-from-cluster-topology: "value-from-cluster-topology"
         nodeDeletionTimeout: "30s"
         nodeVolumeDetachTimeout: "5m"
         minReadySeconds: 5

--- a/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/main/clusterclass-quick-start.yaml
@@ -4,6 +4,11 @@ metadata:
   name: quick-start
 spec:
   controlPlane:
+    metadata:
+      labels:
+        label-from-clusterclass: "value-from-clusterclass"
+      annotations:
+        annotation-from-clusterclass: "value-from-clusterclass"
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
@@ -28,6 +33,11 @@ spec:
     machineDeployments:
     - class: default-worker
       template:
+        metadata:
+          labels:
+            label-from-clusterclass: "value-from-clusterclass"
+          annotations:
+            annotation-from-clusterclass: "value-from-clusterclass"
         bootstrap:
           ref:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/v1.2/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.2/bases/cluster-with-topology.yaml
@@ -16,7 +16,11 @@ spec:
     class: "quick-start"
     version: "${KUBERNETES_VERSION}"
     controlPlane:
-      metadata: {}
+      metadata:
+        labels:
+          label-from-cluster-topology: "value-from-cluster-topology"
+        annotations:
+          annotation-from-cluster-topology: "value-from-cluster-topology"
       # Can't be used as this field doesn't exist in v1.2.x.
       #nodeDeletionTimeout: "30s"
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
@@ -24,6 +28,11 @@ spec:
       machineDeployments:
       - class: "default-worker"
         name: "md-0"
+        metadata:
+          labels:
+            label-from-cluster-topology: "value-from-cluster-topology"
+          annotations:
+            annotation-from-cluster-topology: "value-from-cluster-topology"
         # Can't be used as this field doesn't exist in v1.2.x.
         #nodeDeletionTimeout: "30s"
         replicas: ${WORKER_MACHINE_COUNT}

--- a/test/e2e/data/infrastructure-docker/v1.2/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.2/clusterclass-quick-start.yaml
@@ -4,6 +4,11 @@ metadata:
   name: quick-start
 spec:
   controlPlane:
+    metadata:
+      labels:
+        label-from-clusterclass: "value-from-clusterclass"
+      annotations:
+        annotation-from-clusterclass: "value-from-clusterclass"
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
@@ -28,6 +33,11 @@ spec:
     machineDeployments:
     - class: default-worker
       template:
+        metadata:
+          labels:
+            label-from-clusterclass: "value-from-clusterclass"
+          annotations:
+            annotation-from-clusterclass: "value-from-clusterclass"
         bootstrap:
           ref:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-docker/v1.3/bases/cluster-with-topology.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.3/bases/cluster-with-topology.yaml
@@ -16,7 +16,11 @@ spec:
     class: "quick-start"
     version: "${KUBERNETES_VERSION}"
     controlPlane:
-      metadata: {}
+      metadata:
+        labels:
+          label-from-cluster-topology: "value-from-cluster-topology"
+        annotations:
+          annotation-from-cluster-topology: "value-from-cluster-topology"
       nodeDeletionTimeout: "30s"
       nodeVolumeDetachTimeout: "5m"
       replicas: ${CONTROL_PLANE_MACHINE_COUNT}
@@ -24,6 +28,11 @@ spec:
       machineDeployments:
       - class: "default-worker"
         name: "md-0"
+        metadata:
+          labels:
+            label-from-cluster-topology: "value-from-cluster-topology"
+          annotations:
+            annotation-from-cluster-topology: "value-from-cluster-topology"
         nodeDeletionTimeout: "30s"
         nodeVolumeDetachTimeout: "5m"
         minReadySeconds: 5

--- a/test/e2e/data/infrastructure-docker/v1.3/clusterclass-quick-start.yaml
+++ b/test/e2e/data/infrastructure-docker/v1.3/clusterclass-quick-start.yaml
@@ -4,6 +4,11 @@ metadata:
   name: quick-start
 spec:
   controlPlane:
+    metadata:
+      labels:
+        label-from-clusterclass: "value-from-clusterclass"
+      annotations:
+        annotation-from-clusterclass: "value-from-clusterclass"
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
@@ -28,6 +33,11 @@ spec:
     machineDeployments:
     - class: default-worker
       template:
+        metadata:
+          labels:
+            label-from-clusterclass: "value-from-clusterclass"
+          annotations:
+            annotation-from-clusterclass: "value-from-clusterclass"
         bootstrap:
           ref:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds support to apply labels and annotations to the ControlPlane and MachineDeployment objects. 

Credit to @MaxFedotov for doing the initial implementation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Part of #7731
Related issue: #7006
