### PR TITLE
[WIP] ✨ in-place propagation from MD to MS to Machines

### DIFF
--- a/api/v1beta1/machinedeployment_types.go
+++ b/api/v1beta1/machinedeployment_types.go
@@ -54,8 +54,17 @@ const (
 	// proportions in case the deployment has surge replicas.
 	MaxReplicasAnnotation = "machinedeployment.clusters.x-k8s.io/max-replicas"
 
-	// MachineDeploymentUniqueLabel is the label applied to Machines
-	// in a MachineDeployment containing the hash of the template.
+	// MachineDeploymentUniqueLabel is used to uniquely identify the Machines of a MachineSet.
+	// The MachineDeployment controller will set this label on a MachineSet when it is created.
+	// The label is also applied to the Machines of the MachineSet and used in the MachineSet selector.
+	// Note: For the lifetime of the MachineSet the label's value has to stay the same, otherwise the
+	// MachineSet selector would no longer match its Machines.
+	// Note: In previous Cluster API versions, the label value was the hash of the machine template.
+	// With the introduction of in-place mutation the machine template of the MachineSet can change.
+	// Because of that it is impossible that the label's value to always be the hash of the machine template.
+	// (Because the hash changes when the machine template changes).
+	// As a result, we use a random unique string as value for the machine-template-hash, making it independent
+	// of the machine template.
 	MachineDeploymentUniqueLabel = "machine-template-hash"
 )
 

--- a/internal/controllers/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller_test.go
@@ -141,15 +141,17 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 		}
 		infraTmpl := &unstructured.Unstructured{
 			Object: map[string]interface{}{
+				"kind":       "GenericInfrastructureMachineTemplate",
+				"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+				"metadata": map[string]interface{}{
+					"name":      "md-template",
+					"namespace": namespace.Name,
+				},
 				"spec": map[string]interface{}{
 					"template": infraResource,
 				},
 			},
 		}
-		infraTmpl.SetKind("GenericInfrastructureMachineTemplate")
-		infraTmpl.SetAPIVersion("infrastructure.cluster.x-k8s.io/v1beta1")
-		infraTmpl.SetName("md-template")
-		infraTmpl.SetNamespace(namespace.Name)
 		t.Log("Creating the infrastructure template")
 		g.Expect(env.Create(ctx, infraTmpl)).To(Succeed())
 
@@ -281,15 +283,17 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 		}
 		infraTmpl2 := &unstructured.Unstructured{
 			Object: map[string]interface{}{
+				"kind":       "GenericInfrastructureMachineTemplate",
+				"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+				"metadata": map[string]interface{}{
+					"name":      "md-template-2",
+					"namespace": namespace.Name,
+				},
 				"spec": map[string]interface{}{
 					"template": infraResource2,
 				},
 			},
 		}
-		infraTmpl2.SetKind("GenericInfrastructureMachineTemplate")
-		infraTmpl2.SetAPIVersion("infrastructure.cluster.x-k8s.io/v1beta1")
-		infraTmpl2.SetName("md-template-2")
-		infraTmpl2.SetNamespace(namespace.Name)
 		t.Log("Creating the infrastructure template")
 		g.Expect(env.Create(ctx, infraTmpl2)).To(Succeed())
 

--- a/internal/controllers/machinedeployment/machinedeployment_rolling.go
+++ b/internal/controllers/machinedeployment/machinedeployment_rolling.go
@@ -91,7 +91,7 @@ func (r *Reconciler) reconcileNewMachineSet(ctx context.Context, allMSs []*clust
 		return r.scaleMachineSet(ctx, newMS, *(deployment.Spec.Replicas), deployment)
 	}
 
-	newReplicasCount, err := mdutil.NewMSNewReplicas(deployment, allMSs, newMS)
+	newReplicasCount, err := mdutil.NewMSNewReplicas(deployment, allMSs, *newMS.Spec.Replicas)
 	if err != nil {
 		return err
 	}

--- a/internal/controllers/machinedeployment/machinedeployment_sync_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_sync_test.go
@@ -20,12 +20,16 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	apirand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2/klogr"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -493,6 +497,234 @@ func TestSyncDeploymentStatus(t *testing.T) {
 			assertConditions(t, test.d, test.expectedConditions...)
 		})
 	}
+}
+
+func TestComputeDesiredMachineSet(t *testing.T) {
+	duration5s := &metav1.Duration{Duration: 5 * time.Second}
+	duration10s := &metav1.Duration{Duration: 10 * time.Second}
+
+	infraRef := corev1.ObjectReference{
+		Kind:       "GenericInfrastructureMachineTemplate",
+		Name:       "infra-template-1",
+		APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+	}
+	bootstrapRef := corev1.ObjectReference{
+		Kind:       "GenericBootstrapConfigTemplate",
+		Name:       "bootstrap-template-1",
+		APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
+	}
+
+	deployment := &clusterv1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "default",
+			Name:        "md1",
+			Annotations: map[string]string{"top-level-annotation": "top-level-annotation-value"},
+		},
+		Spec: clusterv1.MachineDeploymentSpec{
+			ClusterName:     "test-cluster",
+			Replicas:        pointer.Int32(3),
+			MinReadySeconds: pointer.Int32(10),
+			Strategy: &clusterv1.MachineDeploymentStrategy{
+				Type: clusterv1.RollingUpdateMachineDeploymentStrategyType,
+				RollingUpdate: &clusterv1.MachineRollingUpdateDeployment{
+					MaxSurge:       intOrStrPtr(1),
+					DeletePolicy:   pointer.String("Random"),
+					MaxUnavailable: intOrStrPtr(0),
+				},
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"k1": "v1"},
+			},
+			Template: clusterv1.MachineTemplateSpec{
+				ObjectMeta: clusterv1.ObjectMeta{
+					Labels:      map[string]string{"machine-label1": "machine-value1"},
+					Annotations: map[string]string{"machine-annotation1": "machine-value1"},
+				},
+				Spec: clusterv1.MachineSpec{
+					Version:           pointer.String("v1.25.3"),
+					InfrastructureRef: infraRef,
+					Bootstrap: clusterv1.Bootstrap{
+						ConfigRef: &bootstrapRef,
+					},
+					NodeDrainTimeout:        duration10s,
+					NodeVolumeDetachTimeout: duration10s,
+					NodeDeletionTimeout:     duration10s,
+				},
+			},
+		},
+	}
+
+	skeletonMS := &clusterv1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "default",
+			Labels:      map[string]string{"machine-label1": "machine-value1"},
+			Annotations: map[string]string{"top-level-annotation": "top-level-annotation-value"},
+		},
+		Spec: clusterv1.MachineSetSpec{
+			ClusterName:     "test-cluster",
+			Replicas:        pointer.Int32(3),
+			MinReadySeconds: 10,
+			DeletePolicy:    "Random",
+			Selector:        metav1.LabelSelector{MatchLabels: map[string]string{"k1": "v1"}},
+			Template:        *deployment.Spec.Template.DeepCopy(),
+		},
+	}
+
+	// Creating a new MS
+	expectedNewMS := skeletonMS.DeepCopy()
+
+	// Creating a new MS when old MSs exist
+	oldMSWhenCreatingNewMS := skeletonMS.DeepCopy()
+	oldMSWhenCreatingNewMS.Spec.Replicas = pointer.Int32(2)
+	expectedNewMSRolling := skeletonMS.DeepCopy()
+	expectedNewMSRolling.Spec.Replicas = pointer.Int32(2) // 4 (maxsurge+replicas) - 2 (replicas of old ms) = 2
+
+	uniqueID := apirand.String(5)
+
+	// Updating an existing MS, not old MSs
+	existingMS := skeletonMS.DeepCopy()
+	existingMSUID := types.UID("abc-123-uid")
+	existingMS.UID = existingMSUID
+	existingMS.Name = deployment.Name + "-" + uniqueID
+	existingMS.Labels = map[string]string{
+		clusterv1.MachineDeploymentUniqueLabel: uniqueID,
+		"ms-label-1":                           "ms-value-1",
+	}
+	existingMS.Annotations = nil
+	existingMS.Spec.Template.Labels = map[string]string{
+		clusterv1.MachineDeploymentUniqueLabel: uniqueID,
+		"ms-label-2":                           "ms-value-2",
+	}
+	existingMS.Spec.Template.Annotations = nil
+	existingMS.Spec.Template.Spec.NodeDrainTimeout = duration5s
+	existingMS.Spec.Template.Spec.NodeDeletionTimeout = duration5s
+	existingMS.Spec.Template.Spec.NodeVolumeDetachTimeout = duration5s
+	existingMS.Spec.DeletePolicy = "Newest"
+	existingMS.Spec.MinReadySeconds = 0
+
+	expectedUpdatedMS := skeletonMS.DeepCopy()
+	expectedUpdatedMS.UID = existingMSUID
+	expectedUpdatedMS.Name = deployment.Name + "-" + uniqueID
+	expectedUpdatedMS.Labels[clusterv1.MachineDeploymentUniqueLabel] = uniqueID
+	expectedUpdatedMS.Spec.Template.Labels[clusterv1.MachineDeploymentUniqueLabel] = uniqueID
+
+	// Updating an existing MS, old MSs exist
+	oldMSWhenUpdatingExistingMS := skeletonMS.DeepCopy()
+	oldMSWhenUpdatingExistingMS.Spec.Replicas = pointer.Int32(4)
+
+	expectedUpdatedMSRolling := skeletonMS.DeepCopy()
+	expectedUpdatedMSRolling.UID = existingMSUID
+	expectedUpdatedMSRolling.Name = deployment.Name + "-" + uniqueID
+	expectedUpdatedMSRolling.Labels[clusterv1.MachineDeploymentUniqueLabel] = uniqueID
+	expectedUpdatedMSRolling.Spec.Template.Labels[clusterv1.MachineDeploymentUniqueLabel] = uniqueID
+
+	test := []struct {
+		name       string
+		deployment *clusterv1.MachineDeployment
+		existingMS *clusterv1.MachineSet
+		oldMSs     []*clusterv1.MachineSet
+		wantErr    bool
+		expectedMS *clusterv1.MachineSet
+	}{
+		{
+			name:       "Computing a new MachineSet - no old MSs",
+			deployment: deployment,
+			existingMS: nil,
+			oldMSs:     nil,
+			wantErr:    false,
+			expectedMS: expectedNewMS,
+		},
+		{
+			name:       "Computing a new MachineSet - old MSs exist",
+			deployment: deployment,
+			existingMS: nil,
+			oldMSs:     []*clusterv1.MachineSet{oldMSWhenCreatingNewMS},
+			wantErr:    false,
+			expectedMS: expectedNewMSRolling,
+		},
+		{
+			name:       "Updating an existing MachineSet - no old MSs",
+			deployment: deployment,
+			existingMS: existingMS,
+			oldMSs:     nil,
+			wantErr:    false,
+			expectedMS: expectedUpdatedMS,
+		},
+		{
+			name:       "Updating an existing MachineSet - old MSs exist",
+			deployment: deployment,
+			existingMS: existingMS,
+			oldMSs:     []*clusterv1.MachineSet{oldMSWhenUpdatingExistingMS},
+			wantErr:    false,
+			expectedMS: expectedUpdatedMSRolling,
+		},
+	}
+
+	log := klogr.New()
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := &Reconciler{}
+			computedMS, err := r.computeDesiredMachineSet(tt.deployment, tt.existingMS, tt.oldMSs, log)
+			if tt.wantErr {
+				g.Expect(err).NotTo(BeNil())
+			} else {
+				g.Expect(err).Should(BeNil())
+				assertMachineSet(g, computedMS, tt.expectedMS)
+			}
+		})
+	}
+}
+
+func assertMachineSet(g *WithT, actualMS *clusterv1.MachineSet, expectedMS *clusterv1.MachineSet) {
+	// check UID
+	if expectedMS.UID != "" {
+		g.Expect(actualMS.UID).Should(Equal(expectedMS.UID))
+	}
+	// Check Name
+	if expectedMS.Name != "" {
+		g.Expect(actualMS.Name).Should(Equal(expectedMS.Name))
+	}
+	// Check Namespace
+	g.Expect(actualMS.Namespace).Should(Equal(expectedMS.Namespace))
+
+	// Check Replicas
+	g.Expect(actualMS.Spec.Replicas).ShouldNot(BeNil())
+	g.Expect(actualMS.Spec.Replicas).Should(HaveValue(Equal(*expectedMS.Spec.Replicas)))
+
+	// Check ClusterName
+	g.Expect(actualMS.Spec.ClusterName).Should(Equal(expectedMS.Spec.ClusterName))
+
+	// Check Labels
+	for k, v := range expectedMS.Labels {
+		g.Expect(actualMS.Labels).Should(HaveKeyWithValue(k, v))
+	}
+	for k, v := range expectedMS.Spec.Template.Labels {
+		g.Expect(actualMS.Spec.Template.Labels).Should(HaveKeyWithValue(k, v))
+	}
+	// If the expected MS is a new MachineSet then make sure that the labels also has the unique identifier key
+	if expectedMS.Name == "" {
+		g.Expect(actualMS.Labels).Should(HaveKey(clusterv1.MachineDeploymentUniqueLabel))
+		g.Expect(actualMS.Spec.Template.Labels).Should(HaveKey(clusterv1.MachineDeploymentUniqueLabel))
+	}
+
+	// Check Annotations
+	// Note: More nuanced validation of the Revision annotation calculations are done when testing `ComputeMachineSetAnnotations`.
+	for k, v := range expectedMS.Annotations {
+		g.Expect(actualMS.Annotations).Should(HaveKeyWithValue(k, v))
+	}
+	for k, v := range expectedMS.Spec.Template.Annotations {
+		g.Expect(actualMS.Spec.Template.Annotations).Should(HaveKeyWithValue(k, v))
+	}
+
+	// Check MinReadySeconds
+	g.Expect(actualMS.Spec.MinReadySeconds).Should(Equal(expectedMS.Spec.MinReadySeconds))
+
+	// Check DeletePolicy
+	g.Expect(actualMS.Spec.DeletePolicy).Should(Equal(expectedMS.Spec.DeletePolicy))
+
+	// Check MachineTemplateSpec
+	g.Expect(actualMS.Spec.Template.Spec).Should(Equal(expectedMS.Spec.Template.Spec))
 }
 
 // asserts the conditions set on the Getter object.

--- a/internal/controllers/machinedeployment/mdutil/util.go
+++ b/internal/controllers/machinedeployment/mdutil/util.go
@@ -19,14 +19,12 @@ package mdutil
 
 import (
 	"fmt"
-	"hash"
-	"hash/fnv"
 	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -39,6 +37,28 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conversion"
 )
+
+// MachineSetsByDecreasingReplicas sorts the list of MachineSets in decreasing order of replicas,
+// using creation time (ascending order) and name (alphabetical) as tie breakers.
+type MachineSetsByDecreasingReplicas []*clusterv1.MachineSet
+
+func (o MachineSetsByDecreasingReplicas) Len() int      { return len(o) }
+func (o MachineSetsByDecreasingReplicas) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+func (o MachineSetsByDecreasingReplicas) Less(i, j int) bool {
+	if o[i].Spec.Replicas == nil {
+		return false
+	}
+	if o[j].Spec.Replicas == nil {
+		return true
+	}
+	if *o[i].Spec.Replicas == *o[j].Spec.Replicas {
+		if o[i].CreationTimestamp.Equal(&o[j].CreationTimestamp) {
+			return o[i].Name < o[j].Name
+		}
+		return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
+	}
+	return *o[i].Spec.Replicas > *o[j].Spec.Replicas
+}
 
 // MachineSetsByCreationTimestamp sorts a list of MachineSet by creation timestamp, using their names as a tie breaker.
 type MachineSetsByCreationTimestamp []*clusterv1.MachineSet
@@ -144,27 +164,6 @@ func skipCopyAnnotation(key string) bool {
 	return annotationsToSkip[key]
 }
 
-// copyDeploymentAnnotationsToMachineSet copies deployment's annotations to machine set's annotations,
-// and returns true if machine set's annotation is changed.
-// Note that apply and revision annotations are not copied.
-func copyDeploymentAnnotationsToMachineSet(deployment *clusterv1.MachineDeployment, ms *clusterv1.MachineSet) bool {
-	msAnnotationsChanged := false
-	if ms.Annotations == nil {
-		ms.Annotations = make(map[string]string)
-	}
-	for k, v := range deployment.Annotations {
-		// newMS revision is updated automatically in getNewMachineSet, and the deployment's revision number is then updated
-		// by copying its newMS revision number. We should not copy deployment's revision to its newMS, since the update of
-		// deployment revision number may fail (revision becomes stale) and the revision number in newMS is more reliable.
-		if skipCopyAnnotation(k) || ms.Annotations[k] == v {
-			continue
-		}
-		ms.Annotations[k] = v
-		msAnnotationsChanged = true
-	}
-	return msAnnotationsChanged
-}
-
 func getMaxReplicasAnnotation(ms *clusterv1.MachineSet, logger logr.Logger) (int32, bool) {
 	return getIntFromAnnotation(ms, clusterv1.MaxReplicasAnnotation, logger)
 }
@@ -184,59 +183,59 @@ func getIntFromAnnotation(ms *clusterv1.MachineSet, annotationKey string, logger
 	return int32(intValue), true
 }
 
-// SetNewMachineSetAnnotations sets new machine set's annotations appropriately by updating its revision and
-// copying required deployment annotations to it; it returns true if machine set's annotation is changed.
-func SetNewMachineSetAnnotations(deployment *clusterv1.MachineDeployment, newMS *clusterv1.MachineSet, newRevision string, exists bool, logger logr.Logger) bool {
-	logger = logger.WithValues("MachineSet", klog.KObj(newMS))
-
-	// First, copy deployment's annotations (except for apply and revision annotations)
-	annotationChanged := copyDeploymentAnnotationsToMachineSet(deployment, newMS)
-	// Then, update machine set's revision annotation
-	if newMS.Annotations == nil {
-		newMS.Annotations = make(map[string]string)
+// ComputeMachineSetAnnotations computes the annotations that should be set on the MachineSet.
+// Note: The passed in newMS is nil if the new MachineSet doesn't exist in the apiserver yet.
+func ComputeMachineSetAnnotations(log logr.Logger, deployment *clusterv1.MachineDeployment, oldMSs []*clusterv1.MachineSet, newMS *clusterv1.MachineSet) (map[string]string, error) {
+	// Copy annotations from Deployment annotations while filtering out some annotations
+	// that we don't want to propagate.
+	annotations := map[string]string{}
+	for k, v := range deployment.Annotations {
+		if skipCopyAnnotation(k) {
+			continue
+		}
+		annotations[k] = v
 	}
-	oldRevision, ok := newMS.Annotations[clusterv1.RevisionAnnotation]
+
 	// The newMS's revision should be the greatest among all MSes. Usually, its revision number is newRevision (the max revision number
-	// of all old MSes + 1). However, it's possible that some of the old MSes are deleted after the newMS revision being updated, and
-	// newRevision becomes smaller than newMS's revision. We should only update newMS revision when it's smaller than newRevision.
+	// of all old MSes + 1). However, it's possible that some old MSes are deleted after the newMS revision being updated, and
+	// newRevision becomes smaller than newMS's revision. We will never decrease a revision of a MachineSet.
+	maxOldRevision := MaxRevision(oldMSs, log)
+	newRevisionInt := maxOldRevision + 1
+	newRevision := strconv.FormatInt(newRevisionInt, 10)
+	if newMS != nil {
+		currentRevision, currentRevisionExists := newMS.Annotations[clusterv1.RevisionAnnotation]
+		if currentRevisionExists {
+			currentRevisionInt, err := strconv.ParseInt(currentRevision, 10, 64)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to parse current revision on MachineSet %s", klog.KObj(newMS))
+			}
+			if newRevisionInt < currentRevisionInt {
+				newRevision = currentRevision
+			}
+		}
 
-	oldRevisionInt, err := strconv.ParseInt(oldRevision, 10, 64)
-	if err != nil {
-		if oldRevision != "" {
-			logger.Error(err, "Updating machine set revision OldRevision not int")
-			return false
+		// Ensure we preserve the revision history annotation in any case if it already exists.
+		// Note: With Server-Side-Apply not setting the annotation would drop it.
+		revisionHistory, revisionHistoryExists := newMS.Annotations[clusterv1.RevisionHistoryAnnotation]
+		if revisionHistoryExists {
+			annotations[clusterv1.RevisionHistoryAnnotation] = revisionHistory
 		}
-		// If the MS annotation is empty then initialise it to 0
-		oldRevisionInt = 0
-	}
-	newRevisionInt, err := strconv.ParseInt(newRevision, 10, 64)
-	if err != nil {
-		logger.Error(err, "Updating machine set revision NewRevision not int")
-		return false
-	}
-	if oldRevisionInt < newRevisionInt {
-		newMS.Annotations[clusterv1.RevisionAnnotation] = newRevision
-		annotationChanged = true
-		logger.V(4).Info("Updating machine set revision", "revision", newRevision)
-	}
-	// If a revision annotation already existed and this machine set was updated with a new revision
-	// then that means we are rolling back to this machine set. We need to preserve the old revisions
-	// for historical information.
-	if ok && annotationChanged {
-		revisionHistoryAnnotation := newMS.Annotations[clusterv1.RevisionHistoryAnnotation]
-		oldRevisions := strings.Split(revisionHistoryAnnotation, ",")
-		if oldRevisions[0] == "" {
-			newMS.Annotations[clusterv1.RevisionHistoryAnnotation] = oldRevision
-		} else {
-			oldRevisions = append(oldRevisions, oldRevision)
-			newMS.Annotations[clusterv1.RevisionHistoryAnnotation] = strings.Join(oldRevisions, ",")
+
+		// If the revision changes then add the old revision to the revision history annotation
+		if currentRevisionExists && currentRevision != newRevision {
+			oldRevisions := strings.Split(revisionHistory, ",")
+			if oldRevisions[0] == "" {
+				annotations[clusterv1.RevisionHistoryAnnotation] = currentRevision
+			} else {
+				annotations[clusterv1.RevisionHistoryAnnotation] = strings.Join(append(oldRevisions, currentRevision), ",")
+			}
 		}
 	}
-	// If the new machine set is about to be created, we need to add replica annotations to it.
-	if !exists && SetReplicasAnnotations(newMS, *(deployment.Spec.Replicas), *(deployment.Spec.Replicas)+MaxSurge(*deployment)) {
-		annotationChanged = true
-	}
-	return annotationChanged
+
+	annotations[clusterv1.RevisionAnnotation] = newRevision
+	annotations[clusterv1.DesiredReplicasAnnotation] = fmt.Sprintf("%d", *deployment.Spec.Replicas)
+	annotations[clusterv1.MaxReplicasAnnotation] = fmt.Sprintf("%d", *(deployment.Spec.Replicas)+MaxSurge(*deployment))
+	return annotations, nil
 }
 
 // FindOneActiveOrLatest returns the only active or the latest machine set in case there is at most one active
@@ -368,17 +367,10 @@ func getMachineSetFraction(ms clusterv1.MachineSet, d clusterv1.MachineDeploymen
 }
 
 // EqualMachineTemplate returns true if two given machineTemplateSpec are equal,
-// ignoring the diff in value of Labels["machine-template-hash"], and the version from external references.
+// ignoring all the in-place propagated fields, and the version from external references.
 func EqualMachineTemplate(template1, template2 *clusterv1.MachineTemplateSpec) bool {
-	t1Copy := template1.DeepCopy()
-	t2Copy := template2.DeepCopy()
-
-	// Remove `machine-template-hash` from the comparison:
-	// 1. The hash result would be different upon machineTemplateSpec API changes
-	//    (e.g. the addition of a new field will cause the hash code to change)
-	// 2. The deployment template won't have hash labels
-	delete(t1Copy.Labels, clusterv1.MachineDeploymentUniqueLabel)
-	delete(t2Copy.Labels, clusterv1.MachineDeploymentUniqueLabel)
+	t1Copy := machineTemplateDeepCopyIgnoringInPlacePropagatedFields(template1)
+	t2Copy := machineTemplateDeepCopyIgnoringInPlacePropagatedFields(template2)
 
 	// Remove the version part from the references APIVersion field,
 	// for more details see issue #2183 and #2140.
@@ -394,9 +386,34 @@ func EqualMachineTemplate(template1, template2 *clusterv1.MachineTemplateSpec) b
 	return apiequality.Semantic.DeepEqual(t1Copy, t2Copy)
 }
 
-// FindNewMachineSet returns the new MS this given deployment targets (the one with the same machine template).
+// machineTemplateDeepCopyIgnoringInPlacePropagatedFields copies a MachineTemplateSpec
+// and sets all fields that should be propagated in-place to nil.
+func machineTemplateDeepCopyIgnoringInPlacePropagatedFields(template *clusterv1.MachineTemplateSpec) *clusterv1.MachineTemplateSpec {
+	templateCopy := template.DeepCopy()
+
+	// Drop labels and annotations
+	templateCopy.Labels = nil
+	templateCopy.Annotations = nil
+
+	// Drop node timeout values
+	templateCopy.Spec.NodeDrainTimeout = nil
+	templateCopy.Spec.NodeDeletionTimeout = nil
+	templateCopy.Spec.NodeVolumeDetachTimeout = nil
+
+	return templateCopy
+}
+
+// FindNewMachineSet returns the new MS this given deployment targets (the one with the same machine template, ignoring in-place mutable fields).
+// NOTE: If we find a matching MachineSet which only differs in in-place mutable fields we can use it to
+// fulfill the intent of the MachineDeployment by just updating the MachineSet to propagate in-place mutable fields.
+// Thus we don't have to create a new MachineSet and we can avoid an unnecessary rollout.
+// NOTE: Even after we changed EqualMachineTemplate to ignore fields that are propagated in-place we can guarantee that if there exists a "new machineset"
+// using the old logic then a new machineset will definitely exist using the new logic. The new logic is looser. Therefore, we will
+// not face a case where there exists a machine set matching the old logic but there does not exist a machineset matching the new logic.
+// In fact previously not matching MS can now start matching the target. Since there could be multiple matches, lets choose the
+// MS with the most replicas so that there is minimum machine churn.
 func FindNewMachineSet(deployment *clusterv1.MachineDeployment, msList []*clusterv1.MachineSet) *clusterv1.MachineSet {
-	sort.Sort(MachineSetsByCreationTimestamp(msList))
+	sort.Sort(MachineSetsByDecreasingReplicas(msList))
 	for i := range msList {
 		if EqualMachineTemplate(&msList[i].Spec.Template, &deployment.Spec.Template) {
 			// In rare cases, such as after cluster upgrades, Deployment may end up with
@@ -510,7 +527,7 @@ func DeploymentComplete(deployment *clusterv1.MachineDeployment, newStatus *clus
 // 1) The new MS is saturated: newMS's replicas == deployment's replicas
 // 2) For RollingUpdateStrategy: Max number of machines allowed is reached: deployment's replicas + maxSurge == all MSs' replicas.
 // 3) For OnDeleteStrategy: Max number of machines allowed is reached: deployment's replicas == all MSs' replicas.
-func NewMSNewReplicas(deployment *clusterv1.MachineDeployment, allMSs []*clusterv1.MachineSet, newMS *clusterv1.MachineSet) (int32, error) {
+func NewMSNewReplicas(deployment *clusterv1.MachineDeployment, allMSs []*clusterv1.MachineSet, newMSReplicas int32) (int32, error) {
 	switch deployment.Spec.Strategy.Type {
 	case clusterv1.RollingUpdateMachineDeploymentStrategyType:
 		// Check if we can scale up.
@@ -523,26 +540,26 @@ func NewMSNewReplicas(deployment *clusterv1.MachineDeployment, allMSs []*cluster
 		maxTotalMachines := *(deployment.Spec.Replicas) + int32(maxSurge)
 		if currentMachineCount >= maxTotalMachines {
 			// Cannot scale up.
-			return *(newMS.Spec.Replicas), nil
+			return newMSReplicas, nil
 		}
 		// Scale up.
 		scaleUpCount := maxTotalMachines - currentMachineCount
 		// Do not exceed the number of desired replicas.
-		scaleUpCount = integer.Int32Min(scaleUpCount, *(deployment.Spec.Replicas)-*(newMS.Spec.Replicas))
-		return *(newMS.Spec.Replicas) + scaleUpCount, nil
+		scaleUpCount = integer.Int32Min(scaleUpCount, *(deployment.Spec.Replicas)-newMSReplicas)
+		return newMSReplicas + scaleUpCount, nil
 	case clusterv1.OnDeleteMachineDeploymentStrategyType:
 		// Find the total number of machines
 		currentMachineCount := TotalMachineSetsReplicaSum(allMSs)
 		if currentMachineCount >= *(deployment.Spec.Replicas) {
 			// Cannot scale up as more replicas exist than desired number of replicas in the MachineDeployment.
-			return *(newMS.Spec.Replicas), nil
+			return newMSReplicas, nil
 		}
 		// Scale up the latest MachineSet so the total amount of replicas across all MachineSets match
 		// the desired number of replicas in the MachineDeployment
 		scaleUpCount := *(deployment.Spec.Replicas) - currentMachineCount
-		return *(newMS.Spec.Replicas) + scaleUpCount, nil
+		return newMSReplicas + scaleUpCount, nil
 	default:
-		return 0, fmt.Errorf("deployment strategy %v isn't supported", deployment.Spec.Strategy.Type)
+		return 0, fmt.Errorf("failed to compute replicas: deployment strategy %v isn't supported", deployment.Spec.Strategy.Type)
 	}
 }
 
@@ -669,33 +686,6 @@ func CloneSelectorAndAddLabel(selector *metav1.LabelSelector, labelKey, labelVal
 	}
 
 	return newSelector
-}
-
-// SpewHashObject writes specified object to hash using the spew library
-// which follows pointers and prints actual values of the nested objects
-// ensuring the hash does not change when a pointer changes.
-func SpewHashObject(hasher hash.Hash, objectToWrite interface{}) error {
-	hasher.Reset()
-	printer := spew.ConfigState{
-		Indent:         " ",
-		SortKeys:       true,
-		DisableMethods: true,
-		SpewKeys:       true,
-	}
-
-	if _, err := printer.Fprintf(hasher, "%#v", objectToWrite); err != nil {
-		return fmt.Errorf("failed to write object to hasher")
-	}
-	return nil
-}
-
-// ComputeSpewHash computes the hash of a MachineTemplateSpec using the spew library.
-func ComputeSpewHash(objectToWrite interface{}) (uint32, error) {
-	machineTemplateSpecHasher := fnv.New32a()
-	if err := SpewHashObject(machineTemplateSpecHasher, objectToWrite); err != nil {
-		return 0, err
-	}
-	return machineTemplateSpecHasher.Sum32(), nil
 }
 
 // GetDeletingMachineCount gets the number of machines that are in the process of being deleted

--- a/internal/controllers/machinedeployment/mdutil/util_test.go
+++ b/internal/controllers/machinedeployment/mdutil/util_test.go
@@ -229,55 +229,55 @@ func TestEqualMachineTemplate(t *testing.T) {
 		Expected       bool
 	}{
 		{
-			Name:     "Same spec, except later does not have labels",
+			Name:     "Same spec, except latter does not have labels",
 			Former:   machineTemplate,
 			Latter:   machineTemplateWithEmptyLabels,
 			Expected: true,
 		},
 		{
-			Name:     "Same spec, except later has different labels",
+			Name:     "Same spec, except latter has different labels",
 			Former:   machineTemplate,
 			Latter:   machineTemplateWithDifferentLabels,
 			Expected: true,
 		},
 		{
-			Name:     "Same spec, except later does not have annotations",
+			Name:     "Same spec, except latter does not have annotations",
 			Former:   machineTemplate,
 			Latter:   machineTemplateWithEmptyAnnotations,
 			Expected: true,
 		},
 		{
-			Name:     "Same spec, except later has different annotations",
+			Name:     "Same spec, except latter has different annotations",
 			Former:   machineTemplate,
 			Latter:   machineTemplateWithDifferentAnnotations,
 			Expected: true,
 		},
 		{
-			Name:     "Spec changes, later has different in-place mutable spec fields",
+			Name:     "Spec changes, latter has different in-place mutable spec fields",
 			Former:   machineTemplate,
 			Latter:   machineTemplateWithDifferentInPlaceMutableSpecFields,
 			Expected: true,
 		},
 		{
-			Name:     "Spec changes, later has different InfrastructureRef",
+			Name:     "Spec changes, latter has different InfrastructureRef",
 			Former:   machineTemplate,
 			Latter:   machineTemplateWithDifferentInfraRef,
 			Expected: false,
 		},
 		{
-			Name:     "Spec changes, later has different Bootstrap.ConfigRef",
+			Name:     "Spec changes, latter has different Bootstrap.ConfigRef",
 			Former:   machineTemplate,
 			Latter:   machineTemplateWithDifferentBootstrapConfigRef,
 			Expected: false,
 		},
 		{
-			Name:     "Same spec, except later has different InfrastructureRef APIVersion",
+			Name:     "Same spec, except latter has different InfrastructureRef APIVersion",
 			Former:   machineTemplate,
 			Latter:   machineTemplateWithDifferentInfraRefAPIVersion,
 			Expected: true,
 		},
 		{
-			Name:     "Same spec, except later has different Bootstrap.ConfigRef APIVersion",
+			Name:     "Same spec, except latter has different Bootstrap.ConfigRef APIVersion",
 			Former:   machineTemplate,
 			Latter:   machineTemplateWithDifferentBootstrapConfigRefAPIVersion,
 			Expected: true,
@@ -324,7 +324,7 @@ func TestFindNewMachineSet(t *testing.T) {
 		expected   *clusterv1.MachineSet
 	}{
 		{
-			Name:       "Get the MachineSet with the MachineTemplate that matches the desired intent on the MachineDeployment",
+			Name:       "Get the MachineSet with the MachineTemplate that matches the intent of the MachineDeployment",
 			deployment: deployment,
 			msList:     []*clusterv1.MachineSet{&oldMS, &matchingMS},
 			expected:   &matchingMS,
@@ -371,7 +371,7 @@ func TestFindOldMachineSets(t *testing.T) {
 
 	newMSHigherName := generateMS(deployment)
 	newMSHigherName.Spec.Replicas = pointer.Int32(1)
-	newMS.Name = "ab"
+	newMSHigherName.Name = "ab"
 
 	oldDeployment := generateDeployment("nginx")
 	oldDeployment.Spec.Template.Spec.InfrastructureRef.Name = "changed-infra-ref"
@@ -890,9 +890,7 @@ func TestComputeMachineSetAnnotations(t *testing.T) {
 				g.Expect(err).ShouldNot(BeNil())
 			} else {
 				g.Expect(err).Should(BeNil())
-				for k, v := range tt.want {
-					g.Expect(got).Should(HaveKeyWithValue(k, v))
-				}
+				g.Expect(got).Should(Equal(tt.want))
 			}
 		})
 	}

--- a/internal/controllers/machineset/machineset_controller.go
+++ b/internal/controllers/machineset/machineset_controller.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -42,6 +43,7 @@ import (
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/internal/controllers/machine"
 	capilabels "sigs.k8s.io/cluster-api/internal/labels"
+	"sigs.k8s.io/cluster-api/internal/util/ssa"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/collections"
@@ -63,6 +65,8 @@ var (
 	// The polling is against a local memory cache.
 	stateConfirmationInterval = 100 * time.Millisecond
 )
+
+const machineSetManagerName = "capi-machineset"
 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
@@ -290,39 +294,6 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 		filteredMachines = append(filteredMachines, machine)
 	}
 
-	// If not already present, add a label specifying the MachineSet name to Machines.
-	// Ensure all required labels exist on the controlled Machines.
-	// This logic is needed to add the `cluster.x-k8s.io/set-name` label to Machines
-	// which were created before the `cluster.x-k8s.io/set-name` label was added to
-	// all Machines created by a MachineSet or if a user manually removed the label.
-	for _, machine := range filteredMachines {
-		mdNameOnMachineSet, mdNameSetOnMachineSet := machineSet.Labels[clusterv1.MachineDeploymentNameLabel]
-		mdNameOnMachine := machine.Labels[clusterv1.MachineDeploymentNameLabel]
-
-		// Note: MustEqualValue is used here as the value of this label will be a hash if the MachineSet name is longer than 63 characters.
-		if msNameLabelValue, ok := machine.Labels[clusterv1.MachineSetNameLabel]; ok && capilabels.MustEqualValue(machineSet.Name, msNameLabelValue) &&
-			(!mdNameSetOnMachineSet || mdNameOnMachineSet == mdNameOnMachine) {
-			// Continue if the MachineSet name label is already set correctly and
-			// either the MachineDeployment name label is not set on the MachineSet or
-			// the MachineDeployment name label is set correctly on the Machine.
-			continue
-		}
-
-		helper, err := patch.NewHelper(machine, r.Client)
-		if err != nil {
-			return ctrl.Result{}, errors.Wrapf(err, "failed to apply %s label to Machine %q", clusterv1.MachineSetNameLabel, machine.Name)
-		}
-		// Note: MustFormatValue is used here as the value of this label will be a hash if the MachineSet name is longer than 63 characters.
-		machine.Labels[clusterv1.MachineSetNameLabel] = capilabels.MustFormatValue(machineSet.Name)
-		// Propagate the MachineDeploymentNameLabel from MachineSet to Machine if it is set on the MachineSet.
-		if mdNameSetOnMachineSet {
-			machine.Labels[clusterv1.MachineDeploymentNameLabel] = mdNameOnMachineSet
-		}
-		if err := helper.Patch(ctx, machine); err != nil {
-			return ctrl.Result{}, errors.Wrapf(err, "failed to apply %s label to Machine %q", clusterv1.MachineSetNameLabel, machine.Name)
-		}
-	}
-
 	// Remediate failed Machines by deleting them.
 	var errs []error
 	for _, machine := range filteredMachines {
@@ -350,6 +321,10 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 	if err != nil {
 		log.Info("Failed while deleting unhealthy machines", "err", err)
 		return ctrl.Result{}, errors.Wrap(err, "failed to remediate machines")
+	}
+
+	if err := r.updateMachines(ctx, machineSet, filteredMachines); err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to update Machines")
 	}
 
 	syncErr := r.syncReplicas(ctx, machineSet, filteredMachines)
@@ -389,6 +364,43 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *clusterv1.Cluster, 
 	return ctrl.Result{}, nil
 }
 
+// updateMachines updates Machines to propagate in-place mutable fields from the MachineSet.
+// Note: It also cleans up managed fields of all Machines so that Machines that were created/patched before the
+// controller adopted SSA can also work with SSA.  Otherwise fields would be co-owned by our "old" "manager" and
+// "capi-machineset" and then we would not be able to e.g. drop labels and annotations.
+// TODO: update the labels and annotations to the corresponding infra machines and the boostrap configs of the filtered machines.
+func (r *Reconciler) updateMachines(ctx context.Context, machineSet *clusterv1.MachineSet, machines []*clusterv1.Machine) error {
+	log := ctrl.LoggerFrom(ctx)
+	for i := range machines {
+		m := machines[i]
+		// If the machine is already being deleted, we don't need to update it.
+		if !m.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		// Cleanup managed fields of all Machines.
+		// We do this so that Machines that were created/patched before the controller adopted SSA can also work with SSA.
+		// Otherwise, fields would be co-owned by our "old" "manager" and "capi-machineset" and then we would not be able
+		// to e.g. drop labels and annotations.
+		if err := ssa.CleanUpManagedFieldsForSSAAdoption(ctx, m, machineSetManagerName, r.Client); err != nil {
+			return errors.Wrapf(err, "failed to update machine: failed to adjust the managedFields of the Machine %q", m.Name)
+		}
+
+		// Update Machine to propagate in-place mutable fields from the MachineSet.
+		updatedMachine := r.computeDesiredMachine(machineSet, m)
+		patchOptions := []client.PatchOption{
+			client.ForceOwnership,
+			client.FieldOwner(machineSetManagerName),
+		}
+		if err := r.Client.Patch(ctx, updatedMachine, client.Apply, patchOptions...); err != nil {
+			log.Error(err, "failed to update Machine", "Machine", klog.KObj(updatedMachine))
+			return errors.Wrapf(err, "failed to update Machine %q", klog.KObj(updatedMachine))
+		}
+		machines[i] = updatedMachine
+	}
+	return nil
+}
+
 // syncReplicas scales Machine resources up or down.
 func (r *Reconciler) syncReplicas(ctx context.Context, ms *clusterv1.MachineSet, machines []*clusterv1.Machine) error {
 	log := ctrl.LoggerFrom(ctx)
@@ -414,18 +426,18 @@ func (r *Reconciler) syncReplicas(ctx context.Context, ms *clusterv1.MachineSet,
 		for i := 0; i < diff; i++ {
 			// Create a new logger so the global logger is not modified.
 			log := log
-			machine := r.getNewMachine(ms)
-
+			machine := r.computeDesiredMachine(ms, nil)
 			// Clone and set the infrastructure and bootstrap references.
 			var (
 				infraRef, bootstrapRef *corev1.ObjectReference
 				err                    error
 			)
 
-			if machine.Spec.Bootstrap.ConfigRef != nil {
+			// Create the BootstrapConfig if necessary.
+			if ms.Spec.Template.Spec.Bootstrap.ConfigRef != nil {
 				bootstrapRef, err = external.CreateFromTemplate(ctx, &external.CreateFromTemplateInput{
 					Client:      r.Client,
-					TemplateRef: machine.Spec.Bootstrap.ConfigRef,
+					TemplateRef: ms.Spec.Template.Spec.Bootstrap.ConfigRef,
 					Namespace:   machine.Namespace,
 					ClusterName: machine.Spec.ClusterName,
 					Labels:      machine.Labels,
@@ -439,15 +451,18 @@ func (r *Reconciler) syncReplicas(ctx context.Context, ms *clusterv1.MachineSet,
 				})
 				if err != nil {
 					conditions.MarkFalse(ms, clusterv1.MachinesCreatedCondition, clusterv1.BootstrapTemplateCloningFailedReason, clusterv1.ConditionSeverityError, err.Error())
-					return errors.Wrapf(err, "failed to clone bootstrap configuration from %s %s while creating a machine", machine.Spec.Bootstrap.ConfigRef.Kind, klog.KRef(machine.Spec.Bootstrap.ConfigRef.Namespace, machine.Spec.Bootstrap.ConfigRef.Name))
+					return errors.Wrapf(err, "failed to clone bootstrap configuration from %s %s while creating a machine",
+						ms.Spec.Template.Spec.Bootstrap.ConfigRef.Kind,
+						klog.KRef(ms.Spec.Template.Spec.Bootstrap.ConfigRef.Namespace, ms.Spec.Template.Spec.Bootstrap.ConfigRef.Name))
 				}
 				machine.Spec.Bootstrap.ConfigRef = bootstrapRef
 				log = log.WithValues(bootstrapRef.Kind, klog.KRef(bootstrapRef.Namespace, bootstrapRef.Name))
 			}
 
+			// Create the InfraMachine.
 			infraRef, err = external.CreateFromTemplate(ctx, &external.CreateFromTemplateInput{
 				Client:      r.Client,
-				TemplateRef: &machine.Spec.InfrastructureRef,
+				TemplateRef: &ms.Spec.Template.Spec.InfrastructureRef,
 				Namespace:   machine.Namespace,
 				ClusterName: machine.Spec.ClusterName,
 				Labels:      machine.Labels,
@@ -461,12 +476,19 @@ func (r *Reconciler) syncReplicas(ctx context.Context, ms *clusterv1.MachineSet,
 			})
 			if err != nil {
 				conditions.MarkFalse(ms, clusterv1.MachinesCreatedCondition, clusterv1.InfrastructureTemplateCloningFailedReason, clusterv1.ConditionSeverityError, err.Error())
-				return errors.Wrapf(err, "failed to clone infrastructure machine from %s %s while creating a machine", machine.Spec.InfrastructureRef.Kind, klog.KRef(machine.Spec.InfrastructureRef.Namespace, machine.Spec.InfrastructureRef.Name))
+				return errors.Wrapf(err, "failed to clone infrastructure machine from %s %s while creating a machine",
+					ms.Spec.Template.Spec.InfrastructureRef.Kind,
+					klog.KRef(ms.Spec.Template.Spec.InfrastructureRef.Namespace, ms.Spec.Template.Spec.InfrastructureRef.Name))
 			}
 			log = log.WithValues(infraRef.Kind, klog.KRef(infraRef.Namespace, infraRef.Name))
 			machine.Spec.InfrastructureRef = *infraRef
 
-			if err := r.Client.Create(ctx, machine); err != nil {
+			// Create the Machine.
+			patchOptions := []client.PatchOption{
+				client.ForceOwnership,
+				client.FieldOwner(machineSetManagerName),
+			}
+			if err := r.Client.Patch(ctx, machine, client.Apply, patchOptions...); err != nil {
 				log.Error(err, "Error while creating a machine")
 				r.recorder.Eventf(ms, corev1.EventTypeWarning, "FailedCreate", "Failed to create machine: %v", err)
 				errs = append(errs, err)
@@ -529,45 +551,77 @@ func (r *Reconciler) syncReplicas(ctx context.Context, ms *clusterv1.MachineSet,
 	return nil
 }
 
-// getNewMachine creates a new Machine object. The name of the newly created resource is going
-// to be created by the API server, we set the generateName field.
-func (r *Reconciler) getNewMachine(machineSet *clusterv1.MachineSet) *clusterv1.Machine {
-	gv := clusterv1.GroupVersion
-	machine := &clusterv1.Machine{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", machineSet.Name),
-			// Note: by setting the ownerRef on creation we signal to the Machine controller that this is not a stand-alone Machine.
-			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(machineSet, machineSetKind)},
-			Namespace:       machineSet.Namespace,
-			Labels:          make(map[string]string),
-			Annotations:     machineSet.Spec.Template.Annotations,
-		},
+// computeDesiredMachine computes the desired Machine.
+// This Machine will be used during reconciliation to:
+// * create a Machine
+// * update an existing Machine
+// Because we are using Server-Side-Apply we always have to calculate the full object.
+// There are small differences in how we calculate the Machine depending on if it
+// is a create or update. Example: for a new Machine we have to calculate a new name,
+// while for an existing Machine we have to use the name of the existing Machine.
+func (r *Reconciler) computeDesiredMachine(machineSet *clusterv1.MachineSet, existingMachine *clusterv1.Machine) *clusterv1.Machine {
+	desiredMachine := &clusterv1.Machine{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       gv.WithKind("Machine").Kind,
-			APIVersion: gv.String(),
+			APIVersion: clusterv1.GroupVersion.String(),
+			Kind:       "Machine",
 		},
-		Spec: machineSet.Spec.Template.Spec,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      names.SimpleNameGenerator.GenerateName(fmt.Sprintf("%s-", machineSet.Name)),
+			Namespace: machineSet.Namespace,
+			// Note: By setting the ownerRef on creation we signal to the Machine controller that this is not a stand-alone Machine.
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(machineSet, machineSetKind)},
+			Labels:          map[string]string{},
+			Annotations:     map[string]string{},
+		},
+		Spec: *machineSet.Spec.Template.Spec.DeepCopy(),
 	}
-	machine.Spec.ClusterName = machineSet.Spec.ClusterName
+	// Set ClusterName.
+	desiredMachine.Spec.ClusterName = machineSet.Spec.ClusterName
 
-	// Set the labels from machineSet.Spec.Template.Labels as labels for the new Machine.
+	// If we are updating an existing Machine reuse the name, uid, infrastructureRef and bootstrap.configRef
+	// from the existingMachine.
+	// Note: we use UID to force SSA to update the existing Machine and not to accidentally create a new Machine.
+	// infrastructureRef and bootstrap.configRef remain the same for an existing Machine.
+	if existingMachine != nil {
+		desiredMachine.SetName(existingMachine.Name)
+		desiredMachine.SetUID(existingMachine.UID)
+		desiredMachine.Spec.Bootstrap.ConfigRef = existingMachine.Spec.Bootstrap.ConfigRef
+		desiredMachine.Spec.InfrastructureRef = existingMachine.Spec.InfrastructureRef
+	}
+
+	// Set the in-place mutable fields.
+	// When we create a new Machine we will just create the Machine with those fields.
+	// When we update an existing Machine will we update the fields on the existing Machine (in-place mutate).
+
+	// Set Labels
 	// Note: We can't just set `machineSet.Spec.Template.Labels` directly and thus "share" the labels
 	// map between Machine and machineSet.Spec.Template.Labels. This would mean that adding the
 	// MachineSetNameLabel and MachineDeploymentNameLabel later on the Machine would also add the labels
 	// to machineSet.Spec.Template.Labels and thus modify the labels of the MachineSet.
 	for k, v := range machineSet.Spec.Template.Labels {
-		machine.Labels[k] = v
+		desiredMachine.Labels[k] = v
 	}
-
-	// Enforce that the MachineSetNameLabel label is set
-	// Note: the MachineSetNameLabel is added by the default webhook to MachineSet.spec.template.labels if a spec.selector is empty.
-	machine.Labels[clusterv1.MachineSetNameLabel] = capilabels.MustFormatValue(machineSet.Name)
+	// Always set the MachineSetNameLabel.
+	// Note: If a client tries to create a MachineSet without a selector, the MachineSet webhook
+	// will add this label automatically. But we want this label to always be present even if the MachineSet
+	// has a selector which doesn't include it. Therefore, we have to set it here explicitly.
+	desiredMachine.Labels[clusterv1.MachineSetNameLabel] = capilabels.MustFormatValue(machineSet.Name)
 	// Propagate the MachineDeploymentNameLabel from MachineSet to Machine if it exists.
 	if mdName, ok := machineSet.Labels[clusterv1.MachineDeploymentNameLabel]; ok {
-		machine.Labels[clusterv1.MachineDeploymentNameLabel] = mdName
+		desiredMachine.Labels[clusterv1.MachineDeploymentNameLabel] = mdName
 	}
 
-	return machine
+	// Set Annotations
+	for k, v := range machineSet.Spec.Template.Annotations {
+		desiredMachine.Annotations[k] = v
+	}
+
+	// Set all other in-place mutable fields.
+	desiredMachine.Spec.NodeDrainTimeout = machineSet.Spec.Template.Spec.NodeDrainTimeout
+	desiredMachine.Spec.NodeDeletionTimeout = machineSet.Spec.Template.Spec.NodeDeletionTimeout
+	desiredMachine.Spec.NodeVolumeDetachTimeout = machineSet.Spec.Template.Spec.NodeVolumeDetachTimeout
+
+	return desiredMachine
 }
 
 // shouldExcludeMachine returns true if the machine should be filtered out, false otherwise.

--- a/internal/controllers/machineset/machineset_controller_test.go
+++ b/internal/controllers/machineset/machineset_controller_test.go
@@ -1131,11 +1131,11 @@ func TestMachineSetReconciler_syncMachines(t *testing.T) {
 		updatedInPlaceMutatingMachine := machines[0]
 		// Verify ManagedFields
 		g.Expect(updatedInPlaceMutatingMachine.ManagedFields).Should(
-			ContainElement(ssa.ManagedFieldMatcher(machineSetManagerName, metav1.ManagedFieldsOperationApply)),
+			ContainElement(ssa.MatchManagedField(machineSetManagerName, metav1.ManagedFieldsOperationApply)),
 			"in-place mutable machine should contain an entry for SSA manager",
 		)
 		g.Expect(updatedInPlaceMutatingMachine.ManagedFields).ShouldNot(
-			ContainElement(ssa.ManagedFieldMatcher("manager", metav1.ManagedFieldsOperationUpdate)),
+			ContainElement(ssa.MatchManagedField("manager", metav1.ManagedFieldsOperationUpdate)),
 			"in-place mutable machine should not contain an entry for old manager",
 		)
 		// Verify Labels
@@ -1160,7 +1160,7 @@ func TestMachineSetReconciler_syncMachines(t *testing.T) {
 		// The deleting machine should not change.
 		updatedDeletingMachine := machines[1]
 		g.Expect(updatedDeletingMachine.ManagedFields).ShouldNot(
-			ContainElement(ssa.ManagedFieldMatcher(machineSetManagerName, metav1.ManagedFieldsOperationApply)),
+			ContainElement(ssa.MatchManagedField(machineSetManagerName, metav1.ManagedFieldsOperationApply)),
 			"deleting machine should not contain an entry for SSA manager",
 		)
 		g.Expect(updatedDeletingMachine.Labels).Should(Equal(deletingMachine.Labels))

--- a/internal/util/ssa/managedfields.go
+++ b/internal/util/ssa/managedfields.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ssa contains utils related to ssa.
+package ssa
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CleanUpManagedFieldsForSSAAdoption deletes the managedField entries on the object that belong to "manager" (Operation=Update)
+// if there is no field yet that is managed by `ssaManager`.
+// It adds an "empty" entry in managedFields of the object if no field is currently managed by "managerName".
+//
+// In previous versions of Cluster API we were writing objects with Create and Patch which resulted in fields
+// being owned by the "manager". After switching to SSA, fields will be owned by `ssaManager`.
+//
+// If we want to be able to drop fields that were previously owned by the "manager" we have to ensure that
+// fields are not co-owned by "manager" and `ssaManager`. Because otherwise when we drop the fields with SSA
+// (i.e. `ssaManager`) the fields would remain as they are still owned by "manager".
+// The following code will do a one-time update on the managed fields to drop all entries for "manager".
+// We won't do this on subsequent reconciles. This case will be identified by checking if `ssaManager` owns any fields.
+// Dropping all existing "manager" entries (which could also be from other controllers) is safe, as we assume that if
+// other controllers are still writing fields on the object they will just do it again and thus gain ownership again.
+func CleanUpManagedFieldsForSSAAdoption(ctx context.Context, obj client.Object, ssaManager string, c client.Client) error {
+	// Return if `ssaManager` already owns any fields.
+	if hasFieldsManagedBy(obj, ssaManager) {
+		return nil
+	}
+
+	// Since there is no field managed by `ssaManager` it means that
+	// this is the first time this object is being processed after the controller calling this function
+	// started to use SSA patches.
+	// It is required to clean-up managedFields from entries created by the regular patches.
+	// This will ensure that `ssaManager` will be able to modify the fields that
+	// were originally owned by "manager".
+	base := obj.DeepCopyObject().(client.Object)
+
+	// Remove managedFieldEntry for manager=manager and operation=update to prevent having two managers holding values.
+	originalManagedFields := obj.GetManagedFields()
+	managedFields := make([]metav1.ManagedFieldsEntry, 0, len(originalManagedFields))
+	for i := range originalManagedFields {
+		if originalManagedFields[i].Manager == "manager" &&
+			originalManagedFields[i].Operation == metav1.ManagedFieldsOperationUpdate {
+			continue
+		}
+		managedFields = append(managedFields, originalManagedFields[i])
+	}
+
+	// Add a seeding managedFieldEntry for SSA executed by the management controller, to prevent SSA to create/infer
+	// a default managedFieldEntry when the first SSA is applied.
+	// More specifically, if an existing object doesn't have managedFields when applying the first SSA the API server
+	// creates an entry with operation=Update (kind of guessing where the object comes from), but this entry ends up
+	// acting as a co-ownership and we want to prevent this.
+	// NOTE: fieldV1Map cannot be empty, so we add metadata.name which will be cleaned up at the first SSA patch.
+	fieldV1Map := map[string]interface{}{
+		"f:metadata": map[string]interface{}{
+			"f:name": map[string]interface{}{},
+		},
+	}
+	fieldV1, err := json.Marshal(fieldV1Map)
+	if err != nil {
+		return errors.Wrap(err, "failed to create seeding fieldV1Map for cleaning up legacy managed fields")
+	}
+	now := metav1.Now()
+	managedFields = append(managedFields, metav1.ManagedFieldsEntry{
+		Manager:    ssaManager,
+		Operation:  metav1.ManagedFieldsOperationApply,
+		APIVersion: obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		Time:       &now,
+		FieldsType: "FieldsV1",
+		FieldsV1:   &metav1.FieldsV1{Raw: fieldV1},
+	})
+
+	obj.SetManagedFields(managedFields)
+
+	return c.Patch(ctx, obj, client.MergeFrom(base))
+}
+
+// hasFieldsManagedBy returns true if any of the fields in obj are managed by manager.
+func hasFieldsManagedBy(obj client.Object, manager string) bool {
+	managedFields := obj.GetManagedFields()
+	for _, mf := range managedFields {
+		if mf.Manager == manager {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/util/ssa/managedfields_test.go
+++ b/internal/util/ssa/managedfields_test.go
@@ -31,7 +31,7 @@ import (
 func TestCleanUpManagedFieldsForSSAAdoption(t *testing.T) {
 	ctx := context.Background()
 
-	ssaManager := "test-manager"
+	ssaManager := "ssa-manager"
 	classicManager := "manager"
 
 	objWithoutAnyManager := &corev1.ConfigMap{
@@ -122,13 +122,13 @@ func TestCleanUpManagedFieldsForSSAAdoption(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithObjects(tt.obj).Build()
 			g.Expect(CleanUpManagedFieldsForSSAAdoption(ctx, tt.obj, ssaManager, fakeClient)).Should(Succeed())
 			g.Expect(tt.obj.GetManagedFields()).Should(
-				ContainElement(ManagedFieldMatcher(ssaManager, metav1.ManagedFieldsOperationApply)))
+				ContainElement(MatchManagedField(ssaManager, metav1.ManagedFieldsOperationApply)))
 			if tt.wantEntryForClassicManager {
 				g.Expect(tt.obj.GetManagedFields()).Should(
-					ContainElement(ManagedFieldMatcher(classicManager, metav1.ManagedFieldsOperationUpdate)))
+					ContainElement(MatchManagedField(classicManager, metav1.ManagedFieldsOperationUpdate)))
 			} else {
 				g.Expect(tt.obj.GetManagedFields()).ShouldNot(
-					ContainElement(ManagedFieldMatcher(classicManager, metav1.ManagedFieldsOperationUpdate)))
+					ContainElement(MatchManagedField(classicManager, metav1.ManagedFieldsOperationUpdate)))
 			}
 		})
 	}

--- a/internal/util/ssa/managedfields_test.go
+++ b/internal/util/ssa/managedfields_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ssa contains utils related to ssa.
+package ssa
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCleanUpManagedFieldsForSSAAdoption(t *testing.T) {
+	ctx := context.Background()
+
+	ssaManager := "test-manager"
+	classicManager := "manager"
+
+	objWithoutAnyManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+	objWithOnlyClassicManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:   classicManager,
+				Operation: metav1.ManagedFieldsOperationUpdate,
+			}},
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+	objWithOnlySSAManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{{
+				Manager:   ssaManager,
+				Operation: metav1.ManagedFieldsOperationApply,
+			}},
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+	objWithClassicManagerAndSSAManager := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm-1",
+			Namespace: "default",
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:   classicManager,
+					Operation: metav1.ManagedFieldsOperationUpdate,
+				},
+				{
+					Manager:   ssaManager,
+					Operation: metav1.ManagedFieldsOperationApply,
+				},
+			},
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}
+
+	tests := []struct {
+		name                       string
+		obj                        client.Object
+		wantEntryForClassicManager bool
+	}{
+		{
+			name:                       "should add an entry for ssaManager if it does not have one",
+			obj:                        objWithoutAnyManager,
+			wantEntryForClassicManager: false,
+		},
+		{
+			name:                       "should add an entry for ssaManager and drop entry for classic manager if it exists",
+			obj:                        objWithOnlyClassicManager,
+			wantEntryForClassicManager: false,
+		},
+		{
+			name:                       "should keep the entry for test-manager if it already has one (no-op)",
+			obj:                        objWithOnlySSAManager,
+			wantEntryForClassicManager: false,
+		},
+		{
+			name:                       "should keep the entry with test-manager if it already has one - should not drop other manager entries (no-op)",
+			obj:                        objWithClassicManagerAndSSAManager,
+			wantEntryForClassicManager: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			fakeClient := fake.NewClientBuilder().WithObjects(tt.obj).Build()
+			g.Expect(CleanUpManagedFieldsForSSAAdoption(ctx, tt.obj, ssaManager, fakeClient)).Should(Succeed())
+			g.Expect(tt.obj.GetManagedFields()).Should(
+				ContainElement(ManagedFieldMatcher(ssaManager, metav1.ManagedFieldsOperationApply)))
+			if tt.wantEntryForClassicManager {
+				g.Expect(tt.obj.GetManagedFields()).Should(
+					ContainElement(ManagedFieldMatcher(classicManager, metav1.ManagedFieldsOperationUpdate)))
+			} else {
+				g.Expect(tt.obj.GetManagedFields()).ShouldNot(
+					ContainElement(ManagedFieldMatcher(classicManager, metav1.ManagedFieldsOperationUpdate)))
+			}
+		})
+	}
+}

--- a/internal/util/ssa/matchers.go
+++ b/internal/util/ssa/matchers.go
@@ -23,8 +23,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ManagedFieldMatcher is a gomega Matcher to check if a ManagedFieldEntry has the provider name and operation.
-func ManagedFieldMatcher(manager string, operation metav1.ManagedFieldsOperationType) types.GomegaMatcher {
+// MatchManagedField is a gomega Matcher to check if a ManagedFieldEntry has the provider name and operation.
+func MatchManagedField(manager string, operation metav1.ManagedFieldsOperationType) types.GomegaMatcher {
 	return &managedFieldMatcher{
 		manager:   manager,
 		operation: operation,
@@ -37,22 +37,22 @@ type managedFieldMatcher struct {
 }
 
 func (mf *managedFieldMatcher) Match(actual interface{}) (bool, error) {
-	managedFieldEntry, ok := actual.(metav1.ManagedFieldsEntry)
+	managedFieldsEntry, ok := actual.(metav1.ManagedFieldsEntry)
 	if !ok {
 		return false, fmt.Errorf("expecting metav1.ManagedFieldEntry got %T", actual)
 	}
 
-	return managedFieldEntry.Manager == mf.manager && managedFieldEntry.Operation == mf.operation, nil
+	return managedFieldsEntry.Manager == mf.manager && managedFieldsEntry.Operation == mf.operation, nil
 }
 
 func (mf *managedFieldMatcher) FailureMessage(actual interface{}) string {
-	managedFieldEntry := actual.(metav1.ManagedFieldsEntry)
+	managedFieldsEntry := actual.(metav1.ManagedFieldsEntry)
 	return fmt.Sprintf("Expected ManagedFieldEntry to match Manager:%s and Operation:%s, got Manager:%s, Operation:%s",
-		mf.manager, mf.operation, managedFieldEntry.Manager, managedFieldEntry.Operation)
+		mf.manager, mf.operation, managedFieldsEntry.Manager, managedFieldsEntry.Operation)
 }
 
 func (mf *managedFieldMatcher) NegatedFailureMessage(actual interface{}) string {
-	managedFieldEntry := actual.(metav1.ManagedFieldsEntry)
+	managedFieldsEntry := actual.(metav1.ManagedFieldsEntry)
 	return fmt.Sprintf("Expected ManagedFieldEntry to not match Manager:%s and Operation:%s, got Manager:%s, Operation:%s",
-		mf.manager, mf.operation, managedFieldEntry.Manager, managedFieldEntry.Operation)
+		mf.manager, mf.operation, managedFieldsEntry.Manager, managedFieldsEntry.Operation)
 }

--- a/internal/util/ssa/matchers.go
+++ b/internal/util/ssa/matchers.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ssa
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ManagedFieldMatcher is a gomega Matcher to check if a ManagedFieldEntry has the provider name and operation.
+func ManagedFieldMatcher(manager string, operation metav1.ManagedFieldsOperationType) types.GomegaMatcher {
+	return &managedFieldMatcher{
+		manager:   manager,
+		operation: operation,
+	}
+}
+
+type managedFieldMatcher struct {
+	manager   string
+	operation metav1.ManagedFieldsOperationType
+}
+
+func (mf *managedFieldMatcher) Match(actual interface{}) (bool, error) {
+	managedFieldEntry, ok := actual.(metav1.ManagedFieldsEntry)
+	if !ok {
+		return false, fmt.Errorf("expecting metav1.ManagedFieldEntry got %T", actual)
+	}
+
+	return managedFieldEntry.Manager == mf.manager && managedFieldEntry.Operation == mf.operation, nil
+}
+
+func (mf *managedFieldMatcher) FailureMessage(actual interface{}) string {
+	managedFieldEntry := actual.(metav1.ManagedFieldsEntry)
+	return fmt.Sprintf("Expected ManagedFieldEntry to match Manager:%s and Operation:%s, got Manager:%s, Operation:%s",
+		mf.manager, mf.operation, managedFieldEntry.Manager, managedFieldEntry.Operation)
+}
+
+func (mf *managedFieldMatcher) NegatedFailureMessage(actual interface{}) string {
+	managedFieldEntry := actual.(metav1.ManagedFieldsEntry)
+	return fmt.Sprintf("Expected ManagedFieldEntry to not match Manager:%s and Operation:%s, got Manager:%s, Operation:%s",
+		mf.manager, mf.operation, managedFieldEntry.Manager, managedFieldEntry.Operation)
+}

--- a/test/e2e/md_rollout.go
+++ b/test/e2e/md_rollout.go
@@ -90,6 +90,14 @@ func MachineDeploymentRolloutSpec(ctx context.Context, inputGetter func() Machin
 			WaitForMachineDeployments:    input.E2EConfig.GetIntervals(specName, "wait-worker-nodes"),
 		}, clusterResources)
 
+		By("Upgrade MachineDeployment in-place mutable fields and wait for in-place propagation")
+		framework.UpgradeMachineDeploymentInPlaceMutableFieldsAndWait(ctx, framework.UpgradeMachineDeploymentInPlaceMutableFieldsAndWaitInput{
+			ClusterProxy:                input.BootstrapClusterProxy,
+			Cluster:                     clusterResources.Cluster,
+			WaitForMachinesToBeUpgraded: input.E2EConfig.GetIntervals(specName, "wait-machine-upgrade"),
+			MachineDeployments:          clusterResources.MachineDeployments,
+		})
+
 		By("Upgrading MachineDeployment Infrastructure ref and wait for rolling upgrade")
 		framework.UpgradeMachineDeploymentInfrastructureRefAndWait(ctx, framework.UpgradeMachineDeploymentInfrastructureRefAndWaitInput{
 			ClusterProxy:                input.BootstrapClusterProxy,

--- a/test/e2e/md_rollout_test.go
+++ b/test/e2e/md_rollout_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("When testing MachineDeployment rolling upgrades", func() {
+var _ = Describe("When testing MachineDeployment rollouts", func() {
 	MachineDeploymentRolloutSpec(ctx, func() MachineDeploymentRolloutSpecInput {
 		return MachineDeploymentRolloutSpecInput{
 			E2EConfig:             e2eConfig,

--- a/test/framework/machine_helpers.go
+++ b/test/framework/machine_helpers.go
@@ -57,7 +57,7 @@ func GetMachinesByMachineDeployments(ctx context.Context, input GetMachinesByMac
 	machineList := &clusterv1.MachineList{}
 	Eventually(func() error {
 		return input.Lister.List(ctx, machineList, opts...)
-	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to list MachineList object for Cluster %s", klog.KRef(input.Namespace, input.ClusterName))
+	}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to list Machines for MachineDeployment %s", klog.KObj(&input.MachineDeployment))
 
 	return machineList.Items
 }

--- a/test/framework/machinedeployment_helpers.go
+++ b/test/framework/machinedeployment_helpers.go
@@ -19,17 +19,21 @@ package framework
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/controllers/topology/machineset"
 	. "sigs.k8s.io/cluster-api/test/framework/ginkgoextensions"
 	"sigs.k8s.io/cluster-api/test/framework/internal/log"
 	"sigs.k8s.io/cluster-api/util"
@@ -260,40 +264,6 @@ type WaitForMachineDeploymentRollingUpgradeToStartInput struct {
 	MachineDeployment *clusterv1.MachineDeployment
 }
 
-// WaitForMachineDeploymentRollingUpgradeToStart waits until rolling upgrade starts.
-func WaitForMachineDeploymentRollingUpgradeToStart(ctx context.Context, input WaitForMachineDeploymentRollingUpgradeToStartInput, intervals ...interface{}) {
-	Expect(ctx).NotTo(BeNil(), "ctx is required for WaitForMachineDeploymentRollingUpgradeToStart")
-	Expect(input.Getter).ToNot(BeNil(), "Invalid argument. input.Getter can't be nil when calling WaitForMachineDeploymentRollingUpgradeToStart")
-	Expect(input.MachineDeployment).ToNot(BeNil(), "Invalid argument. input.MachineDeployment can't be nil when calling WaitForMachineDeploymentRollingUpgradeToStarts")
-
-	log.Logf("Waiting for MachineDeployment rolling upgrade to start")
-	Eventually(func(g Gomega) bool {
-		md := &clusterv1.MachineDeployment{}
-		g.Expect(input.Getter.Get(ctx, client.ObjectKey{Namespace: input.MachineDeployment.Namespace, Name: input.MachineDeployment.Name}, md)).To(Succeed())
-		return md.Status.Replicas != md.Status.AvailableReplicas
-	}, intervals...).Should(BeTrue())
-}
-
-// WaitForMachineDeploymentRollingUpgradeToCompleteInput is the input for WaitForMachineDeploymentRollingUpgradeToComplete.
-type WaitForMachineDeploymentRollingUpgradeToCompleteInput struct {
-	Getter            Getter
-	MachineDeployment *clusterv1.MachineDeployment
-}
-
-// WaitForMachineDeploymentRollingUpgradeToComplete waits until rolling upgrade is complete.
-func WaitForMachineDeploymentRollingUpgradeToComplete(ctx context.Context, input WaitForMachineDeploymentRollingUpgradeToCompleteInput, intervals ...interface{}) {
-	Expect(ctx).NotTo(BeNil(), "ctx is required for WaitForMachineDeploymentRollingUpgradeToComplete")
-	Expect(input.Getter).ToNot(BeNil(), "Invalid argument. input.Getter can't be nil when calling WaitForMachineDeploymentRollingUpgradeToComplete")
-	Expect(input.MachineDeployment).ToNot(BeNil(), "Invalid argument. input.MachineDeployment can't be nil when calling WaitForMachineDeploymentRollingUpgradeToComplete")
-
-	log.Logf("Waiting for MachineDeployment rolling upgrade to complete")
-	Eventually(func(g Gomega) bool {
-		md := &clusterv1.MachineDeployment{}
-		g.Expect(input.Getter.Get(ctx, client.ObjectKey{Namespace: input.MachineDeployment.Namespace, Name: input.MachineDeployment.Name}, md)).To(Succeed())
-		return md.Status.Replicas == md.Status.AvailableReplicas
-	}, intervals...).Should(BeTrue())
-}
-
 // UpgradeMachineDeploymentInfrastructureRefAndWaitInput is the input type for UpgradeMachineDeploymentInfrastructureRefAndWait.
 type UpgradeMachineDeploymentInfrastructureRefAndWaitInput struct {
 	ClusterProxy                ClusterProxy
@@ -312,8 +282,12 @@ func UpgradeMachineDeploymentInfrastructureRefAndWait(ctx context.Context, input
 	mgmtClient := input.ClusterProxy.GetClient()
 
 	for _, deployment := range input.MachineDeployments {
+		// Get MachineSets of the MachineDeployment before the upgrade.
+		msListBeforeUpgrade, err := machineset.GetMachineSetsForDeployment(ctx, mgmtClient, client.ObjectKeyFromObject(deployment))
+		Expect(err).ToNot(HaveOccurred())
+
 		log.Logf("Patching the new infrastructure ref to Machine Deployment %s", klog.KObj(deployment))
-		// Retrieve infra object
+		// Retrieve infra object.
 		infraRef := deployment.Spec.Template.Spec.InfrastructureRef
 		infraObj := &unstructured.Unstructured{}
 		infraObj.SetGroupVersionKind(infraRef.GroupVersionKind())
@@ -325,7 +299,7 @@ func UpgradeMachineDeploymentInfrastructureRefAndWait(ctx context.Context, input
 			return mgmtClient.Get(ctx, key, infraObj)
 		}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to get infra object %s for MachineDeployment %s", klog.KRef(key.Namespace, key.Name), klog.KObj(deployment))
 
-		// Creates a new infra object
+		// Create a new infra object.
 		newInfraObj := infraObj
 		newInfraObjName := fmt.Sprintf("%s-%s", infraRef.Name, util.RandomString(6))
 		newInfraObj.SetName(newInfraObjName)
@@ -334,7 +308,7 @@ func UpgradeMachineDeploymentInfrastructureRefAndWait(ctx context.Context, input
 			return mgmtClient.Create(ctx, newInfraObj)
 		}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to create new infrastructure object %s for MachineDeployment %s", klog.KObj(infraObj), klog.KObj(deployment))
 
-		// Patch the new infra object's ref to the machine deployment
+		// Patch the new infra object's ref to the MachineDeployment.
 		patchHelper, err := patch.NewHelper(deployment, mgmtClient)
 		Expect(err).ToNot(HaveOccurred())
 		infraRef.Name = newInfraObjName
@@ -343,18 +317,141 @@ func UpgradeMachineDeploymentInfrastructureRefAndWait(ctx context.Context, input
 			return patchHelper.Patch(ctx, deployment)
 		}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to patch new infrastructure ref to MachineDeployment %s", klog.KObj(deployment))
 
-		log.Logf("Waiting for rolling upgrade to start.")
-		WaitForMachineDeploymentRollingUpgradeToStart(ctx, WaitForMachineDeploymentRollingUpgradeToStartInput{
-			Getter:            mgmtClient,
-			MachineDeployment: deployment,
-		}, input.WaitForMachinesToBeUpgraded...)
+		Eventually(func(g Gomega) {
+			// Get MachineSets of the MachineDeployment after the upgrade.
+			msListAfterUpgrade, err := machineset.GetMachineSetsForDeployment(ctx, mgmtClient, client.ObjectKeyFromObject(deployment))
+			g.Expect(err).ToNot(HaveOccurred())
 
-		log.Logf("Waiting for rolling upgrade to complete.")
-		WaitForMachineDeploymentRollingUpgradeToComplete(ctx, WaitForMachineDeploymentRollingUpgradeToCompleteInput{
-			Getter:            mgmtClient,
-			MachineDeployment: deployment,
-		}, input.WaitForMachinesToBeUpgraded...)
+			// Find the new MachineSet.
+			newMachineSets := machineSetNames(msListAfterUpgrade).Difference(machineSetNames(msListBeforeUpgrade))
+			g.Expect(newMachineSets).To(HaveLen(1), "expecting exactly 1 MachineSet after rollout")
+			var newMachineSet *clusterv1.MachineSet
+			for _, ms := range msListAfterUpgrade {
+				if newMachineSets.Has(ms.Name) {
+					newMachineSet = ms
+				}
+			}
+
+			// MachineSet should be rolled out.
+			g.Expect(newMachineSet.Spec.Replicas).To(Equal(deployment.Spec.Replicas))
+			g.Expect(*newMachineSet.Spec.Replicas).To(Equal(newMachineSet.Status.Replicas))
+			g.Expect(*newMachineSet.Spec.Replicas).To(Equal(newMachineSet.Status.ReadyReplicas))
+			g.Expect(*newMachineSet.Spec.Replicas).To(Equal(newMachineSet.Status.AvailableReplicas))
+
+			// MachineSet should have the same infrastructureRef as the MachineDeployment.
+			g.Expect(newMachineSet.Spec.Template.Spec.InfrastructureRef).To(Equal(deployment.Spec.Template.Spec.InfrastructureRef))
+		}, input.WaitForMachinesToBeUpgraded...).Should(Succeed())
 	}
+}
+
+// UpgradeMachineDeploymentInPlaceMutableFieldsAndWaitInput is the input type for UpgradeMachineDeploymentInPlaceMutableFieldsAndWait.
+type UpgradeMachineDeploymentInPlaceMutableFieldsAndWaitInput struct {
+	ClusterProxy                ClusterProxy
+	Cluster                     *clusterv1.Cluster
+	MachineDeployments          []*clusterv1.MachineDeployment
+	WaitForMachinesToBeUpgraded []interface{}
+}
+
+// UpgradeMachineDeploymentInPlaceMutableFieldsAndWait upgrades in-place mutable fields in a MachineDeployment
+// and waits for them to be in-place propagated to MachineSets and Machines.
+func UpgradeMachineDeploymentInPlaceMutableFieldsAndWait(ctx context.Context, input UpgradeMachineDeploymentInPlaceMutableFieldsAndWaitInput) {
+	Expect(ctx).NotTo(BeNil(), "ctx is required for UpgradeMachineDeploymentInPlaceMutableFieldsAndWait")
+	Expect(input.ClusterProxy).ToNot(BeNil(), "Invalid argument. input.ClusterProxy can't be nil when calling UpgradeMachineDeploymentInPlaceMutableFieldsAndWait")
+	Expect(input.Cluster).ToNot(BeNil(), "Invalid argument. input.Cluster can't be nil when calling UpgradeMachineDeploymentInPlaceMutableFieldsAndWait")
+	Expect(input.MachineDeployments).ToNot(BeEmpty(), "Invalid argument. input.MachineDeployments can't be empty when calling UpgradeMachineDeploymentInPlaceMutableFieldsAndWait")
+
+	mgmtClient := input.ClusterProxy.GetClient()
+
+	for _, deployment := range input.MachineDeployments {
+		// Get MachineSet and Machines of the MachineDeployment before the upgrade.
+		msListBeforeUpgrade, err := machineset.GetMachineSetsForDeployment(ctx, mgmtClient, client.ObjectKeyFromObject(deployment))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(msListBeforeUpgrade).To(HaveLen(1), "expecting exactly 1 MachineSet")
+		machineSetBeforeUpgrade := msListBeforeUpgrade[0]
+		machinesBeforeUpgrade := GetMachinesByMachineDeployments(ctx, GetMachinesByMachineDeploymentsInput{
+			Lister:            mgmtClient,
+			ClusterName:       input.Cluster.Name,
+			Namespace:         input.Cluster.Namespace,
+			MachineDeployment: *deployment,
+		})
+
+		log.Logf("Patching in-place mutable fields of MachineDeployment %s", klog.KObj(deployment))
+		patchHelper, err := patch.NewHelper(deployment, mgmtClient)
+		Expect(err).ToNot(HaveOccurred())
+		if deployment.Spec.Template.Labels == nil {
+			deployment.Spec.Template.Labels = map[string]string{}
+		}
+		deployment.Spec.Template.Labels["new-label"] = "new-label-value"
+		if deployment.Spec.Template.Annotations == nil {
+			deployment.Spec.Template.Annotations = map[string]string{}
+		}
+		deployment.Spec.Template.Annotations["new-annotation"] = "new-annotation-value"
+		deployment.Spec.Template.Spec.NodeDrainTimeout = &metav1.Duration{Duration: time.Duration(rand.Intn(20)) * time.Second}        //nolint:gosec
+		deployment.Spec.Template.Spec.NodeDeletionTimeout = &metav1.Duration{Duration: time.Duration(rand.Intn(20)) * time.Second}     //nolint:gosec
+		deployment.Spec.Template.Spec.NodeVolumeDetachTimeout = &metav1.Duration{Duration: time.Duration(rand.Intn(20)) * time.Second} //nolint:gosec
+		Eventually(func() error {
+			return patchHelper.Patch(ctx, deployment)
+		}, retryableOperationTimeout, retryableOperationInterval).Should(Succeed(), "Failed to patch in-place mutable fields of MachineDeployment %s", klog.KObj(deployment))
+
+		log.Logf("Waiting for in-place propagation to complete")
+		Eventually(func(g Gomega) {
+			// Get MachineSet and Machines of the MachineDeployment after the upgrade.
+			msListAfterUpgrade, err := machineset.GetMachineSetsForDeployment(ctx, mgmtClient, client.ObjectKeyFromObject(deployment))
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(msListAfterUpgrade).To(HaveLen(1), "expecting exactly 1 MachineSet")
+			machineSetAfterUpgrade := msListAfterUpgrade[0]
+			machinesAfterUpgrade := GetMachinesByMachineDeployments(ctx, GetMachinesByMachineDeploymentsInput{
+				Lister:            mgmtClient,
+				ClusterName:       input.Cluster.Name,
+				Namespace:         input.Cluster.Namespace,
+				MachineDeployment: *deployment,
+			})
+
+			log.Logf("Verify MachineSet and Machines have not been replaced")
+			g.Expect(machineSetAfterUpgrade.Name).To(Equal(machineSetBeforeUpgrade.Name))
+			g.Expect(machineNames(machinesAfterUpgrade).Equal(machineNames(machinesBeforeUpgrade))).To(BeTrue())
+
+			log.Logf("Verify fields have been propagated to MachineSet")
+			// Label should be propagated to MS.Labels.
+			g.Expect(machineSetAfterUpgrade.Labels).To(HaveKeyWithValue("new-label", "new-label-value"))
+			// Annotation should not be propagated to MS.Annotations.
+			g.Expect(machineSetAfterUpgrade.Annotations).ToNot(HaveKeyWithValue("new-annotation", "new-annotation-value"))
+			// Label and annotation should be propagated to MS.Spec.Template.{Labels,Annotations}.
+			g.Expect(machineSetAfterUpgrade.Spec.Template.Labels).To(HaveKeyWithValue("new-label", "new-label-value"))
+			g.Expect(machineSetAfterUpgrade.Spec.Template.Annotations).To(HaveKeyWithValue("new-annotation", "new-annotation-value"))
+			// Timeouts should be propagated.
+			g.Expect(machineSetAfterUpgrade.Spec.Template.Spec.NodeDrainTimeout).To(Equal(deployment.Spec.Template.Spec.NodeDrainTimeout))
+			g.Expect(machineSetAfterUpgrade.Spec.Template.Spec.NodeDeletionTimeout).To(Equal(deployment.Spec.Template.Spec.NodeDeletionTimeout))
+			g.Expect(machineSetAfterUpgrade.Spec.Template.Spec.NodeVolumeDetachTimeout).To(Equal(deployment.Spec.Template.Spec.NodeVolumeDetachTimeout))
+
+			log.Logf("Verify fields have been propagated to Machines")
+			for _, m := range machinesAfterUpgrade {
+				// Label and annotation should be propagated to MS.{Labels,Annotations}.
+				g.Expect(m.Labels).To(HaveKeyWithValue("new-label", "new-label-value"))
+				g.Expect(m.Annotations).To(HaveKeyWithValue("new-annotation", "new-annotation-value"))
+				// Timeouts should be propagated.
+				g.Expect(m.Spec.NodeDrainTimeout).To(Equal(deployment.Spec.Template.Spec.NodeDrainTimeout))
+				g.Expect(m.Spec.NodeDeletionTimeout).To(Equal(deployment.Spec.Template.Spec.NodeDeletionTimeout))
+				g.Expect(m.Spec.NodeVolumeDetachTimeout).To(Equal(deployment.Spec.Template.Spec.NodeVolumeDetachTimeout))
+			}
+		}, input.WaitForMachinesToBeUpgraded...).Should(Succeed())
+	}
+}
+
+func machineNames(machines []clusterv1.Machine) sets.Set[string] {
+	ret := sets.Set[string]{}
+	for _, m := range machines {
+		ret.Insert(m.Name)
+	}
+	return ret
+}
+
+func machineSetNames(machineSets []*clusterv1.MachineSet) sets.Set[string] {
+	ret := sets.Set[string]{}
+	for _, ms := range machineSets {
+		ret.Insert(ms.Name)
+	}
+	return ret
 }
 
 // machineDeploymentOptions returns a set of ListOptions that allows to get all machine objects belonging to a machine deployment.


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR implements the in-place propagation behavior for MachineDeployments.
The PR contains the following features:
- Changes to in-place propagation fields in MachineDeployment will not trigger a MachineSet rollout
- Changes to in-place propagation fields in MachineDeployment are synced to the target MachineSet
   - Example: A user can change`md.spec.template.metadata.labels` without triggering a rollout and the changes will be passed down to the target MachineSet.
- Changes to in-place propagation fields in MachineSet are synced to the target Machines.


**Follow-up work:**
- https://github.com/kubernetes-sigs/cluster-api/pull/8060)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Part of #7731