### PR TITLE
🌱 Deprecate v1alpha3 & v1alpha4

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -219,10 +219,21 @@ issues:
   # changes in PRs and avoid nitpicking.
   exclude-use-default: false
   exclude-rules:
-  # Specific exclude rules for deprecated fields that are still part of the codebase. These should be removed as the referenced deprecated item is removed from the project.
+  # Specific exclude rules for deprecated fields that are still part of the codebase. These
+  # should be removed as the referenced deprecated item is removed from the project.
   - linters:
       - staticcheck
     text: "SA1019: (bootstrapv1.ClusterStatus|scope.Config.Spec.UseExperimentalRetryJoin|DockerMachine.Spec.Bootstrapped|machineStatus.Bootstrapped) is deprecated"
+  # Specific exclude rules for deprecated packages that are still part of the codebase. These
+  # should be removed as the referenced deprecated packages are removed from the project.
+  - linters:
+    - staticcheck
+    text: "SA1019: .* is deprecated: This package will be removed in one of the next releases."
+  # Specific exclude rules for deprecated types that are still part of the codebase. These
+  # should be removed as the referenced deprecated types are removed from the project.
+  - linters:
+    - staticcheck
+    text: "SA1019: (clusterv1alpha3.*|clusterv1alpha4.*) is deprecated: This type will be removed in one of the next releases."
   - linters:
     - revive
     text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"

--- a/api/v1alpha3/doc.go
+++ b/api/v1alpha3/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha3

--- a/api/v1alpha3/machine_types.go
+++ b/api/v1alpha3/machine_types.go
@@ -245,6 +245,8 @@ type Bootstrap struct {
 // +kubebuilder:printcolumn:name="NodeName",type="string",JSONPath=".status.nodeRef.name",description="Node name associated with this machine",priority=1
 
 // Machine is the Schema for the machines API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -266,6 +268,8 @@ func (m *Machine) SetConditions(conditions Conditions) {
 // +kubebuilder:object:root=true
 
 // MachineList contains a list of Machine.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha3/machinedeployment_types.go
+++ b/api/v1alpha3/machinedeployment_types.go
@@ -251,6 +251,8 @@ func (md *MachineDeploymentStatus) GetTypedPhase() MachineDeploymentPhase {
 // +kubebuilder:printcolumn:name="Unavailable",type=integer,JSONPath=".status.unavailableReplicas",description="Total number of unavailable machines targeted by this MachineDeployment"
 
 // MachineDeployment is the Schema for the machinedeployments API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineDeployment struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -262,6 +264,8 @@ type MachineDeployment struct {
 // +kubebuilder:object:root=true
 
 // MachineDeploymentList contains a list of MachineDeployment.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineDeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha3/machinehealthcheck_types.go
+++ b/api/v1alpha3/machinehealthcheck_types.go
@@ -121,6 +121,8 @@ type MachineHealthCheckStatus struct {
 // +kubebuilder:printcolumn:name="CurrentHealthy",type="integer",JSONPath=".status.currentHealthy",description="Current observed healthy machines"
 
 // MachineHealthCheck is the Schema for the machinehealthchecks API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineHealthCheck struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -145,6 +147,8 @@ func (m *MachineHealthCheck) SetConditions(conditions Conditions) {
 // +kubebuilder:object:root=true
 
 // MachineHealthCheckList contains a list of MachineHealthCheck.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineHealthCheckList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha3/machineset_types.go
+++ b/api/v1alpha3/machineset_types.go
@@ -193,6 +193,8 @@ func (m *MachineSet) Validate() field.ErrorList {
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Total number of ready machines targeted by this machineset."
 
 // MachineSet is the Schema for the machinesets API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -204,6 +206,8 @@ type MachineSet struct {
 // +kubebuilder:object:root=true
 
 // MachineSetList contains a list of MachineSet.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha4/cluster_types.go
+++ b/api/v1alpha4/cluster_types.go
@@ -282,6 +282,8 @@ func (v APIEndpoint) String() string {
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed"
 
 // Cluster is the Schema for the clusters API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -387,6 +389,8 @@ func (f ClusterIPFamily) String() string {
 // +kubebuilder:object:root=true
 
 // ClusterList contains a list of Cluster.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha4/clusterclass_types.go
+++ b/api/v1alpha4/clusterclass_types.go
@@ -26,6 +26,8 @@ import (
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of ClusterClass"
 
 // ClusterClass is a template which can be used to create managed topologies.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterClass struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -121,6 +123,8 @@ type LocalObjectTemplate struct {
 // +kubebuilder:object:root=true
 
 // ClusterClassList contains a list of Cluster.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterClassList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha4/doc.go
+++ b/api/v1alpha4/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha4 contains the v1alpha4 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha4

--- a/api/v1alpha4/machine_types.go
+++ b/api/v1alpha4/machine_types.go
@@ -244,6 +244,8 @@ type Bootstrap struct {
 // +kubebuilder:printcolumn:name="NodeName",type="string",JSONPath=".status.nodeRef.name",description="Node name associated with this machine",priority=1
 
 // Machine is the Schema for the machines API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -265,6 +267,8 @@ func (m *Machine) SetConditions(conditions Conditions) {
 // +kubebuilder:object:root=true
 
 // MachineList contains a list of Machine.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha4/machinedeployment_types.go
+++ b/api/v1alpha4/machinedeployment_types.go
@@ -282,6 +282,8 @@ func (md *MachineDeploymentStatus) GetTypedPhase() MachineDeploymentPhase {
 // +kubebuilder:printcolumn:name="Unavailable",type=integer,JSONPath=".status.unavailableReplicas",description="Total number of unavailable machines targeted by this MachineDeployment"
 
 // MachineDeployment is the Schema for the machinedeployments API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineDeployment struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -293,6 +295,8 @@ type MachineDeployment struct {
 // +kubebuilder:object:root=true
 
 // MachineDeploymentList contains a list of MachineDeployment.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineDeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha4/machinehealthcheck_types.go
+++ b/api/v1alpha4/machinehealthcheck_types.go
@@ -134,6 +134,8 @@ type MachineHealthCheckStatus struct {
 // +kubebuilder:printcolumn:name="CurrentHealthy",type="integer",JSONPath=".status.currentHealthy",description="Current observed healthy machines"
 
 // MachineHealthCheck is the Schema for the machinehealthchecks API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineHealthCheck struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -158,6 +160,8 @@ func (m *MachineHealthCheck) SetConditions(conditions Conditions) {
 // +kubebuilder:object:root=true
 
 // MachineHealthCheckList contains a list of MachineHealthCheck.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineHealthCheckList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1alpha4/machineset_types.go
+++ b/api/v1alpha4/machineset_types.go
@@ -205,6 +205,8 @@ func (m *MachineSet) Validate() field.ErrorList {
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Total number of ready machines targeted by this machineset."
 
 // MachineSet is the Schema for the machinesets API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -216,6 +218,8 @@ type MachineSet struct {
 // +kubebuilder:object:root=true
 
 // MachineSetList contains a list of MachineSet.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachineSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/bootstrap/kubeadm/api/v1alpha3/doc.go
+++ b/bootstrap/kubeadm/api/v1alpha3/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha3

--- a/bootstrap/kubeadm/api/v1alpha3/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1alpha3/kubeadmconfig_types.go
@@ -136,6 +136,8 @@ type KubeadmConfigStatus struct {
 // +kubebuilder:subresource:status
 
 // KubeadmConfig is the Schema for the kubeadmconfigs API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -157,6 +159,8 @@ func (c *KubeadmConfig) SetConditions(conditions clusterv1alpha3.Conditions) {
 // +kubebuilder:object:root=true
 
 // KubeadmConfigList contains a list of KubeadmConfig.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/bootstrap/kubeadm/api/v1alpha3/kubeadmconfigtemplate_types.go
+++ b/bootstrap/kubeadm/api/v1alpha3/kubeadmconfigtemplate_types.go
@@ -34,6 +34,8 @@ type KubeadmConfigTemplateResource struct {
 // +kubebuilder:resource:path=kubeadmconfigtemplates,scope=Namespaced,categories=cluster-api
 
 // KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -44,6 +46,8 @@ type KubeadmConfigTemplate struct {
 // +kubebuilder:object:root=true
 
 // KubeadmConfigTemplateList contains a list of KubeadmConfigTemplate.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/bootstrap/kubeadm/api/v1alpha4/doc.go
+++ b/bootstrap/kubeadm/api/v1alpha4/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha4 contains the v1alpha4 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha4

--- a/bootstrap/kubeadm/api/v1alpha4/kubeadmconfig_types.go
+++ b/bootstrap/kubeadm/api/v1alpha4/kubeadmconfig_types.go
@@ -129,6 +129,8 @@ type KubeadmConfigStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of KubeadmConfig"
 
 // KubeadmConfig is the Schema for the kubeadmconfigs API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -150,6 +152,8 @@ func (c *KubeadmConfig) SetConditions(conditions clusterv1alpha4.Conditions) {
 // +kubebuilder:object:root=true
 
 // KubeadmConfigList contains a list of KubeadmConfig.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/bootstrap/kubeadm/api/v1alpha4/kubeadmconfigtemplate_types.go
+++ b/bootstrap/kubeadm/api/v1alpha4/kubeadmconfigtemplate_types.go
@@ -35,6 +35,8 @@ type KubeadmConfigTemplateResource struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of KubeadmConfigTemplate"
 
 // KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -45,6 +47,8 @@ type KubeadmConfigTemplate struct {
 // +kubebuilder:object:root=true
 
 // KubeadmConfigTemplateList contains a list of KubeadmConfigTemplate.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmConfigTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -20,7 +20,8 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        description: "KubeadmConfig is the Schema for the kubeadmconfigs API. \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1013,7 +1014,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        description: "KubeadmConfig is the Schema for the kubeadmconfigs API. \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -20,8 +20,8 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates
-          API.
+        description: "KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1002,8 +1002,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates
-          API.
+        description: "KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
@@ -20,8 +20,9 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: ClusterResourceSetBinding lists all matching ClusterResourceSets
-          with the cluster it belongs to.
+        description: "ClusterResourceSetBinding lists all matching ClusterResourceSets
+          with the cluster it belongs to. \n Deprecated: This type will be removed
+          in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -108,8 +109,9 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: ClusterResourceSetBinding lists all matching ClusterResourceSets
-          with the cluster it belongs to.
+        description: "ClusterResourceSetBinding lists all matching ClusterResourceSets
+          with the cluster it belongs to. \n Deprecated: This type will be removed
+          in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/config/crd/bases/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -20,8 +20,8 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: ClusterResourceSet is the Schema for the clusterresourcesets
-          API.
+        description: "ClusterResourceSet is the Schema for the clusterresourcesets
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -182,8 +182,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: ClusterResourceSet is the Schema for the clusterresourcesets
-          API.
+        description: "ClusterResourceSet is the Schema for the clusterresourcesets
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusterclasses.yaml
@@ -27,8 +27,9 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: ClusterClass is a template which can be used to create managed
-          topologies.
+        description: "ClusterClass is a template which can be used to create managed
+          topologies. \n Deprecated: This type will be removed in one of the next
+          releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/cluster.x-k8s.io_clusters.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_clusters.yaml
@@ -288,7 +288,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: Cluster is the Schema for the clusters API.
+        description: "Cluster is the Schema for the clusters API. \n Deprecated: This
+          type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinedeployments.yaml
@@ -44,7 +44,8 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: MachineDeployment is the Schema for the machinedeployments API.
+        description: "MachineDeployment is the Schema for the machinedeployments API.
+          \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -543,7 +544,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: MachineDeployment is the Schema for the machinedeployments API.
+        description: "MachineDeployment is the Schema for the machinedeployments API.
+          \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -36,8 +36,8 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: MachineHealthCheck is the Schema for the machinehealthchecks
-          API.
+        description: "MachineHealthCheck is the Schema for the machinehealthchecks
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -296,8 +296,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: MachineHealthCheck is the Schema for the machinehealthchecks
-          API.
+        description: "MachineHealthCheck is the Schema for the machinehealthchecks
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinepools.yaml
@@ -36,7 +36,8 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: MachinePool is the Schema for the machinepools API.
+        description: "MachinePool is the Schema for the machinepools API. \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -586,7 +587,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: MachinePool is the Schema for the machinepools API.
+        description: "MachinePool is the Schema for the machinepools API. \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/cluster.x-k8s.io_machines.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machines.yaml
@@ -40,7 +40,8 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: Machine is the Schema for the machines API.
+        description: "Machine is the Schema for the machines API. \n Deprecated: This
+          type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -386,7 +387,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: Machine is the Schema for the machines API.
+        description: "Machine is the Schema for the machines API. \n Deprecated: This
+          type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
+++ b/config/crd/bases/cluster.x-k8s.io_machinesets.yaml
@@ -35,7 +35,8 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: MachineSet is the Schema for the machinesets API.
+        description: "MachineSet is the Schema for the machinesets API. \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -480,7 +481,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: MachineSet is the Schema for the machinesets API.
+        description: "MachineSet is the Schema for the machinesets API. \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/controlplane/kubeadm/api/v1alpha3/doc.go
+++ b/controlplane/kubeadm/api/v1alpha3/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha3

--- a/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha3/kubeadm_control_plane_types.go
@@ -196,6 +196,8 @@ type KubeadmControlPlaneStatus struct {
 // +kubebuilder:printcolumn:name="Unavailable",type=integer,JSONPath=".status.unavailableReplicas",description="Total number of unavailable machines targeted by this control plane"
 
 // KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -217,6 +219,8 @@ func (in *KubeadmControlPlane) SetConditions(conditions clusterv1alpha3.Conditio
 // +kubebuilder:object:root=true
 
 // KubeadmControlPlaneList contains a list of KubeadmControlPlane.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/controlplane/kubeadm/api/v1alpha4/doc.go
+++ b/controlplane/kubeadm/api/v1alpha4/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha4 contains the v1alpha4 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha4

--- a/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_types.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadm_control_plane_types.go
@@ -211,6 +211,8 @@ type KubeadmControlPlaneStatus struct {
 // +kubebuilder:printcolumn:name="Unavailable",type=integer,JSONPath=".status.unavailableReplicas",description="Total number of unavailable machines targeted by this control plane"
 
 // KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -232,6 +234,8 @@ func (in *KubeadmControlPlane) SetConditions(conditions clusterv1alpha4.Conditio
 // +kubebuilder:object:root=true
 
 // KubeadmControlPlaneList contains a list of KubeadmControlPlane.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/controlplane/kubeadm/api/v1alpha4/kubeadmcontrolplanetemplate_types.go
+++ b/controlplane/kubeadm/api/v1alpha4/kubeadmcontrolplanetemplate_types.go
@@ -30,6 +30,8 @@ type KubeadmControlPlaneTemplateSpec struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of KubeadmControlPlaneTemplate"
 
 // KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlaneTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -40,6 +42,8 @@ type KubeadmControlPlaneTemplate struct {
 // +kubebuilder:object:root=true
 
 // KubeadmControlPlaneTemplateList contains a list of KubeadmControlPlaneTemplate.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type KubeadmControlPlaneTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -54,8 +54,8 @@ spec:
     name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane
-          API.
+        description: "KubeadmControlPlane is the Schema for the KubeadmControlPlane
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -1231,8 +1231,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane
-          API.
+        description: "KubeadmControlPlane is the Schema for the KubeadmControlPlane
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -25,8 +25,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates
-          API.
+        description: "KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/exp/addons/api/v1alpha3/clusterresourceset_types.go
+++ b/exp/addons/api/v1alpha3/clusterresourceset_types.go
@@ -115,6 +115,8 @@ func (m *ClusterResourceSet) SetConditions(conditions clusterv1alpha3.Conditions
 // +kubebuilder:subresource:status
 
 // ClusterResourceSet is the Schema for the clusterresourcesets API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -126,6 +128,8 @@ type ClusterResourceSet struct {
 // +kubebuilder:object:root=true
 
 // ClusterResourceSetList contains a list of ClusterResourceSet.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/addons/api/v1alpha3/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1alpha3/clusterresourcesetbinding_types.go
@@ -105,6 +105,8 @@ func (c *ClusterResourceSetBinding) DeleteBinding(clusterResourceSet *ClusterRes
 // +kubebuilder:subresource:status
 
 // ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -124,6 +126,8 @@ type ClusterResourceSetBindingSpec struct {
 // +kubebuilder:object:root=true
 
 // ClusterResourceSetBindingList contains a list of ClusterResourceSetBinding.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetBindingList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/addons/api/v1alpha3/doc.go
+++ b/exp/addons/api/v1alpha3/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/exp/addons/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha3

--- a/exp/addons/api/v1alpha4/clusterresourceset_types.go
+++ b/exp/addons/api/v1alpha4/clusterresourceset_types.go
@@ -117,6 +117,8 @@ func (m *ClusterResourceSet) SetConditions(conditions clusterv1alpha4.Conditions
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of ClusterResourceSet"
 
 // ClusterResourceSet is the Schema for the clusterresourcesets API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -128,6 +130,8 @@ type ClusterResourceSet struct {
 // +kubebuilder:object:root=true
 
 // ClusterResourceSetList contains a list of ClusterResourceSet.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/addons/api/v1alpha4/clusterresourcesetbinding_types.go
+++ b/exp/addons/api/v1alpha4/clusterresourcesetbinding_types.go
@@ -106,6 +106,8 @@ func (c *ClusterResourceSetBinding) DeleteBinding(clusterResourceSet *ClusterRes
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of ClusterResourceSetBinding"
 
 // ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -125,6 +127,8 @@ type ClusterResourceSetBindingSpec struct {
 // +kubebuilder:object:root=true
 
 // ClusterResourceSetBindingList contains a list of ClusterResourceSetBinding.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type ClusterResourceSetBindingList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/addons/api/v1alpha4/doc.go
+++ b/exp/addons/api/v1alpha4/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha4 contains the v1alpha4 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/exp/addons/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha4

--- a/exp/api/v1alpha3/doc.go
+++ b/exp/api/v1alpha3/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/exp/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha3

--- a/exp/api/v1alpha3/machinepool_types.go
+++ b/exp/api/v1alpha3/machinepool_types.go
@@ -213,6 +213,8 @@ func (m *MachinePoolStatus) GetTypedPhase() MachinePoolPhase {
 // +k8s:conversion-gen=false
 
 // MachinePool is the Schema for the machinepools API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachinePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -234,6 +236,8 @@ func (m *MachinePool) SetConditions(conditions clusterv1alpha3.Conditions) {
 // +kubebuilder:object:root=true
 
 // MachinePoolList contains a list of MachinePool.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachinePoolList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/exp/api/v1alpha4/doc.go
+++ b/exp/api/v1alpha4/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha4 contains the v1alpha4 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/exp/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha4

--- a/exp/api/v1alpha4/machinepool_types.go
+++ b/exp/api/v1alpha4/machinepool_types.go
@@ -209,6 +209,8 @@ func (m *MachinePoolStatus) GetTypedPhase() MachinePoolPhase {
 // +k8s:conversion-gen=false
 
 // MachinePool is the Schema for the machinepools API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachinePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -230,6 +232,8 @@ func (m *MachinePool) SetConditions(conditions clusterv1alpha4.Conditions) {
 // +kubebuilder:object:root=true
 
 // MachinePoolList contains a list of MachinePool.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type MachinePoolList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/test/infrastructure/docker/api/v1alpha3/doc.go
+++ b/test/infrastructure/docker/api/v1alpha3/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha3

--- a/test/infrastructure/docker/api/v1alpha3/dockercluster_types.go
+++ b/test/infrastructure/docker/api/v1alpha3/dockercluster_types.go
@@ -73,6 +73,8 @@ type APIEndpoint struct {
 // +kubebuilder:object:root=true
 
 // DockerCluster is the Schema for the dockerclusters API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -94,6 +96,8 @@ func (c *DockerCluster) SetConditions(conditions clusterv1alpha3.Conditions) {
 // +kubebuilder:object:root=true
 
 // DockerClusterList contains a list of DockerCluster.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/test/infrastructure/docker/api/v1alpha3/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1alpha3/dockermachine_types.go
@@ -96,6 +96,8 @@ type DockerMachineStatus struct {
 // +kubebuilder:subresource:status
 
 // DockerMachine is the Schema for the dockermachines API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -117,6 +119,8 @@ func (c *DockerMachine) SetConditions(conditions clusterv1alpha3.Conditions) {
 // +kubebuilder:object:root=true
 
 // DockerMachineList contains a list of DockerMachine.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/test/infrastructure/docker/api/v1alpha3/dockermachinetemplate_types.go
+++ b/test/infrastructure/docker/api/v1alpha3/dockermachinetemplate_types.go
@@ -29,6 +29,8 @@ type DockerMachineTemplateSpec struct {
 // +kubebuilder:resource:path=dockermachinetemplates,scope=Namespaced,categories=cluster-api
 
 // DockerMachineTemplate is the Schema for the dockermachinetemplates API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -39,6 +41,8 @@ type DockerMachineTemplate struct {
 // +kubebuilder:object:root=true
 
 // DockerMachineTemplateList contains a list of DockerMachineTemplate.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachineTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/test/infrastructure/docker/api/v1alpha4/doc.go
+++ b/test/infrastructure/docker/api/v1alpha4/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha4 contains the v1alpha4 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha4

--- a/test/infrastructure/docker/api/v1alpha4/dockercluster_types.go
+++ b/test/infrastructure/docker/api/v1alpha4/dockercluster_types.go
@@ -98,6 +98,8 @@ type APIEndpoint struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of DockerCluster"
 
 // DockerCluster is the Schema for the dockerclusters API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -119,6 +121,8 @@ func (c *DockerCluster) SetConditions(conditions clusterv1alpha4.Conditions) {
 // +kubebuilder:object:root=true
 
 // DockerClusterList contains a list of DockerCluster.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerClusterList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/test/infrastructure/docker/api/v1alpha4/dockerclustertemplate_types.go
+++ b/test/infrastructure/docker/api/v1alpha4/dockerclustertemplate_types.go
@@ -29,6 +29,8 @@ type DockerClusterTemplateSpec struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of DockerClusterTemplate"
 
 // DockerClusterTemplate is the Schema for the dockerclustertemplates API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerClusterTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -40,6 +42,8 @@ type DockerClusterTemplate struct {
 // +kubebuilder:resource:path=dockerclustertemplates,scope=Namespaced,categories=cluster-api
 
 // DockerClusterTemplateList contains a list of DockerClusterTemplate.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerClusterTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/test/infrastructure/docker/api/v1alpha4/dockermachine_types.go
+++ b/test/infrastructure/docker/api/v1alpha4/dockermachine_types.go
@@ -97,6 +97,8 @@ type DockerMachineStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of DockerMachine"
 
 // DockerMachine is the Schema for the dockermachines API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -118,6 +120,8 @@ func (c *DockerMachine) SetConditions(conditions clusterv1alpha4.Conditions) {
 // +kubebuilder:object:root=true
 
 // DockerMachineList contains a list of DockerMachine.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachineList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/test/infrastructure/docker/api/v1alpha4/dockermachinetemplate_types.go
+++ b/test/infrastructure/docker/api/v1alpha4/dockermachinetemplate_types.go
@@ -30,6 +30,8 @@ type DockerMachineTemplateSpec struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of DockerMachineTemplate"
 
 // DockerMachineTemplate is the Schema for the dockermachinetemplates API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachineTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -40,6 +42,8 @@ type DockerMachineTemplate struct {
 // +kubebuilder:object:root=true
 
 // DockerMachineTemplateList contains a list of DockerMachineTemplate.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachineTemplateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclusters.yaml
@@ -20,7 +20,8 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: DockerCluster is the Schema for the dockerclusters API.
+        description: "DockerCluster is the Schema for the dockerclusters API. \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -163,7 +164,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: DockerCluster is the Schema for the dockerclusters API.
+        description: "DockerCluster is the Schema for the dockerclusters API. \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockerclustertemplates.yaml
@@ -25,8 +25,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: DockerClusterTemplate is the Schema for the dockerclustertemplates
-          API.
+        description: "DockerClusterTemplate is the Schema for the dockerclustertemplates
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinepools.yaml
@@ -20,7 +20,8 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: DockerMachinePool is the Schema for the dockermachinepools API.
+        description: "DockerMachinePool is the Schema for the dockermachinepools API.
+          \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -204,7 +205,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: DockerMachinePool is the Schema for the dockermachinepools API.
+        description: "DockerMachinePool is the Schema for the dockermachinepools API.
+          \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachines.yaml
@@ -20,7 +20,8 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: DockerMachine is the Schema for the dockermachines API.
+        description: "DockerMachine is the Schema for the dockermachines API. \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -166,7 +167,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: DockerMachine is the Schema for the dockermachines API.
+        description: "DockerMachine is the Schema for the dockermachines API. \n Deprecated:
+          This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
+++ b/test/infrastructure/docker/config/crd/bases/infrastructure.cluster.x-k8s.io_dockermachinetemplates.yaml
@@ -20,8 +20,8 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: DockerMachineTemplate is the Schema for the dockermachinetemplates
-          API.
+        description: "DockerMachineTemplate is the Schema for the dockermachinetemplates
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -106,8 +106,8 @@ spec:
     name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: DockerMachineTemplate is the Schema for the dockermachinetemplates
-          API.
+        description: "DockerMachineTemplate is the Schema for the dockermachinetemplates
+          API. \n Deprecated: This type will be removed in one of the next releases."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/test/infrastructure/docker/exp/api/v1alpha3/doc.go
+++ b/test/infrastructure/docker/exp/api/v1alpha3/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha3 contains the v1alpha3 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha3

--- a/test/infrastructure/docker/exp/api/v1alpha3/dockermachinepool_types.go
+++ b/test/infrastructure/docker/exp/api/v1alpha3/dockermachinepool_types.go
@@ -116,6 +116,8 @@ type DockerMachinePoolInstanceStatus struct {
 // +kubebuilder:subresource:status
 
 // DockerMachinePool is the Schema for the dockermachinepools API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachinePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -137,6 +139,8 @@ func (c *DockerMachinePool) SetConditions(conditions clusterv1alpha3.Conditions)
 // +kubebuilder:object:root=true
 
 // DockerMachinePoolList contains a list of DockerMachinePool.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachinePoolList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/test/infrastructure/docker/exp/api/v1alpha4/doc.go
+++ b/test/infrastructure/docker/exp/api/v1alpha4/doc.go
@@ -16,4 +16,6 @@ limitations under the License.
 
 // Package v1alpha4 contains the v1alpha4 API implementation.
 // +k8s:conversion-gen=sigs.k8s.io/cluster-api/test/infrastructure/docker/exp/api/v1beta1
+//
+// Deprecated: This package will be removed in one of the next releases.
 package v1alpha4

--- a/test/infrastructure/docker/exp/api/v1alpha4/dockermachinepool_types.go
+++ b/test/infrastructure/docker/exp/api/v1alpha4/dockermachinepool_types.go
@@ -117,6 +117,8 @@ type DockerMachinePoolInstanceStatus struct {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of DockerMachinePool"
 
 // DockerMachinePool is the Schema for the dockermachinepools API.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachinePool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -138,6 +140,8 @@ func (c *DockerMachinePool) SetConditions(conditions clusterv1alpha4.Conditions)
 // +kubebuilder:object:root=true
 
 // DockerMachinePoolList contains a list of DockerMachinePool.
+//
+// Deprecated: This type will be removed in one of the next releases.
 type DockerMachinePoolList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Note: The apiVersions were already deprecated before, we just forgot to mark the Go types accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #8038
