### PR TITLE
🐛 trivy: also build capd & test-extension images

### DIFF
--- a/hack/verify-container-images.sh
+++ b/hack/verify-container-images.sh
@@ -54,6 +54,8 @@ rm ${TOOL_BIN}/trivy.tar.gz
 
 # Builds all the container images to be scanned and cleans up changes to ./*manager_image_patch.yaml ./*manager_pull_policy.yaml.
 make REGISTRY=gcr.io/k8s-staging-cluster-api PULL_POLICY=IfNotPresent TAG=dev docker-build
+make REGISTRY=gcr.io/k8s-staging-cluster-api PULL_POLICY=IfNotPresent TAG=dev docker-capd-build
+make REGISTRY=gcr.io/k8s-staging-cluster-api PULL_POLICY=IfNotPresent TAG=dev docker-build-test-extension
 make clean-release-git
 
 # Scan the images


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR ensures we also build all images on release-1.2 to avoid failing because of missing images

(https://github.com/kubernetes-sigs/cluster-api/actions/runs/3930140568/jobs/6719788260)

On newer branches `docker-build` builds all images.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
