### PR TITLE
 :seedling: Add DefinitionFrom field to ClusterVariable

### DIFF
--- a/api/v1beta1/cluster_types.go
+++ b/api/v1beta1/cluster_types.go
@@ -234,12 +234,18 @@ type MachineHealthCheckTopology struct {
 	MachineHealthCheckClass `json:",inline"`
 }
 
-// ClusterVariable can be used to customize the Cluster through
-// patches. It must comply to the corresponding
-// ClusterClassVariable defined in the ClusterClass.
+// ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+// Variable definition in the ClusterClass `status` variables.
 type ClusterVariable struct {
 	// Name of the variable.
 	Name string `json:"name"`
+
+	// DefinitionFrom specifies where the definition of this Variable is from. DefinitionFrom is `inline` when the
+	// definition is from the ClusterClass `.spec.variables` or the name of a patch defined in the ClusterClass
+	// `.spec.patches` where the patch is external and provides external variables.
+	// This field is mandatory if the variable has `DefinitionsConflict: true` in ClusterClass `status.variables[]`
+	// +optional
+	DefinitionFrom string `json:"definitionFrom,omitempty"`
 
 	// Value of the variable.
 	// Note: the value will be validated against the schema of the corresponding ClusterClassVariable

--- a/api/v1beta1/zz_generated.openapi.go
+++ b/api/v1beta1/zz_generated.openapi.go
@@ -726,13 +726,20 @@ func schema_sigsk8sio_cluster_api_api_v1beta1_ClusterVariable(ref common.Referen
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ClusterVariable can be used to customize the Cluster through patches. It must comply to the corresponding ClusterClassVariable defined in the ClusterClass.",
+				Description: "ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a Variable definition in the ClusterClass `status` variables.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the variable.",
 							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"definitionFrom": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DefinitionFrom specifies where the definition of this Variable is from. DefinitionFrom is `inline` when the definition is from the ClusterClass `.spec.variables` or the name of a patch defined in the ClusterClass `.spec.patches` where the patch is external and provides external variables. This field is mandatory if the variable has `DefinitionsConflict: true` in ClusterClass `status.variables[]`",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -1017,9 +1017,18 @@ spec:
                       defined in the ClusterClass.
                     items:
                       description: ClusterVariable can be used to customize the Cluster
-                        through patches. It must comply to the corresponding ClusterClassVariable
-                        defined in the ClusterClass.
+                        through patches. Each ClusterVariable is associated with a
+                        Variable definition in the ClusterClass `status` variables.
                       properties:
+                        definitionFrom:
+                          description: 'DefinitionFrom specifies where the definition
+                            of this Variable is from. DefinitionFrom is `inline` when
+                            the definition is from the ClusterClass `.spec.variables`
+                            or the name of a patch defined in the ClusterClass `.spec.patches`
+                            where the patch is external and provides external variables.
+                            This field is mandatory if the variable has `DefinitionsConflict:
+                            true` in ClusterClass `status.variables[]`'
+                          type: string
                         name:
                           description: Name of the variable.
                           type: string
@@ -1334,10 +1343,21 @@ spec:
                                     level variables.
                                   items:
                                     description: ClusterVariable can be used to customize
-                                      the Cluster through patches. It must comply
-                                      to the corresponding ClusterClassVariable defined
-                                      in the ClusterClass.
+                                      the Cluster through patches. Each ClusterVariable
+                                      is associated with a Variable definition in
+                                      the ClusterClass `status` variables.
                                     properties:
+                                      definitionFrom:
+                                        description: 'DefinitionFrom specifies where
+                                          the definition of this Variable is from.
+                                          DefinitionFrom is `inline` when the definition
+                                          is from the ClusterClass `.spec.variables`
+                                          or the name of a patch defined in the ClusterClass
+                                          `.spec.patches` where the patch is external
+                                          and provides external variables. This field
+                                          is mandatory if the variable has `DefinitionsConflict:
+                                          true` in ClusterClass `status.variables[]`'
+                                        type: string
                                       name:
                                         description: Name of the variable.
                                         type: string


### PR DESCRIPTION
Add a DefinitionFrom field to the ClusterVariable type for use with conflicting VariableDefinitions.

Part of #7985 
