### PR TITLE
🌱 add comment to disableNodeLabelSync

### DIFF
--- a/internal/controllers/machine/machine_controller.go
+++ b/internal/controllers/machine/machine_controller.go
@@ -91,7 +91,11 @@ type Reconciler struct {
 	// nodeDeletionRetryTimeout determines how long the controller will retry deleting a node
 	// during a single reconciliation.
 	nodeDeletionRetryTimeout time.Duration
-	disableNodeLabelSync     bool
+
+	// disableNodeLabelSync should only be used for tests. This is used to skip the parts of
+	// the controller that need SSA as the current test setup does not support SSA.
+	// This flag should be dropped after the tests are migrated to envtest.
+	disableNodeLabelSync bool
 }
 
 func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This is a follow-up PR to https://github.com/kubernetes-sigs/cluster-api/pull/7173. This adds the missing comment on `disableNodeLabelSync` flag introduced in the PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
