### PR TITLE
🌱 make ensure scripts fail if GOPATH/bin not in PATH

### DIFF
--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -22,6 +22,9 @@ if [[ "${TRACE-0}" == "1" ]]; then
     set -o xtrace
 fi
 
+# shellcheck source=./hack/utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+
 # Ensure the go tool exists and is a viable version.
 verify_go_version() {
   if [[ -z "$(command -v go)" ]]; then
@@ -46,7 +49,9 @@ EOF
   fi
 }
 
+
 verify_go_version
+verify_gopath_bin
 
 # Explicitly opt into go modules, even though we're inside a GOPATH directory
 export GO111MODULE=on

--- a/hack/ensure-kind.sh
+++ b/hack/ensure-kind.sh
@@ -22,6 +22,9 @@ if [[ "${TRACE-0}" == "1" ]]; then
     set -o xtrace
 fi
 
+# shellcheck source=./hack/utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+
 GOPATH_BIN="$(go env GOPATH)/bin"
 MINIMUM_KIND_VERSION=v0.17.0
 goarch="$(go env GOARCH)"
@@ -39,6 +42,7 @@ verify_kind_version() {
       fi
       curl -sLo "${GOPATH_BIN}/kind" "https://github.com/kubernetes-sigs/kind/releases/download/${MINIMUM_KIND_VERSION}/kind-${goos}-${goarch}"
       chmod +x "${GOPATH_BIN}/kind"
+      verify_gopath_bin
     else
       echo "Missing required binary in path: kind"
       return 2

--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -22,6 +22,10 @@ if [[ "${TRACE-0}" == "1" ]]; then
     set -o xtrace
 fi
 
+
+# shellcheck source=./hack/utils.sh
+source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
+
 GOPATH_BIN="$(go env GOPATH)/bin/"
 MINIMUM_KUBECTL_VERSION=v1.19.0
 goarch="$(go env GOARCH)"
@@ -39,6 +43,7 @@ verify_kubectl_version() {
       echo 'kubectl not found, installing'
       curl -sLo "${GOPATH_BIN}/kubectl" "https://dl.k8s.io/release/${MINIMUM_KUBECTL_VERSION}/bin/${goos}/${goarch}/kubectl"
       chmod +x "${GOPATH_BIN}/kubectl"
+      verify_gopath_bin
     else
       echo "Missing required binary in path: kubectl"
       return 2

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -32,3 +32,18 @@ get_capd_root_path() {
 cd_capd_root_path() {
     cd "$(get_capd_root_path)" || exit
 }
+
+# ensure GOPATH/bin is in PATH as we may install binaries to that directory in
+# other ensure-* scripts, and expect them to be found in PATH later on
+verify_gopath_bin() {
+    local gopath_bin
+
+    gopath_bin="$(go env GOPATH)/bin"
+    if ! printenv PATH | grep -q "${gopath_bin}"; then
+        cat <<EOF
+error: \$GOPATH/bin=${gopath_bin} is not in your PATH.
+See https://go.dev/doc/gopath_code for more instructions.
+EOF
+        return 2
+    fi
+}


### PR DESCRIPTION
ensure-kind.sh and ensure-kubectl.sh install binaries into $GOPATH/bin, but nowhere it checks that $GOPATH/bin is in user's PATH. In this case, the newly installed binaries won't be found later on.
