### PR TITLE
🌱 Bump golangci-lint (v1.51.1) and enable some ginkgolinter checks

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,5 +29,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # tag=v3.4.0
         with:
-          version: v1.51.0
+          version: v1.51.1
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
   - errchkjson
   - exportloopref
   - gci
+  - ginkgolinter
   - goconst
   - gocritic
   - godot
@@ -57,16 +58,48 @@ linters:
   - whitespace
 
 linters-settings:
+  gci:
+    local-prefixes: "sigs.k8s.io/cluster-api"
+  ginkgolinter:
+    # Suppress the wrong length assertion warning.
+    suppress-len-assertion: true
+    # Suppress the wrong nil assertion warning.
+    suppress-nil-assertion: false
+    # Suppress the wrong error assertion warning.
+    suppress-err-assertion: true
   godot:
     #   declarations - for top level declaration comments (default);
     #   toplevel     - for top level comments;
     #   all          - for all comments.
     scope: toplevel
     exclude:
-    - '^ \+.*'
-    - '^ ANCHOR.*'
-  gci:
-    local-prefixes: "sigs.k8s.io/cluster-api"
+      - '^ \+.*'
+      - '^ ANCHOR.*'
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - performance
+    disabled-checks:
+      - appendAssign
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - evalOrder
+      - ifElseChain
+      - octalLiteral
+      - regexpSimplify
+      - sloppyReassign
+      - truncateCmp
+      - typeDefFirst
+      - unnamedResult
+      - unnecessaryDefer
+      - whyNoLint
+      - wrapperFunc
+      - rangeValCopy
+      - hugeParam
+  gosec:
+    excludes:
+    - G307 # Deferring unsafe method "Close" on type "\*os.File"
+    - G108 # Profiling endpoint is automatically exposed on /debug/pprof
   importas:
     no-unaliased: true
     alias:
@@ -186,31 +219,6 @@ linters-settings:
       #
       - name: bool-literal-in-expr
       - name: constant-logical-expr
-  gosec:
-    excludes:
-    - G307 # Deferring unsafe method "Close" on type "\*os.File"
-    - G108 # Profiling endpoint is automatically exposed on /debug/pprof
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - performance
-    disabled-checks:
-    - appendAssign
-    - dupImport # https://github.com/go-critic/go-critic/issues/845
-    - evalOrder
-    - ifElseChain
-    - octalLiteral
-    - regexpSimplify
-    - sloppyReassign
-    - truncateCmp
-    - typeDefFirst
-    - unnamedResult
-    - unnecessaryDefer
-    - whyNoLint
-    - wrapperFunc
-    - rangeValCopy
-    - hugeParam
 
 issues:
   max-same-issues: 0

--- a/bootstrap/util/configowner_test.go
+++ b/bootstrap/util/configowner_test.go
@@ -187,7 +187,7 @@ func TestHasNodeRefs(t *testing.T) {
 		unstructuredOwner.SetUnstructuredContent(content)
 		co := ConfigOwner{&unstructuredOwner}
 		result := co.HasNodeRefs()
-		g.Expect(result).To(Equal(false))
+		g.Expect(result).To(BeFalse())
 	})
 	t.Run("should return true if there is a nodeRef for Machine", func(t *testing.T) {
 		g := NewWithT(t)
@@ -217,7 +217,7 @@ func TestHasNodeRefs(t *testing.T) {
 		co := ConfigOwner{&unstructuredOwner}
 
 		result := co.HasNodeRefs()
-		g.Expect(result).To(Equal(true))
+		g.Expect(result).To(BeTrue())
 	})
 	t.Run("should return false if nodes are missing from MachinePool", func(t *testing.T) {
 		g := NewWithT(t)
@@ -279,7 +279,7 @@ func TestHasNodeRefs(t *testing.T) {
 			co := ConfigOwner{&unstructuredOwner}
 
 			result := co.HasNodeRefs()
-			g.Expect(result).To(Equal(false))
+			g.Expect(result).To(BeFalse())
 		}
 	})
 	t.Run("should return true if MachinePool has nodeRefs for all replicas", func(t *testing.T) {
@@ -356,7 +356,7 @@ func TestHasNodeRefs(t *testing.T) {
 			co := ConfigOwner{&unstructuredOwner}
 
 			result := co.HasNodeRefs()
-			g.Expect(result).To(Equal(true))
+			g.Expect(result).To(BeTrue())
 		}
 	})
 }

--- a/exp/runtime/internal/controllers/extensionconfig_controller_test.go
+++ b/exp/runtime/internal/controllers/extensionconfig_controller_test.go
@@ -94,7 +94,7 @@ func TestExtensionReconciler_Reconcile(t *testing.T) {
 		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: util.ObjectKey(extensionConfig)})
 		g.Expect(err).To(BeNil())
 		// If the registry isn't warm the reconcile loop will return Requeue: True
-		g.Expect(res.Requeue).To(Equal(true))
+		g.Expect(res.Requeue).To(BeTrue())
 	})
 
 	t.Run("successful reconcile and discovery on ExtensionConfig create", func(t *testing.T) {

--- a/internal/contract/bootstrap_test.go
+++ b/internal/contract/bootstrap_test.go
@@ -37,7 +37,7 @@ func TestBootstrap(t *testing.T) {
 		got, err := Bootstrap().Ready().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(true))
+		g.Expect(*got).To(BeTrue())
 	})
 	t.Run("Manages status.dataSecretName", func(t *testing.T) {
 		g := NewWithT(t)

--- a/internal/contract/controlplane_test.go
+++ b/internal/contract/controlplane_test.go
@@ -67,7 +67,7 @@ func TestControlPlane(t *testing.T) {
 		got, err := ControlPlane().Ready().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(true))
+		g.Expect(*got).To(BeTrue())
 	})
 	t.Run("Manages status.initialized", func(t *testing.T) {
 		g := NewWithT(t)
@@ -80,7 +80,7 @@ func TestControlPlane(t *testing.T) {
 		got, err := ControlPlane().Initialized().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(true))
+		g.Expect(*got).To(BeTrue())
 	})
 	t.Run("Manages spec.replicas", func(t *testing.T) {
 		g := NewWithT(t)

--- a/internal/contract/infrastructure_cluster_test.go
+++ b/internal/contract/infrastructure_cluster_test.go
@@ -39,7 +39,7 @@ func TestInfrastructureCluster(t *testing.T) {
 		got, err := InfrastructureCluster().Ready().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(true))
+		g.Expect(*got).To(BeTrue())
 	})
 	t.Run("Manages optional status.failureReason", func(t *testing.T) {
 		g := NewWithT(t)

--- a/internal/contract/infrastructure_machine_test.go
+++ b/internal/contract/infrastructure_machine_test.go
@@ -52,7 +52,7 @@ func TestInfrastructureMachine(t *testing.T) {
 		got, err := InfrastructureMachine().Ready().Get(obj)
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Expect(got).ToNot(BeNil())
-		g.Expect(*got).To(Equal(true))
+		g.Expect(*got).To(BeTrue())
 	})
 	t.Run("Manages optional status.failureReason", func(t *testing.T) {
 		g := NewWithT(t)

--- a/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper_test.go
+++ b/internal/controllers/topology/cluster/structuredmerge/serversidepathhelper_test.go
@@ -292,7 +292,7 @@ func TestServerSideApply(t *testing.T) {
 		v3, _, _ := unstructured.NestedString(got.Object, "status", "foo")
 		g.Expect(v3).To(Equal("changed"))
 		v4, _, _ := unstructured.NestedBool(got.Object, "status", "ready")
-		g.Expect(v4).To(Equal(true))
+		g.Expect(v4).To(BeTrue())
 
 		fieldV1 := getTopologyManagedFields(got)
 		g.Expect(fieldV1).ToNot(BeEmpty())
@@ -341,7 +341,7 @@ func TestServerSideApply(t *testing.T) {
 		v3, _, _ := unstructured.NestedString(got.Object, "status", "foo")
 		g.Expect(v3).To(Equal("changed"))
 		v4, _, _ := unstructured.NestedBool(got.Object, "status", "ready")
-		g.Expect(v4).To(Equal(true))
+		g.Expect(v4).To(BeTrue())
 	})
 	t.Run("Topology controller reconcile again with an opinion on a field managed by another controller (co-ownership)", func(t *testing.T) {
 		g := NewWithT(t)

--- a/util/patch/utils_test.go
+++ b/util/patch/utils_test.go
@@ -169,7 +169,7 @@ func TestUnsafeFocusedUnstructured(t *testing.T) {
 
 		// Validate that the status has been copied, without conditions.
 		g.Expect(newObj.Object["status"]).To(HaveLen(1))
-		g.Expect(newObj.Object["status"].(map[string]interface{})["infrastructureReady"]).To(Equal(true))
+		g.Expect(newObj.Object["status"].(map[string]interface{})["infrastructureReady"]).To(BeTrue())
 		g.Expect(newObj.Object["status"].(map[string]interface{})["conditions"]).To(BeNil())
 
 		// When working with conditions, the inner map is going to be removed from the original object.

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -551,7 +551,7 @@ func TestIsExternalManagedControlPlane(t *testing.T) {
 			},
 		}
 		result := IsExternalManagedControlPlane(controlPlane)
-		g.Expect(result).Should(Equal(true))
+		g.Expect(result).Should(BeTrue())
 	})
 
 	t.Run("should return false if control plane status externalManagedControlPlane is false", func(t *testing.T) {
@@ -563,7 +563,7 @@ func TestIsExternalManagedControlPlane(t *testing.T) {
 			},
 		}
 		result := IsExternalManagedControlPlane(controlPlane)
-		g.Expect(result).Should(Equal(false))
+		g.Expect(result).Should(BeFalse())
 	})
 
 	t.Run("should return false if control plane status externalManagedControlPlane is not set", func(t *testing.T) {
@@ -575,7 +575,7 @@ func TestIsExternalManagedControlPlane(t *testing.T) {
 			},
 		}
 		result := IsExternalManagedControlPlane(controlPlane)
-		g.Expect(result).Should(Equal(false))
+		g.Expect(result).Should(BeFalse())
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* Our current golangci-lint version uses a ginkgolinter version that crashes when enabled. This bump allows us to enable ginkgolinter.
* linters-settings is now alphabetized to make it easier to find the correct linter.
* ginkgolinter is partially enabled. Due to the large amount of findings I only enabled a single check to keep this pr a little smaller. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8050
