### PR TITLE
🐛 ClusterClass: remove empty hook entries from annotation

### DIFF
--- a/internal/hooks/tracking.go
+++ b/internal/hooks/tracking.go
@@ -136,7 +136,13 @@ func MarkAsOkToDelete(ctx context.Context, c client.Client, obj client.Object) e
 
 func addToCommaSeparatedList(list string, items ...string) string {
 	set := sets.NewString(strings.Split(list, ",")...)
+
+	// Remove empty strings (that might have been introduced by splitting an empty list)
+	// from the hook list
+	set.Delete("")
+
 	set.Insert(items...)
+
 	return strings.Join(set.List(), ",")
 }
 
@@ -147,6 +153,11 @@ func isInCommaSeparatedList(list, item string) bool {
 
 func removeFromCommaSeparatedList(list string, items ...string) string {
 	set := sets.NewString(strings.Split(list, ",")...)
+
+	// Remove empty strings (that might have been introduced by splitting an empty list)
+	// from the hook list
+	set.Delete("")
+
 	set.Delete(items...)
 	return strings.Join(set.List(), ",")
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Just noticed that our pending hook annotation always has a leading `,`, e.g. `,AfterClusterUpgrade,AfterControlPlaneUpgrade`.

This PR should get rid of it and remove it on existing clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
