### PR TITLE
:seedling: Default and Validate Cluster variables based on ClusterClass status

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -55,6 +55,19 @@ const (
 
 // ANCHOR_END: CommonConditions
 
+// Conditions and condition Reasons for the ClusterClass object.
+const (
+	// ClusterClassVariablesReconciledCondition reports if the ClusterClass variables, including both inline and external
+	// variables, have been successfully reconciled.
+	// This signals that the ClusterClass is ready to be used to default and validate variables on Clusters using
+	// this ClusterClass.
+	ClusterClassVariablesReconciledCondition ConditionType = "VariablesReconciled"
+
+	// VariableDiscoveryFailedReason (Severity=Error) documents a ClusterClass with VariableDiscovery extensions that
+	// failed.
+	VariableDiscoveryFailedReason = "VariableDiscoveryFailed"
+)
+
 // Conditions and condition Reasons for the Cluster object.
 
 const (

--- a/cmd/clusterctl/client/cluster/assets/topology-test/new-clusterclass-and-cluster.yaml
+++ b/cmd/clusterctl/client/cluster/assets/topology-test/new-clusterclass-and-cluster.yaml
@@ -10,6 +10,14 @@ metadata:
   name: my-cluster-class
   namespace: default
 spec:
+  variables:
+    - name: imageRepository
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
+          default: "registry.k8s.io"
+          example: "registry.k8s.io"
   controlPlane:
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/internal/test/builder/builders.go
+++ b/internal/test/builder/builders.go
@@ -255,6 +255,7 @@ type ClusterClassBuilder struct {
 	controlPlaneNodeDeletionTimeout           *metav1.Duration
 	machineDeploymentClasses                  []clusterv1.MachineDeploymentClass
 	variables                                 []clusterv1.ClusterClassVariable
+	statusVariables                           []clusterv1.ClusterClassStatusVariable
 	patches                                   []clusterv1.ClusterClassPatch
 }
 
@@ -317,9 +318,15 @@ func (c *ClusterClassBuilder) WithControlPlaneNodeDeletionTimeout(t *metav1.Dura
 	return c
 }
 
-// WithVariables adds the Variables the ClusterClassBuilder.
+// WithVariables adds the Variables to the ClusterClassBuilder.
 func (c *ClusterClassBuilder) WithVariables(vars ...clusterv1.ClusterClassVariable) *ClusterClassBuilder {
 	c.variables = vars
+	return c
+}
+
+// WithStatusVariables adds the ClusterClassStatusVariables to the ClusterClassBuilder.
+func (c *ClusterClassBuilder) WithStatusVariables(vars ...clusterv1.ClusterClassStatusVariable) *ClusterClassBuilder {
+	c.statusVariables = vars
 	return c
 }
 
@@ -352,6 +359,9 @@ func (c *ClusterClassBuilder) Build() *clusterv1.ClusterClass {
 		Spec: clusterv1.ClusterClassSpec{
 			Variables: c.variables,
 			Patches:   c.patches,
+		},
+		Status: clusterv1.ClusterClassStatus{
+			Variables: c.statusVariables,
 		},
 	}
 	if c.infrastructureClusterTemplate != nil {

--- a/internal/test/builder/zz_generated.deepcopy.go
+++ b/internal/test/builder/zz_generated.deepcopy.go
@@ -148,6 +148,13 @@ func (in *ClusterClassBuilder) DeepCopyInto(out *ClusterClassBuilder) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.statusVariables != nil {
+		in, out := &in.statusVariables, &out.statusVariables
+		*out = make([]v1beta1.ClusterClassStatusVariable, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.patches != nil {
 		in, out := &in.patches, &out.patches
 		*out = make([]v1beta1.ClusterClassPatch, len(*in))

--- a/internal/topology/variables/cluster_variable_validation.go
+++ b/internal/topology/variables/cluster_variable_validation.go
@@ -98,7 +98,7 @@ func validateClusterVariablesDefined(clusterVariables []clusterv1.ClusterVariabl
 	for i, clusterVariable := range clusterVariables {
 		if _, ok := clusterClassVariables[clusterVariable.Name]; !ok {
 			return field.ErrorList{field.Invalid(fldPath.Index(i).Child("name"), clusterVariable.Name,
-				fmt.Sprintf("variable with name %q is not defined in the ClusterClass", clusterVariable.Name))} // TODO: consider if to add ClusterClass name
+				fmt.Sprintf("variable with name %q is not defined in ClusterClass `status.variables`", clusterVariable.Name))} // TODO: consider if to add ClusterClass name
 		}
 	}
 

--- a/internal/webhooks/test/suite_test.go
+++ b/internal/webhooks/test/suite_test.go
@@ -24,9 +24,12 @@ import (
 
 	"k8s.io/component-base/featuregate"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"sigs.k8s.io/cluster-api/api/v1beta1/index"
 	"sigs.k8s.io/cluster-api/feature"
+	"sigs.k8s.io/cluster-api/internal/controllers/clusterclass"
 	"sigs.k8s.io/cluster-api/internal/test/envtest"
 )
 
@@ -44,10 +47,33 @@ func TestMain(m *testing.M) {
 			panic(fmt.Sprintf("unable to setup index: %v", err))
 		}
 	}
+	setupReconcilers := func(ctx context.Context, mgr ctrl.Manager) {
+		unstructuredCachingClient, err := client.NewDelegatingClient(
+			client.NewDelegatingClientInput{
+				// Use the default client for write operations.
+				Client: mgr.GetClient(),
+				// For read operations, use the same cache used by all the controllers but ensure
+				// unstructured objects will be also cached (this does not happen with the default client).
+				CacheReader:       mgr.GetCache(),
+				CacheUnstructured: true,
+			},
+		)
+		if err != nil {
+			panic(fmt.Sprintf("unable to create unstructuredCachineClient: %v", err))
+		}
+		if err := (&clusterclass.Reconciler{
+			Client:                    mgr.GetClient(),
+			APIReader:                 mgr.GetAPIReader(),
+			UnstructuredCachingClient: unstructuredCachingClient,
+		}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 5}); err != nil {
+			panic(fmt.Sprintf("unable to create clusterclass reconciler: %v", err))
+		}
+	}
 
 	os.Exit(envtest.Run(ctx, envtest.RunInput{
-		M:            m,
-		SetupEnv:     func(e *envtest.Environment) { env = e },
-		SetupIndexes: setupIndexes,
+		M:                m,
+		SetupEnv:         func(e *envtest.Environment) { env = e },
+		SetupReconcilers: setupReconcilers,
+		SetupIndexes:     setupIndexes,
 	}))
 }


### PR DESCRIPTION
Default and validate the variables in the Cluster based on the variable definitions in the ClusterClass status instead of the ClusterClass spec.

Part of #7985 
