### PR TITLE
🌱 Improve quick-start test supporting scenarios with more than one infrastructure provider

### DIFF
--- a/test/e2e/quick_start.go
+++ b/test/e2e/quick_start.go
@@ -39,12 +39,31 @@ type QuickStartSpecInput struct {
 	BootstrapClusterProxy framework.ClusterProxy
 	ArtifactFolder        string
 	SkipCleanup           bool
-	ControlPlaneWaiters   clusterctl.ControlPlaneWaiters
+
+	// InfrastructureProvider allows to specify the infrastructure provider to be used when looking for
+	// cluster templates.
+	// If not set, clusterctl will look at the infrastructure provider installed in the management cluster;
+	// if only one infrastructure provider exists, it will be used, otherwise the operation will fail if more than one exists.
+	InfrastructureProvider *string
 
 	// Flavor, if specified is the template flavor used to create the cluster for testing.
-	// If not specified, and the e2econfig variable IPFamily is IPV6, then "ipv6" is used,
-	// otherwise the default flavor is used.
-	Flavor                  *string
+	// If not specified, the default flavor for the selected infrastructure provider is used.
+	Flavor *string
+
+	// ControlPlaneMachineCount defines the number of control plane machines to be added to the workload cluster.
+	// If not specified, 1 will be used.
+	ControlPlaneMachineCount *int64
+
+	// WorkerMachineCount defines number of worker machines to be added to the workload cluster.
+	// If not specified, 1 will be used.
+	WorkerMachineCount *int64
+
+	// Allows to inject functions to be run while waiting for the control plane to be initialized,
+	// which unblocks CNI installation, and for the control plane machines to be ready (after CNI installation).
+	ControlPlaneWaiters clusterctl.ControlPlaneWaiters
+
+	// Allows to inject a function to be run after machines are provisioned.
+	// If not specified, this is a no-op.
 	PostMachinesProvisioned func(managementClusterProxy framework.ClusterProxy, workloadClusterNamespace, workloadClusterName string)
 }
 
@@ -79,10 +98,26 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 	It("Should create a workload cluster", func() {
 		By("Creating a workload cluster")
 
+		infrastructureProvider := clusterctl.DefaultInfrastructureProvider
+		if input.InfrastructureProvider != nil {
+			infrastructureProvider = *input.InfrastructureProvider
+		}
+
 		flavor := clusterctl.DefaultFlavor
 		if input.Flavor != nil {
 			flavor = *input.Flavor
 		}
+
+		controlPlaneMachineCount := pointer.Int64(1)
+		if input.ControlPlaneMachineCount != nil {
+			controlPlaneMachineCount = input.ControlPlaneMachineCount
+		}
+
+		workerMachineCount := pointer.Int64(1)
+		if input.WorkerMachineCount != nil {
+			workerMachineCount = input.WorkerMachineCount
+		}
+
 		clusterName := fmt.Sprintf("%s-%s", specName, util.RandomString(6))
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: input.BootstrapClusterProxy,
@@ -90,13 +125,13 @@ func QuickStartSpec(ctx context.Context, inputGetter func() QuickStartSpecInput)
 				LogFolder:                filepath.Join(input.ArtifactFolder, "clusters", input.BootstrapClusterProxy.GetName()),
 				ClusterctlConfigPath:     input.ClusterctlConfigPath,
 				KubeconfigPath:           input.BootstrapClusterProxy.GetKubeconfigPath(),
-				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				InfrastructureProvider:   infrastructureProvider,
 				Flavor:                   flavor,
 				Namespace:                namespace.Name,
 				ClusterName:              clusterName,
 				KubernetesVersion:        input.E2EConfig.GetVariable(KubernetesVersion),
-				ControlPlaneMachineCount: pointer.Int64(1),
-				WorkerMachineCount:       pointer.Int64(1),
+				ControlPlaneMachineCount: controlPlaneMachineCount,
+				WorkerMachineCount:       workerMachineCount,
 			},
 			ControlPlaneWaiters:          input.ControlPlaneWaiters,
 			WaitForClusterIntervals:      input.E2EConfig.GetIntervals(specName, "wait-cluster"),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the CAPI quick-start test suitable for use cases where there is more than one infrastructure provider in the E2E test config file, like e.g https://github.com/kubernetes-sigs/cluster-api-provider-kubemark/pull/69 

Also, it makes the number of replicas configurable, could make sense when this test spec is used for other provider's pipelines