### PR TITLE
📖 Fix cert manager verification steps in developer guide

### DIFF
--- a/docs/book/src/developer/guide.md
+++ b/docs/book/src/developer/guide.md
@@ -86,11 +86,9 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 
 Ensure the cert-manager webhook service is ready before creating the Cluster API components.
 
-This can be done by running:
-
-```bash
-kubectl wait --for=condition=Available --timeout=300s apiservice v1beta1.webhook.cert-manager.io
-```
+This can be done by following instructions for [manual verification](https://cert-manager.io/docs/installation/verify/#manual-verification)
+from the [cert-manager] web site.
+Note: make sure to follow instructions for the release of cert-manager you are installing.
 
 [cert-manager]: https://github.com/cert-manager/cert-manager
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix outdated verification steps for cert-manager installation in the developer guide, which are confusing for users, see e.g. https://kubernetes.slack.com/archives/C8TSNPY4T/p1674244667994499