### PR TITLE
:seedling:  Run weekly markdown check against all supported branches

### DIFF
--- a/.github/workflows/lint-docs-weekly.yml
+++ b/.github/workflows/lint-docs-weekly.yml
@@ -10,6 +10,9 @@ permissions: {}
 jobs:
   markdown-link-check:
     name: Broken Links
+    strategy:
+      matrix:
+        branch: [ main, release-1.3, release-1.2 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3.3.0


### PR DESCRIPTION
Adds running the weekly markdown link checker against all supported branches to keep links in supported versions of the book up to date.
