### PR TITLE
✨  Add discoverVariables runtime hook to ClusterClass reconcile loop

### DIFF
--- a/api/v1beta1/clusterclass_types.go
+++ b/api/v1beta1/clusterclass_types.go
@@ -535,6 +535,10 @@ type ExternalPatchDefinition struct {
 	// +optional
 	ValidateExtension *string `json:"validateExtension,omitempty"`
 
+	// DiscoverVariablesExtension references an extension which is called to discover variables.
+	// +optional
+	DiscoverVariablesExtension *string `json:"discoverVariablesExtension,omitempty"`
+
 	// Settings defines key value pairs to be passed to the extensions.
 	// Values defined here take precedence over the values defined in the
 	// corresponding ExtensionConfig.
@@ -571,9 +575,9 @@ type ClusterClassStatusVariable struct {
 	// Name is the name of the variable.
 	Name string `json:"name"`
 
-	// DefintionsConflict specifies whether or not there are conflicting definitions for a single variable name.
+	// DefinitionsConflict specifies whether or not there are conflicting definitions for a single variable name.
 	// +optional
-	DefintionsConflict bool `json:"defintionsConflict,omitempty"`
+	DefinitionsConflict bool `json:"definitionsConflict,omitempty"`
 
 	// Definitions is a list of definitions for a variable.
 	Definitions []ClusterClassStatusVariableDefinition `json:"definitions"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -589,6 +589,11 @@ func (in *ExternalPatchDefinition) DeepCopyInto(out *ExternalPatchDefinition) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DiscoverVariablesExtension != nil {
+		in, out := &in.DiscoverVariablesExtension, &out.DiscoverVariablesExtension
+		*out = new(string)
+		**out = **in
+	}
 	if in.Settings != nil {
 		in, out := &in.Settings, &out.Settings
 		*out = make(map[string]string, len(*in))

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -483,9 +483,9 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ClusterClassStatusVariable(ref com
 							Format:      "",
 						},
 					},
-					"defintionsConflict": {
+					"definitionsConflict": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DefintionsConflict specifies whether or not there are conflicting definitions for a single variable name.",
+							Description: "DefinitionsConflict specifies whether or not there are conflicting definitions for a single variable name.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -1042,6 +1042,13 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ExternalPatchDefinition(ref common
 					"validateExtension": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ValidateExtension references an extension which is called to validate the topology.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"discoverVariablesExtension": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DiscoverVariablesExtension references an extension which is called to discover variables.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/cmd/clusterctl/client/alpha/rollout_pauser.go
+++ b/cmd/clusterctl/client/alpha/rollout_pauser.go
@@ -38,7 +38,7 @@ func (r *rollout) ObjectPauser(proxy cluster.Proxy, ref corev1.ObjectReference) 
 			return errors.Wrapf(err, "failed to fetch %v/%v", ref.Kind, ref.Name)
 		}
 		if deployment.Spec.Paused {
-			return errors.Errorf("MachineDeploymet is already paused: %v/%v\n", ref.Kind, ref.Name) //nolint:revive // MachineDeployment is intentionally capitalized.
+			return errors.Errorf("MachineDeployment is already paused: %v/%v\n", ref.Kind, ref.Name) //nolint:revive // MachineDeployment is intentionally capitalized.
 		}
 		if err := pauseMachineDeployment(proxy, ref.Name, ref.Namespace); err != nil {
 			return err

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -833,6 +833,10 @@ spec:
                       description: 'External defines an external patch. Note: Exactly
                         one of Definitions or External must be set.'
                       properties:
+                        discoverVariablesExtension:
+                          description: DiscoverVariablesExtension references an extension
+                            which is called to discover variables.
+                          type: string
                         generateExtension:
                           description: GenerateExtension references an extension which
                             is called to generate patches.
@@ -1622,8 +1626,8 @@ spec:
                         - schema
                         type: object
                       type: array
-                    defintionsConflict:
-                      description: DefintionsConflict specifies whether or not there
+                    definitionsConflict:
+                      description: DefinitionsConflict specifies whether or not there
                         are conflicting definitions for a single variable name.
                       type: boolean
                     name:

--- a/controllers/alias.go
+++ b/controllers/alias.go
@@ -200,6 +200,9 @@ type ClusterClassReconciler struct {
 	Client    client.Client
 	APIReader client.Reader
 
+	// RuntimeClient is a client for calling runtime extensions.
+	RuntimeClient runtimeclient.Client
+
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
 
@@ -212,6 +215,7 @@ func (r *ClusterClassReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 	return (&clusterclasscontroller.Reconciler{
 		Client:                    r.Client,
 		APIReader:                 r.APIReader,
+		RuntimeClient:             r.RuntimeClient,
 		UnstructuredCachingClient: r.UnstructuredCachingClient,
 		WatchFilterValue:          r.WatchFilterValue,
 	}).SetupWithManager(ctx, mgr, options)

--- a/internal/controllers/clusterclass/clusterclass_controller_test.go
+++ b/internal/controllers/clusterclass/clusterclass_controller_test.go
@@ -140,8 +140,8 @@ func assertStatusVariables(actualClusterClass *clusterv1.ClusterClass) error {
 				continue
 			}
 			found = true
-			if statusVar.DefintionsConflict {
-				return errors.Errorf("ClusterClass status %s variable RequiresNamespace does not match. Expected %t , got %t", specVar.Name, false, statusVar.DefintionsConflict)
+			if statusVar.DefinitionsConflict {
+				return errors.Errorf("ClusterClass status %s variable DefinitionsConflict does not match. Expected %v , got %v", specVar.Name, false, statusVar.DefinitionsConflict)
 			}
 			if len(statusVar.Definitions) != 1 {
 				return errors.Errorf("ClusterClass status has multiple definitions for variable %s. Expected a single definition", specVar.Name)
@@ -149,7 +149,7 @@ func assertStatusVariables(actualClusterClass *clusterv1.ClusterClass) error {
 			// For this test assume there is only one status variable definition, and that it should match the spec.
 			statusVarDefinition := statusVar.Definitions[0]
 			if statusVarDefinition.From != clusterv1.VariableDefinitionFromInline {
-				return errors.Errorf("ClusterClass status variable %s namespace field does not match. Expected %s. Got %s", statusVar.Name, clusterv1.VariableDefinitionFromInline, statusVarDefinition.From)
+				return errors.Errorf("ClusterClass status variable %s from field does not match. Expected %s. Got %s", statusVar.Name, clusterv1.VariableDefinitionFromInline, statusVarDefinition.From)
 			}
 			if specVar.Required != statusVarDefinition.Required {
 				return errors.Errorf("ClusterClass status variable %s required field does not match. Expecte %v. Got %v", specVar.Name, statusVarDefinition.Required, statusVarDefinition.Required)
@@ -159,7 +159,7 @@ func assertStatusVariables(actualClusterClass *clusterv1.ClusterClass) error {
 			}
 		}
 		if !found {
-			return errors.Errorf("ClusterClass does not define variable %s", specVar.Name)
+			return errors.Errorf("ClusterClass does not have status for variable %s", specVar.Name)
 		}
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -362,6 +362,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		if err := (&controllers.ClusterClassReconciler{
 			Client:                    mgr.GetClient(),
 			APIReader:                 mgr.GetAPIReader(),
+			RuntimeClient:             runtimeClient,
 			UnstructuredCachingClient: unstructuredCachingClient,
 			WatchFilterValue:          watchFilterValue,
 		}).SetupWithManager(ctx, mgr, concurrency(clusterClassConcurrency)); err != nil {


### PR DESCRIPTION
Add the discoverVariables call to the External patch definition in the ClusterClass and add an implementation of the call in the ClusterClass reconciler.

Part of #7985 
