### PR TITLE
:book: Update coredns version support

### DIFF
--- a/docs/book/src/reference/versions.md
+++ b/docs/book/src/reference/versions.md
@@ -127,15 +127,18 @@ The Kubeadm Control Plane requires the Kubeadm Bootstrap Provider.
 
 ##### CoreDNS
 
-| CAPI Version    | Max CoreDNS Version for Upgrade |
-|-----------------|---------------------------------|
-| v0.3 (v1alpha3) | v1.8.4                          |
-| v0.4 (v1alpha4) | v1.8.4                          |
-| v1.0 (v1beta1)  | v1.8.5                          |
-| v1.1 (v1beta1)  | v1.9.3                          |
-| v1.2 (v1beta1)  | v1.9.3 (v1.10.0 with >= v1.2.7) |
-| v1.3 (v1beta1)  | v1.10.0                         |
-| v1.4 (v1beta1)  | v1.10.1                         |
+| CAPI Version         | Max CoreDNS Version for Upgrade |
+|----------------------|---------------------------------|
+| v0.3 (v1alpha3)      | v1.8.4                          |
+| v0.4 (v1alpha4)      | v1.8.4                          |
+| v1.0 (v1beta1)       | v1.8.5                          |
+| v1.1 (v1beta1)       | v1.9.3                          |
+| v1.2 (v1beta1)       | v1.9.3                          |
+| >= v1.2.7 (v1beta1)  | v1.10.0                         |
+| >= v1.2.11 (v1beta1) | v1.10.1                         |
+| v1.3 (v1beta1)       | v1.10.0                         |
+| >= v1.3.4 (v1beta1)  | v1.10.1                         |
+| v1.4 (v1beta1)       | v1.10.1                         |
 
 #### Kubernetes version specific notes
 


### PR DESCRIPTION

Update CoreDNS supported version for older versions of CAPI from changes in https://github.com/kubernetes-sigs/cluster-api/pull/8078 and https://github.com/kubernetes-sigs/cluster-api/pull/8077