### PR TITLE
:seedling: Run weekly markdown check against all supported branches

### DIFF
--- a/.github/workflows/lint-docs-weekly.yml
+++ b/.github/workflows/lint-docs-weekly.yml
@@ -10,9 +10,14 @@ permissions: {}
 jobs:
   markdown-link-check:
     name: Broken Links
+    strategy:
+      matrix:
+        branch: [ main, release-1.3, release-1.2 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3.3.0
+        with:
+          ref: ${{ matrix.branch }}
       - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # tag=v1
         with:
           use-quiet-mode: 'yes'

--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -111,7 +111,7 @@ This comes down to changing occurrences of the old version to the new version, e
    5. Modify the test specs in `test/e2e/clusterctl_upgrade_test.go` (according to the versions we want to test described above).
       Please note that `InitWithKubernetesVersion` should be the highest mgmt cluster version supported by the respective Cluster API version. 
 2. Update `create-local-repository.py` and `tools/tilt-prepare/main.go`: `v1.3.99` => `v1.4.99`.
-3. Update `.github/workflows/scan.yml` to setup Trivy scanning for the currently supported branches.
+3. Update `.github/workflows/scan.yml` - to setup Trivy scanning - and `.github/workflows/lint-docs-weekly.yml` - to setup link checking in the CAPI book - for the currently supported branches.
 4. Make sure all tests are green (also run `pull-cluster-api-e2e-full-main` and `pull-cluster-api-e2e-workload-upgrade-1-23-latest-main`).
 
 Prior art: https://github.com/kubernetes-sigs/cluster-api/pull/6834/files


### PR DESCRIPTION
Adds running the weekly markdown link checker against all supported branches to keep links in supported versions of the book up to date.
