### PR TITLE
🌱 MachinePool: automatically bump apiVersions like in our other controllers

### DIFF
--- a/exp/controllers/alias.go
+++ b/exp/controllers/alias.go
@@ -28,7 +28,8 @@ import (
 
 // MachinePoolReconciler reconciles a MachinePool object.
 type MachinePoolReconciler struct {
-	Client client.Client
+	Client    client.Client
+	APIReader client.Reader
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
@@ -37,6 +38,7 @@ type MachinePoolReconciler struct {
 func (r *MachinePoolReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	return (&machinepool.MachinePoolReconciler{
 		Client:           r.Client,
+		APIReader:        r.APIReader,
 		WatchFilterValue: r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)
 }

--- a/exp/internal/controllers/machinepool_controller.go
+++ b/exp/internal/controllers/machinepool_controller.go
@@ -59,7 +59,8 @@ const (
 
 // MachinePoolReconciler reconciles a MachinePool object.
 type MachinePoolReconciler struct {
-	Client client.Client
+	Client    client.Client
+	APIReader client.Reader
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string

--- a/exp/internal/controllers/machinepool_controller_phases.go
+++ b/exp/internal/controllers/machinepool_controller_phases.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
@@ -103,6 +104,10 @@ func (r *MachinePoolReconciler) reconcilePhase(mp *expv1.MachinePool) {
 // reconcileExternal handles generic unstructured objects referenced by a MachinePool.
 func (r *MachinePoolReconciler) reconcileExternal(ctx context.Context, cluster *clusterv1.Cluster, m *expv1.MachinePool, ref *corev1.ObjectReference) (external.ReconcileOutput, error) {
 	log := ctrl.LoggerFrom(ctx)
+
+	if err := utilconversion.UpdateReferenceAPIContract(ctx, r.Client, r.APIReader, ref); err != nil {
+		return external.ReconcileOutput{}, err
+	}
 
 	obj, err := external.Get(ctx, r.Client, ref, m.Namespace)
 	if err != nil {

--- a/exp/internal/controllers/machinepool_controller_phases_test.go
+++ b/exp/internal/controllers/machinepool_controller_phases_test.go
@@ -34,6 +34,7 @@ import (
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
+	"sigs.k8s.io/cluster-api/internal/test/builder"
 	"sigs.k8s.io/cluster-api/util/kubeconfig"
 )
 
@@ -69,14 +70,14 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
 						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
-							Kind:       "BootstrapConfig",
+							APIVersion: builder.BootstrapGroupVersion.String(),
+							Kind:       builder.TestBootstrapConfigKind,
 							Name:       "bootstrap-config1",
 						},
 					},
 					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-						Kind:       "InfrastructureConfig",
+						APIVersion: builder.InfrastructureGroupVersion.String(),
+						Kind:       builder.TestInfrastructureMachineTemplateKind,
 						Name:       "infra-config1",
 					},
 				},
@@ -86,8 +87,8 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 	defaultBootstrap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"kind":       "BootstrapConfig",
-			"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+			"kind":       builder.TestBootstrapConfigKind,
+			"apiVersion": builder.BootstrapGroupVersion.String(),
 			"metadata": map[string]interface{}{
 				"name":      "bootstrap-config1",
 				"namespace": metav1.NamespaceDefault,
@@ -99,8 +100,8 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 
 	defaultInfra := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"kind":       "InfrastructureConfig",
-			"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+			"kind":       builder.TestInfrastructureMachineTemplateKind,
+			"apiVersion": builder.InfrastructureGroupVersion.String(),
 			"metadata": map[string]interface{}{
 				"name":      "infra-config1",
 				"namespace": metav1.NamespaceDefault,
@@ -123,7 +124,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		infraConfig := defaultInfra.DeepCopy()
 
 		r := &MachinePoolReconciler{
-			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machinepool)
@@ -152,7 +153,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		infraConfig := defaultInfra.DeepCopy()
 
 		r := &MachinePoolReconciler{
-			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machinepool)
@@ -179,7 +180,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		r := &MachinePoolReconciler{
-			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machinepool)
@@ -222,7 +223,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
 
 		r := &MachinePoolReconciler{
-			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machinepool)
@@ -277,7 +278,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
 
 		r := &MachinePoolReconciler{
-			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machinepool)
@@ -310,7 +311,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
 
 		r := &MachinePoolReconciler{
-			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machinepool)
@@ -350,7 +351,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinepool.Status.NodeRefs = []corev1.ObjectReference{{Kind: "Node", Name: "machinepool-test-node"}}
 
 		r := &MachinePoolReconciler{
-			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machinepool)
@@ -403,7 +404,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		}
 
 		r := &MachinePoolReconciler{
-			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machinepool)
@@ -461,7 +462,7 @@ func TestReconcileMachinePoolPhases(t *testing.T) {
 		machinepool.SetDeletionTimestamp(&deletionTimestamp)
 
 		r := &MachinePoolReconciler{
-			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client: fake.NewClientBuilder().WithObjects(defaultCluster, defaultKubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 		}
 
 		res, err := r.reconcile(ctx, defaultCluster, machinepool)
@@ -487,8 +488,8 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
 						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
-							Kind:       "BootstrapConfig",
+							APIVersion: builder.BootstrapGroupVersion.String(),
+							Kind:       builder.TestBootstrapConfigKind,
 							Name:       "bootstrap-config1",
 						},
 					},
@@ -515,8 +516,8 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 		{
 			name: "new machinepool, bootstrap config ready with data",
 			bootstrapConfig: map[string]interface{}{
-				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": metav1.NamespaceDefault,
@@ -537,8 +538,8 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 		{
 			name: "new machinepool, bootstrap config ready with no data",
 			bootstrapConfig: map[string]interface{}{
-				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": metav1.NamespaceDefault,
@@ -557,8 +558,8 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 		{
 			name: "new machinepool, bootstrap config not ready",
 			bootstrapConfig: map[string]interface{}{
-				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": metav1.NamespaceDefault,
@@ -575,8 +576,8 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 		{
 			name: "new machinepool, bootstrap config is not found",
 			bootstrapConfig: map[string]interface{}{
-				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": wrongNamespace,
@@ -592,8 +593,8 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 		{
 			name: "new machinepool, no bootstrap config or data",
 			bootstrapConfig: map[string]interface{}{
-				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": wrongNamespace,
@@ -606,8 +607,8 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 		{
 			name: "existing machinepool, bootstrap data should not change",
 			bootstrapConfig: map[string]interface{}{
-				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": metav1.NamespaceDefault,
@@ -628,8 +629,8 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 						Spec: clusterv1.MachineSpec{
 							Bootstrap: clusterv1.Bootstrap{
 								ConfigRef: &corev1.ObjectReference{
-									APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
-									Kind:       "BootstrapConfig",
+									APIVersion: builder.BootstrapGroupVersion.String(),
+									Kind:       builder.TestBootstrapConfigKind,
 									Name:       "bootstrap-config1",
 								},
 								DataSecretName: pointer.String("data"),
@@ -650,8 +651,8 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 		{
 			name: "existing machinepool, bootstrap provider is to not ready",
 			bootstrapConfig: map[string]interface{}{
-				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": metav1.NamespaceDefault,
@@ -672,8 +673,8 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 						Spec: clusterv1.MachineSpec{
 							Bootstrap: clusterv1.Bootstrap{
 								ConfigRef: &corev1.ObjectReference{
-									APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
-									Kind:       "BootstrapConfig",
+									APIVersion: builder.BootstrapGroupVersion.String(),
+									Kind:       builder.TestBootstrapConfigKind,
 									Name:       "bootstrap-config1",
 								},
 								DataSecretName: pointer.String("data"),
@@ -701,7 +702,7 @@ func TestReconcileMachinePoolBootstrap(t *testing.T) {
 
 			bootstrapConfig := &unstructured.Unstructured{Object: tc.bootstrapConfig}
 			r := &MachinePoolReconciler{
-				Client: fake.NewClientBuilder().WithObjects(tc.machinepool, bootstrapConfig).Build(),
+				Client: fake.NewClientBuilder().WithObjects(tc.machinepool, bootstrapConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 			}
 
 			res, err := r.reconcileBootstrap(ctx, defaultCluster, tc.machinepool)
@@ -734,14 +735,14 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
 						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
-							Kind:       "BootstrapConfig",
+							APIVersion: builder.BootstrapGroupVersion.String(),
+							Kind:       builder.TestBootstrapConfigKind,
 							Name:       "bootstrap-config1",
 						},
 					},
 					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-						Kind:       "InfrastructureConfig",
+						APIVersion: builder.InfrastructureGroupVersion.String(),
+						Kind:       builder.TestInfrastructureMachineTemplateKind,
 						Name:       "infra-config1",
 					},
 				},
@@ -769,8 +770,8 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 		{
 			name: "new machinepool, infrastructure config ready",
 			infraConfig: map[string]interface{}{
-				"kind":       "InfrastructureConfig",
-				"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestInfrastructureMachineTemplateKind,
+				"apiVersion": builder.InfrastructureGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "infra-config1",
 					"namespace": metav1.NamespaceDefault,
@@ -813,14 +814,14 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 						Spec: clusterv1.MachineSpec{
 							Bootstrap: clusterv1.Bootstrap{
 								ConfigRef: &corev1.ObjectReference{
-									APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
-									Kind:       "BootstrapConfig",
+									APIVersion: builder.BootstrapGroupVersion.String(),
+									Kind:       builder.TestBootstrapConfigKind,
 									Name:       "bootstrap-config1",
 								},
 							},
 							InfrastructureRef: corev1.ObjectReference{
-								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-								Kind:       "InfrastructureConfig",
+								APIVersion: builder.InfrastructureGroupVersion.String(),
+								Kind:       builder.TestInfrastructureMachineTemplateKind,
 								Name:       "infra-config1",
 							},
 						},
@@ -833,8 +834,8 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 				},
 			},
 			bootstrapConfig: map[string]interface{}{
-				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": metav1.NamespaceDefault,
@@ -846,8 +847,8 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 				},
 			},
 			infraConfig: map[string]interface{}{
-				"kind":       "InfrastructureConfig",
-				"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestInfrastructureMachineTemplateKind,
+				"apiVersion": builder.InfrastructureGroupVersion.String(),
 				"metadata":   map[string]interface{}{},
 			},
 			expectError:        true,
@@ -862,8 +863,8 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 		{
 			name: "infrastructure ref is paused",
 			infraConfig: map[string]interface{}{
-				"kind":       "InfrastructureConfig",
-				"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestInfrastructureMachineTemplateKind,
+				"apiVersion": builder.InfrastructureGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "infra-config1",
 					"namespace": metav1.NamespaceDefault,
@@ -909,14 +910,14 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 						Spec: clusterv1.MachineSpec{
 							Bootstrap: clusterv1.Bootstrap{
 								ConfigRef: &corev1.ObjectReference{
-									APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
-									Kind:       "BootstrapConfig",
+									APIVersion: builder.BootstrapGroupVersion.String(),
+									Kind:       builder.TestBootstrapConfigKind,
 									Name:       "bootstrap-config1",
 								},
 							},
 							InfrastructureRef: corev1.ObjectReference{
-								APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-								Kind:       "InfrastructureConfig",
+								APIVersion: builder.InfrastructureGroupVersion.String(),
+								Kind:       builder.TestInfrastructureMachineTemplateKind,
 								Name:       "infra-config1",
 							},
 						},
@@ -929,8 +930,8 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 				},
 			},
 			bootstrapConfig: map[string]interface{}{
-				"kind":       "BootstrapConfig",
-				"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestBootstrapConfigKind,
+				"apiVersion": builder.BootstrapGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "bootstrap-config1",
 					"namespace": metav1.NamespaceDefault,
@@ -942,8 +943,8 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 				},
 			},
 			infraConfig: map[string]interface{}{
-				"kind":       "InfrastructureConfig",
-				"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+				"kind":       builder.TestInfrastructureMachineTemplateKind,
+				"apiVersion": builder.InfrastructureGroupVersion.String(),
 				"metadata": map[string]interface{}{
 					"name":      "infra-config1",
 					"namespace": metav1.NamespaceDefault,
@@ -989,7 +990,7 @@ func TestReconcileMachinePoolInfrastructure(t *testing.T) {
 
 			infraConfig := &unstructured.Unstructured{Object: tc.infraConfig}
 			r := &MachinePoolReconciler{
-				Client: fake.NewClientBuilder().WithObjects(tc.machinepool, infraConfig).Build(),
+				Client: fake.NewClientBuilder().WithObjects(tc.machinepool, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 			}
 
 			res, err := r.reconcileInfrastructure(ctx, defaultCluster, tc.machinepool)
@@ -1042,14 +1043,14 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 				Spec: clusterv1.MachineSpec{
 					Bootstrap: clusterv1.Bootstrap{
 						ConfigRef: &corev1.ObjectReference{
-							APIVersion: "bootstrap.cluster.x-k8s.io/v1beta1",
-							Kind:       "BootstrapConfig",
+							APIVersion: builder.BootstrapGroupVersion.String(),
+							Kind:       builder.TestBootstrapConfigKind,
 							Name:       "bootstrap-config1",
 						},
 					},
 					InfrastructureRef: corev1.ObjectReference{
-						APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
-						Kind:       "InfrastructureConfig",
+						APIVersion: builder.InfrastructureGroupVersion.String(),
+						Kind:       builder.TestInfrastructureMachineTemplateKind,
 						Name:       "infra-config1",
 					},
 				},
@@ -1060,8 +1061,8 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 	defaultBootstrap := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"kind":       "BootstrapConfig",
-			"apiVersion": "bootstrap.cluster.x-k8s.io/v1beta1",
+			"kind":       builder.TestBootstrapConfigKind,
+			"apiVersion": builder.BootstrapGroupVersion.String(),
 			"metadata": map[string]interface{}{
 				"name":      "bootstrap-config1",
 				"namespace": ns.Name,
@@ -1076,8 +1077,8 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 
 	defaultInfra := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"kind":       "InfrastructureConfig",
-			"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
+			"kind":       builder.TestInfrastructureMachineTemplateKind,
+			"apiVersion": builder.InfrastructureGroupVersion.String(),
 			"metadata": map[string]interface{}{
 				"name":      "infra-config1",
 				"namespace": ns.Name,
@@ -1132,7 +1133,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		r := &MachinePoolReconciler{
-			Client:   fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client:   fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 			recorder: record.NewFakeRecorder(32),
 		}
 
@@ -1187,7 +1188,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		r := &MachinePoolReconciler{
-			Client:   fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client:   fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 			recorder: record.NewFakeRecorder(32),
 		}
 
@@ -1226,7 +1227,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		r := &MachinePoolReconciler{
-			Client:   fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client:   fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 			recorder: record.NewFakeRecorder(32),
 		}
 
@@ -1260,7 +1261,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		r := &MachinePoolReconciler{
-			Client:   fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client:   fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 			recorder: record.NewFakeRecorder(32),
 		}
 
@@ -1316,7 +1317,7 @@ func TestReconcileMachinePoolScaleToFromZero(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		r := &MachinePoolReconciler{
-			Client:   fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig).Build(),
+			Client:   fake.NewClientBuilder().WithObjects(testCluster, kubeconfigSecret, machinepool, bootstrapConfig, infraConfig, builder.TestBootstrapConfigCRD, builder.TestInfrastructureMachineTemplateCRD).Build(),
 			recorder: record.NewFakeRecorder(32),
 		}
 

--- a/main.go
+++ b/main.go
@@ -449,6 +449,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if feature.Gates.Enabled(feature.MachinePool) {
 		if err := (&expcontrollers.MachinePoolReconciler{
 			Client:           mgr.GetClient(),
+			APIReader:        mgr.GetAPIReader(),
 			WatchFilterValue: watchFilterValue,
 		}).SetupWithManager(ctx, mgr, concurrency(machinePoolConcurrency)); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "MachinePool")


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Today the MachinePool controller is our only controller that doesn't automatically bump the apiVersions in references.
This PR makes the controller consistent with our other controllers.

Please note, if infra or bootstrap providers (e.g. CABPK) drop api versions (like v1alpha3/v1alpha4) without this change existing MachinePools might break and manual user intervention is required.

Example:

1. MachinePool has been created with a reference to v1alpha3.KubeadmConfig
2. MachinePool controller doesn't bump the ref
3. Cluster API v1.x drops v1alpha3
4. MachinePool controller breaks as v1alpha3 doesn't exist anymore
5. User has to fix the MachinePool manually by upgrading the apiVersion

A comment about ref bumps in other controllers:
* works in: ClusterClass, Cluster, KCP, MS, Machine
* buggy in MD: will be fixed via: https://github.com/kubernetes-sigs/cluster-api/pull/7992
* not implemented in MP: will be fixed in this PR


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6778
