### PR TITLE
🌱  Update golangci-lint to v1.51.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,5 +29,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # tag=v3.4.0
         with:
-          version: v1.50.1
+          version: v1.51.0
           working-directory: ${{matrix.working-directory}}

--- a/util/container/image.go
+++ b/util/container/image.go
@@ -18,10 +18,8 @@ limitations under the License.
 package container
 
 import (
-	//  Import the crypto sha256 algorithm for the docker image parser to work
-	_ "crypto/sha256"
-	//  Import the crypto/sha512 algorithm for the docker image parser to work with 384 and 512 sha hashes
-	_ "crypto/sha512"
+	_ "crypto/sha256" // Import the crypto/sha256 algorithm for the docker image parser to work with sha256 hashes.
+	_ "crypto/sha512" // Import the crypto/sha512 algorithm for the docker image parser to work with 384 and 512 sha hashes.
 	"fmt"
 	"path"
 	"regexp"


### PR DESCRIPTION
Release notes: https://github.com/golangci/golangci-lint/releases/tag/v1.51.0

