### PR TITLE
📖 backport policy: Add go version bumps

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_tracking.md
+++ b/.github/ISSUE_TEMPLATE/release_tracking.md
@@ -68,6 +68,7 @@ Week 17:
 
 Continuously:
 * [Release lead] [Maintain the GitHub release milestone](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#continuously-maintain-the-github-release-milestone)
+* [Release lead] [Bump the Go version](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#continuously-bump-the-go-version)
 * [Communications Manager] [Communicate key dates to the community](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#continuously-communicate-key-dates-to-the-community)
 * [Communications Manager] Improve release process documentation
 * [Communications Manager] Maintain and improve user facing documentation about releases, release policy and release calendar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,8 @@ We generally allow backports of following changes to all supported branches:
 - Dependency bumps for CVE (usually limited to CVE resolution; backports of non-CVE related version bumps are considered exceptions to be evaluated case by case)
 - Cert-manager version bumps (to avoid having releases with cert-manager versions that are out of support, when possible)
 - Changes required to support new Kubernetes versions, when possible. See [supported Kubernetes versions](https://cluster-api.sigs.k8s.io/reference/versions.html#supported-kubernetes-versions) for more details.
+- Changes to use the latest Go patch release. If the Go minor version of a supported branch goes out of support, we will consider on a case-by-case basis
+  to bump to a newer Go minor version (e.g. to pick up CVE fixes). This could have impact on everyone importing Cluster API.
 
 We generally allow backports of following changes only to the latest supported branch:
 - Improvements to existing docs (the latest supported branch hosts the current version of the book)

--- a/docs/release/release-tasks.md
+++ b/docs/release/release-tasks.md
@@ -25,6 +25,7 @@ This document details the responsibilities and tasks for each role in the releas
       - [\[Track\] Bump dependencies](#track-bump-dependencies)
       - [Create a release branch](#create-a-release-branch)
       - [\[Continuously\] Maintain the GitHub release milestone](#continuously-maintain-the-github-release-milestone)
+      - [\[Continuously\] Bump the Go version](#continuously-bump-the-go-version)
       - [\[Repeatedly\] Cut a release](#repeatedly-cut-a-release)
       - [\[Optional\] \[Track\] Bump the Cluster API apiVersion](#optional-track-bump-the-cluster-api-apiversion)
       - [\[Optional\] \[Track\] Bump the Kubernetes version](#optional-track-bump-the-kubernetes-version)
@@ -168,6 +169,17 @@ This can be done by:
 1. Regularly checking in with folks implementing an issue in the milestone.
 2. If nobody is working on an issue in the milestone, drop it from the milestone.
 3. Ensuring we have a plan to get `release-blocking` issues implemented in time.
+
+#### [Continuously] Bump the Go version
+
+The goal of this task is to ensure we are always using the latest Go version for our releases.
+
+1. Keep track of new Go versions
+2. Bump the Go version in supported branches if necessary
+   <br>Prior art: [Bump to Go 1.19.5](https://github.com/kubernetes-sigs/cluster-api/pull/7981)
+
+Note: If the Go minor version of one of our supported branches goes out of supported, we should consider bumping 
+to a newer Go minor version according to our [backport policy](./../../CONTRIBUTING.md#backporting-a-patch).
 
 #### [Repeatedly] Cut a release
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
For context, please see https://github.com/kubernetes-sigs/cluster-api/issues/7974
