### PR TITLE
🐛 test/e2e: Fix cluster cleanup in self-hosted test

### DIFF
--- a/scripts/ci-e2e.sh
+++ b/scripts/ci-e2e.sh
@@ -86,6 +86,16 @@ cleanup() {
   ctr -n moby containers list > "${ARTIFACTS_LOCAL}/containerd-containers.txt" || true
   ctr -n moby images list > "${ARTIFACTS_LOCAL}/containerd-images.txt" || true
   ctr -n moby version > "${ARTIFACTS_LOCAL}/containerd-version.txt" || true
+
+  # Verify that no containers are running at this time
+  # Note: This verifies that all our tests clean up clusters correctly.
+  if [[ ! "$(docker ps -q | wc -l)" -eq "0" ]]
+  then
+     echo "ERROR: Found unexpected running containers:"
+     echo ""
+     docker ps
+     exit 1
+  fi
 }
 trap "cleanup" EXIT SIGINT
 

--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -232,7 +232,7 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		// object. The Cluster object has special processing for the paused field during the move to
 		// avoid having clusterctl as the manager of the field.
 		log.Logf("Ensure clusterctl does not take ownership on any fields on the self-hosted cluster")
-		selfHostedCluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
+		selfHostedCluster = framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
 			Getter:    selfHostedClusterProxy.GetClient(),
 			Name:      cluster.Name,
 			Namespace: selfHostedNamespace.Name,


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently our self-hosted e2e test doesn't cleanup the cluster at the end.

This means that after the self-hosted tests are completed we still have 4 clusters running, e.g.: https://storage.googleapis.com/kubernetes-jenkins/logs/periodic-cluster-api-e2e-main/1614904441369006080/artifacts/localhost/docker-ps.txt

This has probably slightly negative impact on test performance and stability.

This PR fixes it

WIP => only added a validation that no containers are running for now. Actual fix will follow

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
