### PR TITLE
:bug: Fix secret selection logic for ownerRef test

### DIFF
--- a/cmd/clusterctl/client/cluster/ownergraph.go
+++ b/cmd/clusterctl/client/cluster/ownergraph.go
@@ -20,6 +20,9 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 // OwnerGraph contains a graph with all the objects considered by clusterctl move as nodes and the OwnerReference relationship
@@ -50,15 +53,20 @@ func nodeToOwnerRef(n *node, attributes ownerReferenceAttributes) metav1.OwnerRe
 
 // GetOwnerGraph returns a graph with all the objects considered by clusterctl move as nodes and the OwnerReference relationship between those objects as edges.
 // NOTE: this data structure is exposed to allow implementation of E2E tests verifying that CAPI can properly rebuild its
-// own owner references; there is no guarantee about the stability of this API.
+// own owner references; there is no guarantee about the stability of this API. Using this test with providers may require
+// a custom implementation of this function, or the OwnerGraph it returns.
 func GetOwnerGraph(namespace, kubeconfigPath string) (OwnerGraph, error) {
 	p := newProxy(Kubeconfig{Path: kubeconfigPath, Context: ""})
 	invClient := newInventoryClient(p, nil)
 
 	graph := newObjectGraph(p, invClient)
 
+	cl, err := p.NewClient()
+	if err != nil {
+		return OwnerGraph{}, errors.Wrap(err, "failed to create client for ownerGraph")
+	}
 	// Gets all the types defined by the CRDs installed by clusterctl plus the ConfigMap/Secret core types.
-	err := graph.getDiscoveryTypes()
+	err = graph.getDiscoveryTypes()
 	if err != nil {
 		return OwnerGraph{}, errors.Wrap(err, "failed to retrieve discovery types")
 	}
@@ -71,6 +79,17 @@ func GetOwnerGraph(namespace, kubeconfigPath string) (OwnerGraph, error) {
 	}
 	owners := OwnerGraph{}
 	for _, v := range graph.uidToNode {
+		// The Discovery function returns all secrets in the Cluster namespace. Ensure a Secret that is not part of the
+		// Cluster is not added to the OwnerGraph.
+		if v.identity.Kind == "Secret" {
+			clusterSecret, err := isClusterSecret(v.identity, cl)
+			if err != nil {
+				return OwnerGraph{}, err
+			}
+			if !clusterSecret {
+				continue
+			}
+		}
 		n := OwnerGraphNode{Object: v.identity, Owners: []metav1.OwnerReference{}}
 		for owner, attributes := range v.owners {
 			n.Owners = append(n.Owners, nodeToOwnerRef(owner, attributes))
@@ -78,4 +97,13 @@ func GetOwnerGraph(namespace, kubeconfigPath string) (OwnerGraph, error) {
 		owners[string(v.identity.UID)] = n
 	}
 	return owners, nil
+}
+
+// isClusterSecret checks whether a Secret is related to a CAPI Cluster by checking if the secret type is ClusterSecretType.
+func isClusterSecret(ref corev1.ObjectReference, c client.Client) (bool, error) {
+	s := &corev1.Secret{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}, s); err != nil {
+		return false, err
+	}
+	return s.Type == clusterv1.ClusterSecretType, nil
 }

--- a/util/secret/secret.go
+++ b/util/secret/secret.go
@@ -53,7 +53,7 @@ func Name(cluster string, suffix Purpose) string {
 	return fmt.Sprintf("%s-%s", cluster, suffix)
 }
 
-// ParseSecretName return the cluster name and the suffix Purpose in name is a valid cluster secrets,
+// ParseSecretName return the cluster name and the suffix Purpose in name is a valid cluster secret,
 // otherwise it return error.
 func ParseSecretName(name string) (string, Purpose, error) {
 	separatorPos := strings.LastIndex(name, "-")


### PR DESCRIPTION
Fixes a failure in the ownerReference e2e test for Kubernetes versions below v1.24. This ensures that the secrets considered for the ownerReference test are only those directly associated with the Cluster.


