### PR TITLE
:sparkles: feat: support moving capi resources to a desired namespace

### DIFF
--- a/cmd/clusterctl/client/cluster/mover.go
+++ b/cmd/clusterctl/client/cluster/mover.go
@@ -961,22 +961,22 @@ func (o *objectMover) createTargetObject(nodeToCreate *node, toProxy Proxy, toNa
 	return nil
 }
 
-func (o *objectMover) updateObjectNamespaceReferences(obj *unstructured.Unstructured, namespace string) error {
-	if namespace == "" {
+func (o *objectMover) updateObjectNamespaceReferences(u *unstructured.Unstructured, namespace string) error {
+	if u == nil || u.Object == nil || namespace == "" {
 		return nil
 	}
-	obj.SetNamespace(namespace)
-	if fields, knownKind := o.namespaceRefFieldsForKnownKinds[obj.GetKind()]; knownKind {
+	u.SetNamespace(namespace)
+	if fields, knownKind := o.namespaceRefFieldsForKnownKinds[u.GetKind()]; knownKind {
 		for _, nsField := range fields {
-			_, exists, err := unstructured.NestedFieldNoCopy(obj.Object, nsField...)
+			_, exists, err := unstructured.NestedFieldNoCopy(u.Object, nsField...)
 			if err != nil {
 				return errors.Wrapf(err, "error updating %q field of %s",
-					strings.Join(nsField, "."), obj.GetKind())
+					strings.Join(nsField, "."), u.GetKind())
 			}
 			if !exists {
-				return fmt.Errorf("expected %s to contain field %q", obj.GetKind(), strings.Join(nsField, "."))
+				return fmt.Errorf("expected %s to contain field %q", u.GetKind(), strings.Join(nsField, "."))
 			}
-			if err := unstructured.SetNestedField(obj.Object, namespace, nsField...); err != nil {
+			if err := unstructured.SetNestedField(u.Object, namespace, nsField...); err != nil {
 				return err
 			}
 		}

--- a/cmd/clusterctl/client/cluster/mover_test.go
+++ b/cmd/clusterctl/client/cluster/mover_test.go
@@ -1101,7 +1101,7 @@ func Test_objectMover_updateObjectNamespaceReferences(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			"ignores invalid object",
+			"ignores nil object",
 			args{
 				obj:       nil,
 				namespace: "foobar",

--- a/cmd/clusterctl/client/move.go
+++ b/cmd/clusterctl/client/move.go
@@ -38,6 +38,10 @@ type MoveOptions struct {
 	// namespace will be used.
 	Namespace string
 
+	// ToNamespace where the objects are moved to in target environment. If multiple clusters (across namespaces)
+	// are being moved, all of them will be relocated to same namespace.
+	ToNamespace string
+
 	// FromDirectory apply configuration from directory.
 	FromDirectory string
 
@@ -106,7 +110,7 @@ func (c *clusterctlClient) move(options MoveOptions) error {
 		}
 	}
 
-	return fromCluster.ObjectMover().Move(options.Namespace, toCluster, options.DryRun)
+	return fromCluster.ObjectMover().Move(options.Namespace, options.ToNamespace, toCluster, options.DryRun)
 }
 
 func (c *clusterctlClient) fromDirectory(options MoveOptions) error {

--- a/cmd/clusterctl/client/move_test.go
+++ b/cmd/clusterctl/client/move_test.go
@@ -123,6 +123,21 @@ func Test_clusterctlClient_Move(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "does not return an error when ToNamespace is specified",
+			fields: fields{
+				client: fakeClientForMove(),
+			},
+			args: args{
+				options: MoveOptions{
+					FromKubeconfig: Kubeconfig{Path: "kubeconfig", Context: "mgmt-context"},
+					ToKubeconfig:   Kubeconfig{Path: "kubeconfig", Context: "worker-context"},
+					ToNamespace:    "tonamespace",
+					DryRun:         false,
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -298,7 +313,7 @@ type fakeObjectMover struct {
 	fromDirectoryErr error
 }
 
-func (f *fakeObjectMover) Move(_ string, _ cluster.Client, _ bool) error {
+func (f *fakeObjectMover) Move(_, _ string, _ cluster.Client, _ bool) error {
 	return f.moveErr
 }
 

--- a/cmd/clusterctl/cmd/move.go
+++ b/cmd/clusterctl/cmd/move.go
@@ -29,6 +29,7 @@ type moveOptions struct {
 	toKubeconfig          string
 	toKubeconfigContext   string
 	namespace             string
+	toNamespace           string
 	fromDirectory         string
 	toDirectory           string
 	dryRun                bool
@@ -48,6 +49,9 @@ var moveCmd = &cobra.Command{
 	Example: Examples(`
 		Move Cluster API objects and all dependencies between management clusters.
 		clusterctl move --to-kubeconfig=target-kubeconfig.yaml
+
+		Move Cluster API objects and all dependencies and override the namespace during move.
+		clusterctl move --to-kubeconfig=target-kubeconfig.yaml --to-namespace=target-namespace
 
 		Write Cluster API objects and all dependencies from a management cluster to directory.
 		clusterctl move --to-directory /tmp/backup-directory
@@ -72,6 +76,8 @@ func init() {
 		"Context to be used within the kubeconfig file for the destination management cluster. If empty, current context will be used.")
 	moveCmd.Flags().StringVarP(&mo.namespace, "namespace", "n", "",
 		"The namespace where the workload cluster is hosted. If unspecified, the current context's namespace is used.")
+	moveCmd.Flags().StringVar(&mo.toNamespace, "to-namespace", "",
+		"The namespace where the workload cluster is to be relocated. If unspecified, the namespace on origination cluster is used.")
 	moveCmd.Flags().BoolVar(&mo.dryRun, "dry-run", false,
 		"Enable dry run, don't really perform the move actions")
 	moveCmd.Flags().StringVar(&mo.toDirectory, "to-directory", "",
@@ -82,6 +88,8 @@ func init() {
 	moveCmd.MarkFlagsMutuallyExclusive("to-directory", "to-kubeconfig")
 	moveCmd.MarkFlagsMutuallyExclusive("from-directory", "to-directory")
 	moveCmd.MarkFlagsMutuallyExclusive("from-directory", "kubeconfig")
+	moveCmd.MarkFlagsMutuallyExclusive("from-directory", "to-namespace")
+	moveCmd.MarkFlagsMutuallyExclusive("to-directory", "to-namespace")
 
 	RootCmd.AddCommand(moveCmd)
 }
@@ -105,6 +113,7 @@ func runMove() error {
 		FromDirectory:  mo.fromDirectory,
 		ToDirectory:    mo.toDirectory,
 		Namespace:      mo.namespace,
+		ToNamespace:    mo.toNamespace,
 		DryRun:         mo.dryRun,
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

As a developer I would like to move capi resources from one cluster to another cluster and while doing so, i would want to control the namespace the resources are created in the target cluster. Right now, when i perform a move operation, clusters are always moved to the same namespace on target cluster as they are originally created in the originating cluster. I want to be able to control this so that I can move resources from multiple clusters to a single cluster and still organize them by namespace post move operation.

This PR would have been much simpler if not for all the `.spec.<fieldRef>.namespace` references. This can potentially be done in future once #6539 is resolved

**Which issue(s) this PR fixes**:

Fixes #7940 
