### PR TITLE
📖  Fix broken links to release docs

### DIFF
--- a/docs/developer/release-team.md
+++ b/docs/developer/release-team.md
@@ -21,7 +21,7 @@ This document introduces the concept of a release team with the following goals 
 
 Note that this document is intended to be a starting point for the release team. It is not a complete release process document.
 
-More details on the CAPI release process can be found in [this past issue tracking release tasks](https://github.com/kubernetes-sigs/cluster-api/issues/6615) and the current [release documentation](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/developer/releasing.md).
+More details on the CAPI release process can be found in the [release cycle](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-cycle.md) and [release task](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md) documentation.
 
 ## Duration of Term
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Link checker on my fork detected the broken links
(https://github.com/sbueringer/cluster-api/actions/runs/4015108108)

Merged this change into the release-1.2 branch on my fork => Now all green: https://github.com/sbueringer/cluster-api/actions/runs/4015108108/jobs/6896627841

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
