### PR TITLE
🌱 ClusterClass: also consider MD unavailableReplicas for rollout

### DIFF
--- a/internal/controllers/topology/cluster/desired_state_test.go
+++ b/internal/controllers/topology/cluster/desired_state_test.go
@@ -634,22 +634,24 @@ func TestComputeControlPlaneVersion(t *testing.T) {
 			WithGeneration(int64(1)).
 			WithReplicas(int32(2)).
 			WithStatus(clusterv1.MachineDeploymentStatus{
-				ObservedGeneration: 2,
-				Replicas:           2,
-				UpdatedReplicas:    2,
-				AvailableReplicas:  2,
-				ReadyReplicas:      2,
+				ObservedGeneration:  2,
+				Replicas:            2,
+				UpdatedReplicas:     2,
+				AvailableReplicas:   2,
+				ReadyReplicas:       2,
+				UnavailableReplicas: 0,
 			}).
 			Build()
 		machineDeploymentRollingOut := builder.MachineDeployment("test-namespace", "md2").
 			WithGeneration(int64(1)).
 			WithReplicas(int32(2)).
 			WithStatus(clusterv1.MachineDeploymentStatus{
-				ObservedGeneration: 2,
-				Replicas:           1,
-				UpdatedReplicas:    1,
-				AvailableReplicas:  1,
-				ReadyReplicas:      1,
+				ObservedGeneration:  2,
+				Replicas:            1,
+				UpdatedReplicas:     1,
+				AvailableReplicas:   1,
+				ReadyReplicas:       1,
+				UnavailableReplicas: 0,
 			}).
 			Build()
 
@@ -1769,6 +1771,7 @@ func TestComputeMachineDeploymentVersion(t *testing.T) {
 	// - md.spec.replicas == md.status.replicas
 	// - md.spec.replicas == md.status.updatedReplicas
 	// - md.spec.replicas == md.status.readyReplicas
+	// - md.status.unavailableReplicas == 0
 	// - md.Generation < md.status.observedGeneration
 	//
 	// A machine deployment is considered upgrading if any of the above conditions
@@ -1777,22 +1780,24 @@ func TestComputeMachineDeploymentVersion(t *testing.T) {
 		WithGeneration(1).
 		WithReplicas(2).
 		WithStatus(clusterv1.MachineDeploymentStatus{
-			ObservedGeneration: 2,
-			Replicas:           2,
-			UpdatedReplicas:    2,
-			AvailableReplicas:  2,
-			ReadyReplicas:      2,
+			ObservedGeneration:  2,
+			Replicas:            2,
+			UpdatedReplicas:     2,
+			AvailableReplicas:   2,
+			ReadyReplicas:       2,
+			UnavailableReplicas: 0,
 		}).
 		Build()
 	machineDeploymentRollingOut := builder.MachineDeployment("test-namespace", "md-2").
 		WithGeneration(1).
 		WithReplicas(2).
 		WithStatus(clusterv1.MachineDeploymentStatus{
-			ObservedGeneration: 2,
-			Replicas:           1,
-			UpdatedReplicas:    1,
-			AvailableReplicas:  1,
-			ReadyReplicas:      1,
+			ObservedGeneration:  2,
+			Replicas:            1,
+			UpdatedReplicas:     1,
+			AvailableReplicas:   1,
+			ReadyReplicas:       1,
+			UnavailableReplicas: 1,
 		}).
 		Build()
 

--- a/internal/controllers/topology/cluster/scope/state.go
+++ b/internal/controllers/topology/cluster/scope/state.go
@@ -94,5 +94,7 @@ type MachineDeploymentState struct {
 // A machine deployment is considered upgrading if:
 // - if any of the replicas of the machine deployment is not ready.
 func (md *MachineDeploymentState) IsRollingOut() bool {
-	return !mdutil.DeploymentComplete(md.Object, &md.Object.Status) || *md.Object.Spec.Replicas != md.Object.Status.ReadyReplicas
+	return !mdutil.DeploymentComplete(md.Object, &md.Object.Status) ||
+		*md.Object.Spec.Replicas != md.Object.Status.ReadyReplicas ||
+		md.Object.Status.UnavailableReplicas > 0
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
