### PR TITLE
:book: Remove release team links from 1.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ come up, including gaps in documentation!
 
 If you're a more experienced contributor, looking at unassigned issues in the next release milestone is a good way to find work that has been prioritized. For example, if the latest minor release is `v1.0`, the next release milestone is `v1.1`.
 
-Help and contributions are very welcome in the form of code contributions but also in helping to moderate office hours, triaging issues, fixing/investigating flaky tests, being part of the [release team](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-team.md), helping new contributors with their questions, reviewing proposals, etc.
+Help and contributions are very welcome in the form of code contributions but also in helping to moderate office hours, triaging issues, fixing/investigating flaky tests, helping new contributors with their questions, reviewing proposals, etc.
 
 ## Versioning
 

--- a/docs/developer/release-team.md
+++ b/docs/developer/release-team.md
@@ -21,8 +21,6 @@ This document introduces the concept of a release team with the following goals 
 
 Note that this document is intended to be a starting point for the release team. It is not a complete release process document.
 
-More details on the CAPI release process can be found in the [release cycle](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-cycle.md) and [release task](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md) documentation.
-
 ## Duration of Term
 
 Each release team term will last approximately four months, to align with one minor release cycle. A minor release cycle starts right after a minor release and concludes with the release of the next minor release. There is no limit to the number of terms a release team member can serve, meaning that it's possible for a release team member to serve multiple consecutive terms.


### PR DESCRIPTION
Remove release team links from release-1.2 as those docs and the process don't exist at that release. Alternatively the release team docs could be backported to release-1.2, but I think it's fine to not have up-to-date release process information on older branches.

Note: this was caught by the link checker.