### PR TITLE
🌱 remove KCP as a valid resource type for rollback

### DIFF
--- a/cmd/clusterctl/client/alpha/rollout.go
+++ b/cmd/clusterctl/client/alpha/rollout.go
@@ -34,6 +34,10 @@ var validResourceTypes = []string{
 	KubeadmControlPlane,
 }
 
+var validRollbackResourceTypes = []string{
+	MachineDeployment,
+}
+
 // Rollout defines the behavior of a rollout implementation.
 type Rollout interface {
 	ObjectRestarter(cluster.Proxy, corev1.ObjectReference) error

--- a/cmd/clusterctl/client/alpha/rollout_rollbacker.go
+++ b/cmd/clusterctl/client/alpha/rollout_rollbacker.go
@@ -41,7 +41,7 @@ func (r *rollout) ObjectRollbacker(proxy cluster.Proxy, ref corev1.ObjectReferen
 			return err
 		}
 	default:
-		return errors.Errorf("invalid resource type %q, valid values are %v", ref.Kind, validResourceTypes)
+		return errors.Errorf("invalid resource type %q, valid values are %v", ref.Kind, validRollbackResourceTypes)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

KCP is not a valid resource for `clusterctl alpha rollout undo`. This PR fixes that. 
Note that the functionality worked properly. This PR fixes the error message to reflect the correct functionality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
