### PR TITLE
📖 Add doc that clusterctl generate yaml can use raw template URL

### DIFF
--- a/docs/book/src/clusterctl/commands/generate-cluster.md
+++ b/docs/book/src/clusterctl/commands/generate-cluster.md
@@ -69,14 +69,21 @@ clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
 Also following flags are available `--from-config-map-namespace` (defaults to current namespace) and `--from-config-map-key`
 (defaults to `template`).
 
-#### GitHub, local file system folder or standard input
+#### GitHub, raw template URL, local file system folder or standard input
 
-Use the `--from` flag to read cluster templates stored in a GitHub repository, in a local file system folder,
+Use the `--from` flag to read cluster templates stored in a GitHub repository, raw template URL, in a local file system folder,
 or from the standard input; e.g.
 
 ```bash
 clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
    --from https://github.com/my-org/my-repository/blob/main/my-template.yaml > my-cluster.yaml
+```
+
+or
+
+```bash
+clusterctl generate cluster my-cluster --kubernetes-version v1.16.3 \
+   --from https://foo.bar/my-template.yaml > my-cluster.yaml
 ```
 
 or

--- a/docs/book/src/clusterctl/commands/generate-yaml.md
+++ b/docs/book/src/clusterctl/commands/generate-yaml.md
@@ -20,8 +20,10 @@ from environment variables.
 Current usage of the command is as follows:
 ```bash
 # Generates a configuration file with variable values using a template from a
-# specific URL.
+# specific URL as well as a GitHub URL.
 clusterctl generate yaml --from https://github.com/foo-org/foo-repository/blob/main/cluster-template.yaml
+
+clusterctl generate yaml --from https://foo.bar/cluster-template.yaml
 
 # Generates a configuration file with variable values using
 # a template stored locally.


### PR DESCRIPTION
Signed-off-by: Aniruddha Basak <codewithaniruddha@gmail.com>

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
`clusterctl generate yaml` can now use a raw template URL. This is a follow-up PR of the [PR](https://github.com/kubernetes-sigs/cluster-api/pull/7371) documenting the new feature.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7904 

/cc @fabriziopandini 
