### PR TITLE
:seedling: Add clusterclass validation to topology reconciler

### DIFF
--- a/internal/controllers/topology/cluster/blueprint.go
+++ b/internal/controllers/topology/cluster/blueprint.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/internal/controllers/topology/cluster/scope"
@@ -30,17 +29,11 @@ import (
 // getBlueprint gets a ClusterBlueprint with the ClusterClass and the referenced templates to be used for a managed Cluster topology.
 // It also converts and patches all ObjectReferences in ClusterClass and ControlPlane to the latest apiVersion of the current contract.
 // NOTE: This function assumes that cluster.Spec.Topology.Class is set.
-func (r *Reconciler) getBlueprint(ctx context.Context, cluster *clusterv1.Cluster) (_ *scope.ClusterBlueprint, reterr error) {
+func (r *Reconciler) getBlueprint(ctx context.Context, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass) (_ *scope.ClusterBlueprint, reterr error) {
 	blueprint := &scope.ClusterBlueprint{
 		Topology:           cluster.Spec.Topology,
-		ClusterClass:       &clusterv1.ClusterClass{},
+		ClusterClass:       clusterClass,
 		MachineDeployments: map[string]*scope.MachineDeploymentBlueprint{},
-	}
-
-	// Get ClusterClass.
-	key := client.ObjectKey{Name: cluster.Spec.Topology.Class, Namespace: cluster.Namespace}
-	if err := r.Client.Get(ctx, key, blueprint.ClusterClass); err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve ClusterClass/%s", cluster.Spec.Topology.Class)
 	}
 
 	var err error

--- a/internal/controllers/topology/cluster/blueprint_test.go
+++ b/internal/controllers/topology/cluster/blueprint_test.go
@@ -82,10 +82,6 @@ func TestGetBlueprint(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name:    "Fails if ClusterClass does not exist",
-			wantErr: true,
-		},
-		{
 			name: "Fails if ClusterClass does not have reference to the InfrastructureClusterTemplate",
 			clusterClass: builder.ClusterClass(metav1.NamespaceDefault, "clusterclass1").
 				// No InfrastructureClusterTemplate reference!
@@ -318,7 +314,7 @@ func TestGetBlueprint(t *testing.T) {
 				patchHelperFactory:        dryRunPatchHelperFactory(fakeClient),
 				UnstructuredCachingClient: fakeClient,
 			}
-			got, err := r.getBlueprint(ctx, scope.New(cluster).Current.Cluster)
+			got, err := r.getBlueprint(ctx, scope.New(cluster).Current.Cluster, tt.clusterClass)
 
 			// Checks the return error.
 			if tt.wantErr {

--- a/internal/controllers/topology/cluster/cluster_controller_test.go
+++ b/internal/controllers/topology/cluster/cluster_controller_test.go
@@ -18,11 +18,13 @@ package cluster
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -1066,4 +1068,235 @@ func referenceExistsWithCorrectKindAndAPIVersion(reference *corev1.ObjectReferen
 		return fmt.Errorf("apiVersion %v does not match expected %v", reference.APIVersion, apiVersion.String())
 	}
 	return nil
+}
+
+func TestReconciler_DefaultCluster(t *testing.T) {
+	g := NewWithT(t)
+	classBuilder := builder.ClusterClass(metav1.NamespaceDefault, clusterClassName1)
+	topologyBase := builder.ClusterTopology().
+		WithClass(clusterClassName1).
+		WithVersion("1.22.2").
+		WithControlPlaneReplicas(3)
+	mdClass1 := builder.MachineDeploymentClass("worker1").
+		Build()
+	mdTopologyBase := builder.MachineDeploymentTopology("md1").
+		WithClass("worker1").
+		WithReplicas(3)
+	clusterBuilder := builder.Cluster(metav1.NamespaceDefault, clusterName1).
+		WithTopology(topologyBase.DeepCopy().Build())
+
+	tests := []struct {
+		name           string
+		clusterClass   *clusterv1.ClusterClass
+		initialCluster *clusterv1.Cluster
+		wantCluster    *clusterv1.Cluster
+	}{
+		{
+			name: "Default Cluster variables with values from ClusterClass",
+			clusterClass: classBuilder.DeepCopy().
+				WithVariables(clusterv1.ClusterClassVariable{
+					Name:     "location",
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "string",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+						},
+					},
+				}).
+				Build(),
+			initialCluster: clusterBuilder.DeepCopy().
+				Build(),
+			wantCluster: clusterBuilder.DeepCopy().
+				WithTopology(topologyBase.DeepCopy().WithVariables(
+					clusterv1.ClusterVariable{Name: "location", Value: apiextensionsv1.JSON{Raw: []byte(`"us-east"`)}}).
+					Build()).
+				Build(),
+		},
+		{
+			name: "Do not default variable if a value is defined in the Cluster",
+			clusterClass: classBuilder.DeepCopy().
+				WithVariables(clusterv1.ClusterClassVariable{
+					Name:     "location",
+					Required: true,
+					Schema: clusterv1.VariableSchema{
+						OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+							Type:    "string",
+							Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+						},
+					},
+				}).
+				Build(),
+			initialCluster: clusterBuilder.DeepCopy().WithTopology(topologyBase.DeepCopy().WithVariables(
+				clusterv1.ClusterVariable{Name: "location", Value: apiextensionsv1.JSON{Raw: []byte(`"us-west"`)}}).
+				Build()).
+				Build(),
+			wantCluster: clusterBuilder.DeepCopy().WithTopology(topologyBase.DeepCopy().WithVariables(
+				clusterv1.ClusterVariable{Name: "location", Value: apiextensionsv1.JSON{Raw: []byte(`"us-west"`)}}).
+				Build()).
+				Build(),
+		},
+		{
+			name: "Default nested values of Cluster variables with values from ClusterClass",
+			clusterClass: classBuilder.DeepCopy().
+				WithWorkerMachineDeploymentClasses(*mdClass1).
+				WithVariables([]clusterv1.ClusterClassVariable{
+					{
+						Name:     "location",
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type:    "string",
+								Default: &apiextensionsv1.JSON{Raw: []byte(`"us-east"`)},
+							},
+						},
+					},
+					{
+						Name:     "httpProxy",
+						Required: true,
+						Schema: clusterv1.VariableSchema{
+							OpenAPIV3Schema: clusterv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]clusterv1.JSONSchemaProps{
+									"enabled": {
+										Type: "boolean",
+									},
+									"url": {
+										Type:    "string",
+										Default: &apiextensionsv1.JSON{Raw: []byte(`"http://localhost:3128"`)},
+									},
+								},
+							},
+						},
+					}}...).
+				Build(),
+			initialCluster: clusterBuilder.DeepCopy().
+				WithTopology(topologyBase.DeepCopy().
+					WithVariables(
+						clusterv1.ClusterVariable{Name: "location", Value: apiextensionsv1.JSON{Raw: []byte(`"us-west"`)}},
+						clusterv1.ClusterVariable{Name: "httpProxy", Value: apiextensionsv1.JSON{Raw: []byte(`{"enabled":true}`)}}).
+					WithMachineDeployment(mdTopologyBase.DeepCopy().
+						WithVariables(clusterv1.ClusterVariable{
+							Name:  "httpProxy",
+							Value: apiextensionsv1.JSON{Raw: []byte(`{"enabled":true}`)},
+						}).Build()).
+					Build()).
+				Build(),
+			wantCluster: clusterBuilder.DeepCopy().WithTopology(
+				topologyBase.DeepCopy().
+					WithVariables(
+						clusterv1.ClusterVariable{Name: "location", Value: apiextensionsv1.JSON{Raw: []byte(`"us-west"`)}},
+						clusterv1.ClusterVariable{Name: "httpProxy", Value: apiextensionsv1.JSON{Raw: []byte(`{"enabled":true,"url":"http://localhost:3128"}`)}}).
+					WithMachineDeployment(
+						mdTopologyBase.DeepCopy().WithVariables(
+							clusterv1.ClusterVariable{
+								Name: "httpProxy",
+								Value: apiextensionsv1.JSON{
+									// url has been added by defaulting.
+									Raw: []byte(`{"enabled":true,"url":"http://localhost:3128"}`),
+								},
+							}).
+							Build()).
+					Build()).
+				Build(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initObjects := []client.Object{tt.initialCluster, tt.clusterClass}
+			fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(initObjects...).Build()
+			r := &Reconciler{
+				Client:    fakeClient,
+				APIReader: fakeClient,
+			}
+			// Ignore the error here as we expect the ClusterClass to fail in reconciliation as its references do not exist.
+			var _, _ = r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKey{Name: tt.initialCluster.Name, Namespace: tt.initialCluster.Namespace}})
+			got := &clusterv1.Cluster{}
+			g.Expect(fakeClient.Get(ctx, client.ObjectKey{Name: tt.initialCluster.Name, Namespace: tt.initialCluster.Namespace}, got)).To(Succeed())
+			// Compare the spec of the two clusters to ensure that variables are defaulted correctly.
+			g.Expect(reflect.DeepEqual(got.Spec, tt.wantCluster.Spec)).To(BeTrue())
+		})
+	}
+}
+
+func TestReconciler_ValidateCluster(t *testing.T) {
+	g := NewWithT(t)
+	mdTopologyBase := builder.MachineDeploymentTopology("md1").
+		WithClass("worker1").
+		WithReplicas(3)
+	classBuilder := builder.ClusterClass(metav1.NamespaceDefault, clusterClassName1)
+	topologyBase := builder.ClusterTopology().
+		WithClass(clusterClassName1).
+		WithVersion("1.22.2").
+		WithControlPlaneReplicas(3)
+	clusterBuilder := builder.Cluster(metav1.NamespaceDefault, clusterName1).
+		WithTopology(
+			topologyBase.Build())
+	tests := []struct {
+		name              string
+		clusterClass      *clusterv1.ClusterClass
+		cluster           *clusterv1.Cluster
+		wantValidationErr bool
+	}{
+		{
+			name: "Valid cluster should not throw validation error",
+			clusterClass: classBuilder.DeepCopy().
+				WithVariables(clusterv1.ClusterClassVariable{
+					Name: "httpProxy",
+				}).
+				Build(),
+			cluster: clusterBuilder.DeepCopy().
+				Build(),
+			wantValidationErr: false,
+		},
+		{
+			name: "Cluster invalid as it does not define a required variable",
+			clusterClass: classBuilder.DeepCopy().
+				WithVariables(clusterv1.ClusterClassVariable{
+					Name:     "httpProxy",
+					Required: true,
+				}).
+				Build(),
+			cluster: clusterBuilder.
+				Build(),
+			wantValidationErr: true,
+		},
+		{
+			name: "Cluster invalid as it defines an MDTopology without a corresponding MDClass",
+			clusterClass: classBuilder.DeepCopy().
+				WithVariables(clusterv1.ClusterClassVariable{
+					Name:     "httpProxy",
+					Required: true,
+				}).
+				Build(),
+			cluster: clusterBuilder.WithTopology(
+				builder.ClusterTopology().DeepCopy().
+					WithClass(clusterClassName1).
+					WithVersion("1.22.2").
+					WithControlPlaneReplicas(3).
+					WithMachineDeployment(mdTopologyBase.Build()).Build(),
+			).
+				Build(),
+			wantValidationErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initObjects := []client.Object{tt.cluster, tt.clusterClass}
+			fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(initObjects...).Build()
+			r := &Reconciler{
+				Client:    fakeClient,
+				APIReader: fakeClient,
+			}
+			var _, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKey{Name: tt.cluster.Name, Namespace: tt.cluster.Namespace}})
+			// Reconcile will always return an error here as the topology is incomplete. This test checks specifically for
+			// validation errors.
+			validationErrMessage := fmt.Sprintf("Cluster.cluster.x-k8s.io %q is invalid:", tt.cluster.Name)
+			if tt.wantValidationErr {
+				g.Expect(err.Error()).To(ContainSubstring(validationErrMessage))
+				return
+			}
+			g.Expect(err.Error()).ToNot(ContainSubstring(validationErrMessage))
+		})
+	}
 }

--- a/internal/topology/variables/cluster_variable_defaulting.go
+++ b/internal/topology/variables/cluster_variable_defaulting.go
@@ -35,8 +35,8 @@ func DefaultClusterVariables(clusterVariables []clusterv1.ClusterVariable, clust
 }
 
 // DefaultMachineDeploymentVariables defaults MachineDeploymentVariables.
-func DefaultMachineDeploymentVariables(clusterVariables []clusterv1.ClusterVariable, clusterClassVariables []clusterv1.ClusterClassVariable, fldPath *field.Path) ([]clusterv1.ClusterVariable, field.ErrorList) {
-	return defaultClusterVariables(clusterVariables, clusterClassVariables, false, fldPath)
+func DefaultMachineDeploymentVariables(machineDeploymentVariables []clusterv1.ClusterVariable, clusterClassVariables []clusterv1.ClusterClassVariable, fldPath *field.Path) ([]clusterv1.ClusterVariable, field.ErrorList) {
+	return defaultClusterVariables(machineDeploymentVariables, clusterClassVariables, false, fldPath)
 }
 
 // defaultClusterVariables defaults variables.


### PR DESCRIPTION
Add validation for the ClusterClass elements of topology managed Clusters during Cluster Topology reconciliation. Relax the Cluster webhook so that a Cluster can be created even if it references a non-existent ClusterClass.

Fixes #5623 
