### PR TITLE
🐛 test/e2e: don't restart the conformance test container after ginkgo exits

### DIFF
--- a/test/framework/kubetest/run.go
+++ b/test/framework/kubetest/run.go
@@ -190,6 +190,8 @@ func Run(ctx context.Context, input RunInput) error {
 		EnvironmentVars: env,
 		CommandArgs:     args,
 		Entrypoint:      []string{"/usr/local/bin/ginkgo"},
+		// We don't want the conformance test container to restart once ginkgo exits.
+		RestartPolicy: "no",
 	}, ginkgo.GinkgoWriter)
 	if err != nil {
 		return errors.Wrap(err, "Unable to run conformance tests")

--- a/test/infrastructure/container/docker.go
+++ b/test/infrastructure/container/docker.go
@@ -372,6 +372,11 @@ func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContaine
 		Volumes:      map[string]struct{}{},
 	}
 
+	restartPolicy := runConfig.RestartPolicy
+	if restartPolicy == "" {
+		restartPolicy = "unless-stopped"
+	}
+
 	hostConfig := dockercontainer.HostConfig{
 		// Running containers in a container requires privileges.
 		// NOTE: we could try to replicate this with --cap-add, and use less
@@ -383,7 +388,7 @@ func (d *dockerRuntime) RunContainer(ctx context.Context, runConfig *RunContaine
 		NetworkMode:   dockercontainer.NetworkMode(runConfig.Network),
 		Tmpfs:         runConfig.Tmpfs,
 		PortBindings:  nat.PortMap{},
-		RestartPolicy: dockercontainer.RestartPolicy{Name: "unless-stopped"},
+		RestartPolicy: dockercontainer.RestartPolicy{Name: restartPolicy},
 	}
 	networkConfig := network.NetworkingConfig{}
 

--- a/test/infrastructure/container/interface.go
+++ b/test/infrastructure/container/interface.go
@@ -95,6 +95,9 @@ type RunContainerInput struct {
 	PortMappings []PortMapping
 	// IPFamily is the IP version to use.
 	IPFamily clusterv1.ClusterIPFamily
+	// RestartPolicy to use for the container.
+	// If not set, defaults to "unless-stopped".
+	RestartPolicy string
 }
 
 // ExecContainerInput contains values for running exec on a container.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Currently the e2e tests which are running the conformance tests are failing.

E.g. https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-cluster-api-e2e-workload-upgrade-1-18-1-19-release-1-3/1615714183762939904

We introduced a new validation in https://github.com/kubernetes-sigs/cluster-api/pull/7928 which ensures that all containers have been stopped after the e2e test finishes.

This validation discovered that when we run conformance tests the conformance container is still "running" even after the conformance tests are done. This is because after the conformance tests / ginkgo exits Docker will just restart the conformance test container and the conformance tests will run again.

The reason for this is that we are using "unless-stopped" for all the containers we start. This PR changes the behavior to never restart the conformance container after it exits.

Surfaced via this Slack thread: https://kubernetes.slack.com/archives/C8TSNPY4T/p1674057996218879

Thx @aniruddha2000 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
