### PR TITLE
:bug: [release-1.2]  Migration outscale provider release 1.2

### DIFF
--- a/cmd/clusterctl/client/config/providers_client.go
+++ b/cmd/clusterctl/client/config/providers_client.go
@@ -213,7 +213,7 @@ func (p *providersClient) defaults() []Provider {
 		},
 		&provider{
 			name:         OutscaleProviderName,
-			url:          "https://github.com/outscale-dev/cluster-api-provider-outscale/releases/latest/infrastructure-components.yaml",
+			url:          "https://github.com/outscale/cluster-api-provider-outscale/releases/latest/infrastructure-components.yaml",
 			providerType: clusterctlv1.InfrastructureProviderType,
 		},
 		&provider{

--- a/cmd/clusterctl/cmd/config_repositories_test.go
+++ b/cmd/clusterctl/cmd/config_repositories_test.go
@@ -127,7 +127,7 @@ nested              InfrastructureProvider   https://github.com/kubernetes-sigs/
 nutanix             InfrastructureProvider   https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/releases/latest/     infrastructure-components.yaml
 oci                 InfrastructureProvider   https://github.com/oracle/cluster-api-provider-oci/releases/latest/                       infrastructure-components.yaml
 openstack           InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-openstack/releases/latest/        infrastructure-components.yaml
-outscale            InfrastructureProvider   https://github.com/outscale-dev/cluster-api-provider-outscale/releases/latest/            infrastructure-components.yaml
+outscale            InfrastructureProvider   https://github.com/outscale/cluster-api-provider-outscale/releases/latest/                infrastructure-components.yaml
 packet              InfrastructureProvider   https://github.com/kubernetes-sigs/cluster-api-provider-packet/releases/latest/           infrastructure-components.yaml
 sidero              InfrastructureProvider   https://github.com/siderolabs/sidero/releases/latest/                                     infrastructure-components.yaml
 vcd                 InfrastructureProvider   https://github.com/vmware/cluster-api-provider-cloud-director/releases/latest/            infrastructure-components.yaml
@@ -247,7 +247,7 @@ var expectedOutputYaml = `- File: core_components.yaml
 - File: infrastructure-components.yaml
   Name: outscale
   ProviderType: InfrastructureProvider
-  URL: https://github.com/outscale-dev/cluster-api-provider-outscale/releases/latest/
+  URL: https://github.com/outscale/cluster-api-provider-outscale/releases/latest/
 - File: infrastructure-components.yaml
   Name: packet
   ProviderType: InfrastructureProvider

--- a/docs/book/src/reference/providers.md
+++ b/docs/book/src/reference/providers.md
@@ -31,6 +31,7 @@ updated info about which API version they are supporting.
 - [Nutanix](https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix)
 - [OCI](https://github.com/oracle/cluster-api-provider-oci)
 - [OpenStack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack)
+- [Outscale](https://github.com/outscale/cluster-api-provider-outscale)
 - [Sidero](https://github.com/siderolabs/sidero)
 - [Tencent Cloud](https://github.com/TencentCloud/cluster-api-provider-tencent)
 - [vcluster](https://github.com/loft-sh/cluster-api-provider-vcluster)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Migration github repository cluster-api-provider-outscale from organization outscale-dev to outscale also in release-1.2 
Backport in release 1.2:
https://github.com/kubernetes-sigs/cluster-api/pull/7998
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
