### PR TITLE
:book: Fix broken link to CAPZ experimental directory

### DIFF
--- a/docs/proposals/20220725-managed-kubernetes.md
+++ b/docs/proposals/20220725-managed-kubernetes.md
@@ -319,7 +319,7 @@ type GCPManagedClusterSpec struct {
 }
 ```
 
-**This is the design pattern used by AKS in CAPZ**. [An example of how ManagedCluster watches ControlPlane in CAPZ.](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/exp/controllers/azuremanagedcluster_controller.go#L165)
+**This is the design pattern used by AKS in CAPZ**. [An example of how ManagedCluster watches ControlPlane in CAPZ.](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/5c69b44ed847365525504b242da83b5e5da75e4f/controllers/azuremanagedcluster_controller.go#L71)
 
 **Pros**
 


### PR DESCRIPTION
Broken link due to AKS graduation in CAPZ - caught by the weekly markdown checker. 

We might consider not having links to external repos like this if this is a maintenance burden - especially as line numbers can change pretty regularly, without the link checker understanding the change.