### PR TITLE
[WIP] 🌱 E2E: purposeful zero index retrieval

### DIFF
--- a/test/framework/clusterresourceset_helpers.go
+++ b/test/framework/clusterresourceset_helpers.go
@@ -150,7 +150,7 @@ func WaitForClusterResourceSetToApplyResources(ctx context.Context, input WaitFo
 				continue
 			}
 
-			if len(binding.Spec.Bindings) == 0 || !binding.Spec.Bindings[0].IsApplied(resource) {
+			if len(binding.Spec.Bindings) != 1 || !binding.Spec.Bindings[0].IsApplied(resource) {
 				return false
 			}
 		}

--- a/test/framework/daemonset_helpers.go
+++ b/test/framework/daemonset_helpers.go
@@ -54,8 +54,10 @@ func WaitForKubeProxyUpgrade(ctx context.Context, input WaitForKubeProxyUpgradeI
 			return false, err
 		}
 
-		if ds.Spec.Template.Spec.Containers[0].Image == wantKubeProxyImage {
-			return true, nil
+		for _, c := range ds.Spec.Template.Spec.Containers {
+			if c.Image == wantKubeProxyImage {
+				return true, nil
+			}
 		}
 		return false, nil
 	}, intervals...).Should(BeTrue())

--- a/test/framework/deployment_helpers.go
+++ b/test/framework/deployment_helpers.go
@@ -341,13 +341,15 @@ func WaitForDNSUpgrade(ctx context.Context, input WaitForDNSUpgradeInput, interv
 			return false, err
 		}
 
-		// NOTE: coredns image name has changed over time (k8s.gcr.io/coredns,
-		// k8s.gcr.io/coredns/coredns), so we are checking if the version actually changed.
-		if strings.HasSuffix(d.Spec.Template.Spec.Containers[0].Image, fmt.Sprintf(":%s", input.DNSVersion)) &&
-			// Also check whether the upgraded CoreDNS replicas are available and ready for use.
-			d.Status.ObservedGeneration >= d.Generation &&
-			d.Spec.Replicas != nil && d.Status.UpdatedReplicas == *d.Spec.Replicas && d.Status.AvailableReplicas == *d.Spec.Replicas {
-			return true, nil
+		for _, c := range d.Spec.Template.Spec.Containers {
+			// NOTE: coredns image name has changed over time (k8s.gcr.io/coredns,
+			// k8s.gcr.io/coredns/coredns), so we are checking if the version actually changed.
+			if strings.HasSuffix(c.Image, fmt.Sprintf(":%s", input.DNSVersion)) &&
+				// Also check whether the upgraded CoreDNS replicas are available and ready for use.
+				d.Status.ObservedGeneration >= d.Generation &&
+				d.Spec.Replicas != nil && d.Status.UpdatedReplicas == *d.Spec.Replicas && d.Status.AvailableReplicas == *d.Spec.Replicas {
+				return true, nil
+			}
 		}
 
 		return false, nil

--- a/test/framework/machinedeployment_helpers.go
+++ b/test/framework/machinedeployment_helpers.go
@@ -111,6 +111,8 @@ func WaitForMachineDeploymentNodesToExist(ctx context.Context, input WaitForMach
 		}
 		if len(ms.Items) == 0 {
 			return 0, errors.New("no machinesets were found")
+		} else if len(ms.Items) > 1 {
+			return 0, errors.New("expected only one matching MachineSet from MachineDeployment selector")
 		}
 		machineSet := ms.Items[0]
 		selectorMap, err = metav1.LabelSelectorAsMap(&machineSet.Spec.Selector)
@@ -399,6 +401,8 @@ func ScaleAndWaitMachineDeployment(ctx context.Context, input ScaleAndWaitMachin
 		}
 		if len(ms.Items) == 0 {
 			return -1, errors.New("no machinesets were found")
+		} else if len(ms.Items) > 1 {
+			return -1, errors.New("expected only one matching MachineSet from MachineDeployment selector")
 		}
 		machineSet := ms.Items[0]
 		selectorMap, err = metav1.LabelSelectorAsMap(&machineSet.Spec.Selector)
@@ -438,6 +442,7 @@ func ScaleAndWaitMachineDeploymentTopology(ctx context.Context, input ScaleAndWa
 	Expect(input.Cluster.Spec.Topology.Workers).ToNot(BeNil(), "Invalid argument. input.Cluster must have MachineDeployment topologies")
 	Expect(len(input.Cluster.Spec.Topology.Workers.MachineDeployments) >= 1).To(BeTrue(), "Invalid argument. input.Cluster must have at least one MachineDeployment topology")
 
+	// TODO Why are we always only choosing the first MachineDeployment here?
 	mdTopology := input.Cluster.Spec.Topology.Workers.MachineDeployments[0]
 	log.Logf("Scaling machine deployment topology %s from %d to %d replicas", mdTopology.Name, *mdTopology.Replicas, input.Replicas)
 	patchHelper, err := patch.NewHelper(input.Cluster, input.ClusterProxy.GetClient())

--- a/test/framework/machinehealthcheck_helpers.go
+++ b/test/framework/machinehealthcheck_helpers.go
@@ -53,6 +53,7 @@ func DiscoverMachineHealthChecksAndWaitForRemediation(ctx context.Context, input
 		Namespace:   input.Cluster.Namespace,
 	})
 
+	// TODO is this correct or can we be more specific and expect a length 1?
 	Expect(machineHealthChecks).NotTo(BeEmpty())
 
 	for _, mhc := range machineHealthChecks {
@@ -65,6 +66,7 @@ func DiscoverMachineHealthChecksAndWaitForRemediation(ctx context.Context, input
 			MachineHealthCheck: mhc,
 		})
 
+		// TODO is this correct or can we be more specific and expect a length 1?
 		Expect(machines).NotTo(BeEmpty())
 
 		fmt.Fprintln(GinkgoWriter, "Patching MachineHealthCheck unhealthy condition to one of the nodes")

--- a/test/framework/pod_helpers.go
+++ b/test/framework/pod_helpers.go
@@ -60,8 +60,11 @@ func EtcdImageTagCondition(expectedTag string, expectedCount int) PodListConditi
 	return func(pl *corev1.PodList) error {
 		countWithCorrectTag := 0
 		for _, pod := range pl.Items {
-			if strings.Contains(pod.Spec.Containers[0].Image, expectedTag) {
-				countWithCorrectTag++
+			for _, c := range pod.Spec.Containers {
+				if strings.Contains(c.Image, expectedTag) {
+					countWithCorrectTag++
+					break
+				}
 			}
 		}
 		if countWithCorrectTag != expectedCount {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR is in response to observing some `[0]` slice index dependencies in the E2E code. As much as is practical, if we're grabbing the first index of a slice we should be doing that because:

- we are grabbing from a well-known, ordered array, and the first item has significance
- we expect the slice to be a thin wrapper around a single data object, and we just want to dereference the slice and grab the data

I think for both of the above we can be a little more explicit in our code so that if the underlying data does change in unexpected ways, our retrieval flows tell us by erroring out in a clear way.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
