### PR TITLE
:bug:  Use tenancy as filter in ownerReference test

### DIFF
--- a/test/framework/ownerreference_helpers.go
+++ b/test/framework/ownerreference_helpers.go
@@ -177,7 +177,7 @@ var KubernetesReferenceAssertions = map[string]func([]metav1.OwnerReference) err
 	},
 	configMapKind: func(owners []metav1.OwnerReference) error {
 		// The only configMaps considered here are those owned by a ClusterResourceSet.
-		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterResourceSetGVK}, []schema.GroupVersionKind{})
+		return hasOneOfExactOwnersByGVK(owners, []schema.GroupVersionKind{clusterResourceSetGVK})
 	},
 }
 


### PR DESCRIPTION
This change cleans up the implementation introduced in #7973 using the tenancy concept exposed in the objectGraph returned by the call to discovery.

