### PR TITLE
🐛: Make sure the Kubernetes API Server service already created on remote cluster before applying ClusterResourceSets

### DIFF
--- a/exp/addons/internal/controllers/clusterresourceset_controller.go
+++ b/exp/addons/internal/controllers/clusterresourceset_controller.go
@@ -249,6 +249,13 @@ func (r *ClusterResourceSetReconciler) ApplyClusterResourceSet(ctx context.Conte
 		return err
 	}
 
+	// Ensure that the Kubernetes API Server service has been created in the remote cluster before applying the ClusterResourceSet to avoid service IP conflict.
+	// This action is required when the remote cluster Kubernetes version is lower than v1.25.
+	// TODO: Remove this action once CAPI no longer supports Kubernetes versions below v1.25. See: https://github.com/kubernetes-sigs/cluster-api/issues/7804
+	if err = ensureKubernetesServiceCreated(ctx, remoteClient); err != nil {
+		return errors.Wrapf(err, "failed to retrieve the Service for Kubernetes API Server of the cluster %s/%s", cluster.Namespace, cluster.Name)
+	}
+
 	// Get ClusterResourceSetBinding object for the cluster.
 	clusterResourceSetBinding, err := r.getOrCreateClusterResourceSetBinding(ctx, cluster, clusterResourceSet)
 	if err != nil {

--- a/exp/addons/internal/controllers/clusterresourceset_helpers.go
+++ b/exp/addons/internal/controllers/clusterresourceset_helpers.go
@@ -250,3 +250,15 @@ func getClusterNameFromOwnerRef(obj metav1.ObjectMeta) (string, error) {
 	}
 	return "", errors.New("failed to find cluster name in ownerRefs: no cluster ownerRef")
 }
+
+// ensureKubernetesServiceCreated ensures that the Service for Kubernetes API Server has been created.
+func ensureKubernetesServiceCreated(ctx context.Context, client client.Client) error {
+	err := client.Get(ctx, types.NamespacedName{
+		Namespace: metav1.NamespaceDefault,
+		Name:      "kubernetes",
+	}, &corev1.Service{})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/exp/addons/internal/controllers/clusterresourceset_helpers_test.go
+++ b/exp/addons/internal/controllers/clusterresourceset_helpers_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -216,6 +217,57 @@ func TestGetConfigMapFromNamespacedName(t *testing.T) {
 			gs.Expect(err).NotTo(HaveOccurred())
 
 			gs.Expect(*got).To(Equal(*tt.want))
+		})
+	}
+}
+
+func TestEnsureKubernetesServiceCreated(t *testing.T) {
+	g := NewWithT(t)
+
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+	kubernetesAPIServerService := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubernetes",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+
+	tests := []struct {
+		name         string
+		existingObjs []client.Object
+		wantErr      bool
+	}{
+		{
+			name:         "should return nil when Kubernetes API Server Service exists",
+			existingObjs: []client.Object{kubernetesAPIServerService},
+			wantErr:      false,
+		},
+		{
+			name:         "should return error when Kubernetes API Server Service does not exist",
+			existingObjs: []client.Object{},
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gs := NewWithT(t)
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.existingObjs...).
+				Build()
+
+			err := ensureKubernetesServiceCreated(context.TODO(), c)
+
+			if tt.wantErr {
+				gs.Expect(err).To(HaveOccurred())
+				return
+			}
+			gs.Expect(err).NotTo(HaveOccurred())
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
kube-apiserver select the first valid IP from ServiceClusterIPRange to use as the GenericAPIServer service IP, if apply ClusterResourceSet before default kubernetes service has beed created, the GenericAPIServer service IP may  assign to other service and it will make default kubernetes service always create failed by service IP conflict.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/cluster-api/issues/7804
