### PR TITLE
🌱 Remove PopulateDefaultsMachineDeployment and fix how MD controller set revision

### DIFF
--- a/docs/book/src/developer/providers/v1.3-to-v1.4.md
+++ b/docs/book/src/developer/providers/v1.3-to-v1.4.md
@@ -30,6 +30,7 @@ maintainers of providers and consumers of our Go API.
 - `exp/runtime/server.NewServer` has been removed.
 - `--disable-no-echo` option from `clusterctl describe cluster` subcommand has been removed
 - `api/v1beta1.ClusterTopologyManagedFieldsAnnotation` field has been removed.
+- `api/v1beta1.PopulateDefaultsMachineDeployment` func has been removed.
 
 ### API Changes
 

--- a/internal/controllers/machinedeployment/machinedeployment_controller_test.go
+++ b/internal/controllers/machinedeployment/machinedeployment_controller_test.go
@@ -250,7 +250,10 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 		//
 		secondMachineSet := machineSets.Items[0]
 		t.Log("Scaling the MachineDeployment to 3 replicas")
-		modifyFunc := func(d *clusterv1.MachineDeployment) { d.Spec.Replicas = pointer.Int32(3) }
+		desiredMachineDeploymentReplicas := int32(3)
+		modifyFunc := func(d *clusterv1.MachineDeployment) {
+			d.Spec.Replicas = pointer.Int32(desiredMachineDeploymentReplicas)
+		}
 		g.Expect(updateMachineDeployment(ctx, env, deployment, modifyFunc)).To(Succeed())
 		g.Eventually(func() int {
 			key := client.ObjectKey{Name: secondMachineSet.Name, Namespace: secondMachineSet.Namespace}
@@ -258,7 +261,7 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 				return -1
 			}
 			return int(*secondMachineSet.Spec.Replicas)
-		}, timeout).Should(BeEquivalentTo(3))
+		}, timeout).Should(BeEquivalentTo(desiredMachineDeploymentReplicas))
 
 		//
 		// Update a MachineDeployment, expect Reconcile to be called and a new MachineSet to appear.
@@ -393,7 +396,7 @@ func TestMachineDeploymentReconciler(t *testing.T) {
 			if err := env.List(ctx, machineSets, listOpts); err != nil {
 				return false
 			}
-			return machineSets.Items[0].Status.Replicas == *deployment.Spec.Replicas
+			return machineSets.Items[0].Status.Replicas == desiredMachineDeploymentReplicas
 		}, timeout*5).Should(BeTrue())
 
 		t.Log("Verifying MachineSets with old labels are deleted")


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR solves two issues:
1. It removes unnecessary defautling. Our goal is exclusively to modify the MD with the changes done by the modifyFunc, we don't want to do any defaulting additionally.
2. The way updateMachineDeployment was implemented before it overwrote the passed in MachineDeployment and thus dropped all changes previously made by the reconciler. For more details, see the explanation in:  https://github.com/kubernetes-sigs/cluster-api/issues/5470#issue-1032657900


xref: https://kubernetes.slack.com/archives/C8TSNPY4T/p1674580260891629

Tasks:
* [x] verify that the refs in MD are upgraded in the clusterctl upgrade test

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes part of #5470
