### PR TITLE
🐛  bugfix write-to flag should only run filepath.Clean when the output file is not "" or -

### DIFF
--- a/cmd/clusterctl/cmd/util.go
+++ b/cmd/clusterctl/cmd/util.go
@@ -38,15 +38,15 @@ func printYamlOutput(printer client.YamlPrinter, outputFile string) error {
 	if err != nil {
 		return err
 	}
-	outputFile = filepath.Clean(strings.TrimSpace(outputFile))
 	yaml = append(yaml, '\n')
+	outputFile = strings.TrimSpace(outputFile)
 	if outputFile == "" || outputFile == "-" {
 		if _, err := os.Stdout.Write(yaml); err != nil {
 			return errors.Wrap(err, "failed to write yaml to Stdout")
 		}
 		return nil
 	}
-
+	outputFile = filepath.Clean(outputFile)
 	if err := os.WriteFile(outputFile, yaml, 0600); err != nil {
 		return errors.Wrap(err, "failed to write to destination file")
 	}


### PR DESCRIPTION


<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
If this flag is not specified, the return value of filepath.Clean() is "."(dot), but it appears that this was not handled. It now functions as expected.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #7970 
