### PR TITLE
🌱 envtest: add env var to allow writing envtest kubeconfig

### DIFF
--- a/docs/book/src/developer/testing.md
+++ b/docs/book/src/developer/testing.md
@@ -107,6 +107,10 @@ When running individual tests, it could happen that a testenv is started if this
 However, if the tests you are running don't require testenv (i.e. they are only using fake client), you can skip the testenv
 creation by setting the environment variable `CAPI_DISABLE_TEST_ENV` (to any non-empty value).
 
+To debug testenv unit tests it is possible to use:
+* `CAPI_TEST_ENV_KUBECONFIG` to write out a kubeconfig for the testenv to a file location.
+* `CAPI_TEST_ENV_SKIP_STOP` to skip stopping the testenv after test execution.
+
 </aside>
 
 ## End-to-end tests


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This PR adds an env var which allows writing the kubeconfig of envtest to a path to make debugging envtest unit tests easier.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
