### PR TITLE
🌱 test/e2e use informer to stream pod logs

### DIFF
--- a/test/e2e/self_hosted.go
+++ b/test/e2e/self_hosted.go
@@ -183,7 +183,10 @@ func SelfHostedSpec(ctx context.Context, inputGetter func() SelfHostedSpecInput)
 		})
 
 		By("Initializing the workload cluster")
-		clusterctl.InitManagementClusterAndWatchControllerLogs(ctx, clusterctl.InitManagementClusterAndWatchControllerLogsInput{
+		// watchesCtx is used in log streaming to be able to get canceld via cancelWatches after ending the test suite.
+		watchesCtx, cancelWatches := context.WithCancel(ctx)
+		defer cancelWatches()
+		clusterctl.InitManagementClusterAndWatchControllerLogs(watchesCtx, clusterctl.InitManagementClusterAndWatchControllerLogsInput{
 			ClusterProxy:              selfHostedClusterProxy,
 			ClusterctlConfigPath:      input.ClusterctlConfigPath,
 			InfrastructureProviders:   input.E2EConfig.InfrastructureProviders(),

--- a/test/framework/cluster_proxy.go
+++ b/test/framework/cluster_proxy.go
@@ -24,8 +24,10 @@ import (
 	"os"
 	"path"
 	goruntime "runtime"
+	"sync"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -51,6 +54,8 @@ const (
 	// failed leader election and thus controller restarts lead to longer taking retries.
 	// The timeout occurs when listing machines in `GetControlPlaneMachinesByCluster`.
 	retryableOperationTimeout = 3 * time.Minute
+
+	initialCacheSyncTimeout = time.Minute
 )
 
 // ClusterProxy defines the behavior of a type that acts as an intermediary with an existing Kubernetes cluster.
@@ -75,6 +80,9 @@ type ClusterProxy interface {
 
 	// GetRESTConfig returns the REST config for direct use with client-go if needed.
 	GetRESTConfig() *rest.Config
+
+	// GetCache returns a controller-runtime cache to create informer from.
+	GetCache(ctx context.Context) cache.Cache
 
 	// GetLogCollector returns the machine log collector for the Kubernetes cluster.
 	GetLogCollector() ClusterLogCollector
@@ -118,6 +126,8 @@ type clusterProxy struct {
 	scheme                  *runtime.Scheme
 	shouldCleanupKubeconfig bool
 	logCollector            ClusterLogCollector
+	cache                   cache.Cache
+	onceCache               sync.Once
 }
 
 // NewClusterProxy returns a clusterProxy given a KubeconfigPath and the scheme defining the types hosted in the cluster.
@@ -204,6 +214,29 @@ func (p *clusterProxy) GetClientSet() *kubernetes.Clientset {
 	Expect(err).ToNot(HaveOccurred(), "Failed to get client-go client")
 
 	return cs
+}
+
+func (p *clusterProxy) GetCache(ctx context.Context) cache.Cache {
+	p.onceCache.Do(func() {
+		var err error
+		p.cache, err = cache.New(p.GetRESTConfig(), cache.Options{
+			Scheme: p.scheme,
+			Mapper: p.GetClient().RESTMapper(),
+		})
+		Expect(err).ToNot(HaveOccurred(), "Failed to create controller-runtime cache")
+
+		go func() {
+			defer GinkgoRecover()
+			Expect(p.cache.Start(ctx)).To(Succeed())
+		}()
+
+		cacheSyncCtx, cacheSyncCtxCancel := context.WithTimeout(ctx, initialCacheSyncTimeout)
+		defer cacheSyncCtxCancel()
+		Expect(p.cache.WaitForCacheSync(cacheSyncCtx)).
+			To(BeTrue(), fmt.Sprintf("failed waiting for cache for cluster proxy to sync: %v", ctx.Err()))
+	})
+
+	return p.cache
 }
 
 // Apply wraps `kubectl apply ...` and prints the output so we can see what gets applied to the cluster.

--- a/test/framework/clusterctl/clusterctl_helpers.go
+++ b/test/framework/clusterctl/clusterctl_helpers.go
@@ -109,6 +109,7 @@ func InitManagementClusterAndWatchControllerLogs(ctx context.Context, input Init
 		// Start streaming logs from all controller providers
 		framework.WatchDeploymentLogsByName(ctx, framework.WatchDeploymentLogsByNameInput{
 			GetLister:  client,
+			Cache:      input.ClusterProxy.GetCache(ctx),
 			ClientSet:  input.ClusterProxy.GetClientSet(),
 			Deployment: deployment,
 			LogPath:    filepath.Join(input.LogFolder, "logs", deployment.GetNamespace()),
@@ -186,14 +187,6 @@ func UpgradeManagementClusterAndWait(ctx context.Context, input UpgradeManagemen
 			Getter:     client,
 			Deployment: deployment,
 		}, intervals...)
-
-		// Start streaming logs from all controller providers
-		framework.WatchDeploymentLogsByName(ctx, framework.WatchDeploymentLogsByNameInput{
-			GetLister:  client,
-			ClientSet:  input.ClusterProxy.GetClientSet(),
-			Deployment: deployment,
-			LogPath:    filepath.Join(input.LogFolder, "logs", deployment.GetNamespace()),
-		})
 
 		framework.WatchPodMetrics(ctx, framework.WatchPodMetricsInput{
 			GetLister:   client,


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Uses an informer to also start streaming the logs of new pods of deployments which e.g. get created because of deletion of a pod, evictions during upgrades.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7929
