### PR TITLE
:seedling:  Make 'inline' a reserved name for patches

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -120,6 +120,10 @@ const (
 	// instead of being a source of truth for eventual consistency.
 	// This annotation can be used to inform MachinePool status during in-progress scaling scenarios.
 	ReplicasManagedByAnnotation = "cluster.x-k8s.io/replicas-managed-by"
+
+	// VariableDefinitionFromInline indicates a patch or variable was defined in the `.spec` of a ClusterClass
+	// rather than from an external patch extension.
+	VariableDefinitionFromInline = "inline"
 )
 
 const (

--- a/internal/webhooks/patch_validation.go
+++ b/internal/webhooks/patch_validation.go
@@ -69,6 +69,14 @@ func validatePatchName(patch clusterv1.ClusterClassPatch, names sets.Set[string]
 			),
 		)
 	}
+	if patch.Name == clusterv1.VariableDefinitionFromInline {
+		allErrs = append(allErrs,
+			field.Required(
+				path.Child("name"),
+				fmt.Sprintf("%q can not be used as the name of a patch", clusterv1.VariableDefinitionFromInline),
+			),
+		)
+	}
 
 	if names.Has(patch.Name) {
 		allErrs = append(allErrs,


### PR DESCRIPTION
Add a validation rule to prevent ClusterClass authors from using \"inline\" as the name of an external patch. This allows using that name as a reserved name to describe variables with inline definitions.

Part of #7985 
